### PR TITLE
[yarpdatadumper] Add small python helper script to yarpdatadumper

### DIFF
--- a/conf/YarpInstallationHelpers.cmake
+++ b/conf/YarpInstallationHelpers.cmake
@@ -341,8 +341,8 @@ macro(YARP_INSTALL _what)
   if("${_what}" STREQUAL "FILES" OR
      "${_what}" STREQUAL "DIRECTORY" OR
      "${_what}" STREQUAL "PROGRAMS")
-     
-    # TODO FIXME : this should be properly implemented by copying the files at build time using cmake generator expression 
+
+    # TODO FIXME : this should be properly implemented by copying the files at build time using cmake generator expression
     # In a multiple config generator while installing PROGRAMS we need to copy the specified program in multipled directories
     if("${_what}" STREQUAL "PROGRAMS" AND CMAKE_CONFIGURATION_TYPES)
       set(_YI_DESTINATION_LIST)
@@ -355,7 +355,7 @@ macro(YARP_INSTALL _what)
       set(_YI_DESTINATION_LIST)
       list(APPEND _YI_DESTINATION_LIST ${_YI_DESTINATION})
     endif()
-    
+
     foreach(_YI_DESTINATION_CURRENT ${_YI_DESTINATION_LIST})
       # Change DESTINATION argument 'dest' to "${CMAKE_BINARY_DIR}/${dest}"
       string(REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}/" "" _YI_DESTINATION_RELATIVE ${_YI_DESTINATION_CURRENT})

--- a/conf/YarpInstallationHelpers.cmake
+++ b/conf/YarpInstallationHelpers.cmake
@@ -341,23 +341,39 @@ macro(YARP_INSTALL _what)
   if("${_what}" STREQUAL "FILES" OR
      "${_what}" STREQUAL "DIRECTORY" OR
      "${_what}" STREQUAL "PROGRAMS")
-
-    # Change DESTINATION argument 'dest' to "${CMAKE_BINARY_DIR}/${dest}"
-    string(REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}/" "" _YI_DESTINATION_RELATIVE ${_YI_DESTINATION})
-    string(REGEX REPLACE ";DESTINATION;${_YI_DESTINATION}(;|$)" ";DESTINATION;${CMAKE_BINARY_DIR}/${_YI_DESTINATION_RELATIVE}\\1" _copyARGN "${ARGN}")
-
-    # Remove COMPONENT argument
-    string(REGEX REPLACE ";COMPONENT;${_YI_COMPONENT}" "" _copyARGN "${_copyARGN}")
-
-    # Fix PERMISSION argument
-    if ("${_what}" STREQUAL "PROGRAMS" AND NOT DEFINED _YI_PERMISSIONS)
-      list(APPEND _copyARGN "FILE_PERMISSIONS;OWNER_READ;OWNER_WRITE;OWNER_EXECUTE;GROUP_READ;GROUP_EXECUTE;WORLD_READ;WORLD_EXECUTE")
+     
+    # TODO FIXME : this should be properly implemented by copying the files at build time using cmake generator expression 
+    # In a multiple config generator while installing PROGRAMS we need to copy the specified program in multipled directories
+    if("${_what}" STREQUAL "PROGRAMS" AND CMAKE_CONFIGURATION_TYPES)
+      set(_YI_DESTINATION_LIST)
+      foreach(_config ${CMAKE_CONFIGURATION_TYPES})
+        string(TOUPPER ${_config} _CONFIG)
+        list(APPEND _YI_DESTINATION_LIST ${_YI_DESTINATION}/${_config})
+      endforeach()
     else()
-      string(REGEX REPLACE ";PERMISSIONS;" ";FILE_PERMISSIONS;" _copyARGN "${_copyARGN}")
+      # In all other cases we just need to copy the files in just one directories
+      set(_YI_DESTINATION_LIST)
+      list(APPEND _YI_DESTINATION_LIST ${_YI_DESTINATION})
     endif()
+    
+    foreach(_YI_DESTINATION_CURRENT ${_YI_DESTINATION_LIST})
+      # Change DESTINATION argument 'dest' to "${CMAKE_BINARY_DIR}/${dest}"
+      string(REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}/" "" _YI_DESTINATION_RELATIVE ${_YI_DESTINATION_CURRENT})
+      string(REGEX REPLACE ";DESTINATION;${_YI_DESTINATION}(;|$)" ";DESTINATION;${CMAKE_BINARY_DIR}/${_YI_DESTINATION_RELATIVE}\\1" _copyARGN "${ARGN}")
 
-    # Perform the copy
-    file(COPY ${_copyARGN})
+      # Remove COMPONENT argument
+      string(REGEX REPLACE ";COMPONENT;${_YI_COMPONENT}" "" _copyARGN "${_copyARGN}")
+
+      # Fix PERMISSION argument
+      if ("${_what}" STREQUAL "PROGRAMS" AND NOT DEFINED _YI_PERMISSIONS)
+        list(APPEND _copyARGN "FILE_PERMISSIONS;OWNER_READ;OWNER_WRITE;OWNER_EXECUTE;GROUP_READ;GROUP_EXECUTE;WORLD_READ;WORLD_EXECUTE")
+      else()
+        string(REGEX REPLACE ";PERMISSIONS;" ";FILE_PERMISSIONS;" _copyARGN "${_copyARGN}")
+      endif()
+
+      # Perform the copy
+      file(COPY ${_copyARGN})
+    endforeach()
 
     # Perform the real installation
     install(${_what} ${_YI_${_what}} ${_installARGN})

--- a/doc/yarpdatadumper.dox
+++ b/doc/yarpdatadumper.dox
@@ -102,7 +102,7 @@ by the \ref yarpdatadumper.
   provided.
 
 --connect \e portname
-- The parameter \e portname specifies the name of the port to 
+- The parameter \e portname specifies the name of the port to
   connect the dumper to at launch time (\e tcp is used).
 
 --dir \e dirname
@@ -214,6 +214,57 @@ the acquisition will start.
 By pressing CTRL+C the acquisition is terminated.
 
 So, now, have a look inside the directory ./log
+
+\section application_sec Generate a yarpmanager application
+
+To dump data from several yarp ports, it may be convenient
+to launch several yarpdatadumper instances using the yarpmanager.
+
+If you have Python installed on your machine, you can use the
+yarpdatadumperAppGenerator.py utility script to generate a yarpmanager
+application that will launch and connect as many yarpdatadumper as you need.
+
+If for example you need to read the ports /icub/left_leg/stateExt:o and
+/icub/left_leg/analog:o on the host icub15, you can run the generator
+with the following option:
+
+\code
+yarpdatadumperAppGenerator.py  --ports /icub/left_leg/analog:o /icub/left_leg/stateExt:o  --host icub15 --name leftLegDumper
+\endcode
+
+This will generate the following yarpmanager application in the leftLegDumper.xml file:
+
+\code
+<application>
+    <name>leftLegDumper</name>
+    <dependencies>
+        <port>/icub/left_leg/analog:o</port>
+        <port>/icub/left_leg/stateExt:o</port>
+    </dependencies>
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icub/left_leg/analog:o --type bottle </parameters>
+        <node>icub15</node>
+        <tag>data-dumper-icub-left_leg-analog-o</tag>
+    </module>
+    <connection>
+        <from>/icub/left_leg/analog:o</from>
+        <to>/dumper/icub/left_leg/analog:o</to>
+        <protocol>udp</protocol>
+    </connection>
+    <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /dumper/icub/left_leg/stateExt:o --type bottle </parameters>
+        <node>icub15</node>
+        <tag>data-dumper-icub-left_leg-stateExt-o</tag>
+    </module>
+    <connection>
+        <from>/icub/left_leg/stateExt:o</from>
+        <to>/dumper/icub/left_leg/stateExt:o</to>
+        <protocol>udp</protocol>
+    </connection>
+</application>
+\endcode
 
 \author Ugo Pattacini
 

--- a/src/yarpdatadumper/CMakeLists.txt
+++ b/src/yarpdatadumper/CMakeLists.txt
@@ -36,14 +36,9 @@ if(CREATE_YARPDATADUMPER)
           COMPONENT utilities
           DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-   # install also the yarpdatadumperAppGenerator.py helper script
-   # if python is installed
-   find_package(PythonInterp)
-
-   if(PYTHONINTERP_FOUND)
-      yarp_install(PROGRAMS yarpdatadumperAppGenerator.py
-                   COMPONENT utilities
-                   DESTINATION ${CMAKE_INSTALL_BINDIR})
-   endif()
+   # install the yarpdatadumperAppGenerator.py helper script
+   yarp_install(PROGRAMS yarpdatadumperAppGenerator.py
+                COMPONENT utilities
+                DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 endif()

--- a/src/yarpdatadumper/CMakeLists.txt
+++ b/src/yarpdatadumper/CMakeLists.txt
@@ -35,4 +35,15 @@ if(CREATE_YARPDATADUMPER)
   install(TARGETS yarpdatadumper
           COMPONENT utilities
           DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+   # install also the yarpdatadumperAppGenerator.py helper script
+   # if python is installed
+   find_package(PythonInterp)
+
+   if(PYTHONINTERP_FOUND)
+      yarp_install(PROGRAMS yarpdatadumperAppGenerator.py
+                   COMPONENT utilities
+                   DESTINATION ${CMAKE_INSTALL_BINDIR})
+   endif()
+
 endif()

--- a/src/yarpdatadumper/yarpdatadumperAppGenerator.py
+++ b/src/yarpdatadumper/yarpdatadumperAppGenerator.py
@@ -9,7 +9,6 @@ def printPortTags(out_file, ports, port_type, host, additional_flags):
         out_file.write("\t\t<name>yarpdatadumper</name>\n");
         out_file.write("\t\t<parameters>--name /dumper"+port+" --type "+port_type+" "+additional_flags+"</parameters>\n");
         out_file.write("\t\t<node>"+host+"</node>\n");
-        out_file.write("\t\t<tag>data-dumper"+port.replace('/','-').replace(':','-')+"</tag>\n");
         out_file.write("\t</module>\n");
 
         # print connection between datadumper and port

--- a/src/yarpdatadumper/yarpdatadumperAppGenerator.py
+++ b/src/yarpdatadumper/yarpdatadumperAppGenerator.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+import argparse
+
+def printPortTags(out_file, ports, port_type, host, additional_flags):
+    for port in ports:
+        # print datadumper launch
+        out_file.write("\t<module>\n");
+        out_file.write("\t\t<name>yarpdatadumper</name>\n");
+        out_file.write("\t\t<parameters>--name /dumper"+port+" --type "+port_type+" "+additional_flags+"</parameters>\n");
+        out_file.write("\t\t<node>"+host+"</node>\n");
+        out_file.write("\t\t<tag>data-dumper"+port.replace('/','-').replace(':','-')+"</tag>\n");
+        out_file.write("\t</module>\n");
+
+        # print connection between datadumper and port
+        out_file.write("\t<connection>\n");
+        out_file.write("\t\t<from>"+port+"</from>\n");
+        out_file.write("\t\t<to>/dumper"+port+"</to>\n");
+        out_file.write("\t\t<protocol>udp</protocol>\n");
+        out_file.write("\t</connection>\n");
+
+def main():
+    parser = argparse.ArgumentParser(description='Tool for generating a YarpManager XML application for dumping a list of YARP ports using the yarpdatadumper.')
+    parser.add_argument('--ports', nargs='+', dest="ports", action='store', required=True, help='list of ports (serializable to bottles) to dump')
+    parser.add_argument('--imagePorts', nargs='+', dest="imagePorts", action='store', help='list of ports (of to dump')
+    parser.add_argument('--host', nargs=1,  dest="host", action='store', required=True, help='host where to launch the dataDumpers')
+    parser.add_argument('--name', nargs=1,  dest="name", action='store', required=True, help='name of the application, the file will be saved as name.xml')
+    parser.add_argument('--rxTime', action='store_true',help='pass --rxTime flag to the yarpdatadumpers')
+    parser.add_argument('--txTime', action='store_true',help='pass --txTime flag to the yarpdatadumpers')
+    parser.add_argument('--addVideo', action='store_true',help='pass --addVideo flag to the yarpdatadumpers')
+    args = parser.parse_args()
+
+    # open output file
+    filename = args.name[0] + ".xml";
+    out_file = open(filename,"w")
+
+    out_file.write("<application>\n");
+    out_file.write("\t<name>"+args.name[0]+"</name>\n");
+    out_file.write("\t<dependencies>\n");
+    for port in args.ports:
+        out_file.write("\t\t<port>"+port+"</port>\n");
+    out_file.write("\t</dependencies>\n");
+
+    additional_flags = "";
+    if(args.rxTime):
+        additional_flags += " --rxTime";
+    if(args.txTime):
+        additional_flags += " --txTime";
+    if(args.addVideo):
+        additional_flags += " --addVideo";
+
+    if( args.ports is not None):
+        printPortTags(out_file,args.ports,"bottle",args.host[0],additional_flags);
+    if( args.imagePorts is not None):
+        printPortTags(out_file,args.imagePorts,"image",args.host[0],additional_flags);
+
+    out_file.write("</application>\n");
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Script to automatically generate yarpmanager applications.
It is installed only if python is found in the OS.
It should run fine also on Windows, but I did not test it.
Documentation of yarpdatadumper was also updated.

I don't know what is the policy for python scripts in yarp, but this script is definitely useful and it may be helpful for all yarp users, feel free to reject PR if we prefer not to pollute yarp with script in interpreted languages. @drdanz 

Script for helping @fjandrad data collection.

