### PR TITLE
allow hard-coded port /foo to be changed via YARP_RENAME_foo

### DIFF
--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -20,6 +20,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/SemaphoreImpl.h>
 #include <yarp/os/impl/NameClient.h>
+#include <yarp/os/impl/NameConfig.h>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -369,6 +370,14 @@ bool Port::open(const Contact& contact, bool registerName,
     }
 
     ConstString n = contact2.getName();
+
+    NameConfig conf;
+    ConstString nenv = ConstString("YARP_RENAME") + conf.getSafeString(n);
+    ConstString rename = NetworkBase::getEnvironment(nenv.c_str());
+    if (rename!="") {
+        n = rename;
+        contact2 = contact2.addName(n);
+    }
 
     bool local = false;
     if (n == "" && contact2.getPort()<=0) {


### PR DESCRIPTION
Adds support for a port renaming method of last resort. Suppose a program has a port called `/foo/bar` and there is no way provided to change the name of that port other than source code modification.  YARP already supports `YARP_PORT_PREFIX` which allows us to add a prefix to all ports.  Now, a port name can be changed entirely using `YARP_RENAME_foo_bar`.
For example:

```
YARP_RENAME_read=/logger yarp read /read
```

will open a port named "`/logger`" for shells where this syntax is permitted.  Renames (if present) are applied before prefixes (if present).
