### PR TITLE
make methods of yarp::os::Searchable const, fixes #249

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Bottle.h
+++ b/src/libYARP_OS/include/yarp/os/Bottle.h
@@ -279,11 +279,11 @@ public:
 
     void onCommencement();
 
-    virtual bool check(const ConstString& key);
+    virtual bool check(const ConstString& key) const;
 
-    virtual Value& find(const ConstString& key);
+    virtual Value& find(const ConstString& key) const;
 
-    Bottle& findGroup(const ConstString& key);
+    Bottle& findGroup(const ConstString& key) const;
 
     virtual bool isNull() const;
 
@@ -376,8 +376,8 @@ public:
 
 private:
 
-    Value& findGroupBit(const ConstString& key);
-    Value& findBit(const ConstString& key);
+    Value& findGroupBit(const ConstString& key) const;
+    Value& findBit(const ConstString& key) const;
 
     virtual Bottle *create();
 

--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -74,7 +74,7 @@ public:
     const Property& operator = (const Property& prop);
 
     // documented in Searchable
-    bool check(const ConstString& key);
+    bool check(const ConstString& key) const;
 
     /**
      * Associate the given key with the given string, so that
@@ -138,10 +138,10 @@ public:
     void unput(const ConstString& key);
 
     // documented in Searchable
-    virtual Value& find(const ConstString& key);
+    virtual Value& find(const ConstString& key) const;
 
     // documented in Searchable
-    virtual Bottle& findGroup(const ConstString& key);
+    virtual Bottle& findGroup(const ConstString& key) const;
 
     /**
      * Remove all associations.

--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -243,9 +243,9 @@ public:
     yarp::os::Bottle getContexts();
 
     // Searchable interface
-    virtual bool check(const ConstString& key);
-    virtual Value& find(const ConstString& key);
-    virtual Bottle& findGroup(const ConstString& key);
+    virtual bool check(const ConstString& key) const;
+    virtual Value& find(const ConstString& key) const;
+    virtual Bottle& findGroup(const ConstString& key) const;
     virtual bool isNull() const;
     virtual ConstString toString() const;
 

--- a/src/libYARP_OS/include/yarp/os/Searchable.h
+++ b/src/libYARP_OS/include/yarp/os/Searchable.h
@@ -77,7 +77,7 @@ public:
      * @return true iff a property of the given name exists, even if
      * it doesn't have a value associated with it
      */
-    virtual bool check(const ConstString& key) = 0;
+    virtual bool check(const ConstString& key) const = 0;
 
 
     /**
@@ -88,7 +88,7 @@ public:
      * it doesn't have a value associated with it
      */
     virtual bool check(const ConstString& key,
-                       const ConstString& comment);
+                       const ConstString& comment) const;
 
     /**
      * Gets a value corresponding to a given keyword
@@ -98,7 +98,7 @@ public:
      * true.  Otherwise, the value can be read by calling result.asInt(),
      * result.asString(), etc. as appropriate.
      */
-    virtual Value& find(const ConstString& key) = 0;
+    virtual Value& find(const ConstString& key) const = 0;
 
     /**
      * Gets a list corresponding to a given keyword
@@ -110,7 +110,7 @@ public:
      * result.get(i) for i>=1 are the "real" elements of the list.
      *
      */
-    virtual Bottle& findGroup(const ConstString& key) = 0;
+    virtual Bottle& findGroup(const ConstString& key) const = 0;
 
     /**
      * Gets a list corresponding to a given keyword
@@ -123,7 +123,7 @@ public:
      * result.get(i) for i>=1 are the "real" elements of the list.
      *
      */
-    Bottle& findGroup(const ConstString& key, const ConstString& comment);
+    Bottle& findGroup(const ConstString& key, const ConstString& comment) const;
 
     /**
      * Gets a value corresponding to a given keyword.  If a property
@@ -151,7 +151,7 @@ public:
      * value found.
      */
     virtual bool check(const ConstString& key, Value *& result,
-                       const ConstString& comment = "");
+                       const ConstString& comment = "") const;
 
 
     /**
@@ -164,7 +164,7 @@ public:
      * interpreting the value found.
      */
     virtual Value check(const ConstString& key, const Value& fallback,
-                        const ConstString& comment = "");
+                        const ConstString& comment = "") const;
 
     /**
      * Checks if the object is invalid.
@@ -183,9 +183,9 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     virtual void setMonitor(SearchMonitor *monitor, const char *context="");
-    virtual SearchMonitor *getMonitor();
-    virtual ConstString getContext();
-    virtual void reportToMonitor(const SearchReport& report);
+    virtual SearchMonitor *getMonitor() const;
+    virtual ConstString getContext() const;
+    virtual void reportToMonitor(const SearchReport& report) const;
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 };
 

--- a/src/libYARP_OS/include/yarp/os/Value.h
+++ b/src/libYARP_OS/include/yarp/os/Value.h
@@ -228,13 +228,13 @@ public:
     virtual bool write(ConnectionWriter& connection);
 
     // documented in Searchable
-    virtual bool check(const ConstString& key);
+    virtual bool check(const ConstString& key) const;
 
     // documented in Searchable
-    virtual Value& find(const ConstString& key);
+    virtual Value& find(const ConstString& key) const;
 
     // documented in Searchable
-    virtual Bottle& findGroup(const ConstString& key);
+    virtual Bottle& findGroup(const ConstString& key) const;
 
     /**
      * Equality test.

--- a/src/libYARP_OS/include/yarp/os/impl/BottleImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BottleImpl.h
@@ -83,10 +83,10 @@ public:
     virtual bool readRaw(ConnectionReader& connection) = 0;
     virtual bool writeRaw(ConnectionWriter& connection) = 0;
 
-    virtual bool check(const yarp::os::ConstString& key);
+    virtual bool check(const yarp::os::ConstString& key) const;
 
-    virtual yarp::os::Value& find(const yarp::os::ConstString& key);
-    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key);
+    virtual yarp::os::Value& find(const yarp::os::ConstString& key) const;
+    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key) const;
 
     virtual bool operator == (const yarp::os::Value& alt) const;
 
@@ -394,11 +394,11 @@ public:
     static const int code;
     virtual int subCode() const;
 
-    virtual yarp::os::Value& find(const yarp::os::ConstString& key) {
+    virtual yarp::os::Value& find(const yarp::os::ConstString& key) const {
         return content.find(key);
     }
 
-    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key) {
+    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key) const {
         return content.findGroup(key);
     }
     virtual void copy(const Storable& alt) { content = *(alt.asList()); }
@@ -434,11 +434,11 @@ public:
     }
     static const int code;
   
-    virtual yarp::os::Value& find(const yarp::os::ConstString& key) {
+    virtual yarp::os::Value& find(const yarp::os::ConstString& key) const {
         return content.find(key);
     }
 
-    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key) {
+    virtual yarp::os::Bottle& findGroup(const yarp::os::ConstString& key) const {
         return content.findGroup(key);
     }
     virtual void copy(const Storable& alt) { content = *(alt.asDict()); }

--- a/src/libYARP_OS/src/Bottle.cpp
+++ b/src/libYARP_OS/src/Bottle.cpp
@@ -212,7 +212,7 @@ void Bottle::copy(const Bottle& alt, int first, int len) {
                                      len);
 }
 
-Value& Bottle::findGroupBit(const ConstString& key) {
+Value& Bottle::findGroupBit(const ConstString& key) const {
     for (int i=0; i<size(); i++) {
         Value *org = &(get(i));
         Value *cursor = org;
@@ -228,7 +228,7 @@ Value& Bottle::findGroupBit(const ConstString& key) {
 }
 
 
-Value& Bottle::findBit(const ConstString& key) {
+Value& Bottle::findBit(const ConstString& key) const {
     for (int i=0; i<size(); i++) {
         Value *org = &(get(i));
         Value *cursor = org;
@@ -265,7 +265,7 @@ Value& Bottle::findBit(const ConstString& key) {
 }
 
 
-bool Bottle::check(const ConstString& key) {
+bool Bottle::check(const ConstString& key) const {
     Bottle& val = findGroup(key);
     if (!val.isNull())
         return true;
@@ -274,7 +274,7 @@ bool Bottle::check(const ConstString& key) {
 }
 
 
-Value& Bottle::find(const ConstString& key) {
+Value& Bottle::find(const ConstString& key) const {
     Value& val = findBit(key);
 
     if (getMonitor()!=NULL) {
@@ -289,7 +289,7 @@ Value& Bottle::find(const ConstString& key) {
 }
 
 
-Bottle& Bottle::findGroup(const ConstString& key) {
+Bottle& Bottle::findGroup(const ConstString& key) const {
     Value& bb = findGroupBit(key);
 
     if (getMonitor()!=NULL) {

--- a/src/libYARP_OS/src/BottleImpl.cpp
+++ b/src/libYARP_OS/src/BottleImpl.cpp
@@ -1165,15 +1165,15 @@ void BottleImpl::copyRange(const BottleImpl& alt, int first, int len) {
 
 
 
-Value& Storable::find(const ConstString& txt) {
+Value& Storable::find(const ConstString& txt) const {
     return BottleImpl::getNull();
 }
 
-Bottle& Storable::findGroup(const ConstString& txt) {
+Bottle& Storable::findGroup(const ConstString& txt) const {
     return Bottle::getNullBottle();
 }
 
-bool Storable::check(const ConstString& key) {
+bool Storable::check(const ConstString& key) const {
     Bottle& val = findGroup(key);
     if (!val.isNull()) return true;
     Value& val2 = find(key);

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -832,7 +832,7 @@ void Property::put(const ConstString& key, double v) {
     put(key,Value::makeDouble(v));
 }
 
-bool Property::check(const ConstString& key) {
+bool Property::check(const ConstString& key) const {
     return HELPER(implementation).check(key);
 }
 
@@ -842,7 +842,7 @@ void Property::unput(const ConstString& key) {
 }
 
 
-Value& Property::find(const ConstString& key) {
+Value& Property::find(const ConstString& key) const {
     return HELPER(implementation).get(key);
 }
 
@@ -912,7 +912,7 @@ bool Property::write(ConnectionWriter& writer) {
 }
 
 
-Bottle& Property::findGroup(const ConstString& key) {
+Bottle& Property::findGroup(const ConstString& key) const {
     Bottle *result = HELPER(implementation).getBottle(key);
     if (getMonitor()!=NULL) {
         SearchReport report;

--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -1079,17 +1079,17 @@ bool ResourceFinder::setQuiet(bool quiet) {
 
 
 
-bool ResourceFinder::check(const ConstString& key) {
+bool ResourceFinder::check(const ConstString& key) const {
     return config.check(key);
 }
 
 
-Value& ResourceFinder::find(const ConstString& key) {
+Value& ResourceFinder::find(const ConstString& key) const {
     return config.find(key);
 }
 
 
-Bottle& ResourceFinder::findGroup(const ConstString& key) {
+Bottle& ResourceFinder::findGroup(const ConstString& key) const {
     return config.findGroup(key);
 }
 

--- a/src/libYARP_OS/src/Searchable.cpp
+++ b/src/libYARP_OS/src/Searchable.cpp
@@ -35,7 +35,7 @@ yarp::os::Searchable::~Searchable() {
 
 bool yarp::os::Searchable::check(const ConstString& txt,
                                  yarp::os::Value *& result,
-                                 const ConstString& comment) {
+                                 const ConstString& comment) const {
     if (getMonitor()!=NULL && comment!="") {
         SearchReport report;
         report.key = txt;
@@ -53,7 +53,7 @@ bool yarp::os::Searchable::check(const ConstString& txt,
 
 yarp::os::Value yarp::os::Searchable::check(const ConstString& txt,
                                   const yarp::os::Value& fallback,
-                                  const ConstString& comment) {
+                                  const ConstString& comment) const {
     if (getMonitor()!=NULL && comment!="") {
         yarp::os::SearchReport report;
         report.key = txt;
@@ -77,7 +77,7 @@ yarp::os::Value yarp::os::Searchable::check(const ConstString& txt,
 }
 
 bool yarp::os::Searchable::check(const ConstString& key,
-                                 const ConstString& comment) {
+                                 const ConstString& comment) const {
     if (getMonitor()!=NULL && comment!="") {
         yarp::os::SearchReport report;
         report.key = key;
@@ -89,7 +89,7 @@ bool yarp::os::Searchable::check(const ConstString& key,
 }
 
 yarp::os::Bottle& yarp::os::Searchable::findGroup(const ConstString& key,
-                                                  const ConstString& comment) {
+                                                  const ConstString& comment) const {
     if (getMonitor()!=NULL && comment!="") {
         yarp::os::SearchReport report;
         report.key = key;
@@ -111,15 +111,15 @@ void yarp::os::Searchable::setMonitor(yarp::os::SearchMonitor *monitor, const ch
     this->monitorContext = context;
 }
 
-yarp::os::SearchMonitor *yarp::os::Searchable::getMonitor() {
+yarp::os::SearchMonitor *yarp::os::Searchable::getMonitor() const {
     return monitor;
 }
 
-yarp::os::ConstString yarp::os::Searchable::getContext() {
+yarp::os::ConstString yarp::os::Searchable::getContext() const {
     return monitorContext;
 }
 
-void yarp::os::Searchable::reportToMonitor(const yarp::os::SearchReport& report) {
+void yarp::os::Searchable::reportToMonitor(const yarp::os::SearchReport& report) const {
     if (monitor!=NULL) {
         monitor->report(report,monitorContext.c_str());
     }

--- a/src/libYARP_OS/src/Value.cpp
+++ b/src/libYARP_OS/src/Value.cpp
@@ -231,17 +231,17 @@ bool Value::write(ConnectionWriter& connection) {
     return proxy->write(connection);
 }
 
-bool Value::check(const ConstString& key) {
+bool Value::check(const ConstString& key) const {
     ok();
     return proxy->check(key);
 }
 
-Value& Value::find(const ConstString& key) {
+Value& Value::find(const ConstString& key) const {
     ok();
     return proxy->find(key);
 }
 
-Bottle& Value::findGroup(const ConstString& key) {
+Bottle& Value::findGroup(const ConstString& key) const {
     ok();
     return proxy->findGroup(key);
 }


### PR DESCRIPTION
This cleans up an ugly corner of the API a bit. If users have made their own `Searchable`, then they will see a compile-time error that should be fairly clear.
