### PR TITLE
implementing Property.fromCommand() for command line arguments given as a string

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -188,16 +188,16 @@ public:
     /**
      * Interprets a list of command arguments as a list of properties.
      * Keys are named by beginning with "--".  For example, with
-     * command = "program_name --width 10 --height 15", the Property object
+     * arguments = "--width 10 --height 15", the Property object
      * will be the mapping {width => 10, height => 15}.  So:
      * \code
      *   prop.find("width").asInt() // gives 10
      *   prop.find("height").asInt() // gives 15
      * \endcode
-     * @param command the argument
+     * @param arguments the command arguments
      * @param wipe should Property be emptied first
      */
-    void fromCommand(const char *command, bool wipe=true);
+    void fromArguments(const char *arguments, bool wipe=true);
 
     /**
      * Interprets a file as a list of properties.

--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -186,6 +186,20 @@ public:
                      bool wipe=true);
 
     /**
+     * Interprets a list of command arguments as a list of properties.
+     * Keys are named by beginning with "--".  For example, with
+     * command = "program_name --width 10 --height 15", the Property object
+     * will be the mapping {width => 10, height => 15}.  So:
+     * \code
+     *   prop.find("width").asInt() // gives 10
+     *   prop.find("height").asInt() // gives 15
+     * \endcode
+     * @param command the argument
+     * @param wipe should Property be emptied first
+     */
+    void fromCommand(const char *command, bool wipe=true);
+
+    /**
      * Interprets a file as a list of properties.
      * For example, for a file containing:
      * \code

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -791,6 +791,87 @@ public:
         }
         return output.c_str();
     }
+
+    void fromCommand(const char *command, bool wipe=true) {
+        char** szarg = new char*[128 + 1];  // maximum 128 arguments
+        char* szcmd = new char[strlen(command)+1];
+        strcpy(szcmd, command);
+        szarg = new char*[128 + 1];
+        int nargs = 0;
+        parseArguments(szcmd, &nargs, szarg, 128);
+        szarg[nargs]=0;
+        fromCommand(nargs, szarg, wipe);
+        // clear allocated memory for arguments
+        if(szcmd) {
+            delete [] szcmd;
+            szcmd = NULL;
+        }
+        if(szarg) {
+            delete [] szarg;
+            szarg = NULL;
+        }
+    }
+
+    void parseArguments(char *azParam, int *argc, char **argv, int max_arg) {
+        char *pNext = azParam;
+        size_t i;
+        int j;
+        int quoted = 0;
+        size_t len = strlen(azParam);
+
+        // Protect spaces inside quotes, but lose the quotes
+        for(i = 0; i < len; i++) {
+            if ((!quoted) && ('"' == azParam [i])) {
+                quoted = 1;
+                azParam [i] = ' ';
+            } else if ((quoted) && ('"' == azParam [i])) {
+                quoted = 0;
+                azParam [i] = ' ';
+            } else if ((quoted) && (' ' == azParam [i])) {
+                azParam [i] = '\1';
+            }
+        }
+
+        // init
+        memset(argv, 0x00, sizeof(char*) * max_arg);
+        *argc = 1;
+        argv[0] = azParam ;
+
+        while ((NULL != pNext) && (*argc < max_arg)) {
+            splitArguments(pNext, &(argv[*argc]));
+            pNext = argv[*argc];
+
+            if (NULL != argv[*argc]) {
+                *argc += 1;
+            }
+        }
+
+        for(j = 0; j < *argc; j++) {
+            len = strlen(argv[j]);
+            for(i = 0; i < len; i++) {
+                if('\1' == argv[j][i]) {
+                    argv[j][i] = ' ';
+                }
+            }
+        }
+    }
+
+    void splitArguments(char *line, char **args) {
+        char *pTmp = strchr(line, ' ');
+        if (pTmp) {
+           *pTmp = '\0';
+           pTmp++;
+           while ((*pTmp) && (*pTmp == ' ')) {
+               pTmp++;
+           }
+           if (*pTmp == '\0') {
+               pTmp = NULL;
+           }
+        }
+        *args = pTmp;
+    }
+
+
 };
 
 
@@ -921,6 +1002,10 @@ void Property::fromCommand(int argc, char *argv[], bool skipFirst,
 void Property::fromCommand(int argc, const char *argv[], bool skipFirst, bool wipe) {
     summon();
     fromCommand(argc,(char **)argv,skipFirst,wipe);
+}
+
+void Property::fromCommand(const char *command, bool wipe) {
+    HELPER(implementation).fromCommand(command, wipe);
 }
 
 bool Property::fromConfigDir(const ConstString& dirname, const ConstString& section, bool wipe) {

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -1005,6 +1005,7 @@ void Property::fromCommand(int argc, const char *argv[], bool skipFirst, bool wi
 }
 
 void Property::fromCommand(const char *command, bool wipe) {
+    summon();
     HELPER(implementation).fromCommand(command, wipe);
 }
 

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -792,7 +792,7 @@ public:
         return output.c_str();
     }
 
-    void fromCommand(const char *command, bool wipe=true) {
+    void fromArguments(const char *command, bool wipe=true) {
         char** szarg = new char*[128 + 1];  // maximum 128 arguments
         char* szcmd = new char[strlen(command)+1];
         strcpy(szcmd, command);
@@ -1004,9 +1004,9 @@ void Property::fromCommand(int argc, const char *argv[], bool skipFirst, bool wi
     fromCommand(argc,(char **)argv,skipFirst,wipe);
 }
 
-void Property::fromCommand(const char *command, bool wipe) {
+void Property::fromArguments(const char *arguments, bool wipe) {
     summon();
-    HELPER(implementation).fromCommand(command, wipe);
+    HELPER(implementation).fromArguments(arguments, wipe);
 }
 
 bool Property::fromConfigDir(const ConstString& dirname, const ConstString& section, bool wipe) {


### PR DESCRIPTION
This modification adds Property.fromCommand(char* param, bool wipe) method to the Property class to parse the command line arguments given as a string.  For example:

```c++
yarp::os::Property prop;
prop.fromCommand("--verbose --show --from test.config");
cout<<"prop.toString()"<<endl;
...
```
Result: 
```
(show) (from test.config) (verbose)
```

