### PR TITLE
fixes for compatibility with opencv 3.0.0

### DIFF
--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -12,8 +12,7 @@
 #include <deque>
 
 #ifdef ADD_VIDEO
-    #include <cv.h>
-    #include <highgui.h>
+    #include <opencv2/opencv.hpp>
 #endif
 
 #include <yarp/os/all.h>
@@ -425,7 +424,7 @@ public:
             #ifdef ADD_VIDEO
                 if (doSaveFrame)
                 {
-                    cv::Mat img((IplImage*)item.obj->getPtr());
+                    cv::Mat img=cv::cvarrToMat((IplImage*)item.obj->getPtr());
                     videoWriter<<img;
 
                     // write the timecode of the frame

--- a/src/yarpdataplayer-qt/src/worker.cpp
+++ b/src/yarpdataplayer-qt/src/worker.cpp
@@ -157,7 +157,7 @@ int WorkerClass::sendImages(int part, int frame)
         cvCvtColor( img, img, CV_BGR2RGB );
         ImageOf<PixelRgb> &temp = utilities->partDetails[part].imagePort.prepare();
         temp.resize(img->width,img->height);
-        cvCopyImage( img, (IplImage *) temp.getIplImage());
+        cvCopy( img, (IplImage *) temp.getIplImage());
 #else
     if ( !read(img,tmpPath.c_str()) ) {
         LOG_ERROR("Cannot load file %s !\n", tmpPath.c_str() );


### PR DESCRIPTION
- The constructor `cv::Mat(IplImage*)` disappeared and can be thus replaced by `cv::cvarrtoMat()`
- `cvCopy()` takes over `cvCopyImage()`

Hopefully, these changes are back-compatible.