### PR TITLE
Getting the port's owner process and thread ID using port admin commands  

### DIFF
--- a/src/libYARP_OS/include/yarp/os/SystemInfo.h
+++ b/src/libYARP_OS/include/yarp/os/SystemInfo.h
@@ -110,6 +110,15 @@ public:
     } NetworkInfo;
     */
 
+    /**
+     * @brief The ProcessInfo stuct provides the operating system proccess information.
+     */
+    typedef struct ProcessInfo {
+        yarp::os::ConstString name;
+        yarp::os::ConstString arguments;
+        int pid;
+    } ProcessInfo;
+
 public:   
     /**
      * @brief getMemoryInfo
@@ -147,7 +156,16 @@ public:
      */
     static UserInfo getUserInfo();
 
-    //static NetworkInfo getNetworkInfo();
+    /**
+     * @brief gets the operating system process information given by its PID.
+     * If the information cannot be retrieved, ProcessInfo.pid is set to -1
+     * otherwise, it is equal to the given PID as paramter.
+     * @param pid the process (task) PID
+     * @return ProcessInfo
+     */
+    static ProcessInfo getProcessInfo(int pid);
+
+    //static NetworkInfo getNetworkInfo();    
 };
 
 #endif //_YARP2_SYSTEMINFO_

--- a/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
@@ -80,7 +80,7 @@ public:
     int setPriority(int priority = -1, int policy = -1);
     int getPriority();
     int getPolicy();
-    Platform_hthread_t getThreadID() { return hid; }
+    long getTid();
 
     static void setDefaultStackSize(int stackSize);
 
@@ -90,12 +90,14 @@ public:
     static void init();
     static void fini();
 
+    long tid;
+
 private:
     int defaultPriority;
     int defaultPolicy;
     int stackSize;
     Platform_hthread_t hid;
-    Platform_thread_t  id;
+    Platform_thread_t  id;    
     bool active;
     bool opened;
     bool closing;

--- a/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
@@ -80,6 +80,7 @@ public:
     int setPriority(int priority = -1, int policy = -1);
     int getPriority();
     int getPolicy();
+    Platform_hthread_t getThreadID() { return hid; }
 
     static void setDefaultStackSize(int stackSize);
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -22,6 +22,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/PortInfo.h>
+#include <yarp/os/SystemInfo.h>
 #include <yarp/os/DummyConnector.h>
 
 #include <yarp/os/impl/PlatformStdio.h>
@@ -1961,8 +1962,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                     Property *p = acquireProperties(false);
                     if (p) {
                         if (!cmd.get(2).isNull()) {                            
-                            // request: "prop get /portname"
-                            // reply  : "(sched ((priority 30) (policy 1))) (qos ((priority HIGH)))"
+                            // request: "prop get /portname"                            
                             ConstString portName = cmd.get(2).asString();
                             bool bFound = false;
                             if((portName.size() > 0) && (portName[0] == '/')) {
@@ -1972,11 +1972,19 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                     result.clear();
                                     Bottle& sched = result.addList();
                                     sched.addString("sched");
-                                    Property& sched_prop = sched.addDict();
-                                    sched_prop.put("pid", ACE_OS::getpid());
+                                    Property& sched_prop = sched.addDict();                                    
                                     sched_prop.put("tid", (int)this->getTid());
                                     sched_prop.put("priority", this->getPriority());
                                     sched_prop.put("policy", this->getPolicy());
+
+                                    int pid =  ACE_OS::getpid();
+                                    SystemInfo::ProcessInfo info = SystemInfo::getProcessInfo(pid);
+                                    Bottle& proc = result.addList();
+                                    proc.addString("process");
+                                    Property& proc_prop = proc.addDict();
+                                    proc_prop.put("pid", pid);
+                                    proc_prop.put("name", (info.pid !=-1) ? info.name : "unkown");
+                                    proc_prop.put("arguments", (info.pid !=-1) ? info.arguments : "unkown");
                                 }
                                 else {
                                     for (unsigned int i=0; i<units.size(); i++) {
@@ -1988,14 +1996,12 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                                 bFound = true;
                                                 int priority = unit->getPriority();
                                                 int policy = unit->getPolicy();
-                                                int tos = getTypeOfService(unit);
-                                                int pid =  ACE_OS::getpid();
+                                                int tos = getTypeOfService(unit);                                                
                                                 int tid = (int) unit->getTid();
                                                 result.clear();
                                                 Bottle& sched = result.addList();
                                                 sched.addString("sched");
                                                 Property& sched_prop = sched.addDict();
-                                                sched_prop.put("pid", pid);
                                                 sched_prop.put("tid", tid);
                                                 sched_prop.put("priority", priority);
                                                 sched_prop.put("policy", policy);

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1966,33 +1966,47 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                             ConstString portName = cmd.get(2).asString();
                             bool bFound = false;
                             if((portName.size() > 0) && (portName[0] == '/')) {
-                                for (unsigned int i=0; i<units.size(); i++) {
-                                    PortCoreUnit *unit = units[i];
-                                    if (unit && !unit->isFinished()) {
-                                        Route route = unit->getRoute();
-                                        ConstString coreName = (unit->isOutput()) ? route.getToName() : route.getFromName();
-                                        if (portName == coreName) {
-                                            bFound = true;
-                                            int priority = unit->getPriority();
-                                            int policy = unit->getPolicy();
-                                            int tos = getTypeOfService(unit);
-                                            int pid =  ACE_OS::getpid();
-                                            double tid = (double) unit->getThreadID();
-                                            result.clear();
-                                            Bottle& sched = result.addList();
-                                            sched.addString("sched");
-                                            Property& sched_prop = sched.addDict();
-                                            sched_prop.put("priority", priority);
-                                            sched_prop.put("policy", policy);
-                                            sched_prop.put("pid", pid);
-                                            sched_prop.put("tid", tid);
-                                            Bottle& qos = result.addList();
-                                            qos.addString("qos");
-                                            Property& qos_prop = qos.addDict();
-                                            qos_prop.put("tos", tos);
-                                        }
-                                    } // end isFinished()
-                                } // end for loop
+                                // check for their own name
+                                if (portName == getName()) {
+                                    bFound = true;
+                                    result.clear();
+                                    Bottle& sched = result.addList();
+                                    sched.addString("sched");
+                                    Property& sched_prop = sched.addDict();
+                                    sched_prop.put("pid", ACE_OS::getpid());
+                                    sched_prop.put("tid", (int)this->getTid());
+                                    sched_prop.put("priority", this->getPriority());
+                                    sched_prop.put("policy", this->getPolicy());
+                                }
+                                else {
+                                    for (unsigned int i=0; i<units.size(); i++) {
+                                        PortCoreUnit *unit = units[i];
+                                        if (unit && !unit->isFinished()) {
+                                            Route route = unit->getRoute();
+                                            ConstString coreName = (unit->isOutput()) ? route.getToName() : route.getFromName();
+                                            if (portName == coreName) {
+                                                bFound = true;
+                                                int priority = unit->getPriority();
+                                                int policy = unit->getPolicy();
+                                                int tos = getTypeOfService(unit);
+                                                int pid =  ACE_OS::getpid();
+                                                int tid = (int) unit->getTid();
+                                                result.clear();
+                                                Bottle& sched = result.addList();
+                                                sched.addString("sched");
+                                                Property& sched_prop = sched.addDict();
+                                                sched_prop.put("pid", pid);
+                                                sched_prop.put("tid", tid);
+                                                sched_prop.put("priority", priority);
+                                                sched_prop.put("policy", policy);
+                                                Bottle& qos = result.addList();
+                                                qos.addString("qos");
+                                                Property& qos_prop = qos.addDict();
+                                                qos_prop.put("tos", tos);
+                                            }
+                                        } // end isFinished()
+                                    } // end for loop
+                                } // end portName == getname()
 
                                 if(!bFound) {  // cannot find any port matchs the requested one
                                     result.clear();

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1976,12 +1976,16 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                             int priority = unit->getPriority();
                                             int policy = unit->getPolicy();
                                             int tos = getTypeOfService(unit);
+                                            int pid =  ACE_OS::getpid();
+                                            double tid = (double) unit->getThreadID();
                                             result.clear();
                                             Bottle& sched = result.addList();
                                             sched.addString("sched");
                                             Property& sched_prop = sched.addDict();
                                             sched_prop.put("priority", priority);
                                             sched_prop.put("policy", policy);
+                                            sched_prop.put("pid", pid);
+                                            sched_prop.put("tid", tid);
                                             Bottle& qos = result.addList();
                                             qos.addString("qos");
                                             Property& qos_prop = qos.addDict();

--- a/src/libYARP_OS/src/SystemInfo.cpp
+++ b/src/libYARP_OS/src/SystemInfo.cpp
@@ -649,3 +649,39 @@ SystemInfo::LoadInfo SystemInfo::getLoadInfo()
     return load;
 }
 
+
+SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid) {
+    SystemInfo::ProcessInfo info;
+    info.pid = -1; // invalid
+#if defined(__linux__)
+    FILE *file;
+    char cmdline[256] = {0};
+    char filename[256];
+    sprintf(filename, "/proc/%d/cmdline", pid);
+    file = fopen(filename, "r");
+    if (file) {
+        fgets(cmdline, sizeof(cmdline) / sizeof(*cmdline), file);
+        fclose(file);
+        char *p = cmdline;
+        while (*p) {
+            p += strlen(p);
+            if (*(p + 1))
+                *p = ' ';
+            p++;
+        }
+        info.pid = pid;
+        // split the cmdline to find the arguments
+        info.name = cmdline;
+        size_t index = info.name.find(" ");
+        if(index != info.name.npos) {
+            info.name = info.name.substr(0, index);
+            info.arguments = info.name.substr(index+1);
+        }
+    }
+#else
+    // TODO: to be implemented
+    info.pid = -1; // invalid
+#endif
+    return info;
+}
+

--- a/src/libYARP_OS/src/SystemInfo.cpp
+++ b/src/libYARP_OS/src/SystemInfo.cpp
@@ -675,7 +675,8 @@ SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid) {
         size_t index = info.name.find(" ");
         if(index != info.name.npos) {
             info.name = info.name.substr(0, index);
-            info.arguments = info.name.substr(index+1);
+            info.arguments = cmdline;
+            info.arguments = info.arguments.substr(index+1);
         }
     }
 #else
@@ -684,4 +685,3 @@ SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid) {
 #endif
     return info;
 }
-


### PR DESCRIPTION
This pull request add new functionality to the port admin commands (i.e., `prop get` ) to retrieve the process ID of the port's owner and the thread ID of the connection's owner (if exist).  The thread ID equal to -1, indicates that there is not any dedicated thread for the corresponding connections. 

Example: 
`/sender`  --->  `/receiver`

```
$ yarp admin rpc /sender
>> prop get /receiver 
Response: (sched ((priority 0) (pid 24192) (tid 24221) (policy 0))) (qos ((tos 0)))
```
If `/sender` does not have a dedicated thread for the corresponding connection then 
```
>> prop get /receiver
Response: (sched ((priority 0) (pid 24192) (tid -1) (policy 0))) (qos ((tos 0)))
```





  