### PR TITLE
thrift generated files will use yError() in place of fprintf()

### DIFF
--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -2152,7 +2152,7 @@ void t_yarp_generator::generate_service(t_service* tservice) {
       f_cpp_ << ");" << endl;
       indent(f_cpp_) << "if (!yarp().canWrite()) {" << endl;
       indent_up();
-      indent(f_cpp_) << "fprintf(stderr,\"Missing server method '%s'?\\n\",\"";
+      indent(f_cpp_) << "yError(\"Missing server method '%s'?\",\"";
       f_cpp_ << function_prototype(*fn_iter,false,service_name_.c_str());
       f_cpp_ << "\");" << endl;
       indent_down();

--- a/src/libYARP_OS/include/yarp/os/idl/WireTypes.h
+++ b/src/libYARP_OS/include/yarp/os/idl/WireTypes.h
@@ -44,5 +44,6 @@
 #include <yarp/os/NetUint64.h>
 #include <yarp/os/NetFloat32.h>
 #include <yarp/os/NetFloat64.h>
+#include <yarp/os/Log.h>
 
 #endif


### PR DESCRIPTION
Thrift auto-generated files will employ `yError()` and no longer `fprintf()` in order to stream the messages throughout the network and make them be displayed by means of `yarplogger`.

see #462