### PR TITLE
[YARP_OS] reduce memory churn for envelope messages 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_script:
   - mkdir -p build
   - cd build
   - export YARP_CMAKE_OPTIONS="-DTEST_yarpidl_rosmsg=TRUE -DTEST_yarpidl_thrift=TRUE -DCREATE_OPTIONAL_CARRIERS=TRUE -DENABLE_yarpcar_tcpros_carrier=TRUE -DENABLE_yarpcar_rossrv_carrier=TRUE -DENABLE_yarpcar_xmlrpc_carrier=TRUE"
-  - if [ "k$TRAVIS_WITH_ACE" = "kfalse" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DSKIP_ACE=TRUE"; fi
+  - if [ "k$TRAVIS_WITH_ACE" = "kfalse" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DSKIP_ACE=TRUE -DYARP_TEST_HEAP=TRUE"; fi
   - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ${YARP_CMAKE_OPTIONS} ..
   - if [ "$CXX" = "g++" ]; then lcov --directory . --zerocounters; fi
   - cd ..

--- a/src/libYARP_OS/harness/BufferedConnectionWriterTest.cpp
+++ b/src/libYARP_OS/harness/BufferedConnectionWriterTest.cpp
@@ -7,13 +7,21 @@
  *
  */
 
-#include <yarp/os/impl/BufferedConnectionWriter.h>
+#include <yarp/os/DummyConnector.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/os/PortablePair.h>
 #include <yarp/os/StringOutputStream.h>
-
+#include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/UnitTest.h>
+#include <yarp/sig/Image.h>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
+using namespace yarp::sig;
+
+typedef PortablePair<PortablePair<PortablePair<Bottle, ImageOf<PixelRgb> >, 
+                                  PortablePair<ImageOf<PixelRgb>, Stamp> >, 
+                     Bottle> Monster;
 
 class BufferedConnectionWriterTest : public UnitTest {
 public:
@@ -30,8 +38,128 @@ public:
         checkEqual(sos.toString(),"Hello\r\nGreetings\r\n","two line writes");
     }
 
+    void testRestart() {
+        report(0,"test restarting writer without reallocating memory...");
+
+        size_t pool_sizes[] = {BUFFERED_CONNECTION_INITIAL_POOL_SIZE, 13, 7, 3, 1};
+        for (size_t i=0; i<sizeof(pool_sizes)/sizeof(size_t); i++) {
+            StringOutputStream sos;
+            // first we test a message with a few short strings
+            BufferedConnectionWriter bbr;
+            report(0,ConstString("pool size of ") + Bottle::toString(pool_sizes[i]) + " begins");
+            bbr.setInitialPoolSize(pool_sizes[i]);
+            bbr.reset(false);
+            ConstString msg1("Hello");
+            ConstString msg2("Greetings");
+            heapMonitorBegin();
+            bbr.appendLine(msg1);
+            bbr.appendLine(msg2);
+            int ops = heapMonitorEnd();
+            bbr.write(sos);
+            checkEqual(sos.toString(),"Hello\r\nGreetings\r\n","two line writes");
+            if (heapMonitorSupported()) {
+                checkTrue(ops>0,"memory allocation happened");
+            }
+            sos.reset();
+            heapMonitorBegin(false);
+            bbr.restart();
+            bbr.appendLine(msg1);
+            bbr.appendLine(msg2);
+            heapMonitorEnd();
+            bbr.write(sos);
+            checkEqual(sos.toString(),"Hello\r\nGreetings\r\n","two line writes dup");
+
+            // Make sure we survive a small change in message
+            bbr.restart();
+            sos.reset();
+            bbr.appendLine("Space Monkeys");
+            bbr.appendLine("Attack");
+            bbr.write(sos);
+            checkEqual(sos.toString(),"Space Monkeys\r\nAttack\r\n","alternate text");
+
+            // And again, a bigger change this time
+            String test(2048,'x');
+            bbr.restart();
+            sos.reset();
+            bbr.appendLine(test);
+            bbr.appendLine(test);
+            bbr.appendLine(test);
+            bbr.write(sos);
+            ConstString result = sos.toString();
+            ConstString expect = test + "\r\n" + test + "\r\n" + test + "\r\n";
+            checkTrue(result==expect,"long text");
+            sos.reset();
+            heapMonitorBegin(false);
+            bbr.restart();
+            bbr.appendLine(test);
+            bbr.appendLine(test);
+            bbr.appendLine(test);
+            heapMonitorEnd();
+            bbr.write(sos);
+            result = sos.toString();
+            checkTrue(result==expect,"long text, take 2");
+
+            // Try the image class
+            ImageOf<PixelRgb> img1, img2;
+            img1.resize(320,240);
+            img1.zero();
+            img1.pixel(10,5).r = 41;
+            bbr.restart();
+            img1.write(bbr);
+            img1.pixel(10,5).r = 42; // sneak change to external buffer to make sure it was not copied
+            bbr.write(img2);
+            img1.pixel(10,5).r = 43; // now modify original
+            checkTrue(img2.width()==img1.width() && img2.height()==img1.height(), "image size matches");
+            checkEqual(img2.pixel(10,5).r, 42, "pixel behavior is correct");
+            img2.resize(1,1);
+            // Now resend, checking that no memory is allocated
+            bbr.restart();
+            heapMonitorBegin(false);
+            img1.write(bbr);
+            heapMonitorEnd();
+            bbr.write(img2);
+            checkTrue(img2.width()==img1.width() && img2.height()==img1.height(), "image size still matches");
+
+            // Now send something completely different
+            Monster m1, m2;
+            m1.body.fromString("hello (1 (2 (3))) {1 2 3} [done]");
+            m1.head.head.body.resize(41,12);
+            m1.head.body.head.resize(17,63);
+            bbr.restart();
+            m1.write(bbr);
+            bbr.write(m2);
+            checkEqual(m2.body.get(0).asString(),"hello","tail matches");
+            // Now resend, checking that no memory is allocated
+            m2 = Monster();
+            bbr.restart();
+            heapMonitorBegin(false);
+            m1.write(bbr);
+            heapMonitorEnd();
+            bbr.write(m2);
+            checkEqual(m2.body.get(0).asString(),"hello","tail still matches");
+
+            // Now send something completely different
+            Stamp stamp1(42, 1.23), stamp2;
+            bbr.restart();
+            stamp1.write(bbr);
+            bbr.write(stamp2);
+            checkEqual(stamp1.getCount(),stamp2.getCount(),"stamp matches");
+            // Now resend, checking that no memory is allocated
+            stamp2 = Stamp();
+            bbr.restart();
+            heapMonitorBegin(false);
+            stamp1.write(bbr);
+            heapMonitorEnd();
+            bbr.write(stamp2);
+            checkEqual(stamp1.getCount(),stamp2.getCount(),"stamp still matches");
+
+            report(0,ConstString("pool size of ") + Bottle::toString(pool_sizes[i]) + " had " + Bottle::toString(bbr.bufferCount()) + " buffers");
+        }
+    }
+
     virtual void runTests() {
         testWrite();
+        testRestart();
     }
 };
 

--- a/src/libYARP_OS/include/yarp/os/ManagedBytes.h
+++ b/src/libYARP_OS/include/yarp/os/ManagedBytes.h
@@ -130,6 +130,15 @@ public:
 
     bool write(ConnectionWriter& writer);
 
+    /**
+     *
+     * @return true iff the managed data block is owned by this object
+     *
+     */
+    bool isOwner() const {
+        return owned;
+    }
+
 private:
     Bytes b;
     bool owned;

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -26,6 +26,7 @@
 #include <yarp/os/Mutex.h>
 
 #include <yarp/os/impl/PlatformVector.h>
+#include <yarp/os/impl/BufferedConnectionWriter.h>
 
 namespace yarp {
     namespace os {
@@ -114,7 +115,7 @@ public:
      * Constructor.
      */
     PortCore() : stateMutex(1), packetMutex(1), connectionChange(1),
-                 log("port",Logger::get()) {
+        log("port",Logger::get()), envelopeWriter(true) {
         // dormant phase
         listening = false;
         running = false;
@@ -528,6 +529,7 @@ private:
     yarp::os::Contactable *contactable;  ///< user-facing object that contains this PortCore
     yarp::os::Mutex *mutex; ///< callback optional access control lock
     bool mutexOwned;        ///< do we own the optional callback lock
+    BufferedConnectionWriter envelopeWriter; ///< storage area for envelope, if present
 
     void closeMain();
 

--- a/src/libYARP_OS/src/BufferedConnectionWriter.cpp
+++ b/src/libYARP_OS/src/BufferedConnectionWriter.cpp
@@ -10,6 +10,7 @@
 
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/Bottle.h>
+#include <yarp/os/DummyConnector.h>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -20,7 +21,7 @@ bool BufferedConnectionWriter::applyConvertTextMode() {
 
         Bottle b;
         StringOutputStream sos;
-        for (size_t i=0; i<lst.size(); i++) {
+        for (size_t i=0; i<lst_used; i++) {
             yarp::os::ManagedBytes& m = *(lst[i]);
             sos.write(m.usedBytes());
         }
@@ -30,6 +31,7 @@ bool BufferedConnectionWriter::applyConvertTextMode() {
         for (size_t i=0; i<lst.size(); i++) {
             delete lst[i];
         }
+        lst_used = 0;
         target = &lst;
         lst.clear();
         stopPool();
@@ -46,14 +48,127 @@ bool BufferedConnectionWriter::convertTextMode() {
     return true;
 }
 
-
-
-bool BufferedConnectionWriter::forceConvertTextMode() {
-    bool mode = textMode;
-    textMode = true;
-    convertTextMode();
-    textMode = mode;
-    return true;
+String BufferedConnectionWriter::toString() {
+    stopWrite();
+    size_t total_size = dataSize();
+    String output(total_size,0);
+    char *dest = (char *)output.c_str();
+    for (size_t i=0; i<header_used; i++) {
+        const char *data = header[i]->get();
+        size_t len = header[i]->used();
+        memmove(dest,data,len);
+        dest += len;
+    }
+    for (size_t i=0; i<lst_used; i++) {
+        const char *data = lst[i]->get();
+        size_t len = lst[i]->used();
+        memmove(dest,data,len);
+        dest += len;
+    }
+    return output;
 }
 
 
+bool BufferedConnectionWriter::addPool(const yarp::os::Bytes& data) {
+    if (pool!=NULL) {
+        if (data.length()+poolIndex>pool->length()) {
+            pool = NULL;
+        }
+    }
+    if (pool==NULL && data.length()<poolLength) {
+        bool add = false;
+        if (*target_used < target->size()) {
+            yarp::os::ManagedBytes*&bytes = (*target)[*target_used];
+            if (bytes->length()<poolLength) {
+                delete bytes;
+                bytes = new yarp::os::ManagedBytes(poolLength);
+            }
+            pool = bytes;
+            if (pool==NULL) { return false; }
+        } else {
+            pool = new yarp::os::ManagedBytes(poolLength);
+            if (pool==NULL) { return false; }
+            add = true;
+        }
+        (*target_used)++;
+        poolCount++;
+        poolIndex = 0;
+        if (poolLength<65536) {
+            poolLength *= 2;
+        }
+        pool->setUsed(0);
+        if (add) target->push_back(pool);
+    }
+    if (pool!=NULL) {
+        ACE_OS::memcpy(pool->get()+poolIndex,data.get(),data.length());
+        poolIndex += data.length();
+        pool->setUsed(poolIndex);
+        return true;
+    }
+    return false;
+}
+
+
+void BufferedConnectionWriter::push(const Bytes& data, bool copy) {
+    if (copy) {
+        if (addPool(data)) return;
+    }
+    yarp::os::ManagedBytes *buf = NULL;
+    if (*target_used < target->size()) {
+        yarp::os::ManagedBytes*&bytes = (*target)[*target_used];
+        if (bytes->isOwner()!=copy||bytes->length()<data.length()) {
+            delete bytes;
+            bytes = new yarp::os::ManagedBytes(data,false);
+            if (copy) bytes->copy();
+            (*target_used)++;
+            return;
+        }
+        buf = bytes;
+        bytes->setUsed(data.length());
+    } 
+    if (buf == NULL) {
+        buf = new yarp::os::ManagedBytes(data,false);
+        if (copy) buf->copy();
+        target->push_back(buf);
+    } else {
+        if (copy) {
+            buf->copy();
+            memmove(buf->get(),data.get(),data.length());
+        } else {
+            *buf = ManagedBytes(data,false);
+        }
+    }
+    (*target_used)++;
+}
+
+void BufferedConnectionWriter::restart() {
+    lst_used = 0;
+    header_used = 0;
+    reader = NULL;
+    ref = NULL;
+    convertTextModePending = false;
+    target = &lst;
+    target_used = &lst_used;
+    stopPool();
+}
+
+
+void BufferedConnectionWriter::write(OutputStream& os) {
+    stopWrite();
+    for (size_t i=0; i<header_used; i++) {
+        yarp::os::ManagedBytes& b = *(header[i]);
+        os.write(b.usedBytes());
+    }
+    for (size_t i=0; i<lst_used; i++) {
+        yarp::os::ManagedBytes& b = *(lst[i]);
+        os.write(b.usedBytes());
+    }
+}
+
+
+bool BufferedConnectionWriter::write(PortReader& obj) {
+    DummyConnector con;
+    con.setTextMode(isTextMode());
+    if (!write(con.getWriter())) return false;
+    return obj.read(con.getReader());
+}

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1414,10 +1414,10 @@ void PortCore::notifyCompletion(void *tracker) {
 
 
 bool PortCore::setEnvelope(PortWriter& envelope) {
-    BufferedConnectionWriter buf(true);
-    bool ok = envelope.write(buf);
+    envelopeWriter.restart();
+    bool ok = envelope.write(envelopeWriter);
     if (ok) {
-        setEnvelope(buf.toString());
+        setEnvelope(envelopeWriter.toString());
     }
     return ok;
 }


### PR DESCRIPTION
This eliminates one set of unnecessary memory allocations associated with sending envelope messages (e.g. timestamps), see #353. There's more to do for that issue, this is just one piece.  The PR also adds a bunch of documentation to the `BufferedConnectionWriter` class, since I needed to upgrade it a bit.