### PR TITLE
[core] remove fail when default config file is missing

### DIFF
--- a/src/libYARP_OS/harness/ResourceFinderTest.cpp
+++ b/src/libYARP_OS/harness/ResourceFinderTest.cpp
@@ -759,6 +759,51 @@ public:
         breakDownTestArea();
     }
 
+    void testFailOnFrom() {
+        report(0,"test fail behavior on --from / setDefaultConfigFile");
+        setUpTestArea(false);
+
+        {
+            ResourceFinder rf;
+            const char *fname1 = "_yarp_regression_test_rf1.txt";
+            rf.setDefaultContext("my_app");
+            rf.setDefaultConfigFile("my_app.ini");
+            bool configures = rf.configure(NULL,0,NULL);
+            checkTrue(configures,"ok with default file that exists");
+        }
+
+        {
+            ResourceFinder rf;
+            rf.setDefaultContext("my_app");
+            const char *argv[] = { "ignore",
+                                   "--from", "my_app.ini",
+                                   NULL };
+            int argc = 3;
+            bool configures = rf.configure("none",argc,(char **)argv);
+            checkTrue(configures,"ok with from file that exists");
+        }
+
+        {
+            ResourceFinder rf;
+            const char *fname1 = "_yarp_regression_test_rf1.txt";
+            rf.setDefaultContext("my_app");
+            rf.setDefaultConfigFile("my_app_not_there.ini");
+            bool configures = rf.configure(NULL,0,NULL);
+            checkTrue(configures,"ok with default file that does not exist");
+        }
+
+        {
+            ResourceFinder rf;
+            rf.setDefaultContext("my_app");
+            const char *argv[] = { "ignore",
+                                   "--from", "my_app_not_there.ini",
+                                   NULL };
+            int argc = 3;
+            bool configures = rf.configure("none",argc,(char **)argv);
+            checkFalse(configures,"fails with from file that is missing");
+        }
+    }
+
     virtual void runTests() {
         testBasics();
         testCommandLineArgs();
@@ -774,6 +819,7 @@ public:
         testCopy();
         testGetHomeDirsForWriting();
         testFindPlugins();
+        testFailOnFrom();
     }
 };
 

--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -300,7 +300,7 @@ public:
         Property p;
         p.fromCommand(argc,argv,skip);
 
-        //printf("SETTINGS: %s\n", p.toString().c_str());
+        bool user_specified_from = p.check("from");
 
         if (p.check("verbose")) {
             setVerbose(p.check("verbose",Value(1)).asInt());
@@ -368,8 +368,9 @@ public:
             }
             ConstString fromPath = extractPath(from.c_str());
             configFilePath = fromPath;
-            if(!config.fromConfigFile(from,false) )
+            if (!config.fromConfigFile(from,false) && user_specified_from) {
                 configured_normally = false;
+            }
             config.fromCommand(argc,argv,skip,false);
         }
         return configured_normally;


### PR DESCRIPTION
@barbalberto @lornat75 @drdanz this patch adds tests for following ResourceFinder scenarios:
- user calls `rf.setDefaultConfigFile("config.ini")`, and that file is present (config should succeed)
- user calls `rf.setDefaultConfigFile("config.ini")`, but that file is not present (config should succeed)
- user specifies `--from config.ini`, and that file is present (config should succeed)
- user specifies `--from config.ini`, but that file is not present (config should fail)

Is this the desired behavior?

It also adds a fix to make the tests pass. Specifically, it checks for `from` earlier, before defaults get loaded.
