### PR TITLE
Do not omit namespace when preparing carriers and devices

### DIFF
--- a/src/carriers/bayer_carrier/CMakeLists.txt
+++ b/src/carriers/bayer_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(bayer_carrier TYPE BayerCarrier INCLUDE BayerCarrier.h)
+  yarp_prepare_carrier(bayer_carrier TYPE yarp::os::BayerCarrier INCLUDE BayerCarrier.h)
   yarp_add_carrier_fingerprint(bayer.ini bayer_carrier)
 endif (COMPILE_PLUGIN_LIBRARY)
 

--- a/src/carriers/mjpeg_carrier/CMakeLists.txt
+++ b/src/carriers/mjpeg_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_PLUGIN_LIBRARY)
-    yarp_prepare_carrier(mjpeg_carrier TYPE MjpegCarrier INCLUDE MjpegCarrier.h)
+    yarp_prepare_carrier(mjpeg_carrier TYPE yarp::os::MjpegCarrier INCLUDE MjpegCarrier.h)
     yarp_add_carrier_fingerprint(mjpeg.ini mjpeg_carrier)
 endif(COMPILE_PLUGIN_LIBRARY)
 

--- a/src/carriers/mpi_carrier/CMakeLists.txt
+++ b/src/carriers/mpi_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(mpi_carrier TYPE MpiP2PCarrier INCLUDE include/yarp/os/MpiP2PCarrier.h)
+  yarp_prepare_carrier(mpi_carrier TYPE yarp::os::MpiP2PCarrier INCLUDE include/yarp/os/MpiP2PCarrier.h)
   yarp_add_carrier_fingerprint(mpi.ini mpi_carrier mpibcast_carrier)
 endif(COMPILE_PLUGIN_LIBRARY)
 
@@ -40,7 +40,7 @@ endif(NOT SKIP_mpi_carrier)
 
 
 if(COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(mpibcast_carrier TYPE MpiBcastCarrier INCLUDE include/yarp/os/MpiBcastCarrier.h)
+  yarp_prepare_carrier(mpibcast_carrier TYPE yarp::os::MpiBcastCarrier INCLUDE include/yarp/os/MpiBcastCarrier.h)
 endif(COMPILE_PLUGIN_LIBRARY)
 
 if(NOT SKIP_mpibcast_carrier)

--- a/src/carriers/portmonitor_carrier/CMakeLists.txt
+++ b/src/carriers/portmonitor_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(portmonitor_carrier TYPE PortMonitor INCLUDE PortMonitor.h)
+  yarp_prepare_carrier(portmonitor_carrier TYPE yarp::os::PortMonitor INCLUDE PortMonitor.h)
   yarp_add_carrier_fingerprint(portmonitor.ini portmonitor_carrier)
 endif (COMPILE_PLUGIN_LIBRARY)
 

--- a/src/carriers/priority_carrier/CMakeLists.txt
+++ b/src/carriers/priority_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(priority_carrier TYPE PriorityCarrier INCLUDE PriorityCarrier.h)
+  yarp_prepare_carrier(priority_carrier TYPE yarp::os::PriorityCarrier INCLUDE PriorityCarrier.h)
   yarp_add_carrier_fingerprint(priority.ini priority_carrier)
 endif (COMPILE_PLUGIN_LIBRARY)
 

--- a/src/carriers/tcpros_carrier/CMakeLists.txt
+++ b/src/carriers/tcpros_carrier/CMakeLists.txt
@@ -3,8 +3,8 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(tcpros_carrier TYPE TcpRosCarrier INCLUDE TcpRosCarrier.h)
-  yarp_prepare_carrier(rossrv_carrier TYPE RosSrvCarrier INCLUDE TcpRosCarrier.h)
+  yarp_prepare_carrier(tcpros_carrier TYPE yarp::os::TcpRosCarrier INCLUDE TcpRosCarrier.h)
+  yarp_prepare_carrier(rossrv_carrier TYPE yarp::os::RosSrvCarrier INCLUDE TcpRosCarrier.h)
   yarp_add_carrier_fingerprint(ros.ini rossrv_carrier tcpros_carrier)
 endif (COMPILE_PLUGIN_LIBRARY)
 

--- a/src/carriers/xmlrpc_carrier/CMakeLists.txt
+++ b/src/carriers/xmlrpc_carrier/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_PLUGIN_LIBRARY)
-  yarp_prepare_carrier(xmlrpc_carrier TYPE XmlRpcCarrier INCLUDE XmlRpcCarrier.h)
+  yarp_prepare_carrier(xmlrpc_carrier TYPE yarp::os::XmlRpcCarrier INCLUDE XmlRpcCarrier.h)
   yarp_add_carrier_fingerprint(xmlrpc.ini xmlrpc_carrier)
 endif (COMPILE_PLUGIN_LIBRARY)
 

--- a/src/modules/PumaCalibrator/CMakeLists.txt
+++ b/src/modules/PumaCalibrator/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(pumacalibrator TYPE PumaCalibrator INCLUDE PumaCalibrator.h )
+  yarp_prepare_device(pumacalibrator TYPE yarp::dev::PumaCalibrator INCLUDE PumaCalibrator.h )
 ENDIF (COMPILE_DEVICE_LIBRARY)
 
 IF (NOT SKIP_pumacalibrator)

--- a/src/modules/dimax_u2c/CMakeLists.txt
+++ b/src/modules/dimax_u2c/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-    yarp_prepare_device(dimax_u2c TYPE DimaxU2C INCLUDE DimaxU2C.h WRAPPER controlboard)
+    yarp_prepare_device(dimax_u2c TYPE yarp::dev::DimaxU2C INCLUDE DimaxU2C.h WRAPPER controlboard)
 endif(COMPILE_DEVICE_LIBRARY)
 
 if(NOT SKIP_dimax_u2c)

--- a/src/modules/fakebot/CMakeLists.txt
+++ b/src/modules/fakebot/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(fakebot TYPE FakeBot INCLUDE FakeBot.h)
+  yarp_prepare_device(fakebot TYPE yarp::dev::FakeBot INCLUDE FakeBot.h)
   YARP_ADD_DEVICE_FINGERPRINT(fakebot.ini fakebot)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/ffmpeg/CMakeLists.txt
+++ b/src/modules/ffmpeg/CMakeLists.txt
@@ -3,8 +3,8 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(ffmpeg_grabber TYPE FfmpegGrabber INCLUDE FfmpegGrabber.h WRAPPER grabber)
-  yarp_prepare_device(ffmpeg_writer TYPE FfmpegWriter INCLUDE FfmpegWriter.h)
+  yarp_prepare_device(ffmpeg_grabber TYPE yarp::dev::FfmpegGrabber INCLUDE FfmpegGrabber.h WRAPPER grabber)
+  yarp_prepare_device(ffmpeg_writer TYPE yarp::dev::FfmpegWriter INCLUDE FfmpegWriter.h)
   yarp_add_device_fingerprint(ffmpeg.ini ffmpeg_grabber ffmpeg_writer)
 endif()
 

--- a/src/modules/firewirecamera/CMakeLists.txt
+++ b/src/modules/firewirecamera/CMakeLists.txt
@@ -5,7 +5,7 @@
 if(UNIX)
 
   if(COMPILE_DEVICE_LIBRARY)
-    yarp_prepare_device(firewirecamera TYPE FirewireCamera INCLUDE FirewireCamera.h WRAPPER grabber)
+    yarp_prepare_device(firewirecamera TYPE yarp::dev::FirewireCamera INCLUDE FirewireCamera.h WRAPPER grabber)
     yarp_add_device_fingerprint(firewirecamera.ini firewirecamera)
   endif(COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/jrkerr/CMakeLists.txt
+++ b/src/modules/jrkerr/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(jrkerr TYPE JrkerrMotionControl INCLUDE JrkerrMotionControl.h WRAPPER controlboard)
+  yarp_prepare_device(jrkerr TYPE yarp::dev::JrkerrMotionControl INCLUDE JrkerrMotionControl.h WRAPPER controlboard)
   YARP_ADD_DEVICE_FINGERPRINT(jrkerr.ini jrkerr)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/kinect/OpenNI/CMakeLists.txt
+++ b/src/modules/kinect/OpenNI/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(KinectDeviceLocal TYPE KinectDeviceDriverServer INCLUDE KinectYarpDeviceServerLib/KinectDeviceDriverServer.h)
+  yarp_prepare_device(KinectDeviceLocal TYPE yarp::dev::KinectDeviceDriverServer INCLUDE KinectYarpDeviceServerLib/KinectDeviceDriverServer.h)
   yarp_add_device_fingerprint(kinect.ini KinectDeviceLocal KinectDeviceClient)
 endif(COMPILE_DEVICE_LIBRARY)
 
@@ -12,7 +12,7 @@ if(ENABLE_KinectDeviceLocal)
 endif()
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(KinectDeviceClient TYPE KinectDeviceDriverClient INCLUDE KinectYarpDeviceClientLib/KinectDeviceDriverClient.h)
+  yarp_prepare_device(KinectDeviceClient TYPE yarp::dev::KinectDeviceDriverClient INCLUDE KinectYarpDeviceClientLib/KinectDeviceDriverClient.h)
 endif(COMPILE_DEVICE_LIBRARY)
 
 if(ENABLE_KinectDeviceClient)

--- a/src/modules/kinect/freenect/CMakeLists.txt
+++ b/src/modules/kinect/freenect/CMakeLists.txt
@@ -2,8 +2,8 @@
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(primesensecamera TYPE ServerKinect INCLUDE "ServerKinect.h" WRAPPER primesensecamera)
-  yarp_prepare_device(kinect TYPE KinectDeviceDriver INCLUDE "KinectDeviceDriver.h" WRAPPER primesensecamera)
+  yarp_prepare_device(primesensecamera TYPE yarp::dev::ServerKinect INCLUDE "ServerKinect.h" WRAPPER primesensecamera)
+  yarp_prepare_device(kinect TYPE yarp::dev::KinectDeviceDriver INCLUDE "KinectDeviceDriver.h" WRAPPER primesensecamera)
 endif()
 
 if(SKIP_primesensecamera AND SKIP_kinect)

--- a/src/modules/meiMotionControl/CMakeLists.txt
+++ b/src/modules/meiMotionControl/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(meiMotionControl TYPE MEIMotionControl INCLUDE MEIMotionControl.h WRAPPER controlboard)
+  yarp_prepare_device(meiMotionControl TYPE yarp::dev::MEIMotionControl INCLUDE MEIMotionControl.h WRAPPER controlboard)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 
 IF (NOT SKIP_meiMotionControl)

--- a/src/modules/microphone/CMakeLists.txt
+++ b/src/modules/microphone/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(microphone TYPE MicrophoneDeviceDriver INCLUDE MicrophoneDeviceDriver.h WRAPPER grabber)
+  yarp_prepare_device(microphone TYPE yarp::dev::MicrophoneDeviceDriver INCLUDE MicrophoneDeviceDriver.h WRAPPER grabber)
   YARP_ADD_DEVICE_FINGERPRINT(microphone.ini microphone)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/opencv/CMakeLists.txt
+++ b/src/modules/opencv/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-    yarp_prepare_device(opencv_grabber TYPE OpenCVGrabber INCLUDE OpenCVGrabber.h WRAPPER grabber)
+    yarp_prepare_device(opencv_grabber TYPE yarp::dev::OpenCVGrabber INCLUDE OpenCVGrabber.h WRAPPER grabber)
     yarp_add_device_fingerprint(opencv.ini opencv_grabber)
 endif(COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/openni2/CMakeLists.txt
+++ b/src/modules/openni2/CMakeLists.txt
@@ -3,8 +3,8 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if (COMPILE_DEVICE_LIBRARY)
-    yarp_prepare_device(OpenNI2DeviceServer TYPE OpenNI2DeviceDriverServer INCLUDE OpenNI2DeviceDriverServer.h)
-    yarp_prepare_device(OpenNI2DeviceClient TYPE OpenNI2DeviceDriverClient INCLUDE OpenNI2DeviceDriverClient.h)
+    yarp_prepare_device(OpenNI2DeviceServer TYPE yarp::dev::OpenNI2DeviceDriverServer INCLUDE OpenNI2DeviceDriverServer.h)
+    yarp_prepare_device(OpenNI2DeviceClient TYPE yarp::dev::OpenNI2DeviceDriverClient INCLUDE OpenNI2DeviceDriverClient.h)
     yarp_add_device_fingerprint(openni2.ini OpenNI2DeviceServer OpenNI2DeviceClient)
 endif()
 

--- a/src/modules/portaudio/CMakeLists.txt
+++ b/src/modules/portaudio/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(portaudio TYPE PortAudioDeviceDriver INCLUDE PortAudioDeviceDriver.h WRAPPER grabber)
+  yarp_prepare_device(portaudio TYPE yarp::dev::PortAudioDeviceDriver INCLUDE PortAudioDeviceDriver.h WRAPPER grabber)
   yarp_add_device_fingerprint(portaudio.ini portaudio)
 endif(COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/serial/CMakeLists.txt
+++ b/src/modules/serial/CMakeLists.txt
@@ -3,8 +3,8 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(serial TYPE ServerSerial INCLUDE yarp/dev/ServerSerial.h WRAPPER serial)
-  yarp_prepare_device(serialport TYPE SerialDeviceDriver INCLUDE SerialDeviceDriver.h WRAPPER serial)
+  yarp_prepare_device(serial TYPE yarp::dev::ServerSerial INCLUDE yarp/dev/ServerSerial.h WRAPPER serial)
+  yarp_prepare_device(serialport TYPE yarp::dev::SerialDeviceDriver INCLUDE SerialDeviceDriver.h WRAPPER serial)
   yarp_add_device_fingerprint(serial.ini serial serialport)
 endif()
 

--- a/src/modules/stage/CMakeLists.txt
+++ b/src/modules/stage/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(COMPILE_DEVICE_LIBRARY)
-  yarp_prepare_device(stage TYPE StageControl INCLUDE StageControl.h)
+  yarp_prepare_device(stage TYPE yarp::dev::StageControl INCLUDE StageControl.h)
   yarp_add_device_fingerprint(stage.ini stage)
 endif()
 

--- a/src/modules/urbtc/CMakeLists.txt
+++ b/src/modules/urbtc/CMakeLists.txt
@@ -3,8 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(urbtc TYPE UrbtcControl INCLUDE UrbtcControl.h
-		 WRAPPER controlboard)
+  yarp_prepare_device(urbtc TYPE yarp::dev::UrbtcControl INCLUDE UrbtcControl.h WRAPPER controlboard)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 
 IF (NOT SKIP_urbtc)

--- a/src/modules/vfw/CMakeLists.txt
+++ b/src/modules/vfw/CMakeLists.txt
@@ -7,7 +7,7 @@
 # making an instance of VfwGrabber (declared in VfwGrabber.h).
 # Our devices can optionally be declared to have a network wrapper.
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(vfw_grabber TYPE VfwGrabber INCLUDE VfwGrabber.h WRAPPER grabber)
+  yarp_prepare_device(vfw_grabber TYPE yarp::dev::VfwGrabber INCLUDE VfwGrabber.h WRAPPER grabber)
   YARP_ADD_DEVICE_FINGERPRINT(vfw.ini vfw_grabber)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 

--- a/src/modules/wxsdl/CMakeLists.txt
+++ b/src/modules/wxsdl/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
 IF (COMPILE_DEVICE_LIBRARY)
-  YARP_PREPARE_DEVICE(wxsdl TYPE WxsdlWriter INCLUDE WxsdlWriter.h)
+  yarp_prepare_device(wxsdl TYPE yarp::dev::WxsdlWriter INCLUDE WxsdlWriter.h)
   YARP_ADD_DEVICE_FINGERPRINT(wxsdl.ini wxsdl)
 ENDIF (COMPILE_DEVICE_LIBRARY)
 


### PR DESCRIPTION
At the moment this works only because we add "using namespace"s in generated files but I believe that we should not endorse this. Using the full name of the class is more correct and makes it easier to understand what we are passing to the macro.

Also in order to be sure that the class name is always full, one day I would like to remove the "using namespace" from the generated files. Even though this will break some compatibility, it will make it more robust and less error prone.