### PR TITLE
added version check for remotecontrolboard and controlboardwrapper2

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
@@ -810,5 +810,9 @@ public:
 #define VOCAB_TORQUES_DIRECTS VOCAB4('d','t','q','s') //This implements the setRefTorques for the whole part
 #define VOCAB_TORQUES_DIRECT VOCAB3('d','t','q') //This implements the setRefTorque for a single joint
 #define VOCAB_TORQUES_DIRECT_GROUP VOCAB4('d','t','q','g') //This implements the setRefTorques with joint list
+
+// protocol version
+#define VOCAB_PROTOCOL_VERSION VOCAB('p', 'r', 'o', 't')
+
 #endif
 

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -60,6 +60,11 @@
     #pragma warning(disable:4355)
 #endif
 
+
+#define PROTOCOL_VERSION_MAJOR 1
+#define PROTOCOL_VERSION_MINOR 0
+#define PROTOCOL_VERSION_TWEAK 0
+
 /*
  * To optimize memory allocation, for group of joints we can have one mem reserver for rpc port
  * and on e for streaming. The size could be numOfSubDevices*maxNumOfjointForSubdevice.

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -30,6 +30,24 @@ inline void appendTimeStamp(Bottle &bot, Stamp &st)
     bot.addDouble(time);
 }
 
+void RPCMessagesParser::handleProtocolVersionRequest(const yarp::os::Bottle& cmd,
+                                           yarp::os::Bottle& response, bool *rec, bool *ok)
+{
+    if (cmd.get(0).asVocab()!=VOCAB_GET)
+    {
+        *rec=false;
+        *ok=false;
+        return;
+    }
+
+    response.addVocab(VOCAB_PROTOCOL_VERSION);
+    response.addInt(PROTOCOL_VERSION_MAJOR);
+    response.addInt(PROTOCOL_VERSION_MINOR);
+    response.addInt(PROTOCOL_VERSION_TWEAK);
+
+    *rec=true;
+    *ok=true;
+}
 
 void RPCMessagesParser::handleImpedanceMsg(const yarp::os::Bottle& cmd,
                                            yarp::os::Bottle& response, bool *rec, bool *ok)
@@ -1096,6 +1114,9 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
 
             case VOCAB_OPENLOOP_INTERFACE:
                 handleOpenLoopMsg(cmd, response, &rec, &ok);
+            break;
+            case VOCAB_PROTOCOL_VERSION:
+                handleProtocolVersionRequest(cmd, response, &rec, &ok);
             break;
 
             default:

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.h
@@ -128,6 +128,10 @@ public:
     void handleOpenLoopMsg(const yarp::os::Bottle& cmd,
         yarp::os::Bottle& response, bool *rec, bool *ok);
 
+
+    void handleProtocolVersionRequest(const yarp::os::Bottle& cmd,
+         yarp::os::Bottle& response, bool *rec, bool *ok);
+
     /**
     * Initialize the internal data.
     * @return true/false on success/failure

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -29,6 +29,10 @@
 
 #include <stateExtendedReader.hpp>
 
+#define PROTOCOL_VERSION_MAJOR 1
+#define PROTOCOL_VERSION_MINOR 0
+#define PROTOCOL_VERSION_TWEAK 0
+
 using namespace yarp::os;
 using namespace yarp::dev;
 using namespace yarp::sig;
@@ -36,6 +40,7 @@ using namespace yarp::sig;
 namespace yarp{
     namespace dev {
         class RemoteControlBoard;
+        struct ProtocolVersion;
     }
 }
 
@@ -51,6 +56,13 @@ inline bool getTimeStamp(Bottle &bot, Stamp &st)
     }
     return false;
 }
+
+struct yarp::dev::ProtocolVersion
+{
+    int major;
+    int minor;
+    int tweak;
+};
 
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -280,6 +292,8 @@ protected:
     // Semaphore mutex;
     int nj;
     bool njIsKnown;
+
+    ProtocolVersion protocolVersion;
 
     // Check for number of joints, if needed.
     // This is to allow for delayed connection to the remote control board.
@@ -1054,6 +1068,12 @@ public:
 
         state_buffer.setStrict(false);
         command_buffer.attach(command_p);
+
+        bool ignoreCheck=false;
+        ignoreCheck = true; //config.check("ignoreProtocolCheck");
+
+        if (!checkProtocolVersion(ignoreCheck))
+            return false;
 
         if (!isLive()) {
             if (remote!="") {
@@ -3383,6 +3403,56 @@ public:
         }
         else
             return get1VDA(VOCAB_OUTPUTS, outs);
+    }
+
+    bool checkProtocolVersion(bool ignore)
+    {
+        bool error=false;
+        // verify protocol
+        Bottle cmd, reply;
+        cmd.addVocab(VOCAB_GET);
+        cmd.addVocab(VOCAB_PROTOCOL_VERSION);
+        rpc_p.write(cmd, reply);
+    
+        // check size and format of messages, expected [prot] int int int [ok]
+        if (reply.size()!=5)
+           error=true;
+
+        if (reply.get(0).asVocab()!=VOCAB_PROTOCOL_VERSION)
+           error=true;
+
+        if (!error)
+        {
+            protocolVersion.major=reply.get(1).asInt();
+            protocolVersion.minor=reply.get(2).asInt();
+            protocolVersion.tweak=reply.get(3).asInt();
+
+            //verify protocol
+            if (protocolVersion.major!=PROTOCOL_VERSION_MAJOR)
+                error=true;
+        }
+
+        if (!error)
+            return true;
+
+        // protocol did not match
+        fprintf(stderr, "ERROR, expecting protocol %d %d %d, but remotecontrolboard returned protocol version %d %d %d\n", 
+                        PROTOCOL_VERSION_MAJOR, PROTOCOL_VERSION_MINOR, PROTOCOL_VERSION_TWEAK,
+                        protocolVersion.major, protocolVersion.minor, protocolVersion.tweak); 
+
+
+        if (ignore)
+        {
+            fprintf(stderr, "WARNING: ignoring error but please update YARP or the remotecontrolboard implementation\n");
+            return true;
+        }
+        else 
+        {
+            fprintf(stderr, "ERROR: please update YARP or the remotecontrolboard implementation\n");
+            return true;
+        }
+
+        return false;
     }
 };
 


### PR DESCRIPTION
Implement protocol check for emotecontrolboard and controlboardwrapper2. The check only issues a warning. In the future we can make it a strict check (however, the option --ignoreProtocolCheck can be added for debugging, uncomment line RemoteControlBoard.cpp:1073)