### PR TITLE
Ros bayer (cleaned)

### DIFF
--- a/src/carriers/wire_rep_utils/WireTwiddler.cpp
+++ b/src/carriers/wire_rep_utils/WireTwiddler.cpp
@@ -454,6 +454,13 @@ void WireTwiddlerReader::compute(const WireTwiddlerGap& gap) {
         case VOCAB4('b', 'a', 'y', 'e'):
             bpp = 1;
             translated_encoding = VOCAB_PIXEL_MONO;
+            if (encoding == "bayer_grbg8")
+                translated_encoding = VOCAB_PIXEL_ENCODING_BAYER_GRBG8;
+            else
+            {
+                fprintf(stderr, "Warning automatic debayering not yet supported, keeping raw format.\n");
+            } 
+
             break;
         default:
             fprintf(stderr, "Sorry, cannot handle [%s] images yet.\n",

--- a/src/libYARP_sig/CMakeLists.txt
+++ b/src/libYARP_sig/CMakeLists.txt
@@ -18,7 +18,8 @@ set(YARP_sig_HDRS include/yarp/sig/all.h
                   include/yarp/sig/Sound.h
                   include/yarp/sig/Vector.h)
 
-set(YARP_sig_IMPL_HDRS )
+set(YARP_sig_IMPL_HDRS include/yarp/sig/impl/DeBayer.h
+                       include/yarp/gsl_compatibility.h)
 
 set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/Image.cpp
@@ -27,7 +28,8 @@ set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/Matrix.cpp
                   src/Sound.cpp
                   src/SoundFile.cpp
-                  src/Vector.cpp)
+                  src/Vector.cpp
+                  src/DeBayer.cpp)
 
 source_group("Source Files" FILES ${YARP_sig_SRCS})
 source_group("Header Files" FILES ${YARP_sig_HDRS})

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -379,7 +379,15 @@ enum YarpVocabPixelTypesEnum
         VOCAB_PIXEL_RGB_INT = VOCAB4('r','g','b','i'),
         VOCAB_PIXEL_MONO_FLOAT = VOCAB3('d','e','c'),
         VOCAB_PIXEL_RGB_FLOAT = VOCAB4('r','g','b','.'),
-        VOCAB_PIXEL_HSV_FLOAT = VOCAB4('h','s','v','.')
+        VOCAB_PIXEL_HSV_FLOAT = VOCAB4('h','s','v','.'),
+        VOCAB_PIXEL_ENCODING_BAYER_GRBG8 = VOCAB4('g', 'r', 'b', 'g'),   //grbg8
+        VOCAB_PIXEL_ENCODING_BAYER_GRBG16 = VOCAB4('g', 'r', '1', '6'),  //grbg16
+        VOCAB_PIXEL_ENCODING_BAYER_BGGR8 = VOCAB4('b', 'g', 'g', 'r'),     //bggr8
+        VOCAB_PIXEL_ENCODING_BAYER_BGGR16 = VOCAB4('b', 'g', '1', '6'),  //bggr16
+        VOCAB_PIXEL_ENCODING_BAYER_GBRG8 = VOCAB4('g', 'b', 'r', 'g'),  //gbrg8
+        VOCAB_PIXEL_ENCODING_BAYER_GBRG16 = VOCAB4('g', 'b', '1', '6'),  //gbrg16
+        VOCAB_PIXEL_ENCODING_BAYER_RGGB8 = -VOCAB4('r', 'g', 'g', 'b'),   //rggb8
+        VOCAB_PIXEL_ENCODING_BAYER_RGGB16 = VOCAB4('r', 'g', '1', '6')  //rggb16
     };
 
 

--- a/src/libYARP_sig/include/yarp/sig/impl/DeBayer.h
+++ b/src/libYARP_sig/include/yarp/sig/impl/DeBayer.h
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+* Copyright (C) 2015 Istituto Italiano di Tecnologia, iCub Facility
+* Authors: Lorenzo Natale
+* CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+* 
+* Basic implementations of debayering functions. Used to convert Bayer images received
+* in a YARP port. Prototype implementation, in the future we should replace these functions
+* with better implementations, like the ones in the Bayer Carrier. If we decide to implement
+* debayering by chaining carriers this code could be removed completely.
+*/
+
+#ifndef _YARP_IMAGE_DEBAYER_
+#define _YARP_IMAGE_DEBAYER_
+
+#include <yarp/sig/Image.h>
+
+inline bool isBayer8(int v)
+{
+    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG8) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR8) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG8) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB8))
+        return true;
+    else
+        return false;
+}
+
+inline bool isBayer16(int v)
+{
+    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG16) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR16) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG16) ||
+        (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB16))
+        return true;
+    else
+        return false;
+}
+
+/*
+* Nearest neighbor debayer implementation (warning: skip borders)
+*/
+bool deBayer_GRBG8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+bool deBayer_BGGR8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+bool deBayer_RGGB8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+/*
+* Nearest neighbor debayer implementation (warning: skip borders)
+*/
+bool deBayer_GRBG8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+bool deBayer_BGGR8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+inline bool deBayer_RGGB8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize);
+
+#endif

--- a/src/libYARP_sig/src/DeBayer.cpp
+++ b/src/libYARP_sig/src/DeBayer.cpp
@@ -1,0 +1,161 @@
+
+#include <yarp/sig/impl/DeBayer.h>
+#include <yarp/os/Log.h>
+
+bool deBayer_GRBG8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    yAssert((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_BGR) ||
+        (pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_BGRA))
+
+        dest.resize(source.width(), source.height());
+    // perform conversion, skip borders
+    for (int r = 0; r < source.height() - 2; r += 2)
+    {
+        unsigned char *destRow = dest.getRow(r);
+        unsigned char *sourceRowCurrent = source.getRow(r);
+        unsigned char *sourceRowNext = source.getRow(r + 1);
+
+        //row i GRGRGR...
+        for (int c = 0; c < dest.width() - 2; c += 2)
+        {
+            //source is on G pixel 
+            destRow[0] = sourceRowNext[0];       //blue
+            destRow[1] = sourceRowCurrent[0];    //green
+            destRow[2] = sourceRowCurrent[1];    //red
+
+            //jump a pixel in destination
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+
+            //source is now on R pixel
+            destRow[0] = sourceRowNext[0];         //blue
+            destRow[1] = sourceRowCurrent[1];     //green
+            destRow[2] = sourceRowCurrent[0];     //red
+
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+        }
+
+        destRow = dest.getRow(r + 1);
+        sourceRowCurrent = source.getRow(r + 1);
+        sourceRowNext = source.getRow(r + 2);
+
+        //row is now BGBGBG...
+        for (int c = 0; c < dest.width() - 2; c += 2)
+        {
+            //source is on B pixel 
+            destRow[0] = sourceRowCurrent[0];   //blue
+            destRow[1] = sourceRowCurrent[1];   //green
+            destRow[2] = sourceRowNext[1];;     //red
+
+            //jump a pixel in destination
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+
+            //source is now on G pixel
+            destRow[0] = sourceRowCurrent[1];    //blue
+            destRow[1] = sourceRowCurrent[0];    //green
+            destRow[2] = sourceRowNext[0];       //red
+
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+        }
+    }
+    return true;
+}
+
+bool deBayer_GRBG8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    yAssert((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_RGB) ||
+    (pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_RGBA))
+
+    dest.resize(source.width(), source.height());
+    // perform conversion, skip borders
+    for (int r = 0; r < source.height() - 2; r += 2)
+    {
+        unsigned char *destRow = dest.getRow(r);
+        unsigned char *sourceRowCurrent = source.getRow(r);
+        unsigned char *sourceRowNext = source.getRow(r + 1);
+
+        //row i GRGRGR...
+        for (int c = 0; c < source.width() - 2; c += 2)
+        {
+            //source is on G pixel 
+            destRow[0] = sourceRowCurrent[1];    //red
+            destRow[1] = sourceRowCurrent[0];    //green
+            destRow[2] = sourceRowNext[0];;     //blue
+
+            //jump a pixel in destination
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+
+            //source is now on R pixel
+            destRow[0] = sourceRowCurrent[0];     //red
+            destRow[1] = sourceRowCurrent[1];     //green
+            destRow[2] = sourceRowNext[0];        //red
+
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+        }
+
+        destRow = dest.getRow(r + 1);
+        sourceRowCurrent = source.getRow(r + 1);
+        sourceRowNext = source.getRow(r + 2);
+
+        //row is now BGBGBG...
+        for (int c = 0; c < dest.width() - 2; c += 2)
+        {
+            //source is on B pixel 
+            destRow[0] = sourceRowNext[1];      //red
+            destRow[1] = sourceRowCurrent[1];   //green
+            destRow[2] = sourceRowCurrent[0];   //blue
+
+            //jump a pixel in destination
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+
+            //source is now on G pixel
+            destRow[0] = sourceRowNext[0];     //red
+            destRow[1] = sourceRowCurrent[0];  //green
+            destRow[2] = sourceRowCurrent[1];  //blue
+
+            destRow += pixelSize;
+            sourceRowCurrent++;
+            sourceRowNext++;
+        }
+    }
+    return true;
+}
+
+bool deBayer_BGGR8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    YARP_FIXME_NOTIMPLEMENTED("convert_BGGR8_TO_RGB\n");
+    return false;
+}
+
+bool deBayer_RGGB8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    YARP_FIXME_NOTIMPLEMENTED("convert_RGGB8_TO_RGB\n");
+    return false;
+}
+
+bool deBayer_BGGR8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    YARP_FIXME_NOTIMPLEMENTED("convert_BGGR8_TO_BGR\n");
+    return false;
+}
+
+bool deBayer_RGGB8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
+{
+    YARP_FIXME_NOTIMPLEMENTED("convert_RGGB8_TO_BGR\n");
+    return false;
+}
+
+

--- a/src/libYARP_sig/src/DeBayer.cpp
+++ b/src/libYARP_sig/src/DeBayer.cpp
@@ -4,8 +4,8 @@
 
 bool deBayer_GRBG8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
 {
-    yAssert((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_BGR) ||
-        (pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_BGRA))
+    yAssert(((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_BGR)) ||
+        ((pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_BGRA)))
 
         dest.resize(source.width(), source.height());
     // perform conversion, skip borders
@@ -70,8 +70,8 @@ bool deBayer_GRBG8_TO_BGR(yarp::sig::Image &source, yarp::sig::Image &dest, int 
 
 bool deBayer_GRBG8_TO_RGB(yarp::sig::Image &source, yarp::sig::Image &dest, int pixelSize)
 {
-    yAssert((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_RGB) ||
-    (pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_RGBA))
+    yAssert(((pixelSize == 3) && (dest.getPixelCode() == VOCAB_PIXEL_RGB)) ||
+    ((pixelSize == 4 && dest.getPixelCode() == VOCAB_PIXEL_RGBA)))
 
     dest.resize(source.width(), source.height());
     // perform conversion, skip borders


### PR DESCRIPTION
implemented automatic debayering when reading a bayer channel from ROS; when reading from a ImageOf<PixelMono> no debayering is performed leaving freedom to the user to do what he prefers. If the channel is read from a color image it performs debayering. Current implementations are very basic and do nearest neighbor interpolation. Implemented only debayer from 8 bit GRBG to RGB, RGBA, BGR, BGRA. Better functions could be used, for example by taking from the Bayer Carrier.