### PR TITLE
remove unneeded mcast threads

### DIFF
--- a/scripts/admin/check-mcast.sh
+++ b/scripts/admin/check-mcast.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+killall yarp yarpdev
+killall -9 yarp yarpdev
+sleep 2
+
+yarpdev --device test_grabber --framerate 0.5 --width 4 --height 4 --name /src &
+yarp wait /src
+sleep 2
+
+echo "================================================="
+echo "=="
+echo "thread count for yarpdev with 0 outputs"
+ps -eLf | grep "yarpdev" | wc
+echo "=="
+echo "================================================="
+
+yarp read /dest1 mcast://src &
+yarp wait /src /dest1
+sleep 2
+
+echo "================================================="
+echo "=="
+echo "thread count for yarpdev with 1 output"
+ps -eLf | grep "yarpdev" | wc
+echo "=="
+echo "================================================="
+
+yarp read /dest2 mcast://src &
+yarp wait /src /dest2
+sleep 2
+
+echo "================================================="
+echo "=="
+echo "thread count for yarpdev with 2 outputs"
+ps -eLf | grep "yarpdev" | wc
+echo "=="
+echo "================================================="
+
+yarp read /dest3 mcast://src &
+yarp wait /src /dest2
+sleep 2
+
+echo "================================================="
+echo "=="
+echo "thread count for yarpdev with 3 outputs"
+ps -eLf | grep "yarpdev" | wc
+echo "=="
+echo "================================================="
+
+
+killall yarp yarpdev
+killall -9 yarp yarpdev
+

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -339,6 +339,12 @@ void *PortCoreOutputUnit::send(yarp::os::PortWriter& writer,
                                bool *gotReply) {
     bool replied = false;
 
+    if (op!=NULL) {
+        if (!op->getConnection().isActive()) {
+            return NULL;
+        }
+    }
+
     if (!waitBefore || !waitAfter) {
         if (running == false) {
             // we must have a thread if we're going to be skipping waits


### PR DESCRIPTION
An output sending to multiple destinations, with background write enabled, was using more threads than necessary for protocols like multicast.
