### PR TITLE
ControlBoardWrapper2: additional check during attach

### DIFF
--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -591,7 +591,7 @@ bool ControlBoardWrapper::openDeferredAttach(Property& prop)
         tmpDevice->setVerbose(_verb);
 
         int axes=top-base+1;
-        if (!tmpDevice->configure(base, top, axes, nets->get(k).asString().c_str()))
+        if (!tmpDevice->configure(base, top, axes, nets->get(k).asString().c_str(), this))
         {
             yError() <<"configure of subdevice ret false";
             return false;
@@ -689,7 +689,7 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     tmpDevice->setVerbose(_verb);
 
     std::string subDevName ((partName + "_" + prop.find("subdevice").asString().c_str()));
-    if (!tmpDevice->configure(base, top, controlledJoints, subDevName) )
+    if (!tmpDevice->configure(base, top, controlledJoints, subDevName, this) )
     {
         yError() <<"configure of subdevice ret false";
         return false;

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.h
@@ -361,6 +361,9 @@ public:
     */
     bool verbose() const { return _verb; }
 
+    /* Return id of this device */
+    yarp::os::ConstString getId() { return partName; };
+
     /**
     * Default open() method.
     * @return always false since initialization requires parameters.

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.cpp
@@ -54,8 +54,9 @@ SubDevice::SubDevice()
     _subDevVerbose = false;
 }
 
-bool SubDevice::configure(int b, int t, int n, const std::string &key)
+bool SubDevice::configure(int b, int t, int n, const std::string &key, yarp::dev::ControlBoardWrapper *_parent)
 {
+    parent = _parent;
     configuredF=false;
 
     base=b;
@@ -121,6 +122,14 @@ void SubDevice::detach()
 
 bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
 {
+    std::string parentName;
+    if(parent)
+    {
+        parentName = parent->getId();
+    }
+    else
+        parentName = "";
+
     if (id!=k)
         {
             yError()<<"controlBoardWrapper: Wrong device" << k.c_str();
@@ -209,7 +218,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         return false;
     }
 
-    if( ! (vel || vel2) ) // One of the 2 is enough, therefor if both are missing I raise an error
+    if( ! (vel || vel2) ) // One of the 2 is enough, therefore if both are missing I raise an error
     {
         yError("ControlBoarWrapper: neither IVelocityControl nor IVelocityControl2 interface was not found in subdevice. Quitting");
         return false;
@@ -258,6 +267,17 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
     {
         yError("ControlBoarWrapper: check device configuration, number of joints of attached device '%d' less than the one specified during configuration '%d' for %s.", deviceJoints, axes, k.c_str());
         return false;
+    }
+
+    int subdevAxes;
+    if(!pos->getAxes(&subdevAxes))
+    {
+
+        yError() << "ControlBoardWrapper for device <" << parentName << "> attached to subdevice " << k.c_str() << " but it was not ready yet. \n" \
+                 << "Please check the device has been correctly created and all required initialization actions has been performed.";
+                 return false;
+        attachedF=false;
+
     }
     attachedF=true;
     return true;

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.h
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.h
@@ -78,6 +78,8 @@ public:
 
     bool configuredF;
 
+    yarp::dev::ControlBoardWrapper   *parent;
+
     yarp::dev::PolyDriver            *subdevice;
     yarp::dev::IPidControl           *pid;
     yarp::dev::IPositionControl      *pos;
@@ -113,7 +115,7 @@ public:
     void detach();
     inline void setVerbose(bool _verbose) {_subDevVerbose = _verbose; }
 
-    bool configure(int base, int top, int axes, const std::string &id);
+    bool configure(int base, int top, int axes, const std::string &id, yarp::dev::ControlBoardWrapper *_parent);
 
     inline void refreshJointEncoders()
     {


### PR DESCRIPTION
add check that subdevice is correctly configured during attachAll

This check is implemented by calling the getAxes function and checking the return value.
If true it is assumed subdevice is correctly configured, if false the attach action fails.

It'd be nice to propagate the `isValid()` method of the `PolyDriver` to the `DeviceDriver` interface to have a clean API.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/753?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/753'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>