### PR TITLE
OpenNI2: Individual mirroring options for depth and RGB streams (thanks    to Juan Victores for the corrections)

### DIFF
--- a/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.cpp
@@ -127,10 +127,16 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config) {
         colorON = true;
     }
 
-    if(config.check("noMirror", "Disable mirroring")) {
-        mirrorON = false;
+    if(config.check("noRGBMirror", "enable RGB  mirroring")) {
+        rgbMirrorON = false;
     } else {
-        mirrorON = true;
+        rgbMirrorON = true;
+    }
+
+    if(config.check("noDepthMirror", "enable depth mirroring")) {
+        depthMirrorON = false;
+    } else {
+        depthMirrorON = true;
     }
 
     if(config.check("noUserTracking", "Disable user tracking")) {
@@ -205,7 +211,7 @@ bool yarp::dev::OpenNI2DeviceDriverServer::open(yarp::os::Searchable& config) {
         imageRegistration = false;
     }
 
-    skeleton = new OpenNI2SkeletonTracker(userTracking, colorON, mirrorON, mConf, oniPlayback, fileDevice, oniRecord, oniOutputFile, loop, frameSync, imageRegistration, printMode, dMode, cMode);
+    skeleton = new OpenNI2SkeletonTracker(userTracking, colorON, rgbMirrorON, depthMirrorON, mConf, oniPlayback, fileDevice, oniRecord, oniOutputFile, loop, frameSync, imageRegistration, printMode, dMode, cMode);
 
     if (skeleton->getDeviceStatus() == 0) {
         cout << "OpenNI2 Yarp Device started." << endl;

--- a/src/modules/openni2/OpenNI2DeviceDriverServer.h
+++ b/src/modules/openni2/OpenNI2DeviceDriverServer.h
@@ -81,7 +81,7 @@ private:
     BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono16> > *depthFramePort;
     BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > *imageFramePort;
     OpenNI2SkeletonTracker *skeleton;
-    bool withOpenPorts, userTracking, colorON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration;
+    bool withOpenPorts, userTracking, colorON, depthMirrorON, rgbMirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration;
     string fileDevice;
     string oniOutputFile;
 

--- a/src/modules/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.cpp
@@ -12,11 +12,12 @@
 
 OpenNI2SkeletonTracker::SensorStatus *OpenNI2SkeletonTracker::sensorStatus;
 
-OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withColorOn, bool withMirrorOn, double minConf, bool withOniPlayback, string withFileDevice, bool withOniRecord, string withOniOutputFile, bool withLoop, bool withFrameSync, bool withImageRegistration, bool prMode, int depthMode, int colorMode)
+OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withColorOn, bool withRgbMirrorOn, bool withDepthMirrorOn, double minConf, bool withOniPlayback, string withFileDevice, bool withOniRecord, string withOniOutputFile, bool withLoop, bool withFrameSync, bool withImageRegistration, bool prMode, int depthMode, int colorMode)
 {
     userTracking= withTracking;
     colorON = withColorOn;
-    mirrorON = withMirrorOn;
+    rgbMirrorON = withRgbMirrorOn;
+    depthMirrorON = withDepthMirrorOn;
     colorVideoMode=DEFAULT_COLOR_MODE;
     depthVideoMode=DEFAULT_DEPTH_MODE;
     
@@ -174,6 +175,29 @@ int OpenNI2SkeletonTracker::init(){
             {
                 depthStream.setVideoMode(depthModes[depthVideoMode]);
             }
+
+            // If not playback, set depth mirroring (default: off)
+            if (!oniPlayback) 
+            {   
+                depthStream.setMirroringEnabled(depthMirrorON);
+                bool dMirror = depthStream.getMirroringEnabled();
+                
+                if (!dMirror && depthMirrorON) 
+                {
+                    cout << "WARNING: Could not turn on mirroring for depth stream" << endl;
+                }
+                    
+                else if (dMirror && depthMirrorON)
+                {
+                    cout << "Depth stream mirroring: ON" << endl;
+                }
+                    
+                else 
+                {
+                    cout << "Depth stream mirroring: OFF" << endl;
+                }
+            }
+
         }
         if (oniRecord) {
             recorder.attach(depthStream);
@@ -207,7 +231,6 @@ int OpenNI2SkeletonTracker::init(){
                 return rc;
             }
            
-
             // if not playback, set resolution and fps settings for RGB stream
             colorInfo = device.getSensorInfo(openni::SENSOR_COLOR);
             const openni::Array<openni::VideoMode>& colorModes = colorInfo->getSupportedVideoModes();
@@ -215,7 +238,29 @@ int OpenNI2SkeletonTracker::init(){
             {
                 imageStream.setVideoMode(colorModes[colorVideoMode]);
             }
-        
+      
+            // If not playback, set RGB mirroring (default: off)
+            if (!oniPlayback)
+            {
+               imageStream.setMirroringEnabled(rgbMirrorON);
+               bool rgbMirror = imageStream.getMirroringEnabled();
+
+               if (!rgbMirror && rgbMirrorON)
+               {
+                   cout << "WARNING: Could not turn on mirroring for RGB stream" << endl;
+               }
+
+               else if (rgbMirror && rgbMirrorON)
+               {
+                   cout << "RGB mirroring: ON" << endl;
+               }
+
+               else
+               {
+                   cout << "RGB stream mirroring: OFF" << endl;
+               }
+            }
+               
             if (oniRecord) {
             recorder.attach(imageStream);
             }

--- a/src/modules/openni2/OpenNI2SkeletonTracker.h
+++ b/src/modules/openni2/OpenNI2SkeletonTracker.h
@@ -65,7 +65,7 @@ public:
     /**
      * @param userDetection indicates if user callbacks and skeleton tracking should be on
      */
-    OpenNI2SkeletonTracker(bool withTracking = false, bool colorON = true, bool mirrorON = true, double minConf = MINIMUM_CONFIDENCE, bool oniPlayback = false, string fileDevice = "", bool oniRecord  = false, string oniOutputFile = "", bool loop = false, bool frameSync = false, bool imageRegistration = false, bool printMode = false, int depthMode = DEFAULT_DEPTH_MODE, int colorMode = DEFAULT_COLOR_MODE);
+    OpenNI2SkeletonTracker(bool withTracking = false, bool withColorON = true, bool witRgbMirrorON = false, bool withDepthMirrorON = false, double minConf = MINIMUM_CONFIDENCE, bool withOniPlayback = false, string withFileDevice = "", bool withOniRecord  = false, string withOniOutputFile = "", bool withLoop = false, bool withFrameSync = false, bool withImageRegistration = false, bool prMode = false, int depthMode = DEFAULT_DEPTH_MODE, int colorMode = DEFAULT_COLOR_MODE);
     ~OpenNI2SkeletonTracker(void);
     void close();
     /**
@@ -81,7 +81,7 @@ public:
     static SensorStatus *getSensor();
 private:
     static SensorStatus *sensorStatus;
-    bool userTracking, colorON, mirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration, printMode;
+    bool userTracking, colorON, rgbMirrorON, depthMirrorON, oniPlayback, oniRecord, loop, frameSync, imageRegistration, printMode;
     int deviceStatus;
     double minConfidence;
     string fileDevice;


### PR DESCRIPTION
This commit fixes the mirroring behaviour and introduces individual parameters for the mirroring of the RGB and Depth streams:
Specifically:

- Default mirroring behaviour for both streams is ``ON``
- ``--noRGBMirror`` to turn off mirroring for the RGB stream
- ``--noDepthMirror`` to turn off mirroring for the Depth stream

See also https://github.com/robotology/yarp/issues/683

All commits squashed and rebased :)