### PR TITLE
Control board remapper

### DIFF
--- a/scripts/admin/generate-cmake-options.sh
+++ b/scripts/admin/generate-cmake-options.sh
@@ -1,4 +1,4 @@
-### parameters are 
+### parameters are
 # $1: hostname (could be also buildtype)
 # $2: os (macos, winxp, lenny, etch, karmic ...)
 # $3: test type: nightly continuous experimental
@@ -22,6 +22,7 @@ CMAKE_OPTIONS="\
 -DENABLE_yarpcar_human_carrier:BOOL=TRUE \
 -DCREATE_DEVICE_LIBRARY_MODULES:BOOL=TRUE \
 -DENABLE_yarpmod_fakebot:BOOL=TRUE \
+-DENABLE_yarpmod_fakeMotionControl=TRUE \
 -DTEST_yarpidl_rosmsg:BOOL=TRUE \
 -DTEST_yarpidl_thrift:BOOL=TRUE \
 "
@@ -45,12 +46,12 @@ case $3 in
    "Experimental" )
       CMAKE_OPTIONS=" \
         $CMAKE_OPTIONS \
-      " 
+      "
       ;;
    "Continuous" )
      CMAKE_OPTIONS=" \
         $CMAKE_OPTIONS \
-      " 
+      "
       ;;
    "Nightly" )
       CMAKE_OPTIONS=" \

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -146,7 +146,9 @@ set(YARP_devices_SRCS   src/modules/AnalogWrapper/AnalogWrapper.cpp
                         src/modules/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
                         src/modules/Rangefinder2DClient/Rangefinder2DClient.cpp
                         src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
-                        src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.cpp)
+                        src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.cpp
+                        src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
+                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp)
 
 set(YARP_devices_HDRS   src/modules/AnalogWrapper/AnalogWrapper.h
                         src/modules/AnalogSensorClient/AnalogSensorClient.h
@@ -155,7 +157,9 @@ set(YARP_devices_HDRS   src/modules/AnalogWrapper/AnalogWrapper.h
                         src/modules/Rangefinder2DWrapper/Rangefinder2DWrapper.h
                         src/modules/Rangefinder2DClient/Rangefinder2DClient.h
                         src/modules/ControlBoardWrapper/ControlBoardWrapper.h
-                        src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.h)
+                        src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+                        src/modules/ControlBoardRemapper/ControlBoardRemapper.h
+                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.h)
 
 
 # handle the ros / yarp thrift messages

--- a/src/libYARP_dev/src/Drivers.cpp
+++ b/src/libYARP_dev/src/Drivers.cpp
@@ -19,9 +19,7 @@
 #include <yarp/dev/Drivers.h>
 
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/Logger.h>
 
 #include <yarp/os/YarpPlugin.h>
@@ -154,8 +152,6 @@ public:
     }
 };
 
-
-#ifdef YARP_HAS_ACE
 class StubDriver : public DeviceDriver {
 private:
     YarpPluginSettings settings;
@@ -232,7 +228,6 @@ public:
         return settings.getBaseClassName();
     }
 };
-#endif
 
 #define HELPER(x) (*(((DriversHelper*)(x))))
 
@@ -276,7 +271,6 @@ DeviceDriver *Drivers::open(yarp::os::Searchable& prop) {
 }
 
 DriverCreator *DriversHelper::load(const char *name) {
-#ifdef YARP_HAS_ACE
     StubDriver *result = new StubDriver(name,false);
     if (!result->isValid()) {
         delete result;
@@ -291,9 +285,6 @@ DriverCreator *DriversHelper::load(const char *name) {
     add(creator);
     delete result;
     return creator;
-#else
-    return NULL;
-#endif
 }
 
 
@@ -558,7 +549,6 @@ int Drivers::yarpdev(int argc, char *argv[]) {
 }
 
 DeviceDriver *StubDriverCreator::create() {
-#ifdef YARP_HAS_ACE
     //printf("Creating %s from %s\n", desc.c_str(), libname.c_str());
     StubDriver *result = new StubDriver(libname.c_str(),fnname.c_str(),false);
     if (result==NULL) return result;
@@ -569,10 +559,6 @@ DeviceDriver *StubDriverCreator::create() {
     }
     //printf("Created %s from %s\n", desc.c_str(), libname.c_str());
     return result;
-#else
-    fprintf(stderr,"Cannot fill stub drivers without ACE\n");
-    return NULL;
-#endif
 }
 
 

--- a/src/libYARP_dev/src/PopulateDrivers.cpp
+++ b/src/libYARP_dev/src/PopulateDrivers.cpp
@@ -41,6 +41,7 @@ extern DriverCreator *createRangefinder2DWrapper();
 extern DriverCreator *createRangefinder2DClient();
 extern DriverCreator *createRGBDSensorWrapper();
 extern DriverCreator *createRGBDSensorClient();
+extern DriverCreator *createControlBoardRemapper();
 
 #ifndef YARP_NO_DEPRECATED
 extern DriverCreator *createServerControlBoard();
@@ -92,6 +93,7 @@ void Drivers::init() {
     add(createRangefinder2DWrapper());
     add(createRGBDSensorWrapper());
     add(createRGBDSensorClient());
+    add(createControlBoardRemapper());
 
 #ifndef YARP_NO_DEPRECATED
     add(createClientControlBoard());

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -1802,7 +1802,7 @@ bool ControlBoardRemapper::getEncoders(double *encs)
 
         if (p->iJntEnc)
         {
-            bool ok = p->iJntEnc->getEncoder(off, encs);
+            bool ok = p->iJntEnc->getEncoder(off, encs+l);
             ret = ret && ok;
         }
         else

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -1,0 +1,4809 @@
+/*
+ * Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Lorenzo Natale, Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "ControlBoardRemapper.h"
+#include "ControlBoardRemapperHelpers.h"
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/LockGuard.h>
+
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <cassert>
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace std;
+
+// needed for the driver factory.
+DriverCreator *createControlBoardRemapper()
+{
+    return new DriverCreatorOf<yarp::dev::ControlBoardRemapper>
+            ("controlboardremapper", "controlboardwrapper2", "yarp::dev::ControlBoardRemapper");
+}
+
+ControlBoardRemapper::ControlBoardRemapper()
+{
+    controlledJoints = 0;
+    _verb = false;
+
+    axesNames.clear();
+}
+
+ControlBoardRemapper::~ControlBoardRemapper()
+{
+}
+
+bool ControlBoardRemapper::close()
+{
+    return detachAll();
+}
+
+bool ControlBoardRemapper::open(Searchable& config)
+{
+    Property prop;
+    prop.fromString(config.toString().c_str());
+
+    _verb = (prop.check("verbose","if present, give detailed output"));
+    if (_verb)
+    {
+        yInfo("ControlBoardRemapper: running with verbose output\n");
+    }
+
+    if(!parseOptions(prop))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool ControlBoardRemapper::parseOptions(Property& prop)
+{
+    bool ok = true;
+
+    usingAxesNamesForAttachAll  = prop.check("axesNames", "list of networks merged by this wrapper");
+    usingNetworksForAttachAll = prop.check("networks", "list of networks merged by this wrapper");
+
+
+    if( usingAxesNamesForAttachAll &&
+        usingNetworksForAttachAll )
+    {
+        yError() << "controlBoardRemapper: Both axesNames and networks option present, this is not supported.\n";
+        return false;
+    }
+
+    if( !usingAxesNamesForAttachAll &&
+        !usingNetworksForAttachAll )
+    {
+        yError() << "controlBoardRemapper: axesNames option not found";
+        return false;
+    }
+
+    if( usingAxesNamesForAttachAll )
+    {
+        ok = parseAxesNames(prop);
+    }
+
+    if( usingNetworksForAttachAll )
+    {
+        ok = parseNetworks(prop);
+    }
+
+    return ok;
+}
+
+bool ControlBoardRemapper::parseAxesNames(const Property& prop)
+{
+    Bottle *propAxesNames=prop.find("axesNames").asList();
+    if(propAxesNames==0)
+    {
+       yError() <<"ControlBoardRemapper: Error parsing parameters: \"axesNames\" should be followed by a list\n";
+       return false;
+    }
+
+    axesNames.resize(propAxesNames->size());
+    for(int ax=0; ax < propAxesNames->size(); ax++)
+    {
+        axesNames[ax] = propAxesNames->get(ax).asString().c_str();
+    }
+
+    this->setNrOfControlledAxes(axesNames.size());
+
+    return true;
+}
+
+bool ControlBoardRemapper::parseNetworks(const Property& prop)
+{
+    Bottle *nets=prop.find("networks").asList();
+    if(nets==0)
+    {
+       yError() <<"ControlBoardRemapper: Error parsing parameters: \"networks\" should be followed by a list\n";
+       return false;
+    }
+
+    if (!prop.check("joints", "number of joints of the part"))
+    {
+        yError() <<"ControlBoardRemapper: joints options not found when reading networks option";
+        return false;
+    }
+
+    this->setNrOfControlledAxes((size_t)prop.find("joints").asInt());
+
+    int nsubdevices=nets->size();
+    remappedControlBoards.lut.resize(controlledJoints);
+    remappedControlBoards.subdevices.resize(nsubdevices);
+
+    // configure the devices
+    for(int k=0;k<nets->size();k++)
+    {
+        Bottle parameters;
+        int wBase;
+        int wTop;
+        int base;
+        int top;
+
+        parameters=prop.findGroup(nets->get(k).asString().c_str());
+
+        if(parameters.size()==2)
+        {
+            Bottle *bot=parameters.get(1).asList();
+            Bottle tmpBot;
+            if(bot==NULL)
+            {
+                // probably data are not passed in the correct way, try to read them as a string.
+                ConstString bString(parameters.get(1).asString());
+                tmpBot.fromString(bString);
+
+                if(tmpBot.size() != 4)
+                {
+                    yError() << "Error: check network parameters in part description"
+                             << "--> I was expecting "<<nets->get(k).asString().c_str() << " followed by a list of four integers in parenthesis"
+                             << "Got: "<< parameters.toString().c_str() << "\n";
+                    return false;
+                }
+                else
+                {
+                    bot = &tmpBot;
+                }
+            }
+
+            // If I came here, bot is correct
+            wBase=bot->get(0).asInt();
+            wTop=bot->get(1).asInt();
+            base=bot->get(2).asInt();
+            top=bot->get(3).asInt();
+        }
+        else if (parameters.size()==5)
+        {
+            // yError<<"Parameter networks use deprecated syntax\n";
+            wBase=parameters.get(1).asInt();
+            wTop=parameters.get(2).asInt();
+            base=parameters.get(3).asInt();
+            top=parameters.get(4).asInt();
+        }
+        else
+        {
+            yError() <<"Error: check network parameters in part description"
+                     <<"--> I was expecting "<<nets->get(k).asString().c_str() << " followed by a list of four integers in parenthesis"
+                     <<"Got: "<< parameters.toString().c_str() << "\n";
+            return false;
+        }
+
+        RemappedSubControlBoard *tmpDevice=remappedControlBoards.getSubControlBoard((size_t)k);
+        tmpDevice->setVerbose(_verb);
+
+        if( (wTop-wBase) != (top-base) )
+        {
+            yError() <<"Error: check network parameters in network "<<nets->get(k).asString().c_str() <<
+             "I was expecting a well form quadruple of numbers, got instead: "<< parameters.toString().c_str();
+        }
+
+        tmpDevice->id = nets->get(k).asString().c_str();
+
+        for(int j=wBase;j<=wTop;j++)
+        {
+            int off = j-wBase;
+            remappedControlBoards.lut[j].subControlBoardIndex=k;
+            remappedControlBoards.lut[j].axisIndexInSubControlBoard=base+off;
+        }
+    }
+
+    return true;
+}
+
+void ControlBoardRemapper::setNrOfControlledAxes(const size_t nrOfControlledAxes)
+{
+    controlledJoints = nrOfControlledAxes;
+    buffers.controlBoardModes.resize(nrOfControlledAxes,0);
+    buffers.dummyBuffer.resize(nrOfControlledAxes,0.0);
+}
+
+
+bool ControlBoardRemapper::updateAxesName()
+{
+    bool ret = true;
+    axesNames.resize(controlledJoints);
+
+    for(int l=0; l < controlledJoints; l++)
+    {
+        yarp::os::ConstString axNameYARP;
+        bool ok = this->getAxisName(l,axNameYARP);
+        if( ok )
+        {
+            axesNames[l] = axNameYARP.c_str();
+        }
+
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::attachAll(const PolyDriverList &polylist)
+{
+    // For both cases, now configure everything that need
+    // all the attribute to be correctly configured
+    bool ok = false;
+
+    if( usingAxesNamesForAttachAll )
+    {
+        ok = attachAllUsingAxesNames(polylist);
+    }
+
+    if( usingNetworksForAttachAll )
+    {
+        ok = attachAllUsingNetworks(polylist);
+    }
+
+    //check if all devices are attached to the driver
+    bool ready=true;
+    for(unsigned int k=0; k<remappedControlBoards.getNrOfSubControlBoards(); k++)
+    {
+        if (!remappedControlBoards.subdevices[k].isAttached())
+        {
+            ready=false;
+        }
+    }
+
+    if (!ready)
+    {
+        yError("ControlBoardRemapper: AttachAll failed, some subdevice was not found or its attach failed\n");
+        return false;
+    }
+
+    if( ok )
+    {
+        configureBuffers();
+    }
+
+    return ok;
+}
+
+// First we store a map between each axes name
+// in the passed PolyDriverList and the device in which they belong and their index
+struct axisLocation
+{
+    ConstString subDeviceKey;
+    size_t indexOfSubDeviceInPolyDriverList;
+    int indexInSubDevice;
+};
+
+
+bool ControlBoardRemapper::attachAllUsingAxesNames(const PolyDriverList& polylist)
+{
+    std::map<std::string, axisLocation> axesLocationMap;
+
+    for(int p=0;p<polylist.size();p++)
+    {
+        // If there is a device with a specific device key, use it
+        // as a calibrator, otherwise rely on the subcontrolboards
+        // as usual
+        std::string deviceKey=polylist[p]->key.c_str();
+        if(deviceKey == "Calibrator" || deviceKey == "calibrator")
+        {
+            // Set the IRemoteCalibrator interface, the wrapper must point to the calibrator rdevice
+            yarp::dev::IRemoteCalibrator *calibrator;
+            polylist[p]->poly->view(calibrator);
+
+            IRemoteCalibrator::setCalibratorDevice(calibrator);
+            continue;
+        }
+
+        // find if one of the desired axis is in this device
+        yarp::dev::IAxisInfo *iaxinfos = 0;
+        yarp::dev::IEncoders *iencs = 0;
+        polylist[p]->poly->view(iaxinfos);
+        polylist[p]->poly->view(iencs);
+
+        if( !iencs ||
+            !iaxinfos )
+        {
+            yError() <<"ControlBoardRemapper: subdevice " << deviceKey << " does not implemented the required IAxisInfo or IEncoders interfaces";
+            return false;
+        }
+
+        int nrOfSubdeviceAxes;
+        bool ok = iencs->getAxes(&nrOfSubdeviceAxes);
+
+        if( !ok )
+        {
+            yError() <<"ControlBoardRemapper: subdevice " << deviceKey << " does not implemented the required getAxes method";
+            return false;
+        }
+
+        for(int axInSubDevice =0; axInSubDevice < nrOfSubdeviceAxes; axInSubDevice++)
+        {
+            yarp::os::ConstString axNameYARP;
+            ok = iaxinfos->getAxisName(axInSubDevice,axNameYARP);
+
+            std::string axName = axNameYARP.c_str();
+
+            if( !ok )
+            {
+                yError() <<"ControlBoardRemapper: subdevice " << deviceKey << " does not implemented the required getAxisName method";
+                return false;
+            }
+
+            std::map<std::string, axisLocation>::iterator it = axesLocationMap.find(axName);
+            if( it != axesLocationMap.end() )
+            {
+                yError() <<"ControlBoardRemapper: multiple axes have the same name " << axName
+                         <<" on on device " << polylist[p]->key << " with index  " << axInSubDevice
+                         <<" and another on device " << it->second.subDeviceKey << " with index " << it->second.indexInSubDevice;
+                return false;
+            }
+
+            axisLocation newLocation;
+            newLocation.subDeviceKey = polylist[p]->key;
+            newLocation.indexInSubDevice = axInSubDevice;
+            newLocation.indexOfSubDeviceInPolyDriverList = p;
+            axesLocationMap[axName] = newLocation;
+        }
+    }
+
+    // We store the key of all the devices that we actually use in the remapped control device
+    std::vector<std::string> subControlBoardsKeys;
+    std::map<std::string, size_t> subControlBoardKey2IndexInPolyDriverList;
+    std::map<std::string, size_t> subControlBoardKey2IndexInRemappedControlBoards;
+
+
+    // Once we build the axis map, we build the mapping between the remapped axes and
+    // the couple subControlBoard, axis in subControlBoard
+    for(size_t l=0; l < axesNames.size(); l++)
+    {
+        axisLocation loc = axesLocationMap[axesNames[l]];
+        std::string key = loc.subDeviceKey;
+
+        if(std::find(subControlBoardsKeys.begin(), subControlBoardsKeys.end(), key) == subControlBoardsKeys.end())
+        {
+            /* subControlBoardsKeys does not contain key */
+            subControlBoardKey2IndexInRemappedControlBoards[key] = subControlBoardsKeys.size();
+            subControlBoardsKeys.push_back(key);
+            subControlBoardKey2IndexInPolyDriverList[key] = loc.indexOfSubDeviceInPolyDriverList;
+        }
+    }
+
+    assert(controlledJoints == (int) axesNames.size());
+
+    // We have now the number of controlboards to attach to
+    size_t nrOfSubControlBoards = subControlBoardsKeys.size();
+    remappedControlBoards.lut.resize(controlledJoints);
+    remappedControlBoards.subdevices.resize(nrOfSubControlBoards);
+
+    // Open the controlboards
+    for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
+    {
+        size_t p = subControlBoardKey2IndexInPolyDriverList[subControlBoardsKeys[ctrlBrd]];
+        RemappedSubControlBoard *tmpDevice = remappedControlBoards.getSubControlBoard(ctrlBrd);
+        tmpDevice->setVerbose(_verb);
+        tmpDevice->id = subControlBoardsKeys[ctrlBrd];
+        bool ok = tmpDevice->attach(polylist[p]->poly,subControlBoardsKeys[ctrlBrd]);
+
+        if( !ok )
+        {
+            return false;
+        }
+    }
+
+
+    for(size_t l=0; l < axesNames.size(); l++)
+    {
+        axisLocation loc = axesLocationMap[axesNames[l]];
+        remappedControlBoards.lut[l].subControlBoardIndex = subControlBoardKey2IndexInRemappedControlBoards[loc.subDeviceKey];
+        remappedControlBoards.lut[l].axisIndexInSubControlBoard = (size_t)loc.indexInSubDevice;
+    }
+
+    return true;
+}
+
+
+bool ControlBoardRemapper::attachAllUsingNetworks(const PolyDriverList &polylist)
+{
+    for(int p=0;p<polylist.size();p++)
+    {
+        // look if we have to attach to a calibrator
+        std::string subDeviceKey = polylist[p]->key.c_str();
+        if(subDeviceKey == "Calibrator" || subDeviceKey == "calibrator")
+        {
+            // Set the IRemoteCalibrator interface, the wrapper must point to the calibrator rdevice
+            yarp::dev::IRemoteCalibrator *calibrator;
+            polylist[p]->poly->view(calibrator);
+
+            IRemoteCalibrator::setCalibratorDevice(calibrator);
+            continue;
+        }
+
+        // find appropriate entry in list of subdevices and attach
+        unsigned int k=0;
+        for(k=0; k<remappedControlBoards.getNrOfSubControlBoards(); k++)
+        {
+            if (remappedControlBoards.subdevices[k].id==subDeviceKey)
+            {
+                if (!remappedControlBoards.subdevices[k].attach(polylist[p]->poly, subDeviceKey))
+                {
+                    yError("ControlBoardRemapper: attach to subdevice %s failed\n", polylist[p]->key.c_str());
+                    return false;
+                }
+            }
+        }
+    }
+
+    bool ok = updateAxesName();
+
+    if( !ok )
+    {
+        yWarning() << "ControlBoardRemapper: unable to update axesNames";
+    }
+
+    return true;
+}
+
+
+bool ControlBoardRemapper::detachAll()
+{
+    //check if we already instantiated a subdevice previously
+    int devices=remappedControlBoards.getNrOfSubControlBoards();
+    for(int k=0;k<devices;k++)
+        remappedControlBoards.getSubControlBoard(k)->detach();
+
+    IRemoteCalibrator::releaseCalibratorDevice();
+    return true;
+}
+
+void ControlBoardRemapper::configureBuffers()
+{
+    allJointsBuffers.configure(remappedControlBoards);
+    selectedJointsBuffers.configure(remappedControlBoards);
+}
+
+
+bool ControlBoardRemapper::setControlModeAllAxes(const int cm)
+{
+    LockGuard guard(buffers.mutex);
+
+    for(int j=0; j < controlledJoints; j++)
+    {
+        buffers.controlBoardModes[j] = cm;
+    }
+
+    return this->setControlModes(buffers.controlBoardModes.data());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/// ControlBoard methods
+//////////////////////////////////////////////////////////////////////////////
+
+//
+//  IPid Interface
+//
+bool ControlBoardRemapper::setPid(int j, const Pid &p)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->pid)
+    {
+        return s->pid->setPid(off, p);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setPids(const Pid *ps)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->setPid(off, ps[l]);
+            ret=ret&&ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::setReference(int j, double ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->setReference(off, ref);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setReferences(const double *refs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->setReference(off, refs[l]);
+            ret=ret&&ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::setErrorLimit(int j, double limit)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->setErrorLimit(off, limit);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setErrorLimits(const double *limits)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->setErrorLimit(off, limits[l]);
+            ret=ret&&ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getError(int j, double *err)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->getError(off, err);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getErrors(double *errs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->getError(off, errs+l);
+            ret=ret&&ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getOutput(int j, double *out)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->getOutput(off, out);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getOutputs(double *outs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            ret=ret&&p->pid->getOutput(off, outs+l);
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::setOffset(int j, double v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->setOffset(off, v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getPid(int j, Pid *p)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->pid)
+    {
+        return s->pid->getPid(off, p);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getPids(Pid *pids)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->getPid(off, pids+l);
+            ret = ok && ret;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getReference(int j, double *ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->getReference(off, ref);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getReferences(double *refs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->getReference(off, refs+l);
+            ret=ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getErrorLimit(int j, double *limit)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->getErrorLimit(off, limit);
+    }
+    return false;
+}
+
+bool ControlBoardRemapper::getErrorLimits(double *limits)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pid)
+        {
+            bool ok = p->pid->getErrorLimit(off, limits+l);
+            ret=ret&&ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::resetPid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->resetPid(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::disablePid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    return p->iMode2->setControlMode(off, VOCAB_CM_IDLE);
+}
+
+bool ControlBoardRemapper::enablePid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pid)
+    {
+        return p->pid->enablePid(off);
+    }
+
+    return false;
+}
+
+/* IPositionControl */
+bool ControlBoardRemapper::getAxes(int *ax)
+{
+    *ax=controlledJoints;
+    return true;
+}
+
+bool ControlBoardRemapper::setPositionMode()
+{
+    return this->setControlModeAllAxes(VOCAB_CM_POSITION);
+}
+
+bool ControlBoardRemapper::setOpenLoopMode()
+{
+    return this->setControlModeAllAxes(VOCAB_CM_OPENLOOP);
+}
+
+bool ControlBoardRemapper::positionMove(int j, double ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->positionMove(off, ref);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::positionMove(const double *refs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(refs,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->positionMove(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::positionMove(const int n_joints, const int *joints, const double *refs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(refs,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->positionMove(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getTargetPosition(const int j, double* ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        bool ret = p->pos2->getTargetPosition(off, ref);
+        return ret;
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTargetPositions(double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getTargetPositions(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                             allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                             allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(spds,remappedControlBoards);
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::getTargetPositions(const int n_joints, const int *joints, double *targets)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getTargetPositions(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                             selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                             selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(targets,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::relativeMove(int j, double delta)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->relativeMove(off, delta);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::relativeMove(const double *deltas)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(deltas,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->relativeMove(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::relativeMove(const int n_joints, const int *joints, const double *deltas)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(deltas,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->relativeMove(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::checkMotionDone(int j, bool *flag)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->checkMotionDone(off, flag);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::checkMotionDone(bool *flag)
+{
+    bool ret=true;
+    *flag=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pos2)
+        {
+            bool singleJointMotionDone =false;
+            bool ok = p->pos2->checkMotionDone(off, &singleJointMotionDone);
+            ret = ret && ok;
+            *flag = *flag  && singleJointMotionDone;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::checkMotionDone(const int n_joints, const int *joints, bool *flag)
+{
+    bool ret=true;
+    *flag=true;
+
+    for(int j=0;j<n_joints;j++)
+    {
+        int l = joints[j];
+
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->pos2)
+        {
+            bool singleJointMotionDone =false;
+            bool ok = p->pos2->checkMotionDone(off, &singleJointMotionDone);
+            ret = ret && ok;
+            *flag = *flag  && singleJointMotionDone;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefSpeed(int j, double sp)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->setRefSpeed(off, sp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setRefSpeeds(const double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(spds,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->setRefSpeeds(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefSpeeds(const int n_joints, const int *joints, const double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(spds,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->setRefSpeeds(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefAcceleration(int j, double acc)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->setRefAcceleration(off, acc);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setRefAccelerations(const double *accs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(accs,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->setRefAccelerations(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                               allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                               allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefAccelerations(const int n_joints, const int *joints, const double *accs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(accs,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->setRefAccelerations(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                               selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                               selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefSpeed(int j, double *ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->getRefSpeed(off, ref);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getRefSpeeds(double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getRefSpeeds(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                       allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                       allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(spds,remappedControlBoards);
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::getRefSpeeds(const int n_joints, const int *joints, double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getRefSpeeds(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(spds,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefAcceleration(int j, double *acc)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->getRefAcceleration(off, acc);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getRefAccelerations(double *accs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getRefAccelerations(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                              allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                              allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(accs,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefAccelerations(const int n_joints, const int *joints, double *accs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->pos2 )
+        {
+            ok = p->pos2->getRefAccelerations(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                              selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                              selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(accs,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::stop(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->pos2)
+    {
+        return p->pos2->stop(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::stop()
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        ok = p->pos2 ? p->pos2->stop(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                     allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data()) : false;
+
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::stop(const int n_joints, const int *joints)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+    yarp::os::LockGuard(buffers.mutex);
+
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(buffers.dummyBuffer.data(),n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->pos2->stop(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+
+/* IVelocityControl */
+
+bool ControlBoardRemapper::velocityMove(int j, double v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->vel2)
+    {
+        return p->vel2->velocityMove(off, v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::velocityMove(const double *v)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(v,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->vel2->velocityMove(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setVelocityMode()
+{
+    return this->setControlModeAllAxes(VOCAB_CM_VELOCITY);
+}
+
+/* IEncoders */
+bool ControlBoardRemapper::resetEncoder(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->resetEncoder(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::resetEncoders()
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->resetEncoder(off);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::setEncoder(int j, double val)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->setEncoder(off,val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setEncoders(const double *vals)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off = (int) remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex = remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->setEncoder(off, vals[l]);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getEncoder(int j, double *v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->getEncoder(off, v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getEncoders(double *encs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->getEncoder(off, encs);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getEncodersTimed(double *encs, double *t)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->getEncoderTimed(off, encs+l, t+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getEncoderTimed(int j, double *v, double *t)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->getEncoderTimed(off, v, t);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getEncoderSpeed(int j, double *sp)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->getEncoderSpeed(off, sp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getEncoderSpeeds(double *spds)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->getEncoderSpeed(off, spds+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getEncoderAcceleration(int j, double *acc)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iJntEnc)
+    {
+        return p->iJntEnc->getEncoderAcceleration(off,acc);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getEncoderAccelerations(double *accs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iJntEnc)
+        {
+            bool ok = p->iJntEnc->getEncoderSpeed(off, accs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+/* IMotor */
+bool ControlBoardRemapper::getNumberOfMotors(int *num)
+{
+    *num=controlledJoints;
+    return true;
+}
+
+bool ControlBoardRemapper::getTemperature(int m, double* val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->imotor)
+    {
+        return p->imotor->getTemperature(off, val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTemperatures(double *vals)
+{
+    bool ret=true;
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->imotor)
+        {
+            ret=ret&&p->imotor->getTemperature(off, vals+l);
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getTemperatureLimit(int m, double* val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->imotor)
+    {
+        return p->imotor->getTemperatureLimit(off, val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setTemperatureLimit (int m, const double val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->imotor)
+    {
+        return p->imotor->setTemperatureLimit(off,val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getGearboxRatio(int m, double* val)
+{
+    int off = (int)remappedControlBoards.lut[m].subControlBoardIndex;
+    size_t subIndex = remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->imotor)
+    {
+        return p->imotor->getGearboxRatio(off, val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setGearboxRatio(int m, const double val)
+{
+    int off = (int)remappedControlBoards.lut[m].subControlBoardIndex;
+    size_t subIndex = remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->imotor)
+    {
+        return p->imotor->setGearboxRatio(off, val);
+    }
+
+    return false;
+}
+
+/* IRemoteVariables */
+bool ControlBoardRemapper::getRemoteVariable(yarp::os::ConstString key, yarp::os::Bottle& val)
+{
+    yWarning("ControlBoardRemapper: getRemoteVariable is not properly implemented, use at your own risk.");
+
+    bool b = true;
+
+    for (unsigned int i = 0; i < remappedControlBoards.getNrOfSubControlBoards(); i++)
+    {
+        yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(i);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (!p->iVar)
+        {
+            return false;
+        }
+
+        yarp::os::Bottle tmpval;
+        bool ok = p->iVar->getRemoteVariable(key, tmpval);
+
+        if (ok)
+        {
+            val.append(tmpval);
+        }
+
+        b = b && ok;
+    }
+
+    return b;
+}
+
+bool ControlBoardRemapper::setRemoteVariable(yarp::os::ConstString key, const yarp::os::Bottle& val)
+{
+    yWarning("ControlBoardRemapper: setRemoteVariable is not properly implemented, use at your own risk.");
+
+    size_t subIndex = remappedControlBoards.lut[0].subControlBoardIndex;
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iVar)
+    {
+        return p->iVar->setRemoteVariable(key, val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
+{
+    yWarning("ControlBoardRemapper: getRemoteVariablesList is not properly implemented, use at your own risk.");
+
+    size_t subIndex = remappedControlBoards.lut[0].subControlBoardIndex;
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iVar)
+    {
+        return p->iVar->getRemoteVariablesList(listOfKeys);
+    }
+
+    return false;
+}
+
+/* IMotorEncoders */
+
+bool ControlBoardRemapper::resetMotorEncoder(int m)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->resetMotorEncoder(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::resetMotorEncoders()
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iMotEnc)
+        {
+            bool ok = p->iMotEnc->resetMotorEncoder(off);
+            ret= ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setMotorEncoder(int m, const double val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->setMotorEncoder(off,val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setMotorEncoders(const double *vals)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iMotEnc)
+        {
+            bool ok = p->iMotEnc->setMotorEncoder(off, vals[l]);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setMotorEncoderCountsPerRevolution(int m, double cpr)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->setMotorEncoderCountsPerRevolution(off,cpr);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoderCountsPerRevolution(int m, double *cpr)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->getMotorEncoderCountsPerRevolution(off, cpr);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoder(int m, double *v)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->getMotorEncoder(off, v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoders(double *encs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+        if (!p)
+            return false;
+
+        if (p->iMotEnc)
+        {
+            ret=ret&&p->iMotEnc->getMotorEncoder(off, encs+l);
+        }
+        else
+            ret=false;
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getMotorEncodersTimed(double *encs, double *t)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iMotEnc)
+        {
+            bool ok = p->iMotEnc->getMotorEncoderTimed(off, encs, t);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getMotorEncoderTimed(int m, double *v, double *t)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->getMotorEncoderTimed(off, v, t);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoderSpeed(int m, double *sp)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->getMotorEncoderSpeed(off, sp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoderSpeeds(double *spds)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off = (int) remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex = remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iMotEnc)
+        {
+            bool ok = p->iMotEnc->getMotorEncoderSpeed(off, spds + l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getMotorEncoderAcceleration(int m, double *acc)
+{
+    int off = (int) remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iMotEnc)
+    {
+        return p->iMotEnc->getMotorEncoderAcceleration(off,acc);
+    }
+    *acc=0.0;
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorEncoderAccelerations(double *accs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iMotEnc)
+        {
+            bool ok = p->iMotEnc->getMotorEncoderAcceleration(off, accs+l);
+            ret=ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::getNumberOfMotorEncoders(int *num)
+{
+    *num=controlledJoints;
+    return true;
+}
+
+/* IAmplifierControl */
+bool ControlBoardRemapper::enableAmp(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->amp)
+    {
+        return p->amp->enableAmp(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::disableAmp(int j)
+{
+    return this->setControlMode(j, VOCAB_CM_IDLE);
+}
+
+bool ControlBoardRemapper::getAmpStatus(int *st)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->amp)
+        {
+            bool ok = p->amp->getAmpStatus(off, st+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getAmpStatus(int j, int *v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->amp)
+    {
+        return p->amp->getAmpStatus(off,v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getCurrents(double *vals)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->amp)
+        {
+            bool ok = p->amp->getCurrent(off, vals+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getCurrent(int j, double *val)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->amp)
+    {
+        return p->amp->getCurrent(off,val);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setMaxCurrent(int j, double v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->amp)
+    {
+        return p->amp->setMaxCurrent(off,v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMaxCurrent(int j, double* v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->amp)
+    {
+        return p->amp->getMaxCurrent(off,v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getNominalCurrent(int m, double *val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if(!p)
+    {
+        return false;
+    }
+
+    if(!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->getNominalCurrent(off, val);
+}
+
+bool ControlBoardRemapper::getPeakCurrent(int m, double *val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if(!p)
+    {
+        return false;
+    }
+
+    if(!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->getPeakCurrent(off, val);
+}
+
+bool ControlBoardRemapper::setPeakCurrent(int m, const double val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->setPeakCurrent(off, val);
+}
+
+bool ControlBoardRemapper::getPWM(int m, double* val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if(!p)
+    {
+        return false;
+    }
+
+    if(!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->getPWM(off, val);
+}
+bool ControlBoardRemapper::getPWMLimit(int m, double* val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if(!p)
+    {
+        return false;
+    }
+
+    if(!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->getPWMLimit(off, val);
+}
+
+bool ControlBoardRemapper::setPWMLimit(int m, const double val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->setPWMLimit(off, val);
+}
+
+bool ControlBoardRemapper::getPowerSupplyVoltage(int m, double* val)
+{
+    int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if(!p)
+    {
+        return false;
+    }
+
+    if(!p->amp)
+    {
+        return false;
+    }
+
+    return p->amp->getPowerSupplyVoltage(off, val);
+}
+
+
+/* IControlLimits */
+
+bool ControlBoardRemapper::setLimits(int j, double min, double max)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->lim2)
+    {
+        return p->lim2->setLimits(off,min, max);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getLimits(int j, double *min, double *max)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->lim2)
+    {
+        return p->lim2->getLimits(off,min, max);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setVelLimits(int j, double min, double max)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (!p->lim2)
+    {
+        return false;
+    }
+
+    return p->lim2->setVelLimits(off,min, max);
+}
+
+bool ControlBoardRemapper::getVelLimits(int j, double *min, double *max)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if(!p->lim2)
+    {
+        return false;
+    }
+
+    return p->lim2->getVelLimits(off,min, max);
+}
+
+/* IRemoteCalibrator */
+IRemoteCalibrator *ControlBoardRemapper::getCalibratorDevice()
+{
+    return yarp::dev::IRemoteCalibrator::getCalibratorDevice();
+}
+
+bool ControlBoardRemapper::isCalibratorDevicePresent(bool *isCalib)
+{
+    return yarp::dev::IRemoteCalibrator::isCalibratorDevicePresent(isCalib);
+}
+
+bool ControlBoardRemapper::calibrateSingleJoint(int j)
+{
+    if(!getCalibratorDevice())
+    {
+        int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+        size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(subIndex);
+        if (!s)
+        {
+            return false;
+        }
+
+        if (s->remcalib)
+        {
+            return s->remcalib->calibrateSingleJoint(off);
+        }
+
+        return false;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->calibrateSingleJoint(j);
+    }
+}
+
+bool ControlBoardRemapper::calibrateWholePart()
+{
+    if(!getCalibratorDevice())
+    {
+        for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+        {
+            yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(ctrlBrd);
+            if (!s)
+            {
+                return false;
+            }
+
+            if (s->remcalib)
+            {
+                return s->remcalib->calibrateWholePart();
+            }
+        }
+
+        return false;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->calibrateWholePart();
+    }
+}
+
+bool ControlBoardRemapper::homingSingleJoint(int j)
+{
+    if(!getCalibratorDevice())
+    {
+        int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+        size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(subIndex);
+        if (!s)
+        {
+            return false;
+        }
+
+        if (s->remcalib)
+        {
+            return s->remcalib->homingSingleJoint(off);
+        }
+
+        return false;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->homingSingleJoint(j);
+    }
+}
+
+bool ControlBoardRemapper::homingWholePart()
+{
+    if(!getCalibratorDevice())
+    {
+        bool ret = true;
+        for(int l=0;l<controlledJoints;l++)
+        {
+            bool ok = this->homingSingleJoint(l);
+            ret = ret && ok;
+        }
+
+        return ret;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->homingWholePart();
+    }
+}
+
+bool ControlBoardRemapper::parkSingleJoint(int j, bool _wait)
+{
+    if(!getCalibratorDevice())
+    {
+        int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+        size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(subIndex);
+        if (!s)
+        {
+            return false;
+        }
+
+        if (s->remcalib)
+        {
+            return s->remcalib->parkSingleJoint(off,_wait);
+        }
+
+        return false;
+    }
+    else
+    {
+        return getCalibratorDevice()->parkSingleJoint(j, _wait);
+    }
+}
+
+bool ControlBoardRemapper::parkWholePart()
+{
+    if(!getCalibratorDevice())
+    {
+        bool ret = true;
+
+        for(int l=0; l<controlledJoints; l++)
+        {
+            bool _wait = false;
+            bool ok = this->parkSingleJoint(l,_wait);
+            ret = ret && ok;
+        }
+
+        return ret;
+    }
+    else
+    {
+        return getCalibratorDevice()->parkWholePart();
+    }
+}
+
+bool ControlBoardRemapper::quitCalibrate()
+{
+    if(!getCalibratorDevice())
+    {
+        for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+        {
+            yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(ctrlBrd);
+            if (!s)
+            {
+                return false;
+            }
+
+            if (s->remcalib)
+            {
+                return s->remcalib->quitCalibrate();
+            }
+        }
+
+        return false;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->quitCalibrate();
+    }
+}
+
+bool ControlBoardRemapper::quitPark()
+{
+    if(!getCalibratorDevice())
+    {
+        for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+        {
+            yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(ctrlBrd);
+            if (!s)
+            {
+                return false;
+            }
+
+            if (s->remcalib)
+            {
+                return s->remcalib->quitPark();
+            }
+        }
+
+        return false;
+    }
+    else
+    {
+        return IRemoteCalibrator::getCalibratorDevice()->quitPark();
+    }
+}
+
+
+/* IControlCalibration */
+
+bool ControlBoardRemapper::calibrate(int j, double p)
+{
+    int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s = remappedControlBoards.getSubControlBoard(subIndex);
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->calib)
+    {
+        return s->calib->calibrate(off, p);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::calibrate2(int j, unsigned int ui, double v1, double v2, double v3)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->calib2)
+    {
+        return p->calib2->calibrate2(off, ui,v1,v2,v3);
+    }
+    return false;
+}
+
+bool ControlBoardRemapper::setCalibrationParameters(int j, const CalibrationParameters& params)
+{
+    int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->calib2)
+    {
+        return p->calib2->setCalibrationParameters(off, params);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::done(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->calib2)
+    {
+        return p->calib2->done(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::abortPark()
+{
+    yError("ControlBoardRemapper: Calling abortPark -- not implemented\n");
+    return false;
+}
+
+bool ControlBoardRemapper::abortCalibration()
+{
+    yError("ControlBoardRemapper: Calling abortCalibration -- not implemented\n");
+    return false;
+}
+
+/* IAxisInfo */
+
+bool ControlBoardRemapper::getAxisName(int j, yarp::os::ConstString& name)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->info)
+    {
+        return p->info->getAxisName(off, name);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getJointType(int j, yarp::dev::JointTypeEnum& type)
+{
+    int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->info)
+    {
+        return p->info->getJointType(off, type);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setTorqueMode()
+{
+    return this->setControlModeAllAxes(VOCAB_CM_TORQUE);
+}
+
+bool ControlBoardRemapper::getRefTorques(double *refs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getRefTorque(off, refs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefTorque(int j, double *t)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getRefTorque(off, t);
+    }
+    return false;
+}
+
+bool ControlBoardRemapper::setRefTorques(const double *t)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(t,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok;
+
+        if( p->iTorque )
+        {
+            ok = p->iTorque->setRefTorques(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                           allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                           allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefTorque(int j, double t)
+{
+    int off = (int) remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setRefTorque(off, t);
+    }
+    return false;
+}
+
+bool ControlBoardRemapper::setRefTorques(const int n_joints, const int *joints, const double *t)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(t,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iTorque->setRefTorques(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::getBemfParam(int j, double *t)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+        return false;
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getBemfParam(off, t);
+    }
+    return false;
+}
+
+bool ControlBoardRemapper::setBemfParam(int j, double t)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setBemfParam(off, t);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getMotorTorqueParams(off, params);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setMotorTorqueParams(off, params);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setTorquePid(int j, const Pid &pid)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setTorquePid(off, pid);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setImpedance(int j, double stiff, double damp)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iImpedance)
+    {
+        return p->iImpedance->setImpedance(off, stiff, damp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setImpedanceOffset(int j, double offset)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iImpedance)
+    {
+        return p->iImpedance->setImpedanceOffset(off, offset);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorque(int j, double *t)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorque(off, t);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorques(double *t)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getTorque(off, t+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+ }
+
+bool ControlBoardRemapper::getTorqueRange(int j, double *min, double *max)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorqueRange(off, min, max);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorqueRanges(double *min, double *max)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getTorqueRange(off, min+l, max+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+ }
+
+bool ControlBoardRemapper::setTorquePids(const Pid *pids)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->setTorquePid(off, pids[l]);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setTorqueErrorLimit(int j, double limit)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setTorqueErrorLimit(off, limit);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setTorqueErrorLimits(const double *limits)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->setTorqueErrorLimit(off, limits[l]);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getTorqueError(int j, double *err)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorqueError(off, err);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorqueErrors(double *errs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getTorqueError(off, errs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getTorquePidOutput(int j, double *out)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorquePidOutput(off, out);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorquePidOutputs(double *outs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getTorquePidOutput(off, outs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getTorquePid(int j, Pid *pid)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorquePid(off, pid);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getImpedance(int j, double* stiff, double* damp)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iImpedance)
+    {
+        return p->iImpedance->getImpedance(off, stiff, damp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getImpedanceOffset(int j, double* offset)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iImpedance)
+    {
+        return p->iImpedance->getImpedanceOffset(off, offset);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iImpedance)
+    {
+        return p->iImpedance->getCurrentImpedanceLimit(off, min_stiff, max_stiff, min_damp, max_damp);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorquePids(Pid *pids)
+{
+     bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            ret=ret&&p->iTorque->getTorquePid(off, pids+l);
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getTorqueErrorLimit(int j, double *limit)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->getTorqueErrorLimit(off, limit);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getTorqueErrorLimits(double *limits)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iTorque)
+        {
+            bool ok = p->iTorque->getTorqueErrorLimit(off, limits+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::resetTorquePid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->resetTorquePid(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::disableTorquePid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->disableTorquePid(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::enableTorquePid(int j)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->enableTorquePid(off);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setTorqueOffset(int j, double v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iTorque)
+    {
+        return p->iTorque->setTorqueOffset(off,v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setPositionMode(int j)
+{
+    return this->setControlMode(j,VOCAB_CM_POSITION);
+}
+
+bool ControlBoardRemapper::setTorqueMode(int j)
+{
+    return this->setControlMode(j,VOCAB_CM_TORQUE);
+}
+
+bool ControlBoardRemapper::setImpedancePositionMode(int j)
+{
+    bool ok = true;
+    ok = ok && this->setControlMode(j,VOCAB_CM_POSITION);
+    ok = ok && this->setInteractionMode(j,VOCAB_IM_COMPLIANT);
+    return ok;
+}
+
+bool ControlBoardRemapper::setImpedanceVelocityMode(int j)
+{
+    bool ok = true;
+    ok = ok && this->setControlMode(j,VOCAB_CM_VELOCITY);
+    ok = ok && this->setInteractionMode(j,VOCAB_IM_COMPLIANT);
+    return ok;
+}
+
+bool ControlBoardRemapper::setVelocityMode(int j)
+{
+    return this->setControlMode(j,VOCAB_CM_TORQUE);
+}
+
+bool ControlBoardRemapper::setOpenLoopMode(int j)
+{
+    return this->setControlMode(j,VOCAB_CM_OPENLOOP);
+}
+
+bool ControlBoardRemapper::getControlMode(int j, int *mode)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!p)
+        return false;
+
+    return p->iMode2->getControlMode(off, mode);
+
+}
+
+bool ControlBoardRemapper::getControlModes(int *modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok;
+
+        if( p->iMode2 )
+        {
+            ok = p->iInteract->getInteractionModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                                   allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                                   allJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(modes,remappedControlBoards);
+
+    return ret;
+}
+
+// iControlMode2
+bool ControlBoardRemapper::getControlModes(const int n_joints, const int *joints, int *modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok;
+
+        if( p->iMode2 )
+        {
+            ok = p->iMode2->getControlModes(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            selectedJointsBuffers.m_bufferForSubControlBoardControlModes[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(modes,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setControlMode(const int j, const int mode)
+{
+    bool ret = true;
+
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    ret = p->iMode2->setControlMode(off, mode);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setControlModes(const int n_joints, const int *joints, int *modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(modes,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iMode2->setControlModes(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                             selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                             selectedJointsBuffers.m_bufferForSubControlBoardControlModes[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setControlModes(int *modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(modes,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iMode2->setControlModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                             allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                             allJointsBuffers.m_bufferForSubControlBoardControlModes[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefOutput(int j, double v)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iOpenLoop)
+    {
+        return p->iOpenLoop->setRefOutput(off, v);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setRefOutputs(const double *outs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iOpenLoop)
+        {
+            ret=ret&&p->iOpenLoop->setRefOutput(off, outs[l]);
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::setPosition(int j, double ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->posDir)
+    {
+        return p->posDir->setPosition(off, ref);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setPositionDirectMode()
+{
+    return this->setControlModeAllAxes(VOCAB_CM_POSITION_DIRECT);
+}
+
+bool ControlBoardRemapper::setPositions(const int n_joints, const int *joints, double *dpos)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(dpos,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->posDir->setPositions(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                          selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                          selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setPositions(const double *refs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(refs,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->posDir->setPositions(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                          allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                          allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+yarp::os::Stamp ControlBoardRemapper::getLastInputStamp()
+{
+    double averageTimestamp = 0.0;
+    int collectedTimestamps = 0;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return Stamp();
+        }
+
+        if(p->iTimed)
+        {
+            averageTimestamp = averageTimestamp + p->iTimed->getLastInputStamp().getTime();
+            collectedTimestamps++;
+        }
+    }
+
+
+    yarp::os::LockGuard(buffers.mutex);
+
+    if( collectedTimestamps > 0 )
+    {
+        buffers.stamp.update(averageTimestamp/collectedTimestamps);
+    }
+    else
+    {
+        buffers.stamp.update();
+    }
+
+    return buffers.stamp;
+}
+
+bool ControlBoardRemapper::getRefPosition(const int j, double* ref)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->posDir)
+    {
+        bool ret = p->posDir->getRefPosition(off, ref);
+        return ret;
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getRefPositions(double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->posDir )
+        {
+            ok = p->posDir->getRefPositions(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(spds,remappedControlBoards);
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::getRefPositions(const int n_joints, const int *joints, double *targets)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->posDir )
+        {
+            ok = p->posDir->getRefPositions(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(targets,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+
+//
+// IVelocityControl2 Interface
+//
+bool ControlBoardRemapper::velocityMove(const int n_joints, const int *joints, const double *spds)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(spds,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->vel2->velocityMove(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                        selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                        selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefVelocity(const int j, double* vel)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->vel2)
+    {
+        bool ret = p->vel2->getRefVelocity(off, vel);
+        return ret;
+    }
+
+    return false;
+}
+
+
+bool ControlBoardRemapper::getRefVelocities(double* vels)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->vel2 )
+        {
+            ok = p->vel2->getRefVelocities(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                           allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                           allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(vels,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefVelocities(const int n_joints, const int* joints, double* vels)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->vel2 )
+        {
+            ok = p->vel2->getRefVelocities(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                           selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                           selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(vels,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+
+bool ControlBoardRemapper::setVelPid(int j, const Pid &pid)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->vel2)
+    {
+        return s->vel2->setVelPid(off, pid);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setVelPids(const Pid *pids)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->vel2)
+        {
+            bool ok = p->vel2->setVelPid(off, pids[l]);
+            ret= ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getVelPid(int j, Pid *pid)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->vel2)
+    {
+        return s->vel2->getVelPid(off, pid);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getVelPids(Pid *pids)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->vel2)
+        {
+            bool ok = p->vel2->getVelPid(off, pids+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardRemapper::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->iInteract)
+    {
+        return s->iInteract->getInteractionMode(off, mode);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    // Resize the input buffers
+    selectedJointsBuffers.resizeSubControlBoardBuffers(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->iMode2 )
+        {
+            ok = p->iInteract->getInteractionModes(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                                   selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                                   selectedJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    selectedJointsBuffers.fillArbitraryJointVectorFromSubControlBoardBuffers(modes,n_joints,joints,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = true;
+
+        if( p->iMode2 )
+        {
+            ok = p->iInteract->getInteractionModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                                   allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                                   allJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+        }
+        else
+        {
+            ok = false;
+        }
+
+        ret = ret && ok;
+    }
+
+    allJointsBuffers.fillCompleteJointVectorFromSubControlBoardBuffers(modes,remappedControlBoards);
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *s=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!s)
+    {
+        return false;
+    }
+
+    if (s->iInteract)
+    {
+        return s->iInteract->setInteractionMode(off, mode);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(modes,n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iInteract->setInteractionModes(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                                    selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                                    selectedJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(modes,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iInteract->setInteractionModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                                    allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                                    allJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefOutput(int j, double *out)
+{
+    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iOpenLoop)
+    {
+        return p->iOpenLoop->getRefOutput(off, out);
+    }
+
+    return false;
+}
+
+bool ControlBoardRemapper::getRefOutputs(double *outs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iOpenLoop)
+        {
+            bool ok = p->iOpenLoop->getRefOutput(off, outs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -4061,9 +4061,9 @@ bool ControlBoardRemapper::getControlModes(int *modes)
 
         if( p->iMode2 )
         {
-            ok = p->iInteract->getInteractionModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
-                                                   allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
-                                                   allJointsBuffers.m_bufferForSubControlBoardInteractionModes[ctrlBrd].data());
+            ok = p->iMode2->getControlModes(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                            allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                            allJointsBuffers.m_bufferForSubControlBoardControlModes[ctrlBrd].data());
         }
         else
         {

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapper.h
@@ -1,0 +1,639 @@
+/*
+* Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+* Author: Lorenzo Natale, Silvio Traversaro
+* CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+*/
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDREMAPPER_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDREMAPPER_H
+
+#include <yarp/os/Network.h>
+
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/ControlBoardInterfacesImpl.h>
+#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/os/Semaphore.h>
+#include <yarp/dev/Wrapper.h>
+
+#include <string>
+#include <vector>
+
+#include "ControlBoardRemapperHelpers.h"
+
+#ifdef MSVC
+    #pragma warning(disable:4355)
+#endif
+
+namespace yarp {
+namespace dev {
+
+
+/**
+ *  @ingroup dev_impl_wrapper
+ *
+ * \section ControlBoardRemapper
+ * A device that takes a list of axes from multiple controlboards and
+ *  expose them as a single controlboard.
+ *
+ *
+ *  Parameters required by this device are:
+ * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required                    | Description                                                       | Notes |
+ * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:--------------------------: |:-----------------------------------------------------------------:|:-----:|
+ * | axesNames     |      -         | vector of strings  | -      |   -           | Yes     | Ordered list of the axes that are part of the remapped device. |  |
+ *
+ * The axes are then mapped to the wrapped controlboard in the attachAll method, using the
+ * values returned by the getAxisName method of the controlboard. If different axes
+ * in two attached controlboard have the same name, the behaviour of this device is undefined.
+ *
+ * Configuration file using .ini format.
+ *
+ * \code{.unparsed}
+ *  device controlboardremapper
+ *  axesNames (joint1 joint2 joint3)
+ *
+ * ...
+ * \endcode
+ *
+ * For compatibility with the controlboardwrapper2, the
+ * networks keyword can also be used to select the desired joints.
+ * For more information on the syntax of the networks, see the
+ * yarp::dev::ControlBoardWrapper class.
+ *
+ * \code{.unparsed}
+ *  networks (net_larm net_lhand)
+ *  joints 16
+ *  net_larm    0 3  0 3
+ *  net_lhand   4 6  0 2
+ * \endcode
+ *
+ */
+
+class ControlBoardRemapper : public yarp::dev::DeviceDriver,
+                             public yarp::dev::IPidControl,
+                             public yarp::dev::IPositionControl2,
+                             public yarp::dev::IPositionDirect,
+                             public yarp::dev::IVelocityControl2,
+                             public yarp::dev::IEncodersTimed,
+                             public yarp::dev::IMotor,
+                             public yarp::dev::IMotorEncoders,
+                             public yarp::dev::IAmplifierControl,
+                             public yarp::dev::IControlLimits2,
+                             public yarp::dev::IRemoteCalibrator,
+                             public yarp::dev::IControlCalibration,
+                             public yarp::dev::IControlCalibration2,
+                             public yarp::dev::IOpenLoopControl,
+                             public yarp::dev::ITorqueControl,
+                             public yarp::dev::IImpedanceControl,
+                             public yarp::dev::IControlMode2,
+                             public yarp::dev::IMultipleWrapper,
+                             public yarp::dev::IAxisInfo,
+                             public yarp::dev::IPreciselyTimed,
+                             public yarp::dev::IInteractionMode,
+                             public yarp::dev::IRemoteVariables {
+private:
+    std::vector<std::string> axesNames;
+    yarp::dev::RemappedControlBoards remappedControlBoards;
+
+    /** number of axes controlled by this controlboard */
+    int controlledJoints;
+
+    /** Verbosity of the class */
+    bool _verb;
+
+    // to open ports and print more detailed debug messages
+    std::string partName;
+
+    // Buffer data used to simplify implementation of multi joint methods
+    ControlBoardRemapperBuffers buffers;
+
+    // Buffer data used for full controlboard methods
+    ControlBoardSubControlBoardAxesDecomposition allJointsBuffers;
+
+    // Buffer data for multiple arbitary joint methods
+    ControlBoardArbitraryAxesDecomposition selectedJointsBuffers;
+
+    /**
+     * Set the number of controlled axes, resizing appropriatly
+     * all the necessary buffers.
+     */
+    void setNrOfControlledAxes(const size_t nrOfControlledAxes);
+
+    /**
+     * If the class was configured using the networks format,
+     * call this method to update the vector containing the
+     * axesName .
+     */
+    bool updateAxesName();
+
+    /**
+     * Configure buffers used by the device
+     */
+    void configureBuffers();
+
+    // Parse device options
+    bool parseOptions(yarp::os::Property &prop);
+
+    bool usingAxesNamesForAttachAll;
+    bool usingNetworksForAttachAll;
+
+    /***
+     * Parse device options if networks option is passed
+     *
+     * This will fill the axesNames and controlledJoints attributes, while it
+     * leaves empty the remappedDevices attribute that will be then
+     * filled only at the attachAll method.
+     */
+    bool parseAxesNames(const yarp::os::Property &prop);
+
+    /***
+     * Parse device options if networks option is passed
+     *
+     * This will fill the remappedDevices and controlledJoints attributes, while it
+     * leaves empty the axesNames attribute that will be then
+     * filled only at the attachAll method.
+     */
+    bool parseNetworks(const yarp::os::Property &prop);
+
+    /**
+     * attachAll if the networks option is used for configuration.
+     */
+    bool attachAllUsingNetworks(const yarp::dev::PolyDriverList &l);
+
+    /**
+     * attachAll if the axesNames option is used for configuration.
+     */
+    bool attachAllUsingAxesNames(const yarp::dev::PolyDriverList &l);
+
+    /**
+     * Helper for setting the same control mode in all the axes
+     * of the controlboard.
+     */
+    bool setControlModeAllAxes(const int cm);
+
+
+public:
+    /**
+    * Constructor.
+    */
+    ControlBoardRemapper();
+
+    virtual ~ControlBoardRemapper();
+
+    /**
+    * Return the value of the verbose flag.
+    * @return the verbose flag.
+    */
+    bool verbose() const { return _verb; }
+
+    /**
+    * Default open() method.
+    * @return always false since initialization requires parameters.
+    */
+    virtual bool open() { return false; }
+
+    /**
+    * Close the device driver by deallocating all resources and closing ports.
+    * @return true if successful or false otherwise.
+    */
+    virtual bool close();
+
+
+    /**
+    * Open the device driver.
+    * @param prop is a Searchable object which contains the parameters.
+    * Allowed parameters are described in the class documentation.
+    */
+    virtual bool open(yarp::os::Searchable &prop);
+
+    virtual bool detachAll();
+
+    virtual bool attachAll(const yarp::dev::PolyDriverList &l);
+
+    /* IPidControl */
+    virtual bool setPid(int j, const Pid &p);
+
+    virtual bool setPids(const Pid *ps);
+
+    virtual bool setReference(int j, double ref);
+
+    virtual bool setReferences(const double *refs);
+
+    virtual bool setErrorLimit(int j, double limit);
+
+    virtual bool setErrorLimits(const double *limits);
+
+    virtual bool getError(int j, double *err);
+
+    virtual bool getErrors(double *errs);
+
+    virtual bool getOutput(int j, double *out);
+
+    virtual bool getOutputs(double *outs);
+
+    virtual bool setOffset(int j, double v);
+
+    virtual bool getPid(int j, Pid *p);
+
+    virtual bool getPids(Pid *pids);
+
+    virtual bool getReference(int j, double *ref);
+
+    virtual bool getReferences(double *refs);
+
+    virtual bool getErrorLimit(int j, double *limit);
+
+    virtual bool getErrorLimits(double *limits);
+
+    virtual bool resetPid(int j);
+
+    virtual bool disablePid(int j);
+
+    virtual bool enablePid(int j);
+
+    /* IPositionControl */
+    virtual bool getAxes(int *ax);
+
+    virtual bool setPositionMode();
+
+    virtual bool setOpenLoopMode();
+
+    virtual bool positionMove(int j, double ref);
+
+    virtual bool positionMove(const double *refs);
+
+    virtual bool positionMove(const int n_joints, const int *joints, const double *refs);
+
+    virtual bool getTargetPosition(const int joint, double *ref);
+
+    virtual bool getTargetPositions(double *refs);
+
+    virtual bool getTargetPositions(const int n_joint, const int *joints, double *refs);
+
+    virtual bool relativeMove(int j, double delta);
+
+    virtual bool relativeMove(const double *deltas);
+
+    virtual bool relativeMove(const int n_joints, const int *joints, const double *deltas);
+
+    virtual bool checkMotionDone(int j, bool *flag);
+
+    virtual bool checkMotionDone(bool *flag);
+
+    virtual bool checkMotionDone(const int n_joints, const int *joints, bool *flags);
+
+    virtual bool setRefSpeed(int j, double sp);
+
+    virtual bool setRefSpeeds(const double *spds);
+
+    virtual bool setRefSpeeds(const int n_joints, const int *joints, const double *spds);
+
+    virtual bool setRefAcceleration(int j, double acc);
+
+    virtual bool setRefAccelerations(const double *accs);
+
+    virtual bool setRefAccelerations(const int n_joints, const int *joints, const double *accs);
+
+    virtual bool getRefSpeed(int j, double *ref);
+
+    virtual bool getRefSpeeds(double *spds);
+
+    virtual bool getRefSpeeds(const int n_joints, const int *joints, double *spds);
+
+    virtual bool getRefAcceleration(int j, double *acc);
+
+    virtual bool getRefAccelerations(double *accs);
+
+    virtual bool getRefAccelerations(const int n_joints, const int *joints, double *accs);
+
+    virtual bool stop(int j);
+
+    virtual bool stop();
+
+    virtual bool stop(const int n_joints, const int *joints);
+
+    /* IVelocityControl */
+    virtual bool velocityMove(int j, double v);
+
+    virtual bool velocityMove(const double *v);
+
+    virtual bool setVelocityMode();
+
+    /* IEncoders */
+    virtual bool resetEncoder(int j);
+
+    virtual bool resetEncoders();
+
+    virtual bool setEncoder(int j, double val);
+
+    virtual bool setEncoders(const double *vals);
+
+    virtual bool getEncoder(int j, double *v);
+
+    virtual bool getEncoders(double *encs);
+
+    virtual bool getEncodersTimed(double *encs, double *t);
+
+    virtual bool getEncoderTimed(int j, double *v, double *t);
+
+    virtual bool getEncoderSpeed(int j, double *sp);
+
+    virtual bool getEncoderSpeeds(double *spds);
+
+    virtual bool getEncoderAcceleration(int j, double *acc);
+
+    virtual bool getEncoderAccelerations(double *accs);
+
+    /* IMotorEncoders */
+    virtual bool getNumberOfMotorEncoders(int *num);
+
+    virtual bool resetMotorEncoder(int m);
+
+    virtual bool resetMotorEncoders();
+
+    virtual bool setMotorEncoderCountsPerRevolution(int m, const double cpr);
+
+    virtual bool getMotorEncoderCountsPerRevolution(int m, double *cpr);
+
+    virtual bool setMotorEncoder(int m, const double val);
+
+    virtual bool setMotorEncoders(const double *vals);
+
+    virtual bool getMotorEncoder(int m, double *v);
+
+    virtual bool getMotorEncoders(double *encs);
+
+    virtual bool getMotorEncodersTimed(double *encs, double *t);
+
+    virtual bool getMotorEncoderTimed(int m, double *v, double *t);
+
+    virtual bool getMotorEncoderSpeed(int m, double *sp);
+
+    virtual bool getMotorEncoderSpeeds(double *spds);
+
+    virtual bool getMotorEncoderAcceleration(int m, double *acc);
+
+    virtual bool getMotorEncoderAccelerations(double *accs);
+
+    /* IAmplifierControl */
+    virtual bool enableAmp(int j);
+
+    virtual bool disableAmp(int j);
+
+    virtual bool getAmpStatus(int *st);
+
+    virtual bool getAmpStatus(int j, int *v);
+
+    virtual bool getCurrents(double *vals);
+
+    virtual bool getCurrent(int j, double *val);
+
+    virtual bool setMaxCurrent(int j, double v);
+
+    virtual bool getMaxCurrent(int j, double *v);
+
+    virtual bool getNominalCurrent(int m, double *val);
+
+    virtual bool getPeakCurrent(int m, double *val);
+
+    virtual bool setPeakCurrent(int m, const double val);
+
+    virtual bool getPWM(int m, double *val);
+
+    virtual bool getPWMLimit(int m, double *val);
+
+    virtual bool setPWMLimit(int m, const double val);
+
+    virtual bool getPowerSupplyVoltage(int m, double *val);
+
+    /* IControlLimits */
+    virtual bool setLimits(int j, double min, double max);
+
+    virtual bool getLimits(int j, double *min, double *max);
+
+    virtual bool setVelLimits(int j, double min, double max);
+
+    virtual bool getVelLimits(int j, double *min, double *max);
+
+    /* IRemoteVariables */
+
+    virtual bool getRemoteVariable(yarp::os::ConstString key, yarp::os::Bottle &val);
+
+    virtual bool setRemoteVariable(yarp::os::ConstString key, const yarp::os::Bottle &val);
+
+    virtual bool getRemoteVariablesList(yarp::os::Bottle *listOfKeys);
+
+    /* IRemoteCalibrator */
+
+    bool isCalibratorDevicePresent(bool *isCalib);
+
+    virtual yarp::dev::IRemoteCalibrator *getCalibratorDevice();
+
+    virtual bool calibrateSingleJoint(int j);
+
+    virtual bool calibrateWholePart();
+
+    virtual bool homingSingleJoint(int j);
+
+    virtual bool homingWholePart();
+
+    virtual bool parkSingleJoint(int j, bool _wait = true);
+
+    virtual bool parkWholePart();
+
+    virtual bool quitCalibrate();
+
+    virtual bool quitPark();
+
+    /* IControlCalibration */
+
+    using yarp::dev::IControlCalibration2::calibrate;
+
+    virtual bool calibrate(int j, double p);
+
+    virtual bool calibrate2(int j, unsigned int ui, double v1, double v2, double v3);
+
+    virtual bool setCalibrationParameters(int j, const CalibrationParameters &params);
+
+    virtual bool done(int j);
+
+    virtual bool abortPark();
+
+    virtual bool abortCalibration();
+
+    /* IMotor */
+    virtual bool getNumberOfMotors(int *num);
+
+    virtual bool getTemperature(int m, double *val);
+
+    virtual bool getTemperatures(double *vals);
+
+    virtual bool getTemperatureLimit(int m, double *val);
+
+    virtual bool setTemperatureLimit(int m, const double val);
+
+    virtual bool getGearboxRatio(int m, double *val);
+
+    virtual bool setGearboxRatio(int m, const double val);
+
+    /* IAxisInfo */
+    virtual bool getAxisName(int j, yarp::os::ConstString &name);
+
+    virtual bool getJointType(int j, yarp::dev::JointTypeEnum &type);
+
+    virtual bool setTorqueMode();
+
+    virtual bool getRefTorques(double *refs);
+
+    virtual bool getRefTorque(int j, double *t);
+
+    virtual bool setRefTorques(const double *t);
+
+    virtual bool setRefTorque(int j, double t);
+
+    virtual bool setRefTorques(const int n_joint, const int *joints, const double *t);
+
+    virtual bool getBemfParam(int j, double *t);
+
+    virtual bool setBemfParam(int j, double t);
+
+    virtual bool getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters *params);
+
+    virtual bool setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params);
+
+    virtual bool setTorquePid(int j, const Pid &pid);
+
+    virtual bool setImpedance(int j, double stiff, double damp);
+
+    virtual bool setImpedanceOffset(int j, double offset);
+
+    virtual bool getTorque(int j, double *t);
+
+    virtual bool getTorques(double *t);
+
+    virtual bool getTorqueRange(int j, double *min, double *max);
+
+    virtual bool getTorqueRanges(double *min, double *max);
+
+    virtual bool setTorquePids(const Pid *pids);
+
+    virtual bool setTorqueErrorLimit(int j, double limit);
+
+    virtual bool setTorqueErrorLimits(const double *limits);
+
+    virtual bool getTorqueError(int j, double *err);
+
+    virtual bool getTorqueErrors(double *errs);
+
+    virtual bool getTorquePidOutput(int j, double *out);
+
+    virtual bool getTorquePidOutputs(double *outs);
+
+    virtual bool getTorquePid(int j, Pid *pid);
+
+    virtual bool getImpedance(int j, double *stiff, double *damp);
+
+    virtual bool getImpedanceOffset(int j, double *offset);
+
+    virtual bool getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp,
+                                          double *max_damp);
+
+    virtual bool getTorquePids(Pid *pids);
+
+    virtual bool getTorqueErrorLimit(int j, double *limit);
+
+    virtual bool getTorqueErrorLimits(double *limits);
+
+    virtual bool resetTorquePid(int j);
+
+    virtual bool disableTorquePid(int j);
+
+    virtual bool enableTorquePid(int j);
+
+    virtual bool setTorqueOffset(int j, double v);
+
+    virtual bool setPositionMode(int j);
+
+    virtual bool setTorqueMode(int j);
+
+    virtual bool setImpedancePositionMode(int j);
+
+    virtual bool setImpedanceVelocityMode(int j);
+
+    virtual bool setVelocityMode(int j);
+
+    virtual bool setOpenLoopMode(int j);
+
+    virtual bool getControlMode(int j, int *mode);
+
+    virtual bool getControlModes(int *modes);
+
+    // iControlMode2
+    virtual bool getControlModes(const int n_joint, const int *joints, int *modes);
+
+    virtual bool setControlMode(const int j, const int mode);
+
+    virtual bool setControlModes(const int n_joints, const int *joints, int *modes);
+
+    virtual bool setControlModes(int *modes);
+
+    virtual bool setRefOutput(int j, double v);
+
+    virtual bool setRefOutputs(const double *outs);
+
+    virtual bool setPositionDirectMode();
+
+    virtual bool setPosition(int j, double ref);
+
+    virtual bool setPositions(const int n_joints, const int *joints, double *dpos);
+
+    virtual bool setPositions(const double *refs);
+
+    virtual bool getRefPosition(const int joint, double *ref);
+
+    virtual bool getRefPositions(double *refs);
+
+    virtual bool getRefPositions(const int n_joint, const int *joints, double *refs);
+
+    virtual yarp::os::Stamp getLastInputStamp();
+
+    //
+    // IVelocityControl2 Interface
+    //
+    virtual bool velocityMove(const int n_joints, const int *joints, const double *spds);
+
+    virtual bool getRefVelocity(const int joint, double *vel);
+
+    virtual bool getRefVelocities(double *vels);
+
+    virtual bool getRefVelocities(const int n_joint, const int *joints, double *vels);
+
+    virtual bool setVelPid(int j, const Pid &pid);
+
+    virtual bool setVelPids(const Pid *pids);
+
+    virtual bool getVelPid(int j, Pid *pid);
+
+    virtual bool getVelPids(Pid *pids);
+
+    virtual bool getInteractionMode(int j, yarp::dev::InteractionModeEnum *mode);
+
+    virtual bool getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum *modes);
+
+    virtual bool getInteractionModes(yarp::dev::InteractionModeEnum *modes);
+
+    virtual bool setInteractionMode(int j, yarp::dev::InteractionModeEnum mode);
+
+    virtual bool setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum *modes);
+
+    virtual bool setInteractionModes(yarp::dev::InteractionModeEnum *modes);
+
+    virtual bool getRefOutput(int j, double *out);
+
+    virtual bool getRefOutputs(double *outs);
+};
+
+}
+}
+
+#endif

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -225,6 +225,7 @@ bool ControlBoardSubControlBoardAxesDecomposition::configure(const RemappedContr
 
     for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
     {
+        m_nJointsInSubControlBoard[ctrlBrd] = 0;
         m_jointsInSubControlBoard[ctrlBrd].clear();
         m_bufferForSubControlBoard[ctrlBrd].clear();
         m_bufferForSubControlBoardControlModes[ctrlBrd].clear();
@@ -249,7 +250,6 @@ bool ControlBoardSubControlBoardAxesDecomposition::configure(const RemappedContr
         m_bufferForSubControlBoardInteractionModes[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
 
         m_counterForControlBoard[ctrlBrd] = 0;
-        m_nJointsInSubControlBoard[ctrlBrd] = 0;
     }
 
     return true;

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -1,0 +1,547 @@
+/*
+ * Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Lorenzo Natale, Silvio Traversaro
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0.
+ *
+ */
+
+
+#include "ControlBoardRemapperHelpers.h"
+#include <iostream>
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <cassert>
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace std;
+
+
+RemappedSubControlBoard::RemappedSubControlBoard()
+{
+    id = "";
+
+    pid = 0;
+    pos2 = 0;
+    posDir = 0;
+    vel2 = 0;
+    iJntEnc = 0;
+    iMotEnc = 0;
+    amp = 0;
+    lim2 = 0;
+    calib = 0;
+    calib2 = 0;
+    iTimed= 0;
+    info = 0;
+    iOpenLoop=0;
+    iTorque=0;
+    iImpedance=0;
+    iMode2=0;
+    iInteract=0;
+
+    subdevice=0;
+
+    attachedF=false;
+    _subDevVerbose = false;
+}
+
+
+void RemappedSubControlBoard::detach()
+{
+    subdevice=0;
+
+    pid=0;
+    pos2=0;
+    posDir=0;
+    vel2=0;
+    amp = 0;
+    iJntEnc=0;
+    iMotEnc=0;
+    lim2=0;
+    calib=0;
+    calib2=0;
+    info=0;
+    iTorque=0;
+    iImpedance=0;
+    iMode2=0;
+    iTimed=0;
+    iOpenLoop=0;
+    iInteract=0;
+    iVar = 0;
+    attachedF=false;
+}
+
+bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string &k)
+{
+    if (id!=k)
+    {
+        yError()<<"ControlBoardRemapper: Wrong device" << k.c_str();
+        return false;
+    }
+
+    if (d==0)
+    {
+        yError()<<"ControlBoardRemapper: Invalid device (null pointer)";
+        return false;
+    }
+
+    subdevice=d;
+
+    if (subdevice->isValid())
+    {
+        subdevice->view(pid);
+        subdevice->view(pos2);
+        subdevice->view(posDir);
+        subdevice->view(vel2);
+        subdevice->view(amp);
+        subdevice->view(lim2);
+        subdevice->view(calib);
+        subdevice->view(calib2);
+        subdevice->view(remcalib);
+        subdevice->view(info);
+        subdevice->view(iTimed);
+        subdevice->view(iTorque);
+        subdevice->view(iImpedance);
+        subdevice->view(iMode2);
+        subdevice->view(iOpenLoop);
+        subdevice->view(iJntEnc);
+        subdevice->view(iMotEnc);
+        subdevice->view(iInteract);
+        subdevice->view(imotor);
+        subdevice->view(iVar);
+    }
+    else
+    {
+        yError()<<"ControlBoardRemapper: Invalid device " << k << " (isValid() returned false)";
+        return false;
+    }
+
+    if ( (iMode2==0) && (_subDevVerbose ))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IControlMode2 not valid interface";
+    }
+
+    if ((iTorque==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning iTorque not valid interface";
+    }
+
+    if ((iImpedance==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning iImpedance not valid interface";
+    }
+
+    if ((iOpenLoop==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning iOpenLoop not valid interface";
+    }
+
+    if ((iInteract==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning iInteractionMode not valid interface";
+    }
+
+    if ((iMotEnc==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IMotorEncoders not valid interface";
+    }
+
+    if ((imotor==0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IMotor not valid interface";
+    }
+
+    if ((iVar == 0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IRemoveVariables not valid interface";
+    }
+
+    if ((info == 0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IAxisInfo not valid interface";
+    }
+
+
+    // checking minimum set of intefaces required
+    if( !(pos2) )
+    {
+        yError("ControlBoardRemapper: IPositionControl2 interface was not found in subdevice. Quitting");
+        return false;
+    }
+
+    if( ! (vel2) )
+    {
+        yError("ControlBoardRemapper: IVelocityControl2 interface was not found in subdevice. Quitting");
+        return false;
+    }
+
+    if(!iJntEnc)
+    {
+        yError("ControlBoardRemapper: IEncoderTimed interface was not found in subdevice, exiting.");
+        return false;
+    }
+
+    if(!iMode2)
+    {
+        yError("ControlBoardRemapper: IControlMode2 interface was not found in subdevice, exiting.");
+        return false;
+    }
+
+    int deviceJoints=0;
+    if (pos2!=0)
+    {
+        if (!pos2->getAxes(&deviceJoints))
+        {
+            yError() << "ControlBoardRemapper: failed to get axes number for subdevice " << k.c_str();
+            return false;
+        }
+        if(deviceJoints <= 0)
+        {
+            yError("ControlBoardRemapper: attached device has an invalid number of joints (%d)", deviceJoints);
+            return false;
+        }
+    }
+
+    attachedF=true;
+    return true;
+}
+
+bool ControlBoardSubControlBoardAxesDecomposition::configure(const RemappedControlBoards& remappedControlBoards)
+{
+    // Resize buffers
+    m_nrOfControlledAxesInRemappedCtrlBrd = remappedControlBoards.getNrOfRemappedAxes();
+
+    size_t nrOfSubControlBoards = remappedControlBoards.getNrOfSubControlBoards();
+
+    m_nJointsInSubControlBoard.resize(nrOfSubControlBoards,0);
+    m_jointsInSubControlBoard.resize(nrOfSubControlBoards);
+
+    m_bufferForSubControlBoard.resize(nrOfSubControlBoards);
+    m_bufferForSubControlBoardControlModes.resize(nrOfSubControlBoards);
+    m_bufferForSubControlBoardInteractionModes.resize(nrOfSubControlBoards);
+
+    m_counterForControlBoard.resize(nrOfSubControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
+    {
+        m_jointsInSubControlBoard[ctrlBrd].clear();
+        m_bufferForSubControlBoard[ctrlBrd].clear();
+        m_bufferForSubControlBoardControlModes[ctrlBrd].clear();
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].clear();
+    }
+
+    // Fill buffers
+    for(size_t j=0; j < remappedControlBoards.getNrOfRemappedAxes(); j++)
+    {
+        int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+        m_nJointsInSubControlBoard[subIndex]++;
+        m_jointsInSubControlBoard[subIndex].push_back(off);
+    }
+
+    // Reserve enough space in buffers
+    for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
+    {
+        m_bufferForSubControlBoard[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+        m_bufferForSubControlBoardControlModes[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+
+        m_counterForControlBoard[ctrlBrd] = 0;
+        m_nJointsInSubControlBoard[ctrlBrd] = 0;
+    }
+
+    return true;
+}
+
+
+
+void ControlBoardSubControlBoardAxesDecomposition::fillSubControlBoardBuffersFromCompleteJointVector(const double* full, const RemappedControlBoards & remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoard[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+        m_bufferForSubControlBoard[subIndex].push_back(full[j]);
+    }
+}
+
+void ControlBoardSubControlBoardAxesDecomposition::fillCompleteJointVectorFromSubControlBoardBuffers(double* full, const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+        full[j] = m_bufferForSubControlBoard[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+void ControlBoardSubControlBoardAxesDecomposition::fillSubControlBoardBuffersFromCompleteJointVector(const int* full, const RemappedControlBoards & remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoardControlModes[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+        m_bufferForSubControlBoardControlModes[subIndex].push_back(full[j]);
+    }
+}
+
+void ControlBoardSubControlBoardAxesDecomposition::fillCompleteJointVectorFromSubControlBoardBuffers(int* full, const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+        full[j] = m_bufferForSubControlBoardControlModes[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+void ControlBoardSubControlBoardAxesDecomposition::fillSubControlBoardBuffersFromCompleteJointVector(const InteractionModeEnum* full, const RemappedControlBoards & remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+        m_bufferForSubControlBoardInteractionModes[subIndex].push_back(full[j]);
+    }
+}
+
+void ControlBoardSubControlBoardAxesDecomposition::fillCompleteJointVectorFromSubControlBoardBuffers(InteractionModeEnum* full, const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < m_nrOfControlledAxesInRemappedCtrlBrd; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+        full[j] = m_bufferForSubControlBoardInteractionModes[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+bool ControlBoardArbitraryAxesDecomposition::configure(const RemappedControlBoards& remappedControlBoards)
+{
+    // Resize buffers
+    size_t nrOfSubControlBoards = remappedControlBoards.getNrOfSubControlBoards();
+
+    m_nJointsInSubControlBoard.resize(nrOfSubControlBoards,0);
+    m_jointsInSubControlBoard.resize(nrOfSubControlBoards);
+    m_bufferForSubControlBoard.resize(nrOfSubControlBoards);
+    m_bufferForSubControlBoardControlModes.resize(nrOfSubControlBoards);
+    m_bufferForSubControlBoardInteractionModes.resize(nrOfSubControlBoards);
+
+    m_counterForControlBoard.resize(nrOfSubControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
+    {
+        m_jointsInSubControlBoard[ctrlBrd].clear();
+        m_bufferForSubControlBoard[ctrlBrd].clear();
+        m_bufferForSubControlBoardControlModes[ctrlBrd].clear();
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].clear();
+
+    }
+
+    // Count the maximum number of joints
+    for(size_t j=0; j < remappedControlBoards.getNrOfRemappedAxes(); j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+        m_nJointsInSubControlBoard[subIndex]++;
+    }
+
+    // Reserve enough space in buffers
+    for(size_t ctrlBrd=0; ctrlBrd < nrOfSubControlBoards; ctrlBrd++)
+    {
+        m_bufferForSubControlBoard[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+        m_bufferForSubControlBoardControlModes[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+
+        m_counterForControlBoard[ctrlBrd] = 0;
+        m_jointsInSubControlBoard[ctrlBrd].reserve(m_nJointsInSubControlBoard[ctrlBrd]);
+    }
+
+    return true;
+}
+
+
+
+void ControlBoardArbitraryAxesDecomposition::fillArbitraryJointVectorFromSubControlBoardBuffers(double* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        arbitraryVec[j] = m_bufferForSubControlBoard[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::fillSubControlBoardBuffersFromArbitraryJointVector(const double* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    this->createListOfJointsDecomposition(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoard[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        m_bufferForSubControlBoard[subIndex].push_back(arbitraryVec[j]);
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::fillArbitraryJointVectorFromSubControlBoardBuffers(int* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        arbitraryVec[j] = m_bufferForSubControlBoardControlModes[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::fillSubControlBoardBuffersFromArbitraryJointVector(const int* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    this->createListOfJointsDecomposition(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoardControlModes[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        m_bufferForSubControlBoardControlModes[subIndex].push_back(arbitraryVec[j]);
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::fillArbitraryJointVectorFromSubControlBoardBuffers(InteractionModeEnum* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_counterForControlBoard[ctrlBrd] = 0;
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        arbitraryVec[j] = m_bufferForSubControlBoardInteractionModes[subIndex][m_counterForControlBoard[subIndex]];
+        m_counterForControlBoard[subIndex]++;
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::fillSubControlBoardBuffersFromArbitraryJointVector(const InteractionModeEnum* arbitraryVec,
+                                                                                                const int n_joints,
+                                                                                                const int *joints,
+                                                                                                const RemappedControlBoards& remappedControlBoards)
+{
+    this->createListOfJointsDecomposition(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_bufferForSubControlBoardInteractionModes[ctrlBrd].clear();
+    }
+
+    for(int j=0; j < n_joints; j++)
+    {
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+        m_bufferForSubControlBoardInteractionModes[subIndex].push_back(arbitraryVec[j]);
+    }
+}
+
+
+void ControlBoardArbitraryAxesDecomposition::createListOfJointsDecomposition(const int n_joints, const int* joints, const RemappedControlBoards & remappedControlBoards)
+{
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        m_nJointsInSubControlBoard[ctrlBrd] = 0;
+        m_jointsInSubControlBoard[ctrlBrd].clear();
+    }
+
+    // Fill buffers
+    for(int j=0; j < n_joints; j++)
+    {
+        int off=(int)remappedControlBoards.lut[joints[j]].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[joints[j]].subControlBoardIndex;
+
+        m_nJointsInSubControlBoard[subIndex]++;
+        m_jointsInSubControlBoard[subIndex].push_back(off);
+    }
+
+}
+
+void ControlBoardArbitraryAxesDecomposition::resizeSubControlBoardBuffers(const int n_joints, const int *joints, const RemappedControlBoards & remappedControlBoards)
+{
+    // Properly populate the m_nJointsInSubControlBoard and m_jointsInSubControlBoard methods
+    createListOfJointsDecomposition(n_joints,joints,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        assert(m_nJointsInSubControlBoard[ctrlBrd] == m_jointsInSubControlBoard[ctrlBrd].size());
+        m_bufferForSubControlBoard.resize(m_nJointsInSubControlBoard[ctrlBrd]);
+    }
+}
+
+
+
+

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -117,11 +117,6 @@ bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string
         return false;
     }
 
-    if ( (iMode2==0) && (_subDevVerbose ))
-    {
-        yWarning() << "ControlBoardRemapper:  Warning IControlMode2 not valid interface";
-    }
-
     if ((iTorque==0) && (_subDevVerbose))
     {
         yWarning() << "ControlBoardRemapper:  Warning iTorque not valid interface";

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.h
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.h
@@ -1,0 +1,363 @@
+/*
+* Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+* Author: Lorenzo Natale, Silvio Traversaro
+* CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+*/
+
+#ifndef YARP_DEV_CONTROLBOARDREMAPPERHELPERS_H
+#define YARP_DEV_CONTROLBOARDREMAPPERHELPERS_H
+
+
+#include <yarp/os/PortablePair.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/RateThread.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/os/Vocab.h>
+
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IInteractionMode.h>
+#include <yarp/dev/IControlLimits2.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/PreciselyTimed.h>
+
+
+#include <yarp/sig/Vector.h>
+#include <yarp/os/Mutex.h>
+#include <yarp/dev/Wrapper.h>
+
+#include <string>
+#include <vector>
+
+
+#ifdef MSVC
+    #pragma warning(disable:4355)
+#endif
+
+namespace yarp
+{
+
+namespace dev
+{
+
+/*
+ * Helper class for the ControlBoardRemapper.
+ * It contains all the data structure related
+ * to a given controlboard used by the remapper.
+ */
+class RemappedSubControlBoard
+{
+public:
+    std::string id;
+
+    yarp::dev::PolyDriver            *subdevice;
+    yarp::dev::IPidControl           *pid;
+    yarp::dev::IPositionControl2     *pos2;
+    yarp::dev::IVelocityControl2     *vel2;
+    yarp::dev::IEncodersTimed        *iJntEnc;
+    yarp::dev::IMotorEncoders        *iMotEnc;
+    yarp::dev::IAmplifierControl     *amp;
+    yarp::dev::IControlLimits2       *lim2;
+    yarp::dev::IControlCalibration   *calib;
+    yarp::dev::IControlCalibration2  *calib2;
+    yarp::dev::IRemoteCalibrator     *remcalib;
+    yarp::dev::IPreciselyTimed       *iTimed;
+    yarp::dev::ITorqueControl        *iTorque;
+    yarp::dev::IImpedanceControl     *iImpedance;
+    yarp::dev::IOpenLoopControl      *iOpenLoop;
+    yarp::dev::IControlMode2         *iMode2;
+    yarp::dev::IAxisInfo             *info;
+    yarp::dev::IPositionDirect       *posDir;
+    yarp::dev::IInteractionMode      *iInteract;
+    yarp::dev::IMotor                *imotor;
+    yarp::dev::IRemoteVariables      *iVar;
+
+    RemappedSubControlBoard();
+
+    bool attach(yarp::dev::PolyDriver *d, const std::string &id);
+    void detach();
+
+    inline void setVerbose(bool _verbose) {_subDevVerbose = _verbose; }
+
+    bool isAttached()
+    { return attachedF; }
+
+private:
+    bool _subDevVerbose;
+    bool attachedF;
+};
+
+/**
+ * Information in how an axis is
+ * remapped on an axis of a SubControlBoard.
+ */
+class RemappedAxis
+{
+public:
+    /**
+     * The index of the SubControlBoard of the remapped axis
+     * in the RemappedControlBoards class.
+     */
+    size_t subControlBoardIndex;
+
+    /**
+     * The index of the remapped axis in the SubControlBoard.
+     */
+    size_t axisIndexInSubControlBoard;
+};
+
+class RemappedControlBoards
+{
+public:
+    /**
+     * Vector of dimension getNrOfSubControlBoards .
+     */
+    std::vector<RemappedSubControlBoard> subdevices;
+
+    /**
+     * Vector of dimension getNrOfRemappedAxes .
+     */
+    std::vector<RemappedAxis> lut;
+
+    /**
+     * Given a controlboard index between 0 and getNrOfSubControlBoards()-1, return
+     * the relative SubControlBoard.
+     *
+     * @return a reference to the requests SubControlBoard.
+     */
+    inline yarp::dev::RemappedSubControlBoard* getSubControlBoard(size_t i)
+    {
+        return &(subdevices[i]);
+    }
+
+    size_t getNrOfSubControlBoards() const
+    {
+        return subdevices.size();
+    }
+
+    size_t getNrOfRemappedAxes() const
+    {
+        return lut.size();
+    }
+};
+
+class ControlBoardRemapperBuffers
+{
+public:
+    yarp::os::Mutex mutex;
+    std::vector<int> controlBoardModes;
+    std::vector<double> dummyBuffer;
+    yarp::os::Stamp stamp;
+
+};
+
+/**
+ * Class storing the decomposition of all the axes
+ * in the Remapped ControlBoard in the SubControlBoard,
+ * with buffer reading to use to simplify MultiJoint
+ * methods implementation.
+ *
+ */
+class ControlBoardSubControlBoardAxesDecomposition
+{
+public:
+    /**
+     * Resize the buffers using the information in
+     * the RemappedControlBoards
+     */
+    bool configure(const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill buffers for the SubControlBoard from
+     * a vector of joints of the RemappedControlBoards
+     */
+    void fillSubControlBoardBuffersFromCompleteJointVector(const double * full, const RemappedControlBoards & remappedControlBoards);
+
+
+    /**
+      * Fill buffers for the SubControlBoard from
+      * a vector of joints of the RemappedControlBoard
+      * (Version for ControlModes methods)
+      */
+    void fillSubControlBoardBuffersFromCompleteJointVector(const int * full,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill buffers for the SubControlBoard from
+     * a vector of joints of the RemappedControlBoard
+     *
+     * (Version for InteractionModes methods)
+     */
+    void fillSubControlBoardBuffersFromCompleteJointVector(const InteractionModeEnum * full,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill a vector of joints of the ControlBoardRemapper from
+     * the buffers of the SubControlBoard .
+     */
+    void fillCompleteJointVectorFromSubControlBoardBuffers(double * full, const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill a vector of joints of the ControlBoardRemapper from
+     * the buffers of the SubControlBoard .
+     *
+     * Before calling this method you should have called the resizeSubControlBoardBuffers method.
+     * (Version for ControlModes methods)
+     */
+    void fillCompleteJointVectorFromSubControlBoardBuffers(int * full,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill a vector of joints of the ControlBoardRemapper from
+     * the buffers of the SubControlBoard .
+     *
+     * Before calling this method you should have called the resizeSubControlBoardBuffers method.
+     * (Version for InteractionModes methods)
+     */
+    void fillCompleteJointVectorFromSubControlBoardBuffers(InteractionModeEnum * full,
+                                                           const RemappedControlBoards & remappedControlBoards);
+
+
+    /**
+     * Mutex to grab to use this class.
+     */
+    yarp::os::Mutex mutex;
+
+    // Buffer to be used in MultiJoint version of the
+    int m_nrOfControlledAxesInRemappedCtrlBrd;
+    std::vector<int> m_nJointsInSubControlBoard;
+    std::vector< std::vector<int> > m_jointsInSubControlBoard;
+
+
+    std::vector< std::vector<double> > m_bufferForSubControlBoard;
+    std::vector< std::vector<int>    > m_bufferForSubControlBoardControlModes;
+    std::vector< std::vector<InteractionModeEnum>  > m_bufferForSubControlBoardInteractionModes;
+
+    std::vector<int> m_counterForControlBoard;
+};
+
+/**
+ * Class storing the decomposition of a subset ot the total
+ * remapped axes of the remapped controlboard in the
+ * corresponding subsets of the axes of the SubControlBoard.
+ *
+ * This class is meant to be used when implementing multiple joint
+ * methods (the one with the signature const int n_joints, const int *joints, double *dpos )
+ *
+ */
+class ControlBoardArbitraryAxesDecomposition
+{
+    /**
+     * Fill the buffer containing the structure of the decomposition between the
+     * desired list of joints and and their mapping in the subControlboards.
+     */
+    void createListOfJointsDecomposition(const int n_joints, const int *joints, const RemappedControlBoards & remappedControlBoards);
+
+public:
+    /**
+     * Resize the buffers using the information in
+     * the RemappedControlBoards
+     */
+    bool configure(const RemappedControlBoards & remappedControlBoards);
+
+
+    /**
+     * Fill buffers for the SubControlBoard from
+     * a vector of joints of the RemappedControlBoards
+     */
+    void fillSubControlBoardBuffersFromArbitraryJointVector(const double * arbitraryVec,
+                                                            const int n_joints,
+                                                            const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill buffers for the SubControlBoard from
+     * a vector of joints of the RemappedControlBoards
+     * (Version for ControlModes methods)
+     */
+    void fillSubControlBoardBuffersFromArbitraryJointVector(const int * arbitraryVec,
+                                                            const int n_joints,
+                                                            const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill buffers for the SubControlBoard from
+     * a vector of joints of the RemappedControlBoards
+     * (Version for InteractionModes methods)
+     */
+    void fillSubControlBoardBuffersFromArbitraryJointVector(const InteractionModeEnum * arbitraryVec,
+                                                            const int n_joints,
+                                                            const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Resize buffers to have the dimension of specified by the method
+     * (used for multi joint methods that read the data from the subcontrolboards).
+     */
+    void resizeSubControlBoardBuffers(const int n_joints,
+                                      const int *joints,
+                                      const RemappedControlBoards & remappedControlBoards);
+
+    /**
+    * Fill a vector of joints of the ControlBoardRemapper from
+    * the buffers of the SubControlBoard .
+    *
+    * Before calling this method you should have called the resizeSubControlBoardBuffers method.
+    */
+    void fillArbitraryJointVectorFromSubControlBoardBuffers(double * arbitraryVec,
+                                                            const int n_joints, const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill a vector of joints of the ControlBoardRemapper from
+     * the buffers of the SubControlBoard .
+     *
+     * Before calling this method you should have called the resizeSubControlBoardBuffers method.
+     * (Version for ControlModes methods)
+     */
+    void fillArbitraryJointVectorFromSubControlBoardBuffers(int * arbitraryVec,
+                                                            const int n_joints, const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Fill a vector of joints of the ControlBoardRemapper from
+     * the buffers of the SubControlBoard .
+     *
+     * Before calling this method you should have called the resizeSubControlBoardBuffers method.
+     * (Version for InteractionModes methods)
+     */
+    void fillArbitraryJointVectorFromSubControlBoardBuffers(InteractionModeEnum * arbitraryVec,
+                                                            const int n_joints, const int *joints,
+                                                            const RemappedControlBoards & remappedControlBoards);
+
+    /**
+     * Mutex to grab to use this class.
+     */
+    yarp::os::Mutex mutex;
+
+    // Total number of axes in the remapped controlboard
+    int m_nrOfControlledAxesInRemappedCtrlBrd;
+
+    // Vector of size getNrOfSubControlBoards
+    std::vector<int> m_nJointsInSubControlBoard;
+    std::vector< std::vector<int> > m_jointsInSubControlBoard;
+
+    // Buffers for the control board (the size of each one should
+    // match the size of m_nJointsInSubControlBoard[ctrlBoard] and
+    // the size of m_jointsInSubControlBoard[ctrlBoard].size()
+    std::vector< std::vector<double> > m_bufferForSubControlBoard;
+    std::vector< std::vector<int>    > m_bufferForSubControlBoardControlModes;
+    std::vector< std::vector<InteractionModeEnum>  > m_bufferForSubControlBoardInteractionModes;
+
+
+    // Counter used when converting a full vector to
+    // the subcontrolboard buffers
+    std::vector<int> m_counterForControlBoard;
+};
+
+}
+
+}
+
+#endif  //YARP_DEV_CONTROLBOARDWRAPPER_SUBDEVICE_H

--- a/src/modules/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/modules/fakeMotionControl/fakeMotionControl.cpp
@@ -2485,9 +2485,10 @@ bool FakeMotionControl::getRefPositionRaw(int axis, double *ref)
     getControlModeRaw(axis, &mode);
     if( (mode != VOCAB_CM_POSITION) &&
         (mode != VOCAB_CM_MIXED) &&
-        (mode != VOCAB_CM_IMPEDANCE_POS))
+        (mode != VOCAB_CM_IMPEDANCE_POS) &&
+        (mode != VOCAB_CM_POSITION_DIRECT) )
     {
-        yWarning() << "getTargetPosition: Joint " << axis << " is not in POSITION_DIRECT mode, therefore the value returned by \
+        yWarning() << "getRefPosition: Joint " << axis << " is not in POSITION_DIRECT mode, therefore the value returned by \
         this call is for reference only and may not reflect the actual behaviour of the motor/firmware.";
     }
 

--- a/src/modules/fakeMotionControl/fakeMotionControl.h
+++ b/src/modules/fakeMotionControl/fakeMotionControl.h
@@ -167,7 +167,7 @@ private:
     Pid *_cpids;                                /** initial current gains */
 
     std::string *_axisName;                          /** axis name */
-    std::string *_axisType;                          /** axis type */
+    JointTypeEnum *_jointType;                          /** axis type */
 //     ImpedanceLimits     *_impedance_limits;     /** impedancel imits */
     double *_limitsMin;                         /** joint limits, max*/
     double *_limitsMax;                         /** joint limits, min*/
@@ -205,7 +205,6 @@ private:
     positionControlUnitsType _positionControlUnits;
 
     // internal stuff
-    double noiseLevel;
     int     *_controlModes;
     int     *_interactMode;
     bool    *_enabledAmp;           // Middle step toward a full enabled motor controller. Amp (pwm) plus Pid enable command must be sent in order to get the joint into an active state.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,11 @@ if(YARP_COMPILE_TESTS)
         target_link_libraries(harness_os pthread)
     endif()
 
+    # Compile ControlBoardRemapperTest only if fakeMotionControl is enabled
+    if(ENABLE_yarpmod_fakeMotionControl)
+        add_definitions(-DYARP_CONTROLBOARDREMAPPER_TESTS)
+    endif()
+
     # Add in hardware specific tests, if requested
     option(CREATE_PLUGIN_TESTS "Compile plugin tests" FALSE)
     mark_as_advanced(CREATE_PLUGIN_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,14 @@ if(YARP_COMPILE_TESTS)
         add_definitions(-DYARP_USE_PERSISTENT_NAMESERVER=1)
     endif()
 
+    # Add the CMAKE_BINARY_DIR as a macro so the testing infrastructure
+    # can find the device compiled as dynamic plugins
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/YarpBuildLocation.h.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/YarpBuildLocation.h"
+                   @ONLY)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+
     add_executable(testModule ${CMAKE_SOURCE_DIR}/tests/libYARP_OS/testModule/module.cpp)
     target_link_libraries(testModule YARP_init YARP_OS)
 

--- a/tests/YarpBuildLocation.h.in
+++ b/tests/YarpBuildLocation.h.in
@@ -1,0 +1,12 @@
+/*
+ * Copyright: (C) 2016 iCub Facility
+ * Author: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_BUILD_LOCATION_H
+#define YARP_BUILD_LOCATION_H
+
+#cmakedefine CMAKE_BINARY_DIR "@CMAKE_BINARY_DIR@"
+
+#endif

--- a/tests/libYARP_dev/ControlBoardRemapperTest.cpp
+++ b/tests/libYARP_dev/ControlBoardRemapperTest.cpp
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2016 RobotCub Consortium
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <vector>
+
+#include <yarp/os/impl/UnitTest.h>
+
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/PolyDriverList.h>
+#include <yarp/dev/Wrapper.h>
+
+using namespace yarp::os::impl;
+using namespace yarp::os;
+using namespace yarp::dev;
+
+const char *fmcA_file_content   = "device fakeMotionControl\n"
+                                  "[GENERAL]\n"
+                                  "Joints 2\n"
+                                  "\n"
+                                  "AxisName \"axisA1\" \"axisA2\" \n";
+
+const char *fmcB_file_content   = "device fakeMotionControl\n"
+                                  "[GENERAL]\n"
+                                  "Joints 3\n"
+                                  "\n"
+                                  "AxisName \"axisB1\" \"axisB2\" \"axisB3\"\n";
+
+const char *fmcC_file_content   =  "device fakeMotionControl\n"
+                                  "[GENERAL]\n"
+                                  "Joints 4\n"
+                                  "\n"
+                                  "AxisName \"axisC1\" \"axisC2\" \"axisC3\" \"axisC4\"  \n";
+
+
+class ControlBoardRemapperTest : public UnitTest
+{
+public:
+    virtual String getName() { return "ControlBoardRemapperTest"; }
+
+    void testControlBoardRemapper() {
+        report(0,"\ntest the controlboard remapper");
+
+        // We first allocate three fakeMotionControl boards,
+        // that we will remap using the remapper
+        std::vector<PolyDriver *> fmcbs;
+        fmcbs.resize(3);
+
+        std::vector<int> fmcbsSizes;
+        fmcbsSizes.push_back(2);
+        fmcbsSizes.push_back(3);
+        fmcbsSizes.push_back(4);
+
+        std::vector<std::string> fmcbsNames;
+        fmcbsNames.push_back("fakeControlBoardA");
+        fmcbsNames.push_back("fakeControlBoardB");
+        fmcbsNames.push_back("fakeControlBoardC");
+
+
+        for(int i=0; i < 3; i++)
+        {
+            fmcbs[i] = new PolyDriver();
+
+            Property p;
+
+            if(i==0) { p.fromConfig(fmcA_file_content); }
+            if(i==1) { p.fromConfig(fmcB_file_content); }
+            if(i==2) { p.fromConfig(fmcC_file_content); }
+
+            bool result;
+            result = fmcbs[i]->open(p);
+            checkTrue(result, "fakeMotionControlBoard open reported successful");
+
+            if(result)
+            {
+                IPositionControl *pos = NULL;
+                result = fmcbs[i]->view(pos);
+                checkTrue(result, "interface position correctly opened");
+                int axes = 0;
+                pos->getAxes(&axes);
+                checkEqual(axes, fmcbsSizes[i], "fakeMotionControlBoard seems functional");
+            }
+        }
+
+        PolyDriver ddRemapper;
+        Property pRemapper;
+        pRemapper.put("device","controlboardremapper");
+        pRemapper.addGroup("axesNames");
+        Bottle & axesList = pRemapper.findGroup("axesNames").addList();
+        axesList.addString("axisA1");
+        axesList.addString("axisB1");
+        axesList.addString("axisC1");
+        axesList.addString("axisB3");
+        axesList.addString("axisC3");
+        axesList.addString("axisA2");
+        size_t nrOfRemappedAxes = 6;
+
+        bool result = ddRemapper.open(pRemapper);
+        checkTrue(result,"controlboardremapper open reported successful");
+
+        // Attach the fake motion boards to the remapper
+        yarp::dev::PolyDriverList fmcList;
+
+        for(int i=0; i < 3; i++)
+        {
+            fmcList.push(fmcbs[i],fmcbsNames[i].c_str());
+        }
+
+        yarp::dev::IMultipleWrapper *imultwrap = 0;
+        result = ddRemapper.view(imultwrap);
+        checkTrue(result, "interface for multiple wrapper correctly opened");
+
+        result = imultwrap->attachAll(fmcList);
+
+        checkTrue(result, "attachAll successful");
+
+        IPositionControl *pos = NULL;
+        result = ddRemapper.view(pos);
+        checkTrue(result, "interface position correctly opened");
+        int axes = 0;
+        result = pos->getAxes(&axes);
+        checkTrue(result, "getAxes returned correctly");
+        checkEqual(axes, 6, "remapper seems functional");
+
+        IPositionDirect *posdir = 0;
+        result = ddRemapper.view(posdir);
+        checkTrue(result, "direct position interface correctly opened");
+
+        std::vector<double> setPosition(nrOfRemappedAxes), readedPosition(nrOfRemappedAxes);
+
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            setPosition[i]  = i*100.0;
+        }
+
+        // Set position
+        posdir->setPositions(setPosition.data());
+
+        // Read position
+        posdir->getRefPositions(readedPosition.data());
+
+        // Check that the two vector match
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            checkEqual(setPosition[i],readedPosition[i],"Setted position and readed position match");
+        }
+
+        // Close devices
+        imultwrap->detachAll();
+        ddRemapper.close();
+
+        for(int i=0; i < 3; i++)
+        {
+            fmcbs[i]->close();
+            delete fmcbs[i];
+        }
+    }
+
+    virtual void runTests() {
+        Network::setLocalMode(true);
+        testControlBoardRemapper();
+        Network::setLocalMode(false);
+    }
+};
+
+static ControlBoardRemapperTest theControlBoardRemapperTest;
+
+UnitTest& getControlBoardRemapperTest() {
+    return theControlBoardRemapperTest;
+}

--- a/tests/libYARP_dev/TestList.h
+++ b/tests/libYARP_dev/TestList.h
@@ -21,12 +21,15 @@ namespace yarp {
 // need to made one function for each new test, and add to collectTests()
 // method
 extern yarp::os::impl::UnitTest& getPolyDriverTest();
+extern yarp::os::impl::UnitTest& getControlBoardRemapperTest();
+
 
 class yarp::os::impl::TestList {
 public:
     static void collectTests() {
         UnitTest& root = UnitTest::getRoot();
         root.add(getPolyDriverTest());
+        root.add(getControlBoardRemapperTest());
     }
 };
 

--- a/tests/libYARP_dev/TestList.h
+++ b/tests/libYARP_dev/TestList.h
@@ -29,7 +29,9 @@ public:
     static void collectTests() {
         UnitTest& root = UnitTest::getRoot();
         root.add(getPolyDriverTest());
+#ifdef YARP_CONTROLBOARDREMAPPER_TESTS
         root.add(getControlBoardRemapperTest());
+#endif
     }
 };
 

--- a/tests/libYARP_dev/TestList.h
+++ b/tests/libYARP_dev/TestList.h
@@ -21,8 +21,10 @@ namespace yarp {
 // need to made one function for each new test, and add to collectTests()
 // method
 extern yarp::os::impl::UnitTest& getPolyDriverTest();
-extern yarp::os::impl::UnitTest& getControlBoardRemapperTest();
 
+#ifdef YARP_CONTROLBOARDREMAPPER_TESTS
+extern yarp::os::impl::UnitTest& getControlBoardRemapperTest();
+#endif
 
 class yarp::os::impl::TestList {
 public:

--- a/tests/libYARP_dev/harness.cpp
+++ b/tests/libYARP_dev/harness.cpp
@@ -19,6 +19,8 @@
 
 #include "TestList.h"
 
+#include "YarpBuildLocation.h"
+
 #include <stdio.h>
 
 using namespace yarp::os::impl;
@@ -57,9 +59,17 @@ int harness_main(int argc, char *argv[]) {
         if (verbosity>0) {
             Logger::get().setVerbosity(verbosity);
         }
-    
+
         if (String(argv[1])==String("regression")) {
             done = true;
+            // To make sure that the dev test are able to find all the devices
+            // compile by YARP, also the one compiled as dynamic plugins
+            // we add the build directory to the YARP_DATA_DIRS enviromental variable
+            // CMAKE_CURRENT_DIR is the define by the CMakeLists.txt tests file
+            Network::setEnvironment("YARP_DATA_DIRS",
+                                    Network::getEnvironment("YARP_DATA_DIRS")+":"+CMAKE_BINARY_DIR+"/share/yarp");
+
+            // Start the testing system
             UnitTest::startTestSystem();
             TestList::collectTests();  // just in case automation doesn't work
             if (argc>2) {
@@ -69,7 +79,7 @@ int harness_main(int argc, char *argv[]) {
             }
             UnitTest::stopTestSystem();
         }
-    } 
+    }
     if (!done) {
         Companion::main(argc,argv);
     }
@@ -189,7 +199,7 @@ int main(int argc, char *argv[]) {
 
     PolyDriver dd;
 	YARP_DEBUG(Logger::get(), "harness opening...");
-	
+
     bool ok = dd.open(p);
     YARP_DEBUG(Logger::get(), "harness opened.");
     result = ok?0:1;
@@ -197,7 +207,7 @@ int main(int argc, char *argv[]) {
     ConstString wrapperName = "";
     ConstString codeName = "";
 
-    DriverCreator *creator = 
+    DriverCreator *creator =
         Drivers::factory().find(deviceName.c_str());
     if (creator!=NULL) {
         wrapperName = creator->getWrapper();


### PR DESCRIPTION
New version of https://github.com/robotology/yarp/pull/746 , with the test failures fixed and opened against `devel` rather then `master`.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/757%23issuecomment-219368710%22%2C%20%22https%3A//github.com/robotology/yarp/pull/757%23issuecomment-219409909%22%2C%20%22https%3A//github.com/robotology/yarp/pull/757%23issuecomment-219694283%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/757%23issuecomment-219368710%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Apparently%20the%20test%20fails%20if%20YARP%20is%20compiled%20without%20ACE%2C%20investigating.%22%2C%20%22created_at%22%3A%20%222016-05-16T07%3A50%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22Dynamically%20loaded%20drivers%20were%20not%20working%20without%20ACE%2C%20the%20bug%20was%20fixed%20in%20https%3A//github.com/robotology/yarp/pull/757/commits/d117fffc0392a5cb13a7b0b9352b5825a0aa4785%20.%20%22%2C%20%22created_at%22%3A%20%222016-05-16T12%3A06%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40traversaro%20Looks%20good%20now%2C%20but%20you%20opened%20it%20again%20against%20master...%22%2C%20%22created_at%22%3A%20%222016-05-17T11%3A46%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/757#issuecomment-219368710'>General Comment</a></b>
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Apparently the test fails if YARP is compiled without ACE, investigating.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Dynamically loaded drivers were not working without ACE, the bug was fixed in https://github.com/robotology/yarp/pull/757/commits/d117fffc0392a5cb13a7b0b9352b5825a0aa4785 .
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @traversaro Looks good now, but you opened it again against master...


<a href='https://www.codereviewhub.com/robotology/yarp/pull/757?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/757?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/757'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>