### PR TITLE
Update OS X docs

### DIFF
--- a/doc/installation/install_mac.dox
+++ b/doc/installation/install_mac.dox
@@ -67,6 +67,8 @@ The following options are also available:
 \code
 --with-lua
  	Build with Lua bindings
+--with-python
+  Build with Python bindings
 --with-opencv
  	Build the opencv_grabber device
 --with-qt5


### PR DESCRIPTION
Python support was broken in OS X ( #508 ). Now that it is fixed, I have updated the yarp homebrew formula to provide a ''--with-python'' option. 

This commit is the update to the installation docs to reflect the added option.

Commit rebased :)