### PR TITLE
make opencv_grabber attend to --framerate flag, not only the wrapper

### DIFF
--- a/src/modules/opencv/OpenCVGrabber.cpp
+++ b/src/modules/opencv/OpenCVGrabber.cpp
@@ -111,6 +111,13 @@ bool OpenCVGrabber::open(Searchable & config) {
             return false;
         }
 
+        if ( config.check("framerate","if present, specifies desired camera device framerate") ) {
+            double m_fps = config.check("framerate", Value(-1)).asDouble();
+            cvSetCaptureProperty((CvCapture*)m_capture,
+                                 CV_CAP_PROP_FPS,m_fps);
+        }
+
+
     }
 
 


### PR DESCRIPTION
Without this addition, upon:
`yarpdev --device opencv_grabber --framerate 15 --verbose`
the framerate argument is only passed to the grabber wrapper:
`grabber.framerate=15 [0]
    maximum rate in Hz to read from subdevice`
With this addition, opencv_grabber actually sets the framerate on the device:
`opencv_grabber.framerate=15 [-1]
    if present, specifies desired camera device framerate`

Tested and works. My only concern is that I have seen some cases in the past in which an exception can be thrown when lacking certain operating system permissions on the device. A solution for that would be setting this as a separate flag, such as --opencv_framerate, but the resulting syntax would be way too long, and I additionally haven't been able to replicate the exception (*chmod 444 /dev/video** breaks before, on querying number of channels). BTW, this is needed for the Minoru camera and similar, to simultaneously access two webcams through a single USB port.