### PR TITLE
Fix #650

### DIFF
--- a/src/libYARP_dev/src/modules/AnalogSensorClient/AnalogSensorClient.h
+++ b/src/libYARP_dev/src/modules/AnalogSensorClient/AnalogSensorClient.h
@@ -38,8 +38,7 @@ namespace yarp {
 }
 
 /**
-*  @ingroup yarp_dev_modules
-*  \defgroup analogsensorclient analogsensorclient
+*  @ingroup dev_impl_wrapper
 *
 * \section analogsensorclient_parameter Description of input parameters
 *


### PR DESCRIPTION
Fix the grouping of `analogSensorClient` documentation.