### PR TITLE
Fix clock

### DIFF
--- a/src/libYARP_OS/src/NetworkClock.cpp
+++ b/src/libYARP_OS/src/NetworkClock.cpp
@@ -36,8 +36,14 @@ NetworkClock::~NetworkClock() {
     port.interrupt();
     Waiters& waiters = WAITERS(pwaiters);
     Waiters::iterator waiter_i;
-    for(waiter_i = waiters.begin(); waiter_i != waiters.end(); waiter_i++) {
-        waiter_i->second->post();
+
+    waiter_i = waiters.begin();
+    while (waiter_i != waiters.end())
+    {
+        {
+            waiter_i->second->post();
+            waiter_i = waiters.erase(waiter_i);
+        }
     }
     listMutex.unlock();
     if (pwaiters) {
@@ -95,12 +101,7 @@ void NetworkClock::delay(double seconds) {
     listMutex.unlock();
 
     waiter.second->wait();
-
-    listMutex.lock();
     delete(waiter.second);
-    waiters.erase(waiterIterator);
-    listMutex.unlock();
-
 }
 
 bool NetworkClock::isValid() const {
@@ -123,13 +124,18 @@ bool NetworkClock::read(ConnectionReader& reader) {
     Waiters& waiters = WAITERS(pwaiters);
     Waiters::iterator waiter_i;
 
-    for(waiter_i = waiters.begin(); waiter_i != waiters.end(); waiter_i++) {
-        if(waiter_i->first - t  < 1E-12 ) // t - waiter_i->seconds >= 0
+    waiter_i = waiters.begin();
+    while (waiter_i != waiters.end())
+    {
+        if(waiter_i->first - t  < 1E-12 )
+        {
             waiter_i->second->post();
+            waiter_i = waiters.erase(waiter_i);
+        }
+        else
+            waiter_i++;
     }
-
     listMutex.unlock();
-
     return true;
 }
 

--- a/src/libYARP_OS/src/NetworkClock.cpp
+++ b/src/libYARP_OS/src/NetworkClock.cpp
@@ -93,7 +93,7 @@ void NetworkClock::delay(double seconds) {
         // We are shutting down.  The time signal is no longer available.
         // Make a short delay and return.
         listMutex.unlock();
-        SystemClock::delaySystem(1);
+        SystemClock::delaySystem(seconds);
         return;
     }
     waiter.first = now() + seconds;


### PR DESCRIPTION
My proposal to fix the crash when calling UseSystemClock.

3 commit introducing one change each, two of them are needed to fix the issue while the third one is optional.

- Commit: Add 'if(!closing)':  *needed*
 **ratio**: while closing, the destructor is already called, so the  queue of waiting threads has already been deleted once. This is deleting an already delete structure so must be avoided.

- Commit: Mutex static:  *needed*
  **ratio**:  functions like delay(sec) sleep on a ```waiter.second->wait();```
   If they woke up because of a call to ```UseSystemClock```, they actually restart running 'inside' a member function of a class whose destructor has already been called. The first thing they do is taking the mutex, which is already destroyed. This commit makes the mutexs static so their life span can survive the calls of the NetworkClock destructor and does not crash. 
  **Caution**: Changing to static makes a lot of differences, not only the lifespan, so maybe this can actually introduce some impredicted behaviour. From my point of view, since there is always only one clock for an application, the side effect of having a static member should not make any difference, but I'd like some feedback on this.

- Commit: 'add getClock'  -- *optional*
  When calling UseNetworkClock, the clock is not actually instantiated untill it is used the for first time. This force the clock to be created before returning from the UseNetworkClock function, so avoiding possible races between a thread calling this function and another calling the getClock(). I don't think this will actually create any problems bbut I feel safer this way.
