### PR TITLE
Added a LockGuard class.

### DIFF
--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -32,6 +32,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/InputProtocol.h
                  include/yarp/os/InputStream.h
                  include/yarp/os/LocalReader.h
+                 include/yarp/os/LockGuard.h
                  include/yarp/os/Log.h
                  include/yarp/os/ManagedBytes.h
                  include/yarp/os/ModifyingCarrier.h
@@ -220,6 +221,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/IConfig.cpp
                  src/InputStream.cpp
                  src/LocalCarrier.cpp
+                 src/LockGuard.cpp
                  src/Logger.cpp
                  src/ManagedBytes.cpp
                  src/ModifyingCarrier.cpp

--- a/src/libYARP_OS/include/yarp/os/LockGuard.h
+++ b/src/libYARP_OS/include/yarp/os/LockGuard.h
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2013 iCub Facility
+ * Authors: Francesco Romano
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _YARP2_LOCKGUARD_
+#define _YARP2_LOCKGUARD_
+
+#include <yarp/os/api.h>
+
+namespace yarp {
+    namespace os {
+        class Mutex;
+        class LockGuard;
+    }
+}
+
+/** @class 
+ * This class is a mutex wrapper that provides a convenient RAII-style mechanism for owning
+ * a mutex for the duration of a scoped block. When a LockGuard object is created, 
+ * it attempts to take ownership of the mutex it is given. 
+ * When control leaves the scope in which the LockGuard object was created, 
+ * the LockGuard is destructed and the mutex is released.
+ * The lock_guard class is non-copyable. 
+ */
+class YARP_OS_API yarp::os::LockGuard {
+public:
+    /**
+     * Acquires ownership of the given mutex _mutex.
+     * The behavior is undefined if _mutex is destroyed before the LockGuard object is.
+     * @param _mutex the mutex which will be locked
+     */
+    explicit LockGuard(yarp::os::Mutex& _mutex);
+    
+    /**
+     * destructs the LockGuard object, unlocks the underlying mutex
+     */
+    ~LockGuard();
+    
+private:
+    
+    /** Copy constructor is disabled */
+    LockGuard(const LockGuard&);
+    
+    /** Assignment operator is disabled */
+    LockGuard& operator=(const LockGuard&);
+    
+    yarp::os::Mutex& mutex; /*!< underlining mutex */
+};
+
+#endif

--- a/src/libYARP_OS/src/LockGuard.cpp
+++ b/src/libYARP_OS/src/LockGuard.cpp
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2013 iCub Facility
+ * Authors: Francesco Romano
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <yarp/os/LockGuard.h>
+#include <yarp/os/Mutex.h>
+
+namespace yarp {
+    namespace os {
+        LockGuard::LockGuard(yarp::os::Mutex& _mutex)
+            : mutex(_mutex)
+        {
+            mutex.lock();
+        }
+        
+        LockGuard::~LockGuard()
+        {
+            mutex.unlock();
+        }
+        
+        LockGuard::LockGuard(const LockGuard& lg)
+        : mutex(lg.mutex) { }
+        
+        LockGuard& LockGuard::operator=(const LockGuard&) { return *this; }
+    }
+}


### PR DESCRIPTION
Added a LockGuard class which has the same behaviour of std::lock_guard (c++ 11) for a yarp::os::Mutex.

As requested by @lornat75 
