### PR TITLE
Add yarp/os/Things.h to YARP_OS_HDRS in CMakeLists.txt

### DIFF
--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -97,6 +97,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/StringOutputStream.h
                  include/yarp/os/SystemClock.h
                  include/yarp/os/Terminator.h
+                 include/yarp/os/Things.h
                  include/yarp/os/Thread.h
                  include/yarp/os/Time.h
                  include/yarp/os/TwoWayStream.h


### PR DESCRIPTION
The new header src/libYARP_OS/include/yarp/os/Things.h was added in yarp/os/all.h but not in the YARP_OS CMakeLists.txt. 
This is breaking any file external to yarp that is including the yarp/os/all.h header file.
