### PR TITLE
Fix value C4717 warning

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Value.h
+++ b/src/libYARP_OS/include/yarp/os/Value.h
@@ -20,6 +20,9 @@ namespace yarp {
     namespace os {
         class Value;
         class Property;
+        namespace impl {
+            class Storable;
+        }
     }
 }
 
@@ -35,9 +38,9 @@ namespace yarp {
  */
 class YARP_OS_API yarp::os::Value : public Portable, public Searchable {
 private:
-    Value *proxy;
+    yarp::os::impl::Storable *proxy;
 
-    void setProxy(Value *proxy);
+    void setProxy(yarp::os::impl::Storable *proxy);
     void ok() const;
 
 

--- a/src/libYARP_OS/src/Value.cpp
+++ b/src/libYARP_OS/src/Value.cpp
@@ -10,7 +10,6 @@
 #include <yarp/os/Bottle.h>
 
 #include <yarp/os/impl/BottleImpl.h>
-#include <yarp/os/impl/Logger.h>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -28,11 +27,10 @@ Value::Value(int x, bool isVocab) :
         proxy(NULL)
 {
     if (!isVocab) {
-        setProxy(dynamic_cast<Storable*>(makeInt(x)));
+        setProxy(static_cast<Storable*>(makeInt(x)));
     } else {
-        setProxy(dynamic_cast<Storable*>(makeVocab(x)));
+        setProxy(static_cast<Storable*>(makeVocab(x)));
     }
-    yAssert(proxy != NULL);
 }
 
 Value::Value(double x) :
@@ -40,8 +38,7 @@ Value::Value(double x) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(dynamic_cast<Storable*>(makeDouble(x)));
-    yAssert(proxy != NULL);
+    setProxy(static_cast<Storable*>(makeDouble(x)));
 }
 
 Value::Value(const ConstString& str, bool isVocab) :
@@ -50,11 +47,10 @@ Value::Value(const ConstString& str, bool isVocab) :
         proxy(NULL)
 {
     if (!isVocab) {
-        setProxy(dynamic_cast<Storable*>(makeString(str)));
+        setProxy(static_cast<Storable*>(makeString(str)));
     } else {
-        setProxy(dynamic_cast<Storable*>(makeVocab(str)));
+        setProxy(static_cast<Storable*>(makeVocab(str)));
     }
-    yAssert(proxy != NULL);
 }
 
 Value::Value(void *data, int length) :
@@ -62,8 +58,7 @@ Value::Value(void *data, int length) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(dynamic_cast<Storable*>(makeBlob(data, length)));
-    yAssert(proxy != NULL);
+    setProxy(static_cast<Storable*>(makeBlob(data, length)));
 }
 
 Value::Value(const Value& alt) :
@@ -71,8 +66,7 @@ Value::Value(const Value& alt) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(dynamic_cast<Storable*>(alt.clone()));
-    yAssert(proxy != NULL);
+    setProxy(static_cast<Storable*>(alt.clone()));
 }
 
 
@@ -84,7 +78,7 @@ const Value& Value::operator=(const Value& alt)
                 // we are guaranteed to be a Storable
                 ((Storable*)this)->copy(*((Storable*)alt.proxy));
             } else {
-                setProxy(dynamic_cast<Storable*>(alt.clone()));
+                setProxy(static_cast<Storable*>(alt.clone()));
             }
         } else {
             if (alt.proxy) {
@@ -92,7 +86,7 @@ const Value& Value::operator=(const Value& alt)
                     // proxies are guaranteed to be Storable
                     ((Storable*)proxy)->copy(*((Storable*)alt.proxy));
                 } else {
-                    setProxy(dynamic_cast<Storable*>(alt.clone()));
+                    setProxy(static_cast<Storable*>(alt.clone()));
                 }
             } else {
                 if (proxy) {
@@ -100,7 +94,7 @@ const Value& Value::operator=(const Value& alt)
                     proxy = NULL;
                 }
                 if (alt.isLeaf()) {
-                    setProxy(dynamic_cast<Storable*>(alt.clone()));
+                    setProxy(static_cast<Storable*>(alt.clone()));
                 }
             }
         }
@@ -304,7 +298,7 @@ bool Value::operator!=(const Value& alt) const
 }
 
 void Value::fromString(const char *str) {
-    setProxy(dynamic_cast<Storable*>(makeValue(str)));
+    setProxy(static_cast<Storable*>(makeValue(str)));
 }
 
 ConstString Value::toString() const
@@ -418,7 +412,6 @@ void Value::setProxy(Storable *proxy)
         this->proxy = NULL;
     }
     this->proxy = proxy;
-    yAssert(this->proxy!=NULL);
 }
 
 
@@ -426,6 +419,6 @@ void Value::ok() const
 {
     const Value *op = this;
     if (proxy==NULL) {
-        ((Value*)op)->setProxy(dynamic_cast<Storable*>(makeList()));
+        ((Value*)op)->setProxy(static_cast<Storable*>(makeList()));
     }
 }

--- a/src/libYARP_OS/src/Value.cpp
+++ b/src/libYARP_OS/src/Value.cpp
@@ -1,5 +1,3 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
-
 /*
  * Copyright (C) 2006 RobotCub Consortium
  * Authors: Paul Fitzpatrick
@@ -8,10 +6,11 @@
  */
 
 
+#include <yarp/os/Value.h>
+#include <yarp/os/Bottle.h>
+
 #include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/Bottle.h>
-#include <yarp/os/Value.h>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -29,10 +28,11 @@ Value::Value(int x, bool isVocab) :
         proxy(NULL)
 {
     if (!isVocab) {
-        setProxy(makeInt(x));
+        setProxy(dynamic_cast<Storable*>(makeInt(x)));
     } else {
-        setProxy(makeVocab(x));
+        setProxy(dynamic_cast<Storable*>(makeVocab(x)));
     }
+    yAssert(proxy != NULL);
 }
 
 Value::Value(double x) :
@@ -40,7 +40,8 @@ Value::Value(double x) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(makeDouble(x));
+    setProxy(dynamic_cast<Storable*>(makeDouble(x)));
+    yAssert(proxy != NULL);
 }
 
 Value::Value(const ConstString& str, bool isVocab) :
@@ -49,10 +50,11 @@ Value::Value(const ConstString& str, bool isVocab) :
         proxy(NULL)
 {
     if (!isVocab) {
-        setProxy(makeString(str));
+        setProxy(dynamic_cast<Storable*>(makeString(str)));
     } else {
-        setProxy(makeVocab(str));
+        setProxy(dynamic_cast<Storable*>(makeVocab(str)));
     }
+    yAssert(proxy != NULL);
 }
 
 Value::Value(void *data, int length) :
@@ -60,7 +62,8 @@ Value::Value(void *data, int length) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(makeBlob(data, length));
+    setProxy(dynamic_cast<Storable*>(makeBlob(data, length)));
+    yAssert(proxy != NULL);
 }
 
 Value::Value(const Value& alt) :
@@ -68,7 +71,8 @@ Value::Value(const Value& alt) :
         Searchable(),
         proxy(NULL)
 {
-    setProxy(alt.clone());
+    setProxy(dynamic_cast<Storable*>(alt.clone()));
+    yAssert(proxy != NULL);
 }
 
 
@@ -80,7 +84,7 @@ const Value& Value::operator=(const Value& alt)
                 // we are guaranteed to be a Storable
                 ((Storable*)this)->copy(*((Storable*)alt.proxy));
             } else {
-                setProxy(alt.clone());
+                setProxy(dynamic_cast<Storable*>(alt.clone()));
             }
         } else {
             if (alt.proxy) {
@@ -88,7 +92,7 @@ const Value& Value::operator=(const Value& alt)
                     // proxies are guaranteed to be Storable
                     ((Storable*)proxy)->copy(*((Storable*)alt.proxy));
                 } else {
-                    setProxy(alt.clone());
+                    setProxy(dynamic_cast<Storable*>(alt.clone()));
                 }
             } else {
                 if (proxy) {
@@ -96,7 +100,7 @@ const Value& Value::operator=(const Value& alt)
                     proxy = NULL;
                 }
                 if (alt.isLeaf()) {
-                    setProxy(alt.clone());
+                    setProxy(dynamic_cast<Storable*>(alt.clone()));
                 }
             }
         }
@@ -300,7 +304,7 @@ bool Value::operator!=(const Value& alt) const
 }
 
 void Value::fromString(const char *str) {
-    setProxy(makeValue(str));
+    setProxy(dynamic_cast<Storable*>(makeValue(str)));
 }
 
 ConstString Value::toString() const
@@ -407,14 +411,14 @@ Value& Value::getNullValue()
 }
 
 
-void Value::setProxy(Value *proxy)
+void Value::setProxy(Storable *proxy)
 {
     if (this->proxy!=NULL) {
         delete this->proxy;
         this->proxy = NULL;
     }
-    yAssert(proxy!=NULL);
     this->proxy = proxy;
+    yAssert(this->proxy!=NULL);
 }
 
 
@@ -422,6 +426,6 @@ void Value::ok() const
 {
     const Value *op = this;
     if (proxy==NULL) {
-        ((Value*)op)->setProxy(makeList());
+        ((Value*)op)->setProxy(dynamic_cast<Storable*>(makeList()));
     }
 }

--- a/tests/libYARP_OS/ValueTest.cpp
+++ b/tests/libYARP_OS/ValueTest.cpp
@@ -139,12 +139,113 @@ public:
         }
     }
 
+    void checkEqualityOperator() {
+        report(0,"check equality operator");
+
+        {
+            Value v1(10);
+            Value v2(10);
+            checkTrue(v2.isInt(),"(ctor) type ok");
+            checkTrue((v1==v2), "(ctor) operator== ok");
+        }
+
+        {
+            Value v1(10);
+            Value v2(v1);
+            checkTrue(v2.isInt(),"(copy) type ok");
+            checkTrue((v1==v2), "(copy) operator== ok");
+        }
+
+        {
+            Value v1(10);
+            Value v2;
+            v2.fromString("10");
+            checkTrue(v2.isInt(),"(\"10\") type ok");
+            checkTrue((v1==v2), "(\"10\") operator== ok");
+
+            v2.fromString("15");
+            checkTrue(v2.isInt(),"(\"15\") type ok");
+            checkTrue((v1!=v2), "(\"15\") operator!= ok");
+
+            v2.fromString("10.0");
+            checkTrue(v2.isDouble(),"(\"10.0\") type ok");
+            checkTrue((v1!=v2), "(\"10.0\") operator!= ok"); // FIXME why not?
+            checkTrue((v1.asInt()==v2.asInt()), "(\"10.0\") value ok");
+
+            v2.fromString("(10)");
+            checkTrue(v2.isList(),"(\"(10)\") type ok");
+            checkTrue((v1==v2), "(\"(10)\") operator== ok");
+
+            v2.fromString("(15)");
+            checkTrue(v2.isList(),"(\"(15)\") type ok");
+            checkTrue((v1!=v2), "(\"(15)\") operator!= ok");
+
+            v2.fromString("(10 15)");
+            checkTrue(v2.isList(),"(\"(10 15)\") type ok");
+            checkTrue((v1!=v2), "(\"(10 15)\") operator!= ok");
+            checkTrue((v1==v2.asList()->get(0)), "(\"(10 15)\") value ok");
+
+            v2.fromString("(10.0)");
+            checkTrue(v2.isList(),"(\"(10.0)\") type ok");
+            checkTrue((v1!=v2), "(\"(10.0)\") operator!= ok");
+            checkTrue((v1!=v2.asList()->get(0)), "(\"(10.0)\") value ok");  // FIXME why not?
+            checkTrue((v1==v2.asList()->get(0).asInt()), "(\"(10.0)\") value ok");
+
+            v2.fromString("\"10\"");
+            checkTrue(v2.isString(),"(\"\\\"10\\\"\") type ok");
+            checkTrue((v1==v2), "(\"\\\"10\\\"\") operator== ok");
+
+            v2.fromString("\"ten\"");
+            checkTrue(v2.isString(),"(\"ten\") type ok");
+            checkTrue((v1!=v2), "(\"ten\") operator!= ok");
+
+            v2.fromString("true");
+            checkTrue(v2.isBool(),"(\"true\") type ok");
+            checkTrue((v1!=v2), "(\"true\") operator!= ok");
+        }
+
+        {
+            Value v1(10);
+            Bottle b1;
+            b1.addInt64(10);
+            Value v2 = b1.get(0);
+            checkTrue(v2.isInt64(),"(int64) type ok");
+            checkTrue((v1==v2), "(int64) operator!= ok");
+        }
+
+        {
+            Value v1(10);
+            Value v2(10, true);
+            checkTrue(v2.isVocab(),"(vocab) type ok");
+            checkTrue((v1!=v2), "(vocab) operator!= ok");
+        }
+
+        {
+            Value v1(10);
+            int i = 10;
+            Value v2(&i, sizeof(int));
+            checkTrue(v2.isBlob(),"(blob) type ok");
+            checkTrue((v1!=v2), "(blob) operator!= ok");
+            checkTrue((v1==*(reinterpret_cast<const int*>(v2.asBlob()))), "(blob) value ok");
+        }
+
+        {
+            Value v1(15);
+            int i = 10;
+            Value v2(&i, sizeof(int));
+            checkTrue(v2.isBlob(),"(blob) type ok");
+            checkTrue((v1!=v2), "(blob) operator!= ok");
+            checkTrue((v1!=*(reinterpret_cast<const int*>(v2.asBlob()))), "(blob) value ok");
+        }
+    }
+
     virtual void runTests() {
         checkCopy();
         checkMixedCopy();
         checkReadWrite();
         checkAssignment();
         checkInt64();
+        checkEqualityOperator();
     }
 };
 


### PR DESCRIPTION
warning C4717: 'yarp::os::Value::operator==' : recursive on all control
paths, function will cause runtime stack overflow

This warning was introduced by ef31735

Use a ``yarp::os::impl::Storable`` instead of another ``Value`` as proxy. The proxy was already guaranteed to be a Storable (i.e. a class derived by ``Value``), but it was saved as a ``Value`` pointer, probably to hide the existence of the ``Storable`` class.
The ``Storable`` is nonetheless hidden, since it just needs to be forward-declared in the class declaration.
At some point it should disappear again, and should be hidden using the PIMPL idiom.

This change simplifies a lot understanding how the ``Value`` class works.


I also added some unit tests to check the ``Value::operator==()`` operator


CC @pattacini 