### PR TITLE
Fix FfmpegGrabber to work with recent ffmpeg

### DIFF
--- a/src/modules/ffmpeg/FfmpegGrabber.cpp
+++ b/src/modules/ffmpeg/FfmpegGrabber.cpp
@@ -569,7 +569,7 @@ bool FfmpegGrabber::open(yarp::os::Searchable & config) {
 
 
     // Retrieve stream information
-    if(YARP_av_find_stream_info(pFormatCtx)<0) {
+    if(YARP_av_find_stream_info(pFormatCtx, NULL)<0) {
         printf("Could not find stream information in %s\n", fname.c_str());
         return false; // Couldn't find stream information
     }
@@ -579,7 +579,7 @@ bool FfmpegGrabber::open(yarp::os::Searchable & config) {
 
     if (pFormatCtx2!=NULL) {
         
-        if(YARP_av_find_stream_info(pFormatCtx2)<0) {
+        if(YARP_av_find_stream_info(pFormatCtx2, NULL)<0) {
             printf("Could not find stream information in %s\n", fname.c_str());
             return false; // Couldn't find stream information
         }

--- a/src/modules/ffmpeg/FfmpegWriter.cpp
+++ b/src/modules/ffmpeg/FfmpegWriter.cpp
@@ -91,7 +91,7 @@ static AVStream *add_audio_stream(AVFormatContext *oc, CodecID codec_id)
     AVCodecContext *c;
     AVStream *st;
 
-    st = av_new_stream(oc, 1);
+    st = avformat_new_stream(oc, NULL);
     if (!st) {
         fprintf(stderr, "Could not alloc stream\n");
         ::exit(1);
@@ -370,7 +370,7 @@ static AVStream *add_video_stream(AVFormatContext *oc, CodecID codec_id,
     AVCodecContext *c;
     AVStream *st;
 
-    st = av_new_stream(oc, 0);
+    st = avformat_new_stream(oc, NULL);
     if (!st) {
         fprintf(stderr, "Could not alloc stream\n");
         ::exit(1);
@@ -712,7 +712,7 @@ bool FfmpegWriter::delayedOpen(yarp::os::Searchable & config) {
     /* set the output parameters (must be done even if no
        parameters). */
 #ifndef AV_NO_SET_PARAMETERS
-    if (av_set_parameters(oc, NULL) < 0) {
+    if (avformat_write_header(oc, NULL) < 0) {
         fprintf(stderr, "Invalid output format parameters\n");
         ::exit(1);
     }
@@ -731,14 +731,14 @@ bool FfmpegWriter::delayedOpen(yarp::os::Searchable & config) {
 
     /* open the output file, if needed */
     if (!(fmt->flags & AVFMT_NOFILE)) {
-        if (url_fopen(&oc->pb, filename.c_str(), URL_WRONLY) < 0) {
+        if (avio_open(&oc->pb, filename.c_str(), AVIO_FLAG_WRITE) < 0) {
             fprintf(stderr, "Could not open '%s'\n", filename.c_str());
             ::exit(1);
         }
     }
 
     /* write the stream header, if any */
-    av_write_header(oc);
+    avformat_write_header(oc, NULL);
 
     return true;
 }
@@ -764,7 +764,7 @@ bool FfmpegWriter::close() {
     if (!(fmt->flags & AVFMT_NOFILE)) {
         /* close the output file */
 #if LIBAVCODEC_BUILD >= 3354624
-        url_fclose(oc->pb);
+        avio_close(oc->pb);
 #else
         url_fclose(&oc->pb);
 #endif

--- a/src/modules/ffmpeg/ffmpeg_api.h
+++ b/src/modules/ffmpeg/ffmpeg_api.h
@@ -113,8 +113,8 @@ typedef AVFormatParameters YARP_AVDICT;
 #define YARP_avcodec_alloc_frame avcodec_alloc_frame
 #endif
 
-#define YARP_av_find_stream_info av_find_stream_info
-#define YARP_dump_format dump_format
+#define YARP_av_find_stream_info avformat_find_stream_info
+#define YARP_dump_format av_dump_format
 #define YARP_av_close_input_file av_close_input_file
 
 #ifdef USE_AVFORMAT_OPEN_INPUT


### PR DESCRIPTION
Hi,

I know most people use the OpenCVGrabber, but we needed to get the FfmpegGrabber working with a recent version of Ubuntu (14.04). This pull request contains the changes needed.

Best,
Tobias