### PR TITLE
Fix: RF module calls close if configure fails

### DIFF
--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -365,6 +365,7 @@ int RFModule::runModule() {
 int RFModule::runModule(yarp::os::ResourceFinder &rf) {
     if (!configure(rf)) {
         ACE_OS::printf("Module failed to open\n");
+        close();
         return false;
     }
     return runModule();


### PR DESCRIPTION
I found that robotInterface was crashing if the configure function fails. It turns out that I had to explixitly call the close function in order to clean up things.
 So me and @drdanz thought that maybe it'll be easier for user if the RFModule will call the close function by his own if the configure fails, like in the patch proposed.

@paulfitz @lornat75 what di you think about it? Do you see any drawback?

Maybe also the stopModule could call the close?