### PR TITLE
accept absolute paths in ResourceFinder, see issue #51

### DIFF
--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -338,6 +338,16 @@ public:
                                   const char *base2,
                                   const char *base3,
                                   const char *name) {
+        if (name[0]=='/') {
+            return name;
+        }
+#ifdef WIN32
+        if (name[0]!='\0') {
+            if (name[1]==':') {
+                return name;
+            }
+        }
+#endif
         ConstString s = "";
         if (base1!=NULL) {
             s = base1;


### PR DESCRIPTION
ResourceFinder doesn't currently accept absolute paths for --from and other situations, see #51
