### PR TITLE
[ros] omit final null character when sending strings, fixes #452

### DIFF
--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -393,7 +393,6 @@ bool RosTypeCodeGenYarp::writeField(bool bare, const RosField& field) {
     fprintf(out,"    // *** %s ***\n", field.rosName.c_str());
     if (field.rosType=="string") {
         // strings are special; variable length primitive
-        string tweak = bare?"":"+1";
         if (field.isArray) {
             if (!bare) {
                 fprintf(out,"    connection.appendInt(BOTTLE_TAG_LIST|BOTTLE_TAG_STRING);\n");
@@ -407,28 +406,24 @@ bool RosTypeCodeGenYarp::writeField(bool bare, const RosField& field) {
                     counter.c_str(),
                     field.rosName.c_str(),
                     counter.c_str());
-            fprintf(out,"      connection.appendInt(%s[%s].length()%s);\n",
+            fprintf(out,"      connection.appendInt(%s[%s].length());\n",
+                    field.rosName.c_str(),
+                    counter.c_str());
+            fprintf(out,"      connection.appendExternalBlock((char*)%s[%s].c_str(),%s[%s].length());\n",
                     field.rosName.c_str(),
                     counter.c_str(),
-                    tweak.c_str());
-            fprintf(out,"      connection.appendExternalBlock((char*)%s[%s].c_str(),%s[%s].length()%s);\n",
                     field.rosName.c_str(),
-                    counter.c_str(),
-                    field.rosName.c_str(),
-                    counter.c_str(),
-                    tweak.c_str());
+                    counter.c_str());
             fprintf(out,"    }\n");                  
         } else {
             if (!bare) {
                 fprintf(out,"    connection.appendInt(BOTTLE_TAG_STRING);\n");
             }
-            fprintf(out,"    connection.appendInt(%s.length()%s);\n",
+            fprintf(out,"    connection.appendInt(%s.length());\n",
+                    field.rosName.c_str());
+            fprintf(out,"    connection.appendExternalBlock((char*)%s.c_str(),%s.length());\n",
                     field.rosName.c_str(),
-                    tweak.c_str());
-            fprintf(out,"    connection.appendExternalBlock((char*)%s.c_str(),%s.length()%s);\n",
-                    field.rosName.c_str(),
-                    field.rosName.c_str(),
-                    tweak.c_str());
+                    field.rosName.c_str());
         }
     } else if (field.isPrimitive) {
         if (field.isArray) {

--- a/src/libYARP_OS/harness/BottleTest.cpp
+++ b/src/libYARP_OS/harness/BottleTest.cpp
@@ -555,26 +555,27 @@ public:
         char buf1[] = "hello world";
         char buf2[] = "hello world";
         buf2[5] = '\0';
-        ConstString str1(buf1,12);
-        ConstString str2(buf2,12);
-        checkEqual(str1.length(),12,"unmodified string length ok");
-        checkEqual(str2.length(),12,"modified string length ok");
+        size_t len = 11;
+        ConstString str1(buf1,len);
+        ConstString str2(buf2,len);
+        checkEqual(str1.length(),len,"unmodified string length ok");
+        checkEqual(str2.length(),len,"modified string length ok");
         ConstString str3(str2);
-        checkEqual(str3.length(),12,"copied string length ok");
+        checkEqual(str3.length(),len,"copied string length ok");
         Bottle bot;
         bot.addString(str2);
-        checkEqual(bot.get(0).asString().length(),12,"bottled string asString() length ok");
-        checkEqual(bot.get(0).toString().length(),12,"bottled string toString() length ok");
+        checkEqual(bot.get(0).asString().length(),len,"bottled string asString() length ok");
+        checkEqual(bot.get(0).toString().length(),len,"bottled string toString() length ok");
         Bottle bot2 = bot;
-        checkEqual(bot2.get(0).asString().length(),12,"bottled, copied string length ok");
+        checkEqual(bot2.get(0).asString().length(),len,"bottled, copied string length ok");
 
         Bottle bot3;
         bot.write(bot3);
-        checkEqual(bot3.get(0).asString().length(),12,"bottled, serialized string length ok");
+        checkEqual(bot3.get(0).asString().length(),len,"bottled, serialized string length ok");
 
         Bottle bot4;
         bot4.fromString(bot.toString());
-        checkEqual(bot4.get(0).asString().length(),12,"bottled, text-serialized string length ok");
+        checkEqual(bot4.get(0).asString().length(),len,"bottled, text-serialized string length ok");
     }
 
     void testBool() {

--- a/src/libYARP_OS/src/BottleImpl.cpp
+++ b/src/libYARP_OS/src/BottleImpl.cpp
@@ -885,6 +885,7 @@ bool StoreString::readRaw(ConnectionReader& reader) {
     int len = reader.expectInt();
     String buf(YARP_STRINIT(len));
     reader.expectBlock((const char *)buf.c_str(),len);
+    // This is needed for compatiblity with versions of yarp before March 2015
     if (len>0) {
         if (buf[len-1] == '\0') {
             len--;
@@ -895,8 +896,8 @@ bool StoreString::readRaw(ConnectionReader& reader) {
 }
 
 bool StoreString::writeRaw(ConnectionWriter& writer) {
-    writer.appendInt((int)x.length()+1);
-    writer.appendBlock(x.c_str(),x.length()+1); // need \0
+    writer.appendInt((int)x.length());
+    writer.appendBlock(x.c_str(),x.length());
     return true;
 }
 

--- a/src/libYARP_OS/src/WireReader.cpp
+++ b/src/libYARP_OS/src/WireReader.cpp
@@ -209,11 +209,15 @@ bool WireReader::readString(ConstString& str, bool *is_vocab) {
     if (noMore()) return false;
     int len = reader.expectInt();
     if (reader.isError()) return false;
-    if (len<1) return false;
     if (noMore()) return false;
     str.resize(len);
     reader.expectBlock((const char *)str.c_str(),len);
-    str.resize(len-1);
+    // This is needed for compatiblity with versions of yarp before March 2015
+    if (len>0) {
+        if (str[len-1] == '\0') {
+            str.resize(len-1);
+        }
+    }
     return !reader.isError();
 }
 

--- a/src/libYARP_OS/src/WireWriter.cpp
+++ b/src/libYARP_OS/src/WireWriter.cpp
@@ -132,8 +132,8 @@ bool WireWriter::writeTag(const char *tag, int split, int len) {
 
 bool WireWriter::writeString(const yarp::os::ConstString& tag) {
     writer.appendInt(BOTTLE_TAG_STRING);
-    writer.appendInt((int)tag.length()+1);
-    writer.appendString(tag.c_str(),'\0');
+    writer.appendInt((int)tag.length());
+    writer.appendBlock(tag.c_str(),tag.length());
     return !writer.isError();
 }
 


### PR DESCRIPTION
For compatibility with an ancient version of yarp, strings have been up to now transmitted with a null character included. More recent versions of yarp will accept either a string with or without a null termination. This commit stops transmitting that null termination, but preserves the ability to receive a null terminated string for compatibility between programs using different versions of yarp.

The motivation for this change is for ROS compatibility, see #452, but it will also be a step towards removing an awkward corner case where yarp will not faithfully transmit a non-null-terminated string that happens to have a null character embedded as its last character [as opposed to a null-terminated string :-)].