### PR TITLE
[test] add integration test for http protocol against curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
   - cmake --build . --config ${TRAVIS_BUILD_TYPE}
   - ctest --build . --config ${TRAVIS_BUILD_TYPE}
   - if [ "k$TRAVIS_WITH_RUNTIME" = "ktrue" ]; then ../scripts/admin/check-runtime.sh; fi
+  - if [ "k$TRAVIS_WITH_RUNTIME" = "ktrue" ]; then ../tests/integration/check-http.sh; fi
   - cd ..
   - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then build/bin/yarp conf 0 0 local; fi
   - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then YARP_DIR=$PWD/build SWIG_VERSIONS="1.3.40 2.0.12 3.0.2" ./scripts/admin/check-bindings.sh PYTHON JAVA LUA RUBY CSHARP PERL TCL; fi

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -75,15 +75,9 @@ void SocketTwoWayStream::updateAddresses() {
     //int zero = 0;
     int one = 1;
 
-    struct linger lval;
-    lval.l_onoff = 1;
-    lval.l_linger = 0;
-
 #ifdef YARP_HAS_ACE
     stream.set_option (ACE_IPPROTO_TCP, TCP_NODELAY, &one,
                        sizeof(int));
-    stream.set_option (ACE_IPPROTO_TCP, SO_LINGER, &lval,
-                       sizeof(linger));
     ACE_INET_Addr local, remote;
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);
@@ -92,8 +86,6 @@ void SocketTwoWayStream::updateAddresses() {
 #else
     stream.set_option (IPPROTO_TCP, TCP_NODELAY, &one,
                        sizeof(int));
-    stream.set_option (SOL_SOCKET, SO_LINGER, &lval,
-                       sizeof(linger));
     struct sockaddr local, remote;
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -20,4 +20,7 @@ if(YARP_TEST_INTEGRATION)
   add_test("integration::runtime" ${CMAKE_SOURCE_DIR}/scripts/admin/check-runtime.sh)
   set_property(TEST "integration::runtime" PROPERTY WORKING_DIRECTORY ${YARP_BINARY_DIR})
 
+  add_test("integration::http" ${CMAKE_CURRENT_SOURCE_DIR}/check-http.sh)
+  set_property(TEST "integration::http" PROPERTY WORKING_DIRECTORY ${YARP_BINARY_DIR})
+
 endif()

--- a/tests/integration/check-http.sh
+++ b/tests/integration/check-http.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+if [ ! -e CMakeCache.txt ] ; then
+    echo "Please run from build directory"
+    exit 1
+fi
+
+YARP_BIN="$PWD/bin"
+
+########################################################################
+# Some utilities and cleanup code
+
+# Print a header for the test
+function header {
+echo " "
+echo "====================================================================="
+echo "== $1"
+echo " "
+}
+
+# Convert a port name to I.P.AD.DRESS:NUMBER
+function get_uri {
+    port=$1
+    uri=$(${YARP_BIN}/yarp name query $port | sed "s/.* ip //" | sed "s/ port /:/" | sed "s/ .*//")
+    echo $uri
+}
+
+# Track PIDs of some processes we'll be running, for cleanup purposes
+SERVER_ID=""
+HELPER_ID=""
+
+cleanup_helper() {
+    if [ ! "k$HELPER_ID" = "k" ]; then
+	kill $HELPER_ID || true
+	wait $HELPER_ID || true
+	HELPER_ID=""
+    fi
+}
+
+cleanup_all() {
+    cleanup_helper
+    if [ ! "k$SERVER_ID" = "k" ]; then
+	kill $SERVER_ID || true
+	wait $SERVER_ID || true
+	SERVER_ID=""
+    fi
+}
+trap cleanup_all EXIT
+
+########################################################################
+header "Start name server if needed and add cleanup traps"
+
+${YARP_BIN}/yarp where || {
+    echo "Starting yarpserver"
+    ${YARP_BIN}/yarpserver --write > /dev/null &
+    SID=$!
+}
+
+while ! ${YARP_BIN}/yarp detect --write; do
+    echo "Waiting for yarpserver"
+    sleep 1
+done
+
+echo "yarpserver is OK"
+
+########################################################################
+header "Check that curl request succeeds"
+
+port_name=/read/$$
+${YARP_BIN}/yarp read $port_name &
+HELPER_ID=$!
+${YARP_BIN}/yarp wait $port_name
+
+uri=$(get_uri $port_name)
+
+which curl
+curl $uri || {
+    echo "ERROR: *** HTTP connection to name server failed ***"
+    exit 1
+}
+
+echo "Curl request worked fine!"
+
+header "Shutting down"


### PR DESCRIPTION
This is a test for the problem described in #341. I wasn't able to replicate it with a yarp-to-yarp connection, I think yarp is too forgiving, so I show it here against `curl`. This test currently fails for me when compiling without ACE. /cc @drdanz 