### PR TITLE
Updated RPATH behaviour

### DIFF
--- a/conf/YarpOptions.cmake
+++ b/conf/YarpOptions.cmake
@@ -269,10 +269,11 @@ if(INSTALL_WITH_RPATH OR ENABLE_FORCE_RPATH)
         #  - install_dir/something for binaries
         #  - install_dir/lib for libraries
         # in this way if libraries and executables are moved together everything will continue to work
+        file(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
         if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-            set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+            set(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
         else()
-            set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
+            set(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
         endif()
     endif()
     


### PR DESCRIPTION
I changed how RPATH is handled both in OS X and in Linux.
- For CMake < 2.8.12 everything should be the same as before (even if the changes on the linux size should work on older versions of cmake).
- For CMake >= 2.8.12 the changes are the following:
  -- OS X: enabled real support to RPATH introduced in CMake 2.8.12
  -- Linux and OS X: rpath is now relative to the executable. In this way moving the install folder (the one containing `lib` and `bin`) should keep intact the link paths.

Of course RPATH is still off by default.

I tested it on OS X, CMake version 2.8.12 and 3.0.1. I need some more test configurations (e.g. Linux with CMake 2.8.11 and a newer version).
