### PR TITLE
[test] run integration tests via ctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   exclude:
     - compiler: gcc
       env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=false
-    - compiler: gcc
+    - compiler: clang
       env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=true
     - compiler: clang
       env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,18 @@ compiler:
   - clang
 
 env:
-  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_SWIG=false TRAVIS_WITH_RUNTIME=true TRAVIS_WITH_ROS=false
-  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_SWIG=false TRAVIS_WITH_RUNTIME=false TRAVIS_WITH_ROS=false
-  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_SWIG=true TRAVIS_WITH_RUNTIME=false TRAVIS_WITH_ROS=false
-  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_SWIG=false TRAVIS_WITH_RUNTIME=false TRAVIS_WITH_ROS=true
+  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_INTEGRATION_TESTS=false TRAVIS_BLESSED=false
+  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=true
+  - TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=false
 
 matrix:
   exclude:
     - compiler: gcc
-      env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_SWIG=true TRAVIS_WITH_RUNTIME=false TRAVIS_WITH_ROS=false
+      env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=false
+    - compiler: gcc
+      env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=true
     - compiler: clang
-      env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=true TRAVIS_WITH_SWIG=false TRAVIS_WITH_RUNTIME=false TRAVIS_WITH_ROS=true
+      env: TRAVIS_BUILD_TYPE=Profile TRAVIS_CMAKE_GENERATOR="Unix Makefiles" TRAVIS_WITH_ACE=false TRAVIS_WITH_INTEGRATION_TESTS=true TRAVIS_BLESSED=false
 
 notifications:
   irc:
@@ -33,61 +34,59 @@ notifications:
 before_install:
   - sudo add-apt-repository --yes ppa:kalakris/cmake
   - sudo apt-get update -qq
-  - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then wget https://github.com/paulfitz/swigs/releases/download/v0.0.4/swigs.zip; fi
-  - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then unzip -q swigs.zip; mkdir -p cache; mv swigs cache/swig; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then wget https://github.com/paulfitz/swigs/releases/download/v0.0.4/swigs.zip; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then unzip -q swigs.zip; mkdir -p cache; mv swigs cache/swig; fi
 
 install:
   - sudo apt-get install cmake
-  - if [ "k$TRAVIS_WITH_ACE" = "ktrue" ]; then sudo apt-get install libace-dev; fi
-  - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then sudo apt-get install liblua5.1-0-dev lua5.1 tcl-dev tk-dev mono-gmcs; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROS_CI_DESKTOP=`lsb_release -cs`; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROS_CI_VERSION=groovy; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROS_CI_PREFIX=ros-${ROS_CI_VERSION}-; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROS_HOSTNAME=localhost; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROS_MASTER_URI=http://localhost:11311; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then export ROBOT=sim; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then wget http://packages.ros.org/ros.key -O - | sudo apt-key add -; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then sudo apt-get -y update; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then sudo apt-get -y install ${ROS_CI_PREFIX}desktop-full; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then sudo rosdep init && rosdep update; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then source /opt/ros/${ROS_CI_VERSION}/setup.bash; fi
+  - if $TRAVIS_WITH_ACE; then sudo apt-get install libace-dev; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then sudo apt-get install liblua5.1-0-dev lua5.1 tcl-dev tk-dev mono-gmcs; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROS_CI_DESKTOP=`lsb_release -cs`; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROS_CI_VERSION=groovy; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROS_CI_PREFIX=ros-${ROS_CI_VERSION}-; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROS_HOSTNAME=localhost; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROS_MASTER_URI=http://localhost:11311; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export ROBOT=sim; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then wget http://packages.ros.org/ros.key -O - | sudo apt-key add -; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then sudo apt-get -y update; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then sudo apt-get -y install ${ROS_CI_PREFIX}desktop-full; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then sudo rosdep init && rosdep update; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then source /opt/ros/${ROS_CI_VERSION}/setup.bash; fi
   # see http://gronlier.fr/blog/2015/01/adding-code-coverage-to-your-c-project/
-  - if [ "$CXX" = "g++" ]; then wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz; fi
-  - if [ "$CXX" = "g++" ]; then tar xf lcov_1.11.orig.tar.gz; fi
-  - if [ "$CXX" = "g++" ]; then sudo make -C lcov-1.11/ install; fi
-  - if [ "$CXX" = "g++" ]; then gem install coveralls-lcov; fi
+  - if $TRAVIS_BLESSED; then wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz; fi
+  - if $TRAVIS_BLESSED; then tar xf lcov_1.11.orig.tar.gz; fi
+  - if $TRAVIS_BLESSED; then sudo make -C lcov-1.11/ install; fi
+  - if $TRAVIS_BLESSED; then gem install coveralls-lcov; fi
 
 before_script:
   - cmake --version
   - mkdir -p build
   - cd build
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then ln -s ../cache cache; fi
   - export YARP_CMAKE_OPTIONS="-DTEST_yarpidl_rosmsg=TRUE -DTEST_yarpidl_thrift=TRUE -DCREATE_OPTIONAL_CARRIERS=TRUE -DENABLE_yarpcar_tcpros_carrier=TRUE -DENABLE_yarpcar_rossrv_carrier=TRUE -DENABLE_yarpcar_xmlrpc_carrier=TRUE"
-  - if [ "k$TRAVIS_WITH_ACE" = "kfalse" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DSKIP_ACE=TRUE -DYARP_TEST_HEAP=TRUE"; fi
+  - if ! $TRAVIS_WITH_ACE; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DSKIP_ACE=TRUE -DYARP_TEST_HEAP=TRUE"; fi
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DYARP_TEST_INTEGRATION=TRUE"; fi
   - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ${YARP_CMAKE_OPTIONS} ..
-  - if [ "$CXX" = "g++" ]; then lcov --directory . --zerocounters; fi
+  - if $TRAVIS_BLESSED; then lcov --directory . --zerocounters; fi
   - cd ..
 
 script:
   - cd build
   - cmake --build . --config ${TRAVIS_BUILD_TYPE}
+  - if $TRAVIS_WITH_INTEGRATION_TESTS; then bin/yarp conf 0 0 local; fi
   - ctest -VV --build . --config ${TRAVIS_BUILD_TYPE}
-  - if [ "k$TRAVIS_WITH_RUNTIME" = "ktrue" ]; then ../scripts/admin/check-runtime.sh; fi
-  - if [ "k$TRAVIS_WITH_RUNTIME" = "ktrue" ]; then ../tests/integration/check-http.sh; fi
-  - if [ "k$TRAVIS_WITH_RUNTIME" = "ktrue" ]; then ../tests/integration/check-rpc.sh; fi
-  - if [ "k$TRAVIS_WITH_ROS" = "ktrue" ]; then YARP_DIR=$PWD/build YARP_DATA_DIRS=build/share/yarp ../tests/integration/ros/index.sh all; fi
+  - ctest -N --build . --config ${TRAVIS_BUILD_TYPE}
   - cd ..
-  - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then build/bin/yarp conf 0 0 local; fi
-  - if [ "k$TRAVIS_WITH_SWIG" = "ktrue" ]; then YARP_DIR=$PWD/build SWIG_VERSIONS="1.3.40 2.0.12 3.0.2" ./scripts/admin/check-bindings.sh PYTHON JAVA LUA RUBY CSHARP PERL TCL; fi
 
 after_success:
   - cd build
   # capture coverage info
-  - if [ "$CXX" = "g++" ]; then lcov --directory . --capture --output-file coverage.info; fi
+  - if $TRAVIS_BLESSED; then lcov --directory . --capture --output-file coverage.info; fi
   # filter out system and test code
-  - if [ "$CXX" = "g++" ]; then lcov --remove coverage.info '/usr/*' 'tests/*' 'example/*' 'extern/*' 'idls/*' '*/harness/*' 'yarp/build/*' --output-file coverage.info; fi
+  - if $TRAVIS_BLESSED; then lcov --remove coverage.info '/usr/*' 'tests/*' 'example/*' 'extern/*' 'idls/*' '*/harness/*' 'yarp/build/*' --output-file coverage.info; fi
   # debug before upload
-  - if [ "$CXX" = "g++" ]; then lcov --list coverage.info; fi
+  - if $TRAVIS_BLESSED; then lcov --list coverage.info; fi
   # uploads to coveralls
-  - if [ "$CXX" = "g++" ]; then coveralls-lcov --source-encoding=ISO-8859-1 coverage.info; fi
+  - if $TRAVIS_BLESSED; then coveralls-lcov --source-encoding=ISO-8859-1 coverage.info; fi
   - cd ..

--- a/scripts/admin/check-bindings.sh
+++ b/scripts/admin/check-bindings.sh
@@ -12,7 +12,7 @@ if [ ! -e $swig_base ]; then
 fi
 
 # swig_versions="1.3.39 1.3.40 2.0.1 2.0.2 2.0.3 2.0.4 2.0.5 2.0.6 2.0.7 2.0.8 2.0.9 2.0.10 2.0.11 2.0.12 3.0.0 3.0.1 3.0.2"
-default_swig_versions="1.3.39 1.3.40 2.0.2 2.0.5 2.0.6 2.0.10 2.0.12 3.0.0 3.0.1 3.0.2"
+default_swig_versions="1.3.40 2.0.12 3.0.2"
 if [ -z "$SWIG_VERSIONS" ]; then
 swig_versions="$default_swig_versions"
 else
@@ -137,7 +137,12 @@ for lang in $SUPPORTED_LANGUAGES; do
 	echo "Running cmake"
 	set +e
 	rm -f CMakeCache.txt
-	cmake -DCREATE_$lang=TRUE $lang_flags $search_path $YARP_ROOT/bindings > result.txt 2>&1
+	opt_flags=""
+	if [[ "$TRAVIS_WITH_INTEGRATION_TESTS" ]]; then
+	    # turn off optimizations and force use of clang to fit into travis memory limits
+	    opt_flags="-DCMAKE_CXX_FLAGS='-O0' -DCMAKE_C_FLAGS='-O0' -DCMAKE_C_COMPILER='clang' -DCMAKE_CXX_COMPILER='clang++'"
+	fi
+	cmake -DCREATE_$lang=TRUE $opt_flags $lang_flags $search_path $YARP_ROOT/bindings > result.txt 2>&1
 	set -e
 	if [ ! -e CMakeCache.txt ] ; then
 	    cat result.txt

--- a/scripts/admin/check-bindings.sh
+++ b/scripts/admin/check-bindings.sh
@@ -100,6 +100,7 @@ for lang in $SUPPORTED_LANGUAGES; do
 	fi
 	if [ ! -e "$swig_base/$swig_ver" ]; then
 	    echo "CANNOT FIND precompiled versions of swig."
+	    echo "In $PWD, looking in $swig_base/$sig_ver"
 	    echo "Going to compile it from scratch.  Warning: SLOW."
 	    echo "To cache this work, make a directory called '/cache/swig' that I can write in"
 	    base="$PWD"

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,8 +17,10 @@ endforeach()
 # Generate a matrix of SWIG tests
 foreach (lang PYTHON JAVA LUA RUBY CSHARP PERL TCL)
   foreach (swig 1.3.40 2.0.12 3.0.2)
-    add_test("integration::swig::${lang}::${swig}" ${CMAKE_SOURCE_DIR}/scripts/admin/check-bindings.sh ${swig} ${lang})
-    set_property(TEST "integration::swig::${lang}::${swig}" PROPERTY ENVIRONMENT "YARP_ROOT=${CMAKE_SOURCE_DIR}" "YARP_DIR=${CMAKE_BINARY_DIR}")
+    set(test_name "integration::swig::${lang}::${swig}")
+    add_test(${test_name} ${CMAKE_SOURCE_DIR}/scripts/admin/check-bindings.sh ${swig} ${lang})
+    set_property(TEST ${test_name} PROPERTY ENVIRONMENT "YARP_ROOT=${CMAKE_SOURCE_DIR}" "YARP_DIR=${CMAKE_BINARY_DIR}")
+    set_property(TEST ${test_name} PROPERTY WORKING_DIRECTORY ${YARP_BINARY_DIR})
   endforeach()
 endforeach()
 

--- a/tests/integration/ros/index.sh
+++ b/tests/integration/ros/index.sh
@@ -48,8 +48,10 @@ fi
 
 ########################################################################
 if [[ ! "$active_test" = "" ]]; then
-    require_ros_name_server
-    require_name_server
+    if [[ ! "$active_test" = "all" ]]; then
+	require_ros_name_server
+	require_name_server
+    fi
 fi
 
 ########################################################################

--- a/tests/integration/test-helper.sh
+++ b/tests/integration/test-helper.sh
@@ -104,9 +104,13 @@ trap cleanup_all EXIT
 function require_name_server() {
     header "Start yarp name server if needed"
 
+    args=""
+    if [[ ! "$ROS_ID" = "" ]]; then
+	args="--ros"
+    fi
     ${YARP_BIN}/yarp where || {
 	echo "Starting yarpserver"
-	${YARP_BIN}/yarpserver --write --ros > /dev/null &
+	${YARP_BIN}/yarpserver --write $args > /dev/null &
 	SERVER_ID=$!
     }
 


### PR DESCRIPTION
This runs the various integration tests on travis using the regular ctest machinery, resulting in some simplification.  For now it seems necessary to run those tests only under clang, since some swig targets are now too bulky for gcc with the memory travis provides. Example run: https://travis-ci.org/robotology/yarp/builds/51133895