### PR TITLE
Add set_option and get_option to TcpStream

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/TcpStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TcpStream.h
@@ -121,6 +121,15 @@ public:
     // set stream descriptor
     void set_handle(int h) { sd = h; }
 
+    // Wrapper around the setsockopt system call.
+    inline int set_option(int level, int option, void *optval, int optlen) const {
+        return setsockopt(sd, level, option, (char*)optval, optlen);
+    }
+
+    // Wrapper around the getsockopt system call.
+    inline int get_option(int level, int option, void *optval, int *optlen) const {
+        return getsockopt(sd, level, option, (char*)optval, (socklen_t*)optlen);
+    }
 private:
     // stream descriptor
     int sd;


### PR DESCRIPTION
This allows to change socket options when YARP is built with SKIP_ACE
