### PR TITLE
added version check on controlborad remote control board

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
@@ -807,5 +807,8 @@ public:
 #define VOCAB_IMP_PARAM   VOCAB3('i','p','r')
 #define VOCAB_IMP_OFFSET  VOCAB3('i','o','f')
 
+// protocol version
+#define VOCAB_PROTOCOL_VERSION VOCAB('p', 'r', 'o', 't')
+
 #endif
 

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -60,6 +60,11 @@
     #pragma warning(disable:4355)
 #endif
 
+
+#define PROTOCOL_VERSION_MAJOR 1
+#define PROTOCOL_VERSION_MINOR 0
+#define PROTOCOL_VERSION_TWEAK 0
+
 /*
  * To optimize memory allocation, for group of joints we can have one mem reserver for rpc port
  * and on e for streaming. The size could be numOfSubDevices*maxNumOfjointForSubdevice.

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -30,6 +30,24 @@ inline void appendTimeStamp(Bottle &bot, Stamp &st)
     bot.addDouble(time);
 }
 
+void RPCMessagesParser::handleProtocolVersionRequest(const yarp::os::Bottle& cmd,
+                                           yarp::os::Bottle& response, bool *rec, bool *ok)
+{
+    if (cmd.get(0).asVocab()!=VOCAB_GET)
+    {
+        *rec=false;
+        *ok=false;
+        return;
+    }
+
+    response.addVocab(VOCAB_PROTOCOL_VERSION);
+    response.addInt(PROTOCOL_VERSION_MAJOR);
+    response.addInt(PROTOCOL_VERSION_MINOR);
+    response.addInt(PROTOCOL_VERSION_TWEAK);
+
+    *rec=true;
+    *ok=true;
+}
 
 void RPCMessagesParser::handleImpedanceMsg(const yarp::os::Bottle& cmd,
                                            yarp::os::Bottle& response, bool *rec, bool *ok)
@@ -1096,6 +1114,9 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
 
             case VOCAB_OPENLOOP_INTERFACE:
                 handleOpenLoopMsg(cmd, response, &rec, &ok);
+            break;
+            case VOCAB_PROTOCOL_VERSION:
+                handleProtocolVersionRequest(cmd, response, &rec, &ok);
             break;
 
             default:

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.h
@@ -128,6 +128,10 @@ public:
     void handleOpenLoopMsg(const yarp::os::Bottle& cmd,
         yarp::os::Bottle& response, bool *rec, bool *ok);
 
+
+    void handleProtocolVersionRequest(const yarp::os::Bottle& cmd,
+         yarp::os::Bottle& response, bool *rec, bool *ok);
+
     /**
     * Initialize the internal data.
     * @return true/false on success/failure


### PR DESCRIPTION
The check is inactive at the moment and issues only a warning. We can make it strict later. The remotecontrolparameter --ignoreCheck forces to ignore the check (for debugging purposes).