### PR TITLE
[NetworkClock] fix synchronization issue in accessing NetworkClock while switching to SystemClock

### DIFF
--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -68,7 +68,19 @@ static Clock *getClock() {
             nc->open(name);
         }
     }
-    return pclock;
+
+    Clock * retClock;
+    if( pclock == 0 )
+    {
+        retClock = 0;
+    }
+    else
+    {
+        lock();
+        retClock = pclock;
+        unlock();
+    }
+    return retClock;
 }
 
 void Time::delay(double seconds) {


### PR DESCRIPTION
Fixes https://github.com/robotology/yarp/issues/564 . 
Given that this is usually a critical piece of code, it would be nice to test it on Coman/Walkman infrastructure before merging : @arocchi @EnricoMingo @liesrock @barbalberto  . 