### PR TITLE
Use set_package_properties to set package properties

### DIFF
--- a/conf/FindACE.cmake
+++ b/conf/FindACE.cmake
@@ -107,3 +107,10 @@ if(NOT ACE_FOUND)
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(ACE DEFAULT_MSG ACE_LIBRARIES ACE_INCLUDE_DIRS)
 endif()
+
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(ACE PROPERTIES DESCRIPTION "The ADAPTIVE Communication Environment"
+                                          URL "http://www.cs.wustl.edu/~schmidt/ACE.html")
+endif()

--- a/conf/FindAtlas.cmake
+++ b/conf/FindAtlas.cmake
@@ -58,3 +58,9 @@ mark_as_advanced(ATLAS_INCLUDE_DIR
                  ATLAS_LAPACK_ATLAS_LIBRARY)
 
 set(Atlas_FOUND ${ATLAS_FOUND})
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(Atlas PROPERTIES DESCRIPTION "Automatically Tuned Linear Algebra Software"
+                                            URL "http://math-atlas.sourceforge.net/")
+endif(COMMAND set_package_properties)

--- a/conf/FindGSL.cmake
+++ b/conf/FindGSL.cmake
@@ -120,3 +120,9 @@ mark_as_advanced(${GSL_MARK}
                  GSLCBLAS_LIBRARY
                  GSL_BLAS_HEADER
                  GSL_LIBRARY)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GSL PROPERTIES DESCRIPTION "GNU Scientific Library, a numerical library for C and C++ programmers"
+                                          URL "https://www.gnu.org/software/gsl/")
+endif()

--- a/conf/FindGooCanvas.cmake
+++ b/conf/FindGooCanvas.cmake
@@ -18,3 +18,8 @@
 include(MacroStandardFindModule)
 macro_standard_find_module(GooCanvas goocanvas)
 
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GooCanvas PROPERTIES DESCRIPTION "A canvas widget for GTK+ that uses the cairo 2D library for drawing"
+                                                URL "https://live.gnome.org/GooCanvas")
+endif()

--- a/conf/FindGooCanvasMM.cmake
+++ b/conf/FindGooCanvasMM.cmake
@@ -18,3 +18,8 @@
 include(MacroStandardFindModule)
 macro_standard_find_module(GooCanvasMM goocanvasmm-1.0)
 
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GooCanvasMM PROPERTIES DESCRIPTION "A GtkMM wrapper for GooCanvas"
+                                                  URL "http://live.gnome.org/GooCanvas")
+endif()

--- a/conf/FindGthread.cmake
+++ b/conf/FindGthread.cmake
@@ -100,3 +100,10 @@ if (NOT Gthread_FOUND)
     mark_as_advanced(Gthread_INCLUDE_DIRS Gthread_LIBRARIES)
 
 endif (NOT Gthread_FOUND)
+
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(Gthread PROPERTIES DESCRIPTION "Glib thread library"
+                                              URL "http://developer.gnome.org/glib/")
+endif()

--- a/conf/FindGtkDatabox.cmake
+++ b/conf/FindGtkDatabox.cmake
@@ -17,3 +17,9 @@
 
 include(MacroStandardFindModule)
 macro_standard_find_module(GtkDatabox gtkdatabox)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GtkDatabox PROPERTIES DESCRIPTION "A GTK+ widget for live display of large amounts of fluctuating numerical data"
+                                                 URL "http://sourceforge.net/projects/gtkdatabox/")
+endif()

--- a/conf/FindGtkDataboxMM.cmake
+++ b/conf/FindGtkDataboxMM.cmake
@@ -17,3 +17,9 @@
 
 include(MacroStandardFindModule)
 macro_standard_find_module(GtkDataboxMM gtkdataboxmm-0.9)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GtkDataboxMM PROPERTIES DESCRIPTION "A GtkMM wrapper for GtkDatabox"
+                                                   URL "http://sourceforge.net/projects/gtkdataboxmm/")
+endif()

--- a/conf/FindGtkMM.cmake
+++ b/conf/FindGtkMM.cmake
@@ -7,3 +7,9 @@ if(UNIX)
 elseif(WIN32 AND NOT CYGWIN)
     include(FindGtkMMWin32)
 endif(UNIX)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GtkMM PROPERTIES DESCRIPTION "C++ interface for the GTK+ GUI library"
+                                            URL "http://www.gtkmm.org/")
+endif()

--- a/conf/FindGtkPlus.cmake
+++ b/conf/FindGtkPlus.cmake
@@ -97,3 +97,8 @@ endif(UNIX)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GtkPlus DEFAULT_MSG GtkPlus_LIBRARIES GtkPlus_INCLUDE_DIRS)
 
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(GtkPlus PROPERTIES DESCRIPTION "GTK+ graphical user interface library"
+                                              URL "http://www.gtk.org/")
+endif()

--- a/conf/FindOpenCV.cmake
+++ b/conf/FindOpenCV.cmake
@@ -530,3 +530,8 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OpenCV DEFAULT_MSG OpenCV_LIBRARIES)
 
 
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(OpenCV PROPERTIES DESCRIPTION "Open source computer vision library"
+                                             URL "http://opencv.org/")
+endif()

--- a/conf/FindSQLite.cmake
+++ b/conf/FindSQLite.cmake
@@ -17,3 +17,9 @@
 
 include(MacroStandardFindModule)
 macro_standard_find_module(SQLite sqlite3)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(SQLite PROPERTIES DESCRIPTION "Self-contained, serverless, zero-configuration, transactional SQL database engine"
+                                             URL "http://sqlite.org/")
+endif()

--- a/conf/FindTinyXML.cmake
+++ b/conf/FindTinyXML.cmake
@@ -16,3 +16,9 @@
 
 include(MacroStandardFindModule)
 macro_standard_find_module(TinyXML tinyxml)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(TinyXML PROPERTIES DESCRIPTION "A small, simple XML parser for the C++ language"
+                                              URL "http://www.grinninglizard.com/tinyxml/index.html")
+endif()


### PR DESCRIPTION
The command is used only if if FeatureSummary was included (otherwise
the command won't exist)

This allows to use FeatureSummary to print a nice output with the
installed and missing packages
