### PR TITLE
YarpOSXUtilities.cmake: Fix name when TARGET_DEST is not defined

### DIFF
--- a/conf/YarpOSXUtilities.cmake
+++ b/conf/YarpOSXUtilities.cmake
@@ -28,7 +28,7 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
     set(_target_orig ${_DADB_TARGET_ORIG})
 
     if(NOT DEFINED _DADB_TARGET_DEST)
-      set(_target_dest ${_target}.app)
+      set(_target_dest ${_target_orig}.app)
     else()
       set(_target_dest ${_DADB_TARGET_DEST})
     endif()


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/791?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/791'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>