### PR TITLE
[YARP_OS] make yarp-internal debug messages evaporate in release mode

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/Logger.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Logger.h
@@ -194,7 +194,11 @@ private:
 #define YARP_ERROR(log,x) ((Logger*)&log)->internal_error(x)
 #define YARP_WARN(log,x)  ((Logger*)&log)->internal_warning(x)
 #define YARP_INFO(log,x)  ((Logger*)&log)->internal_info(x)
-#define YARP_DEBUG(log,x) ((Logger*)&log)->internal_debug(x)
+#ifndef NDEBUG
+#  define YARP_DEBUG(log,x) ((Logger*)&log)->internal_debug(x)
+#else
+#  define YARP_DEBUG(log,x)
+#endif
 #define YARP_FAIL(log,x)  ((Logger*)&log)->internal_fail(x)
 
 #define YARP_LONGEST_MESSAGE 1000


### PR DESCRIPTION
The yarp library has a lot of internal debug messages which are
hidden by default but can be shown by setting the YARP_VERBOSE
environment variable.  This commit strips the code generating these
messages from the release build, in order to improve performance.
Debug builds are untouched.