### PR TITLE
Improvements to "yarp plugin"

### DIFF
--- a/scripts/yarp_completion
+++ b/scripts/yarp_completion
@@ -23,7 +23,12 @@ _get_yarp_carriers(){
 echo $(yarp connect --list-carriers 2>/dev/null)
 }
 
-_yarp() 
+_get_yarp_plugins(){
+echo $(yarp plugin --list 2>/dev/null)
+}
+
+
+_yarp()
 {
     COMPREPLY=()
 
@@ -44,6 +49,7 @@ _yarp()
     local command="${COMP_WORDS[1]}"
     local cmds=$(_get_yarp_help)
     local connectopts=(--persist --persist-to --persist-from --list-carriers --help)
+    local pluginopts=(--help --list --all --search-path)
 
     completion=""
     if [ $COMP_CWORD -eq 1 ]; then
@@ -110,7 +116,12 @@ _yarp()
                 if [ $COMP_CWORD -eq 2 ]; then completion="list"; fi ;;
             conf)
                 if [ $COMP_CWORD -eq 2 ]; then completion="--clean"; fi ;;
-             *)
+            plugin)
+                if [ $COMP_CWORD -eq 2 ]; then
+                    completion="${pluginopts[@]} $(_get_yarp_plugins)"
+                fi
+                ;;
+            *)
                 ;;
         esac
 
@@ -121,7 +132,7 @@ _yarp()
     fi;
 
     return 0
-        
+
 }
 
 _yarprun() {
@@ -174,7 +185,7 @@ _yarprun() {
             esac
         fi
     fi
-    
+
     COMPREPLY=( $(compgen -W "${completion}" -- ${cur}) )
 
     return 0

--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -249,13 +249,26 @@ public:
                         bool wipe=true);
 
     /**
+     * Interprets all files in a directory as lists of properties as
+     * described in fromConfigFile().
+     *
+     * @param dirname the name of the file to read from
+     * @param section if specified names the subsection for each file,
+     * otherwise use the same section for all files
+     * @param wipe should Property be emptied first
+     * @return true if file exists and can be read
+     */
+    bool fromConfigDir(const ConstString& firname,
+                       const ConstString& section = ConstString(),
+                       bool wipe = true);
+
+    /**
      * Parses text in the configuration format described in
      * fromConfigFile().
      * @param txt the configuration text
      * @param wipe should Property be emptied first
      */
     void fromConfig(const char *txt, bool wipe=true);
-
 
     /**
      * Variant of fromConfig(txt,wipe) that includes extra

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -434,6 +434,29 @@ public:
         return true;
     }
 
+    bool fromConfigDir(const ConstString& dirname, const ConstString& section, bool wipe=true) {
+        Property p;
+        if (section.empty()) {
+            return fromConfigFile(dirname, p, wipe);
+        }
+
+        YARP_DEBUG(Logger::get(), String("looking for ") + dirname.c_str());
+
+        ACE_DIR *dir = ACE_OS::opendir(dirname.c_str());
+        if (!dir) {
+            YARP_ERROR(Logger::get(), String("cannot read from ") + dirname);
+            return false;
+        }
+
+        String txt;
+        if (!readDir(dirname, dir, txt, section)) {
+            YARP_ERROR(Logger::get(), String("cannot read from ") + dirname);
+            return false;
+        }
+
+        fromConfig(txt.c_str(), p, wipe);
+        return true;
+    }
 
     void fromConfig(const char *txt,Searchable& env, bool wipe=true) {
         StringInputStream sis;
@@ -896,6 +919,11 @@ void Property::fromCommand(int argc, char *argv[], bool skipFirst,
 void Property::fromCommand(int argc, const char *argv[], bool skipFirst, bool wipe) {
     summon();
     fromCommand(argc,(char **)argv,skipFirst,wipe);
+}
+
+bool Property::fromConfigDir(const ConstString& dirname, const ConstString& section, bool wipe) {
+    summon();
+    return HELPER(implementation).fromConfigDir(dirname, section, wipe);
 }
 
 bool Property::fromConfigFile(const ConstString& fname, bool wipe) {

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -319,7 +319,7 @@ public:
         }
     }
 
-    bool readDir(const ConstString& dirname, ACE_DIR *&dir, String& result) {
+    bool readDir(const ConstString& dirname, ACE_DIR *&dir, String& result, const ConstString& section=ConstString()) {
         bool ok = true;
         YARP_DEBUG(Logger::get(),
                    String("reading directory ") + dirname);
@@ -338,8 +338,12 @@ public:
             if (len<4) continue;
             if (name.substr(len-4)!=".ini") continue;
             ConstString fname = ConstString(dirname) + "/" + name;
-            ok = ok && readFile(fname,result,false);
-            result += "\n[]\n";  // reset any nested sections
+            if (section.empty()) {
+                ok = ok && readFile(fname,result,false);
+                result += "\n[]\n";  // reset any nested sections
+            } else {
+                result += "[include " + section + " \"" + fname + "\" \"" + fname + "\"]\n";
+            }
         }
         free(namelist);
         return ok;


### PR DESCRIPTION
* Add method "Property::fromConfigDir" to save the name of the .ini file that generated a part of the config
* Use it to retrieve the name of the .ini file that imports a plugin
* Improve plugin command. It is now able to detect broken plugins and shows a better output. Also improve the help and implement the following commands:
   * yarp plugin --help
   * yarp plugin --list
   * yarp plugin --all
   * yarp plugin --search-path
* Update bash completion for "yarp plugin"

Examples:

```
$ yarp plugin --help
Print information about installed plugins

Usage:
 * Test a specific plugin:
     yarp plugin <pluginname>
     yarp plugin /path/to/plugin/<libraryname>.(so|dll|dylib) <pluginpart>
 * Test all the plugins:
     yarp plugin --all
 * Print a list of plugins:
     yarp plugin --list
 * Print plugin search path:
     yarp plugin --search-path
 * Print this help and exit:
     yarp plugin --help
```

```
$ yarp plugin --list
bayer
cuda
dynamixelAX12Ftdi
[...]
```

```
$ yarp plugin bayer
Yes, this is a YARP plugin
  * library:        /opt/iit/lib/yarp/yarp_bayer.so
  * system version: 5
  * class name:     yarp::os::BayerCarrier
  * base class:     yarp::os::Carrier

$ yarp plugin cuda
Yes, this is a YARP plugin
  Cannot find or load shared library

$ yarp plugin dynamixelAX12Ftdi
Yes, this is a YARP plugin
  * library:        /opt/iit/lib/yarp/dynamixelAX12FtdiDriver.so
  * system version: 5
  * class name:     yarp::dev::DynamixelAX12FtdiDriver
  * base class:     yarp::dev::DeviceDriver
*** Error in `yarp': free(): invalid size: 0x0000000002501a00 ***

  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  X                                                     X
  X                       WARNING                       X
  X                                                     X
  X            === This plugin is BROKEN ===            X
  X                                                     X
  X                                                     X
  X  Author information: The most plausible reason is   X
  X  that the destructor is deleting some pointer that  X
  X  is not allocated in the constructor, and that is   X
  X  not initialized to a null pointer.                 X
  X                                                     X
  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

```

```
$ yarp plugin --all           
Runtime plugins found:

carrier bayer
  * ini file:       /opt/iit/share/yarp/plugins/bayer.ini
  * config:         bayer (type carrier) (name bayer) (subtype recv) (library yarp_bayer) (part bayer_carrier) (code "not applicable")
  * library:        /opt/iit/lib/yarp/yarp_bayer.so
  * system version: 5
  * class name:     yarp::os::BayerCarrier
  * base class:     yarp::os::Carrier

device cuda
  * ini file:       /opt/iit/share/yarp/plugins/cuda.ini
  * config:         cuda (type device) (name cuda) (library ycuda) (part cuda)
  Cannot find or load shared library

device dynamixelAX12Ftdi
  * ini file:       /opt/iit/share/yarp/plugins/dynamixelAX12Ftdi.ini
  * config:         dynamixelAX12Ftdi (type device) (name dynamixelAX12Ftdi) (library dynamixelAX12FtdiDriver) (part dynamixelAX12Ftdi)
  * library:        /opt/iit/lib/yarp/dynamixelAX12FtdiDriver.so
  * system version: 5
  * class name:     yarp::dev::DynamixelAX12FtdiDriver
  * base class:     yarp::dev::DeviceDriver

  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  X                                                     X
  X                       WARNING                       X
  X                                                     X
  X            === This plugin is BROKEN ===            X
  X                                                     X
  X                                                     X
  X  Author information: The most plausible reason is   X
  X  that the destructor is deleting some pointer that  X
  X  is not allocated in the constructor, and that is   X
  X  not initialized to a null pointer.                 X
  X                                                     X
  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```


```
$ yarp plugin --search-path
Search path:
  * yarp:       /opt/iit/lib/yarp
  * iCub:       /opt/iit/lib/iCub
```


Yes, the dynamixelAX12Ftdi is actually broken, I did not fix it (yet) because it helped testing this :grin:
