### PR TITLE
implements Networkbase::setConnectionQos() API

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -378,6 +378,7 @@ namespace yarp {
 %include <yarp/os/RpcClient.h>
 %include <yarp/os/DummyConnector.h>
 %include <yarp/os/Things.h>
+%include <yarp/os/QosStyle.h>
 
 %define MAKE_COMMS(name)
 %feature("notabstract") yarp::os::BufferedPort<name>;

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -117,7 +117,8 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/YarpPluginSelector.h
                  include/yarp/os/YarpPluginSettings.h
                  include/yarp/os/SystemInfo.h
-                 include/yarp/os/SystemInfoSerializer.h)
+                 include/yarp/os/SystemInfoSerializer.h
+                 include/yarp/os/QosStyle.h)
 
 if(NOT YARP_NO_DEPRECATED)
   list(APPEND YARP_OS_HDRS include/yarp/os/begin_pack_for_net.h
@@ -341,7 +342,8 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/WireWriter.cpp
                  src/ydr.cpp
                  src/hmac_sha2.c
-                 src/sha2.c)
+                 src/sha2.c
+                 src/QosStyle.cpp)
 
 
 if (NOT SKIP_ACE)

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -16,6 +16,7 @@
 #include <yarp/os/Value.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/NameStore.h>
+#include <yarp/os/QosStyle.h>
 
 //protects against some dangerous ACE macros
 #ifdef main
@@ -27,6 +28,7 @@ namespace yarp {
         class NetworkBase;
         class Network;
         class ContactStyle;
+        class QosStyle;
     }
 }
 
@@ -560,6 +562,19 @@ public:
      *
      */
     static int getDefaultPortRange();
+
+    /**
+     * Adjust the Qos preferences of a connection.
+     * @param src the name of an output port
+     * @param dest the name of an input port
+     * @param srcStyle the Qos preference of the output port
+     * @param destStyle the Qos preference of the input port
+     * @return true if the Qos preferences is set correctly
+     */
+    static bool setConnectionQos(const ConstString& src, const ConstString& dest,
+                                 const QosStyle& srcStyle, const QosStyle destStyle,
+                                 bool quite=true);
+
 };
 
 /**

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -573,7 +573,17 @@ public:
      */
     static bool setConnectionQos(const ConstString& src, const ConstString& dest,
                                  const QosStyle& srcStyle, const QosStyle destStyle,
-                                 bool quite=true);
+                                 bool quiet=true);
+
+    /**
+     * Adjust the Qos preferences of a connection.
+     * @param src the name of an output port
+     * @param dest the name of an input port
+     * @param style the Qos preference of both input and output ports
+     * @return true if the Qos preferences is set correctly
+     */
+    static bool setConnectionQos(const ConstString& src, const ConstString& dest,
+                                 const QosStyle& style, bool quiet=true);
 
 };
 

--- a/src/libYARP_OS/include/yarp/os/QosStyle.h
+++ b/src/libYARP_OS/include/yarp/os/QosStyle.h
@@ -1,0 +1,74 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _YARP2_QOSSTYLE_
+#define _YARP2_QOSSTYLE_
+
+#include <yarp/os/Vocab.h>
+
+namespace yarp {
+    namespace os {
+        class QosStyle;
+    }
+}
+
+/**
+ * \ingroup comm_class
+ *
+ * Preferences for the port's Quality of Service.
+ * All fields have sensible defaults.
+ *
+ */
+class YARP_OS_API yarp::os::QosStyle {
+public:
+
+    /**
+     * The PacketPriorityType defines the packets
+     * quality of service (priority) levels
+     */
+    enum PacketPriorityType {
+        LOW = VOCAB3('L','O','W'),
+        NORM = VOCAB4('N','O','R', 'M'),
+        HIGH = VOCAB4('H','I','G','H'),
+        CRIT = VOCAB4('C','R','I','T')
+    };
+
+    /**
+     * @brief threadPriority controls the priority of the yarp port's
+     * thread (if available) which handles the data transmission.
+     * Notice that not every yarp port has dedicated
+     * thread for communication (e.g., BufferedPorts have dedicated thread)
+     */
+    int threadPriority;
+
+    /**
+     * @brief threadPolicy controls the scheduling policy of the yarp
+     * port's thread (if available) which handles the data transmission.
+     * Notice that not every yarp port has dedicated
+     * thread for communication (e.g., BufferedPorts have dedicated thread)
+     */
+    int threadPolicy;
+
+
+    /**
+     * @brief packetPriority controls the communication packets priority levels
+     * by adjusting the IPV4/6 DSCP value.
+     */
+    PacketPriorityType packetPriority;
+
+
+    /**
+     *
+     * Constructor.  Sets all options to reasonable defaults.
+     *
+     */
+    explicit QosStyle();
+};
+
+#endif

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -721,8 +721,13 @@ ConstString NetworkBase::readString(bool *eof) {
 }
 
 bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& dest,
+                                   const QosStyle& style, bool quiet) {
+    return setConnectionQos(src, dest, style, style, quiet);
+}
+
+bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& dest,
                                    const QosStyle& srcStyle, const QosStyle destStyle,
-                                   bool quite) {
+                                   bool quiet) {
 
     //e.g.,  prop set /portname (sched ((priority 30) (policy 1))) (qos ((priority HIGH)))
     yarp::os::Bottle cmd, reply;
@@ -743,12 +748,12 @@ bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& de
     Contact srcCon = Contact::fromString(src);
     bool ret = write(srcCon, cmd, reply, true, true, 2.0);
     if(!ret) {
-        if(!quite)
+        if(!quiet)
              ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",src.c_str());
         return false;
     }
     if(reply.get(0).asString() != "ok") {
-        if(!quite)
+        if(!quiet)
              ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
                              src.c_str(), reply.toString().c_str());
         return false;
@@ -772,12 +777,12 @@ bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& de
     Contact destCon = Contact::fromString(dest);
     ret = write(destCon, cmd, reply, true, true, 2.0);
     if(!ret) {
-        if(!quite)
+        if(!quiet)
              ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",dest.c_str());
         return false;
     }
     if(reply.get(0).asString() != "ok") {
-        if(!quite)
+        if(!quiet)
              ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
                              dest.c_str(), reply.toString().c_str());
         return false;

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1996,7 +1996,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                             Bottle* sched_prop = sched.find("sched").asList();
                                             if(sched_prop != NULL) {
                                                 int prio = -1;
-                                                int policy = -1;                                                
+                                                int policy = -1;
                                                 if(sched_prop->check("priority"))
                                                     prio = sched_prop->find("priority").asInt();
                                                 if(sched_prop->check("policy"))

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1974,8 +1974,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                     Property *p = acquireProperties(false);
                     bool bOk = true;
                     if (p) {
-                        p->put(cmd.get(2).asString(), cmd.get(3));
-                        Bottle* value = cmd.get(3).asList();
+                        p->put(cmd.get(2).asString(), cmd.get(3));                        
 
                         // check if we need to set the PortCoreUnit scheduling policy
                         // e.g., "prop set /portname (sched ((priority 30) (policy 1)))"
@@ -1983,7 +1982,8 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                         // SCHED_OTHER : policy=0, priority=[0 ..  0]
                         // SCHED_FIFO  : policy=1, priority=[1 .. 99]
                         // SCHED_RR    : policy=2, priority=[1 .. 99]
-                        if(value && value->check("sched"))
+                        Bottle& sched = cmd.findGroup("sched");
+                        if(!sched.isNull())
                         {
                             if((cmd.get(2).asString().size() > 0) && (cmd.get(2).asString()[0] == '/')) {
                                 bOk = false;
@@ -1993,10 +1993,10 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                         Route route = unit->getRoute();
                                         ConstString portName = (unit->isOutput()) ? route.getToName() : route.getFromName();
                                         if (portName == cmd.get(2).asString()) {
-                                            Bottle* sched_prop = value->find("sched").asList();
+                                            Bottle* sched_prop = sched.find("sched").asList();
                                             if(sched_prop != NULL) {
                                                 int prio = -1;
-                                                int policy = -1;
+                                                int policy = -1;                                                
                                                 if(sched_prop->check("priority"))
                                                     prio = sched_prop->find("priority").asInt();
                                                 if(sched_prop->check("policy"))
@@ -2016,7 +2016,8 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                         // e.g., "prop set /portname (qos ((priority HIGH)))"
                         // e.g., "prop set /portname (qos ((dscp AF12)))"
                         // e.g., "prop set /portname (qos ((tos 12)))"
-                        if(value && value->check("qos"))
+                        Bottle& qos = cmd.findGroup("qos");
+                        if(!qos.isNull())
                         {
                             if((cmd.get(2).asString().size() > 0) && (cmd.get(2).asString()[0] == '/')) {
                                 bOk = false;
@@ -2026,7 +2027,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                         Route route = unit->getRoute();
                                         ConstString portName = route.getToName();
                                         if (portName == cmd.get(2).asString()) {
-                                            Bottle* qos_prop = value->find("qos").asList();
+                                            Bottle* qos_prop = qos.find("qos").asList();
                                             if(qos_prop != NULL) {
                                                 if(qos_prop->check("priority")) {
                                                     NetInt32 priority = qos_prop->find("priority").asVocab();

--- a/src/libYARP_OS/src/QosStyle.cpp
+++ b/src/libYARP_OS/src/QosStyle.cpp
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2006 RobotCub Consortium
+ * Authors: Paul Fitzpatrick
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <yarp/os/QosStyle.h>
+
+
+yarp::os::QosStyle::QosStyle() :
+        threadPriority(0),
+        threadPolicy(-1),
+        packetPriority(yarp::os::QosStyle::NORM){
+}


### PR DESCRIPTION
This pull-request implements a new API `Networkbase::setConnectionQos()` to adjust the QoS preferences of a connection. The QoS preferences are applied to the both side of a connection. That adjusts the communication's thread real-time properties (the thread which handles asynchronous read/write within a port object) and the IPV4/6 packets DSCP value. These features had already been implemented in YARP but now have been made available using the  `setConnectionQos()` API.  

Here is an example: 

```c++
yarp::os::QosStyle qos;
qos.threadPriority = 10;
qos.threadPolicy = 1;  // SCHED_FIFO on Unix
qos.packetPriority = yarp::os::QosStyle::HIGH; // DSCP 36
Network::setConnectionQos("/output", "/input", qos, qos);
```
The above example adjust the communication thread's (if available) real-time properties of the connection ("/output" -> "/input") to be scheduled using `SCHED_FIFO` with priority=10. The packets DSCP value is also set to 36 using  `yarp::os::QosStyle::HIGH`. The API offers 4 levels of predefined packet priorities as defined in `yarp/os/QosStyle.h` : 

```c++
    enum PacketPriorityType {
        LOW = VOCAB3('L','O','W'),   // DSCP = 10
        NORM = VOCAB4('N','O','R', 'M'),   // DSCP = 0
        HIGH = VOCAB4('H','I','G','H'),   // DSCP = 36
        CRIT = VOCAB4('C','R','I','T')   // DSCP = 44
    };
```

 

