### PR TITLE
Pack macros

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -327,6 +327,10 @@ namespace yarp {
 	%enddef
 	#endif
 
+%define YARP_BEGIN_PACK
+%enddef
+%define YARP_END_PACK
+%enddef
 %define PACKED_FOR_NET 
 %enddef
 

--- a/conf/template/yarp_config_system.h.in
+++ b/conf/template/yarp_config_system.h.in
@@ -1,9 +1,10 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright: (C) 2009 RobotCub Consortium
+ * Copyright: (C) 2006-2009 RobotCub Consortium
  *            (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
  * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
+ *          Giorgio Metta <giorgio.metta@iit.it>
  *          Daniele E. Domenichelli <daniele.domenichelli@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
@@ -129,6 +130,97 @@
 #else
   #define YARP_COMPILER_DEPRECATED_WARNING(x)
 #endif
+
+
+///@{
+
+/**
+ * \def YARP_BEGIN_PACK
+ *
+ * Starts 1 byte packing for structs/classes.
+ *
+ * Instructs the compiler that the following structure/class has to be
+ * packed with 1 byte boundary.  This is conditionally generated depending
+ * on the compiler and architecture. It assures interoperability of network
+ * communication between compilers.
+ *
+ * \see \ref port_expert_data, YARP_END_PACK
+ */
+
+/**
+ * \def YARP_END_PACK
+ *
+ * Ends 1 byte packing for structs/classes.
+ *
+ * Instructs the compiler that the default packing can be reinstated.
+ *
+ * \see \ref port_expert_data YARP_BEGIN_PACK
+ */
+
+/**
+ * \def PACKED_FOR_NET
+ *
+ * FIXME Add documentation.
+ *
+ * \see \ref port_expert_data
+ */
+
+///@}
+
+
+#if defined(CYGWIN)
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+#  define YARP_END_PACK \
+     _Pragma("pack()")
+#elif defined(_MSC_VER)
+// use packing and make no apologies about it
+#  define YARP_BEGIN_PACK \
+     __pragma(warning(push)) \
+     __pragma(warning(disable:4103)) \
+     __pragma(pack(push, 1))
+#  define YARP_END_PACK \
+     __pragma(pack(pop)) \
+     __pragma(warning(pop))
+#elif defined(__linux__)
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+#  define YARP_END_PACK _Pragma("pack()")
+#elif defined(__DARWIN__)
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+#  define YARP_END_PACK \
+     _Pragma("pack()")
+#elif defined(__APPLE__)
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+#  define YARP_END_PACK \
+     _Pragma("pack()")
+#elif defined(__QNX4__)
+#  define YARP_BEGIN_PACK \
+     _Pragma(" pack (push) ;") \
+     _Pragma(" pack (1) ;")
+#  define YARP_END_PACK \
+     _Pragma(" pack (pop) ;")
+#elif defined(__QNX6__)
+//_Pragma("align 1")
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+//_Pragma("align 0")
+#  define YARP_END_PACK \
+     _Pragma("pack()")
+#else
+//#warning "Platform not known, guessing, please update "
+#  define YARP_BEGIN_PACK \
+     _Pragma("pack(1)")
+#  define YARP_END_PACK \
+     _Pragma("pack()")
+#endif
+
+#ifndef PACKED_FOR_NET
+#  define PACKED_FOR_NET
+#endif
+
 
 
 #endif

--- a/conf/template/yarp_config_system.h.in
+++ b/conf/template/yarp_config_system.h.in
@@ -2,7 +2,9 @@
 
 /*
  * Copyright: (C) 2009 RobotCub Consortium
- * Author: Paul Fitzpatrick
+ *            (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
+ *          Daniele E. Domenichelli <daniele.domenichelli@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -33,5 +35,100 @@
 #cmakedefine YARP_HAS_EXECINFO
 
 #define YARP_POINTER_SIZE ${YARP_POINTER_SIZE}
+
+
+///@{
+
+/**
+ * \def YARP_COMPILER_MESSAGE
+ *
+ * Print a message at build time on supported compilers.
+ *
+ * For example:
+ * \code{.c}
+ * YARP_COMPILER_MESSAGE(This is a custom compiler message)
+ * \endcode
+ * will print "This is a custom compiler message".
+ *
+ * \param x Message.
+ *
+ * \see YARP_COMPILER_WARNING, YARP_COMPILER_ERROR, YARP_COMPILER_DEPRECATED_WARNING
+ */
+
+/**
+ * \def YARP_COMPILER_WARNING
+ *
+ * Generate a warning at build time on supported compilers.
+ *
+ * For example:
+ * \code{.c}
+ * YARP_COMPILER_WARNING(This is a custom compiler warning)
+ * \endcode
+ * will generate a warning "This is a custom compiler warning"
+ *
+ * \param x Warning message.
+ *
+ * \see YARP_COMPILER_MESSAGE, YARP_COMPILER_ERROR, YARP_COMPILER_DEPRECATED_WARNING
+ *
+ */
+
+/**
+ * \def YARP_COMPILER_ERROR
+ *
+ * Generate an error at build time on supported compilers.
+ *
+ * For example:
+ * \code{.c}
+ * YARP_COMPILER_ERROR(This is a custom compiler error)
+ * \endcode
+ * will generate an error "This is a custom compiler error".
+ *
+ * \param x Error message.
+ *
+ * \see YARP_COMPILER_MESSAGE, YARP_COMPILER_WARNING, YARP_COMPILER_DEPRECATED_WARNING
+ */
+
+/**
+ * \def YARP_COMPILER_DEPRECATED_WARNING
+ *
+ * Generate a warning at build time on supported compilers if deprecated
+ * warnings are enabled.
+ *
+ * This can be useful for example to deprecate a header file.
+ *
+ * \param x Deprecation message.
+ *
+ * \see YARP_COMPILER_MESSAGE, YARP_COMPILER_WARNING, YARP_COMPILER_ERROR
+ */
+
+///@}
+
+
+#if defined(_MSC_VER)
+  // see https://support.microsoft.com/kb/155196/en-us
+  #define __YARP_STR2(x) #x
+  #define __YARP_STR1(x) __YARP_STR2(x)
+  #define __YARP_LOC __FILE__ "("__STR1__(__LINE__)")"
+  #define YARP_COMPILER_MESSAGE(x) __pragma(message(__LOC__ " : msg" #x)
+  #define YARP_COMPILER_WARNING(x) __pragma(message(__LOC__ " : warning msg" #x)
+  #define YARP_COMPILER_ERROR(x)  __pragma(message(__LOC__ " : error msg" #x)
+#elif defined(__GNUC__)
+  // see https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html
+  #define __YARP_DO_PRAGMA(x) _Pragma (#x)
+  #define YARP_COMPILER_MESSAGE(x) __YARP_DO_PRAGMA(message #x)
+  #define YARP_COMPILER_WARNING(x) __YARP_DO_PRAGMA(GCC warning #x)
+  #define YARP_COMPILER_ERROR(x)  __YARP_DO_PRAGMA(GCC error #x)
+#else
+  #define YARP_COMPILER_MESSAGE(x)
+  #define YARP_COMPILER_WARNING(x)
+  #define YARP_COMPILER_ERROR(x)
+#endif
+
+#ifndef YARP_NO_DEPRECATED_WARNINGS
+  #define YARP_COMPILER_DEPRECATED_WARNING(x) YARP_COMPILER_WARNING(x)
+#else
+  #define YARP_COMPILER_DEPRECATED_WARNING(x)
+#endif
+
 
 #endif

--- a/doc/port_expert.dox
+++ b/doc/port_expert.dox
@@ -301,13 +301,14 @@ may add different amounts of "padding" into your structure
 
 If you define your data-structure as follows:
 \code
-#include <yarp/os/begin_pack_for_net.h>
+#include <yarp/conf/system.h>
+YARP_BEGIN_PACK
 class Target {
 public:
   NetInt32 x;
   NetInt32 y;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 \endcode
 Then you'll be in better shape.  The integers now have a well defined
 representation, and the compiler is requested not to introduce padding.
@@ -316,8 +317,9 @@ So this is a portable representation.
 Even better, for YARP, is to add in a small "header" that describes
 your data-type.  If you defined Target as follows:
 \code
+#include <yarp/conf/system.h>
 #include <yarp/os/Bottle.h>
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class Target {
 public:
     NetInt32 tag;
@@ -329,7 +331,7 @@ public:
         len = 2;
     }
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 \endcode
 
 Then suddenly ports carrying this data become a lot easy to

--- a/example/port_power/TargetVer1.h
+++ b/example/port_power/TargetVer1.h
@@ -9,12 +9,14 @@
 #ifndef TARGETVER1_INC
 #define TARGETVER1_INC
 
-#include <yarp/os/begin_pack_for_net.h>
+#include <yarp/conf/system.h>
+
+YARP_BEGIN_PACK
 class Target {
 public:
     NetInt32 x;
     NetInt32 y;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 #endif

--- a/example/port_power/TargetVer1b.h
+++ b/example/port_power/TargetVer1b.h
@@ -9,9 +9,10 @@
 #ifndef TARGETVER1B_INC
 #define TARGETVER1B_INC
 
+#include <yarp/conf/system.h>
 #include <yarp/os/Bottle.h>
 
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class Target {
 public:
     Target() {
@@ -24,6 +25,6 @@ public:
     NetInt32 x;
     NetInt32 y;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 #endif

--- a/src/carriers/wire_rep_utils/BlobNetworkHeader.h
+++ b/src/carriers/wire_rep_utils/BlobNetworkHeader.h
@@ -10,11 +10,12 @@
 #ifndef BLOBHEADER_INC
 #define BLOBHEADER_INC
 
+#include <yarp/conf/system.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetInt32.h>
 
 // translate to blobs for now; better translation requires type system
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class BlobNetworkHeader {
 public:
     yarp::os::NetInt32 listTag;
@@ -29,6 +30,6 @@ public:
     }
 
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 #endif

--- a/src/carriers/wire_rep_utils/WireImage.h
+++ b/src/carriers/wire_rep_utils/WireImage.h
@@ -10,6 +10,7 @@
 #ifndef YARP2_WIREIMAGE
 #define YARP2_WIREIMAGE
 
+#include <yarp/conf/system.h>
 #include <yarp/os/SizedWriter.h>
 #include <yarp/os/StringOutputStream.h>
 #include <yarp/os/ConnectionWriter.h>
@@ -34,14 +35,14 @@
     // uint8[] data      --> real payload
     */
 
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class RosImageStamp {
 public:
     yarp::os::NetInt32 seq;
     yarp::os::NetInt32 sec;
     yarp::os::NetInt32 nsec;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 /**
  *

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -8,7 +8,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/AbstractContactable.h
                  include/yarp/os/all.h
                  include/yarp/os/api.h
-                 include/yarp/os/begin_pack_for_net.h
                  include/yarp/os/BinPortable.h
                  include/yarp/os/Bottle.h
                  include/yarp/os/BufferedPort.h
@@ -26,7 +25,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/ContactStyle.h
                  include/yarp/os/DummyConnector.h
                  include/yarp/os/Election.h
-                 include/yarp/os/end_pack_for_net.h
                  include/yarp/os/Event.h
                  include/yarp/os/Face.h
                  include/yarp/os/IConfig.h
@@ -117,6 +115,11 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/YarpPlugin.h
                  include/yarp/os/YarpPluginSelector.h
                  include/yarp/os/YarpPluginSettings.h)
+
+if(NOT YARP_NO_DEPRECATED)
+  list(APPEND YARP_OS_HDRS include/yarp/os/begin_pack_for_net.h
+                           include/yarp/os/end_pack_for_net.h)
+endif()
 
 set(YARP_OS_IDL_HDRS include/yarp/os/idl/BareStyle.h
                      include/yarp/os/idl/BottleStyle.h

--- a/src/libYARP_OS/harness/BinPortableTest.cpp
+++ b/src/libYARP_OS/harness/BinPortableTest.cpp
@@ -7,6 +7,8 @@
  *
  */
 
+#include <yarp/conf/system.h>
+
 #include <yarp/os/BinPortable.h>
 #include <yarp/os/PortReaderBuffer.h>
 #include <yarp/os/Port.h>
@@ -24,7 +26,7 @@ using namespace yarp::os::impl;
 using namespace yarp::os;
 
 
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class BinPortableTarget {
 public:
     BinPortableTarget() {
@@ -37,7 +39,7 @@ public:
     NetInt32 x;
     NetInt32 y;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 
 class BinPortableTest : public UnitTest {

--- a/src/libYARP_OS/include/yarp/os/SharedLibraryClassApi.h
+++ b/src/libYARP_OS/include/yarp/os/SharedLibraryClassApi.h
@@ -25,7 +25,6 @@ namespace yarp {
 // to compile those DLLs and your own code.
 
 #define YARP_SHAREDLIBRARYCLASSAPI_PADDING (30-2*(YARP_POINTER_SIZE/4))
-#include <yarp/os/begin_pack_for_net.h>
 extern "C" {
 
     /**
@@ -35,6 +34,7 @@ extern "C" {
      * using create() or destroy().
      *
      */
+    YARP_BEGIN_PACK
     struct yarp::os::SharedLibraryClassApi {
     public:
         NetInt32 startCheck;    // Constant: this should be 'Y' 'A' 'R' 'P'.
@@ -53,8 +53,8 @@ extern "C" {
         NetInt32 roomToGrow[YARP_SHAREDLIBRARYCLASSAPI_PADDING]; // Padding.
         NetInt32 endCheck;      // Constant: should be 'P' 'L' 'U' 'G'.
     };
+    YARP_END_PACK
 }
-#include <yarp/os/end_pack_for_net.h>
 
 #define YARP_SHARED_CLASS_FN extern "C" YARP_EXPORT
 

--- a/src/libYARP_OS/include/yarp/os/begin_pack_for_net.h
+++ b/src/libYARP_OS/include/yarp/os/begin_pack_for_net.h
@@ -1,113 +1,12 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
-
-
 /*
  * Copyright (C) 2006 RobotCub Consortium
- * Authors: Paul Fitzpatrick, Giorgio Metta
+ * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
+ *          Giorgio Metta <giorgio.metta@iit.it>
+ *          Daniele E. Domenichelli <daniele.domenichelli@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-///
-/// $Id: begin_pack_for_net.h,v 1.7 2007-11-26 16:31:25 eshuy Exp $
-///
+#include <yarp/conf/system.h>
 
-/**
- * \file begin_pack_for_net.h Starts 1 byte packing for structs/classes.
- * Instructs the compiler that the following structure/class has to be
- * packed with 1 byte boundary.  This is conditionally generated depending
- * on the compiler and architecture. It assures interoperability of network
- * communication between compilers.
- * @see end_pack_for_net.h
- */
-
-#ifdef CYGWIN
-#ifndef YARP2_CYGWIN
-#define YARP2_CYGWIN
-#endif
-#endif
-
-#ifdef WIN32
-#ifndef YARP2_WINDOWS
-#define YARP2_WINDOWS
-#endif
-#endif
-
-#ifdef _WIN32
-#ifndef YARP2_WINDOWS
-#define YARP2_WINDOWS
-#endif
-#endif
-
-#ifdef __WIN__
-#ifndef YARP2_WINDOWS
-#define YARP2_WINDOWS
-#endif
-#endif
-
-#ifdef __WINDOWS__
-#ifndef YARP2_WINDOWS
-#define YARP2_WINDOWS
-#endif
-#endif
-
-#ifdef WINDOWS
-#ifndef YARP2_WINDOWS
-#define YARP2_WINDOWS
-#endif
-#endif
-
-
-#ifdef YARP2_CYGWIN
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#else
-#ifdef YARP2_WINDOWS
-// use packing and make no apologies about it
-#pragma warning (disable:4103)
-#pragma pack(push, 1)
-#define YARP_PACKING_CONSIDERED
-#endif
-#endif
-
-#ifdef __linux__
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#else
-#ifdef __linux__
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#endif
-#endif
-
-#ifdef __DARWIN__
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#endif
-
-#ifdef __APPLE__
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#endif
-
-#ifdef __QNX4__
-#pragma  pack (push) ;
-#pragma  pack (1) ;
-#define YARP_PACKING_CONSIDERED
-#endif
-
-#ifdef __QNX6__
-///#pragma  align 1
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#endif
-
-#ifndef YARP_PACKING_CONSIDERED
-//#warning "Platform not known, guessing, please update begin_pack_for_net.h"
-#pragma pack(1)
-#define YARP_PACKING_CONSIDERED
-#endif
-
-#ifndef PACKED_FOR_NET
-#define PACKED_FOR_NET
-#endif
+YARP_COMPILER_DEPRECATED_WARNING(begin_pack_for_net.h is deprecated. Use YARP_BEGIN_PACK/YARP_END_PACK instead)
+YARP_BEGIN_PACK

--- a/src/libYARP_OS/include/yarp/os/end_pack_for_net.h
+++ b/src/libYARP_OS/include/yarp/os/end_pack_for_net.h
@@ -1,66 +1,12 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
-
 /*
  * Copyright (C) 2006 RobotCub Consortium
- * Authors: Paul Fitzpatrick, Giorgio Metta
+ * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
+ *          Giorgio Metta <giorgio.metta@iit.it>
+ *          Daniele E. Domenichelli <daniele.domenichelli@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-///
-/// $Id: end_pack_for_net.h,v 1.7 2007-02-02 15:45:20 eshuy Exp $
-///
-///
+#include <yarp/conf/system.h>
 
-/**
- * \file yarp/os/end_pack_for_net.h Ends 1 byte packing for structs/classes.
- * Instructs the compiler that the default packing can be reinstated.
- * @see yarp/os/begin_pack_for_net.h
- */
-
-#ifdef YARP2_CYGWIN
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#else
-#ifdef YARP2_WINDOWS
-#pragma pack(pop)
-#define YARP_UNPACKING_CONSIDERED
-#endif
-#endif
-
-#ifdef __linux__
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifdef __linux__
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifdef __DARWIN__
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifdef __APPLE__
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifdef __QNX4__
-#pragma  pack (pop) ;
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifdef __QNX6__
-///#pragma align 0
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
-
-#ifndef YARP_UNPACKING_CONSIDERED
-//#warning "Platform not known, guessing, please update end_pack_for_net.h"
-#pragma pack()
-#define YARP_UNPACKING_CONSIDERED
-#endif
+YARP_COMPILER_DEPRECATED_WARNING(end_pack_for_net.h is deprecated. Use YARP_BEGIN_PACK/YARP_END_PACK instead)
+YARP_END_PACK

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -10,6 +10,7 @@
 #ifndef _YARP2_IMAGE_
 #define _YARP2_IMAGE_
 
+#include <yarp/conf/system.h>
 #include <yarp/os/Portable.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/NetUint16.h>
@@ -382,7 +383,7 @@ enum YarpVocabPixelTypesEnum
     };
 
 
-#include <yarp/os/begin_pack_for_net.h>
+
 
 #include <yarp/os/NetInt32.h>
 
@@ -407,6 +408,7 @@ namespace yarp {
         /**
          * Packed RGB pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgb
         {
             unsigned char r,g,b;
@@ -415,10 +417,12 @@ namespace yarp {
             PixelRgb(unsigned char n_r, unsigned char n_g, unsigned char n_b)
             { r = n_r;  g = n_g;  b = n_b; }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Packed RGBA pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgba
         {
             unsigned char r,g,b,a;
@@ -428,10 +432,12 @@ namespace yarp {
                       unsigned char n_b, unsigned char n_a)
             { r = n_r;  g = n_g;  b = n_b; a = n_a; }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Packed BGRA pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelBgra
         {
             unsigned char b,g,r,a;
@@ -441,10 +447,12 @@ namespace yarp {
                       unsigned char n_b, unsigned char n_a)
             { r = n_r;  g = n_g;  b = n_b; a = n_a; }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Packed RGB pixel type, with pixels stored in reverse order.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelBgr
         {
             unsigned char b,g,r;
@@ -452,13 +460,16 @@ namespace yarp {
             PixelBgr(unsigned char n_r, unsigned char n_g, unsigned char n_b)
             { r = n_r;  g = n_g;  b = n_b; }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Packed HSV (hue/saturation/value pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelHsv {
             unsigned char h,s,v;
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Signed byte pixel type.
@@ -468,9 +479,11 @@ namespace yarp {
         /**
          * Signed, packed RGB pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgbSigned {
             char r,g,b;
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Floating point pixel type.
@@ -480,16 +493,19 @@ namespace yarp {
         /**
          * Floating point RGB pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgbFloat {
             float r,g,b;
             PixelRgbFloat() { r = g = b = 0; }
             PixelRgbFloat(float n_r, float n_g, float n_b)
             { r = n_r;  g = n_g;  b = n_b; }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Integer RGB pixel type.
          */
+        YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgbInt {
             yarp::os::NetInt32 r,g,b;
             PixelRgbInt() { r = g = b = 0; }
@@ -497,15 +513,16 @@ namespace yarp {
                 r = n_r; g = n_g; b = n_b;
             }
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        YARP_END_PACK
 
         /**
          * Floating point HSV pixel type.
          */
+        YARP_BEGIN_PACK
         struct PixelHsvFloat {
             float h,s,v;
         } /** \cond */ PACKED_FOR_NET /** \endcond */;
-
-#include <yarp/os/end_pack_for_net.h>
+        YARP_END_PACK
 
     }
 }

--- a/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
@@ -10,6 +10,8 @@
 #ifndef _YARP2_IMAGENETWORKHEADER_
 #define _YARP2_IMAGENETWORKHEADER_
 
+#include <yarp/conf/system.h>
+
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Bottle.h>
 
@@ -26,7 +28,7 @@ namespace yarp {
  * Byte order in image header for network transmission.
  *
  */
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class yarp::sig::ImageNetworkHeader
 {
 public:
@@ -66,6 +68,6 @@ public:
     }
 
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 #endif

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -6,9 +6,11 @@
 * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 */
 
-// $Id: Matrix.cpp,v 1.20 2009-05-12 16:02:29 eshuy Exp $ 
-#include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
+
+#include <yarp/conf/system.h>
+
+#include <yarp/sig/Vector.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/NetFloat64.h>
@@ -26,8 +28,7 @@ using namespace yarp::os;
 #define RES(v) ((PlatformVector<T> *)v)
 #define RES_ITERATOR(v) ((PLATFORM_VECTOR_ITERATOR(double) *)v)
 
-#include <yarp/os/begin_pack_for_net.h>
-
+YARP_BEGIN_PACK
 class MatrixPortContentHeader
 {
 public:
@@ -40,8 +41,7 @@ public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
 } PACKED_FOR_NET;
-
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 /// network stuff
 #include <yarp/os/NetInt32.h>

--- a/src/libYARP_sig/src/SoundFile.cpp
+++ b/src/libYARP_sig/src/SoundFile.cpp
@@ -7,12 +7,16 @@
  *
  */
 
-#include <yarp/sig/Sound.h>
 #include <yarp/sig/SoundFile.h>
+
+#include <yarp/conf/system.h>
+
 #include <yarp/os/NetInt16.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/Vocab.h>
+
+#include <yarp/sig/Sound.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -21,7 +25,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 using namespace yarp::sig::file;
 
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class PcmWavHeader {
 public:
     NetInt32 wavHeader;
@@ -50,7 +54,7 @@ public:
     void setup_to_write(const Sound& sound, FILE *fp);
     bool parse_from_file(FILE *fp);
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 bool PcmWavHeader::parse_from_file(FILE *fp)
 {

--- a/src/libYARP_sig/src/Vector.cpp
+++ b/src/libYARP_sig/src/Vector.cpp
@@ -6,8 +6,10 @@
 * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 */
 
-// $Id: Vector.cpp,v 1.28 2009-06-15 17:47:37 eshuy Exp $
 #include <yarp/sig/Vector.h>
+
+#include <yarp/conf/system.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/NetFloat64.h>
@@ -16,6 +18,8 @@
 #include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/Logger.h>
+
+#include <yarp/sig/Matrix.h>
 
 using namespace yarp::sig;
 using namespace yarp::os;
@@ -30,14 +34,14 @@ using namespace yarp::os;
 
 ///////////////////
 
-#include <yarp/os/begin_pack_for_net.h>
+YARP_BEGIN_PACK
 class VectorPortContentHeader
 {
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
 } PACKED_FOR_NET;
-#include <yarp/os/end_pack_for_net.h>
+YARP_END_PACK
 
 bool VectorBase::read(yarp::os::ConnectionReader& connection) {
     // auto-convert text mode interaction


### PR DESCRIPTION
Using headers for packing the structures is risky since headers might end up being moved away from the structure.
This patch replaces the ``begin_pack_for_net.h`` and ``end_pack_from_net.h`` headers with two macros: ``YARP_BEGIN_PACK`` and ``YARP_END_PACK``.

The first commit adds some macro to generate portable errors and warnings at build time, this is here because I needed it in order to cause a deprecated warning when ``begin_pack_for_net.h`` and ``end_pack_from_net.h`` are used, but since I think it is an useful feature, therefore I made it "public"

I'm not sure if ``yarp/conf/system.h`` is the right place for these things, though, @paulfitz what do you think?