### PR TITLE
Fix some issues with yarp connections and yarpmanager

### DIFF
--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1472,6 +1472,7 @@ bool PortCore::getEnvelope(PortReader& envelope) {
 
 // Shorthand to create a nested (tag, val) pair to add to a message.
 #define STANZA(name,tag,val) Bottle name; name.addString(tag); name.addString(val.c_str());
+#define STANZA_INT(name,tag,val) Bottle name; name.addString(tag); name.addInt(val);
 
 // Make an RPC connection to talk to a ROS API, send a message, get reply.
 // NOTE: ROS support can now be moved out of here, once all documentation
@@ -1702,6 +1703,15 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                 result.addList() = bfrom;
                                 result.addList() = bto;
                                 result.addList() = bcarrier;
+                                Carrier *carrier = Carriers::chooseCarrier(route.getCarrierName());
+                                if (carrier->isConnectionless()) {
+                                    STANZA_INT(bconnectionless, "connectionless", 1);
+                                    result.addList() = bconnectionless;
+                                }
+                                if (!carrier->isPush()) {
+                                    STANZA_INT(breverse, "push", 0);
+                                    result.addList() = breverse;
+                                }
                             }
                         }
                     }
@@ -1730,6 +1740,15 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                 result.addList() = bfrom;
                                 result.addList() = bto;
                                 result.addList() = bcarrier;
+                                Carrier *carrier = Carriers::chooseCarrier(route.getCarrierName());
+                                if (carrier->isConnectionless()) {
+                                    STANZA_INT(bconnectionless, "connectionless", 1);
+                                    result.addList() = bconnectionless;
+                                }
+                                if (!carrier->isPush()) {
+                                    STANZA_INT(breverse, "push", 0);
+                                    result.addList() = breverse;
+                                }
                             }
                         }
                     }

--- a/src/libYARP_manager/include/yarp/manager/broker.h
+++ b/src/libYARP_manager/include/yarp/manager/broker.h
@@ -49,11 +49,13 @@ public:
     virtual bool kill() = 0;
     virtual bool connect(const char* from, const char* to,
                         const char* carrier, bool persist=false) = 0;
-    virtual bool disconnect(const char* from, const char* to) = 0;
+    virtual bool disconnect(const char* from, const char* to,
+                            const char* carrier) = 0;
     virtual int  running(void) = 0; // 0 if is not running and 1 if is running; otherwise -1.
     virtual bool exists(const char* port) = 0;
     virtual const char* requestRpc(const char* szport, const char* request, double timeout=0.0) = 0;
-    virtual bool connected(const char* from, const char* to) = 0;
+    virtual bool connected(const char* from, const char* to,
+                           const char* carrier) = 0;
     virtual const char* error(void) = 0;
     virtual bool initialized(void) = 0;
     virtual bool attachStdout(void) = 0;

--- a/src/libYARP_manager/include/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/localbroker.h
@@ -58,11 +58,13 @@ public:
     bool kill();
     bool connect(const char* from, const char* to,
                  const char* carrier, bool persist=false);
-    bool disconnect(const char* from, const char* to);
+    bool disconnect(const char* from, const char* to,
+                    const char *carrier);
     int running(void);
     bool exists(const char* port);
     const char* requestRpc(const char* szport, const char* request, double timeout);
-    bool connected(const char* from, const char* to);
+    bool connected(const char* from, const char* to,
+                   const char* carrier);
     const char* error(void);
     bool initialized(void) { return bInitialized;}
     bool attachStdout(void);

--- a/src/libYARP_manager/include/yarp/manager/yarpbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/yarpbroker.h
@@ -53,12 +53,12 @@ public:
      bool kill();
      bool connect(const char* from, const char* to,
                         const char* carrier, bool persist=false);
-     bool disconnect(const char* from, const char* to);
+     bool disconnect(const char* from, const char* to, const char* carrier);
      bool rmconnect(const char* from, const char* to);
      int running(void);
      bool exists(const char* port);
      const char* requestRpc(const char* szport, const char* request, double timeout);
-     bool connected(const char* from, const char* to);
+     bool connected(const char* from, const char* to, const char* carrier);
      const char* error(void);
      bool initialized(void) { return bInitialized;}
      bool attachStdout(void);

--- a/src/libYARP_manager/src/execstate.cpp
+++ b/src/libYARP_manager/src/execstate.cpp
@@ -436,7 +436,7 @@ void Dying::disconnectAllPorts(void)
         for(itr=executable->getConnections().begin();
             itr!=executable->getConnections().end(); itr++)
         {
-            if( !executable->getBroker()->disconnect((*itr).from(), (*itr).to()) )
+            if( !executable->getBroker()->disconnect((*itr).from(), (*itr).to(), (*itr).carrier()) )
             {
                 OSTRINGSTREAM msg;
                 msg<<"cannot disconnect "<<(*itr).from() <<" to "<<(*itr).to();

--- a/src/libYARP_manager/src/executable.cpp
+++ b/src/libYARP_manager/src/executable.cpp
@@ -191,7 +191,7 @@ void Executable::watchdogImplement(void)
     {
         CnnIterator itr;
         for(itr=connections.begin(); itr!=connections.end(); itr++)
-            if( !broker->connected((*itr).from(), (*itr).to()) )
+            if( !broker->connected((*itr).from(), (*itr).to(), (*itr).carrier()) )
                 execMachine->connectionFailed(&(*itr));
     }
 }

--- a/src/libYARP_manager/src/localbroker.cpp
+++ b/src/libYARP_manager/src/localbroker.cpp
@@ -363,7 +363,7 @@ bool LocalBroker::connect(const char* from, const char* to,
     }
 
     NetworkBase::connect(from, to, carrier);
-    if(!connected(from, to))
+    if(!connected(from, to, carrier))
     {
         strError = "cannot connect ";
         strError +=from;
@@ -373,7 +373,7 @@ bool LocalBroker::connect(const char* from, const char* to,
     return true;
 }
 
-bool LocalBroker::disconnect(const char* from, const char* to)
+bool LocalBroker::disconnect(const char* from, const char* to, const char *carrier)
 {
 
     if(!from)
@@ -402,7 +402,7 @@ bool LocalBroker::disconnect(const char* from, const char* to)
         return true;
     }
 
-    if(!connected(from, to))
+    if(!connected(from, to, carrier))
         return true;
 
     if(!NetworkBase::disconnect(from, to))
@@ -464,7 +464,7 @@ const char* LocalBroker::requestRpc(const char* szport, const char* request, dou
     return response.toString().c_str();
 }
 
-bool LocalBroker::connected(const char* from, const char* to)
+bool LocalBroker::connected(const char* from, const char* to, const char* carrier)
 {
     if(!exists(from) || !exists(to))
         return false;

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -923,7 +923,8 @@ bool Manager::disconnect(unsigned int id)
     //connector.init();
 
     if( !connector.disconnect(connections[id].from(),
-                            connections[id].to()) )
+                              connections[id].to(),
+                              connections[id].carrier()) )
     {
         logger->addError(connector.error());
         //cout<<connector.error()<<endl;
@@ -939,7 +940,7 @@ bool Manager::disconnect(void)
     //connector.init();
     CnnIterator cnn;
     for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
-        if( !connector.disconnect((*cnn).from(), (*cnn).to()) )
+        if( !connector.disconnect((*cnn).from(), (*cnn).to(), (*cnn).carrier()) )
             {
                 logger->addError(connector.error());
                 //cout<<connector.error()<<endl;
@@ -992,7 +993,8 @@ bool Manager::connected(unsigned int id)
     //YarpBroker connector;
     //connector.init();
     return connector.connected(connections[id].from(),
-                            connections[id].to());
+                               connections[id].to(),
+                               connections[id].carrier());
 }
 
 
@@ -1003,7 +1005,7 @@ bool Manager::connected(void)
     CnnIterator cnn;
     bool bConnected = true;
     for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
-        if( !connector.connected((*cnn).from(), (*cnn).to()) )
+        if( !connector.connected((*cnn).from(), (*cnn).to(), (*cnn).carrier()) )
             bConnected = false;
     return bConnected;
 }

--- a/src/libYARP_manager/src/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarpbroker.cpp
@@ -421,7 +421,7 @@ bool YarpBroker::connect(const char* from, const char* to,
             return true;
 
         NetworkBase::connect(from, to, style);
-        if(!connected(from, to))
+        if(!connected(from, to, carrier))
         {
             strError = "cannot connect ";
             strError +=from;
@@ -434,7 +434,7 @@ bool YarpBroker::connect(const char* from, const char* to,
         string topic = string("topic:/") + string(from) + string(to);
         NetworkBase::connect(from, topic.c_str(), style);
         NetworkBase::connect(topic.c_str(), to, style);
-        if(!connected(from, to))
+        if(!connected(from, to, carrier))
         {
             strError = "a persistent connection from ";
             strError +=from;
@@ -448,7 +448,7 @@ bool YarpBroker::connect(const char* from, const char* to,
     return true;
 }
 
-bool YarpBroker::disconnect(const char* from, const char* to)
+bool YarpBroker::disconnect(const char* from, const char* to, const char* carrier)
 {
 
     if(!from)
@@ -479,12 +479,13 @@ bool YarpBroker::disconnect(const char* from, const char* to)
     }
     */
 
-    if(!connected(from, to))
+    if(!connected(from, to, carrier))
         return true;
 
     ContactStyle style;
     style.quiet = true;
     style.timeout = CONNECTION_TIMEOUT;
+    style.carrier = carrier;
     if(!NetworkBase::disconnect(from, to, style))
     {
         strError = "cannot disconnect ";
@@ -546,16 +547,16 @@ const char* YarpBroker::requestRpc(const char* szport, const char* request, doub
     return response.toString().c_str();
 }
 
-bool YarpBroker::connected(const char* from, const char* to)
+bool YarpBroker::connected(const char* from, const char* to, const char* carrier)
 {
     if(!exists(from) || !exists(to))
         return false;
     ContactStyle style;
     style.quiet = true;
     style.timeout = CONNECTION_TIMEOUT;
+    style.carrier = carrier;
     return NetworkBase::isConnected(from, to, style);
 }
-
 
 bool YarpBroker::getSystemInfo(const char* server, SystemInfoSerializer& info)
 {


### PR DESCRIPTION
### e9295b3671f3114a65421c66c53c1f7838de03b7 YARP_OS: Improve PortCore list [in|out] commands

They also return now:

* `(connectionless 1)` when the connection is connectionless (i.e. udp)
* `(push 0)` when the connection is not push (i.e. mjpeg)

### 685a19b1bf4e378460e87620a99f137411cf1e87 Fix some cases of connections leaving a streaming connection pending
When connecting two ports, if a connection already exists between these two ports, this is disconnected and replaced with the new connection. This usually happens on the same side, for example if a connection is "udp" and a "tcp" connection is requested, the sending port is contacted, and the connection is closed.

When connecting using a "pull" carrier (i.e. mjpeg), if a connection between the two ports exists it is closed, but on the receiver side. This is not a problem for "connected" connections, like tcp, because the sender notices that the receiver cut the connection, but for "connectionless" connections (like udp and mcast), the receiver has no way to know that the receiver stopped listening and therefore it cannot know that it should stop streaming data. (The same thing should theoretically happen with a "pull-connectionless" carrier followed by a normal one)

This means that the port continues streaming data that is not read by anyone until a disconnect command is sent.
    
The process executing the disconnection does not necessarily know anything about the carriers (for example mjpeg could not be built on the system calling "yarp connect"), therefore since now this information is returned by the PortCore list [in|out] commands (see e9295b3671f3114a65421c66c53c1f7838de03b7), we use this information to detect the cases when the disconnection will not happen automatically, and eventually we send a disconnection command to the port sending data.

#### WARNING
**This means that each "connect" and "disconnect" command needs to execute an extra "list" command, but unfortunately there is no other way to know whether a disconnect command should be sent or not.**
I don't think this will be an issue, but please comment here if you think it is. @lornat75, @pattacini, @vtikha, @traversaro, @apaikan

### c108b3c2fff17774587dfa12b31bf5de7e4c47f8 YARP_manager: Pass carrier with connected and disconnect commands

This allows yarp to know whether the connection is push or pull, and therefore it will report the correct status and properly perform the disconnection. (Fixes #595)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215102134%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215114829%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215134474%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215353662%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215355004%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215574764%22%2C%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-218758449%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/736%23issuecomment-215102134%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40robotology/wysiwyd-developers%20%40matejhof%20%5Cr%5CnIt%20seems%20that%20this%20PR%20fixes%20the%20problem%20with%20%60udp%60%20connections.%22%2C%20%22created_at%22%3A%20%222016-04-27T14%3A30%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20we%20still%20have%20the%20problem%20with%20udp%20connections.%20This%20happens%20only%20with%20the%20manager.%20I%20am%20moving%20it%20to%20a%20separate%20issue%20%23742%22%2C%20%22created_at%22%3A%20%222016-04-27T15%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20I%20go%20on%20and%20merge%20this%3F%20Does%20the%20extra%20%5C%22list%5C%22%20command%20seem%20reasonable%3F%22%2C%20%22created_at%22%3A%20%222016-04-27T16%3A12%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20a%20little%20concerned%20because%20this%20PR%20has%20a%20large%20impact%20and%20need%20to%20be%20%28very%29%20well%20tested.%20%22%2C%20%22created_at%22%3A%20%222016-04-28T08%3A40%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40drdanz%20%5Cr%5Cn%3E%20the%20receiver%20has%20no%20way%20to%20know%20that%20the%20receiver%20stopped%20listening%20and%20therefore%20it%20cannot%20know%20that%20it%20should%20stop%20streaming%20data%5Cr%5Cn%5Cr%5CnI%20guess%20it%20is%20the%20%2A%2Asender%2A%2A%20that%20has%20no%20way%20to%20know%20etc%20etc%2C%20right%3F%22%2C%20%22created_at%22%3A%20%222016-04-28T08%3A46%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40traversaro%20yep%2C%20sorry%20for%20the%20confusion%22%2C%20%22created_at%22%3A%20%222016-04-28T21%3A56%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing%20this.%20I%20will%20rebase%20and%20reopen%20it%20as%20a%20merge%20to%20the%20devel%20branch%20after%20tomorrow%20release%22%2C%20%22created_at%22%3A%20%222016-05-12T13%3A34%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/736#issuecomment-215102134'>General Comment</a></b>
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @robotology/wysiwyd-developers @matejhof
It seems that this PR fixes the problem with `udp` connections.
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> Actually we still have the problem with udp connections. This happens only with the manager. I am moving it to a separate issue #742
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Can I go on and merge this? Does the extra "list" command seem reasonable?
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> I am a little concerned because this PR has a large impact and need to be (very) well tested.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> @drdanz
> the receiver has no way to know that the receiver stopped listening and therefore it cannot know that it should stop streaming data
I guess it is the **sender** that has no way to know etc etc, right?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @traversaro yep, sorry for the confusion
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Closing this. I will rebase and reopen it as a merge to the devel branch after tomorrow release


<a href='https://www.codereviewhub.com/robotology/yarp/pull/736?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/736?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/736'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>