### PR TITLE
DepthImage PortMonitor example: invert scale

### DIFF
--- a/example/portmonitor/depth_image/DepthImage.cpp
+++ b/example/portmonitor/depth_image/DepthImage.cpp
@@ -74,13 +74,16 @@ yarp::os::Things& DepthImageConverter::update(yarp::os::Things& thing)
         for(int w=0; w<img->width(); w++)
         {
             float inVal = inPixels[w + (h * img->width())];
-            int val = (int) (inVal * 255 / (max - min));
-            if(val >= 255)
-                val = 250;
-            if(val <= 1)
-                val = 1;
-            pixels[w + (h * (img->width() ))] = (char) val;
-            fflush(stdout);
+            if (inVal != inVal /* NaN */ || inVal < min || inVal > max) {
+                pixels[w + (h * (img->width() ))] = 0;
+            } else {
+                int val = (int) (255.0 - (inVal * 255.0 / (max - min)));
+                if(val >= 255)
+                    val = 255;
+                if(val <= 0)
+                    val = 0;
+                pixels[w + (h * (img->width() ))] = (char) val;
+            }
         }
     }
     th.setPortWriter(&outImg);


### PR DESCRIPTION
@barbalberto
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/756?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/756'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>