### PR TITLE
Forced the refresh of the nameserver properties (host, port)

### DIFF
--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -1279,7 +1279,9 @@ bool NetworkBase::setNameServerContact(Contact &nameServerContact)
         setNameServerName(nameServerContact.getName());
     nameConfig.fromFile();
     nameConfig.setAddress(nameServerContact);
-    return nameConfig.toFile();
+    bool result = nameConfig.toFile();
+    getNameSpace().activate(true);
+    return result;
 }
 
 


### PR DESCRIPTION
When `setNameServerContact` was called the properties were correctly saved to the configuration file, but it was not reloaded (until next run of yarp).
I forced the reload by calling `activate` with the `true` flag.
I don't know if this is the most correct way.

cc @lornat75 

PS:
I think that nobody (but me) uses this function, so I think I'll not break any compatibility
PPS:
@lornat75 the fact that all configurations passes through file writing causes some issues in some configuration, e.g. read-only filesystem, etc.. I think this is quite old yarp code, but maybe we can open a (low priority) issue on making optional the writing, and/or allowing yarp to be configured also in-memory. cc @alecive 
