### PR TITLE
Added option to skip binaries compilation

### DIFF
--- a/conf/YarpOptions.cmake
+++ b/conf/YarpOptions.cmake
@@ -328,3 +328,6 @@ if(TEST_MACHINE_HOSTNAME)
   message(STATUS "TEST_MACHINE_OS_TYPE: ${TEST_MACHINE_OS_TYPE}")
   message(STATUS "TEST_MACHINE_TEST_TYPE: ${TEST_MACHINE_TEST_TYPE}")
 endif()
+
+# Add the option to build only libraries and skip the binaries
+option(YARP_BUILD_LIBRARIES_ONLY "Build only libraries. Skip binaries." FALSE)

--- a/conf/YarpOptions.cmake
+++ b/conf/YarpOptions.cmake
@@ -331,3 +331,4 @@ endif()
 
 # Add the option to build only libraries and skip the binaries
 option(YARP_BUILD_LIBRARIES_ONLY "Build only libraries. Skip binaries." FALSE)
+mark_as_advanced(YARP_BUILD_LIBRARIES_ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,9 @@ endif()
 add_subdirectory(modules)
 add_subdirectory(carriers)
 
-add_subdirectory(idls)
+if (NOT YARP_BUILD_LIBRARIES_ONLY)
+    add_subdirectory(idls)
+endif()
 
 add_subdirectory(libYARP_name)
 add_subdirectory(libYARP_init)
@@ -30,33 +32,36 @@ add_subdirectory(libYARP_logger)
 add_subdirectory(libyarpc)
 add_subdirectory(libyarpcxx)
 
-# executables
-add_subdirectory(yarpserver)
-add_subdirectory(yarp)
-add_subdirectory(yarprun)
-add_subdirectory(yarphear)
-add_subdirectory(yarpdev)
-add_subdirectory(yarpmanager-console)
-add_subdirectory(yarplogger-console)
-add_subdirectory(yarpdatadumper)
+if (NOT YARP_BUILD_LIBRARIES_ONLY)
+    # executables
+    add_subdirectory(yarpserver)
+    add_subdirectory(yarp)
+    add_subdirectory(yarprun)
+    add_subdirectory(yarphear)
+    add_subdirectory(yarpdev)
+    add_subdirectory(yarpmanager-console)
+    add_subdirectory(yarplogger-console)
+    add_subdirectory(yarpdatadumper)
 
-# Qt5 GUIs
-add_subdirectory(yarpview-qt)
-add_subdirectory(yarpscope-qt)
-add_subdirectory(yarpmanager-qt)
-add_subdirectory(yarplogger-qt)
-add_subdirectory(yarpdataplayer-qt)
-add_subdirectory(yarpmotorgui-qt)
-add_subdirectory(yarpbatterygui-qt)
+    # Qt5 GUIs
+    add_subdirectory(yarpview-qt)
+    add_subdirectory(yarpscope-qt)
+    add_subdirectory(yarpmanager-qt)
+    add_subdirectory(yarplogger-qt)
+    add_subdirectory(yarpdataplayer-qt)
+    add_subdirectory(yarpmotorgui-qt)
+    add_subdirectory(yarpbatterygui-qt)
 
-# GTK2 GUIs
-add_subdirectory(yarpview-gtk)
-add_subdirectory(yarpscope-gtk)
-add_subdirectory(yarpmanager-gtk)
-add_subdirectory(yarpbuilder-gtk)
-add_subdirectory(yarpdataplayer-gtk)
-add_subdirectory(yarpmotorgui-gtk)
+    # GTK2 GUIs
+    add_subdirectory(yarpview-gtk)
+    add_subdirectory(yarpscope-gtk)
+    add_subdirectory(yarpmanager-gtk)
+    add_subdirectory(yarpbuilder-gtk)
+    add_subdirectory(yarpdataplayer-gtk)
+    add_subdirectory(yarpmotorgui-gtk)
 
-# data
-add_subdirectory(yarpmanager)
-add_subdirectory(yarpdataplayer)
+    # data
+    add_subdirectory(yarpmanager)
+    add_subdirectory(yarpdataplayer)
+
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Paul Fitzpatrick
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-if(YARP_COMPILE_TESTS)
+if(YARP_COMPILE_TESTS AND NOT YARP_BUILD_LIBRARIES_ONLY)
 
     if(YARP_USE_PERSISTENT_NAMESERVER)
         add_definitions(-DYARP_USE_PERSISTENT_NAMESERVER=1)


### PR DESCRIPTION
Added `YARP_BUILD_LIBRARIES_ONLY`, by default to NO.
If set to YES only libraries will be build: no `add_executable` cmake command will be called.

I could have missed something, so double check is welcome.
The rationale behind this is to allow the compilation only of yarp libraries

cc: @lornat75 @drdanz @vtikha @alecive 