### PR TITLE
Install yarpidl_rosmsg and yarpidl_thrift targets

### DIFF
--- a/src/idls/rosmsg/CMakeLists.txt
+++ b/src/idls/rosmsg/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(src)
 add_executable(yarpidl_rosmsg src/main.cpp src/RosType.cpp src/RosTypeCodeGenYarp.cpp src/RosType.h src/RosTypeCodeGenYarp.h)
 
 target_link_libraries(yarpidl_rosmsg YARP_init)
+install(TARGETS yarpidl_rosmsg COMPONENT utilities DESTINATION bin)
 
 option(TEST_yarpidl_rosmsg "Test ROS msg based IDL" OFF)
 if (TEST_yarpidl_rosmsg)

--- a/src/idls/thrift/CMakeLists.txt
+++ b/src/idls/thrift/CMakeLists.txt
@@ -42,6 +42,7 @@ if (THRIFT_ROOT)
     ${thrift_source_c}
     ${insert_source_cc}
     )
+  install(TARGETS yarpidl_thrift COMPONENT utilities DESTINATION bin)
 endif ()
 
 if (NOT THRIFT_ROOT)
@@ -71,7 +72,7 @@ if (NOT THRIFT_ROOT)
 
 endif ()
 
-INSTALL(TARGETS yarpidl_thrift COMPONENT utilities DESTINATION bin)
+install(TARGETS yarpidl_thrift COMPONENT utilities DESTINATION bin)
 
 option(TEST_yarpidl_thrift "Test thrift-based IDL" OFF)
 if (TEST_yarpidl_thrift)


### PR DESCRIPTION
I'm not sure if there is a good reason why they are not installed...
