### PR TITLE
ControlBoardWrapper2 get axis names for ROS topic from motionControl device

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -249,6 +249,7 @@ private:
     bool              _verb;        // make it work and propagate to subdevice if --subdevice option is used
 
     yarp::os::Bottle getOptions();
+    bool updateAxisName();
     bool checkROSParams(yarp::os::Searchable &config);
     bool initialize_ROS();
     bool initialize_YARP(yarp::os::Searchable &prop);

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.cpp
@@ -199,6 +199,9 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
     if ((iVar == 0) && (_subDevVerbose))
         yWarning() << "controlBoardWrapper:  Warning iVar not valid interface";
 
+    if ((info == 0) && (_subDevVerbose))
+        yWarning() << "controlBoardWrapper:  Warning info not valid interface";
+
     int deviceJoints=0;
 
     // checking minimum set of intefaces required


### PR DESCRIPTION
Right now, if axisname is not available in the subdevice, the one inside [ROS] group will be used