### PR TITLE
Console with localbroker

### DIFF
--- a/src/yarpmanager-qt/applicationviewwidget.cpp
+++ b/src/yarpmanager-qt/applicationviewwidget.cpp
@@ -948,24 +948,11 @@ void ApplicationViewWidget::onYARPView()
 /*! \brief Launch YARPHear Inspection modality*/
 void ApplicationViewWidget::onYARPHear()
 {
-
-
     if(manager.busy()){
         return;
     }
     yarp::manager::ErrorLogger* logger  = yarp::manager::ErrorLogger::Instance();
-
-    #if defined(WIN32)
-        {
-            QString  msg;
-            msg = QString("Error inspecting hear temporarely not supported in windows");
-            logger->addError(msg.toLatin1().data());
-            reportErrors();
-        }
-     return;
-    #endif
-
-
+    
     for(int i=0;i<ui->connectionList->topLevelItemCount();i++){
         QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);
         if(it->isSelected()){
@@ -1034,16 +1021,6 @@ void ApplicationViewWidget::onYARPRead()
         return;
     }
     yarp::manager::ErrorLogger* logger  = yarp::manager::ErrorLogger::Instance();
-
-    #if defined(WIN32)
-        {
-            QString  msg;
-            msg = QString("Error inspecting hear temporarely not supported in windows");
-            logger->addError(msg.toLatin1().data());
-            reportErrors();
-        }
-     return;
-    #endif
 
     for(int i=0;i<ui->connectionList->topLevelItemCount();i++){
         QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);

--- a/src/yarpmanager-qt/main.cpp
+++ b/src/yarpmanager-qt/main.cpp
@@ -46,9 +46,11 @@ int main(int argc, char *argv[])
 {
 
 #if defined(WIN32)
-    // We create a console. This is inherited by console processes created by the localhost broker
-    // This console is not actually needed so we hide it. In principle we could redirect the output
-    // of all processes to this console, in practice this would be end up soon in a big mess.
+    // We create a console. This is inherited by console processes created by the localhost broker. 
+    // It is useful because new processes can receive ctrl+brk signals and shutdown cleanly.
+    // This console is not actually needed for printing so we hide it.  In principle we could 
+    // redirect the output of all processes to this console, in practice this would be end up 
+    // soon in a big mess.
    AllocConsole();
    HWND hwnd = GetConsoleWindow();
    HWND hide = FindWindowA("ConsoleWindowClass",NULL);


### PR DESCRIPTION
This PR re-enables inspection of connections. Created consoles are detached from the manager and are not closed when the manager closes. however this is the same behavior that we had previously and in linux so let's keep it and improve later. #542 