### PR TITLE
attaching portmonitor plug-ins directly to the port using Yarp admin commands

### DIFF
--- a/src/carriers/portmonitor_carrier/PortMonitor.h
+++ b/src/carriers/portmonitor_carrier/PortMonitor.h
@@ -86,7 +86,8 @@ public:
     }
 
     virtual bool configure(yarp::os::ConnectionState& proto);
-    
+    virtual bool configureFromProperty(yarp::os::Property& options);
+
     //virtual bool modifiesIncomingData();
     virtual bool acceptIncomingData(yarp::os::ConnectionReader& reader);
 

--- a/src/libYARP_OS/include/yarp/os/Carrier.h
+++ b/src/libYARP_OS/include/yarp/os/Carrier.h
@@ -461,6 +461,10 @@ public:
         return true;
     }
 
+    virtual bool configureFromProperty(yarp::os::Property& options) {
+        return true;
+    }
+
     /**
      * Configure carrier from port administrative commands.
      *

--- a/src/libYARP_OS/include/yarp/os/ModifyingCarrier.h
+++ b/src/libYARP_OS/include/yarp/os/ModifyingCarrier.h
@@ -35,7 +35,7 @@ public:
     virtual bool modifiesReply();
     virtual void setCarrierParams(const yarp::os::Property& params);
     virtual void getCarrierParams(yarp::os::Property& params);
-
+    virtual bool configureFromProperty(yarp::os::Property& prop);
     // only remains to implement modifyIncomingData()
 };
 

--- a/src/libYARP_OS/src/ModifyingCarrier.cpp
+++ b/src/libYARP_OS/src/ModifyingCarrier.cpp
@@ -44,3 +44,7 @@ void yarp::os::ModifyingCarrier::setCarrierParams(const yarp::os::Property &para
 
 void yarp::os::ModifyingCarrier::getCarrierParams(yarp::os::Property &params) {
 }
+
+bool yarp::os::ModifyingCarrier::configureFromProperty(yarp::os::Property& prop) {
+    return false;
+}

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -1306,6 +1306,9 @@ public:
     virtual bool configure(ConnectionState& proto) {
         return getContent().configure(proto);
     }
+    virtual bool configureFromProperty(yarp::os::Property& options) {
+        return getContent().configureFromProperty(options);
+    }
 };
 
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1613,10 +1613,6 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
             }
             break;
             case VOCAB2('i','n'): {
-                result.clear();
-                result.addVocab(Vocab::encode("fail"));
-                result.addString("attaching plug-in at input port is not supported!");
-                /*
                 String propString = cmd.get(2).asString().c_str();
                 Property prop(propString.c_str());
                 String errMsg;
@@ -1628,8 +1624,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                 else {
                     result.clear();
                     result.addVocab(Vocab::encode("ok"));
-                }
-                */
+                }                
             }
             break;
             default:

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -254,6 +254,8 @@ void PortCore::close() {
         delete prop;
         prop = NULL;
     }
+    modifier.releaseOutModifier();
+    modifier.releaseInModifier();
 }
 
 
@@ -1237,6 +1239,18 @@ bool PortCore::readBlock(ConnectionReader& reader, void *id, OutputStream *os) {
 
 bool PortCore::send(PortWriter& writer, PortReader *reader,
                     PortWriter *callback) {
+    // check if there is any modifier
+    // we need to protect this part while the modifier
+    // plugin is loading or unloading!
+    modifier.outputMutex.lock();
+    if(modifier.outputModifier) {
+        if(!modifier.outputModifier->acceptOutgoingData(writer)) {
+            modifier.outputMutex.unlock();
+            return false;
+        }
+        modifier.outputModifier->modifyOutgoingData(writer);
+    }
+    modifier.outputMutex.unlock();
     if (!logNeeded) {
         return sendHelper(writer,PORTCORE_SEND_NORMAL,reader,callback);
     }
@@ -1550,6 +1564,12 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
         result.addString("[prop] [set] $portname  # set Qos properies of a connection to/from a port");
         result.addString("[prop] [get] $cur_port  # get information about current process (e.g., scheduling priority, pid)");
         result.addString("[prop] [set] $cur_port  # set properties of the current process (e.g., scheduling priority, pid)");
+        result.addString("[atch] [out] $prop      # attach a portmonitor plug-in to the port's output");
+        result.addString("[atch] [in]  $prop      # attach a portmonitor plug-in to the port's input");
+        result.addString("[dtch] [out]            # detach portmonitor plug-in from the port's output");
+        result.addString("[dtch] [in]             # detach portmonitor plug-in from the port's input");
+        //result.addString("[atch] $portname $prop  # attach a portmonitor plug-in to the connection to/from $portname");
+        //result.addString("[dtch] $portname        # detach any portmonitor plug-in from the connection to/from $portname");
         break;
     case VOCAB3('v','e','r'):
         // Gives a version number for the administrative commands.
@@ -1572,6 +1592,75 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
             int v = (r[0]=='A')?0:-1;
             result.addInt(v);
             result.addString(r.c_str());
+        }
+        break;
+    case VOCAB4('a','t','c', 'h'):
+        {
+            switch (cmd.get(1).asVocab()) {
+            case VOCAB3('o','u', 't'): {
+                String propString = cmd.get(2).asString().c_str();
+                Property prop(propString.c_str());
+                String errMsg;
+                if(!attachPortMonitor(prop, true, errMsg)) {
+                    result.clear();
+                    result.addVocab(Vocab::encode("fail"));
+                    result.addString(errMsg.c_str());
+                }
+                else {
+                    result.clear();
+                    result.addVocab(Vocab::encode("ok"));
+                }
+            }
+            break;
+            case VOCAB2('i','n'): {
+                result.clear();
+                result.addVocab(Vocab::encode("fail"));
+                result.addString("attaching plug-in at input port is not supported!");
+                /*
+                String propString = cmd.get(2).asString().c_str();
+                Property prop(propString.c_str());
+                String errMsg;
+                if(!attachPortMonitor(prop, false, errMsg)) {
+                    result.clear();
+                    result.addVocab(Vocab::encode("fail"));
+                    result.addString(errMsg.c_str());
+                }
+                else {
+                    result.clear();
+                    result.addVocab(Vocab::encode("ok"));
+                }
+                */
+            }
+            break;
+            default:
+                result.clear();
+                result.addVocab(Vocab::encode("fail"));
+                result.addString("attach command must be followd by [out] or [in]");
+            };
+        }
+        break;
+    case VOCAB4('d','t','c', 'h'):
+        {
+            switch (cmd.get(1).asVocab()) {
+            case VOCAB3('o','u', 't'): {                
+                if(dettachPortMonitor(true))
+                    result.addVocab(Vocab::encode("ok"));
+                else
+                    result.addVocab(Vocab::encode("fail"));
+            }
+            break;
+            case VOCAB2('i','n'): {
+                if(dettachPortMonitor(false))
+                    result.addVocab(Vocab::encode("ok"));
+                else
+                    result.addVocab(Vocab::encode("fail"));
+            }
+            break;
+            default:
+                result.clear();
+                result.addVocab(Vocab::encode("fail"));
+                result.addString("dettach command must be followd by [out] or [in]");
+            };
         }
         break;
     case VOCAB3('d','e','l'):
@@ -2259,6 +2348,67 @@ int PortCore::getTypeOfService(PortCoreUnit *unit) {
             return ip->getOutput().getOutputStream().getTypeOfService();
     }
     return -1;
+}
+
+// attach a portmonitor plugin to the port or to a specific connection
+bool PortCore::attachPortMonitor(yarp::os::Property& prop, bool isOutput, String &errMsg) {
+    // attach to the current port
+    Carrier *portmonitor = Carriers::chooseCarrier("portmonitor");
+    if(!portmonitor) {
+        errMsg = "Portmonitor carrier modifier cannot be find or it is not enabled in Yarp!";
+        return false;
+    }
+
+    if(isOutput) {
+        dettachPortMonitor(true);
+        prop.put("source", getName());
+        prop.put("destination", "");
+        prop.put("sender_side", 1);
+        prop.put("receiver_side", 0);
+        prop.put("carrier", "");
+        modifier.outputMutex.lock();
+        modifier.outputModifier = portmonitor;
+        if(!modifier.outputModifier->configureFromProperty(prop)) {
+            modifier.releaseOutModifier();
+            errMsg = "Failed to configure the portmonitor plug-in";
+            modifier.outputMutex.unlock();
+            return false;
+        }
+        modifier.outputMutex.unlock();
+    }
+    else {
+        dettachPortMonitor(false);
+        prop.put("source", "");
+        prop.put("destination", getName());
+        prop.put("sender_side", 0);
+        prop.put("receiver_side", 1);
+        prop.put("carrier", "");
+        modifier.inputMutex.lock();
+        modifier.inputModifier = portmonitor;
+        if(!modifier.inputModifier->configureFromProperty(prop)) {
+            modifier.releaseInModifier();
+            errMsg = "Failed to configure the portmonitor plug-in";
+            modifier.inputMutex.unlock();
+            return false;
+        }
+        modifier.inputMutex.unlock();
+    }
+    return true;
+}
+
+// detach the portmonitor from the port or specific connection
+bool PortCore::dettachPortMonitor(bool isOutput) {
+    if(isOutput) {
+        modifier.outputMutex.lock();
+        modifier.releaseOutModifier();
+        modifier.outputMutex.unlock();
+    }
+    else {
+        modifier.inputMutex.lock();
+        modifier.releaseInModifier();
+        modifier.inputMutex.unlock();
+    }
+    return true;
 }
 
 void PortCore::reportUnit(PortCoreUnit *unit, bool active) {


### PR DESCRIPTION
**This pull-request allows attaching directly a pmonitor plug-in to a Yarp port.**

Motivation
-------------
 Up to now, a portmonitor plug-in could be attach to a specific connection either in the sender or receiver side. This could be useful if the user is interested in filtering/modifying data only within a specific connection. However, if the result of a plug-in is needed to be used by two different modules, the plug-in must be replicated twice for each connection. Thus it would be useful to have the plug-in attached directly to a port which process the outgoing data from the port before passing it to the connection's carriers. 

Usage
--------
Plug-ins (written in C++ or Lua) can be directly attached to a port using the Yarp admin port's commands. See the example below: 

|          sender         |      receiver 1      |      receiver 2       |
| ---------------------- | ----------------------| ----------------------|
| `$ yarp write /w`   |  `$ yarp read /r1` |  `$ yarp read /r2` |

```
$ yarp connect /w /r1
$ yarp connect /w /r2
```
```
$ yarp admin rpc /w
>> atch out "(type lua) (context monitors) (file bot_modifier.lua)"
Response: [ok]
>>
```
Now if you write something in the sender terminal, the corresponding message is modified by the `bot_modifier.lua` plugin and is handed to bother receivers. 

To remove the plug-in, in the yarp admin terminal simply type: 
```
$ yarp admin rpc /w
>> dtch out
```
Available commands: 
```
[atch] [out] $prop      # attach a portmonitor plug-in to the port's output
[atch] [in]  $prop      # attach a portmonitor plug-in to the port's input
[dtch] [out]            # detach portmonitor plug-in from the port's output
[dtch] [in]             # detach portmonitor plug-in from the port's input
```
Q&A
------

- What are the dependencies and what if the portmonitor carrier is not enabled in YARP? 
 Well. The implementation leverages `yarp::os::Carriers::chooseCarrier` method to look for the portmonitor plug-in at the run time. Nothing for the portmonitor's implementation is directly included in the Yarp PortCore. If the portmonitor carrier is not found, an informative message will be returned. 

- Can I attach a plug-in to the input port? 
 Yes.  Since Yarp ports are bidirectional (can be simultaneously read and write), you need to specify that in which  direction the plug-in should modify the data. To attach a plug-in to an input port, you need to send the `atch in <parameter>` admin command to the corresponding port. 

- What happen if i have a plug-in at the port and one on the connection? 
 Nothing strange! the plug-ins are chained in this case. The data will be processed by both of them. The order is as bellow: 

```
Port.write() -> [port out plug-in] -> [carrier sender plug-in]    ------->
Port.read() <- [port in plug-in]  <-  [carrier receiver plug-in]  <-------                                                                                                      
```

TODO
--------
- Adding a command to the yarp companions. e.g., `yarp attach <param>` and `yarp detach <param>`. We need to agree on the syntax!

- Adding portmonitor to the import port is disabled in this commit since it needs further reliability tests.   

- This commit should be eventually merged  with the `portmonitor_plugins` branch which allows loading the portmonitor C++  (dll) plug-ins using YARP plug-in manager. 
 