### PR TITLE
[swig] fix translation of Contactable::setEnvelope, fixes #372

### DIFF
--- a/bindings/tests/csharp/TestStamp.cs
+++ b/bindings/tests/csharp/TestStamp.cs
@@ -1,0 +1,25 @@
+using System;
+
+// Copyright: (C) 2015 iCub Facility
+// Author: Paul Fitzpatrick
+// CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ 
+// I don't really know C#, just bluffing from Java
+
+namespace HelloNameSpace
+{
+    public class TestStamp
+    {
+	static void Main(string[] args)
+	{
+	    Network.init();
+	    BufferedPortBottle p = new BufferedPortBottle();
+	    if (!p.open("/csharp")) System.Environment.Exit(1);
+	    Stamp ts = new Stamp(); 
+	    p.setEnvelope(ts);
+	    p.close();
+	    Network.fini();
+	}
+    }
+}
+

--- a/bindings/tests/csharp/run.sh
+++ b/bindings/tests/csharp/run.sh
@@ -16,6 +16,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "HELLO $CSLIB // $DIR"
 
 echo "We compile using gmcs, the Mono C# Compiler"
-rm -rf test_string.exe
-gmcs -out:test_string.exe $DIR/TestString.cs $CSLIB/*.cs
-./test_string.exe
+for f in TestString TestStamp; do
+    rm -rf $f.exe
+    gmcs -out:$f.exe $DIR/$f.cs $CSLIB/*.cs
+    ./$f.exe
+done

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -641,6 +641,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 	}
 }
 
+%extend yarp::os::Contactable {
+  bool setEnvelope(Portable& data) {
+    return self->setEnvelope(*((PortWriter*)(&data)));
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////
 // Deal with PolyDriver idiom that doesn't translate too well
 


### PR DESCRIPTION
This method expects a PortWriter. Users will typically pass a Portable
which is both a PortReader and a PortWriter. Swig has a tough time
translating multiple inheritance (for good reason), so translations
may not know that Portables are PortWriters (see #372 for example).
We can help out by explicitly accepting Portables.