### PR TITLE
Update ResourceFinder documentation

### DIFF
--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -26,6 +26,9 @@ namespace yarp {
 /**
  *
  * Helper class for finding config files and other external resources.
+ * 
+ * More details on this class behaviour can be found in
+ * \ref yarp_resource_finder_tutorials.
  *
  */
 class YARP_OS_API yarp::os::ResourceFinder : public Searchable{


### PR DESCRIPTION
Add a link to the full ResourceFinder behaviour specification in related docstring documentation. 
For a programmer/user the most natural place to look up the behaviour of the method is the Doxygen documentation
of the method itself, and at the moment there was no link at all in ResourceFinder documentation to the specification. 

cc @lornat75 Not an expert, but I had trouble understand the documentation of ResourceFinder::configure method. Is it still valid or is it outdated? 
