### PR TITLE
Added a setNameServerContact 

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Contact.h
+++ b/src/libYARP_OS/include/yarp/os/Contact.h
@@ -81,6 +81,14 @@ public:
     Contact addHost(const ConstString& host) const;
 
     /**
+     * Returns a new Contact with the previous information plus the updated
+     * port number
+     * @param portnumber port number
+     * @return a new contact the the port number updated
+     */
+    Contact addPort(int portnumber) const;
+
+    /**
      * Constructor for a socket contact.
      * Creates an unnamed contact, with information about
      * how to reach it using socket communication.
@@ -231,6 +239,19 @@ public:
     float getTimeout() const;
 
     ConstString getRegName() const;
+
+    /**
+     * Set the host to be the input parameter
+     * @param the new host
+     */
+    void setHost(const ConstString& host);
+
+    /**
+     * Set the port to be the input parameter
+     * @param the new port
+     */
+    void setPort(int port);
+
 
 private:
     ConstString regName;

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -530,6 +530,14 @@ public:
                                     bool& scanNeeded,
                                     bool& serverUsed);
 
+    /** 
+     * Set explicitly the nameserver information 
+     *
+     * @param nameServerContact the NameServer contact information (e.g. IP, port)
+     * @return true if succeed. False otherwise
+     */
+    static bool setNameServerContact(Contact &nameServerContact);
+
     /**
      *
      * Search for a configuration file in YARP's standard config

--- a/src/libYARP_OS/src/Contact.cpp
+++ b/src/libYARP_OS/src/Contact.cpp
@@ -100,8 +100,13 @@ Contact Contact::addHost(const ConstString& host) const {
     return result;
 }
 
+Contact Contact::addPort(int portnumber) const {
+    Contact result(*this);
+    result.port = portnumber;
+    return result;
+}
 
-Contact Contact::bySocket(const ConstString& carrier, 
+Contact Contact::bySocket(const ConstString& carrier,
                           const ConstString& machineName,
                           int portNumber) {
     Contact result;
@@ -328,6 +333,15 @@ void Contact::setTimeout(float timeout) {
 void Contact::setNested(const yarp::os::NestedContact& flavor) {
     this->flavor = flavor;
 }
+
+void Contact::setHost(const ConstString& host) {
+    this->hostName = host;
+}
+
+void Contact::setPort(int port) {
+    this->port = port;
+}
+
 
 float Contact::getTimeout() const {
     return timeout;

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -1237,10 +1237,9 @@ Contact NetworkBase::detectNameServer(bool useDetectedServer,
 bool NetworkBase::setNameServerContact(Contact &nameServerContact)
 {
     NameConfig nameConfig;
+    nameConfig.fromFile();
     nameConfig.setAddress(nameServerContact);
-    String configFileName = nameConfig.getConfigFileName(YARP_CONFIG_NAMESPACE_FILENAME);
-    nameConfig.writeConfig(configFileName, getNameServerName() + "\n");
-    return true;
+    return nameConfig.toFile();
 }
 
 

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -1234,6 +1234,15 @@ Contact NetworkBase::detectNameServer(bool useDetectedServer,
                                            serverUsed);
 }
 
+bool NetworkBase::setNameServerContact(Contact &nameServerContact)
+{
+    NameConfig nameConfig;
+    nameConfig.setAddress(nameServerContact);
+    String configFileName = nameConfig.getConfigFileName(YARP_CONFIG_NAMESPACE_FILENAME);
+    nameConfig.writeConfig(configFileName, getNameServerName() + "\n");
+    return true;
+}
+
 
 bool NetworkBase::writeToNameServer(PortWriter& cmd,
                                     PortReader& reply,


### PR DESCRIPTION
It is now possible to explicitly set the server address without using the detect method.

This addresses https://github.com/robotology/yarp/issues/394