### PR TITLE
Deprecate setXxxxMode() methods

### DIFF
--- a/bindings/driver_qos.lua
+++ b/bindings/driver_qos.lua
@@ -42,11 +42,18 @@ if ipos == nil then
     os.exit()
 end
 
+icm = driver:viewIControlMode2()
+if icm == nil then
+    print("Cannot open the IControlMode2 interface");
+    driver:close()
+    os.exit()
+end
+
 -- send position command to motors
 for i=1,100 do
     position = math.random(-90, 10)
     print("setting position of joint 0 to "..position)
-    ipos:setPositionMode()
+    icm:setControlMode(0, VOCAB_CM_POSITION)
     ipos:setRefSpeed(0, 30)
     ipos:positionMove(0, position)
     yarp.Time_delay(0.5)

--- a/example/dev/fake_motor.cpp
+++ b/example/dev/fake_motor.cpp
@@ -29,16 +29,6 @@ public:
         return true;
     }
 
-    /** Set position mode. This command
-     * is required by control boards implementing different
-     * control methods (e.g. velocity/torque), in some cases
-     * it can be left empty.
-     * return true/false on success/failure
-     */
-    virtual bool setPositionMode() {
-        return true;
-    }
-
     /** Set new reference point for a single axis.
      * @param j joint number
      * @param ref specifies the new ref point

--- a/example/tutorial/fakebot/FakeBot.h
+++ b/example/tutorial/fakebot/FakeBot.h
@@ -87,10 +87,6 @@ public:
         return true;
     }
 
-    virtual bool setPositionMode() {
-        return true;
-    }
-
     virtual bool positionMove(int j, double ref) {
         if (j<njoints) {
             pos[j] = ref;
@@ -279,12 +275,6 @@ public:
         for (int i=0; i<njoints; i++) {
             accs[i] = 0;
         }
-        return true;
-    }
-
-
-
-    virtual bool setVelocityMode() {
         return true;
     }
 

--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfacesImpl.inl
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfacesImpl.inl
@@ -39,13 +39,18 @@ bool ImplementPositionControl<DERIVED, IMPLEMENT>::positionMove(int j, double v)
     return iPosition->positionMoveRaw(k, enc);
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 template <class DERIVED, class IMPLEMENT>
-bool ImplementPositionControl<DERIVED, IMPLEMENT>::setPositionMode()
+YARP_DEPRECATED bool ImplementPositionControl<DERIVED, IMPLEMENT>::setPositionMode()
 {
     if (helper==0) return false;
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     iPosition->setPositionModeRaw();
+YARP_WARNING_POP
     return true;
 }
+#endif // YARP_NO_DEPRECATED
 
 template <class DERIVED, class IMPLEMENT>
 bool ImplementPositionControl<DERIVED, IMPLEMENT>::positionMove(const double *refs)
@@ -274,11 +279,16 @@ bool ImplementVelocityControl<DERIVED, IMPLEMENT>::getAxes(int *axes)
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 template <class DERIVED, class IMPLEMENT>
-bool ImplementVelocityControl<DERIVED, IMPLEMENT>::setVelocityMode()
+YARP_DEPRECATED bool ImplementVelocityControl<DERIVED, IMPLEMENT>::setVelocityMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return iVelocity->setVelocityModeRaw();
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED
 
 template <class DERIVED, class IMPLEMENT>
 bool ImplementVelocityControl<DERIVED, IMPLEMENT>::velocityMove(int j, double sp)

--- a/src/libYARP_dev/include/yarp/dev/IOpenLoopControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IOpenLoopControl.h
@@ -64,10 +64,13 @@ public:
      */
     virtual bool getOutputsRaw(double *v)=0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Enable open loop mode.
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setOpenLoopModeRaw()=0;
+    YARP_DEPRECATED virtual bool setOpenLoopModeRaw() { return false; }
+#endif
 };
 
 
@@ -118,10 +121,14 @@ public:
      */
     virtual bool getOutputs(double *v)=0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Enable open loop mode.
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setOpenLoopMode()=0;
+    YARP_DEPRECATED virtual bool setOpenLoopMode() { return false; }
+#endif
+
 };
 
 // all sets in streaming

--- a/src/libYARP_dev/include/yarp/dev/IPositionControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionControl.h
@@ -37,13 +37,16 @@ public:
      */
     virtual bool getAxes(int *ax) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /** Set position mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
-     * return true/false on success failure
+     * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setPositionModeRaw()=0;
+    YARP_DEPRECATED virtual bool setPositionModeRaw() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /** Set new reference point for a single axis.
      * @param j joint number
@@ -179,13 +182,16 @@ public:
      */
     virtual bool getAxes(int *ax) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /** Set position mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
-     * return true/false on success/failure
+     * @return true/false on success/failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setPositionMode()=0;
+    YARP_DEPRECATED virtual bool setPositionMode() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /** Set new reference point for a single axis.
      * @param j joint number

--- a/src/libYARP_dev/include/yarp/dev/IPositionControl2.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionControl2.h
@@ -32,7 +32,9 @@ class yarp::dev::IPositionControl2Raw: public IPositionControlRaw
 public:
     //     IPositionControlRaw interface
     using IPositionControlRaw::getAxes;
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     using IPositionControlRaw::setPositionModeRaw;
+#endif // YARP_NO_DEPRECATED
     using IPositionControlRaw::positionMoveRaw;
     using IPositionControlRaw::relativeMoveRaw;
     using IPositionControlRaw::checkMotionDoneRaw;
@@ -157,7 +159,9 @@ public:
 
     //     IPositionControl interface
     using IPositionControl::getAxes;
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     using IPositionControl::setPositionMode;
+#endif // YARP_NO_DEPRECATED
     using IPositionControl::positionMove;
     using IPositionControl::relativeMove;
     using IPositionControl::checkMotionDone;

--- a/src/libYARP_dev/include/yarp/dev/IPositionControl2Impl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionControl2Impl.h
@@ -69,7 +69,9 @@ public:
      */
     virtual bool getAxes(int *axis);
 
-    virtual bool setPositionMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionMode();
+#endif // YARP_NO_DEPRECATED
     virtual bool positionMove(int j, double ref);
     virtual bool positionMove(const int n_joint, const int *joints, const double *refs);
     virtual bool positionMove(const double *refs);
@@ -129,8 +131,10 @@ public:
     virtual bool getAxes(int *ax)
     {return NOT_YET_IMPLEMENTED("getAxes");}
 
-    virtual bool setPositionModeRaw()
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionModeRaw()
     {return NOT_YET_IMPLEMENTED("setPositionModeRaw");}
+#endif // YARP_NO_DEPRECATED
 
     virtual bool positionMoveRaw(int j, double ref)
     {return NOT_YET_IMPLEMENTED("positionMoveRaw");}

--- a/src/libYARP_dev/include/yarp/dev/IPositionDirect.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionDirect.h
@@ -39,14 +39,16 @@ public:
      */
     virtual bool getAxes(int *ax)=0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set position direct mode. This command
      * is required to switch control boards to low-level position
      * control method.
      * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setPositionDirectMode()=0;
-
+    YARP_DEPRECATED virtual bool setPositionDirectMode() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /** Set new position for a single axis.
      * @param j joint number
@@ -133,13 +135,16 @@ public:
      */
     virtual bool getAxes(int *axes) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set position direct mode. This command
      * is required to switch control boards to low-level position
      * control method.
      * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setPositionDirectModeRaw()=0;
+    YARP_DEPRECATED virtual bool setPositionDirectModeRaw() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /** Set new position for a single axis.
      * @param j joint number

--- a/src/libYARP_dev/include/yarp/dev/IPositionDirectImpl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionDirectImpl.h
@@ -62,7 +62,9 @@ public:
     virtual ~ImplementPositionDirect();
 
     virtual bool getAxes(int *axes);
-    virtual bool setPositionDirectMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionDirectMode();
+#endif // YARP_NO_DEPRECATED
     virtual bool setPosition(int j, double ref);
     virtual bool setPositions(const int n_joint, const int *joints, double *refs);
     virtual bool setPositions(const double *refs);
@@ -102,8 +104,10 @@ public:
     virtual bool getAxes(int *axis)
     {return NOT_YET_IMPLEMENTED("getAxes");}
 
-    virtual bool setPositionDirectMode()
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionDirectMode()
     {return NOT_YET_IMPLEMENTED("setPositionDirectMode");}
+#endif // YARP_NO_DEPRECATED
 
     virtual bool setPosition(int j, double ref)
     {return NOT_YET_IMPLEMENTED("setPosition");}

--- a/src/libYARP_dev/include/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ITorqueControl.h
@@ -49,14 +49,17 @@ public:
      */
     virtual bool getAxes(int *ax) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set torque control mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
      * @return true/false on success/failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setTorqueMode()=0;
+    YARP_DEPRECATED virtual bool setTorqueMode() { return false; }
+#endif // YARP_NO_DEPRECATED
 
    /** Get the reference value of the torque for all joints.
      * This is NOT the feedback (see getTorques instead).
@@ -278,14 +281,17 @@ public:
      */
     virtual bool getAxes(int *ax) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set torque control mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
      * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setTorqueModeRaw()=0;
+    YARP_DEPRECATED virtual bool setTorqueModeRaw() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /** Get the value of the torque on a given joint (this is the
      * feedback if you have a torque sensor).

--- a/src/libYARP_dev/include/yarp/dev/IVelocityControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IVelocityControl.h
@@ -36,14 +36,17 @@ public:
      */
     virtual bool getAxes(int *axis) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set position mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
      * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setVelocityModeRaw()=0;
+    YARP_DEPRECATED virtual bool setVelocityModeRaw() { return false; }
+#endif
 
     /**
      * Start motion at a given speed, single joint.
@@ -123,14 +126,17 @@ public:
      */
     virtual bool getAxes(int *axes) = 0;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
      * Set velocity mode. This command
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
      * @return true/false on success failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setVelocityMode()=0;
+    YARP_DEPRECATED virtual bool setVelocityMode() { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /**
      * Start motion at a given speed, single joint.

--- a/src/libYARP_dev/include/yarp/dev/IVelocityControl2.h
+++ b/src/libYARP_dev/include/yarp/dev/IVelocityControl2.h
@@ -34,7 +34,9 @@ public:
 
     // Inherit from IVelocityControl
     using IVelocityControl::getAxes;
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     using IVelocityControl::setVelocityMode;
+#endif // YARP_NO_DEPRECATED
     using IVelocityControl::velocityMove;
     using IVelocityControl::setRefAcceleration;
     using IVelocityControl::setRefAccelerations;
@@ -156,7 +158,9 @@ public:
 
     // Inherit from IVelocityControl
     using IVelocityControlRaw::getAxes;
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     using IVelocityControlRaw::setVelocityModeRaw;
+#endif // YARP_NO_DEPRECATED
     using IVelocityControlRaw::velocityMoveRaw;
     using IVelocityControlRaw::setRefAccelerationRaw;
     using IVelocityControlRaw::setRefAccelerationsRaw;

--- a/src/libYARP_dev/include/yarp/dev/IVelocityControl2Impl.h
+++ b/src/libYARP_dev/include/yarp/dev/IVelocityControl2Impl.h
@@ -59,7 +59,9 @@ public:
     virtual ~ImplementVelocityControl2();
 
     virtual bool getAxes(int *axes);
-    virtual bool setVelocityMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setVelocityMode();
+#endif // YARP_NO_DEPRECATED
     virtual bool velocityMove(int j, double sp);
     virtual bool velocityMove(const double *sp);
     virtual bool setRefAcceleration(int j, double acc);
@@ -119,8 +121,10 @@ public:
     virtual bool getAxes(int *axes)
     {return NOT_YET_IMPLEMENTED("getAxesRaw");}
 
-    virtual bool setVelocityModeRaw()
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setVelocityModeRaw()
     {return NOT_YET_IMPLEMENTED("setVelocityModeRaw");}
+#endif // YARP_NO_DEPRECATED
 
     virtual bool velocityMoveRaw(int j, double sp)
     {return NOT_YET_IMPLEMENTED("velocityMoveRaw");}

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlBoardInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlBoardInterfaces.h
@@ -84,7 +84,9 @@ public:
      */
     virtual bool getAxes(int *axis);
 
-    virtual bool setPositionMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionMode();
+#endif // YARP_NO_DEPRECATED
     virtual bool positionMove(int j, double ref);
     virtual bool positionMove(const double *refs);
     virtual bool relativeMove(int j, double delta);
@@ -150,7 +152,9 @@ public:
 
     virtual bool getAxes(int *axes);
 
-    virtual bool setVelocityMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setVelocityMode();
+#endif // YARP_NO_DEPRECATED
 
     virtual bool velocityMove(int j, double v);
     virtual bool velocityMove(const double *v);
@@ -857,8 +861,10 @@ public:
     virtual bool getAxes(int *ax)
     {return NOT_YET_IMPLEMENTED("getAxes");}
 
-    virtual bool setPositionModeRaw()
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionModeRaw()
     {return NOT_YET_IMPLEMENTED("setPositionModeRaw");}
+#endif // YARP_NO_DEPRECATED
 
     virtual bool positionMoveRaw(int j, double ref)
     {return NOT_YET_IMPLEMENTED("positionMoveRaw");}

--- a/src/libYARP_dev/include/yarp/dev/ImplementOpenLoopControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementOpenLoopControl.h
@@ -33,7 +33,9 @@ public:
     bool getRefOutputs(double *v);
     bool getOutput(int j, double *v);
     bool getOutputs(double *v);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     bool setOpenLoopMode();
+#endif // YARP_NO_DEPRECATED
 };
 
 #endif

--- a/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
@@ -57,7 +57,9 @@ public:
     virtual ~ImplementTorqueControl();
 
     virtual bool getAxes(int *ax);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     virtual bool setTorqueMode();
+#endif // YARP_NO_DEPRECATED
     virtual bool getRefTorque(int j, double *);
     virtual bool getRefTorques(double *t);
     virtual bool setRefTorques(const double *t);

--- a/src/libYARP_dev/include/yarp/dev/TestMotor.h
+++ b/src/libYARP_dev/include/yarp/dev/TestMotor.h
@@ -84,10 +84,15 @@ public:
         return true;
     }
 
-    virtual bool setPositionMode() {
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+    YARP_DEPRECATED virtual bool setPositionMode() {
         posMode = true;
         return true;
     }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     virtual bool positionMove(int j, double ref) {
         posMode = true;
@@ -304,11 +309,15 @@ public:
         return true;
     }
 
-    virtual bool setVelocityMode() {
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+    YARP_DEPRECATED virtual bool setVelocityMode() {
         posMode = false;
         return false;
     }
-
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     virtual bool velocityMove(int j, double sp) {
         posMode = false;

--- a/src/libYARP_dev/src/ClientControlBoard.cpp
+++ b/src/libYARP_dev/src/ClientControlBoard.cpp
@@ -1799,9 +1799,10 @@ public:
      * is required by control boards implementing different
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
-     * return true/false on success/failure
+     * @return true/false on success/failure
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setPositionMode() {
+    YARP_DEPRECATED virtual bool setPositionMode() {
         return set1V(VOCAB_POSITION_MODE);
     }
 
@@ -2093,8 +2094,9 @@ public:
     /**
      * Set the controller to velocity mode.
      * @return true/false on success/failure.
+     * @deprecated since YARP 2.3.65
      */
-    virtual bool setVelocityMode() {
+    YARP_DEPRECATED virtual bool setVelocityMode() {
         return set1V(VOCAB_VELOCITY_MODE);
     }
 
@@ -2291,7 +2293,7 @@ public:
         return send1V1I(VOCAB_CALIBRATE_DONE, j);
     }
 
-    bool setTorqueMode() {
+    YARP_DEPRECATED bool setTorqueMode() {
         return set1V(VOCAB_TORQUE_MODE);
     }
 
@@ -2659,7 +2661,7 @@ public:
 //        return send3V1I(VOCAB_SET, VOCAB_ICONTROLMODE, VOCAB_CM_IMPEDANCE_VEL, j);
     }
 
-    bool setOpenLoopMode()
+    YARP_DEPRECATED bool setOpenLoopMode()
     {
 //        return setControlModes(VOCAB_OPENLOOP_MODE);
         return set1V(VOCAB_OPENLOOP_MODE);
@@ -2801,7 +2803,7 @@ public:
         return CHECK_FAIL(ok, response);
     }
 
-    bool setPositionDirectMode()
+    YARP_DEPRECATED bool setPositionDirectMode()
     {
         return set1V(VOCAB_POSITION_DIRECT);
     }

--- a/src/libYARP_dev/src/IPositionControl2Impl.cpp
+++ b/src/libYARP_dev/src/IPositionControl2Impl.cpp
@@ -68,10 +68,15 @@ bool ImplementPositionControl2::uninitialize()
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED
 bool ImplementPositionControl2::setPositionMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return iPosition2->setPositionModeRaw();
+YARP_WARNING_POP
 }
+#endif
 
 bool ImplementPositionControl2::positionMove(int j, double ang)
 {

--- a/src/libYARP_dev/src/IPositionDirectImpl.cpp
+++ b/src/libYARP_dev/src/IPositionDirectImpl.cpp
@@ -62,10 +62,15 @@ bool ImplementPositionDirect::getAxes(int *axes)
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 bool ImplementPositionDirect::setPositionDirectMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return iPDirect->setPositionDirectModeRaw();
+YARP_WARNING_POP
 }
+#endif
 
 bool ImplementPositionDirect::setPosition(int j, double ref)
 {

--- a/src/libYARP_dev/src/IVelocityControl2Impl.cpp
+++ b/src/libYARP_dev/src/IVelocityControl2Impl.cpp
@@ -65,10 +65,15 @@ bool ImplementVelocityControl2::getAxes(int *ax)
 }
 
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 bool ImplementVelocityControl2::setVelocityMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return iVelocity2->setVelocityModeRaw();
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED
 
 bool ImplementVelocityControl2::velocityMove(int j, double sp)
 {

--- a/src/libYARP_dev/src/OpenLoopControlImpl.cpp
+++ b/src/libYARP_dev/src/OpenLoopControlImpl.cpp
@@ -96,7 +96,12 @@ bool ImplementOpenLoopControl::getOutputs(double *v)
     return ret;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 bool ImplementOpenLoopControl::setOpenLoopMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setOpenLoopModeRaw();
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED

--- a/src/libYARP_dev/src/ServerControlBoard.cpp
+++ b/src/libYARP_dev/src/ServerControlBoard.cpp
@@ -670,9 +670,10 @@ public:
     * is required by control boards implementing different
     * control methods (e.g. velocity/torque), in some cases
     * it can be left empty.
-    * return true/false on success/failure
+    * @return true/false on success/failure
+    * @deprecated since YARP 2.3.65
     */
-    virtual bool setPositionMode() {
+    YARP_DEPRECATED virtual bool setPositionMode() {
         if (pos)
             return pos->setPositionMode();
         return false;
@@ -892,8 +893,9 @@ public:
     /**
     * Set the controller to velocity mode.
     * @return true/false on success/failure.
+    * @deprecated since YARP 2.3.65
     */
-    virtual bool setVelocityMode() {
+    YARP_DEPRECATED virtual bool setVelocityMode() {
         if (vel)
             return vel->setVelocityMode();
         return false;
@@ -1161,8 +1163,9 @@ public:
      * control methods (e.g. velocity/torque), in some cases
      * it can be left empty.
      * @return true/false on success failure
+    * @deprecated since YARP 2.3.65
      */
-    virtual bool setTorqueMode()
+    YARP_DEPRECATED virtual bool setTorqueMode()
     {
         if (trq)
             return trq->setTorqueMode();

--- a/src/libYARP_dev/src/TorqueControlImpl.cpp
+++ b/src/libYARP_dev/src/TorqueControlImpl.cpp
@@ -64,10 +64,15 @@ bool ImplementTorqueControl::getAxes(int *axes)
     return iTorqueRaw->getAxes(axes);
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
 bool ImplementTorqueControl::setTorqueMode()
 {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return iTorqueRaw->setTorqueModeRaw();
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED
 
 bool ImplementTorqueControl::getRefTorque(int j, double *r)
 {

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -1383,12 +1383,16 @@ bool ControlBoardWrapper::getAxes(int *ax) {
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 /**
 * Set position mode. This command
 * is required by control boards implementing different
 * control methods (e.g. velocity/torque), in some cases
 * it can be left empty.
-* return true/false on success/failure
+* @return true/false on success/failure
+* @deprecated since YARP 2.3.65
 */
 bool ControlBoardWrapper::setPositionMode() {
     bool ret=true;
@@ -1455,6 +1459,8 @@ bool ControlBoardWrapper::setOpenLoopMode() {
     }
     return ret;
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 /**
 * Set new reference point for a single axis.
@@ -2573,6 +2579,9 @@ bool ControlBoardWrapper::velocityMove(const double *v)
     return ret;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool ControlBoardWrapper::setVelocityMode()
 {
     bool ret=true;
@@ -2602,6 +2611,8 @@ bool ControlBoardWrapper::setVelocityMode()
     }
     return ret;
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 /* IEncoders */
 
@@ -3808,6 +3819,9 @@ bool ControlBoardWrapper::getJointType(int j, yarp::dev::JointTypeEnum& type)
     return false;
 }
 
+#ifndef YARP_NO_DEPRECATED // since 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool ControlBoardWrapper::setTorqueMode()
 {
     bool ret=true;
@@ -3835,6 +3849,8 @@ bool ControlBoardWrapper::setTorqueMode()
     }
     return ret;
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 bool ControlBoardWrapper::getRefTorques(double *refs)
 {
@@ -4928,6 +4944,9 @@ bool ControlBoardWrapper::setPosition(int j, double ref)
     return false;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool ControlBoardWrapper::setPositionDirectMode()
 {
     bool ret=true;
@@ -4948,6 +4967,8 @@ bool ControlBoardWrapper::setPositionDirectMode()
     }
     return ret;
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 bool ControlBoardWrapper::setPositions(const int n_joints, const int *joints, double *dpos)
 {

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -530,15 +530,18 @@ public:
     */
     virtual bool getAxes(int *ax);
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
     * Set position mode. This command
     * is required by control boards implementing different
     * control methods (e.g. velocity/torque), in some cases
     * it can be left empty.
-    * return true/false on success/failure
+    * @return true/false on success/failure
+    * @deprecated since YARP 2.3.65
     */
-    virtual bool setPositionMode();
-    virtual bool setOpenLoopMode();
+    YARP_DEPRECATED virtual bool setPositionMode();
+    YARP_DEPRECATED virtual bool setOpenLoopMode();
+#endif // YARP_NO_DEPRECATED
 
     /**
     * Set new reference point for a single axis.
@@ -766,12 +769,14 @@ public:
     */
     virtual bool velocityMove(const double *v);
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
     /**
     * Set the controller to velocity mode.
     * @return true/false on success/failure.
+    * @deprecated since YARP 2.3.65
     */
-    virtual bool setVelocityMode();
-
+    YARP_DEPRECATED virtual bool setVelocityMode();
+#endif // YARP_NO_DEPRECATED
     /* IEncoders */
 
     /**
@@ -1233,7 +1238,9 @@ public:
 
     virtual bool getJointType(int j, yarp::dev::JointTypeEnum& type);
 
-    virtual bool setTorqueMode();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setTorqueMode();
+#endif // YARP_NO_DEPRECATED
 
     virtual bool getRefTorques(double *refs);
 
@@ -1334,7 +1341,10 @@ public:
 
     virtual bool setRefOutputs(const double *outs);
 
-    virtual bool setPositionDirectMode();
+    // IPositionDirect
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    YARP_DEPRECATED virtual bool setPositionDirectMode();
+#endif // YARP_NO_DEPRECATED
 
     virtual bool setPosition(int j, double ref);
 

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -618,7 +618,14 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
                         delete [] modes;
                     }
                     else
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                         *ok = rpc_ITorque->setTorqueMode();
+YARP_WARNING_POP
+#else
+                        *ok = false;
+#endif // YARP_NO_DEPRECATED
                 }
                 break;
 
@@ -1663,35 +1670,52 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                             }
                             break;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
                             case VOCAB_TORQUE_MODE:
                             {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 ok = rpc_ITorque->setTorqueMode();
+YARP_WARNING_POP
                             }
                             break;
 
                             case VOCAB_VELOCITY_MODE:
                             {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 ok = rpc_IVelCtrl->setVelocityMode();
+YARP_WARNING_POP
                             }
                             break;
 
                             case VOCAB_POSITION_MODE:
                             {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 ok = rpc_IPosCtrl->setPositionMode();
+YARP_WARNING_POP
                             }
                             break;
 
                             case VOCAB_POSITION_DIRECT:
                             {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 ok = rpc_IPosDirect->setPositionDirectMode();
+YARP_WARNING_POP
                             }
                             break;
 
                             case VOCAB_OPENLOOP_MODE:
                             {
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 ok = rpc_IOpenLoop->setOpenLoopMode();
+YARP_WARNING_POP
                             }
                             break;
+#endif // YARP_NO_DEPRECATED
 
                             case VOCAB_POSITION_MOVE:
                             {

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2333,6 +2333,9 @@ public:
         return get1V1I(VOCAB_AXES, *ax);
     }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     /**
      * Set position mode. This command
      * is required by control boards implementing different
@@ -2340,10 +2343,11 @@ public:
      * it can be left empty.
      * return true/false on success/failure
      */
-    virtual bool setPositionMode() {
+    YARP_DEPRECATED virtual bool setPositionMode() {
         return set1V(VOCAB_POSITION_MODE);
     }
-
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
     /**
      * Set new reference point for a single axis.
      * @param j joint number
@@ -2671,13 +2675,18 @@ public:
         return true;
     }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     /**
      * Set the controller to velocity mode.
      * @return true/false on success/failure.
      */
-    virtual bool setVelocityMode() {
+    YARP_DEPRECATED virtual bool setVelocityMode() {
         return set1V(VOCAB_VELOCITY_MODE);
     }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     /* IAmplifierControl */
 
@@ -2952,8 +2961,13 @@ public:
     bool virtual done(int j)
     { return send1V1I(VOCAB_CALIBRATE_DONE, j); }
 
-    bool setTorqueMode()
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+    YARP_DEPRECATED bool setTorqueMode()
     { return set1V(VOCAB_TORQUE_MODE); }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     bool getRefTorque(int j, double *t)
     { return get2V1I1D(VOCAB_TORQUE, VOCAB_REF, j, t); }

--- a/src/modules/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
+++ b/src/modules/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
@@ -389,13 +389,6 @@ bool DynamixelAX12FtdiDriver::getAxes(int *ax) {
     return true;
 }
 
-/*
- * The only supported mode, position control mode
- */
-bool DynamixelAX12FtdiDriver::setPositionMode() {
-    return true;
-}
-
 bool DynamixelAX12FtdiDriver::positionMove(int j, double ref) {
     double speed;
     int blankReturnSize = -1;
@@ -556,16 +549,6 @@ int DynamixelAX12FtdiDriver::normaliseSpeed(double speed) {
         speed = 114;
     }
     return (int) (1024 * speed / 114 - 1);
-}
-
-/**
- * AX12 does not support torque mode. 
- * to implement this interface is only to inherit the getTorque to read the 
- * torque values
- */
-bool DynamixelAX12FtdiDriver::setTorqueMode() {
-    ACE_OS::fprintf(stderr, "Note: AX12 does not support torque control mode. This is only used to get torque feedback.\n");
-    return NOT_YET_IMPLEMENTED("setTorqueMode");
 }
 
 bool DynamixelAX12FtdiDriver::getRefTorques(double *t) {

--- a/src/modules/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
+++ b/src/modules/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
@@ -214,10 +214,7 @@ public:
     virtual int readParameter(unsigned char id, unsigned char param);
 
     bool getAxes(int *ax);
-    /*
-     * The only supported mode, position control mode
-     */
-    bool setPositionMode();
+
     /**
      * @param refs should be in range [1 300]
      */
@@ -238,7 +235,6 @@ public:
     bool stop(int j);
     bool stop();
 
-    bool setTorqueMode();
     bool getRefTorques(double *t);
     bool getRefTorque(int j, double *t);
     bool setTorques(const double *t);

--- a/src/modules/SerialServoBoard/SerialServoBoard.cpp
+++ b/src/modules/SerialServoBoard/SerialServoBoard.cpp
@@ -42,10 +42,6 @@ bool SerialServoBoard::getAxes(int *ax) {
 }
 
 
-bool SerialServoBoard::setPositionMode() {
-    return true;
-}
-
 
 bool SerialServoBoard::positionMove(int j, double ref) {
     positions[j]=ref;

--- a/src/modules/SerialServoBoard/SerialServoBoard.h
+++ b/src/modules/SerialServoBoard/SerialServoBoard.h
@@ -52,7 +52,6 @@ public:
     double *speeds;
 
     bool getAxes(int *ax);
-    bool setPositionMode();
     bool positionMove(int j, double ref);
     bool positionMove(const double *refs);
     bool relativeMove(int j, double delta);

--- a/src/modules/dimax_u2c/DimaxU2C.cpp
+++ b/src/modules/dimax_u2c/DimaxU2C.cpp
@@ -85,9 +85,6 @@ bool DimaxU2C::getAxes(int *ax) {
     *ax = numJoints;
     return true;
 }
-bool DimaxU2C::setPositionMode() {
-    return true;
-}
 
 bool DimaxU2C::positionMoveRaw(int j, double ref) {
     printf("DimaxU2C::positionMoveRaw(%d,%f)\n",j,ref);

--- a/src/modules/dimax_u2c/DimaxU2C.h
+++ b/src/modules/dimax_u2c/DimaxU2C.h
@@ -61,7 +61,6 @@ public:
     // virtual methods implementing IPositionControlRaw Interface
     // POSITION CONTROL INTERFACE RAW
     virtual bool getAxes(int *ax);
-    virtual bool setPositionMode();
 
     /**
      * Raw position control. Calls the servo setPosition method which

--- a/src/modules/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/modules/fakeMotionControl/fakeMotionControl.cpp
@@ -1212,11 +1212,6 @@ bool FakeMotionControl::setOffsetRaw(int j, double v)
 //    Velocity control interface raw  //
 ////////////////////////////////////////
 
-bool FakeMotionControl::setVelocityModeRaw()
-{
-   return false;
-}
-
 bool FakeMotionControl::velocityMoveRaw(int j, double sp)
 {
     int mode=0;
@@ -1274,11 +1269,6 @@ bool FakeMotionControl::getAxes(int *ax)
     *ax=_njoints;
 
     return true;
-}
-
-bool FakeMotionControl::setPositionModeRaw()
-{
-    return DEPRECATED("setPositionModeRaw");
 }
 
 bool FakeMotionControl::positionMoveRaw(int j, double ref)
@@ -2112,12 +2102,6 @@ bool FakeMotionControl::getVelLimitsRaw(int axis, double *min, double *max)
 
 
 // Torque control
-bool FakeMotionControl::setTorqueModeRaw()
-{
-    bool ret = true;
-    return ret;
-}
-
 bool FakeMotionControl::getTorqueRaw(int j, double *t)
 {
     return true;
@@ -2326,11 +2310,6 @@ bool FakeMotionControl::getVelPidsRaw(Pid *pids)
 }
 
 // PositionDirect Interface
-bool FakeMotionControl::setPositionDirectModeRaw()
-{
-    return DEPRECATED("setPositionDirectModeRaw");
-}
-
 bool FakeMotionControl::setPositionRaw(int j, double ref)
 {
     _posDir_references[j] = ref;
@@ -2496,11 +2475,6 @@ bool FakeMotionControl::setInteractionModesRaw(yarp::dev::InteractionModeEnum* m
 //
 // OPENLOOP interface
 //
-bool FakeMotionControl::setOpenLoopModeRaw()
-{
-    return DEPRECATED("setOpenLoopModeRaw");
-}
-
 bool FakeMotionControl::setRefOutputRaw(int j, double v)
 {
      return false;

--- a/src/modules/fakeMotionControl/fakeMotionControl.h
+++ b/src/modules/fakeMotionControl/fakeMotionControl.h
@@ -240,6 +240,14 @@ public:
     bool alloc(int njoints);
     bool init(void);
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.65
+    // Hide -Woverloaded-virtual warnings
+    using yarp::dev::IPositionControlRaw::setPositionModeRaw;
+    using yarp::dev::IVelocityControlRaw::setVelocityModeRaw;
+    using yarp::dev::ITorqueControlRaw::setTorqueModeRaw;
+    using yarp::dev::IOpenLoopControlRaw::setOpenLoopModeRaw;
+#endif
+
     /////////   PID INTERFACE   /////////
     virtual bool setPidRaw(int j, const Pid &pid);
     virtual bool setPidsRaw(const Pid *pids);
@@ -264,7 +272,6 @@ public:
 
     // POSITION CONTROL INTERFACE RAW
     virtual bool getAxes(int *ax);
-    virtual bool setPositionModeRaw();
     virtual bool positionMoveRaw(int j, double ref);
     virtual bool positionMoveRaw(const double *refs);
     virtual bool relativeMoveRaw(int j, double delta);
@@ -296,7 +303,6 @@ public:
     virtual bool getTargetPositionsRaw(const int n_joint, const int *joints, double *refs);
 
     //  Velocity control interface raw
-    virtual bool setVelocityModeRaw();
     virtual bool velocityMoveRaw(int j, double sp);
     virtual bool velocityMoveRaw(const double *sp);
 
@@ -406,7 +412,6 @@ public:
     virtual bool getVelLimitsRaw(int axis, double *min, double *max);
 
     // Torque control
-    virtual bool setTorqueModeRaw();
     virtual bool getTorqueRaw(int j, double *t);
     virtual bool getTorquesRaw(double *t);
     virtual bool getBemfParamRaw(int j, double *bemf);
@@ -456,7 +461,6 @@ public:
     virtual bool getCurrentImpedanceLimitRaw(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp);
 
     // PositionDirect Interface
-    virtual bool setPositionDirectModeRaw();
     virtual bool setPositionRaw(int j, double ref);
     virtual bool setPositionsRaw(const int n_joint, const int *joints, double *refs);
     virtual bool setPositionsRaw(const double *refs);
@@ -486,8 +490,6 @@ public:
     virtual bool getRefOutputsRaw(double *outs);
     virtual bool getOutputRaw(int j, double *out);
     virtual bool getOutputsRaw(double *outs);
-    virtual bool setOpenLoopModeRaw();
-
     void run();
 private:
     void cleanup(void);

--- a/src/modules/fakebot/FakeBot.h
+++ b/src/modules/fakebot/FakeBot.h
@@ -93,10 +93,6 @@ public:
         return true;
     }
 
-    virtual bool setPositionMode() {
-        return true;
-    }
-
     virtual bool positionMove(int j, double ref) {
         if (j<njoints) {
             pos[j] = ref;
@@ -308,11 +304,6 @@ public:
         bool ret = getEncoder(j, enc);
         *time = yarp::os::Time::now();
         return ret;
-    }
-
-
-    virtual bool setVelocityMode() {
-        return true;
     }
 
     virtual bool velocityMove(int j, double sp) {

--- a/src/modules/meiMotionControl/MEIMotionControl.h
+++ b/src/modules/meiMotionControl/MEIMotionControl.h
@@ -381,7 +381,6 @@ public:
     //
     /// POSITION CONTROL INTERFACE RAW
     virtual bool getAxes(int *ax);
-    virtual bool setPositionMode();
     virtual bool positionMoveRaw(int j, double ref);
     virtual bool positionMoveRaw(const double *refs);
     virtual bool relativeMoveRaw(int j, double delta);
@@ -403,7 +402,6 @@ public:
 
     ///////////// Velocity control interface raw
     ///
-    virtual bool setVelocityMode();
     virtual bool velocityMoveRaw(int j, double sp);
     virtual bool velocityMoveRaw(const double *sp);
 	int safeVMove(double *spds, double *accs);


### PR DESCRIPTION
This patch deprecates the following methods

* IPositionControl::setPositionMode()
* IPositionControlRaw::setPositionModeRaw()
* IVelocityControl::setVelocityMode()
* IVelocityControlRaw::setVelocityModeRaw()
* ITorqueControl::setTorqueMode()
* ITorqueControlRaw::setTorqueModeRaw()
* IPositionDirect::setPositionDirectMode()
* IPositionDirectRaw::setPositionDirectModeRaw()
* IOpenLoopControl::setOpenLoopMode()
* IOpenLoopControlRaw::setOpenLoopModeRaw()


The modules in YARP_dev should behave exactly like before, unless YARP_NO_DEPRECATED is enabled.

For the modules in src/modules (DynamixelAX12Ftdi, SerialServoBoard, dimax_u2c, fakeMotionControl, fakebot, meiMotionControl) and for the examples, I just removed the methods, I don't know if it is worth updating...

I'm not 100% sure about the latest commit (f5fd7ff) it's a lua script and I didn't try it…



CC: @randaz81 
