### PR TITLE
Fix ControlBoardWrapper behaviour if the device name does not contains //

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -162,7 +162,10 @@ bool ControlBoardWrapper::open(Searchable& config)
     rootName = prop.check("rootName",Value("/"), "starting '/' if needed.").asString().c_str();
     partName=prop.check("name",Value("controlboard"), "prefix for port names").asString().c_str();
     rootName+=(partName);
-    rootName.replace(rootName.find("//"), 2, "/");
+    if( rootName.find("//") != std::string::npos )
+    {
+        rootName.replace(rootName.find("//"), 2, "/");
+    }
 
     // attach readers.
     // inputRPCPort.setReader(RPC_parser);


### PR DESCRIPTION
Without this, ControlBoardWrapper will raise a `std::replace` **exception** when processing device names that does not contain "//". 
This was silently breaking the gazebo controlboard and I am afraid is **breaking** all the properly configured controlboard wrappers, even the one on the **real robots**. 

@barbalberto aside from this bug, this replace call is a bit suboptimal. 
Introducing an undocumented behaviour in loading configuration instead of fixing a malformed configuration file is harmful.
