### PR TITLE
MonitorObject.h is now installed

### DIFF
--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -37,6 +37,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/ManagedBytes.h
                  include/yarp/os/MessageStack.h
                  include/yarp/os/ModifyingCarrier.h
+                 include/yarp/os/MonitorObject.h
                  include/yarp/os/MultiNameSpace.h
                  include/yarp/os/Mutex.h
                  include/yarp/os/Name.h

--- a/src/libYARP_OS/include/yarp/os/MonitorObject.h
+++ b/src/libYARP_OS/include/yarp/os/MonitorObject.h
@@ -56,7 +56,7 @@ public:
    
     /**
      * This will be called when one of the peer connections to the same import port receives data
-     * \Note this is available only if the portmonitor object attached to the input port
+     * @note this is available only if the portmonitor object attached to the input port
      */
     virtual void trig(void) { }
 
@@ -77,7 +77,7 @@ public:
      *
      * @param thing An instance of yarp::os::Thing object which can be used
      *        to typecast the data to the correct type. 
-     * @ return An instance of modified data in form of Thing
+     * @return An instance of modified data in form of Thing
      */
     virtual yarp::os::Things& update(yarp::os::Things& thing) { return thing; }
 
@@ -88,7 +88,7 @@ public:
      *
      * @param thing An instance of yarp::os::Thing object which can be used
      *        to typecast the data to the correct type.
-     * @ return An instance of modified data in form of Thing
+     * @return An instance of modified data in form of Thing
      */
     virtual yarp::os::Things& updateReply(yarp::os::Things& thing) { return thing; }
 };


### PR DESCRIPTION
Fixed a documentation issue on MonitorObject.h
**Rewrote header guard macro**

I put in bold the reason why I opened a PR.
In particular, as this [link](http://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier) states, macro starting with a single or double underscore are reserved.
I modified only one for now, but I think we should change also the others.

@drdanz @lornat75 @traversaro 