### PR TITLE
Change controlBoardWrapper2 input streaming port to BufferedPort, add…

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -215,7 +215,7 @@ private:
 
 
     yarp::os::BufferedPort<yarp::sig::Vector>  outputPositionStatePort;   // Port /state:o streaming out the encoder positions
-    yarp::os::Port inputStreamingPort;          // Input streaming port for high frequency commands
+    yarp::os::BufferedPort<CommandMessage>     inputStreamingPort;        // Input streaming port for high frequency commands
     yarp::os::Port inputRPCPort;                // Input RPC port for set/get remote calls
     yarp::os::Stamp time;                       // envelope to attach to the state port
     yarp::os::Semaphore timeMutex;
@@ -235,7 +235,6 @@ private:
     yarp::os::PortWriterBuffer<sensor_msgs_JointState>  rosOutputState_buffer;      // Buffer associated to the ROS topic
     yarp::os::Publisher<sensor_msgs_JointState>         rosPublisherPort;           // Dedicated ROS topic publisher
 
-    yarp::os::PortReaderBuffer<CommandMessage>      inputStreaming_buffer;          // Buffer associated to the inputStreamingPort port
     yarp::os::PortReaderBuffer<yarp::os::Bottle>    inputRPC_buffer;                // Buffer associated to the inputRPCPort port
     yarp::dev::impl::RPCMessagesParser              RPC_parser;                     // Message parser associated to the inputRPCPort port
     yarp::dev::impl::StreamingMessagesParser        streaming_parser;               // Message parser associated to the inputStreamingPort port


### PR DESCRIPTION
… read Strict option

Add check if more then 20 messages are in queue to be read, warn the user of
a possible overflow (reader not able to handle all messages fast enough)