### PR TITLE
Release notes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,14 +3,15 @@ Alessandro Roncone <alessandro.roncone@iit.it> <alecive87@gmail.com>
 Alessandro Scalzo <alessandro.scalzo@iit.it>
 Alessandro Scalzo <alessandro.scalzo@iit.it> <icub@ale.humanoids.iit.it>
 Ali Paikan <ali.paikan@iit.it> <ali.paikan@gmail.com>
+Claudio Fantacci <claudio.fantacci@iit.it> <claudio.fantacci@gmail.com>
 Daniele E. Domenichelli <daniele.domenichelli@iit.it> <daniele.domenichelli@gmail.com>
 Daniele E. Domenichelli <daniele.domenichelli@iit.it> <ddomenichelli@kde.org>
 Davide Perrone <dperrone@aitek.it> <aitek4iit@aitek.it>
 Davide Perrone <dperrone@aitek.it> <syndacate2004@gmail.com>
 Elena Ceseracciu <elena.ceseracciu@iit.it> <eowyn83@gmail.com>
 Enrico Mingo <Enrico.Mingo@iit.it>
-Francesco Romano <francesco.romano.1987@gmail.com>
-Francesco Romano <francesco.romano.1987@gmail.com> <makaveli@Makas-iMac.local>
+Francesco Romano <francesco.romano@iit.it> <francesco.romano.1987@gmail.com>
+Francesco Romano <francesco.romano@iit.it> <makaveli@Makas-iMac.local>
 Gabriele Nava <gabriele.nava@mail.polimi.it>
 Holger Friedrich <holgerf@vsi.cs.uni-frankfurt.de> <holgerfriedrich@users.noreply.github.com>
 Juan G Victores <jcgvicto@gmail.com> <jgvictores>

--- a/conf/YarpDoc.cmake
+++ b/conf/YarpDoc.cmake
@@ -54,7 +54,7 @@ if(DOXYGEN_FOUND)
        YARP_DOXYGEN_DOCBOOK)
 
       # Prepare configuration for normal documentation
-      set(DOX_PATTERNS "*.h *.dox *.cpp")
+      set(DOX_PATTERNS "*.h *.cpp *.dox *.md")
       set(DOX_GENERATE_HTML NO)
       set(DOX_GENERATE_DOCSET NO)
       set(DOX_GENERATE_HTMLHELP NO)

--- a/conf/template/Doxyfile.in
+++ b/conf/template/Doxyfile.in
@@ -798,8 +798,9 @@ INPUT                  = @CMAKE_BINARY_DIR@/generated_include \
                          @CMAKE_SOURCE_DIR@/src/libYARP_name/src \
                          @CMAKE_SOURCE_DIR@/src/modules \
                          @CMAKE_SOURCE_DIR@/src/carriers \
-                         @CMAKE_SOURCE_DIR@/doc/spec \
                          @CMAKE_SOURCE_DIR@/doc \
+                         @CMAKE_SOURCE_DIR@/doc/spec \
+                         @CMAKE_SOURCE_DIR@/doc/release \
                          @CMAKE_SOURCE_DIR@/.github/CONTRIBUTING.md
 
 # This tag can be used to specify the character encoding of the source files

--- a/conf/template/Doxyfile.in
+++ b/conf/template/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.9.1
+# Doxyfile 1.8.11
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -356,6 +356,13 @@ IDL_PROPERTY_SUPPORT   = YES
 # The default value is: NO.
 
 DISTRIBUTE_GROUP_DOC   = NO
+
+# If one adds a struct or class to a group and this option is enabled, then also
+# any nested class or struct is added to the same group. By default this option
+# is disabled and one has to add nested compounds explicitly via \ingroup.
+# The default value is: NO.
+
+GROUP_NESTED_COMPOUNDS = NO
 
 # Set the SUBGROUPING tag to YES to allow class member groups of the same type
 # (for instance a group of public functions) to be put as a subgroup of that
@@ -746,6 +753,12 @@ WARN_IF_DOC_ERROR      = YES
 
 WARN_NO_PARAMDOC       = YES
 
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered.
+# The default value is: NO.
+
+WARN_AS_ERROR          = NO
+
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
 # will be replaced by the file and line number from which the warning originated
@@ -769,7 +782,7 @@ WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen.log
 # The INPUT tag is used to specify the files and/or directories that contain
 # documented source files. You may enter file names like myfile.cpp or
 # directories like /usr/src/myproject. Separate the files or directories with
-# spaces.
+# spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_BINARY_DIR@/generated_include \
@@ -800,12 +813,17 @@ INPUT_ENCODING         = UTF-8
 
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard patterns (like *.cpp and
-# *.h) to filter out the source-files in the directories. If left blank the
-# following patterns are tested:*.c, *.cc, *.cxx, *.cpp, *.c++, *.java, *.ii,
-# *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h, *.hh, *.hxx, *.hpp,
-# *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc, *.m, *.markdown,
-# *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
-# *.qsf, *.as and *.js.
+# *.h) to filter out the source-files in the directories.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# read by doxygen.
+#
+# If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
+# *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
+# *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
+# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
+# *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
 
 FILE_PATTERNS          = @DOX_PATTERNS@
 
@@ -892,6 +910,10 @@ IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc \
 # Note that the filter must not add or remove lines; it is applied before the
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# properly processed by doxygen.
 
 INPUT_FILTER           =
 
@@ -901,6 +923,10 @@ INPUT_FILTER           =
 # (like *.cpp=my_cpp_filter). See INPUT_FILTER for further information on how
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# properly processed by doxygen.
 
 FILTER_PATTERNS        =
 
@@ -1018,7 +1044,7 @@ VERBATIM_HEADERS       = YES
 # rich C++ code for which doxygen's built-in parser lacks the necessary type
 # information.
 # Note: The availability of this option depends on whether or not doxygen was
-# compiled with the --with-libclang option.
+# generated with the -Duse-libclang=ON option for CMake.
 # The default value is: NO.
 
 CLANG_ASSISTED_PARSING = NO
@@ -1654,9 +1680,12 @@ COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
-# that should be included in the LaTeX output. To get the times font for
-# instance you can specify
-# EXTRA_PACKAGES=times
+# that should be included in the LaTeX output. The package can be specified just
+# by its name or with the correct syntax as to be used with the LaTeX
+# \usepackage command. To get the times font for instance you can specify :
+# EXTRA_PACKAGES=times or EXTRA_PACKAGES={times}
+# To use the option intlimits with the amsmath package you can specify:
+# EXTRA_PACKAGES=[intlimits]{amsmath}
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
@@ -1758,6 +1787,14 @@ LATEX_SOURCE_CODE      = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
+
+# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
+# page will contain the date and time when the page was generated. Setting this
+# to NO can help when comparing the output of multiple runs.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_LATEX is set to YES.
+
+LATEX_TIMESTAMP        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
@@ -2270,7 +2307,8 @@ INCLUDED_BY_GRAPH      = YES
 #
 # Note that enabling this option will significantly increase the time of a run.
 # So in most cases it will be better to enable call graphs for selected
-# functions only using the \callgraph command.
+# functions only using the \callgraph command. Disabling a call graph can be
+# accomplished by means of the command \hidecallgraph.
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2281,7 +2319,8 @@ CALL_GRAPH             = NO
 #
 # Note that enabling this option will significantly increase the time of a run.
 # So in most cases it will be better to enable caller graphs for selected
-# functions only using the \callergraph command.
+# functions only using the \callergraph command. Disabling a caller graph can be
+# accomplished by means of the command \hidecallergraph.
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2304,13 +2343,17 @@ GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
 
 # The DOT_IMAGE_FORMAT tag can be used to set the image format of the images
-# generated by dot.
+# generated by dot. For an explanation of the image formats see the section
+# output formats in the documentation of the dot tool (Graphviz (see:
+# http://www.graphviz.org/)).
 # Note: If you choose svg you need to set HTML_FILE_EXTENSION to xhtml in order
 # to make the SVG files visible in IE 9+ (other browsers do not have this
 # requirement).
 # Possible values are: png, png:cairo, png:cairo:cairo, png:cairo:gd, png:gd,
 # png:gd:gd, jpg, jpg:cairo, jpg:cairo:gd, jpg:gd, jpg:gd:gd, gif, gif:cairo,
-# gif:cairo:gd, gif:gd, gif:gd:gd and svg.
+# gif:cairo:gd, gif:gd, gif:gd:gd, svg, png:gd, png:gd:gd, png:cairo,
+# png:cairo:gd, png:cairo:cairo, png:cairo:gdiplus, png:gdiplus and
+# png:gdiplus:gdiplus.
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 

--- a/doc/changes.dox
+++ b/doc/changes.dox
@@ -12,18 +12,9 @@ This page lists the main changes introduced in YARP at each release.
 
 \tableofcontents
 
-\section sec-2-3-4 YARP next release (2.3.4)
-
-- Added yarpmanager++ which merges the functionalities of the yarpmanager and yarpbuilder
-- Deprecated all guis based on Gtk.
-- The following YARP methods have been deprecated:
-  - iPositionControl::setPositionMode()
-  - iVelocityControl::setVelocityMode()
-  - iTorqueControl::setTorqueMode()
-  - iOpenLoopControl::setOpenLoopMode()
-- added yarpRobotInterface executable (moved from icub-main where it was called robotinterface)
-- ResourceFinder::configure(argc,argv,bool) accepts a third optional parameter to keep/skip the first command line argument
-
+\section rel-v2_3_65 YARP 2.3.65
+\li \subpage md_doc_release_v2_3_65_1
+\li \subpage md_doc_release_v2_3_65
 
  *
  */

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -73,7 +73,7 @@ Interoperability:
 More information:
 \li \subpage what_is_yarp
 \li \subpage md_.github_CONTRIBUTING
-\li \subpage changelog 
+\li \subpage changelog
 
 YARP resources:
 \li \ref download

--- a/doc/release/v2_3_65.md
+++ b/doc/release/v2_3_65.md
@@ -1,8 +1,11 @@
 YARP 2.3.65 (2016-05-13) Release Notes
 ======================================
 
+
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+2.3.65%22)
+
+
 
 Important Changes
 -----------------
@@ -26,7 +29,6 @@ Bug Fixes
 
 
 
-
 New Features
 ------------
 
@@ -34,7 +36,6 @@ New Features
 
 * `ResourceFinder::configure(argc,argv,bool)` accepts a third optional parameter
   to keep/skip the first command line argument
-
 
 ### yarprobotinterface
 
@@ -55,6 +56,7 @@ in YARP with a few non compatible changes:
 
 A new `yarpmanager++` tool which merges the functionalities of the `yarpmanager`
 and `yarpbuilder` was added.
+
 
 
 Deprecated Features
@@ -84,3 +86,38 @@ Deprecated Features
 ### GUIs
 * All guis based on GTK2 are now considered deprecated and will be removed in
   the next release.
+
+
+
+Contributors
+------------
+
+This is a list of people that contributed to this release (generated from the
+git history using `git shortlog -ens --no-merges v2.3.64..v2.3.65`):
+
+```
+   480  Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+    92  Alberto Cardellino <alberto.cardellino@iit.it>
+    81  Marco Randazzo <marco.randazzo@iit.it>
+    57  Ali Paikan <ali.paikan@iit.it>
+    48  Ugo Pattacini <ugo.pattacini@iit.it>
+    44  Lorenzo Natale <lorenzo.natale@iit.it>
+    24  Francesco Romano <francesco.romano@iit.it>
+    24  Silvio Traversaro <silvio.traversaro@iit.it>
+    17  Matteo Brunettini <matteo.brunettini@iit.it>
+    15  Vadim Tikhanoff <vadim.tikhanoff@iit.it>
+     5  Giulia Vezzani <giulia.vezzani@iit.it>
+     4  Alessandro Roncone <alessandro.roncone@iit.it>
+     4  Elena Ceseracciu <elena.ceseracciu@iit.it>
+     4  Konstantinos Theofilis <kostas@ams.eng.osaka-u.ac.jp>
+     3  Davide Perrone <dperrone@aitek.it>
+     3  YARP Developers <yarp0-devel@lists.sourceforge.net>
+     2  Claudio Fantacci <claudio.fantacci@iit.it>
+     2  Davide Pollarolo <davide.pollarolo@iit.it>
+     2  Francesco Nori <francesco.nori@iit.it>
+     1  Alessio Rocchi <alessio.rocchi@iit.it>
+     1  Davide Tome <davide.tome@iit.it>
+     1  Francesca Stramandinoli <francesca.stramandinoli@iit.it>
+     1  Gabriele Nava <gabriele.nava@mail.polimi.it>
+     1  Valentina Gaggero <valentina.gaggero@iit.it>
+```

--- a/doc/release/v2_3_65.md
+++ b/doc/release/v2_3_65.md
@@ -1,0 +1,86 @@
+YARP 2.3.65 (2016-05-13) Release Notes
+======================================
+
+A (partial) list of bug fixed and issues resolved in this release can be found
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+2.3.65%22)
+
+Important Changes
+-----------------
+
+* YARP is now automatically installed with the RPATH enabled.
+  This can be disabled by setting the `CMAKE_SKIP_RPATH` or
+  `CMAKE_SKIP_INSTALL_RPATH` variables.
+* The `portmonitor` can now be built without LUA and uses YARP plugins system
+  of having to locate the shared libraries manually.
+
+
+
+Bug Fixes
+---------
+
+### YARP_OS
+
+* Fixed memory leaks when building with c++11.
+* Fixed `yarp::os::Thread::getKey()` method for c++11.
+* Fixed race condition in `yarp::os::Thread::getKey()`.
+
+
+
+
+New Features
+------------
+
+### YARP_OS
+
+* `ResourceFinder::configure(argc,argv,bool)` accepts a third optional parameter
+  to keep/skip the first command line argument
+
+
+### yarprobotinterface
+
+The `robotInterface` tool in
+[robotology/icub-main](https://github.com/robotology/icub-main/) was imported
+in YARP with a few non compatible changes:
+
+* `robotInterface` was renamed `yarprobotinterface` to follow the convention
+  with yarp executables
+* The RPC port opened is now /<robotname>/yarprobotinterface
+* The default `.ini` file name is now `yarprobotinterface.ini`
+* The DTD line for XML files is now
+```xml
+<!DOCTYPE [...] PUBLIC "-//YARP//DTD yarprobotinterface 1.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV1.0.dtd">
+```
+
+### yarpmanager++
+
+A new `yarpmanager++` tool which merges the functionalities of the `yarpmanager`
+and `yarpbuilder` was added.
+
+
+Deprecated Features
+-------------------
+
+### YARP_OS
+
+* `yarp::os::Module` is now deprecated in favour of `yarp::os::RFModule`.
+* `YARP_ASSERT` is now deprecated in favour of `yAssert`.
+
+### YARP_dev
+
+* The following YARP methods have been deprecated:
+  - iPositionControl::setPositionMode()
+  - iVelocityControl::setVelocityMode()
+  - iTorqueControl::setTorqueMode()
+  - iOpenLoopControl::setOpenLoopMode()
+
+### Devices
+* `controlboard` and `clientcontrolboard` devices are now deprecated in favour
+  of `controlboardwrapper2` and `remote_controlboard`.
+
+### Tools
+* `yarpserver2` and `yarpserver3` are now considered deprecated and will be
+  removed in the next release.
+
+### GUIs
+* All guis based on GTK2 are now considered deprecated and will be removed in
+  the next release.

--- a/doc/release/v2_3_65_1.md
+++ b/doc/release/v2_3_65_1.md
@@ -1,0 +1,25 @@
+YARP 2.3.65.1 (UNRELEASED) Release Notes
+========================================
+
+A (partial) list of bug fixed and issues resolved in this release can be found
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+2.3.65.1%22)
+
+Bug Fixes
+---------
+
+### YARP_dev
+
+* Add missing `YARP_dev_API` export symbol to `StubImplPositionDirectRaw`
+* Fix errors on ROS topic message, in particular:
+  * measurement unit for linear joints.
+  * timeStamps for joint message. This fixes issue on ROS TF while using 
+    simulator.
+
+### Modules
+
+* Critical bugfix for laserHokuyo
+
+### GUIs
+
+* `yarpmanager++`: fixed crashes on deleting connection after changing prefix (#761)
+* `yarpmanager++`: fixed connections do not update when prefix is changed (#751)

--- a/doc/release/v2_3_65_1.md
+++ b/doc/release/v2_3_65_1.md
@@ -1,8 +1,11 @@
 YARP 2.3.65.1 (UNRELEASED) Release Notes
 ========================================
 
+
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+2.3.65.1%22)
+
+
 
 Bug Fixes
 ---------
@@ -23,3 +26,14 @@ Bug Fixes
 
 * `yarpmanager++`: fixed crashes on deleting connection after changing prefix (#761)
 * `yarpmanager++`: fixed connections do not update when prefix is changed (#751)
+
+
+
+Contributors
+------------
+
+This is a list of people that contributed to this release (generated from the
+git history using `git shortlog -ens --no-merges v2.3.65..v2.3.65.1`):
+
+```
+```


### PR DESCRIPTION
Add release notes for v2.3.65 and v2.3.65.1

Improve format of the changelog page.

The release notes are written using markdown instead of doxygen, so that
they can be copy-pasted in the release page on github.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/777%23issuecomment-221902302%22%2C%20%22https%3A//github.com/robotology/yarp/pull/777%23issuecomment-222082433%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/777%23issuecomment-221902302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20%5C%22changelog%5C%22%20page%20will%20contain%20only%20a%20link%20to%20the%20release%20notes%20for%20all%20the%20releases.%5Cr%5Cn%40lornat75%20%40pattacini%20Does%20this%20look%20ok%20to%20you%3F%22%2C%20%22created_at%22%3A%20%222016-05-26T15%3A18%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20fine%2C%20although%20I%20can%27t%20see%20how%20it%20would%20look%20like%20in%20the%20online%20page.%20The%20main%20thing%20is%20to%20be%20able%20to%20list%20all%20important%20changes%20introduced%20between%20releases.%22%2C%20%22created_at%22%3A%20%222016-05-27T07%3A47%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/777#issuecomment-221902302'>General Comment</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> The "changelog" page will contain only a link to the release notes for all the releases.
@lornat75 @pattacini Does this look ok to you?
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> Looks fine, although I can't see how it would look like in the online page. The main thing is to be able to list all important changes introduced between releases.


<a href='https://www.codereviewhub.com/robotology/yarp/pull/777?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/777?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/777'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>