### PR TITLE
Implement several of the std::string methods missing in ConstString

### DIFF
--- a/conf/doxygen/Doxyfile.part.template
+++ b/conf/doxygen/Doxyfile.part.template
@@ -2002,7 +2002,8 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          YARP_math_API= \
                          YARP_name_API= \
                          YARP_sig_API= \
-                         YARP_init_API=
+                         YARP_init_API= \
+                         YARP_WRAP_STL_STRING
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/libYARP_OS/include/yarp/os/ConstString.h
+++ b/src/libYARP_OS/include/yarp/os/ConstString.h
@@ -25,7 +25,7 @@ namespace yarp {
 }
 
 
-#else
+#else // YARP_WRAP_STL_STRING
 
 // yarp::os::ConstString == opaque/inline wrapped version of std::string
 #include <yarp/conf/numeric.h>
@@ -47,27 +47,70 @@ namespace yarp {
 class YARP_OS_API yarp::os::ConstString {
 public:
 
+    static const size_t npos;
+
+    typedef char value_type;
+    typedef std::char_traits<char> traits_type;
+    typedef std::allocator<char> allocator_type;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+
+    typedef char& reference;
+    typedef const char& const_reference;
+    typedef char* pointer;
+    typedef const char* const_pointer;
+
+    typedef std::string::iterator iterator;
+    typedef std::string::const_iterator const_iterator;
+    typedef std::reverse_iterator<iterator> reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+
 #ifndef YARP_WRAP_STL_STRING_INLINE
+    /** @{ */
 
     /**
-     * Constructor.  Creates an empty string.
+     * Constructor.
+     * Creates an empty string.
      */
     ConstString();
 
     /**
-     * Constructor.  Stores a copy of the null-terminated specified string.
-     * @param str the string to copy
+     * Copy constructor.
+     * @param str The string to be copied.
+     */
+    ConstString(const ConstString& str);
+
+    /**
+     * Constructor.
+     * Stores a copy of the substring.
+     * @param str The string to be copied.
+     * @param pos Position of the first character to be copied.
+     * @param len Length of the substring to be copied.
+     */
+    ConstString(const ConstString& str, size_t pos, size_t len = npos);
+
+    /**
+     * Constructor.
+     * Stores a copy of the null-terminated specified string.
+     * @param str The string to be copied.
      */
     ConstString(const char *str);
 
     /**
-     * Constructor.  Stores a copy of the specified string.
-     * @param str the string to copy
-     * @param len number of bytes to copy
+     * Constructor.
+     * Stores a copy of the specified string.
+     * @param str The string to be copied.
+     * @param len Number of bytes to copy.
      */
-    ConstString(const char *str, int len);
+    ConstString(const char *str, size_t len);
 
-    ConstString(size_t len, char v);
+    /**
+     * Constructor.
+     * Fills the string with a character.
+     * @param len Number of characters to copy.
+     * @param v The character to copy.
+     */
+    ConstString(size_t len, char c);
 
     /**
      * Destructor.
@@ -75,74 +118,23 @@ public:
     ~ConstString();
 
     /**
-     * Copy constructor.
+     * Assignment operator.
+     * @param str The string to be copied.
      */
-    ConstString(const ConstString& alt);
+    ConstString& operator=(const ConstString& str);
 
     /**
-     * Accesses the character sequence stored in this object.
+     * Assignment operator.
+     * @param str The string to be copied.
      */
-    const char *c_str() const;
+    ConstString& operator=(const char* str);
 
-    const char *data() const;
+     /**
+      * Assignment operator.
+      * @param c The character to be copied.
+      */
+    ConstString& operator=(char c);
 
-    ConstString& assign(const char *s, size_t n);
-
-    /**
-     * Typecast operator to C-style string.
-     */
-    //operator const char *() const {
-    //return c_str();
-    //}
-
-    char& operator[](size_t idx);
-    const char& operator[](size_t idx) const;
-
-    const ConstString& operator = (const ConstString& alt);
-
-    bool operator <(const ConstString& alt) const;
-    bool operator >(const ConstString& alt) const;
-
-    bool operator ==(const ConstString& alt) const;
-    bool operator !=(const ConstString& alt) const;
-
-    bool operator ==(const char *str) const;
-    bool operator !=(const char *str) const;
-
-    bool operator <=(const ConstString& alt) const;
-    bool operator >=(const ConstString& alt) const;
-
-    ConstString operator + (char ch) const;
-    ConstString operator + (const char *str) const;
-    ConstString operator + (const ConstString& alt) const;
-
-    const ConstString& operator += (char ch);
-    const ConstString& operator += (const char *str);
-    const ConstString& operator += (const ConstString& alt);
-
-    size_t length() const;
-
-    size_t size() const { return length(); }
-
-    void resize(size_t n);
-
-    size_t find(const ConstString& needle) const;
-    size_t find(const char *needle) const;
-    size_t find(const char *needle, size_t start) const;
-    size_t find(char needle, size_t start) const;
-    size_t rfind(char needle) const;
-
-    ConstString substr(size_t start = 0, size_t n = (size_t)(-1)) const;
-
-    static size_t npos;
-
-    typedef size_t size_type;
-
-    unsigned long hash() const;
-
-    void clear();
-
-    bool empty() const;
 
     // ConstString is implemented internally as a std::string
     // We cannot expose that implementation without coupling
@@ -159,29 +151,164 @@ public:
     inline ConstString(const std::string& str) {
         init(str.c_str(),str.length());
     }
+    /** @} */
 
+
+    /**
+     * \name Iterators
+     * @{
+     */
+    iterator begin();
+    const_iterator begin() const;
+
+    iterator end();
+    const_iterator end() const;
+
+    reverse_iterator rbegin();
+    const_reverse_iterator rbegin() const;
+
+    reverse_iterator rend();
+    const_reverse_iterator rend() const;
+    /** @} */
+
+
+    /**
+     * \name Capacity
+     * @{
+     */
+    size_t size() const;
+    size_t length() const;
+    size_t max_size() const;
+    void resize(size_t n);
+    void resize(size_t n, char c);
+    size_t capacity() const;
+    void reserve(size_t n = 0);
+    void clear();
+    bool empty() const;
+    /** @} */
+
+
+    /**
+     * \name Element access
+     * @{
+     */
+    char& operator[](size_t idx);
+    const char& operator[](size_t idx) const;
+
+    char& at(size_t pos);
+    const char& at(size_t pos) const;
+    /** @} */
+
+
+    /**
+     * \name Modifiers
+     * @{
+     */
+    ConstString& operator+=(const ConstString& str);
+    ConstString& operator+=(const char *str);
+    ConstString& operator+=(char ch);
+
+    void push_back (char c);
+
+    ConstString& assign(const char *s, size_t n);
+
+    ConstString& erase(size_t pos = 0, size_t len = npos);
+    iterator erase(iterator p);
+    iterator erase(iterator first, iterator last);
+
+    void swap(ConstString& str);
+    /** @} */
+
+
+    /**
+     * \name String operations
+     * @{
+     */
+
+    /**
+     * Accesses the character sequence stored in this object.
+     */
+    const char *c_str() const;
+
+    /**
+     * Get string data.
+     */
+    const char *data() const;
+
+    /**
+     * Get allocator.
+     */
+    allocator_type get_allocator() const;
+
+    /**
+     * Copy sequence of characters from string.
+     */
+    size_t copy(char* str, size_t len, size_t pos = 0) const;
+
+    /**
+     * Find content in string.
+     */
+    size_t find(const ConstString& needle, size_t start = 0) const;
+    size_t find(const char *needle, size_t start = 0) const;
+    size_t find(const char *needle, size_t start, size_t len) const;
+    size_t find(char needle, size_t start = 0) const;
+
+    /**
+     * Find the last occurrence of content in string.
+     */
+    size_t rfind(const ConstString& needle, size_t start = npos) const;
+    size_t rfind(const char *needle, size_t start = npos) const;
+    size_t rfind(const char *needle, size_t start, size_t len) const;
+    size_t rfind(char needle, size_t start = npos) const;
+
+    /**
+     * Generate a substring.
+     */
+    ConstString substr(size_t start = 0, size_t n = npos) const;
+    /** @} */
+
+
+
+    /**
+     * \name Non std::string
+     * @{
+     */
+    unsigned long hash() const;
+    /** @} */
+
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:
     void init(const char *str, size_t len);
-
     void *implementation;
+#endif
 
-#else
+#else // YARP_WRAP_STL_STRING_INLINE
 
     inline ConstString() {}
 
+    inline ConstString(const ConstString& str) : s(str.s) {}
+
+    inline ConstString(const ConstString& str, size_t pos, size_t len = npos) : s(str.s, pos, len) {}
+
     inline ConstString(const char *str) : s(str) {}
 
-    inline ConstString(const char *str, int len) : s(str,len) {}
+    inline ConstString(const char *str, size_t len) : s(str,len) {}
 
-    inline ConstString(size_t len, char v) : s(len,v) {}
+    inline ConstString(size_t len, char c) : s(len, c) {}
 
     inline ~ConstString() {}
 
-    inline ConstString(const ConstString& alt) : s(alt.s) {}
 
     inline const char *c_str() const { return s.c_str(); }
 
     inline const char *data() const { return s.data(); }
+
+    inline allocator_type get_allocator() const { return s.get_allocator(); }
+
+    inline size_t copy(char* str, size_t len, size_t pos = 0) const { return s.copy(str, len, pos); }
+
+    inline void push_back (char c) { s.push_back(c); }
 
     inline ConstString& assign(const char *s, size_t n) {
         this->s.assign(s,n);
@@ -189,70 +316,99 @@ private:
     }
 
     inline char& operator[](size_t idx) { return s[idx]; }
-
     inline const char& operator[](size_t idx) const { return s[idx]; }
 
-    inline const ConstString& operator = (const ConstString& alt) {
-        s = alt.s;
+    inline char& at(size_t pos) { return s.at(pos); }
+    inline const char& at(size_t pos) const { return s.at(pos); }
+
+    inline const ConstString& operator=(const ConstString& str) {
+        s = str.s;
         return *this;
     }
 
-    inline bool operator < (const ConstString& alt) const { return (s<alt.s); }
-    inline bool operator > (const ConstString& alt) const { return (s>alt.s); }
+    inline ConstString& operator=(const char* str) {
+        s = str;
+        return *this;
+    }
 
-    inline bool operator == (const ConstString& alt) const { return (s==alt.s); }
-    inline bool operator != (const ConstString& alt) const { return (s!=alt.s); }
+    inline ConstString& operator=(char c) {
+        s = c;
+        return *this;
+    }
 
-    inline bool operator == (const char *str) const { return (s==str); }
-    inline bool operator != (const char *str) const { return (s!=str); }
-
-    inline bool operator <= (const ConstString& alt) const { return (s<=alt.s); }
-    inline bool operator >= (const ConstString& alt) const { return (s>=alt.s); }
-
-    inline ConstString operator + (char ch) const { return s + ch; }
-    inline ConstString operator + (const char *str) const { return s + str; }
-    inline ConstString operator + (const ConstString& alt) const { return s + alt.s; }
-
-    inline const ConstString& operator += (char ch) {
+    inline const ConstString& operator+=(char ch) {
         s += ch;
         return *this;
     }
 
-    inline const ConstString& operator += (const char *str) {
+    inline const ConstString& operator+=(const char *str) {
         s += str;
         return *this;
     }
 
-    inline const ConstString& operator += (const ConstString& alt) {
-        s += alt.s;
+    inline const ConstString& operator+=(const ConstString& str) {
+        s += str.s;
         return *this;
     }
 
-    inline size_t length() const { return s.length(); }
-
-    inline size_t size() const { return length(); }
-
-    inline void resize(size_t n) { s.resize(n); }
-
-    inline size_t find(const ConstString& needle) const { return s.find(needle.s); }
-    inline size_t find(const char *needle) const        { return s.find(needle); }
-    inline size_t find(const char *needle, size_t start) const { return s.find(needle,start); }
-    inline size_t find(char needle, size_t start) const { return s.find(needle,start); }
-    inline size_t rfind(char needle) const { return s.rfind(needle); }
-
-    inline ConstString substr(size_t start = 0, size_t n = (size_t)(-1)) const {
-        return s.substr(start,n);
+    inline ConstString& erase(size_t pos = 0, size_t len = npos) {
+        s.erase(pos, len);
+        return *this;
     }
 
-    static size_t npos;
+    inline iterator erase(iterator p) {
+        return s.erase(p);
+    }
 
-    typedef size_t size_type;
+    inline iterator erase(iterator first, iterator last) {
+        return s.erase(first, last);
+    }
+
+    inline void swap(ConstString& str) { s.swap(str.s); }
+
+    inline size_t size() const { return s.length(); }
+
+    inline size_t length() const { return s.length(); }
+
+    inline size_t max_size() const { return s.max_size(); }
+
+    inline void resize(size_t n) { s.resize(n); }
+    inline void resize(size_t n, char c) { s.resize(n, c); }
+
+    inline size_t capacity() const { return s.capacity(); }
+
+    inline void reserve(size_t n = 0) { s.reserve(n); }
+
+    inline size_t find(const ConstString& needle, size_t start = 0) const { return s.find(needle.s, start); }
+    inline size_t find(const char *needle, size_t start = 0) const { return s.find(needle, start); }
+    inline size_t find(const char *needle, size_t start, size_t len) const { return s.find(needle, start, len); }
+    inline size_t find(char needle, size_t start = 0) const { return s.find(needle, start); };
+
+    inline size_t rfind(const ConstString& needle, size_t start = npos) const { return s.rfind(needle.s, start); }
+    inline size_t rfind(const char *needle, size_t start = npos) const { return s.rfind(needle, start); }
+    inline size_t rfind(const char *needle, size_t start, size_t len) const { return s.rfind(needle, start, len); }
+    inline size_t rfind(char needle, size_t start = npos) const { return s.rfind(needle, start); };
+
+    inline ConstString substr(size_t start = 0, size_t n = npos) const { return s.substr(start,n); }
+
 
     unsigned long hash() const;
 
     inline void clear() { s.clear(); }
 
     inline bool empty() const { return s.empty(); }
+
+    inline iterator begin() { return s.begin(); }
+    inline const_iterator begin() const { return s.begin(); }
+
+    inline iterator end() { return s.end(); }
+    inline const_iterator end() const { return s.end(); }
+
+    inline reverse_iterator rbegin() { return s.rbegin(); }
+    inline const_reverse_iterator rbegin() const { return s.rbegin(); }
+
+    inline reverse_iterator rend() { return s.rend(); }
+    inline const_reverse_iterator rend() const { return s.rend(); }
 
     inline operator std::string() const
     { return s; }
@@ -264,23 +420,182 @@ private:
 private:
     std::string s;
 
-#endif
+#endif // YARP_WRAP_STL_STRING_INLINE
 };
 
 namespace yarp {
     namespace os {
-        YARP_OS_API yarp::os::ConstString operator + (const char *txt,
-                                                      const yarp::os::ConstString& alt);
-
-        inline std::ostream& operator<<(std::ostream& stream,
-                                        const yarp::os::ConstString& alt) {
-            stream << (std::string)alt;
+        /**
+         * @{
+         * Extract string from stream.
+         */
+        inline std::istream& operator>>(std::istream& stream,
+                                        yarp::os::ConstString& str) {
+            stream >> (std::string&)str;
             return stream;
         }
+        /** @} */
+
+        /**
+         * @{
+         * Insert string into stream
+         */
+        inline std::ostream& operator<<(std::ostream& stream,
+                                        const yarp::os::ConstString& str) {
+            stream << (const std::string&)str;
+            return stream;
+        }
+        /** @} */
+
+        /**
+         * @{
+         * Concatenate ConstString
+         */
+        inline yarp::os::ConstString operator+(const yarp::os::ConstString& lhs,
+                                               const yarp::os::ConstString& rhs) {
+            return operator+((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline yarp::os::ConstString operator+(const yarp::os::ConstString& lhs,
+                                               const char* rhs) {
+            return operator+((const std::string&)lhs, rhs);
+        }
+
+        inline yarp::os::ConstString operator+(const char* lhs,
+                                               const yarp::os::ConstString& rhs) {
+            return operator+(lhs, (const std::string&)rhs);
+        }
+
+        inline yarp::os::ConstString operator+(const yarp::os::ConstString& lhs,
+                                               char rhs) {
+            return operator+((const std::string&)lhs, rhs);
+        }
+
+        inline yarp::os::ConstString operator+(char lhs,
+                                               const yarp::os::ConstString& rhs) {
+            return operator+(lhs, (const std::string&)rhs);
+        }
+        /** @} */
+
+        /**
+         * @{
+         * Relational operations for ConstString
+         */
+        inline bool operator==(const yarp::os::ConstString& lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator==((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator==(const char* lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator==(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator==(const yarp::os::ConstString& lhs,
+                               const char* rhs) {
+            return operator==((const std::string&)lhs, rhs);
+        }
+
+        inline bool operator!=(const yarp::os::ConstString& lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator!=((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator!=(const char* lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator!=(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator!=(const yarp::os::ConstString& lhs,
+                               const char* rhs) {
+            return operator!=((const std::string&)lhs, rhs);
+        }
+
+        inline bool operator<(const yarp::os::ConstString& lhs,
+                              const yarp::os::ConstString& rhs) {
+            return operator<((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator<(const char* lhs,
+                              const yarp::os::ConstString& rhs) {
+            return operator<(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator<(const yarp::os::ConstString& lhs,
+                              const char* rhs) {
+            return operator<((const std::string&)lhs, rhs);
+        }
+
+        inline bool operator<=(const yarp::os::ConstString& lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator<=((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator<=(const char* lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator<=(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator<=(const yarp::os::ConstString& lhs,
+                               const char* rhs) {
+            return operator<=((const std::string&)lhs, rhs);
+        }
+
+        inline bool operator>(const yarp::os::ConstString& lhs,
+                              const yarp::os::ConstString& rhs) {
+            return operator>((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator>(const char* lhs,
+                              const yarp::os::ConstString& rhs) {
+            return operator>(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator>(const yarp::os::ConstString& lhs,
+                              const char* rhs) {
+            return operator>((const std::string&)lhs, rhs);
+        }
+
+        inline bool operator>=(const yarp::os::ConstString& lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator>=((const std::string&)lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator>=(const char* lhs,
+                               const yarp::os::ConstString& rhs) {
+            return operator>=(lhs, (const std::string&)rhs);
+        }
+
+        inline bool operator>=(const yarp::os::ConstString& lhs,
+                               const char* rhs) {
+            return operator>=((const std::string&)lhs, rhs);
+        }
+        /** @} */
+
+        using std::swap;
     }
 }
 
-#endif
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace std {
+    inline void swap(yarp::os::ConstString& x, yarp::os::ConstString& y) {
+        swap((std::string&)x, (std::string&)y);
+    }
 
-#endif
+    inline std::istream& getline(std::istream& is, yarp::os::ConstString& str, char delim) {
+        return getline(is, (std::string&)str, delim);
+    }
+
+    inline std::istream& getline(std::istream& is, yarp::os::ConstString& str) {
+        return getline(is, (std::string&)str);
+    }
+
+}
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+
+
+#endif // YARP_WRAP_STL_STRING
+
+#endif // _YARP2_CONSTSTRING_
 

--- a/src/libYARP_OS/src/ConstString.cpp
+++ b/src/libYARP_OS/src/ConstString.cpp
@@ -101,7 +101,14 @@ ConstString::allocator_type ConstString::get_allocator() const {
 }
 
 size_t ConstString::copy(char* str, size_t len, size_t pos) const {
+#ifdef _MSC_VER
+ #pragma warning(push)
+ #pragma warning(disable : 4996)
+#endif
     return HELPER(implementation).copy(str, len, pos);
+#ifdef _MSC_VER
+ #pragma warning(pop)
+#endif
 }
 
 size_t ConstString::length() const {

--- a/src/libYARP_OS/src/ConstString.cpp
+++ b/src/libYARP_OS/src/ConstString.cpp
@@ -24,7 +24,7 @@ using namespace yarp::os;
 
 
 
-size_t ConstString::npos = std::string::npos;
+const size_t ConstString::npos = std::string::npos;
 
 #ifndef YARP_WRAP_STL_STRING_INLINE
 
@@ -36,23 +36,32 @@ ConstString::ConstString() {
     yAssert(implementation!=NULL);
 }
 
+ConstString::ConstString(const ConstString& str) {
+    implementation = new std::string(HELPER(str.implementation));
+    yAssert(implementation!=NULL);
+}
+
+ConstString::ConstString(const ConstString& str, size_t pos, size_t len) {
+    implementation = new std::string(HELPER(str.implementation), pos, len);
+}
+
 ConstString::ConstString(const char *str) {
     implementation = new std::string(str);
     yAssert(implementation!=NULL);
 }
 
-ConstString::ConstString(const char *str, int len) {
-    implementation = new std::string(str,len);
+ConstString::ConstString(const char *str, size_t len) {
+    implementation = new std::string(str, len);
     yAssert(implementation!=NULL);
 }
 
 void ConstString::init(const char *str, size_t len) {
-    implementation = new std::string(str,len);
+    implementation = new std::string(str, len);
     yAssert(implementation!=NULL);
 }
 
-ConstString::ConstString(size_t len, char v) {
-    implementation = new std::string(len,v);
+ConstString::ConstString(size_t len, char c) {
+    implementation = new std::string(len, c);
     yAssert(implementation!=NULL);
 }
 
@@ -63,13 +72,19 @@ ConstString::~ConstString() {
     }
 }
 
-ConstString::ConstString(const ConstString& alt) {
-    implementation = new std::string(HELPER(alt.implementation));
-    yAssert(implementation!=NULL);
+
+ConstString& ConstString::operator=(const ConstString& str) {
+    HELPER(implementation) = HELPER(str.implementation);
+    return (*this);
 }
 
-const ConstString& ConstString::operator = (const ConstString& alt) {
-    HELPER(implementation) = HELPER(alt.implementation);
+ConstString& ConstString::operator=(const char* str) {
+    HELPER(implementation) = str;
+    return (*this);
+}
+
+ConstString& ConstString::operator=(char c) {
+    HELPER(implementation) = c;
     return (*this);
 }
 
@@ -81,99 +96,108 @@ const char *ConstString::data() const {
     return HELPER(implementation).data();
 }
 
-
-bool ConstString::operator <(const ConstString& alt) const {
-    return HELPER(implementation) < HELPER(alt.implementation);
+ConstString::allocator_type ConstString::get_allocator() const {
+    return HELPER(implementation).get_allocator();
 }
 
-bool ConstString::operator >(const ConstString& alt) const {
-    return HELPER(implementation) > HELPER(alt.implementation);
-}
-
-bool ConstString::operator ==(const ConstString& alt) const {
-    return HELPER(implementation) == HELPER(alt.implementation);
-}
-
-bool ConstString::operator !=(const ConstString& alt) const {
-    return HELPER(implementation) != HELPER(alt.implementation);
-}
-
-bool ConstString::operator ==(const char *str) const {
-    return HELPER(implementation) == str;
-}
-
-bool ConstString::operator !=(const char *str) const {
-    return HELPER(implementation) != str;
+size_t ConstString::copy(char* str, size_t len, size_t pos) const {
+    return HELPER(implementation).copy(str, len, pos);
 }
 
 size_t ConstString::length() const {
     return HELPER(implementation).length();
 }
 
+size_t ConstString::size() const {
+    return HELPER(implementation).size();
+}
+
+size_t ConstString::max_size() const {
+    return HELPER(implementation).max_size();
+}
+
 void ConstString::resize(size_t n) {
     HELPER(implementation).resize(n);
 }
 
-
-bool ConstString::operator <=(const ConstString& alt) const {
-    return HELPER(implementation) <= HELPER(alt.implementation);
+void ConstString::resize(size_t n, char c) {
+    HELPER(implementation).resize(n, c);
 }
 
-bool ConstString::operator >=(const ConstString& alt) const {
-    return HELPER(implementation) >= HELPER(alt.implementation);
+size_t ConstString::capacity() const {
+    return HELPER(implementation).capacity();
 }
 
-ConstString ConstString::operator + (char ch) const {
-    std::string helper(HELPER(implementation));
-    helper += ch;
-    return ConstString(helper.c_str());
+void ConstString::reserve(size_t n) {
+    HELPER(implementation).reserve(n);
 }
 
-ConstString ConstString::operator + (const char *str) const {
-    std::string helper(HELPER(implementation));
-    helper += str;
-    return ConstString(helper.c_str());
-}
-
-ConstString ConstString::operator + (const ConstString& alt) const {
-    std::string helper(HELPER(implementation));
-    helper += HELPER(alt.implementation);
-    return ConstString(helper.c_str());
-}
-
-const ConstString& ConstString::operator += (char ch) {
+ConstString& ConstString::operator+=(char ch) {
     HELPER(implementation) += ch;
     return *this;
 }
 
-const ConstString& ConstString::operator += (const char *str) {
+ConstString& ConstString::operator+=(const char *str) {
     HELPER(implementation) += str;
     return *this;
 }
 
-const ConstString& ConstString::operator += (const ConstString& alt) {
-    HELPER(implementation) += HELPER(alt.implementation);
+ConstString& ConstString::operator+=(const ConstString& str) {
+    HELPER(implementation) += HELPER(str.implementation);
     return *this;
 }
 
-size_t ConstString::find(const ConstString& needle) const{
-    return HELPER(implementation).find(HELPER(needle.implementation));
+void ConstString::push_back (char c) {
+    HELPER(implementation).push_back(c);
 }
 
-size_t ConstString::find(const char *needle) const {
-    return HELPER(implementation).find(needle);
+ConstString& ConstString::erase(size_t pos, size_t len) {
+    HELPER(implementation).erase(pos, len);
+    return *this;
+}
+
+ConstString::iterator ConstString::erase(iterator p) {
+    return HELPER(implementation).erase(p);
+}
+
+ConstString::iterator ConstString::erase(iterator first, iterator last) {
+    return HELPER(implementation).erase(first, last);
+}
+
+void ConstString::swap(ConstString& str) {
+    HELPER(implementation).swap(HELPER(str.implementation));
+}
+
+size_t ConstString::find(const ConstString& needle, size_t start) const {
+    return HELPER(implementation).find(HELPER(needle.implementation), start);
 }
 
 size_t ConstString::find(const char *needle, size_t start) const {
+    return HELPER(implementation).find(needle, start);
+}
+
+size_t ConstString::find(const char *needle, size_t start, size_t len) const {
+    return HELPER(implementation).find(needle, start, len);
+}
+
+size_t ConstString::find(char needle, size_t start) const {
     return HELPER(implementation).find(needle,start);
 }
 
-size_t ConstString::find(const char needle, size_t start) const {
-    return HELPER(implementation).find(needle,start);
+size_t ConstString::rfind(const ConstString& needle, size_t start) const {
+    return HELPER(implementation).rfind(HELPER(needle.implementation), start);
 }
 
-size_t ConstString::rfind(const char needle) const {
-    return HELPER(implementation).rfind(needle);
+size_t ConstString::rfind(const char *needle, size_t start) const {
+    return HELPER(implementation).rfind(needle, start);
+}
+
+size_t ConstString::rfind(const char *needle, size_t start, size_t len) const {
+    return HELPER(implementation).rfind(needle, start, len);
+}
+
+size_t ConstString::rfind(char needle, size_t start) const {
+    return HELPER(implementation).rfind(needle,start);
 }
 
 ConstString ConstString::substr(size_t start, size_t n) const {
@@ -189,12 +213,52 @@ bool ConstString::empty() const {
     return HELPER(implementation).empty();
 }
 
+ConstString::iterator ConstString::begin() {
+    return HELPER(implementation).begin();
+}
+
+ConstString::const_iterator ConstString::begin() const {
+    return HELPER(implementation).begin();
+}
+
+ConstString::iterator ConstString::end() {
+    return HELPER(implementation).end();
+}
+
+ConstString::const_iterator ConstString::end() const {
+    return HELPER(implementation).end();
+}
+
+ConstString::reverse_iterator ConstString::rbegin() {
+    return HELPER(implementation).rbegin();
+}
+
+ConstString::const_reverse_iterator ConstString::rbegin() const {
+    return HELPER(implementation).rbegin();
+}
+
+ConstString::reverse_iterator ConstString::rend() {
+    return HELPER(implementation).rend();
+}
+
+ConstString::const_reverse_iterator ConstString::rend() const {
+    return HELPER(implementation).rend();
+}
+
 char& ConstString::operator[](size_t idx) {
     return HELPER(implementation)[idx];
 }
 
 const char& ConstString::operator[](size_t idx) const {
     return HELPER(implementation)[idx];
+}
+
+char& ConstString::at(size_t pos) {
+    return HELPER(implementation).at(pos);
+}
+
+const char& ConstString::at(size_t pos) const {
+    return HELPER(implementation).at(pos);
 }
 
 ConstString& ConstString::assign(const char *s, size_t n) {
@@ -221,11 +285,6 @@ unsigned long ConstString::hash() const {
         }
     }
     return h;
-}
-
-ConstString yarp::os::operator + (const char *txt,
-                                  const yarp::os::ConstString& alt) {
-    return ConstString(txt) + alt;
 }
 
 #endif


### PR DESCRIPTION
Several methods are still missing, but this is a step towards having the same API as `std::string` that may cause confusion when `YARP_WRAP_STL_STRING` is disabled