### PR TITLE
Simplify use of controlboardwrapper2

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -346,21 +346,23 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
         return false;
     }
 
-    // getting parameters in simStyle... this is different from usual checks of controlBoardWrapper2
-    Bottle &general = p.findGroup("GENERAL", "section for general motor control parameters");
-    if(general.isNull())
+    yarp::dev::IEncoders iencs = 0;
+   
+    subDeviceOwned->view(iencs);
+   
+    if (iencs == 0)
     {
-        yError("Cannot find GENERAL group configuration parameters\n");
+        yError("Opening IEncoders interface of controlBoardWrapper2 subdevice... FAILED\n");
         return false;
     }
 
-    Value & myjoints = general.find("TotalJoints");
-    if(myjoints.isNull())
+    bool getAx = iencs->getAxes(controlledJoints);
+    
+    if (!getAx)
     {
-        yError("ControlBoardWrapper: error, 'TotalJoints' parameter not valid\n");
+        yError("Calling getAxes of controlBoardWrapper2 subdevice... FAILED\n");
         return false;
     }
-    controlledJoints = myjoints.asInt();
     yDebug("joints parameter is %d\n", controlledJoints);
 
 

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -356,7 +356,7 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
         return false;
     }
 
-    bool getAx = iencs->getAxes(controlledJoints);
+    bool getAx = iencs->getAxes(&controlledJoints);
     
     if (!getAx)
     {

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -346,7 +346,7 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
         return false;
     }
 
-    yarp::dev::IEncoders iencs = 0;
+    yarp::dev::IEncoders * iencs = 0;
    
     subDeviceOwned->view(iencs);
    


### PR DESCRIPTION
Minimize number of parameters if only one subdevice is used. 
See https://github.com/robotology/yarp/issues/310#issuecomment-62872910 .