### PR TITLE
[YARP_OS] add hooks for checking heap allocation in regression tests

### DIFF
--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -385,6 +385,12 @@ if (YARP_USE_READLINE)
     target_link_libraries(YARP_OS LINK_PRIVATE ${Readline_LIBRARY})
 endif ()
 
+option(YARP_TEST_HEAP "Replace new/delete operators with test harness (may be incompatible with ACE)" FALSE)
+mark_as_advanced(YARP_TEST_HEAP)
+if (YARP_TEST_HEAP)
+    add_definitions(-DYARP_TEST_HEAP)
+endif()
+
 install(TARGETS YARP_OS
         EXPORT YARP
         COMPONENT runtime

--- a/src/libYARP_OS/harness/TestList.h
+++ b/src/libYARP_OS/harness/TestList.h
@@ -60,6 +60,7 @@ extern yarp::os::impl::UnitTest& getPublisherTest();
 extern yarp::os::impl::UnitTest& getLogTest();
 extern yarp::os::impl::UnitTest& getLogStreamTest();
 extern yarp::os::impl::UnitTest& getMessageStackTest();
+extern yarp::os::impl::UnitTest& getUnitTestTest();
 
 class yarp::os::impl::TestList {
 public:
@@ -102,6 +103,7 @@ public:
         root.add(getLogTest());
         root.add(getLogStreamTest());
         root.add(getMessageStackTest());
+        root.add(getUnitTestTest());
 
 #ifdef YARPRUN_TEST
         root.add(getRunTest());

--- a/src/libYARP_OS/harness/UnitTestTest.cpp
+++ b/src/libYARP_OS/harness/UnitTestTest.cpp
@@ -1,0 +1,61 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Author: Paul Fitzpatrick
+ *
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/impl/UnitTest.h>
+
+using namespace yarp::os;
+using namespace yarp::os::impl;
+
+class UnitTestTest : public UnitTest {
+public:
+    virtual String getName() { return "UnitTestTest"; }
+
+    void checkHeapMonitor() {
+        if (!heapMonitorSupported()) {
+            report(0, "skipping heap monitor check, requires YARP_TEST_HEAP to be set");
+            return;
+        }
+        report(0, "check heap monitor is functional");
+
+        // check some heap use is detected
+        heapMonitorBegin();
+        Bottle b("1 2 3");
+        int ops = heapMonitorEnd();
+        checkTrue(ops>0,"memory allocation used in parsing bottle");
+
+        // check some ordinary operations pass
+        Bottle b2("4 5 6");
+        heapMonitorBegin();
+        int a = 2 + b2.size();
+        ops = heapMonitorEnd();
+        checkEqual(a,5,"math works");
+        checkTrue(ops==0,"no memory allocation used in adding two numbers");
+
+        // check that when we promise no heap use, but it happens, then
+        // we get an error
+        UnitTest isolatedTest(NULL);
+        report(0, "DO NOT PANIC about heap operation assertions below this line, it is part of the test");
+        isolatedTest.heapMonitorBegin(false); // assert no memory allocation
+        Bottle b3("1 2 3");                   // we lied!
+        ops = isolatedTest.heapMonitorEnd();
+        report(0, "DO NOT PANIC about heap operation assertions above this line, it is part of the test");
+        checkTrue(ops>0,"memory allocation was detected");
+        checkTrue(!isolatedTest.isOk(),"memory allocation was flagged as error");
+    }
+
+    virtual void runTests() {
+        checkHeapMonitor();
+    }
+};
+
+static UnitTestTest theUnitTestTest;
+
+UnitTest& getUnitTestTest() {
+    return theUnitTestTest;
+}

--- a/src/libYARP_OS/include/yarp/os/impl/UnitTest.h
+++ b/src/libYARP_OS/include/yarp/os/impl/UnitTest.h
@@ -39,7 +39,7 @@ public:
 
     void report(int severity, const String& problem);
 
-    virtual String getName() = 0;
+    virtual String getName() { return "isolated test"; }
 
     static void startTestSystem();
     static UnitTest& getRoot();
@@ -87,6 +87,51 @@ public:
     bool isOk() {
         return !hasProblem;
     }
+
+    /**
+     *
+     * Check if YARP has been compiled with YARP_TEST_HEAP set, and so
+     * can monitor heap activity.
+     *
+     * @return true if YARP is compiled with hooks for monitoring heap
+     * activity
+     *
+     */
+    static bool heapMonitorSupported();
+
+    /**
+     *
+     * Begin monitoring heap activity, specifically calls to
+     * new/new[]/delete/delete[]. It is important to eventually call
+     * heapMonitorEnd() to stop monitoring heap activity.  You must
+     * guarantee that no heap activity is occurring in any other
+     * threads when you call this method.
+     *
+     * @param expectAllocations set to true if heap activity is expected,
+     * set to false if heap activity is unexpected (stack traces will be
+     * shown for every new/delete in this case)
+     *
+     */
+    void heapMonitorBegin(bool expectAllocations = true);
+
+    /**
+     *
+     * @return a cumulative count of new/delete calls since the last call
+     * to this method or to heapMonitorBegin()
+     *
+     */
+    int heapMonitorOps();
+
+    /**
+     *
+     * Stop monitoring heap activity.  You must guarantee that no
+     * heap activity is occurring in any other threads when you call
+     * this method.
+     *
+     * @return the output of heapMonitorOps()
+     *
+     */
+    int heapMonitorEnd();
 
 private:
     UnitTest *parent;


### PR DESCRIPTION
This is some support for memory checks I'll be adding in later PRs, basically adding tests that yarp does not allocate memory during performance-sensitive operations.

It relies on overriding new/delete.  This appears to conflict with something ACE is doing.  Reserving these tests for a no-ace build is fine for my purposes.  None of this code will be run unless YARP is compiled with a special `YARP_TEST_HEAP` flag (marked as advanced).