### PR TITLE
setExternal2 works well on python 2.7 and above

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -298,7 +298,7 @@ void setExternal(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 }  
 
 void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
-#if PY_VERSION_HEX >= 0x03000000
+#if PY_VERSION_HEX >= 0x02070000
         Py_buffer img_buffer;
         int reply;
         reply = PyObject_GetBuffer(mem, &img_buffer, PyBUF_SIMPLE);


### PR DESCRIPTION
The memoryview object defined in python 3 was backported to python 2.7, so the 2.7 Buffer functions work as their python 3 counterparts. This means that setExternal2 works properly on python 2.7.

Thus, people using Python greater than 2.7 are advised to use setExternal2.
