### PR TITLE
Fix several race conditions in yarp::os::Thread

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
@@ -46,10 +46,7 @@ public:
     virtual bool start();
 
     bool isClosing();
-
-    bool isRunning() {
-        return active;
-    }
+    bool isRunning();
 
     virtual void beforeStart();
     virtual void afterStart(bool success);
@@ -96,7 +93,7 @@ private:
     int defaultPolicy;
     int stackSize;
     Platform_hthread_t hid;
-    bool active;
+    bool active; // FIXME should be atomic
     bool opened;
     bool closing;
     bool needJoin;

--- a/src/libYARP_OS/src/Thread.cpp
+++ b/src/libYARP_OS/src/Thread.cpp
@@ -60,6 +60,7 @@ Thread::Thread() :
 
 
 Thread::~Thread() {
+    ((ThreadImpl*)implementation)->close();
     if (implementation!=NULL) {
         delete ((ThreadImpl*)implementation);
         implementation = NULL;

--- a/src/libYARP_OS/src/Thread.cpp
+++ b/src/libYARP_OS/src/Thread.cpp
@@ -21,6 +21,9 @@ public:
     ThreadCallbackAdapter(Thread& owner) : owner(owner) {
     }
 
+    virtual ~ThreadCallbackAdapter() {
+    }
+
     virtual void beforeStart() {
         owner.beforeStart();
     }

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -79,16 +79,18 @@ PLATFORM_THREAD_RETURN theExecutiveBranch (void *args)
 
     if (success)
     {
-#if defined(__linux__)
-        // Use the POSIX syscalls to get
-        // the real thread ID (gettid) on Linux machine
-        thread->tid = (long) syscall(SYS_gettid);
-#endif
-
         // c++11 std::thread, pthread and ace threads on some platforms do not
         // return the thread id, therefore it must be set before calling run(),
         // to avoid a race condition in case the run() method checks it.
         thread->id = PLATFORM_THREAD_SELF();
+
+#if defined(__linux__)
+        // Use the POSIX syscalls to get
+        // the real thread ID (gettid) on Linux machine
+        thread->tid = (long) syscall(SYS_gettid);
+#else
+        thread->tid = (long int)thread->id;
+#endif
 
         thread->setPriority();
         thread->run();
@@ -272,7 +274,6 @@ bool ThreadImpl::start() {
 #endif
     if (result==0)
     {
-        tid = (long int)id;
         // we must, at some point in the future, join the thread
         needJoin = true;
 

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -243,10 +243,15 @@ bool ThreadImpl::start() {
     if (s==0) {
         s = (size_t)defaultStackSize;
     }
+    // c++11 std::thread, pthread and ace threads on some platforms do not
+    // return the thread id, therefore we set it in theExecutiveBranch() for all
+    // platforms. We don't set id here and use a dummy instead, since setting it
+    // in both places could cause a race condition.
+    ACE_thread_t dummy_id;
     int result = ACE_Thread::spawn((ACE_THR_FUNC)theExecutiveBranch,
                                    (void *)this,
                                    THR_JOINABLE | THR_NEW_LWP,
-                                   &id,
+                                   &dummy_id,
                                    &hid,
                                    ACE_DEFAULT_THREAD_PRIORITY,
                                    0,

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -309,11 +309,20 @@ void ThreadImpl::synchroPost()
 
 void ThreadImpl::notify(bool s)
 {
+    threadMutex->wait();
     active=s;
+    threadMutex->post();
 }
 
 bool ThreadImpl::isClosing() {
     return closing;
+}
+
+bool ThreadImpl::isRunning() {
+    threadMutex->wait();
+    bool b = active;
+    threadMutex->post();
+    return b;
 }
 
 int ThreadImpl::getCount() {

--- a/tests/libYARP_OS/SemaphoreTest.cpp
+++ b/tests/libYARP_OS/SemaphoreTest.cpp
@@ -28,6 +28,7 @@ public:
     virtual void run() {
         x.wait();
         state = 2;
+        x.post();
     }
 };
 
@@ -52,10 +53,11 @@ public:
         Time::delay(0.5); 
         checkEqual(helper.state,1,"helper blocked");
         helper.x.post();
-        for (int i=0; i<20&&helper.state==1; i++) {
-            Time::delay(0.1); 
-        }
+        Time::delay(0.5);
+        helper.x.wait();
         checkEqual(helper.state,2,"helper unblocked");
+        helper.x.post();
+        helper.stop();
     }
 
     void checkTimed() {

--- a/tests/libYARP_OS/ThreadTest.cpp
+++ b/tests/libYARP_OS/ThreadTest.cpp
@@ -42,17 +42,24 @@ private:
         double delay;
         bool hold;
         bool active;
+        Semaphore mutex;
 
-        ThreadDelay(double delay = 0.5, bool hold = false) {
-            this->delay = delay;
-            this->hold = hold;
-            active = true;
+        ThreadDelay(double delay = 0.5, bool hold = false) :
+                delay(delay),
+                hold(hold),
+                active(true),
+                mutex(1)
+        {
         }
 
         virtual void run() {
+            bool h;
             do {
                 Time::delay(delay);
-            } while (hold);
+                mutex.wait();
+                h = hold;
+                mutex.post();
+            } while (h);
             active = false;
         }
     };
@@ -184,27 +191,34 @@ private:
 
     class Thread5: public Thread {
     public:
-        Thread5():state(0),fail(false){}
+        Thread5() : state(0), fail(false), mutex(1) {}
         int state;
         bool fail;
+        Semaphore mutex;
 
         void threadWillFail(bool f)
         {
+            mutex.wait();
             state=0;
             fail=f;
+            mutex.post();
         }
 
         virtual bool threadInit()
         {
             Time::delay(0.5);
+            mutex.wait();
             state=1;
+            mutex.post();
             return !fail;
         }
 
         virtual void afterStart(bool s)
         {
+            mutex.wait();
             if(!s)
                 state++;
+            mutex.post();
         }
 
         virtual void run()
@@ -213,7 +227,9 @@ private:
         virtual void threadRelease()
         {
             Time::delay(0.5);
+            mutex.wait();
             state++;
+            mutex.post();
         }
     };
 
@@ -353,15 +369,21 @@ public:
         report(0,"Checking init/release synchronization");
         report(0,"Starting thread... thread will wait 0.5 second");
         t.start();
+        t.mutex.wait();
         checkEqual(1, t.state, "Start synchronized on init");
+        t.mutex.post();
 
         report(0,"Stopping thread... thread will wait 0.5 second");
         t.stop();
+        t.mutex.wait();
         checkEqual(2, t.state, "Stop synchronized on release");
+        t.mutex.post();
 
         t.threadWillFail(true);
         t.start();
+        t.mutex.wait();
         checkEqual(2, t.state, "Start synchronized on failed init");
+        t.mutex.post();
 
         report(0, "done");
     }
@@ -438,7 +460,9 @@ public:
         t.start();
         t.join(1);
         checkTrue(t.active,"timeout join returns before thread stops");
+        t.mutex.wait();
         t.hold = false;
+        t.mutex.post();
         t.stop();
         checkFalse(t.active,"flag behaves correctly");
         t.hold = false;


### PR DESCRIPTION
Start removing the race conditions reported by valgrind helgrind and drd tools.
This should make easier to debug the issues with ROS.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221576466%22%2C%20%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221587299%22%2C%20%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221783290%22%2C%20%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221794753%22%2C%20%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221816423%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/768%23issuecomment-221576466%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20changes%20look%20fine%20by%20me%2C%20although%20it%20is%20difficult%20to%20predict%20all%20effects%20the%20PR%20may%20have.%20%5Cr%5Cn%5Cr%5Cn%40drdanz%3A%20are%20you%20sure%20it%20is%20a%20good%20idea%20to%20commit%20this%20into%20master%20and%20not%20devel%3F%20%22%2C%20%22created_at%22%3A%20%222016-05-25T13%3A30%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40lornat75%20I%27m%20not%20sure%20of%20anything%20when%20I%20touch%20YARP_OS%20%3Alaughing%3A%5Cr%5Cn%5Cr%5CnTechnically%2C%20from%20what%20I%20understood%20about%20the%20new%20workflow%2C%20the%20changes%20here%20belong%20to%20%60master%60%20since%20they%20are%20%5C%22bugfixes%5C%22%20and%20do%20not%20change%20the%20API/ABI%20%28ThreadCallbackAdapter%20is%20a%20private%20class%20so%20adding%20the%20virtual%20destructor%20in%201526f93%20is%20not%20a%20change%20in%20the%20ABI%29.%5Cr%5Cn7b54c6c%20and%201540f13%20are%20the%20only%20ones%20that%20might%20cause%20some%20unexpected%20behaviour%2C%20even%20though%20this%20part%20is%20well%20covered%20by%20the%20unit%20tests.%20The%20other%20changes%20are%20rather%20trivial.%5Cr%5Cn%5Cr%5CnIf%20you%20think%20it%20is%20safer%20to%20commit%20these%20to%20%60devel%60%2C%20I%20have%20no%20objections%20to%20do%20so%2C%20since%20it%20is%20probably%20safer%2C%20and%20since%20also%20%40pattacini%20expressed%20concern%20over%20this...%20We%20should%20take%20some%20time%20to%20re-discuss%20the%20policies%2C%20though%2C%20and%20find%20some%20way%20to%20discern%20what%20goes%20to%20%60master%60%20and%20what%20goes%20to%20%60devel%60%20that%20includes%20something%20about%20%5C%22safe%5C%22%20or%20%5C%22not%20safe%5C%22%20%28that%20probably%20will%20force%20us%20to%20push%20any%20change%20to%20YARP_OS%20to%20go%20to%20%60devel%60%20%3Asweat_smile%3A%20%29%22%2C%20%22created_at%22%3A%20%222016-05-25T14%3A07%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20there%20a%20regression%20test%20for%20yarp_os%3F%20I%20know%20there%20is%20on%20for%20yarp_dev.%5Cr%5CnIf%20tests%20are%20fine%2C%20may%20the%20PR%20considered%20safer%3F%22%2C%20%22created_at%22%3A%20%222016-05-26T05%3A47%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40drdanz%2C%20I%20think%20we%20can%20commit%20to%20devel%20bugfixes%20we%20would%20like%20to%20test%20before%20they%20are%20integrated%20in%20the%20%60stable%60%20master.%20In%20this%20case%20it%20is%20borderline%20so%20it%20does%20not%20matter%20%28we%20do%20have%20regression%20tests%20which%20may%20catch%20most%20problems%29.%22%2C%20%22created_at%22%3A%20%222016-05-26T07%3A11%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40barbalberto%20%60YARP_OS%60%20has%20plenty%20of%20unit%20tests%20for%20this%20part%2C%20in%20fact%20I%20just%20fixed%20the%20race%20conditions%20showed%20by%20the%20tests%20for%20Thread%20and%20Semaphore.%5Cr%5CnAnyway%20I%20will%20close%20this%20and%20merge%20it%20to%20%60devel%60.%22%2C%20%22created_at%22%3A%20%222016-05-26T09%3A01%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/768#issuecomment-221576466'>General Comment</a></b>
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> These changes look fine by me, although it is difficult to predict all effects the PR may have.
@drdanz: are you sure it is a good idea to commit this into master and not devel?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @lornat75 I'm not sure of anything when I touch YARP_OS :laughing:
Technically, from what I understood about the new workflow, the changes here belong to `master` since they are "bugfixes" and do not change the API/ABI (ThreadCallbackAdapter is a private class so adding the virtual destructor in 1526f93 is not a change in the ABI).
7b54c6c and 1540f13 are the only ones that might cause some unexpected behaviour, even though this part is well covered by the unit tests. The other changes are rather trivial.
If you think it is safer to commit these to `devel`, I have no objections to do so, since it is probably safer, and since also @pattacini expressed concern over this... We should take some time to re-discuss the policies, though, and find some way to discern what goes to `master` and what goes to `devel` that includes something about "safe" or "not safe" (that probably will force us to push any change to YARP_OS to go to `devel` :sweat_smile: )
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> Is there a regression test for yarp_os? I know there is on for yarp_dev.
If tests are fine, may the PR considered safer?
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> @drdanz, I think we can commit to devel bugfixes we would like to test before they are integrated in the `stable` master. In this case it is borderline so it does not matter (we do have regression tests which may catch most problems).
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @barbalberto `YARP_OS` has plenty of unit tests for this part, in fact I just fixed the race conditions showed by the tests for Thread and Semaphore.
Anyway I will close this and merge it to `devel`.


<a href='https://www.codereviewhub.com/robotology/yarp/pull/768?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/768?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/768'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>