### PR TITLE
[YARP_OS] Properly cast the object in plugin create and destroy functions

### DIFF
--- a/src/libYARP_OS/src/SharedLibraryFactory.cpp
+++ b/src/libYARP_OS/src/SharedLibraryFactory.cpp
@@ -73,7 +73,7 @@ bool yarp::os::SharedLibraryFactory::isValid() const {
     if (api.structureSize != sizeof(SharedLibraryClassApi)) {
         return false;
     }
-    if (api.systemVersion != 4) {
+    if (api.systemVersion != 5) {
         return false;
     }
     if (api.endCheck != VOCAB4('P','L','U','G')) {


### PR DESCRIPTION
When deleting a device/carrier from a plugin, if the
yarp::dev::DeviceDriver/yarp::os::Carrier class is not the first
inherited class, instead of the destructor of the class a complete
different function was called by delete.

The double cast in the _create() and _destroy() functions are required
to ensure that everything works when `basename` is not the first
inherited class:
 *  _create() will return a valid `basename` or a null pointer if
   `classname` does not inherit from `basename`.
 * _destroy() will ensure that we are calling `classname` destructor
   even if `basename` is not the first inherited class. If the
   dynamic_cast fails, it will not delete the object (that is probably
   leaked), but it is less dangerous than executing some other random
   function.

Also bump plugin system version an tweak version numbers.

Fixes #435