### PR TITLE
added to yarp write completition a single history file for each differen...

### DIFF
--- a/src/libYARP_OS/src/Companion.cpp
+++ b/src/libYARP_OS/src/Companion.cpp
@@ -38,6 +38,7 @@
 #include <yarp/os/Ping.h>
 #include <yarp/os/YarpPlugin.h>
 #include <yarp/os/SystemClock.h>
+#include <yarp/os/ConstString.h>
 
 #include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/PlatformSignal.h>
@@ -49,13 +50,10 @@
 // we do not have configuration information, disable some features.
 #endif
 
-#include <stdio.h>
-
 #ifdef WITH_READLINE
     #include <readline/readline.h>
     #include <readline/history.h>
     #include <vector>
-    #include <yarp/os/ConstString.h>
     static std::vector<yarp::os::impl::String> commands;
     static yarp::os::Port* rpcHelpPort=NULL;
     static bool commandListInitialized=false;
@@ -2062,8 +2060,14 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
     if (ACE_OS::isatty(ACE_OS::fileno(stdin))) //if interactive mode
     {
         hist_file=yarp::os::ResourceFinder::getDataHome();
-        hist_file += "/yarp_write_history";
-        hist_file += targets[0];
+        ConstString slash=NetworkBase::getDirectorySeparator();
+        hist_file += slash;
+        hist_file += "yarp_write";
+        ACE_OS::mkdir(hist_file.c_str());
+        std::string temp=targets[0];
+        std::replace(temp.begin(),temp.end(),'/','_');
+        hist_file += slash;
+        hist_file += temp;
         read_history(hist_file.c_str());
         disable_file_history=false;
     }


### PR DESCRIPTION
...t port

My "yarp write" use case is exit and start it again many times, I believe that having the possibility to carry history from one execution to another is fundamental, yet I didn't want to pollute each yarp write with the history of all the other opened ports. This seems a reasonable solution, notice that if the user does not have any ~/.yarp_write_history folder, nothing will happen (as it is now).
