### PR TITLE
Docs: Improve yarp::os::Property documentation

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -20,17 +20,14 @@ namespace yarp {
 /**
  * \ingroup key_class
  *
+ * \brief A class for storing options and configuration information.
  *
- * A class for storing options and configuration information.
- * Use put() to add keyword/value pairs, and get() or check()
- * to look them up afterwards.
- * It can
- * read from configuration files using the fromConfigFile() method,
- * and from command line options using the fromCommand() method, and
- * from any Searchable object (include Bottle objects) using the
- * fromString() method.
+ * Use put() to add keyword/value pairs, and get() or check() to look them up
+ * afterwards.
+ * It can read from configuration files using the fromConfigFile() method, and
+ * from command line options using the fromCommand() method, and from any
+ * Searchable object (include Bottle objects) using the fromString() method.
  * Property objects can be searched efficiently.
- *
  */
 class YARP_OS_API yarp::os::Property : public Searchable, public Portable {
 
@@ -45,7 +42,6 @@ public:
      * hash map storing the data.  Set to 0 for default size.
      * The bigger this number, the more memory used, but the
      * more efficient the map.
-     *
      */
     Property(int hash_size = 0);
 
@@ -66,70 +62,96 @@ public:
     virtual ~Property();
 
     /**
-     * Assignment.
+     * Assignment operator.
      */
-    const Property& operator = (const Property& prop);
+    const Property& operator=(const Property& prop);
 
     // documented in Searchable
     bool check(const ConstString& key) const;
 
     /**
-     * Associate the given key with the given string, so that
-     * find(key).asString() will give that string.
+     * \brief Associate the given \c key with the given string.
+     *
+     * After the association <code>find(key).asString()</code> will return that
+     * string.
+     * If \c key is already associated, the value will be replaced with the new
+     * one.
+     *
      * @param key the key
      * @param value the string value
      */
     void put(const ConstString& key, const ConstString& value);
 
     /**
-     * Associate the given key with the given value, so that
-     * find(key).asString() will give that value.
+     * \brief Associate the given \c key with the given value
+     *
+     * After the association <code>find(key).asString()</code> will return that
+     * value.
+     * If \c key is already associated, the value will be replaced with the new
+     * one.
+     *
      * @param key the key
      * @param value the value
      */
     void put(const ConstString& key, const Value& value);
 
     /**
-     * Associate the given key with the given value, so that
-     * find(key) will give that value.  The Property
-     * object is responsible for deallocating the value.
+     * \brief Associate the given \c key with the given value.
+     *
+     * After the association <code>find(key)</code> will return that value.
+     * The Property object is responsible for deallocating the value.
+     * If \c key is already associated, the value will be replaced with the new
+     * one.
+     *
      * @param key the key
      * @param value the value
      */
     void put(const ConstString& key, Value *value);
 
     /**
-     * Associate the given key with the given integer, so that
-     * find(key).asInt() will give that integer.
+     * \brief Associate the given \c key with the given integer.
+     *
+     * After the association <code>find(key).asInt()</code> will return that
+     * integer.
+     * If \c key is already associated, the value will be replaced with the new
+     * one.
+     *
      * @param key the key
      * @param value the integer value
      */
     void put(const ConstString& key, int value);
 
     /**
-     * Associate the given key with the given floating point number, so that
-     * find(key).asDouble() will give that number.
+     * \brief Associate the given \c key with the given floating point number
+     *
+     * After the association <code>find(key).asDouble()</code> will return that
+     * number.
+     * If \c key is already associated, the value will be replaced with the new
+     * one.
+     *
      * @param key the key
      * @param value the floating point value
      */
     void put(const ConstString& key, double value);
 
     /**
+     * \brief Add a nested group.
      *
-     * Add a nested group. Careful: the group object returned is
-     * valid only until the next read from the Property it was added
-     * to.  As soon as there is a request for data from that Property,
-     * then it ceases to be usable.
+     * \warning the group object returned is valid only until the next read from
+     * the Property it was added to. As soon as there is a request for data from
+     * that Property, then it ceases to be usable.
      *
      * @param key the key
      * @return the nested group, represented as a Property
-     *
      */
     Property& addGroup(const ConstString& key);
 
     /**
-     * Remove the association from the given key to a value, if present.
-     * Guarantees that find(key).isNull() will be true.
+     * \brief Remove the association from the given \c key to a value, if
+     *        present.
+     *
+     * Guarantees that <code>find(key).isNull()</code> will be true.
+     *
      * @param key the key
      */
     void unput(const ConstString& key);
@@ -141,35 +163,54 @@ public:
     virtual Bottle& findGroup(const ConstString& key) const;
 
     /**
-     * Remove all associations.
-     * Guarantees that find(key).isNull() will be true for all values of key.
+     * \brief Remove all associations.
+     *
+     * Guarantees that <code>find(key).isNull()</code> will be true for all
+     * values of \c key.
      */
     void clear();
 
     /**
-     * Interprets a string as a list of properties. Uses the the same
-     * format as a Bottle.  The first element of every sub-list
-     * is interpreted as a key.  For example, with
-     * text = "(width 10) (height 15)", the Property object
-     * will be the mapping {width => 10, height => 15}.  So:
+     * \brief Interprets a string as a list of properties.
+     *
+     * Uses the the same format as a Bottle.
+     * The first element of every sub-list is interpreted as a key.
+     * For example, with text = <code>(width 10) (height 15)</code>, the
+     * Property object will be the mapping
+     * <code>{width => 10, height => 15}</code>.
+     * Therefore:
      * \code
      *   prop.find("width").asInt() // gives 10
      *   prop.find("height").asInt() // gives 15
      * \endcode
+     *
+     * If a key is duplicated, only the latest will be used.
+     * For example, with text = <code>(foo bar) (foo baz)</code>, the Property
+     * object will be the mapping <code>{foo => baz}</code>.
+     *
      * @param txt the textual form of the Property object
      * @param wipe should Property be emptied first
      */
     void fromString(const ConstString& txt, bool wipe=true);
 
     /**
-     * Interprets a list of command arguments as a list of properties.
-     * Keys are named by beginning with "--".  For example, with
-     * argv = "program_name --width 10 --height 15", the Property object
-     * will be the mapping {width => 10, height => 15}.  So:
+     * \brief Interprets a list of command arguments as a list of properties.
+     *
+     * Keys are named by beginning with \c \-\-.
+     * For example, with argv =
+     * <code>program_name \-\-width 10 \-\-height 15</code>, the Property object
+     * will be the mapping <code>{width => 10, height => 15}</code>.
+     * Therefore:
      * \code
      *   prop.find("width").asInt() // gives 10
      *   prop.find("height").asInt() // gives 15
      * \endcode
+     *
+     * If a key is duplicated, only the latest will be used.
+     * For example, with argv =
+     * <code>program_name \-\-foo bar \-\-foo baz</code>, the Property object
+     * will be the mapping <code>{foo => baz}</code>.
+     *
      * @param argc the number of arguments
      * @param argv the list of arguments
      * @param skipFirst set to true if the first argument should be skipped
@@ -179,25 +220,59 @@ public:
     void fromCommand(int argc, char *argv[], bool skipFirst=true,
                      bool wipe=true);
 
-    void fromCommand(int argc, const char *argv[], bool skipFirst=true,
-                     bool wipe=true);
-
     /**
-     * Interprets a list of command arguments as a list of properties.
-     * Keys are named by beginning with "--".  For example, with
-     * arguments = "--width 10 --height 15", the Property object
-     * will be the mapping {width => 10, height => 15}.  So:
+     * \brief Interprets a list of command arguments as a list of properties.
+     *
+     * Keys are named by beginning with \c \-\-.
+     * For example, with argv =
+     * <code>program_name \-\-width 10 \-\-height 15</code>, the Property object
+     * will be the mapping <code>{width => 10, height => 15}</code>.
+     * Therefore:
      * \code
      *   prop.find("width").asInt() // gives 10
      *   prop.find("height").asInt() // gives 15
      * \endcode
+     *
+     * If a key is duplicated, only the latest will be used.
+     * For example, with argv =
+     * <code>program_name \-\-foo bar \-\-foo baz</code>, the Property object
+     * will be the mapping <code>{foo => baz}</code>.
+     *
+     * @param argc the number of arguments
+     * @param argv the list of arguments
+     * @param skipFirst set to true if the first argument should be skipped
+     * (which is the right thing to do for arguments passed to main())
+     * @param wipe should Property be emptied first
+     */
+    void fromCommand(int argc, const char *argv[], bool skipFirst=true,
+                     bool wipe=true);
+
+    /**
+     * \brief Interprets a list of command arguments as a list of properties.
+     *
+     * Keys are named by beginning with \c \-\-.
+     * For example, with argv =
+     * <code>program_name \-\-width 10 \-\-height 15</code>, the Property object
+     * will be the mapping <code>{width => 10, height => 15}</code>.
+     * Therefore:
+     * \code
+     *   prop.find("width").asInt() // gives 10
+     *   prop.find("height").asInt() // gives 15
+     * \endcode
+     *
+     * If a key is duplicated, only the latest will be used.
+     * For example, with argv =
+     * <code>program_name \-\-foo bar \-\-foo baz</code>, the Property object
+     * will be the mapping {foo => baz}.
+     *
      * @param arguments the command arguments
      * @param wipe should Property be emptied first
      */
     void fromArguments(const char *arguments, bool wipe=true);
 
     /**
-     * Interprets a file as a list of properties.
+     * \brief Interprets a file as a list of properties.
+     *
      * For example, for a file containing:
      * \code
      *   width 10
@@ -209,6 +284,16 @@ public:
      *   prop.find("width").asInt() // gives 10
      *   prop.find("height").asInt() // gives 15
      * \endcode
+     *
+     * If a key is duplicated, only the latest will be used.
+     * For example, for a file containing:
+     * \code
+     *   foo bar
+     *   foo baz
+     * \endcode
+     *
+     * the Property object will be the mapping {foo => baz}.
+     *
      * Lines of the form "[NAME]" will result in nested subproperties.
      * For example, for a file containing:
      * \code
@@ -224,6 +309,24 @@ public:
      * \code
      *   prop.findGroup("SIZE").find("width").asInt() // gives 10
      *   prop.findGroup("APPEARANCE").find("color").asString() // gives red
+     * \endcode
+     *
+     * \warning If a key in a group is duplicated, they will be both included as
+     * the value for the group, since the value will be a Bottle, that can
+     * include duplicate values. In this case, the Value returned by find(),
+     * will be the first and not the latter.
+     * For example, for a file containing:
+     * \code
+     * [GROUP]
+     * foo bar
+     * foo baz
+     * \endcode
+     * the structure of the Property object will be
+     * "(GROUP (foo bar) (foo baz))".
+     * Therefore
+     * \code
+     * prop.findGroup("GROUP").toString() // gives "(foo bar) (foo baz)"
+     * prop.findGroup("GROUP").find("foo").asString(); // gives "bar", and NOT "baz"
      * \endcode
      *
      * It is possible to nest configuration files.  To include
@@ -246,10 +349,13 @@ public:
     bool fromConfigFile(const ConstString& fname, bool wipe=true);
 
     /**
-     * Variant of fromConfigFile(fname,wipe) that includes extra
-     * "environment variables".  These will be expanded, along
-     * with any other variables in the environment, if present
-     * in the configuration file in $variable or ${variable} form.
+     * \brief Variant of fromConfigFile(fname,wipe) that includes extra
+     * "environment variables".
+     *
+     * These will be expanded, along with any other variables in the
+     * environment, if present in the configuration file in
+     * <code>$variable</code> or <code>${variable}</code> form.
+     *
      * @param fname the name of the file to read from
      * @param env extra set of environment variables
      * @param wipe should Property be emptied first
@@ -260,7 +366,7 @@ public:
                         bool wipe=true);
 
     /**
-     * Interprets all files in a directory as lists of properties as
+     * \brief Interprets all files in a directory as lists of properties as
      * described in fromConfigFile().
      *
      * @param dirname the name of the file to read from
@@ -274,18 +380,22 @@ public:
                        bool wipe = true);
 
     /**
-     * Parses text in the configuration format described in
+     * \brief Parses text in the configuration format described in
      * fromConfigFile().
+     *
      * @param txt the configuration text
      * @param wipe should Property be emptied first
      */
     void fromConfig(const char *txt, bool wipe=true);
 
     /**
-     * Variant of fromConfig(txt,wipe) that includes extra
-     * "environment variables".  These will be expanded, along
-     * with any other variables in the environment, if present
-     * in the configuration file in $variable or ${variable} form.
+     * Variant of fromConfig(const char*, bool) that includes extra
+     * "environment variables".
+     *
+     * These will be expanded, along with any other variables in the
+     * environment, if present in the configuration file in
+     * <code>$variable<code> or <code>${variable}</code> form.
+     *
      * @param txt the configuration text
      * @param env extra set of environment variables
      * @param wipe should Property be emptied first
@@ -294,11 +404,13 @@ public:
                     Searchable& env,
                     bool wipe=true);
 
-
     /**
-     * Parses text in a url, adding anything of the form foo=bar
-     * as a property
-     * @param url the text of the url, of form ...prop1=val1&prop2=val2...
+     * \brief Parses text in a url.
+     *
+     * Anything of the form <code>foo=bar</code> is added as a property.
+     *
+     * @param url the text of the url, of form
+     *            <code>...prop1=val1&prop2=val2...</code>
      * @param wipe should Property be emptied first
      */
     void fromQuery(const char *url,


### PR DESCRIPTION
Add documentation about the behaviour of `yarp::os::Property` when a duplicate value is added.
General cleanup and improvement of the documentation
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/775?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/775'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>