### PR TITLE
Add runtime check for deprecated devices and deprecate controlboard and clientcontrolboard devices

### DIFF
--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -89,7 +89,6 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
 set(YARP_dev_IMPL_HDRS )
 
 set(YARP_dev_SRCS src/ControlBoardInterfacesImpl.cpp
-                  src/ClientControlBoard.cpp
                   src/ControlBoardPid.cpp
                   src/ControlCalibrationImpl.cpp
                   src/RemoteCalibratorImpl.cpp
@@ -117,12 +116,28 @@ set(YARP_dev_SRCS src/ControlBoardInterfacesImpl.cpp
                   src/PopulateDrivers.cpp
                   src/RemoteFrameGrabber.cpp
                   src/RemoteFrameGrabberDC1394.cpp
-                  src/ServerControlBoard.cpp
                   src/ServerFrameGrabber.cpp
                   src/ServerSerial.cpp
                   src/TestFrameGrabber.cpp
                   src/TorqueControlImpl.cpp
                   src/IAxisInfoImpl.cpp)
+
+if(NOT YARP_NO_DEPRECATED)
+  set(YARP_dev_DEPRECATED_SRCS src/ClientControlBoard.cpp    # since YARP 2.3.65
+                               src/ServerControlBoard.cpp)   # since YARP 2.3.65
+  list(APPEND YARP_dev_SRCS ${YARP_dev_DEPRECATED_SRCS})
+  if(MSVC)
+    set_source_files_properties(${YARP_dev_DEPRECATED_SRCS}
+                                PROPERTIES COMPILE_FLAGS "/wd4996")
+  else()
+    check_cxx_compiler_flag("-Wno-deprecated-declarations" CXX_HAS_WNO_DEPRECATED_DECLARATIONS)
+    if(CXX_HAS_WNO_DEPRECATED_DECLARATIONS)
+      set_source_files_properties(${YARP_dev_DEPRECATED_SRCS}
+                                  PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+    endif()
+  endif()
+endif()
+
 
 set(YARP_devices_SRCS   src/modules/AnalogWrapper/AnalogWrapper.cpp
                         src/modules/AnalogSensorClient/AnalogSensorClient.cpp

--- a/src/libYARP_dev/include/yarp/dev/DeviceDriver.h
+++ b/src/libYARP_dev/include/yarp/dev/DeviceDriver.h
@@ -22,6 +22,7 @@ namespace yarp {
      */
     namespace dev {
         class DeviceDriver;
+        class DeprecatedDeviceDriver;
         class DeviceResponder;
     }
 }
@@ -98,6 +99,22 @@ public:
     virtual DeviceDriver *getImplementation() {
         return this;
     }
+};
+
+/**
+ * \ingroup dev_class
+ *
+ * Interface implemented by deprecated device drivers.
+ *
+ * When a device is deprecated, replace yarp::dev::DeviceDriver with
+ * yarp::dev::DeprecatedDeviceDriver in the list of interfaces implemented by
+ * the class, in order to let YARP know that the class is deprecated.
+ *
+ * Deprecated device drivers cannot be opened as PolyDriver unless the
+ * "allow-deprecated-devices" option is passed in the configuration.
+ */
+class YARP_dev_API yarp::dev::DeprecatedDeviceDriver : public yarp::dev::DeviceDriver
+{
 };
 
 

--- a/src/libYARP_dev/src/ClientControlBoard.cpp
+++ b/src/libYARP_dev/src/ClientControlBoard.cpp
@@ -243,6 +243,7 @@ public:
 * The client side of the control board, connects to a ServerControlBoard.
 */
 class yarp::dev::ClientControlBoard :
+    public DeprecatedDeviceDriver,
     public IPidControl,
     public IPositionControl2,
     public IVelocityControl2,
@@ -258,7 +259,6 @@ class yarp::dev::ClientControlBoard :
 //    public IControlMode,
     public IControlMode2,
     public IOpenLoopControl,
-    public DeviceDriver,
     public IPositionDirect,
     public IInteractionMode
 {
@@ -938,6 +938,8 @@ public:
     }
 
     virtual bool open(Searchable& config) {
+        yWarning("clientcontrolboard device is deprecated. Use remote_controlboard instead.");
+
         remote = config.find("remote").asString().c_str();
         local = config.find("local").asString().c_str();
 

--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -270,6 +270,17 @@ bool PolyDriver::coreOpen(yarp::os::Searchable& prop) {
             //YARP_DEBUG(Logger::get(),String("Discarded ") + str);
             driver = NULL;
         } else {
+            yarp::dev::DeprecatedDeviceDriver *ddd = NULL;
+            driver->view(ddd);
+            if(ddd) {
+                if(config->check("allow-deprecated-devices")) {
+                    yWarning("Device \"%s\" is deprecated. Opening since the \"allow-deprecated-devices\" option was passed in the configuration.", str.c_str());
+                } else {
+                    yError("Device \"%s\" is deprecated. Pass the \"allow-deprecated-devices\" option in the configuration if you want to open it anyway.", str.c_str());
+                    driver->close();
+                    return false;
+                }
+            }
             if (creator!=NULL) {
                 ConstString name = creator->getName();
                 ConstString wrapper = creator->getWrapper();

--- a/src/libYARP_dev/src/PopulateDrivers.cpp
+++ b/src/libYARP_dev/src/PopulateDrivers.cpp
@@ -29,10 +29,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-
 extern DriverCreator *createRemoteControlBoard();
-extern DriverCreator *createServerControlBoard();
-extern DriverCreator *createClientControlBoard();
 extern DriverCreator *createAnalogSensorClient();
 extern DriverCreator *createAnalogWrapper();
 extern DriverCreator *createControlBoardWrapper();
@@ -44,6 +41,11 @@ extern DriverCreator *createRangefinder2DWrapper();
 extern DriverCreator *createRangefinder2DClient();
 extern DriverCreator *createRGBDSensorWrapper();
 extern DriverCreator *createRGBDSensorClient();
+
+#ifndef YARP_NO_DEPRECATED
+extern DriverCreator *createServerControlBoard();
+extern DriverCreator *createClientControlBoard();
+#endif // YARP_NO_DEPRECATED
 
 void Drivers::init() {
 
@@ -78,9 +80,9 @@ void Drivers::init() {
                                                     "",
                                                     "yarp::dev::DeviceGroup"));
 
+    add(createRemoteControlBoard());
     add(createServerInertial());
     add(createControlBoardWrapper());
-    add(createRemoteControlBoard());
     add(createBatteryClient());
     add(createRangefinder2DClient());
     add(createAnalogSensorClient());
@@ -88,8 +90,11 @@ void Drivers::init() {
     add(createVirtualAnalogWrapper());
     add(createBatteryWrapper());
     add(createRangefinder2DWrapper());
-    add(createClientControlBoard());
-    add(createServerControlBoard());
     add(createRGBDSensorWrapper());
     add(createRGBDSensorClient());
+
+#ifndef YARP_NO_DEPRECATED
+    add(createClientControlBoard());
+    add(createServerControlBoard());
+#endif // YARP_NO_DEPRECATED
 }

--- a/src/libYARP_dev/src/ServerControlBoard.cpp
+++ b/src/libYARP_dev/src/ServerControlBoard.cpp
@@ -123,7 +123,7 @@ public:
 *
 */
 class yarp::dev::ServerControlBoard :
-    public DeviceDriver,
+    public DeprecatedDeviceDriver,
     public Thread,
     public IPidControl,
     public IPositionControl,
@@ -259,6 +259,8 @@ public:
     * and all parameters required by the wrapped device driver.
     */
     virtual bool open(Searchable& prop) {
+        yWarning("controlboard device is deprecated. Use controlboardwrapper2 instead.");
+
         rpc_p.setRpcServer();
         state_p.setWriteOnly();
         Vector v;

--- a/src/yarprobotinterface/Module.cpp
+++ b/src/yarprobotinterface/Module.cpp
@@ -72,6 +72,9 @@ bool RobotInterface::Module::configure(yarp::os::ResourceFinder &rf)
     // argument
     setName(mPriv->robot.portprefix().c_str());
 
+    mPriv->robot.setVerbose(rf.check("verbose"));
+    mPriv->robot.setAllowDeprecatedDevices(rf.check("allow-deprecated-devices"));
+
     yarp::os::ConstString rpcPortName("/" + getName() + "/yarprobotinterface");
     mPriv->rpcPort.open(rpcPortName);
     attach(mPriv->rpcPort);

--- a/src/yarprobotinterface/Robot.cpp
+++ b/src/yarprobotinterface/Robot.cpp
@@ -405,6 +405,30 @@ std::string& RobotInterface::Robot::portprefix()
     return mPriv->portprefix;
 }
 
+void RobotInterface::Robot::setVerbose(bool verbose)
+{
+    for (DeviceList::iterator dit = devices().begin(); dit != devices().end(); ++dit) {
+        Device &device = *dit;
+        ParamList &params = device.params();
+        // Do not override "verbose" param if explicitly set in the xml
+        if(verbose && !RobotInterface::hasParam(params, "verbose")) {
+            device.params().push_back(Param("verbose", "1"));
+        }
+    }
+}
+
+void RobotInterface::Robot::setAllowDeprecatedDevices(bool allowDeprecatedDevices)
+{
+    for (DeviceList::iterator dit = devices().begin(); dit != devices().end(); ++dit) {
+        Device &device = *dit;
+        ParamList &params = device.params();
+        // Do not override "allow-deprecated-devices" param if explicitly set in the xml
+        if(allowDeprecatedDevices && !RobotInterface::hasParam(params, "allow-deprecated-devices")) {
+            device.params().push_back(Param("allow-deprecated-devices", "1"));
+        }
+    }
+}
+
 RobotInterface::ParamList& RobotInterface::Robot::params()
 {
     return mPriv->params;

--- a/src/yarprobotinterface/Robot.h
+++ b/src/yarprobotinterface/Robot.h
@@ -26,6 +26,10 @@ public:
     std::string& name();
     unsigned int& build();
     std::string& portprefix();
+
+    void setVerbose(bool verbose);
+    void setAllowDeprecatedDevices(bool allowDeprecatedDevices);
+
     ParamList& params();
     DeviceList& devices();
     Device& device(const std::string &name);


### PR DESCRIPTION
This patch adds a generic method to deprecate devices. Since devices are "plugins" and therefore the compiler does not see them, the check must necessarily be at run time.

In order to deprecate a device, the user just needs to inherit from `yarp::dev::DeprecatedDeviceDriver` instead of `yarp::dev::DeviceDriver` and possibly add a warning in the `open(Searchable& config)` method.

```diff
- class foo : public yarp::dev::DeviceDriver
+ class foo : public yarp::dev::DeprecatedDeviceDriver
```

(In yarp compilation should also be disabled when `YARP_NO_DEPRECATED` is enabled).

When a deprecated device is opened as a `PolyDriver` it will refuse to open unless the `allow-deprecated-devices` option is passed. Please note that it can be still used from the source code by explicitly opening the class, if this is the case, then the class should also be declared deprecated (i.e. in YARP using `YARP_DEPRECATED` macro) to generate compile time warnings.

Both yarpdev and yarprobotinterface refuse to open deprecated devices, but accept the `--allow-deprecated-devices` option that is passed to the opened devices.

----------

**Note**: The implementation could also have been a bool in the `DeviceDriver` class, or in some other place, or maybe an extra interface, but I think that in this way the `DeviceDriver` class is cleaner and it makes it easier to spot deprecated devices. The extra `dynamic_cast` required by this is performed only once, when the device is opened, therefore I believe that it should not be a big problem. If you do not agree, I can change it to something else.

----------

This patch also **deprecates** the `controlboard` and `clientcontrolboard` devices, since these were replaced by `controlboardwrapper2` and `remote_controlboard`.

----------

@barbalberto, @randaz81