### PR TITLE
adding Yarp Octave binding

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright: (C) 2009 RobotCub Consortium
-# Authors: Paul Fitzpatrick, Arjan Gijsberts, Lorenzo Natale, Fabien Benureau, Stephane Lallee
+# Authors: Paul Fitzpatrick, Arjan Gijsberts, Lorenzo Natale, Fabien Benureau, Stephane Lallee, Ali Paikan
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 cmake_minimum_required(VERSION 2.8.9)
@@ -45,6 +45,7 @@ set(CREATE_ALLEGRO FALSE CACHE BOOL "Do you want to create the Allegro Common Li
 set(CREATE_TCL FALSE CACHE BOOL "Do you want to create the TCL interface")
 set(CREATE_RUBY FALSE CACHE BOOL "Do you want to create the Ruby interface")
 set(CREATE_LUA FALSE CACHE BOOL "Do you want to create the Lua interface")
+set(CREATE_OCTAVE FALSE CACHE BOOL "Do you want to create the Octave interface")
 
 
 
@@ -337,5 +338,25 @@ if(CREATE_LUA)
   endif()
   set(YARP_COLLISION_AVOIDANCE TRUE)
 endif(CREATE_LUA)
+
+#############################################################################
+## Create Octave bindings
+
+if(CREATE_OCTAVE)
+  set(CMAKE_SWIG_FLAGS "-Wall;-module;yarp")
+  find_package(Octave REQUIRED)
+  set(target_name yarp_octave)
+  get_filename_component(OCTAVE_INCLUDE_TOP ${OCTAVE_INCLUDE_DIR} DIRECTORY)
+  include_directories(${OCTAVE_INCLUDE_DIRS} ${OCTAVE_INCLUDE_TOP})
+  swig_add_module(${target_name} octave yarp.i)
+  swig_link_libraries(${target_name} ${OCTAVE_LIBRARIES})
+  set_target_properties(${target_name} PROPERTIES PREFIX "")
+  set_target_properties(${target_name} PROPERTIES OUTPUT_NAME "yarp")
+  set_target_properties(${target_name} PROPERTIES SUFFIX ".oct")
+  if(YARP_COLLISION_AVOIDANCE)
+    set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/octave)
+  endif()
+  set(YARP_COLLISION_AVOIDANCE TRUE)
+endif(CREATE_OCTAVE)
 
 endif()

--- a/bindings/example.m
+++ b/bindings/example.m
@@ -1,0 +1,46 @@
+% Copyright: (C) 2011 Robotics, Brain and Cognitive Sciences - Italian Institute of Technology (IIT)
+% Author: Ali Paikan <ali.paikan@iit.it>
+% Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+
+% Setting yarp binding library path
+% you can avoid this if the 'yarp.oct' is already 
+% the octave load path
+addpath([getenv('YARP_ROOT') '/build/lib/octave']);
+
+% Import Yarp library
+yarp;
+
+% Initialize Yarp network
+yarp.Network.init();
+
+
+% Create and open a port
+p = yarp.BufferedPortBottle();
+p.open('/octave');
+ret = p.open('/octave');
+if ret == 0 
+    return
+endif
+
+
+% write some data to the port
+for i=1:100
+    wb = p.prepare();
+    wb.clear();
+    wb.addString('count');
+    wb.addInt(i);
+    wb.addString('of');
+    wb.addInt(100);
+    p.write();
+    wb.toString()
+    yarp.Time.delay(0.5)
+endfor
+
+% Close the port
+p.close();
+
+% Deinitialize yarp network
+yarp.Network.fini();
+
+

--- a/bindings/example_img.m
+++ b/bindings/example_img.m
@@ -1,0 +1,56 @@
+% Copyright: (C) 2011 Robotics, Brain and Cognitive Sciences - Italian Institute of Technology (IIT)
+% Author: Ali Paikan <ali.paikan@iit.it>
+% Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+
+% Setting yarp binding library path
+% you can avoid this if the 'yarp.oct' is already 
+% the octave load path
+addpath([getenv('YARP_ROOT') '/build/lib/octave']);
+
+% Import Yarp library
+yarp;
+
+% Initialize Yarp network
+yarp.Network.init();
+
+
+% Create and open a port
+p = yarp.BufferedPortImageRgb();
+ret = p.open('/img/in');
+if ret == 0 
+    return
+endif
+
+
+% read a single-frame image data from 
+% the port and show it using imshow
+img = p.read();
+img.width()
+img.height()
+I = [];
+
+%TODO: we need to avoid this dirty image copy
+for x=1:img.width()
+    for y=1:img.height()
+        I(y, x, 1) = img.pixel(x-1, y-1).r/255;
+        I(y, x, 2) = img.pixel(x-1, y-1).g/255;
+        I(y, x, 3) = img.pixel(x-1, y-1).b/255;
+    endfor
+endfor
+
+bw = edge(rgb2gray(I));
+
+figure;
+subplot(1,2,1);
+imshow(I);
+subplot(1,2,2);
+imshow(bw);
+
+% Close the port
+p.close();
+
+% Deinitialize yarp network
+yarp.Network.fini();
+
+

--- a/conf/FindOctave.cmake
+++ b/conf/FindOctave.cmake
@@ -1,0 +1,177 @@
+# - Find Octave
+# GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
+# available at http://www.gnu.org/software/octave/
+#
+# This module defines: 
+#  OCTAVE_EXECUTABLE           - octave interpreter
+#  OCTAVE_INCLUDE_DIRS         - include path for mex.h, mexproto.h
+#  OCTAVE_LIBRARIES            - required libraries: octinterp, octave, cruft
+#  OCTAVE_OCTINTERP_LIBRARY    - path to the library octinterp
+#  OCTAVE_OCTAVE_LIBRARY       - path to the library octave
+#  OCTAVE_CRUFT_LIBRARY        - path to the library cruft
+#  OCTAVE_VERSION_STRING       - octave version string
+#  OCTAVE_MAJOR_VERSION        - major version
+#  OCTAVE_MINOR_VERSION        - minor version
+#  OCTAVE_PATCH_VERSION        - patch version
+#  OCTAVE_OCT_FILE_DIR         - object files that will be dynamically loaded
+#  OCTAVE_OCT_LIB_DIR          - oct libraries
+#  OCTAVE_ROOT_DIR             - octave prefix
+#
+# The macro octave_add_oct allows to create compiled modules.
+# octave_add_oct ( target_name
+#         [SOURCES] source1 [source2 ...]
+#         [LINK_LIBRARIES  lib1 [lib2 ...]]
+#         [EXTENSION ext]
+# )
+#
+# To install it, you can the use the variable OCTAVE_OCT_FILE_DIR as follow:
+#  file ( RELATIVE_PATH PKG_OCTAVE_OCT_FILE_DIR ${OCTAVE_ROOT_DIR} ${OCTAVE_OCT_FILE_DIR} )                   
+#  install (
+#    TARGETS target_name
+#    DESTINATION ${PKG_OCTAVE_OCT_FILE_DIR}
+#  ) 
+#=============================================================================
+# Copyright 2013, Julien Schueller
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met: 
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer. 
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution. 
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies, 
+# either expressed or implied, of the FreeBSD Project.
+#=============================================================================
+find_program( OCTAVE_CONFIG_EXECUTABLE
+              NAMES octave-config 
+            )
+if ( OCTAVE_CONFIG_EXECUTABLE )
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p PREFIX
+                    OUTPUT_VARIABLE OCTAVE_ROOT_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )        
+                    
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p BINDIR
+                    OUTPUT_VARIABLE OCTAVE_BIN_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )        
+                    
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTINCLUDEDIR
+                    OUTPUT_VARIABLE OCTAVE_INCLUDE_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )                
+                    
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTLIBDIR
+                    OUTPUT_VARIABLE OCTAVE_LIBRARIES_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )                
+              
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTFILEDIR
+                    OUTPUT_VARIABLE OCTAVE_OCT_FILE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+                              
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTLIBDIR
+                    OUTPUT_VARIABLE OCTAVE_OCT_LIB_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+                    
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -v
+                    OUTPUT_VARIABLE OCTAVE_VERSION_STRING
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )    
+                    
+  if ( OCTAVE_VERSION_STRING )                 
+    string ( REGEX REPLACE "([0-9]+)\\..*" "\\1" OCTAVE_MAJOR_VERSION ${OCTAVE_VERSION_STRING} )
+    string ( REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1" OCTAVE_MINOR_VERSION ${OCTAVE_VERSION_STRING} )
+    string ( REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OCTAVE_PATCH_VERSION ${OCTAVE_VERSION_STRING} )               
+  endif ()                  
+endif ()
+find_program( OCTAVE_EXECUTABLE
+              HINTS ${OCTAVE_BIN_PATHS}
+              NAMES octave
+            )
+find_library( OCTAVE_OCTINTERP_LIBRARY
+              NAMES octinterp liboctinterp
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+find_library( OCTAVE_OCTAVE_LIBRARY
+              NAMES octave liboctave
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+find_library( OCTAVE_CRUFT_LIBRARY
+              NAMES cruft libcruft
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+    
+set ( OCTAVE_LIBRARIES ${OCTAVE_OCTINTERP_LIBRARY} )
+list ( APPEND OCTAVE_LIBRARIES ${OCTAVE_OCTAVE_LIBRARY} ) 
+list ( APPEND OCTAVE_LIBRARIES ${OCTAVE_CRUFT_LIBRARY} ) 
+    
+find_path ( OCTAVE_INCLUDE_DIR 
+            NAMES mex.h
+            HINTS ${OCTAVE_INCLUDE_PATHS}
+          )
+    
+set ( OCTAVE_INCLUDE_DIRS ${OCTAVE_INCLUDE_DIR} )
+macro ( octave_add_oct FUNCTIONNAME )
+  set ( _CMD SOURCES )
+  set ( _SOURCES )
+  set ( _LINK_LIBRARIES )
+  set ( _EXTENSION )
+  set ( _OCT_EXTENSION oct )
+  foreach ( _ARG ${ARGN})
+    if ( ${_ARG} MATCHES SOURCES )
+      set ( _CMD SOURCES )
+    elseif ( ${_ARG} MATCHES LINK_LIBRARIES  )
+      set ( _CMD LINK_LIBRARIES  )
+    elseif ( ${_ARG} MATCHES EXTENSION )
+      set ( _CMD EXTENSION )
+    else ()
+      if ( ${_CMD} MATCHES SOURCES )
+        list ( APPEND _SOURCES "${_ARG}" )
+      elseif ( ${_CMD} MATCHES LINK_LIBRARIES  )
+        list ( APPEND _LINK_LIBRARIES "${_ARG}" )
+      elseif ( ${_CMD} MATCHES EXTENSION )
+        set ( _OCT_EXTENSION ${_ARG} )
+      endif ()
+    endif ()
+  endforeach ()
+  add_library ( ${FUNCTIONNAME} SHARED ${_SOURCES} )
+  target_link_libraries ( ${FUNCTIONNAME} ${OCTAVE_LIBRARIES} ${_LINK_LIBRARIES} )
+  set_target_properties ( ${FUNCTIONNAME} PROPERTIES
+    PREFIX ""
+    SUFFIX  ".${_OCT_EXTENSION}"
+  )
+endmacro ()
+# handle REQUIRED and QUIET options
+include ( FindPackageHandleStandardArgs )
+if ( CMAKE_VERSION LESS 2.8.3 )
+  find_package_handle_standard_args ( Octave DEFAULT_MSG OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES OCTAVE_VERSION_STRING )
+else ()
+  find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
+endif ()
+mark_as_advanced (
+  OCTAVE_OCT_FILE_DIR
+  OCTAVE_OCT_LIB_DIR
+  OCTAVE_OCTINTERP_LIBRARY
+  OCTAVE_OCTAVE_LIBRARY
+  OCTAVE_CRUFT_LIBRARY
+  OCTAVE_LIBRARIES
+  OCTAVE_INCLUDE_DIR
+  OCTAVE_INCLUDE_DIRS
+  OCTAVE_ROOT_DIR
+  OCTAVE_VERSION_STRING
+  OCTAVE_MAJOR_VERSION
+  OCTAVE_MINOR_VERSION
+  OCTAVE_PATCH_VERSION
+)
+

--- a/doc/yarp_swig.dox
+++ b/doc/yarp_swig.dox
@@ -33,6 +33,7 @@ Then, install any language-specific packages needed.
  - \ref yarp_swig_python
  - \ref yarp_swig_matlab
  - \ref yarp_swig_lua
+ - \ref yarp_swig_octave
  - \ref Other tested languages are: Perl, Chicken Scheme, C#, Allegro Common Lisp, TCL, and Ruby.  Procedure is same as for Java/Python.  You may need to install a development package for your desired language.  To find out:
    - On Linux: Check http://www.dabeaz.com/cgi-bin/wiki.pl?DeveloperInfo/GettingStarted
    - On OSX: A surprising amount of stuff comes pre-installed.
@@ -149,6 +150,18 @@ which classpath.txt
 \endverbatim
 
 
+@section yarp_swig_octave YARP for Octave
+For using Yarp from octave on Linux, be sure to install octave development packages, e.g. on Debian/Ubuntu:
+\verbatim
+sudo apt-get install liboctave-dev
+\endverbatim
+
+After \ref yarp_swig_compile, make sure that Octave-Yarp binding library (i.e., yarp.oct) is in the octave Load-path list or manually set it within your octave script. For example:  
+\verbatim
+ octave> addpath([getenv('YARP_ROOT') '/build/lib/octave']);
+\endverbatim
+
+
 @section yarp_swig_lua YARP for Lua
 For Lua on linux, be sure to install Lua development files, e.g. on Debian/Ubuntu:
 \verbatim
@@ -175,6 +188,7 @@ After \ref yarp_swig_compile, make sure that the Lua-Yarp binding shared library
 \verbatim
 export LUA_CPATH=";;;$YARP_ROOT/bindings/build-lua/?.so"
 \endverbatim
+
 
 
 @section yarp_swig_configure Configuring YARP language bindings


### PR DESCRIPTION
## Using Yarp from Octave

Swig already supports Octave binding. Thus it is not a bad idea to have Yarp-Octave binding. I have tested some simple examples of using YARP within octave on Linux and it works fine.  

The compilation is easy and fine. I have not tested everything in Octave but the Port/BufferedPort reading/writing works correctly. 
