### PR TITLE
Use ACE::abort instead of ACE::exit to kill RFModule

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -39,7 +39,7 @@ namespace yarp {
         /**
         * Wrapper for ACE_OS::abort().
         */
-        YARP_OS_API void abort(void);
+        YARP_OS_API void abort(bool verbose=false);
 
         /**
         * Wrapper for ACE_OS::getenv().

--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -37,6 +37,11 @@ namespace yarp {
         YARP_OS_API void exit(int v);
 
         /**
+        * Wrapper for ACE_OS::abort().
+        */
+        YARP_OS_API void abort(void);
+
+        /**
         * Wrapper for ACE_OS::getenv().
         * @param v string that containt the environment variable name
         * @return the value corresponding to the envarionment variable v

--- a/src/libYARP_OS/src/Os.cpp
+++ b/src/libYARP_OS/src/Os.cpp
@@ -37,8 +37,13 @@ yarp::os::YarpSignalHandler yarp::os::signal(int signum, yarp::os::YarpSignalHan
 
 void yarp::os::exit(int v)
 {
-    ACE_OS::exit(v); //may cause crash...
+    ACE_OS::exit(v); //may cause crash... exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/
     //::exit(v);     //...this seems to work(?)
+}
+
+void yarp::os::abort()
+{
+    ACE_OS::abort();   // exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/ and http://www.cplusplus.com/reference/cstdlib/abort/
 }
 
 const char *yarp::os::getenv(const char *var)

--- a/src/libYARP_OS/src/Os.cpp
+++ b/src/libYARP_OS/src/Os.cpp
@@ -41,8 +41,16 @@ void yarp::os::exit(int v)
     //::exit(v);     //...this seems to work(?)
 }
 
-void yarp::os::abort()
+void yarp::os::abort(bool verbose)
 {
+#if defined(WIN32)
+	if (verbose==false)
+	{
+		//to suppress windows dialog message
+		_set_abort_behavior(0, _WRITE_ABORT_MSG);
+		_set_abort_behavior(0, _CALL_REPORTFAULT);
+	}
+#endif
     ACE_OS::abort();   // exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/ and http://www.cplusplus.com/reference/cstdlib/abort/
 }
 

--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -253,6 +253,16 @@ static void handler (int sig) {
         //printf("sent %s, got %s\n", cmd.toString().c_str(),
         //     reply.toString().c_str());
    // }
+
+#if defined(WIN32)
+	//on windows we need to reset the handler after beeing called, otherwise it will not be called anymore.
+	//see http://www.geeksforgeeks.org/write-a-c-program-that-doesnt-terminate-when-ctrlc-is-pressed/
+
+	//Additionally, from http://www.linuxprogrammingblog.com/all-about-linux-signals?page=show 
+	//The signal(2) function is the oldest and simplest way to install a signal handler but it's deprecated. 
+	// There are few reasons and most important is that the original Unix implementation would reset the signal handler to it's default value after signal is received.
+	ACE_OS::signal(SIGINT, (ACE_SignalHandler)handler);
+#endif
 }
 
 // Special case for windows. Do not return, wait for the the main thread to return.

--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -236,7 +236,7 @@ static void handler (int sig) {
     ct++;
     if (ct>3) {
         ACE_OS::printf("Aborting (calling exit())...\n");
-        yarp::os::exit(1);
+        yarp::os::abort();
     }
     ACE_OS::printf("[try %d of 3] Trying to shut down\n",
                    ct);

--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -235,7 +235,7 @@ static void handler (int sig) {
     static int ct = 0;
     ct++;
     if (ct>3) {
-        ACE_OS::printf("Aborting (calling exit())...\n");
+        ACE_OS::printf("Aborting (calling abort())...\n");
         yarp::os::abort();
     }
     ACE_OS::printf("[try %d of 3] Trying to shut down\n",


### PR DESCRIPTION
Add yarp::os::abort to wrap ace::abort.
Use abort to kill RFmodule at 4th CRTL+C, because exit is not recommended for multithread process according to http://www.cplusplus.com/reference/cstdlib/exit and causes random segfaults when used.
