### PR TITLE
Remove useless PACKED_FOR_NET macro

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -331,8 +331,6 @@ namespace yarp {
 %enddef
 %define YARP_END_PACK
 %enddef
-%define PACKED_FOR_NET 
-%enddef
 
 #if defined( SWIGALLEGROCL )
   %include "compat.h"

--- a/conf/template/yarp_config_system.h.in
+++ b/conf/template/yarp_config_system.h.in
@@ -157,14 +157,6 @@
  * \see \ref port_expert_data YARP_BEGIN_PACK
  */
 
-/**
- * \def PACKED_FOR_NET
- *
- * FIXME Add documentation.
- *
- * \see \ref port_expert_data
- */
-
 ///@}
 
 
@@ -216,11 +208,5 @@
 #  define YARP_END_PACK \
      _Pragma("pack()")
 #endif
-
-#ifndef PACKED_FOR_NET
-#  define PACKED_FOR_NET
-#endif
-
-
 
 #endif

--- a/doc/port_expert.dox
+++ b/doc/port_expert.dox
@@ -307,7 +307,7 @@ class Target {
 public:
   NetInt32 x;
   NetInt32 y;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 \endcode
 Then you'll be in better shape.  The integers now have a well defined
@@ -330,7 +330,7 @@ public:
         tag = BOTTLE_TAG_LIST + BOTTLE_TAG_INT;
         len = 2;
     }
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 \endcode
 

--- a/example/port_power/TargetVer1.h
+++ b/example/port_power/TargetVer1.h
@@ -16,7 +16,7 @@ class Target {
 public:
     NetInt32 x;
     NetInt32 y;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 #endif

--- a/example/port_power/TargetVer1b.h
+++ b/example/port_power/TargetVer1b.h
@@ -24,7 +24,7 @@ public:
     NetInt32 len;
     NetInt32 x;
     NetInt32 y;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 #endif

--- a/src/carriers/wire_rep_utils/BlobNetworkHeader.h
+++ b/src/carriers/wire_rep_utils/BlobNetworkHeader.h
@@ -29,7 +29,7 @@ public:
         blobLen = len;
     }
 
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 #endif

--- a/src/carriers/wire_rep_utils/WireImage.h
+++ b/src/carriers/wire_rep_utils/WireImage.h
@@ -41,7 +41,7 @@ public:
     yarp::os::NetInt32 seq;
     yarp::os::NetInt32 sec;
     yarp::os::NetInt32 nsec;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 /**

--- a/src/libYARP_OS/harness/BinPortableTest.cpp
+++ b/src/libYARP_OS/harness/BinPortableTest.cpp
@@ -38,7 +38,7 @@ public:
     NetInt32 len;
     NetInt32 x;
     NetInt32 y;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 

--- a/src/libYARP_OS/include/yarp/os/begin_pack_for_net.h
+++ b/src/libYARP_OS/include/yarp/os/begin_pack_for_net.h
@@ -9,4 +9,10 @@
 #include <yarp/conf/system.h>
 
 YARP_COMPILER_DEPRECATED_WARNING(begin_pack_for_net.h is deprecated. Use YARP_BEGIN_PACK/YARP_END_PACK instead)
+
+// Left here for compatibility with old code
+#ifndef PACKED_FOR_NET
+#  define PACKED_FOR_NET
+#endif
+
 YARP_BEGIN_PACK

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -416,7 +416,7 @@ namespace yarp {
             PixelRgb() { r = g = b = 0; }
             PixelRgb(unsigned char n_r, unsigned char n_g, unsigned char n_b)
             { r = n_r;  g = n_g;  b = n_b; }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -431,7 +431,7 @@ namespace yarp {
             PixelRgba(unsigned char n_r, unsigned char n_g,
                       unsigned char n_b, unsigned char n_a)
             { r = n_r;  g = n_g;  b = n_b; a = n_a; }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -446,7 +446,7 @@ namespace yarp {
             PixelBgra(unsigned char n_r, unsigned char n_g,
                       unsigned char n_b, unsigned char n_a)
             { r = n_r;  g = n_g;  b = n_b; a = n_a; }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -459,7 +459,7 @@ namespace yarp {
             PixelBgr() { b = g = r = 0; }
             PixelBgr(unsigned char n_r, unsigned char n_g, unsigned char n_b)
             { r = n_r;  g = n_g;  b = n_b; }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -468,7 +468,7 @@ namespace yarp {
         YARP_BEGIN_PACK
         struct YARP_sig_API PixelHsv {
             unsigned char h,s,v;
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -482,7 +482,7 @@ namespace yarp {
         YARP_BEGIN_PACK
         struct YARP_sig_API PixelRgbSigned {
             char r,g,b;
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -499,7 +499,7 @@ namespace yarp {
             PixelRgbFloat() { r = g = b = 0; }
             PixelRgbFloat(float n_r, float n_g, float n_b)
             { r = n_r;  g = n_g;  b = n_b; }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -512,7 +512,7 @@ namespace yarp {
             PixelRgbInt(int n_r, int n_g, int n_b) {
                 r = n_r; g = n_g; b = n_b;
             }
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
         /**
@@ -521,7 +521,7 @@ namespace yarp {
         YARP_BEGIN_PACK
         struct PixelHsvFloat {
             float h,s,v;
-        } /** \cond */ PACKED_FOR_NET /** \endcond */;
+        };
         YARP_END_PACK
 
     }

--- a/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
@@ -67,7 +67,7 @@ public:
         paramBlobLen = image.getRawImageSize();
     }
 
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 #endif

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -40,7 +40,7 @@ public:
     yarp::os::NetInt32 cols;
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 /// network stuff

--- a/src/libYARP_sig/src/SoundFile.cpp
+++ b/src/libYARP_sig/src/SoundFile.cpp
@@ -53,7 +53,7 @@ public:
 
     void setup_to_write(const Sound& sound, FILE *fp);
     bool parse_from_file(FILE *fp);
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 bool PcmWavHeader::parse_from_file(FILE *fp)

--- a/src/libYARP_sig/src/Vector.cpp
+++ b/src/libYARP_sig/src/Vector.cpp
@@ -40,7 +40,7 @@ class VectorPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
-} PACKED_FOR_NET;
+};
 YARP_END_PACK
 
 bool VectorBase::read(yarp::os::ConnectionReader& connection) {


### PR DESCRIPTION
It looks like that this macro is useless, perhaps something left from before the introduction of the ``#pragma``s
I moved the definition of the macro in ``yarp/os/begin_pack_for_net.h`` in order to keep compatibility with the old code and removed all occurrences.
