### PR TITLE
Cleanup of tutorials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,13 @@ before_script:
   - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ${YARP_CMAKE_OPTIONS} ..
   - if [ "$TRAVIS_BUILD_TYPE" == "Profile" ]; then lcov --directory . --zerocounters; fi
   - cd ..
+  # build also the os examples 
+  - cd ./example/os
+  - mkdir build
+  - cd build
+  - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ..
+  - cmake --build . --config ${TRAVIS_BUILD_TYPE}
+  - cd ../..
 
 script:
   - cd build

--- a/doc/yarp_cmake_hello.dox
+++ b/doc/yarp_cmake_hello.dox
@@ -13,7 +13,8 @@ And here's a simple test program, call it "hello.cpp"
 
 \include example/cmake/hello/hello.cpp
 
-Now run CMake (see \ref using_cmake), and compile!
+Now make a "build" directory inside the "hello" folder, then from the build directory 
+run CMake (see \ref using_cmake), and compile!
 This example is available in the example/cmake/hello directory
 of the YARP source code.  See example/cmake/with_opencv for an
 example of compiling YARP with OpenCV.

--- a/example/os/image_process_module.cpp
+++ b/example/os/image_process_module.cpp
@@ -34,7 +34,7 @@ using namespace yarp::sig::draw;
  */
 
 
-class ImageProcessModule : public Module {
+class ImageProcessModule : public RFModule {
 private:
     // Make a port for reading and writing images
     BufferedPort<ImageOf<PixelRgb> > port;
@@ -76,9 +76,14 @@ public:
 int main(int argc, char *argv[]) {
     // Initialize the yarp network
     Network yarp;
+    
+    /* prepare and configure the resource finder */
+    ResourceFinder rf;
+    rf.configure(argc, argv);
+    rf.setVerbose(true);
 
     // Create and run our module
     ImageProcessModule module;
     module.setName("/worker");
-    return module.runModule(argc,argv);
+    return module.runModule(rf);
 }


### PR DESCRIPTION
- in yarp/example/os/image_process_module.cpp the input of module.runModule() has been modified according to what is required by the RFmodule.cpp (which substitutes the deprecated code Module.cpp) 

- in yarp/doc/yarp_cmake_hello.dox it has been added the suggestion to create a build directory inside the source folder and launch cmake from it