### PR TITLE
Make class name available for plugin devices

### DIFF
--- a/src/libYARP_OS/include/yarp/os/SharedLibraryFactory.h
+++ b/src/libYARP_OS/include/yarp/os/SharedLibraryFactory.h
@@ -125,6 +125,20 @@ public:
     ConstString getName() const;
 
     /**
+     * Get the type associated with this factory.
+     *
+     * @return the type associated with this factory.
+     */
+    ConstString getClassName() const;
+
+    /**
+     * Get the base type associated with this factory.
+     *
+     * @return the base type associated with this factory.
+     */
+    ConstString getBaseClassName() const;
+
+    /**
      *
      * Specify function to use as factory.
      *
@@ -141,6 +155,8 @@ private:
     int returnValue;
     int rct;
     ConstString name;
+    ConstString className;
+    ConstString baseClassName;
 };
 
 

--- a/src/libYARP_OS/include/yarp/os/YarpPlugin.h
+++ b/src/libYARP_OS/include/yarp/os/YarpPlugin.h
@@ -125,6 +125,36 @@ public:
 
     /**
      *
+     * @return the name of the objects constructed by this plugin
+     *
+     */
+    ConstString getName() {
+        if (!factory) return ConstString();
+        return factory->getName();
+    }
+
+    /**
+     *
+     * @return the type of the objects constructed by this plugin
+     *
+     */
+    ConstString getClassName() {
+        if (!factory) return ConstString();
+        return factory->getClassName();
+    }
+
+    /**
+     *
+     * @return the base class the objects constructed by this plugin
+     *
+     */
+    ConstString getBaseClassName() {
+        if (!factory) return ConstString();
+        return factory->getBaseClassName();
+    }
+
+    /**
+     *
      * @return the factory object associated with the plugin
      *
      */

--- a/src/libYARP_OS/include/yarp/os/YarpPluginSettings.h
+++ b/src/libYARP_OS/include/yarp/os/YarpPluginSettings.h
@@ -73,6 +73,21 @@ public:
 
     /**
      *
+     * Set the information about the class and the base class
+     * constructed by this plugin.
+     *
+     * @param class_name the name of the class
+     * @param baseclass_name the name of the base class
+     */
+    void setClassInfo(const ConstString& class_name,
+                      const ConstString& baseclass_name) {
+        this->class_name = class_name;
+        this->baseclass_name = baseclass_name;
+    }
+
+
+    /**
+     *
      * Use a selector to find a plugin or plugins.  If the name
      * of the plugin has already been set, the selector will be used to
      * increase what is known about the plugin.
@@ -163,8 +178,31 @@ public:
         return selector;
     }
 
+    /**
+     *
+     * @return the name of the wrapper, if set
+     *
+     */
     ConstString getWrapperName() const {
         return wrapper_name;
+    }
+
+    /**
+     *
+     * @return the name of the class, if set
+     *
+     */
+    ConstString getClassName() const {
+        return class_name;
+    }
+
+    /**
+     *
+     * @return the name of the base class, if set
+     *
+     */
+    ConstString getBaseClassName() const {
+        return class_name;
     }
 
     /**
@@ -201,6 +239,8 @@ private:
     ConstString fn_name;
     ConstString fn_ext;
     ConstString wrapper_name;
+    ConstString class_name;
+    ConstString baseclass_name;
     YarpPluginSelector *selector;
     bool verbose;
 

--- a/src/libYARP_OS/src/SharedLibraryFactory.cpp
+++ b/src/libYARP_OS/src/SharedLibraryFactory.cpp
@@ -31,6 +31,8 @@ yarp::os::SharedLibraryFactory::~SharedLibraryFactory() {
 bool yarp::os::SharedLibraryFactory::open(const char *dll_name, const char *fn_name) {
     returnValue = 0;
     name = "";
+    className = "";
+    baseClassName = "";
     status = STATUS_NONE;
     api.startCheck = 0;
     if (!lib.open(dll_name)) {
@@ -51,6 +53,13 @@ bool yarp::os::SharedLibraryFactory::open(const char *dll_name, const char *fn_n
     }
     status = STATUS_OK;
     name = dll_name;
+
+    char buf[256];
+    api.getClassName(buf, 256);
+    className = buf;
+    api.getBaseClassName(buf, 256);
+    baseClassName = buf;
+
     return true;
 }
 
@@ -97,6 +106,14 @@ int yarp::os::SharedLibraryFactory::removeRef() {
 
 yarp::os::ConstString yarp::os::SharedLibraryFactory::getName() const {
     return name;
+}
+
+yarp::os::ConstString yarp::os::SharedLibraryFactory::getClassName() const {
+    return className;
+}
+
+yarp::os::ConstString yarp::os::SharedLibraryFactory::getBaseClassName() const {
+    return baseClassName;
 }
 
 bool yarp::os::SharedLibraryFactory::useFactoryFunction(void *factory) {

--- a/src/libYARP_dev/src/Drivers.cpp
+++ b/src/libYARP_dev/src/Drivers.cpp
@@ -187,6 +187,8 @@ public:
             dev.open(*plugin.getFactory());
             settings.setLibraryMethodName(plugin.getFactory()->getName(),
                                           settings.getMethodName());
+            settings.setClassInfo(plugin.getFactory()->getClassName(),
+                                  plugin.getFactory()->getBaseClassName());
         }
     }
 
@@ -222,6 +224,14 @@ public:
 
     ConstString getPluginName() {
         return settings.getPluginName();
+    }
+
+    ConstString getClassName() {
+        return settings.getClassName();
+    }
+
+    ConstString getBaseClassName() {
+        return settings.getBaseClassName();
     }
 };
 #endif
@@ -275,7 +285,11 @@ DriverCreator *DriversHelper::load(const char *name) {
         result = NULL;
         return NULL;
     }
-    DriverCreator *creator = new StubDriverCreator(result->getPluginName().c_str(), result->getwrapName().c_str(), "", result->getDllName().c_str(), result->getFnName().c_str());
+    DriverCreator *creator = new StubDriverCreator(result->getPluginName().c_str(),
+                                                   result->getwrapName().c_str(),
+                                                   result->getClassName().c_str(),
+                                                   result->getDllName().c_str(),
+                                                   result->getFnName().c_str());
     add(creator);
     delete result;
     return creator;


### PR DESCRIPTION
This info is already available in the library, but it is not exposed for
use.
There are probably not many reasons for exposing this information, but
without this, the plugin factory ignores the name of the class for the
plugins, and therefore the documentation generated by harness_dev is
different.