### PR TITLE
Fix deadlock while using network clock

### DIFF
--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -19,6 +19,7 @@
 #include <yarp/os/impl/NameConfig.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/SystemClock.h>
 #include <yarp/os/Time.h>
 
 #include <errno.h>
@@ -466,7 +467,7 @@ public:
         if (prev!=NULL) {
             double t = prev->get(0).asDouble();
             int flag = prev->get(1).asInt();
-            if (Time::now()-t<RESOURCE_FINDER_CACHE_TIME) {
+            if (SystemClock::nowSystem()-t<RESOURCE_FINDER_CACHE_TIME) {
                 if (flag) return s;
                 return "";
             }
@@ -482,7 +483,7 @@ public:
         bool ok = exists(s.c_str(),isDir);
         Value status;
         yAssert(status.asList());
-        status.asList()->addDouble(Time::now());
+        status.asList()->addDouble(SystemClock::nowSystem());
         status.asList()->addInt(ok?1:0);
         cache.put(s,status);
         if (ok) {


### PR DESCRIPTION
This deadlock was caused by PR https://github.com/robotology/yarp/pull/546 .

Basically until now all yarp basic utilities and functions were not calling `Time` functions, so they could work perfectly even if yarp was using a network clock that was not publishing any data. 

After https://github.com/robotology/yarp/pull/546 , any call to `Connect` (at least with tcp carrier I guess) will cause the invocation of the ResourceFinder, that invoked the `Time::now()` call, that itself was trying to call `Connect` if used with a Network Clock:
![authmacdeadlock](https://cloud.githubusercontent.com/assets/1857049/9255790/de4ddea4-41eb-11e5-842d-ff1cdfbbeaf0.png)

This PR solve the issue by always using the SystemClock (instead of the NetworkClock) in the ResourceFinder (even because the time information is only used for a local cache. 

@drdanz beside this issue, don't you think that invoking the ResourceFinder just for doing a `Connect` is an overkill ? I guess most user of the API are not expecting it. 

