### PR TITLE
restore previous behavior consoles are now created hidden. added dumm…

### DIFF
--- a/src/libYARP_manager/src/localbroker.cpp
+++ b/src/libYARP_manager/src/localbroker.cpp
@@ -145,7 +145,7 @@ LocalBroker::LocalBroker()
     bOnlyConnector = bInitialized = false;
     ID = 0;
     fd_stdout = NULL;
-    setWindowMode(WINDOW_VISIBLE);
+    setWindowMode(WINDOW_HIDDEN);
 }
 
 
@@ -299,7 +299,7 @@ bool LocalBroker::kill()
     strError.clear();
 
 #if defined(WIN32)
-    stopCmd(ID);
+    killCmd(ID);
     stopStdout();
 #else
     stopStdout();
@@ -594,26 +594,28 @@ int LocalBroker::ExecuteCmd(void)
 
     string strDisplay=getDisplay();
 
-    //this is common to all processes
-    cmd_startup_info.dwFlags |= STARTF_USESHOWWINDOW;
-    cmd_startup_info.wShowWindow = SW_SHOWNA;
-    windowMode=WINDOW_VISIBLE;
+    DWORD dwCreationFlags;
 
+    //these come from xml
+    /* 
+    // These are not supported until we find a way to send break signals to 
+    // consoles that are not inherited
     if (strDisplay=="--visible_na")
-    {
         windowMode=WINDOW_VISIBLE;
-        cmd_startup_info.wShowWindow = SW_SHOWNA;
-    }
-    if (strDisplay=="--minimized")
-    {
-        windowMode=WINDOW_MINIMIZED;
-        cmd_startup_info.wShowWindow = SW_MINIMIZE;
-    }
     if (strDisplay=="--hidden")
-    {
         windowMode=WINDOW_HIDDEN;
-        cmd_startup_info.wShowWindow = SW_HIDE;
+    */
 
+    // this is for "attach to stoud only"
+    if (windowMode==WINDOW_VISIBLE)
+    { 
+        //this is common to all processes
+        cmd_startup_info.dwFlags |= STARTF_USESHOWWINDOW;
+        cmd_startup_info.wShowWindow = SW_SHOWNA;
+        dwCreationFlags=CREATE_NEW_CONSOLE;
+    }
+    if (windowMode==WINDOW_HIDDEN)
+    {
         // Setting up child process and pipe for stdout (useful for attaching stdout)
         SECURITY_ATTRIBUTES pipe_sec_attr;
         pipe_sec_attr.nLength = sizeof(SECURITY_ATTRIBUTES);
@@ -627,7 +629,11 @@ int LocalBroker::ExecuteCmd(void)
         cmd_startup_info.hStdOutput = write_to_pipe_cmd_to_stdout;
 
         cmd_startup_info.dwFlags |= STARTF_USESTDHANDLES;
+
+        dwCreationFlags=CREATE_NEW_PROCESS_GROUP; //CREATE_NEW_CONSOLE|CREATE_NEW_PROCESS_GROUP,
     }
+  
+
 
     /*
      * setting environment variable for child process
@@ -666,12 +672,12 @@ int LocalBroker::ExecuteCmd(void)
                                 NULL,          // process security attributes
                                 NULL,          // primary thread security attributes
                                 TRUE,          // handles are inherited
-                                CREATE_NEW_PROCESS_GROUP | CREATE_NEW_CONSOLE,
+                                dwCreationFlags,
                                 (LPVOID) chNewEnv, // use new environment
                                 bWorkdir?strWorkdirOk.c_str():NULL, // working directory
                                 &cmd_startup_info,   // STARTUPINFO pointer
                                 &cmd_process_info);  // receives PROCESS_INFORMATION
-
+       
     if (!bSuccess && bWorkdir)
     {
             bSuccess=CreateProcess(NULL,    // command name
@@ -679,7 +685,7 @@ int LocalBroker::ExecuteCmd(void)
                                     NULL,          // process security attributes
                                     NULL,          // primary thread security attributes
                                     TRUE,          // handles are inherited
-                                    CREATE_NEW_PROCESS_GROUP | CREATE_NEW_CONSOLE,
+                                    dwCreationFlags,
                                     (LPVOID) chNewEnv, // use new environment
                                     strWorkdirOk.c_str(), // working directory
                                     &cmd_startup_info,   // STARTUPINFO pointer
@@ -732,11 +738,13 @@ bool LocalBroker::stopCmd(int pid)
 
     LocalTerminateParams params(pid);
     EnumWindows((WNDENUMPROC)LocalTerminateAppEnum,(LPARAM)&params);
-    //if (!params.nWin)
-   // {
-    GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid);
-    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
-   // }
+    
+    // I believe we do not need this. It is ignored by console applications created with CREATE_NEW_PROCESS_GROUP 
+    GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid); 
+
+    //send BREAK_EVENT becaue we created the process with CREATE_NEW_PROCESS_GROUP
+    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid); 
+    
     CloseHandle(hProc);
     return true;
 }

--- a/src/yarpmanager-qt/applicationviewwidget.cpp
+++ b/src/yarpmanager-qt/applicationviewwidget.cpp
@@ -948,10 +948,23 @@ void ApplicationViewWidget::onYARPView()
 /*! \brief Launch YARPHear Inspection modality*/
 void ApplicationViewWidget::onYARPHear()
 {
+
+
     if(manager.busy()){
         return;
     }
     yarp::manager::ErrorLogger* logger  = yarp::manager::ErrorLogger::Instance();
+
+    #if defined(WIN32)
+        {
+            QString  msg;
+            msg = QString("Error inspecting hear temporarely not supported in windows");
+            logger->addError(msg.toLatin1().data());
+            reportErrors();
+        }
+     return;
+    #endif
+
 
     for(int i=0;i<ui->connectionList->topLevelItemCount();i++){
         QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);
@@ -1021,6 +1034,16 @@ void ApplicationViewWidget::onYARPRead()
         return;
     }
     yarp::manager::ErrorLogger* logger  = yarp::manager::ErrorLogger::Instance();
+
+    #if defined(WIN32)
+        {
+            QString  msg;
+            msg = QString("Error inspecting hear temporarely not supported in windows");
+            logger->addError(msg.toLatin1().data());
+            reportErrors();
+        }
+     return;
+    #endif
 
     for(int i=0;i<ui->connectionList->topLevelItemCount();i++){
         QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);

--- a/src/yarpmanager-qt/main.cpp
+++ b/src/yarpmanager-qt/main.cpp
@@ -44,6 +44,14 @@ void onSignal(int signum);
 
 int main(int argc, char *argv[])
 {
+    // We create a console. This is inherited by console processes created by the localhost broker
+    // This console is not actually needed so we hide it. In principle we could redirect the output
+    // of all processes to this console, in practice this would be end up soon in a big mess.
+   AllocConsole();
+   HWND hwnd = GetConsoleWindow();
+   HWND hide = FindWindowA("ConsoleWindowClass",NULL);
+   ShowWindow(hide, 0);
+    
     QApplication a(argc, argv);
 
     // Setup resource finder

--- a/src/yarpmanager-qt/main.cpp
+++ b/src/yarpmanager-qt/main.cpp
@@ -44,6 +44,8 @@ void onSignal(int signum);
 
 int main(int argc, char *argv[])
 {
+
+#if defined(WIN32)
     // We create a console. This is inherited by console processes created by the localhost broker
     // This console is not actually needed so we hide it. In principle we could redirect the output
     // of all processes to this console, in practice this would be end up soon in a big mess.
@@ -51,7 +53,7 @@ int main(int argc, char *argv[])
    HWND hwnd = GetConsoleWindow();
    HWND hide = FindWindowA("ConsoleWindowClass",NULL);
    ShowWindow(hide, 0);
-    
+#endif
     QApplication a(argc, argv);
 
     // Setup resource finder


### PR DESCRIPTION
…y console to the manager so that new processes can inherit console and receive break signals and perform smooth shutdown. still problems with inspect but hese are less critical and easier to fix (#542)