### PR TITLE
setRefTorque/s implemented using streaming instead of RPC

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
@@ -807,5 +807,8 @@ public:
 #define VOCAB_IMP_PARAM   VOCAB3('i','p','r')
 #define VOCAB_IMP_OFFSET  VOCAB3('i','o','f')
 
+#define VOCAB_TORQUES_DIRECTS VOCAB4('d','t','q','s') //This implements the setRefTorques for the whole part
+#define VOCAB_TORQUES_DIRECT VOCAB3('d','t','q') //This implements the setRefTorque for a single joint
+#define VOCAB_TORQUES_DIRECT_GROUP VOCAB4('d','t','q','g') //This implements the setRefTorques with joint list
 #endif
 

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/StreamingMessagesParser.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/StreamingMessagesParser.cpp
@@ -30,6 +30,7 @@ void StreamingMessagesParser::init(ControlBoardWrapper *x) {
     stream_IVel = dynamic_cast<yarp::dev::IVelocityControl *> (x);
     stream_IVel2 = dynamic_cast<yarp::dev::IVelocityControl2 *> (x);
     stream_IOpenLoop=dynamic_cast<yarp::dev::IOpenLoopControl *> (x);
+    stream_ITorque=dynamic_cast<yarp::dev::ITorqueControl *> (x);
 }
 
 
@@ -149,6 +150,28 @@ void StreamingMessagesParser::onRead(CommandMessage& v)
                 bool ok = stream_IPosDirect->setPosition(b.get(1).asInt(), cmdVector[0]); // cmdVector.data());
                 if (!ok)
                 {   yError("Errors while trying to command an streaming position direct message on joint %d\n", b.get(1).asInt() ); }
+            }
+        }
+        break;
+        
+        case VOCAB_TORQUES_DIRECT:
+        {
+            if (stream_ITorque)
+            {
+                bool ok = stream_ITorque->setRefTorque(b.get(1).asInt(), cmdVector[0]);
+                if (!ok)
+                {   yError("Errors while trying to command a streaming torque direct message on all joints\n"); }
+            }
+        }
+        break;
+        
+        case VOCAB_TORQUES_DIRECTS:
+        {
+            if (stream_ITorque)
+            {
+                bool ok = stream_ITorque->setRefTorques(cmdVector.data());
+                if (!ok)
+                {   yError("Errors while trying to command a streaming torque direct message on all joints\n"); }
             }
         }
         break;

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/StreamingMessagesParser.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/StreamingMessagesParser.h
@@ -79,6 +79,7 @@ protected:
     yarp::dev::IVelocityControl     *stream_IVel;
     yarp::dev::IVelocityControl2    *stream_IVel2;
     yarp::dev::IOpenLoopControl     *stream_IOpenLoop;
+    yarp::dev::ITorqueControl       *stream_ITorque;
     int                              stream_nJoints;
 
 public:

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2393,10 +2393,39 @@ public:
     { return get2V1DA(VOCAB_TORQUE, VOCAB_REFS, t); }
 
     bool setRefTorques(const double *t)
-    { return set2V1DA(VOCAB_TORQUE, VOCAB_REFS, t); }
+    {
+        //Now we use streaming instead of rpc
+        //return set2V1DA(VOCAB_TORQUE, VOCAB_REFS, t);
+        if (!isLive()) return false;
+        CommandMessage& c = command_buffer.get();
+        c.head.clear();
+        c.head.addVocab(VOCAB_TORQUES_DIRECTS);
+
+        c.body.resize(nj);
+
+        memcpy(c.body.data(), t, sizeof(double) * nj);
+
+        command_buffer.write(writeStrict_moreJoints);
+        return true;
+    }
 
     bool setRefTorque(int j, double v)
-    { return set2V1I1D(VOCAB_TORQUE, VOCAB_REF, j, v); }
+    {
+        //return set2V1I1D(VOCAB_TORQUE, VOCAB_REF, j, v);
+        // use the streaming port!
+        if (!isLive()) return false;
+        CommandMessage& c = command_buffer.get();
+        c.head.clear();
+        // in streaming port only SET command can be sent, so it is implicit
+        c.head.addVocab(VOCAB_TORQUES_DIRECT);
+        c.head.addInt(j);
+
+        c.body.clear();
+        c.body.resize(1);
+        c.body[0] = v;
+        command_buffer.write(writeStrict_singleJoint);
+        return true;
+    }
 
     bool getBemfParam(int j, double *t)
     { return get2V1I1D(VOCAB_TORQUE, VOCAB_BEMF, j, t); }


### PR DESCRIPTION
This PR should change how the `setRefTorque` and `setRefTorques` handle the request passing from RPC to streaming.