### PR TITLE
OpenNI2 device detects and handles RGB-less sensors

### DIFF
--- a/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
@@ -130,12 +130,20 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
         colorON = true;
     }
 
-    if(config.check("noMirror", "Disable mirroring")) mirrorON = false;
-    else mirrorON = true;
+    if(config.check("noMirror", "Disable mirroring")) {
+        mirrorON = false;
+    }
+    else {
+        mirrorON = true;
+    }
     
-    if(config.check("noUserTracking", "Disable user tracking")) userTracking = false;
-    else userTracking = true;
-
+    if(config.check("noUserTracking", "Disable user tracking")) {
+        userTracking = false;
+    }
+    else {
+        userTracking = true;
+    }
+    
     if(config.check("printVideoModes", "Print supported video modes"))
     {
         printMode = true;
@@ -188,6 +196,9 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
 
     if (config.check("minConfidence", "Set minimum confidence (default=0.6)")){
         mConf = config.find("minConfidence").asDouble();
+    }
+    else {
+        mConf = MINIMUM_CONFIDENCE;
     }
     
     if (config.check("loop", "Set playback to loop")){

--- a/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
@@ -18,7 +18,7 @@ yarp::dev::OpenNI2DeviceDriverServer::~OpenNI2DeviceDriverServer(void)
 {
 }
 
-void yarp::dev::OpenNI2DeviceDriverServer::openPorts(string portPrefix, bool userTracking, bool camerasON){
+void yarp::dev::OpenNI2DeviceDriverServer::openPorts(string portPrefix, bool userTracking, bool colorON){
     
     string receivingPortName = portPrefix+":i";
     receivingPort = new BufferedPort<Bottle>();
@@ -33,7 +33,7 @@ void yarp::dev::OpenNI2DeviceDriverServer::openPorts(string portPrefix, bool use
         depthFramePort = new BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono16> >();
         string strTemp = portPrefix+PORTNAME_DEPTHFRAME+":o";
         depthFramePort->open(strTemp.c_str());
-        if(camerasON){
+        if(colorON){
         imageFramePort = new BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >();
         strTemp = portPrefix+PORTNAME_IMAGEFRAME+":o";
         imageFramePort->open(strTemp.c_str());
@@ -48,7 +48,7 @@ void yarp::dev::OpenNI2DeviceDriverServer::sendSensorData(){
     // creating a timestamp with the current system time in seconds.milliseconds
     Stamp timestamp(index,Time::now());
     // cameras data
-    if(camerasON){
+    if(colorON){
         // image frame data
         imageFramePort->prepare() = OpenNI2SkeletonTracker::getSensor()->imageFrame;
         imageFramePort->setEnvelope(timestamp);
@@ -124,10 +124,10 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
     bool printMode;
 
     if(config.check("noRGB", "Use only depth sensor")) {
-        camerasON = false;
+        colorON = false;
     }
     else {
-        camerasON = true;
+        colorON = true;
     }
 
     if(config.check("noMirror", "Disable mirroring")) mirrorON = false;
@@ -178,12 +178,12 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
     if(config.check("name", "Name for the port prefix (default=/OpenNI2)")){
         portPrefix = config.find("name").asString();
         withOpenPorts = true;
-        openPorts(portPrefix, userTracking, camerasON);
+        openPorts(portPrefix, userTracking, colorON);
     }
     else {
         portPrefix = "/OpenNI2";
         withOpenPorts  = true;
-        openPorts(portPrefix, userTracking, camerasON);
+        openPorts(portPrefix, userTracking, colorON);
     }
 
     if (config.check("minConfidence", "Set minimum confidence (default=0.6)")){
@@ -211,7 +211,7 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
 	imageRegistration = false;
     }
     
-    skeleton = new OpenNI2SkeletonTracker(userTracking, camerasON, mirrorON, mConf, oniPlayback, fileDevice, oniRecord, oniOutputFile, loop, frameSync, imageRegistration, printMode, dMode, cMode);
+    skeleton = new OpenNI2SkeletonTracker(userTracking, colorON, mirrorON, mConf, oniPlayback, fileDevice, oniRecord, oniOutputFile, loop, frameSync, imageRegistration, printMode, dMode, cMode);
     
     if (skeleton->getDeviceStatus() == 0) {
     cout << "OpenNI2 Yarp Device started." << endl;
@@ -237,7 +237,7 @@ bool yarp::dev::OpenNI2DeviceDriverServer::close(){
         }
        
         depthFramePort->close(); 
-        if(camerasON){
+        if(colorON){
             imageFramePort->close();
         }
         receivingPort->close();

--- a/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
@@ -157,6 +157,7 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config){
     }
    else{
       cMode = 0; 
+   }
 
    if(config.check("playback", "Play from .oni file")) {
         oniPlayback = true;

--- a/src/modules/openni2/OpenNI2DeviceDriverServer.h
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.h
@@ -81,14 +81,14 @@ private:
     BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono16> > *depthFramePort;
     BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > *imageFramePort;
     OpenNI2SkeletonTracker *skeleton;
-    bool withOpenPorts, userTracking, camerasON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration;
+    bool withOpenPorts, userTracking, colorON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration;
     string fileDevice;
     string oniOutputFile;
 
     /**
      * Opens the depth sensor and rgb camera image ports
      */
-    void openPorts(string portPrefix, bool withUserTracking, bool withCamerasON);
+    void openPorts(string portPrefix, bool withUserTracking, bool withColorOn);
     /**
      * Sends the sensor data to the rgb and depth frame ports. Also sends the userSkeleton data to the mainBottle port.
      *

--- a/src/modules/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.cpp
@@ -223,24 +223,27 @@ int OpenNI2SkeletonTracker::init(){
             {
                 imageStream.setVideoMode(colorModes[colorVideoMode]);
             }
-        }
         
-        if (oniRecord) {
+            if (oniRecord) {
             recorder.attach(imageStream);
-        }
+            }
 
-        rc = imageStream.start();
-        if (rc != openni::STATUS_OK)
-        {
-            printf("Couldn't start the RGB stream\n%s\n", openni::OpenNI::getExtendedError());
-            deviceStatus = rc;
-            return rc;
-        }
+            rc = imageStream.start();
+            if (rc != openni::STATUS_OK)
+            {
+                printf("Couldn't start the RGB stream\n%s\n", openni::OpenNI::getExtendedError());
+                deviceStatus = rc;
+                return rc;
+            }
         
+            else {
+                fpsCount = imageStream.getVideoMode().getFps();
+                cout << "RGB video mode: " << colorVideoMode << " - " << imageStream.getVideoMode().getResolutionX() << "x" << imageStream.getVideoMode().getResolutionY() << " - " << fpsCount << " fps" << endl;
+                cout << "RGB stream started..." << endl;
+            }
+        }
         else {
-            fpsCount = imageStream.getVideoMode().getFps();
-            cout << "RGB video mode: " << colorVideoMode << " - " << imageStream.getVideoMode().getResolutionX() << "x" << imageStream.getVideoMode().getResolutionY() << " - " << fpsCount << " fps" << endl;
-            cout << "RGB stream started..." << endl;
+            camerasON = false;
         }
 
     }

--- a/src/modules/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.cpp
@@ -14,27 +14,23 @@
 
 OpenNI2SkeletonTracker::SensorStatus *OpenNI2SkeletonTracker::sensorStatus;
 
-OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withCamerasOn, bool withMirrorOn, double minConf, bool withOniPlayback, string withFileDevice, bool withOniRecord, string withOniOutputFile, bool withLoop, bool withFrameSync, bool withImageRegistration, bool prMode, int depthMode, int colorMode)
+OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withColorOn, bool withMirrorOn, double minConf, bool withOniPlayback, string withFileDevice, bool withOniRecord, string withOniOutputFile, bool withLoop, bool withFrameSync, bool withImageRegistration, bool prMode, int depthMode, int colorMode)
 {
     userTracking= withTracking;
-    colorON = withCamerasOn;
+    colorON = withColorOn;
     mirrorON = withMirrorOn;
     colorVideoMode=DEFAULT_COLOR_MODE;
     depthVideoMode=DEFAULT_DEPTH_MODE;
+    
     if (colorMode <= 11 && colorMode >= 0){
     colorVideoMode=colorMode;
     }
+    
     if (depthMode <= 10 && depthMode >= 0){
     depthVideoMode=depthMode;
     }
-    if (minConf != MINIMUM_CONFIDENCE){
-        minConfidence = minConf;
-    }
-
-    else{
-        minConfidence = MINIMUM_CONFIDENCE;
-    }
-
+    
+    minConfidence = minConf;
     oniPlayback = withOniPlayback;
     oniRecord = withOniRecord;
     if (oniPlayback) {
@@ -53,12 +49,10 @@ OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withCamer
     initVars();
 }
 
-OpenNI2SkeletonTracker::~OpenNI2SkeletonTracker(void)
-{
+OpenNI2SkeletonTracker::~OpenNI2SkeletonTracker(void){
 }
 
 void OpenNI2SkeletonTracker::close(){
-   
     if (oniRecord) {
         recorder.stop();
         cout << "Stopping recorder device...";
@@ -278,9 +272,7 @@ int OpenNI2SkeletonTracker::init(){
         }
 
     if (userTracking){
-        
         // setup and start user tracking
-
         nite::Status niteRc = nite::NiTE::initialize();
         niteRc = userTracker.create(&device);
 
@@ -289,7 +281,6 @@ int OpenNI2SkeletonTracker::init(){
             printf("Couldn't create user tracker\n");
             return niteRc;
         }
-        
         else {
             cout << "User tracker started..." << endl;
         }
@@ -303,7 +294,6 @@ int OpenNI2SkeletonTracker::init(){
         if (rc != openni::STATUS_OK) {
             printf("Couldn't start recorder\n");
         }
-
         else {
             cout << "Recorder started..." << endl;
         }
@@ -436,7 +426,6 @@ void OpenNI2SkeletonTracker::updateSensor(){
 }
 
 void OpenNI2SkeletonTracker::updateJointInformation(const nite::UserData& user, nite::JointType joint, int jIndex){
-    
     int i = user.getId();
     UserSkeleton *userSkeleton = &getSensor()->userSkeleton[i-1];
     
@@ -444,7 +433,6 @@ void OpenNI2SkeletonTracker::updateJointInformation(const nite::UserData& user, 
     userSkeleton->stillTracking = true;
     
     if (user.getSkeleton().getJoint(joint).getPositionConfidence() > minConfidence) {
-        
         // position
         double x = user.getSkeleton().getJoint(joint).getPosition().x;
         userSkeleton->skeletonPointsPos[jIndex][0]= x;
@@ -455,7 +443,6 @@ void OpenNI2SkeletonTracker::updateJointInformation(const nite::UserData& user, 
     }
     
     if (user.getSkeleton().getJoint(joint).getOrientationConfidence() > minConfidence){
-        
         // orientation
         userSkeleton->skeletonPointsOri[jIndex][0] = user.getSkeleton().getJoint(joint).getOrientation().w;
         userSkeleton->skeletonPointsOri[jIndex][1] = user.getSkeleton().getJoint(joint).getOrientation().x;
@@ -470,8 +457,7 @@ void OpenNI2SkeletonTracker::updateJointInformation(const nite::UserData& user, 
 }
 
 
-void OpenNI2SkeletonTracker::updateUserState(const nite::UserData& user, unsigned long long ts)
-{
+void OpenNI2SkeletonTracker::updateUserState(const nite::UserData& user, unsigned long long ts){
     int tmpID = user.getId();
     // if user is new
     if (user.isNew())
@@ -536,3 +522,4 @@ void OpenNI2SkeletonTracker::updateUserState(const nite::UserData& user, unsigne
 int OpenNI2SkeletonTracker::getDeviceStatus(){
     return deviceStatus;
 }
+

--- a/src/modules/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.cpp
@@ -17,7 +17,7 @@ OpenNI2SkeletonTracker::SensorStatus *OpenNI2SkeletonTracker::sensorStatus;
 OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withCamerasOn, bool withMirrorOn, double minConf, bool withOniPlayback, string withFileDevice, bool withOniRecord, string withOniOutputFile, bool withLoop, bool withFrameSync, bool withImageRegistration, bool prMode, int depthMode, int colorMode)
 {
     userTracking= withTracking;
-    camerasON = withCamerasOn;
+    colorON = withCamerasOn;
     mirrorON = withMirrorOn;
     colorVideoMode=DEFAULT_COLOR_MODE;
     depthVideoMode=DEFAULT_DEPTH_MODE;
@@ -81,7 +81,7 @@ void OpenNI2SkeletonTracker::close(){
         depthStream.destroy();
         cout << "Done" << endl;
     
-    if (camerasON){
+    if (colorON){
         cout << "Destroying RGB stream...";
         imageStream.destroy();
         cout << "Done" << endl;
@@ -203,7 +203,7 @@ int OpenNI2SkeletonTracker::init(){
             frameCount = playbackControl->getNumberOfFrames(depthStream);
         }
     
-    if (camerasON){        
+    if (colorON){        
         // setup and start colour stream
         if (device.getSensorInfo(openni::SENSOR_COLOR) != NULL)
         {
@@ -243,7 +243,7 @@ int OpenNI2SkeletonTracker::init(){
             }
         }
         else {
-            camerasON = false;
+            colorON = false;
             cout << "No RGB camera found, RGB stream disabled" << endl;
         }
 
@@ -262,7 +262,7 @@ int OpenNI2SkeletonTracker::init(){
                 }
             }
 
-            if (camerasON)
+            if (colorON)
             {
                 colorInfo = device.getSensorInfo(openni::SENSOR_COLOR);
                 const openni::Array<openni::VideoMode>& colorModes= colorInfo->getSupportedVideoModes();
@@ -316,7 +316,7 @@ void OpenNI2SkeletonTracker::initVars(){
     sensorStatus = new SensorStatus;
    
     // read frames from streams
-    if (camerasON){
+    if (colorON){
         imageStream.readFrame(&imageFrameRef);
     }
     depthStream.readFrame(&depthFrameRef);
@@ -326,7 +326,7 @@ void OpenNI2SkeletonTracker::initVars(){
     sensorStatus->depthFrame.resize(depthMode.getResolutionX(), depthMode.getResolutionY());
     sensorStatus->depthFrame.zero();
     
-    if (camerasON){
+    if (colorON){
     // get RGB mode properties and prepare imageFrame
     imageMode = imageStream.getVideoMode();
     sensorStatus->imageFrame.resize(imageMode.getResolutionX(), imageMode.getResolutionY());
@@ -355,7 +355,7 @@ OpenNI2SkeletonTracker::SensorStatus *OpenNI2SkeletonTracker::getSensor(){
 
 void OpenNI2SkeletonTracker::updateSensor(){
     // get camera image
-    if(camerasON){ 
+    if(colorON){ 
             if (imageStream.isValid()){
         imageStream.readFrame(&imageFrameRef);
             }

--- a/src/modules/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.cpp
@@ -244,6 +244,7 @@ int OpenNI2SkeletonTracker::init(){
         }
         else {
             camerasON = false;
+            cout << "No RGB camera found, RGB stream disabled" << endl;
         }
 
     }

--- a/src/modules/openni2/OpenNI2SkeletonTracker.h
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.h
@@ -67,7 +67,7 @@ public:
     /**
      * @param userDetection indicates if user callbacks and skeleton tracking should be on
      */
-    OpenNI2SkeletonTracker(bool withTracking = false, bool camerasON = true, bool mirrorON = true, double minConf = MINIMUM_CONFIDENCE, bool oniPlayback = false, string fileDevice = "", bool oniRecord  = false, string oniOutputFile = "", bool loop = false, bool frameSync = false, bool imageRegistration = false, bool printMode = false, int depthMode = DEFAULT_DEPTH_MODE, int colorMode = DEFAULT_COLOR_MODE);
+    OpenNI2SkeletonTracker(bool withTracking = false, bool colorON = true, bool mirrorON = true, double minConf = MINIMUM_CONFIDENCE, bool oniPlayback = false, string fileDevice = "", bool oniRecord  = false, string oniOutputFile = "", bool loop = false, bool frameSync = false, bool imageRegistration = false, bool printMode = false, int depthMode = DEFAULT_DEPTH_MODE, int colorMode = DEFAULT_COLOR_MODE);
     ~OpenNI2SkeletonTracker(void);
     void close();
     /**
@@ -83,7 +83,7 @@ public:
     static SensorStatus *getSensor();
 private:
     static SensorStatus *sensorStatus;
-    bool userTracking, camerasON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration, printMode;
+    bool userTracking, colorON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration, printMode;
     int deviceStatus;
     double minConfidence;
     string fileDevice;


### PR DESCRIPTION
With this PR:

- Sensors with no RGB cameras are correctly initialised and RGB functionality is disabled
- The ``--noCameras`` option has been replaced with ``--noRGB``. This disables all RGB-related functionality
- Removed a warning during compilation
- Some general cleaning of white lines etc.

Commits squashed and rebased :)
Documentation will update shortly.

Many thanks to @David-Estevez for his work and testing!