### PR TITLE
fix race condition leading to segfault when closing yarp read (#680).…

### DIFF
--- a/src/libYARP_OS/src/Companion.cpp
+++ b/src/libYARP_OS/src/Companion.cpp
@@ -171,9 +171,6 @@ static void companion_sigint_handler(int sig) {
         }
         if (port!=NULL) {
             port->interrupt();
-#ifndef YARP2_WINDOWS
-            port->close();
-#endif
         }
     } else {
         fprintf(stderr,"Aborting...\n");


### PR DESCRIPTION
… The sig handler should not touch the port after it has called interrupt because the port (a pointer to BottleReader::core) will be deleted when BottleReader goes out of scope (at the end of int Companion::read(). To trigger deterministically add a delay after calling interrupt() in the signal handler and a significantly longer delay in cmdRead() before returning from read().