### PR TITLE
Fix logical ‘and’ of mutually exclusive tests is always false [-Wlogical-op] warnings

### DIFF
--- a/src/libYARP_sig/src/ImageFile.cpp
+++ b/src/libYARP_sig/src/ImageFile.cpp
@@ -200,24 +200,6 @@ static bool ReadHeader(FILE *fp, int *height, int *width, int *color)
             while (ch != '\n');
             ch = fgetc(fp);
         }
-    /*
-      while (ch=='\n' || ch=='\r')
-      {
-      ch = getc(fp);
-      }
-      ungetc(ch,fp);
-    */
-
-    while(ch<'0'&&ch>'9'&&ch!=-1)
-        {
-            ch = fgetc(fp);
-        }
-
-    if (ch<'0'&&ch>'9')
-        {
-            warn("cannot read header information from pgm/ppm file");
-            return false;
-        }
     ungetc(ch, fp);
 
     /// LATER: not portable?


### PR DESCRIPTION
This patch fixes these 2 logical operation warnings:

```
[ 26%] Building CXX object src/libYARP_sig/CMakeFiles/YARP_sig.dir/src/ImageFile.cpp.o
/opt/iit/src/yarp/src/libYARP_sig/src/ImageFile.cpp: In function ‘bool ReadHeader(FILE*, int*, int*, int*)’:
/opt/iit/src/yarp/src/libYARP_sig/src/ImageFile.cpp:211:17: warning: logical ‘and’ of mutually exclusive tests is always false [-Wlogical-op]
     while(ch<'0'&&ch>'9'&&ch!=-1)
                 ^
/opt/iit/src/yarp/src/libYARP_sig/src/ImageFile.cpp:216:15: warning: logical ‘and’ of mutually exclusive tests is always false [-Wlogical-op]
     if (ch<'0'&&ch>'9')
               ^
```

I *think* that the goal of the author was to jump at the first character that is a number, therefore this patch just fixes the warnings. The old conditions made it impossible to enter these 2 `if` blocks.

I don't know if this code is being used, but according to [raw PGM](http://netpbm.sourceforge.net/doc/pgm.html) (`P5`) and  [raw PPM] (http://netpbm.sourceforge.net/doc/ppm.html) (`P6`) documentation, only whitespace (blanks, TABs, CRs, LFs) can be after the `P5`/`P6` line, therefore I think that this whole block is useless, and perhaps should be removed. Opinions? Merge it like this or remove the blocks?





