### PR TITLE
implementing QoS support in the remote_controlboard driver for real-time applications

### DIFF
--- a/bindings/driver_qos.lua
+++ b/bindings/driver_qos.lua
@@ -17,15 +17,16 @@ options:put("local", "/motor/lua/right_arm")
 options:put("remote", "/icubSim/right_arm")
 
 -- setting QoS pereferences for the driver (local and remote)
+HIGH = 36
 qos_local = options:addGroup("local_qos")
 qos_local:put("thread_priority", 20)
 qos_local:put("thread_policy", 1)
-qos_local:put("packet_priority", yarp.Vocab_encode("HIGH"))
+qos_local:put("packet_priority", HIGH)
 
 qos_remote = options:addGroup("remote_qos")
 qos_remote:put("thread_priority", 30)
 qos_remote:put("thread_policy", 1)
-qos_remote:put("packet_priority", yarp.Vocab_encode("HIGH"))
+qos_remote:put("packet_priority", HIGH)
 
 -- open the driver
 driver = yarp.PolyDriver(options)

--- a/bindings/driver_qos.lua
+++ b/bindings/driver_qos.lua
@@ -1,0 +1,60 @@
+#!/usr/bin/lua 
+
+-- Copyright: (C) 2011 Robotics, Brain and Cognitive Sciences - Italian Institute of Technology (IIT)
+-- Author: Ali Paikan <ali.paikan@iit.it>
+-- Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+
+-- LUA_CPATH should have the path to yarp-lua binding library (i.e. yarp.so, yarp.dll) 
+require("yarp")
+
+-- initialize yarp network
+yarp.Network()
+
+options = yarp.Property()
+options:put("device", "remote_controlboard")
+options:put("local", "/motor/lua/right_arm")
+options:put("remote", "/icubSim/right_arm")
+
+-- setting QoS pereferences for the driver (local and remote)
+qos_local = options:addGroup("local_qos")
+qos_local:put("thread_priority", 20)
+qos_local:put("thread_policy", 1)
+qos_local:put("packet_priority", yarp.Vocab_encode("HIGH"))
+
+qos_remote = options:addGroup("remote_qos")
+qos_remote:put("thread_priority", 30)
+qos_remote:put("thread_policy", 1)
+qos_remote:put("packet_priority", yarp.Vocab_encode("HIGH"))
+
+-- open the driver
+driver = yarp.PolyDriver(options)
+if driver:isValid() == false then
+    print("Cannot open the device");
+    os.exit()
+end
+
+-- open the interfaces
+ipos = driver:viewIPositionControl()
+if ipos == nil then 
+    print("Cannot open the IPositionControl interface");
+    driver:close()
+    os.exit()
+end
+
+-- send position command to motors
+for i=1,100 do
+    position = math.random(-90, 10)
+    print("setting position of joint 0 to "..position)
+    ipos:setPositionMode()
+    ipos:setRefSpeed(0, 30)
+    ipos:positionMove(0, position)
+    yarp.Time_delay(0.5)
+end
+
+
+driver:close()
+
+-- Deinitialize yarp network
+yarp.Network_fini()
+

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -572,7 +572,7 @@ public:
      * @return true if the Qos preferences is set correctly
      */
     static bool setConnectionQos(const ConstString& src, const ConstString& dest,
-                                 const QosStyle& srcStyle, const QosStyle destStyle,
+                                 const QosStyle& srcStyle, const QosStyle& destStyle,
                                  bool quiet=true);
 
     /**

--- a/src/libYARP_OS/include/yarp/os/QosStyle.h
+++ b/src/libYARP_OS/include/yarp/os/QosStyle.h
@@ -32,43 +32,100 @@ public:
      * The PacketPriorityType defines the packets
      * quality of service (priority) levels
      */
-    enum PacketPriorityType {
-        LOW = VOCAB3('L','O','W'),
-        NORM = VOCAB4('N','O','R', 'M'),
-        HIGH = VOCAB4('H','I','G','H'),
-        CRIT = VOCAB4('C','R','I','T')
+    enum PacketPriorityType {        
+        NORM = 0,
+        LOW  = 10,
+        HIGH = 36,
+        CRIT = 44
     };
 
     /**
-     * @brief threadPriority controls the priority of the yarp port's
-     * thread (if available) which handles the data transmission.
-     * Notice that not every yarp port has dedicated
-     * thread for communication (e.g., BufferedPorts have dedicated thread)
-     */
-    int threadPriority;
-
-    /**
-     * @brief threadPolicy controls the scheduling policy of the yarp
-     * port's thread (if available) which handles the data transmission.
-     * Notice that not every yarp port has dedicated
-     * thread for communication (e.g., BufferedPorts have dedicated thread)
-     */
-    int threadPolicy;
-
-
-    /**
-     * @brief packetPriority controls the communication packets priority levels
-     * by adjusting the IPV4/6 DSCP value.
-     */
-    PacketPriorityType packetPriority;
-
-
-    /**
-     *
      * Constructor.  Sets all options to reasonable defaults.
-     *
      */
     explicit QosStyle();
+
+
+    /**
+     * @brief sets the packet priority given as DSCP class
+     * @param dscp the packet DSCP class
+     * @return true if the packet priority is correctly given (e.g., "CS0", "AF42")
+     */
+    bool setPacketPriorityByDscp(const ConstString& dscp);
+
+
+    /**
+     * @brief sets the packet priority given as PacketPriorityType
+     * @param priority the packet priority
+     */
+    void setPacketPriorityByType(PacketPriorityType priority);
+
+
+    /**
+     * @brief sets the packet priority given as TOS value
+     * @param tos the packet TOS
+     */
+    void setPacketPriority(int tos) {
+        packetPriority = tos;
+    }
+
+
+    /**
+     * @brief sets the communication thread priority level
+     * @param priority the thread's priority
+     */
+    void setThreadPriority(int priority) {
+        threadPriority = priority;
+    }
+
+
+    /**
+     * @brief sets the communication thread scheduling policy
+     * @param policy the thread's real-time scheduling policy
+     */
+    void setThreadPolicy(int policy) {
+        threadPolicy = policy;
+    }
+
+
+    /**
+     * @brief returns the packet TOS value
+     * @return the TOS
+     */
+    int getPacketPriorty() const {
+        return packetPriority;
+    }
+
+
+    /**
+     * @brief returns the communication thread priority level
+     * @return the thread priority
+     */
+    int getThreadPriority() const {
+        return threadPriority;
+    }
+
+
+    /**
+     * @brief returns the communication thread scheduling policy
+     * @return the thread scheduling policy
+     */
+    int getThreadPolicy() const {
+        return threadPolicy;
+    }
+
+
+    /**
+     * @brief returns the IPV4/6 DSCP value given as DSCP code
+     * @param vocab a DSCP code (e.g., CS0)
+     * @return the actual DSCP value
+     */
+    static int getDSCPByVocab(int vocab);
+
+private:
+    int threadPriority;
+    int threadPolicy;
+    int packetPriority;
+
 };
 
 #endif

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -444,6 +444,7 @@ public:
     void releaseProperties(Property *prop);
 
     int getDSCPByVocab(NetInt32 code);
+    bool setTypeOfService(PortCoreUnit *unit, int tos);
 
     bool setCallbackLock(yarp::os::Mutex *mutex = NULL) {
         removeCallbackLock();

--- a/src/libYARP_OS/include/yarp/os/impl/PortCoreInputUnit.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCoreInputUnit.h
@@ -115,6 +115,9 @@ public:
             ip->getReceiver().getCarrierParams(params);
     }
 
+    // return the protocol object
+    InputProtocol* getInPutProtocol() { return ip; }
+
     virtual bool isBusy();
 
 private:

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -770,10 +770,10 @@ bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& de
     Property& sched_prop2 = sched2.addDict();
     sched_prop2.put("priority", destStyle.threadPriority);
     sched_prop2.put("policy", destStyle.threadPolicy);    
-    //Bottle& qos2 = cmd.addList();
-    //qos2.addString("qos");
-    //Property& qos_prop2 = qos2.addDict();
-    //qos_prop2.put("priority", Vocab::decode(destStyle.packetPriority));
+    Bottle& qos2 = cmd.addList();
+    qos2.addString("qos");
+    Property& qos_prop2 = qos2.addDict();
+    qos_prop2.put("priority", Vocab::decode(destStyle.packetPriority));
     Contact destCon = Contact::fromString(dest);
     ret = write(destCon, cmd, reply, true, true, 2.0);
     if(!ret) {

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -726,66 +726,72 @@ bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& de
 }
 
 bool NetworkBase::setConnectionQos(const ConstString& src, const ConstString& dest,
-                                   const QosStyle& srcStyle, const QosStyle destStyle,
+                                   const QosStyle& srcStyle, const QosStyle &destStyle,
                                    bool quiet) {
 
-    //e.g.,  prop set /portname (sched ((priority 30) (policy 1))) (qos ((priority HIGH)))
+    //e.g.,  prop set /portname (sched ((priority 30) (policy 1))) (qos ((tos 0)))
     yarp::os::Bottle cmd, reply;
 
-    // set the source Qos
-    cmd.addString("prop");
-    cmd.addString("set");
-    cmd.addString(dest.c_str());
-    Bottle& sched = cmd.addList();
-    sched.addString("sched");
-    Property& sched_prop = sched.addDict();
-    sched_prop.put("priority", srcStyle.threadPriority);
-    sched_prop.put("policy", srcStyle.threadPolicy);
-    Bottle& qos = cmd.addList();
-    qos.addString("qos");
-    Property& qos_prop = qos.addDict();
-    qos_prop.put("priority", Vocab::decode(srcStyle.packetPriority));
-    Contact srcCon = Contact::fromString(src);
-    bool ret = write(srcCon, cmd, reply, true, true, 2.0);
-    if(!ret) {
-        if(!quiet)
-             ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",src.c_str());
-        return false;
-    }
-    if(reply.get(0).asString() != "ok") {
-        if(!quiet)
-             ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
-                             src.c_str(), reply.toString().c_str());
-        return false;
+    // ignore if everything left as default
+    if(srcStyle.getPacketPriorty()!=-1 || srcStyle.getThreadPolicy() !=-1) {
+        // set the source Qos
+        cmd.addString("prop");
+        cmd.addString("set");
+        cmd.addString(dest.c_str());
+        Bottle& sched = cmd.addList();
+        sched.addString("sched");
+        Property& sched_prop = sched.addDict();
+        sched_prop.put("priority", srcStyle.getThreadPriority());
+        sched_prop.put("policy", srcStyle.getThreadPolicy());
+        Bottle& qos = cmd.addList();
+        qos.addString("qos");
+        Property& qos_prop = qos.addDict();
+        qos_prop.put("tos", srcStyle.getPacketPriorty());
+        Contact srcCon = Contact::fromString(src);
+        bool ret = write(srcCon, cmd, reply, true, true, 2.0);
+        if(!ret) {
+            if(!quiet)
+                 ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",src.c_str());
+            return false;
+        }
+        if(reply.get(0).asString() != "ok") {
+            if(!quiet)
+                 ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
+                                 src.c_str(), reply.toString().c_str());
+            return false;
+        }
     }
 
-    // set the destination Qos
-    cmd.clear();
-    reply.clear();
-    cmd.addString("prop");
-    cmd.addString("set");
-    cmd.addString(src.c_str());
-    Bottle& sched2 = cmd.addList();
-    sched2.addString("sched");
-    Property& sched_prop2 = sched2.addDict();
-    sched_prop2.put("priority", destStyle.threadPriority);
-    sched_prop2.put("policy", destStyle.threadPolicy);    
-    Bottle& qos2 = cmd.addList();
-    qos2.addString("qos");
-    Property& qos_prop2 = qos2.addDict();
-    qos_prop2.put("priority", Vocab::decode(destStyle.packetPriority));
-    Contact destCon = Contact::fromString(dest);
-    ret = write(destCon, cmd, reply, true, true, 2.0);
-    if(!ret) {
-        if(!quiet)
-             ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",dest.c_str());
-        return false;
-    }
-    if(reply.get(0).asString() != "ok") {
-        if(!quiet)
-             ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
-                             dest.c_str(), reply.toString().c_str());
-        return false;
+    // ignore if everything left as default
+    if(destStyle.getPacketPriorty()!=-1 || destStyle.getThreadPolicy() !=-1) {
+        // set the destination Qos
+        cmd.clear();
+        reply.clear();
+        cmd.addString("prop");
+        cmd.addString("set");
+        cmd.addString(src.c_str());
+        Bottle& sched2 = cmd.addList();
+        sched2.addString("sched");
+        Property& sched_prop2 = sched2.addDict();
+        sched_prop2.put("priority", destStyle.getThreadPriority());
+        sched_prop2.put("policy", destStyle.getThreadPolicy());
+        Bottle& qos2 = cmd.addList();
+        qos2.addString("qos");
+        Property& qos_prop2 = qos2.addDict();
+        qos_prop2.put("tos", destStyle.getPacketPriorty());
+        Contact destCon = Contact::fromString(dest);
+        bool ret = write(destCon, cmd, reply, true, true, 2.0);
+        if(!ret) {
+            if(!quiet)
+                 ACE_OS::fprintf(stderr, "Cannot write to '%s'\n",dest.c_str());
+            return false;
+        }
+        if(reply.get(0).asString() != "ok") {
+            if(!quiet)
+                 ACE_OS::fprintf(stderr, "Cannot set qos properties of '%s'. (%s)\n",
+                                 dest.c_str(), reply.toString().c_str());
+            return false;
+        }
     }
     return true;
 }

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2045,7 +2045,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                                         bOk = setTypeOfService(unit, dscp<<2);
                                                 }
                                                 else if(qos_prop->check("dscp")) {
-                                                    int dscp = getDSCPByVocab(qos_prop->find("dscp").asVocab());
+                                                    int dscp = QosStyle::getDSCPByVocab(qos_prop->find("dscp").asVocab());
                                                     if (dscp < 0)
                                                         dscp = qos_prop->find("dscp").asInt();
                                                     if((dscp>=0) && (dscp<64))
@@ -2053,6 +2053,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                                 }
                                                 else if(qos_prop->check("tos")) {
                                                     int tos = qos_prop->find("tos").asInt();
+                                                    printf("setting tos of %s to %d (dsp: %d)\n", portName.c_str(), tos, tos>>2);
                                                     // set the TOS value (backward compatibility)
                                                     bOk = setTypeOfService(unit, tos);
                                                 }
@@ -2115,40 +2116,6 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
     return true;
 }
 
-//                Class 1          Class 2         Class 3         Class 4
-//          ------------------------------------------------------------------
-// Low Drop	 | AF11 (DSCP 10)	AF21 (DSCP 18)	AF31 (DSCP 26)	AF41 (DSCP 34)
-// Med Drop	 | AF12 (DSCP 12)	AF22 (DSCP 20)	AF32 (DSCP 28)	AF42 (DSCP 36)
-// High Drop | AF13 (DSCP 14)	AF23 (DSCP 22)	AF33 (DSCP 30)	AF43 (DSCP 38)
-inline int PortCore::getDSCPByVocab(NetInt32 code) {
-    int dscp;
-    switch(code) {
-        case VOCAB3('C','S','0')    : dscp = 0; break;
-        case VOCAB3('C','S','1')    : dscp = 8; break;
-        case VOCAB3('C','S','2')    : dscp = 16; break;
-        case VOCAB3('C','S','3')    : dscp = 24; break;
-        case VOCAB3('C','S','4')    : dscp = 32; break;
-        case VOCAB3('C','S','5')    : dscp = 40; break;
-        case VOCAB3('C','S','6')    : dscp = 48; break;
-        case VOCAB3('C','S','7')    : dscp = 56; break;
-        case VOCAB4('A','F','1','1'): dscp = 10; break;
-        case VOCAB4('A','F','1','2'): dscp = 12; break;
-        case VOCAB4('A','F','1','3'): dscp = 14; break;
-        case VOCAB4('A','F','2','1'): dscp = 18; break;
-        case VOCAB4('A','F','2','2'): dscp = 20; break;
-        case VOCAB4('A','F','2','3'): dscp = 22; break;
-        case VOCAB4('A','F','3','1'): dscp = 26; break;
-        case VOCAB4('A','F','3','2'): dscp = 28; break;
-        case VOCAB4('A','F','3','3'): dscp = 30; break;
-        case VOCAB4('A','F','4','1'): dscp = 34; break;
-        case VOCAB4('A','F','4','2'): dscp = 36; break;
-        case VOCAB4('A','F','4','3'): dscp = 38; break;
-        case VOCAB2('V','A')        : dscp = 44; break;
-        case VOCAB2('E','F')        : dscp = 46; break;
-        default: dscp = -1;
-    };
-    return dscp;
-}
 
 bool PortCore::setTypeOfService(PortCoreUnit *unit, int tos) {
     if(unit->isOutput()) {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2053,7 +2053,6 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                                 }
                                                 else if(qos_prop->check("tos")) {
                                                     int tos = qos_prop->find("tos").asInt();
-                                                    printf("setting tos of %s to %d (dsp: %d)\n", portName.c_str(), tos, tos>>2);
                                                     // set the TOS value (backward compatibility)
                                                     bOk = setTypeOfService(unit, tos);
                                                 }

--- a/src/libYARP_OS/src/QosStyle.cpp
+++ b/src/libYARP_OS/src/QosStyle.cpp
@@ -10,7 +10,57 @@
 
 
 yarp::os::QosStyle::QosStyle() :
-        threadPriority(0),
+        threadPriority(-1),
         threadPolicy(-1),
-        packetPriority(yarp::os::QosStyle::NORM){
+        packetPriority(-1){
+}
+
+bool yarp::os::QosStyle::setPacketPriorityByDscp(const ConstString& dscp) {
+    int value = yarp::os::QosStyle::getDSCPByVocab(yarp::os::Vocab::encode(dscp));
+    if(value == -1)
+        return false;
+    packetPriority = value<<2;
+    return true;
+}
+
+
+void yarp::os::QosStyle::setPacketPriorityByType(PacketPriorityType priority) {
+    packetPriority = ((int)priority)<<2;
+}
+
+
+
+//                Class 1          Class 2         Class 3         Class 4
+//          ------------------------------------------------------------------
+// Low Drop	 | AF11 (DSCP 10)	AF21 (DSCP 18)	AF31 (DSCP 26)	AF41 (DSCP 34)
+// Med Drop	 | AF12 (DSCP 12)	AF22 (DSCP 20)	AF32 (DSCP 28)	AF42 (DSCP 36)
+// High Drop | AF13 (DSCP 14)	AF23 (DSCP 22)	AF33 (DSCP 30)	AF43 (DSCP 38)
+int yarp::os::QosStyle::getDSCPByVocab(int vocab) {
+    int dscp;
+    switch(vocab) {
+        case VOCAB3('C','S','0')    : dscp = 0; break;
+        case VOCAB3('C','S','1')    : dscp = 8; break;
+        case VOCAB3('C','S','2')    : dscp = 16; break;
+        case VOCAB3('C','S','3')    : dscp = 24; break;
+        case VOCAB3('C','S','4')    : dscp = 32; break;
+        case VOCAB3('C','S','5')    : dscp = 40; break;
+        case VOCAB3('C','S','6')    : dscp = 48; break;
+        case VOCAB3('C','S','7')    : dscp = 56; break;
+        case VOCAB4('A','F','1','1'): dscp = 10; break;
+        case VOCAB4('A','F','1','2'): dscp = 12; break;
+        case VOCAB4('A','F','1','3'): dscp = 14; break;
+        case VOCAB4('A','F','2','1'): dscp = 18; break;
+        case VOCAB4('A','F','2','2'): dscp = 20; break;
+        case VOCAB4('A','F','2','3'): dscp = 22; break;
+        case VOCAB4('A','F','3','1'): dscp = 26; break;
+        case VOCAB4('A','F','3','2'): dscp = 28; break;
+        case VOCAB4('A','F','3','3'): dscp = 30; break;
+        case VOCAB4('A','F','4','1'): dscp = 34; break;
+        case VOCAB4('A','F','4','2'): dscp = 36; break;
+        case VOCAB4('A','F','4','3'): dscp = 38; break;
+        case VOCAB2('V','A')        : dscp = 44; break;
+        case VOCAB2('E','F')        : dscp = 46; break;
+        default: dscp = -1;
+    };
+    return dscp;
 }

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -967,22 +967,22 @@ public:
         if (config.check("local_qos")) {
             Bottle& qos = config.findGroup("local_qos");
             if(qos.check("thread_priority"))
-                localQos.threadPriority = qos.find("thread_priority").asInt();
+                localQos.setThreadPriority(qos.find("thread_priority").asInt());
             if(qos.check("thread_policy"))
-                localQos.threadPolicy = qos.find("thread_policy").asInt();
+                localQos.setThreadPolicy(qos.find("thread_policy").asInt());
             if(qos.check("packet_priority"))
-                localQos.packetPriority = (QosStyle::PacketPriorityType) qos.find("packet_priority").asInt();
+                localQos.setPacketPriorityByType((QosStyle::PacketPriorityType) qos.find("packet_priority").asInt());
         }
 
         yarp::os::QosStyle remoteQos;
         if (config.check("remote_qos")) {
             Bottle& qos = config.findGroup("remote_qos");
             if(qos.check("thread_priority"))
-                remoteQos.threadPriority = qos.find("thread_priority").asInt();
+                remoteQos.setThreadPriority(qos.find("thread_priority").asInt());
             if(qos.check("thread_policy"))
-                remoteQos.threadPolicy = qos.find("thread_policy").asInt();
+                remoteQos.setThreadPolicy(qos.find("thread_policy").asInt());
             if(qos.check("packet_priority"))
-                remoteQos.packetPriority = (QosStyle::PacketPriorityType) qos.find("packet_priority").asInt();
+                remoteQos.setPacketPriorityByType((QosStyle::PacketPriorityType) qos.find("packet_priority").asInt());
         }
 
         bool writeStrict_isFound = config.check("writeStrict");

--- a/tests/libYARP_OS/NetworkTest.cpp
+++ b/tests/libYARP_OS/NetworkTest.cpp
@@ -239,9 +239,9 @@ public:
         bt.addString("test");
         p1.write();
         yarp::os::QosStyle style;
-        style.threadPriority = 0;
-        style.threadPolicy = 0;
-        style.packetPriority = yarp::os::QosStyle::NORM;
+        style.setThreadPriority(0);
+        style.setThreadPolicy(0);
+        style.setPacketPriorityByType(yarp::os::QosStyle::NORM);
         checkTrue(Network::setConnectionQos(p1.getName(), p2.getName(), style, style, false),
                   "connection Qos working");
         Network::disconnect(p1.getName(), p2.getName());


### PR DESCRIPTION
This pull-requests implements the QoS support into the `remote_controlboard` driver. The driver can be opened using desired QoS preferences to prioritize the connections (e.g., `/icub/right_arm/state:o` to `/client/right_arm/state:i`). Thus, for example, a real-time controller can open a driver for a control board which has higher priority than other less-critical drivers/modules (e.g., yarpmotorgui). The QoS preferences can be individually configured for the local and remote ports of the driver. These preferences will be applied individually to each side of the connections if available. The QoS preferences are applied only for the `state`, `stateEx` and `Command` ports! 

 Here is a simple Lua script which demonstratess how the QoS properties can be configured for a driver:  

```lua
options = yarp.Property()
options:put("device", "remote_controlboard")
options:put("local", "/client/right_arm")
options:put("remote", "/icub/right_arm")

-- setting QoS preferences for the driver (local)
qos_local = options:addGroup("local_qos")
qos_local:put("thread_priority", 20)
qos_local:put("thread_policy", 1)
qos_local:put("packet_priority", yarp.Vocab_encode("HIGH"))  
-- C++ equivalent is qos_local.put("packet_priority", (int)QosStyle::HIGH)

-- setting QoS preferences for the driver (remote)
qos_remote = options:addGroup("remote_qos")
qos_remote:put("thread_priority", 30)
qos_remote:put("thread_policy", 1)
qos_remote:put("packet_priority", yarp.Vocab_encode("HIGH"))

-- open the driver
driver = yarp.PolyDriver(options)
...
```

- TODO: the similar implementaion should be done for the other drivers: `CartesianController`, `GazeController`, ...