### PR TITLE
[bindings] Fixing Lua and Java bindings for old SWIG versions

### DIFF
--- a/bindings/std_string_java.i
+++ b/bindings/std_string_java.i
@@ -1,0 +1,126 @@
+// This is java/std_string.i as of commit 12a9671440e9408a07d59a8936e75da096fea5fc
+// on https://github.com/swig/swig , to be used with SWIG versions <2.0.7
+// to be able to use the typemaps also for other strings than std::string
+// According to http://www.swig.org/legal.html , this code was permissively licensed
+// to be redistributed without restriction.
+
+// Copyright: (C) 1995-2011 The SWIG developers
+// CopyPolicy: permissive licence, BSD- and GPL-compatible
+
+/* -----------------------------------------------------------------------------
+ * std_string.i
+ *
+ * Typemaps for std::string and const std::string&
+ * These are mapped to a Java String and are passed around by value.
+ *
+ * To use non-const std::string references use the following %apply.  Note
+ * that they are passed by value.
+ * %apply const std::string & {std::string &};
+ * ----------------------------------------------------------------------------- */
+
+%{
+#include <string>
+%}
+
+namespace std {
+
+%naturalvar string;
+
+class string;
+
+// string
+%typemap(jni) string "jstring"
+%typemap(jtype) string "String"
+%typemap(jstype) string "String"
+%typemap(javadirectorin) string "$jniinput"
+%typemap(javadirectorout) string "$javacall"
+
+%typemap(in) string
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+    }
+    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+    if (!$1_pstr) return $null;
+    $1.assign($1_pstr);
+    jenv->ReleaseStringUTFChars($input, $1_pstr); %}
+
+%typemap(directorout) string
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   if (!$1_pstr) return $null;
+   $result.assign($1_pstr);
+   jenv->ReleaseStringUTFChars($input, $1_pstr); %}
+
+%typemap(directorin,descriptor="Ljava/lang/String;") string
+%{ $input = jenv->NewStringUTF($1.c_str()); %}
+
+%typemap(out) string
+%{ $result = jenv->NewStringUTF($1.c_str()); %}
+
+%typemap(javain) string "$javainput"
+
+%typemap(javaout) string {
+    return $jnicall;
+  }
+
+%typemap(typecheck) string = char *;
+
+%typemap(throws) string
+%{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.c_str());
+   return $null; %}
+
+// const string &
+%typemap(jni) const string & "jstring"
+%typemap(jtype) const string & "String"
+%typemap(jstype) const string & "String"
+%typemap(javadirectorin) const string & "$jniinput"
+%typemap(javadirectorout) const string & "$javacall"
+
+%typemap(in) const string &
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   if (!$1_pstr) return $null;
+   $*1_ltype $1_str($1_pstr);
+   $1 = &$1_str;
+   jenv->ReleaseStringUTFChars($input, $1_pstr); %}
+
+%typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const string &
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   if (!$1_pstr) return $null;
+   /* possible thread/reentrant code problem */
+   static $*1_ltype $1_str;
+   $1_str = $1_pstr;
+   $result = &$1_str;
+   jenv->ReleaseStringUTFChars($input, $1_pstr); %}
+
+%typemap(directorin,descriptor="Ljava/lang/String;") const string &
+%{ $input = jenv->NewStringUTF($1.c_str()); %}
+
+%typemap(out) const string &
+%{ $result = jenv->NewStringUTF($1->c_str()); %}
+
+%typemap(javain) const string & "$javainput"
+
+%typemap(javaout) const string & {
+    return $jnicall;
+  }
+
+%typemap(typecheck) const string & = char *;
+
+%typemap(throws) const string &
+%{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.c_str());
+   return $null; %}
+
+}
+

--- a/bindings/std_string_lua.i
+++ b/bindings/std_string_lua.i
@@ -1,0 +1,136 @@
+// This is a custom version of lua/std_string.i to be used with SWIG versions <2.0.7
+// to be able to use the typemaps also for other strings than std::string
+// (replicates https://github.com/swig/swig/commit/12a9671440e9408a07d59a8936e75da096fea5fc#diff-c8b76f46d45561c8d9832d5bb98e770d )
+// According to http://www.swig.org/legal.html , the original code was permissively licensed
+// to be redistributed without restriction.
+
+// Copyright: (C) 1995-2011 The SWIG developers
+// CopyPolicy: permissive licence, BSD- and GPL-compatible
+
+/* -----------------------------------------------------------------------------
+ * std_string.i
+ *
+ * std::string typemaps for LUA
+ * ----------------------------------------------------------------------------- */
+
+%{
+#include <string>
+%}
+
+/*
+Only std::string and const std::string& are typemapped
+they are converted to the Lua strings automatically
+
+std::string& and std::string* are not
+they must be explicitly managed (see below)
+
+eg.
+
+std::string test_value(std::string x) {
+   return x;
+}
+
+can be used as
+
+s="hello world"
+s2=test_value(s)
+assert(s==s2)
+*/
+
+namespace std {
+
+%naturalvar string;
+
+/*
+Bug report #1526022:
+Lua strings and std::string can contain embedded zero bytes
+Therefore a standard out typemap should not be:
+  lua_pushstring(L,$1.c_str());
+but
+  lua_pushlstring(L,$1.data(),$1.size());
+
+Similarly for getting the string
+  $1 = (char*)lua_tostring(L, $input);
+becomes
+  $1.assign(lua_tostring(L,$input),lua_strlen(L,$input));
+
+Not using: lua_tolstring() as this is only found in Lua 5.1 & not 5.0.2
+*/
+
+%typemap(in,checkfn="lua_isstring") string
+%{$1.assign(lua_tostring(L,$input),lua_strlen(L,$input));%}
+
+%typemap(out) string
+%{ lua_pushlstring(L,$1.data(),$1.size()); SWIG_arg++;%}
+
+%typemap(in,checkfn="lua_isstring") const string& ($*1_ltype temp)
+%{temp.assign(lua_tostring(L,$input),lua_strlen(L,$input)); $1=&temp;%}
+
+%typemap(out) const string&
+%{ lua_pushlstring(L,$1->data(),$1->size()); SWIG_arg++;%}
+
+// for throwing of any kind of string, string ref's and string pointers
+// we convert all to lua strings
+%typemap(throws) string, string&, const string&
+%{ lua_pushlstring(L,$1.data(),$1.size()); SWIG_fail;%}
+
+%typemap(throws) string*, const string*
+%{ lua_pushlstring(L,$1->data(),$1->size()); SWIG_fail;%}
+
+%typecheck(SWIG_TYPECHECK_STRING) string, const string& {
+  $1 = lua_isstring(L,$input);
+}
+
+/*
+std::string& can be wrapped, but you must inform SWIG if it is in or out
+
+eg:
+void fn(std::string& str);
+Is this an in/out/inout value?
+
+Therefore you need the usual
+%apply (std::string& INOUT) {std::string& str};
+or
+%apply std::string& INOUT {std::string& str};
+typemaps to tell SWIG what to do.
+*/
+
+%typemap(in) string &INPUT=const string &;
+%typemap(in, numinputs=0) string &OUTPUT ($*1_ltype temp)
+%{ $1 = &temp; %}
+%typemap(argout) string &OUTPUT
+%{ lua_pushlstring(L,$1->data(),$1->size()); SWIG_arg++;%}
+%typemap(in) string &INOUT =const string &;
+%typemap(argout) string &INOUT = string &OUTPUT;
+
+/*
+A really cut down version of the string class
+
+This provides basic mapping of lua strings <-> std::string
+and little else
+(the std::string has a lot of unneeded functions anyway)
+
+note: no fn's taking the const string&
+as this is overloaded by the const char* version
+*/
+
+  class string {
+    public:
+      string();
+      string(const char*);
+      //string(const string&);
+      unsigned int size() const;
+      unsigned int length() const;
+      bool empty() const;
+      // no support for operator[]
+      const char* c_str()const;
+      const char* data()const;
+      // assign does not return a copy of this object
+      // (no point in a scripting language)
+      void assign(const char*);
+      //void assign(const string&);
+      // no support for all the other features
+      // it's probably better to do it in lua
+  };
+}
+

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -18,25 +18,38 @@
 %feature("director") yarp::os::RFModule;
 %feature("autodoc", "1");
 
-// Try to translate std::string and std::vector to native equivalents
-%include "std_string.i"
+
 #if !defined(SWIGCHICKEN) && !defined(SWIGALLEGROCL)
   %include "std_vector.i"
 #endif
 
 // Try to make yarp::os::ConstString act like std::string
 #if !defined(SWIGJAVA) && !defined(SWIGLUA)
+  // Try to translate std::string and std::vector to native equivalents
+  %include "std_string.i"
   %typemaps_std_string(yarp::os::ConstString, char, SWIG_AsCharPtrAndSize, 
 		       SWIG_FromCharPtrAndSize, %checkcode(STDSTRING)); 
   %define YARP_WRAP_STL_STRING %enddef
   %ignore yarp::os::ConstString;
 #else
-  %define _YARP2_CONSTSTRING_ %enddef
-  namespace yarp {
-    namespace os {
-      typedef std::string ConstString;
-    }
-  }
+  #if (SWIG_VERSION >=0x020007)
+    // Try to translate std::string and std::vector to native equivalents
+    %include "std_string.i"
+//    %define _YARP2_CONSTSTRING_ %enddef
+//    namespace yarp {
+//      namespace os {
+//        typedef std::string ConstString;
+//      }
+//    }
+  #else
+    #if defined (SWIGLUA)
+      %include "std_string_lua.i"
+    #endif
+    #if defined (SWIGJAVA)
+      %include "std_string_java.i"
+    #endif
+  #endif
+%apply std::string {yarp::os::ConstString};
 #endif
 
 #if defined(SWIGCSHARP)


### PR DESCRIPTION
As SWIG version 2.0.7 fixed a bug in std_string.i files provided for Java and Lua languages (thanks @paulfitz for finding out), we should provide correct files to be used with older SWIG versions. This should solve issue #83.
I am not sure if the copyright notice I added is correct, could someone check it?
