### PR TITLE
Propagate return values alongside the data

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -840,16 +840,16 @@ void ControlBoardWrapper::run()
         yarp_struct.controlMode.resize(controlledJoints);
         yarp_struct.interactionMode.resize(controlledJoints);
 
-        getEncoders(yarp_struct.jointPosition.data());
-        getEncoderSpeeds(yarp_struct.jointVelocity.data());
-        getEncoderAccelerations(yarp_struct.jointAcceleration.data());
-        getMotorEncoders(yarp_struct.motorPosition.data());
-        getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
-        getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
-        getTorques(yarp_struct.torque.data());
-        getOutputs(yarp_struct.pidOutput.data());
-        getControlModes(yarp_struct.controlMode.data());
-        getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.data());
+        yarp_struct.jointPosition_isValid       = getEncoders(yarp_struct.jointPosition.data());
+        yarp_struct.jointVelocity_isValid       = getEncoderSpeeds(yarp_struct.jointVelocity.data());
+        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.data());
+        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.data());
+        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
+        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
+        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.data());
+        yarp_struct.pidOutput_isValid           = getOutputs(yarp_struct.pidOutput.data());
+        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.data());
+        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.data());
 
         extendedOutputStatePort.setEnvelope(time);
         extendedOutputState_buffer.write();

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -1500,8 +1500,12 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *v = last_singleJoint.jointPosition[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.jointPosition_isValid)
+                *v = last_singleJoint.jointPosition[0];
+            else
+                ret = false;
         }
         if (ret && Time::now()-localArrivalTime>TIMEOUT)
             ret=false;
@@ -1527,8 +1531,12 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *v = last_singleJoint.jointPosition[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.jointPosition_isValid)
+                *v = last_singleJoint.jointPosition[0];
+            else
+                ret = false;
         }
         *t=lastStamp.getTime();
 
@@ -1579,8 +1587,12 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.jointPosition.begin(), last_wholePart.jointPosition.end(), encs);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.jointPosition_isValid)
+                std::copy(last_wholePart.jointPosition.begin(), last_wholePart.jointPosition.end(), encs);
+            else
+                ret = false;
         }
         return ret;
     }
@@ -1621,9 +1633,15 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.jointPosition.begin(), last_wholePart.jointPosition.end(), encs);
-            std::fill_n(ts, nj, lastStamp.getTime());
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.jointPosition_isValid)
+            {
+                std::copy(last_wholePart.jointPosition.begin(), last_wholePart.jointPosition.end(), encs);
+                std::fill_n(ts, nj, lastStamp.getTime());
+            }
+            else
+                ret = false;
         }
 
         ////////////////////////// HANDLE TIMEOUT
@@ -1649,8 +1667,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *sp = last_singleJoint.jointVelocity[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.jointVelocity_isValid)
+            {
+                *sp = last_singleJoint.jointVelocity[0];
+            }
+            else
+                ret = false;
+
             return ret;
         }
     }
@@ -1672,8 +1697,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.jointVelocity.begin(), last_wholePart.jointVelocity.end(), spds);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.jointVelocity_isValid)
+            {
+                std::copy(last_wholePart.jointVelocity.begin(), last_wholePart.jointVelocity.end(), spds);
+            }
+            else
+                ret = false;
+
             return ret;
         }
     }
@@ -1695,8 +1727,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *acc = last_singleJoint.jointAcceleration[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.jointAcceleration_isValid)
+            {
+                *acc = last_singleJoint.jointAcceleration[0];
+            }
+            else
+                ret = false;
             return ret;
         }
     }
@@ -1717,8 +1755,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.jointAcceleration.begin(), last_wholePart.jointAcceleration.end(), accs);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.jointAcceleration_isValid)
+            {
+                std::copy(last_wholePart.jointAcceleration.begin(), last_wholePart.jointAcceleration.end(), accs);
+            }
+            else
+                ret = false;
+
             return ret;
         }
     }
@@ -1828,8 +1873,14 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *v = last_singleJoint.motorPosition[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.motorPosition_isValid)
+            {
+                *v = last_singleJoint.motorPosition[0];
+            }
+            else
+                ret = false;
         }
         if (ret && Time::now()-localArrivalTime>TIMEOUT)
             ret=false;
@@ -1854,8 +1905,14 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *v = last_singleJoint.motorPosition[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.motorPosition_isValid)
+            {
+                *v = last_singleJoint.motorPosition[0];
+            }
+            else
+                ret = false;
         }
 
         *t=lastStamp.getTime();
@@ -1908,8 +1965,14 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.motorPosition.begin(), last_wholePart.motorPosition.end(), encs);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.motorPosition_isValid)
+            {
+                std::copy(last_wholePart.motorPosition.begin(), last_wholePart.motorPosition.end(), encs);
+            }
+            else
+                ret = false;
         }
         return ret;
     }
@@ -1951,9 +2014,15 @@ public:
         {
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.motorPosition.begin(), last_wholePart.motorPosition.end(), encs);
-            std::fill_n(ts, nj, lastStamp.getTime());
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.motorPosition_isValid)
+            {
+                std::copy(last_wholePart.motorPosition.begin(), last_wholePart.motorPosition.end(), encs);
+                std::fill_n(ts, nj, lastStamp.getTime());
+            }
+            else
+                ret = false;
         }
 
         ////////////////////////// HANDLE TIMEOUT
@@ -1977,8 +2046,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *sp = last_singleJoint.motorVelocity[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.motorVelocity_isValid)
+            {
+                *sp = last_singleJoint.motorVelocity[0];
+            }
+            else
+                ret = false;
             return ret;
         }
     }
@@ -1996,8 +2071,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.motorVelocity.begin(), last_wholePart.motorVelocity.end(), spds);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.motorVelocity_isValid)
+            {
+                std::copy(last_wholePart.motorVelocity.begin(), last_wholePart.motorVelocity.end(), spds);
+            }
+            else
+                ret = false;
             return ret;
         }
         else
@@ -2019,8 +2100,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *acc = last_singleJoint.motorAcceleration[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.motorAcceleration_isValid)
+            {
+                *acc = last_singleJoint.motorAcceleration[0];
+            }
+            else
+                ret = false;
             return ret;
         }
         else
@@ -2041,8 +2128,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.motorAcceleration.begin(), last_wholePart.motorAcceleration.end(), accs);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.motorAcceleration_isValid)
+            {
+                std::copy(last_wholePart.motorAcceleration.begin(), last_wholePart.motorAcceleration.end(), accs);
+            }
+            else
+                ret = false;
             return ret;
         }
         else
@@ -2679,8 +2772,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *t = last_singleJoint.torque[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.torque_isValid)
+            {
+                *t = last_singleJoint.torque[0];
+            }
+            else
+                ret = false;
+
             return ret;
         }
     }
@@ -2696,8 +2796,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.torque.begin(), last_wholePart.torque.end(), t);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.torque_isValid)
+            {
+                std::copy(last_wholePart.torque.begin(), last_wholePart.torque.end(), t);
+            }
+            else
+                ret = false;
             return ret;
         }
     }
@@ -2953,8 +3059,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ok = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *mode = last_singleJoint.controlMode[0];
             extendedPortMutex.post();
+
+            if(ok && last_singleJoint.controlMode_isValid)
+            {
+                *mode = last_singleJoint.controlMode[0];
+            }
+            else
+                ok = false;
         }
         return ok;
 
@@ -2998,9 +3110,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ok = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            for (int i = 0; i < n_joint; i++)
-                modes[i] = last_wholePart.controlMode[joints[i]];
             extendedPortMutex.post();
+
+            if(ok && last_wholePart.controlMode_isValid)
+            {
+                for (int i = 0; i < n_joint; i++)
+                    modes[i] = last_wholePart.controlMode[joints[i]];
+            }
+            else
+                ok = false;
         }
         return ok;
     }
@@ -3034,8 +3152,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ok = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.controlMode.begin(), last_wholePart.controlMode.end(), modes);
             extendedPortMutex.post();
+
+            if(ok && last_wholePart.controlMode_isValid)
+            {
+                std::copy(last_wholePart.controlMode.begin(), last_wholePart.controlMode.end(), modes);
+            }
+            else
+                ok = false;
         }
         return ok;
     }
@@ -3298,8 +3422,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ok = extendedIntputStatePort.getLast(axis, last_singleJoint, lastStamp, localArrivalTime);
-            *mode = (yarp::dev::InteractionModeEnum)last_singleJoint.interactionMode[0];
             extendedPortMutex.post();
+
+            if(ok && last_singleJoint.interactionMode_isValid)
+            {
+                *mode = (yarp::dev::InteractionModeEnum)last_singleJoint.interactionMode[0];
+            }
+            else
+                ok = false;
         }
         return ok;
     }
@@ -3350,9 +3480,15 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ok = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            for (int i = 0; i < n_joints; i++)
-                modes[i] = (yarp::dev::InteractionModeEnum)last_wholePart.interactionMode[joints[i]];
             extendedPortMutex.post();
+
+            if(ok && last_wholePart.interactionMode_isValid)
+            {
+                for (int i = 0; i < n_joints; i++)
+                    modes[i] = (yarp::dev::InteractionModeEnum)last_wholePart.interactionMode[joints[i]];
+            }
+            else
+                ok = false;
         }
         return ok;
     }
@@ -3365,8 +3501,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.interactionMode.begin(), last_wholePart.interactionMode.end(), (int*)modes);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.interactionMode_isValid)
+            {
+                std::copy(last_wholePart.interactionMode.begin(), last_wholePart.interactionMode.end(), (int*)modes);
+            }
+            else
+                ret = false;
         }
         else
         {
@@ -3551,8 +3693,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(j, last_singleJoint, lastStamp, localArrivalTime);
-            *out = last_singleJoint.pidOutput[0];
             extendedPortMutex.post();
+
+            if(ret && last_singleJoint.pidOutput_isValid)
+            {
+                *out = last_singleJoint.pidOutput[0];
+            }
+            else
+                ret = false;
             return ret;
         }
         else
@@ -3590,8 +3738,14 @@ public:
             double localArrivalTime=0.0;
             extendedPortMutex.wait();
             bool ret = extendedIntputStatePort.getLast(last_wholePart, lastStamp, localArrivalTime);
-            std::copy(last_wholePart.pidOutput.begin(), last_wholePart.pidOutput.end(), outs);
             extendedPortMutex.post();
+
+            if(ret && last_wholePart.pidOutput_isValid)
+            {
+                std::copy(last_wholePart.pidOutput.begin(), last_wholePart.pidOutput.end(), outs);
+            }
+            else
+                ret = false;
             return ret;
         }
         else

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/stateExtendedReader.cpp
@@ -89,16 +89,26 @@ bool StateExtendedInputPort::getLast(int j, jointData &data, Stamp &stamp, doubl
     bool ret=valid;
     if (ret)
     {
-        data.jointPosition[0]        = last.jointPosition[j];
-        data.jointVelocity[0]        = last.jointVelocity[j];
-        data.jointAcceleration[0]    = last.jointAcceleration[j];
-        data.motorPosition[0]        = last.motorPosition[j];
-        data.motorVelocity[0]        = last.motorVelocity[j];
-        data.motorAcceleration[0]    = last.motorAcceleration[j];
-        data.torque[0]          = last.torque[j];
-        data.pidOutput[0]       = last.pidOutput[j];
-        data.controlMode[0]     = last.controlMode[j];
-        data.interactionMode[0] = last.interactionMode[j];
+        data.jointPosition[0]           = last.jointPosition[j];
+        data.jointPosition_isValid      = last.jointPosition_isValid;
+        data.jointVelocity[0]           = last.jointVelocity[j];
+        data.jointVelocity_isValid      = last.jointVelocity_isValid;
+        data.jointAcceleration[0]       = last.jointAcceleration[j];
+        data.jointAcceleration_isValid  = last.jointAcceleration_isValid;
+        data.motorPosition[0]           = last.motorPosition[j];
+        data.motorPosition_isValid      = last.motorPosition_isValid;
+        data.motorVelocity[0]           = last.motorVelocity[j];
+        data.motorVelocity_isValid      = last.motorVelocity_isValid;
+        data.motorAcceleration[0]       = last.motorAcceleration[j];
+        data.motorAcceleration_isValid  = last.motorAcceleration_isValid;
+        data.torque[0]                  = last.torque[j];
+        data.torque_isValid             = last.torque_isValid;
+        data.pidOutput[0]               = last.pidOutput[j];
+        data.pidOutput_isValid          = last.pidOutput_isValid;
+        data.controlMode[0]             = last.controlMode[j];
+        data.controlMode_isValid        = last.controlMode_isValid;
+        data.interactionMode[0]         = last.interactionMode[j];
+        data.interactionMode_isValid    = last.interactionMode_isValid;
 
         stamp=lastStamp;
         localArrivalTime=now;

--- a/src/libYARP_dev/src/modules/msgs/stateExt.thrift
+++ b/src/libYARP_dev/src/modules/msgs/stateExt.thrift
@@ -2,14 +2,24 @@
 struct jointData
 {
   1: list<double> jointPosition;
-  2: list<double> jointVelocity;
-  3: list<double> jointAcceleration;
-  4: list<double> motorPosition;
-  5: list<double> motorVelocity;
-  6: list<double> motorAcceleration;
-  7: list<double> torque;
-  8: list<double> pidOutput;
-  9: list<i32>	  controlMode;
-  10: list<i32>	  interactionMode;
+  2: bool jointPosition_isValid;
+  3: list<double> jointVelocity;
+  4: bool jointVelocity_isValid;
+  5: list<double> jointAcceleration;
+  6: bool jointAcceleration_isValid;
+  7: list<double> motorPosition;
+  8: bool motorPosition_isValid;
+  9: list<double> motorVelocity;
+  10: bool motorVelocity_isValid;
+  11: list<double> motorAcceleration;
+  12: bool motorAcceleration_isValid;
+  13: list<double> torque;
+  14: bool torque_isValid;
+  15: list<double> pidOutput;
+  16: bool pidOutput_isValid;
+  17: list<i32>	  controlMode;
+  18: bool controlMode_isValid;
+  19: list<i32>	  interactionMode;
+  20: bool interactionMode_isValid;
 }
 

--- a/src/libYARP_dev/src/modules/msgs/yarp/include/jointData.h
+++ b/src/libYARP_dev/src/modules/msgs/yarp/include/jointData.h
@@ -14,50 +14,80 @@ class jointData : public yarp::os::idl::WirePortable {
 public:
   // Fields
   std::vector<double>  jointPosition;
+  bool jointPosition_isValid;
   std::vector<double>  jointVelocity;
+  bool jointVelocity_isValid;
   std::vector<double>  jointAcceleration;
+  bool jointAcceleration_isValid;
   std::vector<double>  motorPosition;
+  bool motorPosition_isValid;
   std::vector<double>  motorVelocity;
+  bool motorVelocity_isValid;
   std::vector<double>  motorAcceleration;
+  bool motorAcceleration_isValid;
   std::vector<double>  torque;
+  bool torque_isValid;
   std::vector<double>  pidOutput;
+  bool pidOutput_isValid;
   std::vector<int32_t>  controlMode;
+  bool controlMode_isValid;
   std::vector<int32_t>  interactionMode;
+  bool interactionMode_isValid;
 
   // Default constructor
-  jointData() {
+  jointData() : jointPosition_isValid(0), jointVelocity_isValid(0), jointAcceleration_isValid(0), motorPosition_isValid(0), motorVelocity_isValid(0), motorAcceleration_isValid(0), torque_isValid(0), pidOutput_isValid(0), controlMode_isValid(0), interactionMode_isValid(0) {
   }
 
   // Constructor with field values
-  jointData(const std::vector<double> & jointPosition,const std::vector<double> & jointVelocity,const std::vector<double> & jointAcceleration,const std::vector<double> & motorPosition,const std::vector<double> & motorVelocity,const std::vector<double> & motorAcceleration,const std::vector<double> & torque,const std::vector<double> & pidOutput,const std::vector<int32_t> & controlMode,const std::vector<int32_t> & interactionMode) : jointPosition(jointPosition), jointVelocity(jointVelocity), jointAcceleration(jointAcceleration), motorPosition(motorPosition), motorVelocity(motorVelocity), motorAcceleration(motorAcceleration), torque(torque), pidOutput(pidOutput), controlMode(controlMode), interactionMode(interactionMode) {
+  jointData(const std::vector<double> & jointPosition,const bool jointPosition_isValid,const std::vector<double> & jointVelocity,const bool jointVelocity_isValid,const std::vector<double> & jointAcceleration,const bool jointAcceleration_isValid,const std::vector<double> & motorPosition,const bool motorPosition_isValid,const std::vector<double> & motorVelocity,const bool motorVelocity_isValid,const std::vector<double> & motorAcceleration,const bool motorAcceleration_isValid,const std::vector<double> & torque,const bool torque_isValid,const std::vector<double> & pidOutput,const bool pidOutput_isValid,const std::vector<int32_t> & controlMode,const bool controlMode_isValid,const std::vector<int32_t> & interactionMode,const bool interactionMode_isValid) : jointPosition(jointPosition), jointPosition_isValid(jointPosition_isValid), jointVelocity(jointVelocity), jointVelocity_isValid(jointVelocity_isValid), jointAcceleration(jointAcceleration), jointAcceleration_isValid(jointAcceleration_isValid), motorPosition(motorPosition), motorPosition_isValid(motorPosition_isValid), motorVelocity(motorVelocity), motorVelocity_isValid(motorVelocity_isValid), motorAcceleration(motorAcceleration), motorAcceleration_isValid(motorAcceleration_isValid), torque(torque), torque_isValid(torque_isValid), pidOutput(pidOutput), pidOutput_isValid(pidOutput_isValid), controlMode(controlMode), controlMode_isValid(controlMode_isValid), interactionMode(interactionMode), interactionMode_isValid(interactionMode_isValid) {
   }
 
   // Copy constructor
   jointData(const jointData& __alt) : WirePortable(__alt)  {
     this->jointPosition = __alt.jointPosition;
+    this->jointPosition_isValid = __alt.jointPosition_isValid;
     this->jointVelocity = __alt.jointVelocity;
+    this->jointVelocity_isValid = __alt.jointVelocity_isValid;
     this->jointAcceleration = __alt.jointAcceleration;
+    this->jointAcceleration_isValid = __alt.jointAcceleration_isValid;
     this->motorPosition = __alt.motorPosition;
+    this->motorPosition_isValid = __alt.motorPosition_isValid;
     this->motorVelocity = __alt.motorVelocity;
+    this->motorVelocity_isValid = __alt.motorVelocity_isValid;
     this->motorAcceleration = __alt.motorAcceleration;
+    this->motorAcceleration_isValid = __alt.motorAcceleration_isValid;
     this->torque = __alt.torque;
+    this->torque_isValid = __alt.torque_isValid;
     this->pidOutput = __alt.pidOutput;
+    this->pidOutput_isValid = __alt.pidOutput_isValid;
     this->controlMode = __alt.controlMode;
+    this->controlMode_isValid = __alt.controlMode_isValid;
     this->interactionMode = __alt.interactionMode;
+    this->interactionMode_isValid = __alt.interactionMode_isValid;
   }
 
   // Assignment operator
   const jointData& operator = (const jointData& __alt) {
     this->jointPosition = __alt.jointPosition;
+    this->jointPosition_isValid = __alt.jointPosition_isValid;
     this->jointVelocity = __alt.jointVelocity;
+    this->jointVelocity_isValid = __alt.jointVelocity_isValid;
     this->jointAcceleration = __alt.jointAcceleration;
+    this->jointAcceleration_isValid = __alt.jointAcceleration_isValid;
     this->motorPosition = __alt.motorPosition;
+    this->motorPosition_isValid = __alt.motorPosition_isValid;
     this->motorVelocity = __alt.motorVelocity;
+    this->motorVelocity_isValid = __alt.motorVelocity_isValid;
     this->motorAcceleration = __alt.motorAcceleration;
+    this->motorAcceleration_isValid = __alt.motorAcceleration_isValid;
     this->torque = __alt.torque;
+    this->torque_isValid = __alt.torque_isValid;
     this->pidOutput = __alt.pidOutput;
+    this->pidOutput_isValid = __alt.pidOutput_isValid;
     this->controlMode = __alt.controlMode;
+    this->controlMode_isValid = __alt.controlMode_isValid;
     this->interactionMode = __alt.interactionMode;
+    this->interactionMode_isValid = __alt.interactionMode_isValid;
     return *this;
   }
 
@@ -70,44 +100,84 @@ public:
 private:
   bool write_jointPosition(yarp::os::idl::WireWriter& writer);
   bool nested_write_jointPosition(yarp::os::idl::WireWriter& writer);
+  bool write_jointPosition_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_jointPosition_isValid(yarp::os::idl::WireWriter& writer);
   bool write_jointVelocity(yarp::os::idl::WireWriter& writer);
   bool nested_write_jointVelocity(yarp::os::idl::WireWriter& writer);
+  bool write_jointVelocity_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_jointVelocity_isValid(yarp::os::idl::WireWriter& writer);
   bool write_jointAcceleration(yarp::os::idl::WireWriter& writer);
   bool nested_write_jointAcceleration(yarp::os::idl::WireWriter& writer);
+  bool write_jointAcceleration_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_jointAcceleration_isValid(yarp::os::idl::WireWriter& writer);
   bool write_motorPosition(yarp::os::idl::WireWriter& writer);
   bool nested_write_motorPosition(yarp::os::idl::WireWriter& writer);
+  bool write_motorPosition_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_motorPosition_isValid(yarp::os::idl::WireWriter& writer);
   bool write_motorVelocity(yarp::os::idl::WireWriter& writer);
   bool nested_write_motorVelocity(yarp::os::idl::WireWriter& writer);
+  bool write_motorVelocity_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_motorVelocity_isValid(yarp::os::idl::WireWriter& writer);
   bool write_motorAcceleration(yarp::os::idl::WireWriter& writer);
   bool nested_write_motorAcceleration(yarp::os::idl::WireWriter& writer);
+  bool write_motorAcceleration_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_motorAcceleration_isValid(yarp::os::idl::WireWriter& writer);
   bool write_torque(yarp::os::idl::WireWriter& writer);
   bool nested_write_torque(yarp::os::idl::WireWriter& writer);
+  bool write_torque_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_torque_isValid(yarp::os::idl::WireWriter& writer);
   bool write_pidOutput(yarp::os::idl::WireWriter& writer);
   bool nested_write_pidOutput(yarp::os::idl::WireWriter& writer);
+  bool write_pidOutput_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_pidOutput_isValid(yarp::os::idl::WireWriter& writer);
   bool write_controlMode(yarp::os::idl::WireWriter& writer);
   bool nested_write_controlMode(yarp::os::idl::WireWriter& writer);
+  bool write_controlMode_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_controlMode_isValid(yarp::os::idl::WireWriter& writer);
   bool write_interactionMode(yarp::os::idl::WireWriter& writer);
   bool nested_write_interactionMode(yarp::os::idl::WireWriter& writer);
+  bool write_interactionMode_isValid(yarp::os::idl::WireWriter& writer);
+  bool nested_write_interactionMode_isValid(yarp::os::idl::WireWriter& writer);
   bool read_jointPosition(yarp::os::idl::WireReader& reader);
   bool nested_read_jointPosition(yarp::os::idl::WireReader& reader);
+  bool read_jointPosition_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_jointPosition_isValid(yarp::os::idl::WireReader& reader);
   bool read_jointVelocity(yarp::os::idl::WireReader& reader);
   bool nested_read_jointVelocity(yarp::os::idl::WireReader& reader);
+  bool read_jointVelocity_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_jointVelocity_isValid(yarp::os::idl::WireReader& reader);
   bool read_jointAcceleration(yarp::os::idl::WireReader& reader);
   bool nested_read_jointAcceleration(yarp::os::idl::WireReader& reader);
+  bool read_jointAcceleration_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_jointAcceleration_isValid(yarp::os::idl::WireReader& reader);
   bool read_motorPosition(yarp::os::idl::WireReader& reader);
   bool nested_read_motorPosition(yarp::os::idl::WireReader& reader);
+  bool read_motorPosition_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_motorPosition_isValid(yarp::os::idl::WireReader& reader);
   bool read_motorVelocity(yarp::os::idl::WireReader& reader);
   bool nested_read_motorVelocity(yarp::os::idl::WireReader& reader);
+  bool read_motorVelocity_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_motorVelocity_isValid(yarp::os::idl::WireReader& reader);
   bool read_motorAcceleration(yarp::os::idl::WireReader& reader);
   bool nested_read_motorAcceleration(yarp::os::idl::WireReader& reader);
+  bool read_motorAcceleration_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_motorAcceleration_isValid(yarp::os::idl::WireReader& reader);
   bool read_torque(yarp::os::idl::WireReader& reader);
   bool nested_read_torque(yarp::os::idl::WireReader& reader);
+  bool read_torque_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_torque_isValid(yarp::os::idl::WireReader& reader);
   bool read_pidOutput(yarp::os::idl::WireReader& reader);
   bool nested_read_pidOutput(yarp::os::idl::WireReader& reader);
+  bool read_pidOutput_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_pidOutput_isValid(yarp::os::idl::WireReader& reader);
   bool read_controlMode(yarp::os::idl::WireReader& reader);
   bool nested_read_controlMode(yarp::os::idl::WireReader& reader);
+  bool read_controlMode_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_controlMode_isValid(yarp::os::idl::WireReader& reader);
   bool read_interactionMode(yarp::os::idl::WireReader& reader);
   bool nested_read_interactionMode(yarp::os::idl::WireReader& reader);
+  bool read_interactionMode_isValid(yarp::os::idl::WireReader& reader);
+  bool nested_read_interactionMode_isValid(yarp::os::idl::WireReader& reader);
 
 public:
 
@@ -172,6 +242,13 @@ public:
       communicate();
       did_set_jointPosition();
     }
+    void set_jointPosition_isValid(const bool jointPosition_isValid) {
+      will_set_jointPosition_isValid();
+      obj->jointPosition_isValid = jointPosition_isValid;
+      mark_dirty_jointPosition_isValid();
+      communicate();
+      did_set_jointPosition_isValid();
+    }
     void set_jointVelocity(const std::vector<double> & jointVelocity) {
       will_set_jointVelocity();
       obj->jointVelocity = jointVelocity;
@@ -185,6 +262,13 @@ public:
       mark_dirty_jointVelocity();
       communicate();
       did_set_jointVelocity();
+    }
+    void set_jointVelocity_isValid(const bool jointVelocity_isValid) {
+      will_set_jointVelocity_isValid();
+      obj->jointVelocity_isValid = jointVelocity_isValid;
+      mark_dirty_jointVelocity_isValid();
+      communicate();
+      did_set_jointVelocity_isValid();
     }
     void set_jointAcceleration(const std::vector<double> & jointAcceleration) {
       will_set_jointAcceleration();
@@ -200,6 +284,13 @@ public:
       communicate();
       did_set_jointAcceleration();
     }
+    void set_jointAcceleration_isValid(const bool jointAcceleration_isValid) {
+      will_set_jointAcceleration_isValid();
+      obj->jointAcceleration_isValid = jointAcceleration_isValid;
+      mark_dirty_jointAcceleration_isValid();
+      communicate();
+      did_set_jointAcceleration_isValid();
+    }
     void set_motorPosition(const std::vector<double> & motorPosition) {
       will_set_motorPosition();
       obj->motorPosition = motorPosition;
@@ -213,6 +304,13 @@ public:
       mark_dirty_motorPosition();
       communicate();
       did_set_motorPosition();
+    }
+    void set_motorPosition_isValid(const bool motorPosition_isValid) {
+      will_set_motorPosition_isValid();
+      obj->motorPosition_isValid = motorPosition_isValid;
+      mark_dirty_motorPosition_isValid();
+      communicate();
+      did_set_motorPosition_isValid();
     }
     void set_motorVelocity(const std::vector<double> & motorVelocity) {
       will_set_motorVelocity();
@@ -228,6 +326,13 @@ public:
       communicate();
       did_set_motorVelocity();
     }
+    void set_motorVelocity_isValid(const bool motorVelocity_isValid) {
+      will_set_motorVelocity_isValid();
+      obj->motorVelocity_isValid = motorVelocity_isValid;
+      mark_dirty_motorVelocity_isValid();
+      communicate();
+      did_set_motorVelocity_isValid();
+    }
     void set_motorAcceleration(const std::vector<double> & motorAcceleration) {
       will_set_motorAcceleration();
       obj->motorAcceleration = motorAcceleration;
@@ -241,6 +346,13 @@ public:
       mark_dirty_motorAcceleration();
       communicate();
       did_set_motorAcceleration();
+    }
+    void set_motorAcceleration_isValid(const bool motorAcceleration_isValid) {
+      will_set_motorAcceleration_isValid();
+      obj->motorAcceleration_isValid = motorAcceleration_isValid;
+      mark_dirty_motorAcceleration_isValid();
+      communicate();
+      did_set_motorAcceleration_isValid();
     }
     void set_torque(const std::vector<double> & torque) {
       will_set_torque();
@@ -256,6 +368,13 @@ public:
       communicate();
       did_set_torque();
     }
+    void set_torque_isValid(const bool torque_isValid) {
+      will_set_torque_isValid();
+      obj->torque_isValid = torque_isValid;
+      mark_dirty_torque_isValid();
+      communicate();
+      did_set_torque_isValid();
+    }
     void set_pidOutput(const std::vector<double> & pidOutput) {
       will_set_pidOutput();
       obj->pidOutput = pidOutput;
@@ -269,6 +388,13 @@ public:
       mark_dirty_pidOutput();
       communicate();
       did_set_pidOutput();
+    }
+    void set_pidOutput_isValid(const bool pidOutput_isValid) {
+      will_set_pidOutput_isValid();
+      obj->pidOutput_isValid = pidOutput_isValid;
+      mark_dirty_pidOutput_isValid();
+      communicate();
+      did_set_pidOutput_isValid();
     }
     void set_controlMode(const std::vector<int32_t> & controlMode) {
       will_set_controlMode();
@@ -284,6 +410,13 @@ public:
       communicate();
       did_set_controlMode();
     }
+    void set_controlMode_isValid(const bool controlMode_isValid) {
+      will_set_controlMode_isValid();
+      obj->controlMode_isValid = controlMode_isValid;
+      mark_dirty_controlMode_isValid();
+      communicate();
+      did_set_controlMode_isValid();
+    }
     void set_interactionMode(const std::vector<int32_t> & interactionMode) {
       will_set_interactionMode();
       obj->interactionMode = interactionMode;
@@ -298,56 +431,113 @@ public:
       communicate();
       did_set_interactionMode();
     }
+    void set_interactionMode_isValid(const bool interactionMode_isValid) {
+      will_set_interactionMode_isValid();
+      obj->interactionMode_isValid = interactionMode_isValid;
+      mark_dirty_interactionMode_isValid();
+      communicate();
+      did_set_interactionMode_isValid();
+    }
     const std::vector<double> & get_jointPosition() {
       return obj->jointPosition;
+    }
+    bool get_jointPosition_isValid() {
+      return obj->jointPosition_isValid;
     }
     const std::vector<double> & get_jointVelocity() {
       return obj->jointVelocity;
     }
+    bool get_jointVelocity_isValid() {
+      return obj->jointVelocity_isValid;
+    }
     const std::vector<double> & get_jointAcceleration() {
       return obj->jointAcceleration;
+    }
+    bool get_jointAcceleration_isValid() {
+      return obj->jointAcceleration_isValid;
     }
     const std::vector<double> & get_motorPosition() {
       return obj->motorPosition;
     }
+    bool get_motorPosition_isValid() {
+      return obj->motorPosition_isValid;
+    }
     const std::vector<double> & get_motorVelocity() {
       return obj->motorVelocity;
+    }
+    bool get_motorVelocity_isValid() {
+      return obj->motorVelocity_isValid;
     }
     const std::vector<double> & get_motorAcceleration() {
       return obj->motorAcceleration;
     }
+    bool get_motorAcceleration_isValid() {
+      return obj->motorAcceleration_isValid;
+    }
     const std::vector<double> & get_torque() {
       return obj->torque;
+    }
+    bool get_torque_isValid() {
+      return obj->torque_isValid;
     }
     const std::vector<double> & get_pidOutput() {
       return obj->pidOutput;
     }
+    bool get_pidOutput_isValid() {
+      return obj->pidOutput_isValid;
+    }
     const std::vector<int32_t> & get_controlMode() {
       return obj->controlMode;
+    }
+    bool get_controlMode_isValid() {
+      return obj->controlMode_isValid;
     }
     const std::vector<int32_t> & get_interactionMode() {
       return obj->interactionMode;
     }
+    bool get_interactionMode_isValid() {
+      return obj->interactionMode_isValid;
+    }
     virtual bool will_set_jointPosition() { return true; }
+    virtual bool will_set_jointPosition_isValid() { return true; }
     virtual bool will_set_jointVelocity() { return true; }
+    virtual bool will_set_jointVelocity_isValid() { return true; }
     virtual bool will_set_jointAcceleration() { return true; }
+    virtual bool will_set_jointAcceleration_isValid() { return true; }
     virtual bool will_set_motorPosition() { return true; }
+    virtual bool will_set_motorPosition_isValid() { return true; }
     virtual bool will_set_motorVelocity() { return true; }
+    virtual bool will_set_motorVelocity_isValid() { return true; }
     virtual bool will_set_motorAcceleration() { return true; }
+    virtual bool will_set_motorAcceleration_isValid() { return true; }
     virtual bool will_set_torque() { return true; }
+    virtual bool will_set_torque_isValid() { return true; }
     virtual bool will_set_pidOutput() { return true; }
+    virtual bool will_set_pidOutput_isValid() { return true; }
     virtual bool will_set_controlMode() { return true; }
+    virtual bool will_set_controlMode_isValid() { return true; }
     virtual bool will_set_interactionMode() { return true; }
+    virtual bool will_set_interactionMode_isValid() { return true; }
     virtual bool did_set_jointPosition() { return true; }
+    virtual bool did_set_jointPosition_isValid() { return true; }
     virtual bool did_set_jointVelocity() { return true; }
+    virtual bool did_set_jointVelocity_isValid() { return true; }
     virtual bool did_set_jointAcceleration() { return true; }
+    virtual bool did_set_jointAcceleration_isValid() { return true; }
     virtual bool did_set_motorPosition() { return true; }
+    virtual bool did_set_motorPosition_isValid() { return true; }
     virtual bool did_set_motorVelocity() { return true; }
+    virtual bool did_set_motorVelocity_isValid() { return true; }
     virtual bool did_set_motorAcceleration() { return true; }
+    virtual bool did_set_motorAcceleration_isValid() { return true; }
     virtual bool did_set_torque() { return true; }
+    virtual bool did_set_torque_isValid() { return true; }
     virtual bool did_set_pidOutput() { return true; }
+    virtual bool did_set_pidOutput_isValid() { return true; }
     virtual bool did_set_controlMode() { return true; }
+    virtual bool did_set_controlMode_isValid() { return true; }
     virtual bool did_set_interactionMode() { return true; }
+    virtual bool did_set_interactionMode_isValid() { return true; }
     void clean() {
       dirty_flags(false);
     }
@@ -376,10 +566,22 @@ public:
       is_dirty_jointPosition = true;
       mark_dirty();
     }
+    void mark_dirty_jointPosition_isValid() {
+      if (is_dirty_jointPosition_isValid) return;
+      dirty_count++;
+      is_dirty_jointPosition_isValid = true;
+      mark_dirty();
+    }
     void mark_dirty_jointVelocity() {
       if (is_dirty_jointVelocity) return;
       dirty_count++;
       is_dirty_jointVelocity = true;
+      mark_dirty();
+    }
+    void mark_dirty_jointVelocity_isValid() {
+      if (is_dirty_jointVelocity_isValid) return;
+      dirty_count++;
+      is_dirty_jointVelocity_isValid = true;
       mark_dirty();
     }
     void mark_dirty_jointAcceleration() {
@@ -388,10 +590,22 @@ public:
       is_dirty_jointAcceleration = true;
       mark_dirty();
     }
+    void mark_dirty_jointAcceleration_isValid() {
+      if (is_dirty_jointAcceleration_isValid) return;
+      dirty_count++;
+      is_dirty_jointAcceleration_isValid = true;
+      mark_dirty();
+    }
     void mark_dirty_motorPosition() {
       if (is_dirty_motorPosition) return;
       dirty_count++;
       is_dirty_motorPosition = true;
+      mark_dirty();
+    }
+    void mark_dirty_motorPosition_isValid() {
+      if (is_dirty_motorPosition_isValid) return;
+      dirty_count++;
+      is_dirty_motorPosition_isValid = true;
       mark_dirty();
     }
     void mark_dirty_motorVelocity() {
@@ -400,10 +614,22 @@ public:
       is_dirty_motorVelocity = true;
       mark_dirty();
     }
+    void mark_dirty_motorVelocity_isValid() {
+      if (is_dirty_motorVelocity_isValid) return;
+      dirty_count++;
+      is_dirty_motorVelocity_isValid = true;
+      mark_dirty();
+    }
     void mark_dirty_motorAcceleration() {
       if (is_dirty_motorAcceleration) return;
       dirty_count++;
       is_dirty_motorAcceleration = true;
+      mark_dirty();
+    }
+    void mark_dirty_motorAcceleration_isValid() {
+      if (is_dirty_motorAcceleration_isValid) return;
+      dirty_count++;
+      is_dirty_motorAcceleration_isValid = true;
       mark_dirty();
     }
     void mark_dirty_torque() {
@@ -412,10 +638,22 @@ public:
       is_dirty_torque = true;
       mark_dirty();
     }
+    void mark_dirty_torque_isValid() {
+      if (is_dirty_torque_isValid) return;
+      dirty_count++;
+      is_dirty_torque_isValid = true;
+      mark_dirty();
+    }
     void mark_dirty_pidOutput() {
       if (is_dirty_pidOutput) return;
       dirty_count++;
       is_dirty_pidOutput = true;
+      mark_dirty();
+    }
+    void mark_dirty_pidOutput_isValid() {
+      if (is_dirty_pidOutput_isValid) return;
+      dirty_count++;
+      is_dirty_pidOutput_isValid = true;
       mark_dirty();
     }
     void mark_dirty_controlMode() {
@@ -424,38 +662,70 @@ public:
       is_dirty_controlMode = true;
       mark_dirty();
     }
+    void mark_dirty_controlMode_isValid() {
+      if (is_dirty_controlMode_isValid) return;
+      dirty_count++;
+      is_dirty_controlMode_isValid = true;
+      mark_dirty();
+    }
     void mark_dirty_interactionMode() {
       if (is_dirty_interactionMode) return;
       dirty_count++;
       is_dirty_interactionMode = true;
       mark_dirty();
     }
+    void mark_dirty_interactionMode_isValid() {
+      if (is_dirty_interactionMode_isValid) return;
+      dirty_count++;
+      is_dirty_interactionMode_isValid = true;
+      mark_dirty();
+    }
     void dirty_flags(bool flag) {
       is_dirty = flag;
       is_dirty_jointPosition = flag;
+      is_dirty_jointPosition_isValid = flag;
       is_dirty_jointVelocity = flag;
+      is_dirty_jointVelocity_isValid = flag;
       is_dirty_jointAcceleration = flag;
+      is_dirty_jointAcceleration_isValid = flag;
       is_dirty_motorPosition = flag;
+      is_dirty_motorPosition_isValid = flag;
       is_dirty_motorVelocity = flag;
+      is_dirty_motorVelocity_isValid = flag;
       is_dirty_motorAcceleration = flag;
+      is_dirty_motorAcceleration_isValid = flag;
       is_dirty_torque = flag;
+      is_dirty_torque_isValid = flag;
       is_dirty_pidOutput = flag;
+      is_dirty_pidOutput_isValid = flag;
       is_dirty_controlMode = flag;
+      is_dirty_controlMode_isValid = flag;
       is_dirty_interactionMode = flag;
-      dirty_count = flag ? 10 : 0;
+      is_dirty_interactionMode_isValid = flag;
+      dirty_count = flag ? 20 : 0;
     }
     bool is_dirty;
     int dirty_count;
     bool is_dirty_jointPosition;
+    bool is_dirty_jointPosition_isValid;
     bool is_dirty_jointVelocity;
+    bool is_dirty_jointVelocity_isValid;
     bool is_dirty_jointAcceleration;
+    bool is_dirty_jointAcceleration_isValid;
     bool is_dirty_motorPosition;
+    bool is_dirty_motorPosition_isValid;
     bool is_dirty_motorVelocity;
+    bool is_dirty_motorVelocity_isValid;
     bool is_dirty_motorAcceleration;
+    bool is_dirty_motorAcceleration_isValid;
     bool is_dirty_torque;
+    bool is_dirty_torque_isValid;
     bool is_dirty_pidOutput;
+    bool is_dirty_pidOutput_isValid;
     bool is_dirty_controlMode;
+    bool is_dirty_controlMode_isValid;
     bool is_dirty_interactionMode;
+    bool is_dirty_interactionMode_isValid;
   };
 };
 

--- a/src/libYARP_dev/src/modules/msgs/yarp/src/jointData.cpp
+++ b/src/libYARP_dev/src/modules/msgs/yarp/src/jointData.cpp
@@ -41,6 +41,20 @@ bool jointData::nested_read_jointPosition(yarp::os::idl::WireReader& reader) {
   }
   return true;
 }
+bool jointData::read_jointPosition_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointPosition_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_jointPosition_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointPosition_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read_jointVelocity(yarp::os::idl::WireReader& reader) {
   {
     jointVelocity.clear();
@@ -76,6 +90,20 @@ bool jointData::nested_read_jointVelocity(yarp::os::idl::WireReader& reader) {
       }
     }
     reader.readListEnd();
+  }
+  return true;
+}
+bool jointData::read_jointVelocity_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointVelocity_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_jointVelocity_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointVelocity_isValid)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -117,6 +145,20 @@ bool jointData::nested_read_jointAcceleration(yarp::os::idl::WireReader& reader)
   }
   return true;
 }
+bool jointData::read_jointAcceleration_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointAcceleration_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_jointAcceleration_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(jointAcceleration_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read_motorPosition(yarp::os::idl::WireReader& reader) {
   {
     motorPosition.clear();
@@ -152,6 +194,20 @@ bool jointData::nested_read_motorPosition(yarp::os::idl::WireReader& reader) {
       }
     }
     reader.readListEnd();
+  }
+  return true;
+}
+bool jointData::read_motorPosition_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorPosition_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_motorPosition_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorPosition_isValid)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -193,6 +249,20 @@ bool jointData::nested_read_motorVelocity(yarp::os::idl::WireReader& reader) {
   }
   return true;
 }
+bool jointData::read_motorVelocity_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorVelocity_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_motorVelocity_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorVelocity_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read_motorAcceleration(yarp::os::idl::WireReader& reader) {
   {
     motorAcceleration.clear();
@@ -228,6 +298,20 @@ bool jointData::nested_read_motorAcceleration(yarp::os::idl::WireReader& reader)
       }
     }
     reader.readListEnd();
+  }
+  return true;
+}
+bool jointData::read_motorAcceleration_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorAcceleration_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_motorAcceleration_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(motorAcceleration_isValid)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -269,6 +353,20 @@ bool jointData::nested_read_torque(yarp::os::idl::WireReader& reader) {
   }
   return true;
 }
+bool jointData::read_torque_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(torque_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_torque_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(torque_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read_pidOutput(yarp::os::idl::WireReader& reader) {
   {
     pidOutput.clear();
@@ -304,6 +402,20 @@ bool jointData::nested_read_pidOutput(yarp::os::idl::WireReader& reader) {
       }
     }
     reader.readListEnd();
+  }
+  return true;
+}
+bool jointData::read_pidOutput_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(pidOutput_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_pidOutput_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(pidOutput_isValid)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -345,6 +457,20 @@ bool jointData::nested_read_controlMode(yarp::os::idl::WireReader& reader) {
   }
   return true;
 }
+bool jointData::read_controlMode_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(controlMode_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_controlMode_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(controlMode_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read_interactionMode(yarp::os::idl::WireReader& reader) {
   {
     interactionMode.clear();
@@ -383,23 +509,47 @@ bool jointData::nested_read_interactionMode(yarp::os::idl::WireReader& reader) {
   }
   return true;
 }
+bool jointData::read_interactionMode_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(interactionMode_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool jointData::nested_read_interactionMode_isValid(yarp::os::idl::WireReader& reader) {
+  if (!reader.readBool(interactionMode_isValid)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool jointData::read(yarp::os::idl::WireReader& reader) {
   if (!read_jointPosition(reader)) return false;
+  if (!read_jointPosition_isValid(reader)) return false;
   if (!read_jointVelocity(reader)) return false;
+  if (!read_jointVelocity_isValid(reader)) return false;
   if (!read_jointAcceleration(reader)) return false;
+  if (!read_jointAcceleration_isValid(reader)) return false;
   if (!read_motorPosition(reader)) return false;
+  if (!read_motorPosition_isValid(reader)) return false;
   if (!read_motorVelocity(reader)) return false;
+  if (!read_motorVelocity_isValid(reader)) return false;
   if (!read_motorAcceleration(reader)) return false;
+  if (!read_motorAcceleration_isValid(reader)) return false;
   if (!read_torque(reader)) return false;
+  if (!read_torque_isValid(reader)) return false;
   if (!read_pidOutput(reader)) return false;
+  if (!read_pidOutput_isValid(reader)) return false;
   if (!read_controlMode(reader)) return false;
+  if (!read_controlMode_isValid(reader)) return false;
   if (!read_interactionMode(reader)) return false;
+  if (!read_interactionMode_isValid(reader)) return false;
   return !reader.isError();
 }
 
 bool jointData::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireReader reader(connection);
-  if (!reader.readListHeader(10)) return false;
+  if (!reader.readListHeader(20)) return false;
   return read(reader);
 }
 
@@ -427,6 +577,14 @@ bool jointData::nested_write_jointPosition(yarp::os::idl::WireWriter& writer) {
   }
   return true;
 }
+bool jointData::write_jointPosition_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointPosition_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_jointPosition_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointPosition_isValid)) return false;
+  return true;
+}
 bool jointData::write_jointVelocity(yarp::os::idl::WireWriter& writer) {
   {
     if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointVelocity.size()))) return false;
@@ -449,6 +607,14 @@ bool jointData::nested_write_jointVelocity(yarp::os::idl::WireWriter& writer) {
     }
     if (!writer.writeListEnd()) return false;
   }
+  return true;
+}
+bool jointData::write_jointVelocity_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointVelocity_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_jointVelocity_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointVelocity_isValid)) return false;
   return true;
 }
 bool jointData::write_jointAcceleration(yarp::os::idl::WireWriter& writer) {
@@ -475,6 +641,14 @@ bool jointData::nested_write_jointAcceleration(yarp::os::idl::WireWriter& writer
   }
   return true;
 }
+bool jointData::write_jointAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointAcceleration_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_jointAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(jointAcceleration_isValid)) return false;
+  return true;
+}
 bool jointData::write_motorPosition(yarp::os::idl::WireWriter& writer) {
   {
     if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorPosition.size()))) return false;
@@ -497,6 +671,14 @@ bool jointData::nested_write_motorPosition(yarp::os::idl::WireWriter& writer) {
     }
     if (!writer.writeListEnd()) return false;
   }
+  return true;
+}
+bool jointData::write_motorPosition_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorPosition_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_motorPosition_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorPosition_isValid)) return false;
   return true;
 }
 bool jointData::write_motorVelocity(yarp::os::idl::WireWriter& writer) {
@@ -523,6 +705,14 @@ bool jointData::nested_write_motorVelocity(yarp::os::idl::WireWriter& writer) {
   }
   return true;
 }
+bool jointData::write_motorVelocity_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorVelocity_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_motorVelocity_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorVelocity_isValid)) return false;
+  return true;
+}
 bool jointData::write_motorAcceleration(yarp::os::idl::WireWriter& writer) {
   {
     if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorAcceleration.size()))) return false;
@@ -545,6 +735,14 @@ bool jointData::nested_write_motorAcceleration(yarp::os::idl::WireWriter& writer
     }
     if (!writer.writeListEnd()) return false;
   }
+  return true;
+}
+bool jointData::write_motorAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorAcceleration_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_motorAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(motorAcceleration_isValid)) return false;
   return true;
 }
 bool jointData::write_torque(yarp::os::idl::WireWriter& writer) {
@@ -571,6 +769,14 @@ bool jointData::nested_write_torque(yarp::os::idl::WireWriter& writer) {
   }
   return true;
 }
+bool jointData::write_torque_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(torque_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_torque_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(torque_isValid)) return false;
+  return true;
+}
 bool jointData::write_pidOutput(yarp::os::idl::WireWriter& writer) {
   {
     if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(pidOutput.size()))) return false;
@@ -593,6 +799,14 @@ bool jointData::nested_write_pidOutput(yarp::os::idl::WireWriter& writer) {
     }
     if (!writer.writeListEnd()) return false;
   }
+  return true;
+}
+bool jointData::write_pidOutput_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(pidOutput_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_pidOutput_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(pidOutput_isValid)) return false;
   return true;
 }
 bool jointData::write_controlMode(yarp::os::idl::WireWriter& writer) {
@@ -619,6 +833,14 @@ bool jointData::nested_write_controlMode(yarp::os::idl::WireWriter& writer) {
   }
   return true;
 }
+bool jointData::write_controlMode_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(controlMode_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_controlMode_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(controlMode_isValid)) return false;
+  return true;
+}
 bool jointData::write_interactionMode(yarp::os::idl::WireWriter& writer) {
   {
     if (!writer.writeListBegin(BOTTLE_TAG_INT, static_cast<uint32_t>(interactionMode.size()))) return false;
@@ -643,23 +865,41 @@ bool jointData::nested_write_interactionMode(yarp::os::idl::WireWriter& writer) 
   }
   return true;
 }
+bool jointData::write_interactionMode_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(interactionMode_isValid)) return false;
+  return true;
+}
+bool jointData::nested_write_interactionMode_isValid(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeBool(interactionMode_isValid)) return false;
+  return true;
+}
 bool jointData::write(yarp::os::idl::WireWriter& writer) {
   if (!write_jointPosition(writer)) return false;
+  if (!write_jointPosition_isValid(writer)) return false;
   if (!write_jointVelocity(writer)) return false;
+  if (!write_jointVelocity_isValid(writer)) return false;
   if (!write_jointAcceleration(writer)) return false;
+  if (!write_jointAcceleration_isValid(writer)) return false;
   if (!write_motorPosition(writer)) return false;
+  if (!write_motorPosition_isValid(writer)) return false;
   if (!write_motorVelocity(writer)) return false;
+  if (!write_motorVelocity_isValid(writer)) return false;
   if (!write_motorAcceleration(writer)) return false;
+  if (!write_motorAcceleration_isValid(writer)) return false;
   if (!write_torque(writer)) return false;
+  if (!write_torque_isValid(writer)) return false;
   if (!write_pidOutput(writer)) return false;
+  if (!write_pidOutput_isValid(writer)) return false;
   if (!write_controlMode(writer)) return false;
+  if (!write_controlMode_isValid(writer)) return false;
   if (!write_interactionMode(writer)) return false;
+  if (!write_interactionMode_isValid(writer)) return false;
   return !writer.isError();
 }
 
 bool jointData::write(yarp::os::ConnectionWriter& connection) {
   yarp::os::idl::WireWriter writer(connection);
-  if (!writer.writeListHeader(10)) return false;
+  if (!writer.writeListHeader(20)) return false;
   return write(writer);
 }
 bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
@@ -673,11 +913,23 @@ bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
     if (!writer.writeString("jointPosition")) return false;
     if (!obj->nested_write_jointPosition(writer)) return false;
   }
+  if (is_dirty_jointPosition_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("jointPosition_isValid")) return false;
+    if (!obj->nested_write_jointPosition_isValid(writer)) return false;
+  }
   if (is_dirty_jointVelocity) {
     if (!writer.writeListHeader(3)) return false;
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("jointVelocity")) return false;
     if (!obj->nested_write_jointVelocity(writer)) return false;
+  }
+  if (is_dirty_jointVelocity_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("jointVelocity_isValid")) return false;
+    if (!obj->nested_write_jointVelocity_isValid(writer)) return false;
   }
   if (is_dirty_jointAcceleration) {
     if (!writer.writeListHeader(3)) return false;
@@ -685,11 +937,23 @@ bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
     if (!writer.writeString("jointAcceleration")) return false;
     if (!obj->nested_write_jointAcceleration(writer)) return false;
   }
+  if (is_dirty_jointAcceleration_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("jointAcceleration_isValid")) return false;
+    if (!obj->nested_write_jointAcceleration_isValid(writer)) return false;
+  }
   if (is_dirty_motorPosition) {
     if (!writer.writeListHeader(3)) return false;
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("motorPosition")) return false;
     if (!obj->nested_write_motorPosition(writer)) return false;
+  }
+  if (is_dirty_motorPosition_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("motorPosition_isValid")) return false;
+    if (!obj->nested_write_motorPosition_isValid(writer)) return false;
   }
   if (is_dirty_motorVelocity) {
     if (!writer.writeListHeader(3)) return false;
@@ -697,11 +961,23 @@ bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
     if (!writer.writeString("motorVelocity")) return false;
     if (!obj->nested_write_motorVelocity(writer)) return false;
   }
+  if (is_dirty_motorVelocity_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("motorVelocity_isValid")) return false;
+    if (!obj->nested_write_motorVelocity_isValid(writer)) return false;
+  }
   if (is_dirty_motorAcceleration) {
     if (!writer.writeListHeader(3)) return false;
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("motorAcceleration")) return false;
     if (!obj->nested_write_motorAcceleration(writer)) return false;
+  }
+  if (is_dirty_motorAcceleration_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("motorAcceleration_isValid")) return false;
+    if (!obj->nested_write_motorAcceleration_isValid(writer)) return false;
   }
   if (is_dirty_torque) {
     if (!writer.writeListHeader(3)) return false;
@@ -709,11 +985,23 @@ bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
     if (!writer.writeString("torque")) return false;
     if (!obj->nested_write_torque(writer)) return false;
   }
+  if (is_dirty_torque_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("torque_isValid")) return false;
+    if (!obj->nested_write_torque_isValid(writer)) return false;
+  }
   if (is_dirty_pidOutput) {
     if (!writer.writeListHeader(3)) return false;
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("pidOutput")) return false;
     if (!obj->nested_write_pidOutput(writer)) return false;
+  }
+  if (is_dirty_pidOutput_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("pidOutput_isValid")) return false;
+    if (!obj->nested_write_pidOutput_isValid(writer)) return false;
   }
   if (is_dirty_controlMode) {
     if (!writer.writeListHeader(3)) return false;
@@ -721,11 +1009,23 @@ bool jointData::Editor::write(yarp::os::ConnectionWriter& connection) {
     if (!writer.writeString("controlMode")) return false;
     if (!obj->nested_write_controlMode(writer)) return false;
   }
+  if (is_dirty_controlMode_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("controlMode_isValid")) return false;
+    if (!obj->nested_write_controlMode_isValid(writer)) return false;
+  }
   if (is_dirty_interactionMode) {
     if (!writer.writeListHeader(3)) return false;
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("interactionMode")) return false;
     if (!obj->nested_write_interactionMode(writer)) return false;
+  }
+  if (is_dirty_interactionMode_isValid) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("interactionMode_isValid")) return false;
+    if (!obj->nested_write_interactionMode_isValid(writer)) return false;
   }
   return !writer.isError();
 }
@@ -756,55 +1056,105 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  jointPosition")) return false;
       }
+      if (field=="jointPosition_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool jointPosition_isValid")) return false;
+      }
       if (field=="jointVelocity") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  jointVelocity")) return false;
+      }
+      if (field=="jointVelocity_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool jointVelocity_isValid")) return false;
       }
       if (field=="jointAcceleration") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  jointAcceleration")) return false;
       }
+      if (field=="jointAcceleration_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool jointAcceleration_isValid")) return false;
+      }
       if (field=="motorPosition") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  motorPosition")) return false;
+      }
+      if (field=="motorPosition_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool motorPosition_isValid")) return false;
       }
       if (field=="motorVelocity") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  motorVelocity")) return false;
       }
+      if (field=="motorVelocity_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool motorVelocity_isValid")) return false;
+      }
       if (field=="motorAcceleration") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  motorAcceleration")) return false;
+      }
+      if (field=="motorAcceleration_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool motorAcceleration_isValid")) return false;
       }
       if (field=="torque") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  torque")) return false;
       }
+      if (field=="torque_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool torque_isValid")) return false;
+      }
       if (field=="pidOutput") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<double>  pidOutput")) return false;
+      }
+      if (field=="pidOutput_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool pidOutput_isValid")) return false;
       }
       if (field=="controlMode") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<int32_t>  controlMode")) return false;
       }
+      if (field=="controlMode_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool controlMode_isValid")) return false;
+      }
       if (field=="interactionMode") {
         if (!writer.writeListHeader(1)) return false;
         if (!writer.writeString("std::vector<int32_t>  interactionMode")) return false;
       }
+      if (field=="interactionMode_isValid") {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeString("bool interactionMode_isValid")) return false;
+      }
     }
-    if (!writer.writeListHeader(11)) return false;
+    if (!writer.writeListHeader(21)) return false;
     writer.writeString("*** Available fields:");
     writer.writeString("jointPosition");
+    writer.writeString("jointPosition_isValid");
     writer.writeString("jointVelocity");
+    writer.writeString("jointVelocity_isValid");
     writer.writeString("jointAcceleration");
+    writer.writeString("jointAcceleration_isValid");
     writer.writeString("motorPosition");
+    writer.writeString("motorPosition_isValid");
     writer.writeString("motorVelocity");
+    writer.writeString("motorVelocity_isValid");
     writer.writeString("motorAcceleration");
+    writer.writeString("motorAcceleration_isValid");
     writer.writeString("torque");
+    writer.writeString("torque_isValid");
     writer.writeString("pidOutput");
+    writer.writeString("pidOutput_isValid");
     writer.writeString("controlMode");
+    writer.writeString("controlMode_isValid");
     writer.writeString("interactionMode");
+    writer.writeString("interactionMode_isValid");
     return true;
   }
   bool nested = true;
@@ -830,42 +1180,82 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       will_set_jointPosition();
       if (!obj->nested_read_jointPosition(reader)) return false;
       did_set_jointPosition();
+    } else if (key == "jointPosition_isValid") {
+      will_set_jointPosition_isValid();
+      if (!obj->nested_read_jointPosition_isValid(reader)) return false;
+      did_set_jointPosition_isValid();
     } else if (key == "jointVelocity") {
       will_set_jointVelocity();
       if (!obj->nested_read_jointVelocity(reader)) return false;
       did_set_jointVelocity();
+    } else if (key == "jointVelocity_isValid") {
+      will_set_jointVelocity_isValid();
+      if (!obj->nested_read_jointVelocity_isValid(reader)) return false;
+      did_set_jointVelocity_isValid();
     } else if (key == "jointAcceleration") {
       will_set_jointAcceleration();
       if (!obj->nested_read_jointAcceleration(reader)) return false;
       did_set_jointAcceleration();
+    } else if (key == "jointAcceleration_isValid") {
+      will_set_jointAcceleration_isValid();
+      if (!obj->nested_read_jointAcceleration_isValid(reader)) return false;
+      did_set_jointAcceleration_isValid();
     } else if (key == "motorPosition") {
       will_set_motorPosition();
       if (!obj->nested_read_motorPosition(reader)) return false;
       did_set_motorPosition();
+    } else if (key == "motorPosition_isValid") {
+      will_set_motorPosition_isValid();
+      if (!obj->nested_read_motorPosition_isValid(reader)) return false;
+      did_set_motorPosition_isValid();
     } else if (key == "motorVelocity") {
       will_set_motorVelocity();
       if (!obj->nested_read_motorVelocity(reader)) return false;
       did_set_motorVelocity();
+    } else if (key == "motorVelocity_isValid") {
+      will_set_motorVelocity_isValid();
+      if (!obj->nested_read_motorVelocity_isValid(reader)) return false;
+      did_set_motorVelocity_isValid();
     } else if (key == "motorAcceleration") {
       will_set_motorAcceleration();
       if (!obj->nested_read_motorAcceleration(reader)) return false;
       did_set_motorAcceleration();
+    } else if (key == "motorAcceleration_isValid") {
+      will_set_motorAcceleration_isValid();
+      if (!obj->nested_read_motorAcceleration_isValid(reader)) return false;
+      did_set_motorAcceleration_isValid();
     } else if (key == "torque") {
       will_set_torque();
       if (!obj->nested_read_torque(reader)) return false;
       did_set_torque();
+    } else if (key == "torque_isValid") {
+      will_set_torque_isValid();
+      if (!obj->nested_read_torque_isValid(reader)) return false;
+      did_set_torque_isValid();
     } else if (key == "pidOutput") {
       will_set_pidOutput();
       if (!obj->nested_read_pidOutput(reader)) return false;
       did_set_pidOutput();
+    } else if (key == "pidOutput_isValid") {
+      will_set_pidOutput_isValid();
+      if (!obj->nested_read_pidOutput_isValid(reader)) return false;
+      did_set_pidOutput_isValid();
     } else if (key == "controlMode") {
       will_set_controlMode();
       if (!obj->nested_read_controlMode(reader)) return false;
       did_set_controlMode();
+    } else if (key == "controlMode_isValid") {
+      will_set_controlMode_isValid();
+      if (!obj->nested_read_controlMode_isValid(reader)) return false;
+      did_set_controlMode_isValid();
     } else if (key == "interactionMode") {
       will_set_interactionMode();
       if (!obj->nested_read_interactionMode(reader)) return false;
       did_set_interactionMode();
+    } else if (key == "interactionMode_isValid") {
+      will_set_interactionMode_isValid();
+      if (!obj->nested_read_interactionMode_isValid(reader)) return false;
+      did_set_interactionMode_isValid();
     } else {
       // would be useful to have a fallback here
     }


### PR DESCRIPTION
Each value broadcasted inside the stateExt port is paired with a boolean flag telling if the value is valid or not.
The flag will be set to true if the corresponding getXXX function in the remote device driver was succesful or false otherwise.
In this way if the user application tries a getMotorAcceleration and the robot/simulator does not implement this function (or it fails somehow) the return value in the user application will be false.
Right now, since all broadcasted values are always available the return value was always true but I think this is not correct.
This will re-establish the same behaviour of the former version of yarp without the stateExt.