### PR TITLE
Add methods to send envelope with the stream and send envelope with mjpeg

### DIFF
--- a/doc/carrier_expert.dox
+++ b/doc/carrier_expert.dox
@@ -220,6 +220,15 @@ administrative headers on your carrier (e.g. disconnection requests, for
 example).  Normally this should be true.
 </dd>
 
+<dt>yarp::os::Carrier::handleEnvelope</dt>
+
+<dd>Carriers that do not distinguish data from administrative headers
+(i.e. canEscape returns false), can overload this method to handle the
+envelope inside the stream. On the receiving side, the InputStream will
+have to overload the setReadEnvelopeCallback method, and execute the
+callback as soon as the envelope is ready.
+</dd>
+
 <dt>yarp::os::Carrier::requireAck</dt>
 
 <dd>Does you want YARP to use flow control?  If this is set, YARP

--- a/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
@@ -160,6 +160,10 @@ bool MjpegCarrier::write(ConnectionState& proto, SizedWriter& writer) {
     //jpeg_set_quality(&cinfo, 85, TRUE);
     dbg_printf("Starting to compress...\n");
     jpeg_start_compress(&cinfo, TRUE);
+    if(!envelope.empty()) {
+        jpeg_write_marker(&cinfo, JPEG_COM, reinterpret_cast<const JOCTET*>(envelope.c_str()), envelope.length() + 1);
+        envelope.clear();
+    }
     dbg_printf("Done compressing (height %d)\n", cinfo.image_height);
     while (cinfo.next_scanline < cinfo.image_height) {
         dbg_printf("Writing row %d...\n", cinfo.next_scanline);

--- a/src/carriers/mjpeg_carrier/MjpegCarrier.h
+++ b/src/carriers/mjpeg_carrier/MjpegCarrier.h
@@ -45,6 +45,7 @@ class yarp::os::MjpegCarrier : public Carrier {
 private:
     bool firstRound;
     bool sender;
+    yarp::os::ConstString envelope;
 public:
     MjpegCarrier() {
         firstRound = true;
@@ -77,6 +78,10 @@ public:
 
     virtual bool canEscape() {
         return false;
+    }
+
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) {
+        this->envelope = envelope;
     }
 
     virtual bool requireAck() {

--- a/src/carriers/mjpeg_carrier/MjpegDecompression.h
+++ b/src/carriers/mjpeg_carrier/MjpegDecompression.h
@@ -11,6 +11,7 @@
 #define YARP2_MJPEGDECOMPRESSION_INC
 
 #include <yarp/os/ManagedBytes.h>
+#include <yarp/os/InputStream.h>
 #include <yarp/sig/Image.h>
 
 namespace yarp {
@@ -27,10 +28,13 @@ public:
 
     virtual ~MjpegDecompression();
 
-    bool decompress(const yarp::os::Bytes& data, 
+    bool decompress(const yarp::os::Bytes& data,
                     yarp::sig::ImageOf<yarp::sig::PixelRgb>& image);
 
     bool isAutomatic() const;
+
+    bool setReadEnvelopeCallback(yarp::os::InputStream::readEnvelopeCallbackType callback,
+                                 void* data);
 };
 
 #endif

--- a/src/carriers/mjpeg_carrier/MjpegStream.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegStream.cpp
@@ -80,13 +80,11 @@ YARP_SSIZE_T MjpegStream::read(const Bytes& b) {
         if (autocompress) {
             cimg.allocate(len);
             delegate->getInputStream().readFull(cimg.bytes());
-
-            if (!decompression.decompress(cimg.bytes(),img)) {
+            if (!decompression.decompress(cimg.bytes(), img)) {
                 if (delegate->getInputStream().isOk()) {
                     yError("Skipping a problematic JPEG frame");
                 }
             }
-
             imgHeader.setFromImage(img);
             phase = 1;
             cursor = (char*)(&imgHeader);

--- a/src/carriers/mjpeg_carrier/MjpegStream.h
+++ b/src/carriers/mjpeg_carrier/MjpegStream.h
@@ -48,15 +48,20 @@ private:
     bool sender;
     bool firstRound;
     bool autocompress;
+    yarp::os::Bytes envelope;
+    readEnvelopeCallbackType readEnvelopeCallback;
+    void* readEnvelopeCallbackData;
 public:
-    MjpegStream(TwoWayStream *delegate, bool sender,
-                bool autocompress) : sender(sender),
-                                     autocompress(autocompress) {
-        this->delegate = delegate;
-        firstRound = true;
-        phase = 0;
-        cursor = NULL;
-        remaining = 0;
+    MjpegStream(TwoWayStream *delegate, bool sender, bool autocompress) :
+            delegate(delegate),
+            phase(0),
+            cursor(NULL),
+            remaining(0),
+            sender(sender),
+            firstRound(true),
+            autocompress(autocompress),
+            readEnvelopeCallback(NULL),
+            readEnvelopeCallbackData(NULL) {
     }
 
     virtual ~MjpegStream() {
@@ -106,6 +111,12 @@ public:
         delegate->getInputStream().interrupt();
     }
 
+    virtual bool setReadEnvelopeCallback(InputStream::readEnvelopeCallbackType callback, void* data) {
+        if (!autocompress) {
+            return false;
+        }
+        return decompression.setReadEnvelopeCallback(callback, data);
+    }
 };
 
 #endif

--- a/src/libYARP_OS/include/yarp/os/Carrier.h
+++ b/src/libYARP_OS/include/yarp/os/Carrier.h
@@ -149,6 +149,20 @@ public:
     virtual bool canEscape() = 0;
 
     /**
+     * Carriers that do not distinguish data from administrative headers
+     * (i.e. canEscape returns false), can overload this method to
+     * handle the envelope inside the stream.
+     * On the receiving side, the InputStream will have to overload the
+     * yarp::os::InputStream::setReadEnvelopeCallback method, and
+     * execute the callback as soon as the envelope is ready.
+     *
+     * @param envelope the envelope to transmit bundled with data.
+     */
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) {
+        YARP_UNUSED(envelope);
+    }
+
+    /**
      * Check if carrier has flow control, requiring sent messages
      * to be acknowledged by recipient.
      *

--- a/src/libYARP_OS/include/yarp/os/Connection.h
+++ b/src/libYARP_OS/include/yarp/os/Connection.h
@@ -59,6 +59,19 @@ public:
     virtual bool isBareMode() { return false; }
 
     /**
+     * Carriers that do not distinguish data from administrative headers
+     * (i.e. canEscape returns false), can overload this method to
+     * handle the envelope inside the stream.
+     * On the receiving side, the InputStream will have to overload the
+     * yarp::os::InputStream::setReadEnvelopeCallback method, and
+     * execute the callback as soon as the envelope is ready.
+     *
+     * @param envelope the envelope to transmit bundled with data.
+     */
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) = 0;
+
+
+    /**
      * Check if carrier can encode administrative messages, as opposed
      * to just user data.  The word escape is used in the sense of
      * escape character or escape sequence here.
@@ -258,6 +271,7 @@ public:
     virtual bool isValid() { return false; }
     virtual bool isTextMode() { return true; }
     virtual bool canEscape() { return true; }
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) { }
     virtual bool requireAck() { return false; }
     virtual bool supportReply() { return false; }
     virtual bool isLocal() { return false; }

--- a/src/libYARP_OS/include/yarp/os/InputStream.h
+++ b/src/libYARP_OS/include/yarp/os/InputStream.h
@@ -158,6 +158,27 @@ public:
      *
      */
     YARP_SSIZE_T readDiscard(size_t len);
+
+    /**
+     *
+     * Callback type for setting the envelope from a message in carriers that
+     * cannot be escaped.
+     *
+     */
+    typedef void (*readEnvelopeCallbackType)(void*, const yarp::os::Bytes& envelope);
+
+    /**
+     *
+     * Install a callback that the InputStream will have to call when the
+     * envelope is read from a message in carriers that cannot be escaped.
+     *
+     * @param callback the callback to execute
+     * @param data a pointer that should be passed as first parameter to the
+     *        \c callback function
+     * @return true iff the \c callback was installed.
+     *
+     */
+    virtual bool setReadEnvelopeCallback(readEnvelopeCallbackType callback, void* data) { return false; }
 };
 
 #endif

--- a/src/libYARP_OS/include/yarp/os/impl/PortCoreInputUnit.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCoreInputUnit.h
@@ -130,6 +130,8 @@ private:
     void closeMain();
 
     bool skipIncomingData(yarp::os::ConnectionReader& reader);
+
+    static void envelopeReadCallback(void* data, const Bytes& envelope);
 };
 
 #endif

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -1017,6 +1017,10 @@ public:
         return getContent().canEscape();
     }
 
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) {
+        getContent().handleEnvelope(envelope);
+    }
+
     virtual bool requireAck() {
         return getContent().requireAck();
     }

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1425,7 +1425,7 @@ bool PortCore::setEnvelope(PortWriter& envelope) {
 
 void PortCore::setEnvelope(const String& envelope) {
     this->envelope = envelope;
-    for (unsigned int i=0; i<envelope.length(); i++) {
+    for (unsigned int i=0; i<this->envelope.length(); i++) {
         // It looks like envelopes are constrained to be printable ASCII?
         // I'm not sure why this would be.  TODO check.
         if (this->envelope[i]<32) {

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -163,6 +163,11 @@ void PortCoreInputUnit::run() {
 
     void *id = (void *)this;
 
+    if (ip!=NULL && !ip->getConnection().canEscape()) {
+        InputStream *is = &ip->getInputStream();
+        is->setReadEnvelopeCallback(envelopeReadCallback, this);
+    }
+
     while (!done) {
         ConnectionReader& br = ip->beginRead();
 
@@ -486,3 +491,13 @@ bool PortCoreInputUnit::isBusy() {
     return busy;
 }
 
+
+void PortCoreInputUnit::envelopeReadCallback(void* data, const Bytes& envelope)
+{
+    PortCoreInputUnit *p = reinterpret_cast<PortCoreInputUnit*>(data);
+    if (!p) {
+        return;
+    }
+    p->getOwner().setEnvelope(envelope.get());
+    p->ip->setEnvelope(envelope.get());
+}

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -266,41 +266,47 @@ bool PortCoreOutputUnit::sendHelper() {
 
             bool suppressReply = (buf.getReplyHandler()==NULL);
 
-            if (op->getConnection().canEscape()&&!done) {
-                buf.addToHeader();
-
-                if (cachedEnvelope!="") {
-                    // this will be the new way to signal that replies
-                    // are not expected
-                    //PortCommand pc('\0', String(suppressReply?"D ":"d ") +
-                    //             cachedEnvelope);
-                    //pc.writeBlock(buf);
-
-                    // This is the backwards-compatible method.
-                    // To be used until YARP 2.1.2 is a "long time ago".
-                    if (cachedEnvelope=="__ADMIN") {
-                        PortCommand pc('a', "");
-                        pc.write(buf);
-                    } else {
-                        PortCommand pc('\0', String(suppressReply?"do ":"d ") +
-                                       cachedEnvelope);
-                        pc.write(buf);
+            if (!done) {
+                if (!op->getConnection().canEscape()) {
+                    if (cachedEnvelope!="") {
+                        op->getConnection().handleEnvelope(cachedEnvelope);
                     }
-
                 } else {
-                    // this will be the new way to signal that replies
-                    // are not expected
-                    //PortCommand pc(suppressReply?'D':'d',"");
-                    //pc.writeBlock(buf);
+                    buf.addToHeader();
 
-                    // This is the backwards-compatible method.
-                    // To be used until YARP 2.1.2 is a "long time ago".
-                    if (suppressReply) {
-                        PortCommand pc('\0', "do");
-                        pc.write(buf);
+                    if (cachedEnvelope!="") {
+                        // this will be the new way to signal that replies
+                        // are not expected
+                        //PortCommand pc('\0', String(suppressReply?"D ":"d ") +
+                        //             cachedEnvelope);
+                        //pc.writeBlock(buf);
+
+                        // This is the backwards-compatible method.
+                        // To be used until YARP 2.1.2 is a "long time ago".
+                        if (cachedEnvelope=="__ADMIN") {
+                            PortCommand pc('a', "");
+                            pc.write(buf);
+                        } else {
+                            PortCommand pc('\0', String(suppressReply?"do ":"d ") +
+                                        cachedEnvelope);
+                            pc.write(buf);
+                        }
+
                     } else {
-                        PortCommand pc('d', "");
-                        pc.write(buf);
+                        // this will be the new way to signal that replies
+                        // are not expected
+                        //PortCommand pc(suppressReply?'D':'d',"");
+                        //pc.writeBlock(buf);
+
+                        // This is the backwards-compatible method.
+                        // To be used until YARP 2.1.2 is a "long time ago".
+                        if (suppressReply) {
+                            PortCommand pc('\0', "do");
+                            pc.write(buf);
+                        } else {
+                            PortCommand pc('d', "");
+                            pc.write(buf);
+                        }
                     }
                 }
             }
@@ -314,7 +320,7 @@ bool PortCoreOutputUnit::sendHelper() {
                 done = true;
             }
         }
-        
+
         if (buf.dropRequested()) {
             done = true;
         }


### PR DESCRIPTION
Allow envelope to be carried inside the stream instead of by administrative messages, and use the new methods to allow mjpeg to carry the envelope inside its stream.

The carrier will have to overload the ``yarp::os::Carrier::handleEnvelope`` method (that by default does nothing). This method will be called by the ``PortCoreOutputUnit`` for non-escapable ``Carriers`` (like the mjpeg carrier) instead of sending the administrative command containing the envelope.

On the receiving side, the ``PortCoreInputUnit`` will install a callback using the ``yarp::os::InputStream::setReadEnvelopeCallback`` method (that should be overloaded by non-escapable carriers that want to handle the envelope). The input stream must then execute the callback as soon as the envelope is ready. This is necessary, unless we want break compatibility, because a delegate could be used to read objects from the network (basically we should modify any class derived by [``PortReader``](http://wiki.icub.org/yarpdoc/classyarp_1_1os_1_1PortReader.html)), and when the control comes back to the ``PortCoreInputUnit`` (i.e. after the ``readBlock()`` call) it is too late to set the envelope. For example, when the ``readBlock()`` returns, ``yarp read ... envelope`` will already have displayed a message without the envelope (for the first message) or using the envelope from the previous messages.



The COM special marker is used during jpeg compression for this purpose. See also [libjpeg documentation](http://svn.code.sf.net/p/libjpeg-turbo/code/trunk/libjpeg.txt). On the receiving side, there is no check on the message received. This is intentional and it means that if some web camera sends some comment using the COM marker, the receiver will interpret it as the envelope. If people starts complaining about this, perhaps we could choose one of the APP0 through APP15 marker instead, or perhaps using some sort of protocol inside the envelope to ensure that we are receiving an envelope and not some random comment. Anyway for now this shouldn't be a big issue.
