### PR TITLE
crtical bugfix for laser wrapper

### DIFF
--- a/src/libYARP_dev/src/modules/Rangefinder2DWrapper/Rangefinder2DWrapper.h
+++ b/src/libYARP_dev/src/modules/Rangefinder2DWrapper/Rangefinder2DWrapper.h
@@ -38,12 +38,6 @@
 #include <yarp/os/Publisher.h>
 #include <sensor_msgs_LaserScan.h>
 
-#define DEFAULT_DUMMY_MIN_DISTANCE      0.0             // [m]
-#define DEFAULT_DUMMY_MAX_DISTANCE      100.0           // [m]
-
-#define DEFAULT_DUMMY_MIN_ANGLE_DEG     0.0             // angular min scan range in degrees
-#define DEFAULT_DUMMY_MAX_ANGLE_DEG     360.0           // angular max scan range in degrees
-
 namespace yarp{
     namespace dev{
         class Rangefinder2DWrapper;
@@ -94,6 +88,7 @@ private:
     std::string sensorId;
     double minAngle, maxAngle;
     double minDistance, maxDistance;
+    double resolution;
 
     bool checkROSParams(yarp::os::Searchable &config);
     bool initialize_ROS();

--- a/src/modules/laserHokuyo/laserHokuyo.cpp
+++ b/src/modules/laserHokuyo/laserHokuyo.cpp
@@ -42,8 +42,15 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
     //list of mandatory options
     //TODO change comments
     period = general_config.check("Period", Value(50), "Period of the sampling thread").asInt();
+
+    if (general_config.check("max_angle") == false) { yError() << "Missing max_angle param"; return false; }
+    if (general_config.check("min_angle") == false) { yError() << "Missing min_angle param"; return false; }
+    max_angle = general_config.find("max_angle").asDouble();
+    min_angle = general_config.find("min_angle").asDouble();
+
     start_position = general_config.check("Start_Position", Value(0), "Start position").asInt();
     end_position = general_config.check("End_Position", Value(1080), "End Position").asInt();
+
     error_codes = general_config.check("Convert_Error_Codes", Value(0), "Substitute error codes with legal measurments").asInt();
     yarp::os::ConstString s = general_config.check("Laser_Mode", Value("GD"), "Laser Mode (GD/MD").asString();
 
@@ -281,8 +288,8 @@ bool laserHokuyo::setDistanceRange(double min, double max)
 bool laserHokuyo::getScanLimits(double& min, double& max)
 {
     //degrees
-    min = 0;
-    max = 270;
+    min = min_angle;
+    max = max_angle;
     return true;
 }
 

--- a/src/modules/laserHokuyo/laserHokuyo.h
+++ b/src/modules/laserHokuyo/laserHokuyo.h
@@ -38,6 +38,8 @@ protected:
     int sensorsNum;
     int start_position;
     int end_position;
+    double min_angle;
+    double max_angle;
     int error_codes;
     int internal_status;
     std::string info;


### PR DESCRIPTION
angle_increment is now obtained from the hardware device. Before it was fixed to 1, preventing correct operation of laserHokuyo device (which has angle_increment=0.25)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/788%23issuecomment-224272011%22%2C%20%22https%3A//github.com/robotology/yarp/pull/788%23discussion_r66088521%22%2C%20%22https%3A//github.com/robotology/yarp/pull/788%23issuecomment-224309790%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/788%23issuecomment-224272011%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22One%20of%20the%20travis%20build%20failed%2C%20but%20it%20seems%20yet%20another%20random%20failure%2C%20since%20it%20is%20unrelated%20to%20this%20patch...%20I%20restarted%20the%20build%2C%20let%27s%20see%20if%20it%20works%20this%20time%22%2C%20%22created_at%22%3A%20%222016-06-07T12%3A57%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-06-07T15%3A04%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204ea206c02a89bccf3db6e54b73355c57bbc239aa%20src/modules/laserHokuyo/laserHokuyo.cpp%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/788%23discussion_r66088521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Technically%2C%20this%20change%20adds%20parameters%20to%20the%20device%2C%20therefore%20it%20does%20not%20belong%20to%20%60master%60...%22%2C%20%22created_at%22%3A%20%222016-06-07T15%3A04%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/modules/laserHokuyo/laserHokuyo.cpp%3AL42-57%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 4ea206c02a89bccf3db6e54b73355c57bbc239aa src/modules/laserHokuyo/laserHokuyo.cpp 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/788#discussion_r66088521'>File: src/modules/laserHokuyo/laserHokuyo.cpp:L42-57</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Technically, this change adds parameters to the device, therefore it does not belong to `master`...
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/788#issuecomment-224272011'>General Comment</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> One of the travis build failed, but it seems yet another random failure, since it is unrelated to this patch... I restarted the build, let's see if it works this time


<a href='https://www.codereviewhub.com/robotology/yarp/pull/788?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/788?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/788'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>