### PR TITLE
[CMake] Add YARP_ADD_IDL Function

### DIFF
--- a/conf/YarpIDL.cmake
+++ b/conf/YarpIDL.cmake
@@ -1,5 +1,6 @@
-# Copyright: (C) 2012 IITRBCS
-# Authors: Elena Ceseracciu, Paul Fitzpatrick
+# Copyright (C)  2012 Robotics Brain and Cognitive Sciences, Istituto Italiano di Tecnologia
+# Copyright (C)  2014 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Elena Ceseracciu, Paul Fitzpatrick, Daniele E. Domenichelli
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 # yarp_idl_to_dir
@@ -12,10 +13,29 @@
 #   yarp_idl_to_dir(foo.thrift foo)
 #   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS)
 #   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS INCLUDE_PATHS)
+#
+#
+# yarp_add_idl
+# ------------
+#
+# Take one or more IDL files and generate code at build time.
+# Files will be regenerated whenever the IDL file changes.
+#
+#   yarp_add_idl(<var> <file> [file [...]])
+#
+# The <var> variable, will contain the generated files, and can be
+# added to the an add_executable or add_library call. For example:
+#
+#   set(THRIFT_FILES file1.thrift
+#                    file2.msg
+#                    file3.srv)
+#   yarp_add_idl(THRIFT_GEN_FILES ${THRIFT_FILES})
+#   add_executable(foo main.cpp ${THRIFT_GEN_FILES})
+
 
 
 # Avoid multiple inclusions of this file
-if(COMMAND yarp_idl_to_dir)
+if(COMMAND yarp_add_idl)
   return()
 endif()
 
@@ -140,4 +160,149 @@ function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
         list(GET out_vars 2 target_paths)
         set(${target_paths} ${output_dir} ${output_dir}/include PARENT_SCOPE)
     endif()
+endfunction()
+
+
+function(YARP_ADD_IDL var first_file)
+
+  # Ensure that the output variable is empty
+  unset(${var})
+  unset(include_dirs)
+
+  foreach(file ${first_file} ${ARGN})
+
+    # Ensure that the filename is relative to the current source directory
+    if (IS_ABSOLUTE ${file})
+      file(RELATIVE_PATH file ${CMAKE_CURRENT_SOURCE_DIR} ${file})
+    endif()
+
+    # Extract a name and extension.
+    get_filename_component(path ${file} PATH)
+    get_filename_component(basename ${file} NAME_WE)
+    get_filename_component(ext ${file} EXT)
+    string(TOLOWER ${ext} ext)
+
+    # Figure out format we are working with and determine which files
+    # will be generated
+    if("${ext}" STREQUAL ".thrift")
+      set(family thrift)
+      set(gen_srcs)
+      set(gen_hdrs)
+
+      # Read thrift file
+      file(READ ${file} file_content)
+
+      # Remove comments
+      string(REGEX REPLACE "/\\*[^*]?[^/]+\\*/" "" file_content ${file_content})
+      string(REGEX REPLACE "#[^\n]+" "" file_content ${file_content})
+      string(REGEX REPLACE "//[^\n]+" "" file_content ${file_content})
+
+      # Match "enum"s, "struct"s and "service"s defined in the file
+      string(REGEX MATCHALL "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" objects ${file_content})
+
+      # Find object name and append generated files
+      foreach(object ${objects})
+        string(REGEX MATCH "^(enum|struct|service)[ \t\n]+([^ \t\n{]+)" unused ${object})
+        set(objectname ${CMAKE_MATCH_2})
+        if(NOT "${object}" MATCHES "{[^}]+}[ \t\n]*(\\([^\\)]*yarp.name[^\\)]+\\))")
+          # No files are generated for YARP types.
+          list(APPEND gen_srcs ${objectname}.cpp)
+          list(APPEND gen_hdrs ${objectname}.h)
+        endif()
+      endforeach()
+
+      # Remove "enum"s, "struct"s and "service"s
+      string (REGEX REPLACE "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" "" file_content ${file_content})
+
+      # Find if at least one "const" or "typedef" is defined
+      if("${file_content}" MATCHES "(const|typedef)[ \t]+([^ \t\n]+)[ \t]*([^ \t\n]+)")
+        list(APPEND gen_hdrs ${basename}_common.h)
+      endif()
+
+    elseif("${ext}" MATCHES "^\\.(msg|srv)$")
+      set(family rosmsg)
+      set(gen_srcs )
+      set(gen_hdrs ${basename}.h)
+
+      if(NOT "${path}" STREQUAL "")
+        string(REGEX REPLACE "[^a-zA-Z0-9]" "_" clean_path ${path})
+        list(APPEND gen_hdrs ${clean_path}_${basename}.h)
+      endif()
+      if("${ext}" STREQUAL ".srv")
+        list(APPEND gen_hdrs ${basename}Reply.h)
+        if(NOT "${path}" STREQUAL "")
+          list(APPEND gen_hdrs ${clean_path}_${basename}Reply.h)
+        endif()
+      endif()
+
+    else()
+        message(FATAL_ERROR "Unknown extension ${ext}. Supported extensiona are .thrift, .msg, and .srv")
+    endif()
+
+    # Choose target depending on family and on whether we are building
+    # or using YARP
+    if(TARGET YARP::yarpidl_${family})
+        # Outside YARP
+        set(YARPIDL_${family}_COMMAND YARP::yarpidl_${family})
+    else()
+        # Building YARP
+        # FIXME CMake 2.8.12 Use ALIAS and always YARP::yarpidl_${family}
+        set(YARPIDL_${family}_COMMAND yarpidl_${family})
+    endif()
+
+    # Set intermediate output directory, remove extra '/' and ensure that
+    # the directory exists.
+    set(tmp_dir ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/yarpidl_${family}/${path})
+    string(REGEX REPLACE "/(/|$)" "\\1" tmp_dir "${tmp_dir}")
+    make_directory(${tmp_dir})
+
+    # Set output directories and remove extra "/"
+    set(srcs_out_dir ${CMAKE_CURRENT_BINARY_DIR}/src/${path})
+    set(hdrs_out_dir ${CMAKE_CURRENT_BINARY_DIR}/include/${path})
+    string(REGEX REPLACE "/(/|$)" "\\1" srcs_out_dir "${srcs_out_dir}")
+    string(REGEX REPLACE "/(/|$)" "\\1" hdrs_out_dir "${hdrs_out_dir}")
+
+
+    # Prepare main command
+    set(cmd ${YARPIDL_${family}_COMMAND} --out ${tmp_dir} --gen yarp:include_prefix --I ${CMAKE_CURRENT_SOURCE_DIR} ${file})
+
+    # Ensure that they are executed in the order they are added
+    # FIXME is this an issue?
+    set(extra_deps ${${var}})
+
+    # Prepare copy command and populate output variable
+    unset(output)
+    foreach(gen_file ${gen_srcs})
+      set(in "${tmp_dir}/${gen_file}")
+      set(out "${srcs_out_dir}/${gen_file}")
+      list(APPEND output "${out}")
+      list(APPEND cmd COMMAND ${CMAKE_COMMAND} -E copy "${in}" "${out}")
+    endforeach()
+    foreach(gen_file ${gen_hdrs})
+      set(in "${tmp_dir}/${gen_file}")
+      set(out "${hdrs_out_dir}/${gen_file}")
+      list(APPEND output "${out}")
+      list(APPEND cmd COMMAND ${CMAKE_COMMAND} -E copy "${in}" "${out}")
+    endforeach()
+
+    if(NOT "${output}" STREQUAL "")
+      add_custom_command(OUTPUT ${output}
+                         DEPENDS ${file}
+                                 ${extra_deps}
+                         COMMAND ${cmd}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                         COMMENT "Generating code from ${file}")
+
+      # Append output to return variable
+      list(APPEND ${var} ${output})
+
+      # Force CMake to run again if the file is modified
+      configure_file("${file}" "${tmp_dir}/${basename}${ext}" COPYONLY)
+    endif()
+
+  endforeach()
+
+  set(${var} ${${var}} PARENT_SCOPE)
+  include_directories("${CMAKE_CURRENT_BINARY_DIR}/include/")
+
 endfunction()

--- a/conf/YarpIDL.cmake
+++ b/conf/YarpIDL.cmake
@@ -39,7 +39,6 @@ if(COMMAND yarp_add_idl)
   return()
 endif()
 
-
 function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
     # Store optional output variable(s).
     set(out_vars ${ARGN})
@@ -163,17 +162,92 @@ function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
 endfunction()
 
 
+# Internal function.
+# Calculate a list of sources generated from a .thrift file
+function(_YARP_IDL_THRIFT_TO_FILE_LIST file path basename ext gen_srcs_var gen_hdrs_var)
+  set(gen_srcs)
+  set(gen_hdrs)
+
+  # Read thrift file
+  file(READ ${file} file_content)
+
+  # Remove comments
+  string(REGEX REPLACE "/\\*[^*]?[^/]+\\*/" "" file_content ${file_content})
+  string(REGEX REPLACE "#[^\n]+" "" file_content ${file_content})
+  string(REGEX REPLACE "//[^\n]+" "" file_content ${file_content})
+
+  # Match "enum"s, "struct"s and "service"s defined in the file
+  string(REGEX MATCHALL "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" objects ${file_content})
+
+  # Find object name and append generated files
+  foreach(object ${objects})
+    string(REGEX MATCH "^(enum|struct|service)[ \t\n]+([^ \t\n{]+)" unused ${object})
+    set(objectname ${CMAKE_MATCH_2})
+    if(NOT "${object}" MATCHES "{[^}]+}[ \t\n]*(\\([^\\)]*yarp.name[^\\)]+\\))")
+      # No files are generated for YARP types.
+      list(APPEND gen_srcs ${objectname}.cpp)
+      list(APPEND gen_hdrs ${objectname}.h)
+    endif()
+  endforeach()
+
+  # Remove "enum"s, "struct"s and "service"s
+  string (REGEX REPLACE "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" "" file_content ${file_content})
+
+  # Find if at least one "const" or "typedef" is defined
+  if("${file_content}" MATCHES "(const|typedef)[ \t]+([^ \t\n]+)[ \t]*([^ \t\n]+)")
+    list(APPEND gen_hdrs ${basename}_common.h)
+  endif()
+
+  set(${gen_srcs_var} ${gen_srcs} PARENT_SCOPE)
+  set(${gen_hdrs_var} ${gen_hdrs} PARENT_SCOPE)
+endfunction()
+
+
+# Internal function.
+# Calculate a list of sources generated from a .msg or a .srv file
+function(_YARP_IDL_ROSMSG_TO_FILE_LIST file path basename ext gen_srcs_var gen_hdrs_var)
+  set(gen_srcs )
+  set(gen_hdrs ${basename}.h)
+
+  get_filename_component(ext ${file} EXT)
+
+  if(NOT "${path}" STREQUAL "")
+    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" clean_path ${path})
+    list(APPEND gen_hdrs ${clean_path}_${basename}.h)
+  endif()
+  if("${ext}" STREQUAL ".srv")
+    list(APPEND gen_hdrs ${basename}Reply.h)
+    if(NOT "${path}" STREQUAL "")
+      list(APPEND gen_hdrs ${clean_path}_${basename}Reply.h)
+    endif()
+  endif()
+
+  # Read rosmsg file
+  file(READ ${file} file_content)
+
+  # Check if Header.h or TickTime.h will be created
+  if("${file_content}" MATCHES "(^|\n)Header[ \t]")
+    list(APPEND gen_hdrs Header.h TickTime.h)
+  elseif("${file_content}" MATCHES "(^|\n)time[ \t]")
+    list(APPEND gen_hdrs TickTime.h)
+  endif()
+
+  set(${gen_srcs_var} ${gen_srcs} PARENT_SCOPE)
+  set(${gen_hdrs_var} ${gen_hdrs} PARENT_SCOPE)
+endfunction()
+
+
 function(YARP_ADD_IDL var first_file)
 
   # Ensure that the output variable is empty
   unset(${var})
   unset(include_dirs)
 
-  foreach(file ${first_file} ${ARGN})
+  foreach(file "${first_file}" ${ARGN})
 
     # Ensure that the filename is relative to the current source directory
-    if (IS_ABSOLUTE ${file})
-      file(RELATIVE_PATH file ${CMAKE_CURRENT_SOURCE_DIR} ${file})
+    if (IS_ABSOLUTE "${file}")
+      file(RELATIVE_PATH file "${CMAKE_CURRENT_SOURCE_DIR}" "${file}")
     endif()
 
     # Extract a name and extension.
@@ -186,85 +260,41 @@ function(YARP_ADD_IDL var first_file)
     # will be generated
     if("${ext}" STREQUAL ".thrift")
       set(family thrift)
-      set(gen_srcs)
-      set(gen_hdrs)
-
-      # Read thrift file
-      file(READ ${file} file_content)
-
-      # Remove comments
-      string(REGEX REPLACE "/\\*[^*]?[^/]+\\*/" "" file_content ${file_content})
-      string(REGEX REPLACE "#[^\n]+" "" file_content ${file_content})
-      string(REGEX REPLACE "//[^\n]+" "" file_content ${file_content})
-
-      # Match "enum"s, "struct"s and "service"s defined in the file
-      string(REGEX MATCHALL "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" objects ${file_content})
-
-      # Find object name and append generated files
-      foreach(object ${objects})
-        string(REGEX MATCH "^(enum|struct|service)[ \t\n]+([^ \t\n{]+)" unused ${object})
-        set(objectname ${CMAKE_MATCH_2})
-        if(NOT "${object}" MATCHES "{[^}]+}[ \t\n]*(\\([^\\)]*yarp.name[^\\)]+\\))")
-          # No files are generated for YARP types.
-          list(APPEND gen_srcs ${objectname}.cpp)
-          list(APPEND gen_hdrs ${objectname}.h)
-        endif()
-      endforeach()
-
-      # Remove "enum"s, "struct"s and "service"s
-      string (REGEX REPLACE "(enum|struct|service)[ \t\n]+([^ \t\n]+)[ \t\n]*{[^}]+}([ \t\n]*\\([^\\)]+\\))?" "" file_content ${file_content})
-
-      # Find if at least one "const" or "typedef" is defined
-      if("${file_content}" MATCHES "(const|typedef)[ \t]+([^ \t\n]+)[ \t]*([^ \t\n]+)")
-        list(APPEND gen_hdrs ${basename}_common.h)
-      endif()
-
+      _yarp_idl_thrift_to_file_list("${file}" "${path}" "${basename}" ${ext} gen_srcs gen_hdrs)
     elseif("${ext}" MATCHES "^\\.(msg|srv)$")
       set(family rosmsg)
-      set(gen_srcs )
-      set(gen_hdrs ${basename}.h)
-
-      if(NOT "${path}" STREQUAL "")
-        string(REGEX REPLACE "[^a-zA-Z0-9]" "_" clean_path ${path})
-        list(APPEND gen_hdrs ${clean_path}_${basename}.h)
-      endif()
-      if("${ext}" STREQUAL ".srv")
-        list(APPEND gen_hdrs ${basename}Reply.h)
-        if(NOT "${path}" STREQUAL "")
-          list(APPEND gen_hdrs ${clean_path}_${basename}Reply.h)
-        endif()
-      endif()
-
+      _yarp_idl_rosmsg_to_file_list("${file}" "${path}" "${basename}" ${ext} gen_srcs gen_hdrs)
     else()
         message(FATAL_ERROR "Unknown extension ${ext}. Supported extensiona are .thrift, .msg, and .srv")
     endif()
 
+
     # Choose target depending on family and on whether we are building
     # or using YARP
+    # FIXME CMake 2.8.12 Use ALIAS and always YARP::yarpidl_${family}
     if(TARGET YARP::yarpidl_${family})
         # Outside YARP
         set(YARPIDL_${family}_COMMAND YARP::yarpidl_${family})
     else()
         # Building YARP
-        # FIXME CMake 2.8.12 Use ALIAS and always YARP::yarpidl_${family}
         set(YARPIDL_${family}_COMMAND yarpidl_${family})
     endif()
 
     # Set intermediate output directory, remove extra '/' and ensure that
     # the directory exists.
-    set(tmp_dir ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/yarpidl_${family}/${path})
+    set(tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/yarpidl_${family}/${path}")
     string(REGEX REPLACE "/(/|$)" "\\1" tmp_dir "${tmp_dir}")
     make_directory(${tmp_dir})
 
     # Set output directories and remove extra "/"
-    set(srcs_out_dir ${CMAKE_CURRENT_BINARY_DIR}/src/${path})
-    set(hdrs_out_dir ${CMAKE_CURRENT_BINARY_DIR}/include/${path})
+    set(srcs_out_dir "${CMAKE_CURRENT_BINARY_DIR}/src/${path}")
+    set(hdrs_out_dir "${CMAKE_CURRENT_BINARY_DIR}/include/${path}")
     string(REGEX REPLACE "/(/|$)" "\\1" srcs_out_dir "${srcs_out_dir}")
     string(REGEX REPLACE "/(/|$)" "\\1" hdrs_out_dir "${hdrs_out_dir}")
 
 
     # Prepare main command
-    set(cmd ${YARPIDL_${family}_COMMAND} --out ${tmp_dir} --gen yarp:include_prefix --I ${CMAKE_CURRENT_SOURCE_DIR} ${file})
+    set(cmd ${YARPIDL_${family}_COMMAND} --out "${tmp_dir}" --gen yarp:include_prefix --I "${CMAKE_CURRENT_SOURCE_DIR}" "${file}")
 
     # Ensure that they are executed in the order they are added
     # FIXME is this an issue?

--- a/src/idls/rosmsg/tests/demo/CMakeLists.txt
+++ b/src/idls/rosmsg/tests/demo/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(YARP REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 include(YarpIDL)
 
+# Test using yarp_idl_to_dir
 set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}/bits")
 yarp_idl_to_dir(SharedData.msg ${generated_libs_dir} S1 H1)
 yarp_idl_to_dir(Demo.msg ${generated_libs_dir} S2 H2)
@@ -25,4 +26,19 @@ target_link_libraries(demo_test ${YARP_LIBRARIES})
 
 add_test(demo_basic demo_test --help)
 
+
+# Test using yarp_add_idl
+set(IDL_FILES SharedData.msg
+              Demo.msg
+              Tennis.srv
+              Rpc.srv
+              HeaderTest.msg
+              HeaderTest2.srv)
+yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
+
+include_directories(${YARP_INCLUDE_DIRS})
+add_executable(demo_test2 main.cpp ${IDL_GEN_FILES})
+target_link_libraries(demo_test2 ${YARP_LIBRARIES})
+
+add_test(demo_basic2 demo_test2 --help)
 

--- a/src/idls/thrift/tests/demo/CMakeLists.txt
+++ b/src/idls/thrift/tests/demo/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(YARP REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 include(YarpIDL)
 
+# Test using yarp_idl_to_dir
 set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}")
 yarp_idl_to_dir(demo.thrift ${generated_libs_dir} S1 H1 I1)
 yarp_idl_to_dir(namespaced.thrift ${generated_libs_dir} S2 H2 I2)
@@ -26,3 +27,16 @@ target_link_libraries(demo_test ${YARP_LIBRARIES})
 add_test(demo_basic demo_test)
 
 
+# Test using yarp_add_idl
+set(IDL_FILES demo.thrift
+              namespaced.thrift
+              objects3D.thrift
+              wrapping.thrift
+              sub/directory/clock_rpc.thrift
+              settings.thrift)
+yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
+include_directories(${YARP_INCLUDE_DIRS})
+add_executable(demo_test2 main.cpp ${IDL_GEN_FILES})
+target_link_libraries(demo_test2 ${YARP_LIBRARIES})
+
+add_test(demo_basic2 demo_test2)


### PR DESCRIPTION
Add a new ``YARP_ADD_IDL`` function that takes one or more IDL files and generate code at build time.
Files will be regenerated whenever the IDL file changes.

```cmake
yarp_add_idl(<var> <file> [file [...]])
```

The ``<var>`` variable, will contain the generated files, and can be added to the an ``add_executable`` or ``add_library call``. For example:

```cmake
set(THRIFT_FILES file1.thrift
                 file2.msg
                 file3.srv)
yarp_add_idl(THRIFT_GEN_FILES ${THRIFT_FILES})
add_executable(foo main.cpp ${THRIFT_GEN_FILES})
```