### PR TITLE
header file changes to catch up with gtkmm-2.24.3

### DIFF
--- a/src/yarpmanager/gymanager/gymanager.cpp
+++ b/src/yarpmanager/gymanager/gymanager.cpp
@@ -13,7 +13,7 @@
 #endif
 
 #include <iostream>
-#include <gtkmm/main.h>
+#include <gtkmm.h>
 
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>

--- a/src/yarpscope/src/Graph.h
+++ b/src/yarpscope/src/Graph.h
@@ -9,7 +9,7 @@
 #ifndef YARPSCOPE_GRAPH_H
 #define YARPSCOPE_GRAPH_H
 
-#include <glibmm/refptr.h>
+#include <glibmm.h>
 
 
 namespace Glib

--- a/src/yarpscope/src/main.cpp
+++ b/src/yarpscope/src/main.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Network.h>
 
-#include <gtkmm/main.h>
+#include <gtkmm.h>
 
 //#include <glibmm/i18n.h>
 #define _(String) (String)


### PR DESCRIPTION
Some changes are needed to compile against a recent version of gtkmm in use by homebrew, see mxcl/homebrew#19416 and #7.  With these changes, I can compile YARP just fine using the current library versions in homebrew (also removing a dependency on glademm).

@drdanz, the change to gtkdatabox would more appropriately be made upstream, right?
