### PR TITLE
[modules] Fix imuBosch_BNO055

### DIFF
--- a/src/modules/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/modules/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -118,14 +118,14 @@ bool BoschIMU::close()
     return true;
 }
 
-bool BoschIMU::checkReadResponse(char* response)
+bool BoschIMU::checkReadResponse(unsigned char* response)
 {
-    if(response[0] == (char) REPLY_HEAD)
+    if(response[0] == (unsigned char) REPLY_HEAD)
     {
         return true;
     }
 
-    if(response[0] == (char) ERROR_HEAD)
+    if(response[0] == (unsigned char) ERROR_HEAD)
     {
         if(response[1] != REGISTER_NOT_READY)   // if error is 0x07, do not print error messages
             yError("Bosch BNO055 IMU - Received error response (0x%02X) - code 0x%02X", response[0], response[1]);
@@ -141,11 +141,11 @@ bool BoschIMU::checkReadResponse(char* response)
     return false;
 }
 
-bool BoschIMU::checkWriteResponse(char* response)
+bool BoschIMU::checkWriteResponse(unsigned char* response)
 {
-    if(response[0] == (char) ERROR_HEAD)
+    if(response[0] == (unsigned char) ERROR_HEAD)
     {
-        if(response[1] == (char) WRITE_SUCC)
+        if(response[1] == (unsigned char) WRITE_SUCC)
         {
             return true;
         }
@@ -162,7 +162,7 @@ bool BoschIMU::checkWriteResponse(char* response)
     return false;
 }
 
-bool BoschIMU::sendReadCommand(char register_add, int len, char* buf, std::string comment)
+bool BoschIMU::sendReadCommand(unsigned char register_add, int len, unsigned char* buf, std::string comment)
 {
     int command_len;
     int nbytes_w;
@@ -217,7 +217,7 @@ bool BoschIMU::sendReadCommand(char register_add, int len, char* buf, std::strin
     return success;
 }
 
-bool BoschIMU::sendWriteCommand(char register_add, int len, char* cmd, std::string comment)
+bool BoschIMU::sendWriteCommand(unsigned char register_add, int len, unsigned char* cmd, std::string comment)
 {
     int command_len = 4+len;
     int nbytes_w;
@@ -225,7 +225,7 @@ bool BoschIMU::sendWriteCommand(char register_add, int len, char* cmd, std::stri
     command[0]= START_BYTE;     // start byte
     command[1]= WRITE_CMD;      // read operation
     command[2]= register_add;   // operation mode register
-    command[3]= (char) len;     // length 1 byte
+    command[3]= (unsigned char) len;     // length 1 byte
     for(int i=0; i<len; i++)
         command[4+i] = cmd[i];  // data
 
@@ -257,7 +257,7 @@ bool BoschIMU::sendWriteCommand(char register_add, int len, char* cmd, std::stri
     return true;
 }
 
-int BoschIMU::readBytes(char* buffer, int bytes)
+int BoschIMU::readBytes(unsigned char* buffer, int bytes)
 {
     int r = 0;
     int bytesRead = 0;
@@ -284,7 +284,7 @@ void BoschIMU::dropGarbage()
     return;
 }
 
-void BoschIMU::printBuffer(char* buffer, int length)
+void BoschIMU::printBuffer(unsigned char* buffer, int length)
 {
     for(int i=0; i< length; i++)
         printf("\t0x%02X ", buffer[i]);
@@ -314,7 +314,7 @@ void BoschIMU::readSysError()
 
 bool BoschIMU::threadInit()
 {
-    char msg;
+    unsigned char msg;
 
     msg = 0x00;
     if(!sendWriteCommand(REG_PAGE_ID, 1, &msg, "PAGE_ID") )
@@ -499,7 +499,6 @@ void BoschIMU::run()
     data[3] = (double) raw_data[0]/100.0;
     data[4] = (double) raw_data[1]/100.0;
     data[5] = (double) raw_data[2]/100.0;
-//     yDebug() << "Accel x: " << data[3] << "y: " << data[4] << "z: " << data[5];
 
     ///////////////////////////////////////////
     //
@@ -558,7 +557,7 @@ void BoschIMU::run()
     raw_data[1] = response[5] << 8 | response[4];
     raw_data[2] = response[7] << 8 | response[6];
     raw_data[3] = response[9] << 8 | response[8];
-
+    
     quaternion[0] = ((double) raw_data[1])/(2<<13);
     quaternion[1] = ((double) raw_data[2])/(2<<13);
     quaternion[2] = ((double) raw_data[3])/(2<<13);

--- a/src/modules/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/modules/imuBosch_BNO055/imuBosch_BNO055.h
@@ -140,14 +140,14 @@ protected:
     int                         fd_ser;
     yarp::os::ResourceFinder    rf;
 
-    char command[MAX_MSG_LENGTH];
-    char response[MAX_MSG_LENGTH];
+    unsigned char command[MAX_MSG_LENGTH];
+    unsigned char response[MAX_MSG_LENGTH];
 
-    bool checkWriteResponse(char *response);
-    bool checkReadResponse(char *response);
+    bool checkWriteResponse(unsigned char *response);
+    bool checkReadResponse(unsigned char *response);
 
-    void printBuffer(char *buffer, int length);
-    int  readBytes(char *buffer, int bytes);
+    void printBuffer(unsigned char *buffer, int length);
+    int  readBytes(unsigned char *buffer, int bytes);
     void dropGarbage();
 
     long int           totMessagesRead;
@@ -155,8 +155,8 @@ protected:
 
     void readSysError();
 
-    bool sendReadCommand( char register_add, int len, char* buf, std::string comment = "");
-    bool sendWriteCommand(char register_add, int len, char* cmd, std::string comment = "");
+    bool sendReadCommand(unsigned char register_add, int len, unsigned char* buf, std::string comment = "");
+    bool sendWriteCommand(unsigned char register_add, int len, unsigned char* cmd, std::string comment = "");
 
 public:
     BoschIMU();


### PR DESCRIPTION
The use of char (a signed type) for the byte buffer was corrupting
positive measures when converting from 2 bytes to a single 16 bit value.

The same bug is affecting the driver present in the cer repository.

cc @barbalberto
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-226465854%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-226481937%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-226497746%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-226797582%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227115109%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227119303%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227119559%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227169717%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227195537%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227197009%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227199243%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227200856%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227201281%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227202663%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227203981%22%2C%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-227221501%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/801%23issuecomment-226465854%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20problem%20related%20to%20signed/unsigned%20was%20in%20this%20type%20of%20code%20%3A%20https%3A//github.com/robotology/yarp/pull/801/files%23diff-a35baaba64e46400cd458b5a5dfa64d7L558%20.%20%22%2C%20%22created_at%22%3A%20%222016-06-16T12%3A04%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%20good%20catch.%20I%27ll%20test%20it%20on%20the%20CER%20robot%20%5Cr%5Cn%20%5Cr%5CnThe%20bosch%20imu%20driver%20has%20been%20moved%20from%20CER%20repo%20to%20yarp%20one%20in%20commit%20https%3A//github.com/robotology/cer/commit/03b12a068bd8adcc46fd78d575e1a33835470561%22%2C%20%22created_at%22%3A%20%222016-06-16T13%3A17%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20found%20one%20more%20bug%20in%20the%20device%2C%20let%27s%20wait%20before%20merging.%20%22%2C%20%22created_at%22%3A%20%222016-06-16T14%3A14%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20can%20merge%20this%20PR%3A%20the%20other%20bugs%20that%20I%20found%20touch%20different%20parts%20of%20the%20code%2C%20so%20it%20is%20better%20to%20discuss%20them%20in%20a%20separate%20issue.%20%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A16%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22Anybody%20with%20write%20access%20can%20merge%20this%20PR%3F%20%22%2C%20%22created_at%22%3A%20%222016-06-20T11%3A16%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40traversaro%20the%20PR%20branch%20was%20not%20in%20sync%20with%20%60master%60.%20Just%20rebased.%5Cr%5CnWe%20have%20to%20wait%20for%20CI%27s%20outcome%20before%20merging%22%2C%20%22created_at%22%3A%20%222016-06-20T11%3A39%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%20thanks%2C%20I%20did%20not%20realized%20it%20was%20not%20in%20synch%21%20%22%2C%20%22created_at%22%3A%20%222016-06-20T11%3A40%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40traversaro%20AppVeyor%20is%20failing...%22%2C%20%22created_at%22%3A%20%222016-06-20T15%3A04%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pattacini%20It%20was%20an%20unrelated%20failure%2C%20restarting%20the%20build%20fixed%20AppVeyor.%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A32%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20accidentally%20pushed%20on%20the%20%60Update%20branch%27%20button%2C%20but%20I%20did%20not%20really%20understand%20if%20that%20was%20required%20or%20not.%20%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A37%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20required%20only%20when%20the%20PR%20branch%20and%20the%20master%20branch%20are%20not%20in%20synch.%5Cr%5CnWaiting%20for%20CI%27s%20again%20%3Asmile%3A%20%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A46%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20it%20is%20something%20that%20changed%20recently%3F%20%3F_%3F%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A51%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20optional%20and%20can%20be%20tuned%20on%20branch%20basis.%5Cr%5CnGiven%20the%20latest%20policies%20for%20the%20workflow%2C%20%40drdanz%20made%20pushing%20to%20%60master%60%20quite%20restrictive.%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A53%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20it%27s%20not%20required%2C%20actually%20it%20is%20quite%20annoying%20as%20it%20creates%20merge%20commits%2C%20please%20rebase%20your%20branch%20instead%20of%20pushing%20that%20button%2C%20I%27m%20not%20accepting%20PRs%20containing%20%5C%22Merge%20branch%20%27master%27%20into%20xxx%5C%22%20in%20YARP%20%3Asmiling_imp%3A%22%2C%20%22created_at%22%3A%20%222016-06-20T16%3A57%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40drdanz%20I%20thought%20pressing%20the%20button%20was%20like%20rebasing...%20my%20fault.%5Cr%5CnAnyway%2C%20the%20policy%20forces%20to%20have%20synced%20branches%3A%20of%20course%20rebased%20is%20better%20than%20merged%20%3Asmile_cat%3A%20%22%2C%20%22created_at%22%3A%20%222016-06-20T17%3A02%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20should%20be%20ok%20now...%22%2C%20%22created_at%22%3A%20%222016-06-20T18%3A06%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/801#issuecomment-226465854'>General Comment</a></b>
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> The problem related to signed/unsigned was in this type of code : https://github.com/robotology/yarp/pull/801/files#diff-a35baaba64e46400cd458b5a5dfa64d7L558 .
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> :+1 good catch. I'll test it on the CER robot
The bosch imu driver has been moved from CER repo to yarp one in commit https://github.com/robotology/cer/commit/03b12a068bd8adcc46fd78d575e1a33835470561
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> I found one more bug in the device, let's wait before merging.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> I think we can merge this PR: the other bugs that I found touch different parts of the code, so it is better to discuss them in a separate issue.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Anybody with write access can merge this PR?
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @traversaro the PR branch was not in sync with `master`. Just rebased.
We have to wait for CI's outcome before merging
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Ok thanks, I did not realized it was not in synch!
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @traversaro AppVeyor is failing...
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> @pattacini It was an unrelated failure, restarting the build fixed AppVeyor.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> I accidentally pushed on the `Update branch' button, but I did not really understand if that was required or not.
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> It's required only when the PR branch and the master branch are not in synch.
Waiting for CI's again :smile:
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> But it is something that changed recently? ?_?
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> It's optional and can be tuned on branch basis.
Given the latest policies for the workflow, @drdanz made pushing to `master` quite restrictive.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> No, it's not required, actually it is quite annoying as it creates merge commits, please rebase your branch instead of pushing that button, I'm not accepting PRs containing "Merge branch 'master' into xxx" in YARP :smiling_imp:
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @drdanz I thought pressing the button was like rebasing... my fault.
Anyway, the policy forces to have synced branches: of course rebased is better than merged :smile_cat:
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> It should be ok now...


<a href='https://www.codereviewhub.com/robotology/yarp/pull/801?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/801?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/801'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>