### PR TITLE
Creation of the .msg file by yarpidl_rosmsg

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -136,9 +136,13 @@ git merge master
 ```
 ##### Work in progress PR
 As final note, in case you need to start a PR but you deem it still **work-in-progress**
-and don't want anyone merge it by mistake, do the following:
+and don't want anyone to merge it by mistake, do the following:
 - Put `[WIP]` at the beginning of the PR title.
 - Mark the PR with the label `"Status: In Progress"`.
+
+Once you're happy about your work, just remove the `[WIP]` tag as well as the label,
+and drop a message within the PR to notify the community that reviews are welcome
+and merging is now possible.
 
 ### Development branch: `devel`
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -133,8 +133,12 @@ git pull --rebase origin/devel
 
 ```
 git merge master
-
 ```
+##### Work in progress PR
+As final note, in case you need to start a PR but you deem it still **work-in-progress**
+and don't want anyone merge it by mistake, do the following:
+- Put `[WIP]` at the beginning of the PR title.
+- Mark the PR with the label `"Status: In Progress"`.
 
 ### Development branch: `devel`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 YARP
 ====
 
-[![YARP Homepage](https://img.shields.io/badge/YARP-Yet_Another_Robot_Platform-orange.svg)](http://wiki.icub.org/yarpdoc/)
+[![YARP Homepage](https://img.shields.io/badge/YARP-Yet_Another_Robot_Platform-orange.svg)](http://www.yarp.it/)
 [![Latest Release](https://img.shields.io/github/release/robotology/yarp.svg?label=Latest Release)](https://github.com/robotology/yarp/releases)
 
 YARP is a library and toolkit for communication and device interfaces,
@@ -16,7 +16,7 @@ used on everything from humanoids to embedded devices.
 Installation
 ------------
 
-See full instructions at http://wiki.icub.org/yarpdoc/install.html
+See full instructions at http://www.yarp.it/install.html
 
 On OSX:
 
@@ -42,7 +42,7 @@ Tutorials
 
 There's a comprehensive list of tutorials here:
 
- * http://wiki.icub.org/yarpdoc/tutorials.html
+ * http://www.yarp.it/tutorials.html
 
 License
 -------

--- a/doc/dox_header.html
+++ b/doc/dox_header.html
@@ -95,7 +95,7 @@ h2:after {
 <div class=title>YARP&nbsp;Online</div>
 <ul class=menu>
 <li class=menu><a href="http://wiki.icub.org/yarp">Home&nbsp;Page</a></li>
-<li class=menu><a href="http://wiki.icub.org/yarpdoc/download.html">Downloads</a></li>
+<li class=menu><a href="http://www.yarp.it/download.html">Downloads</a></li>
 <li class=menu><a href="http://wiki.icub.org/wiki/YARP">Wiki</a></li>
 <li class=menu><a href="http://wiki.icub.org/wiki/Robotcub-hackers">Mailing&nbsp;list</a></li>
 </ul>

--- a/doc/installation/check_your_installation.dox
+++ b/doc/installation/check_your_installation.dox
@@ -53,7 +53,7 @@ Now, anything typed on the YARP write will be sent and printed on the read side.
 
 You can also use the yarpdataplayer to replay a recorded sequence. This will reproduce all the sensory information available on the real robot during a simple experiment. Follow the instructions here:
 
-http://wiki.icub.org/yarpdoc/group__yarpdataplayerExample.html
+http://www.yarp.it/group__yarpdataplayerExample.html
 
 \image html installation/check-your-installation-yarpdataplayer-example.jpg
 

--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -13,6 +13,9 @@ Important Changes
 Bug Fixes
 ---------
 
+### idls
+
+* The script executed by RosTypeSearch::fetchFromRos now supports the creation of .msg files in a non-existing directory
 
 ### YARP_OS
 

--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -18,6 +18,12 @@ Bug Fixes
 
 * Fix PlatformThread for OSX, no ACE, no c++11
 
+
+### YARP_DEV
+
+* Fix yarp::dev::BatteryClient::getBatteryTemperature()
+
+
 ### Modules
 
 * Rangefinder2DWrapper: angle_increment is now obtained from the hardware device

--- a/doc/rfmodule.dox
+++ b/doc/rfmodule.dox
@@ -13,7 +13,7 @@ The RFModule helper class simplify writing a generic module. It provides support
 \li Parses messages from a port to monitor module activity and set/get parameters 
 \li Use the ResourceFinder class to handle parameters
 
-You do not need to understand the details of the ResourceFinder to proceed with this tutorial. However it may be useful: <a href="http://wiki.icub.org/yarpdoc/yarp_resource_finder_tutorials.html">Resource Finder Tutorials</a>.
+You do not need to understand the details of the ResourceFinder to proceed with this tutorial. However it may be useful: <a href="http://www.yarp.it/yarp_resource_finder_tutorials.html">Resource Finder Tutorials</a>.
 
 This is how a module will look like:
 

--- a/example/external/c/yarpmin.c
+++ b/example/external/c/yarpmin.c
@@ -460,7 +460,7 @@ yarpConnection yarp_prepare_to_read_binary(yarpAddressPtr address) {
     }
 
     // Following tcp protocol documented at: 
-    //   http://wiki.icub.org/yarpdoc/yarp_protocol.html
+    //   http://www.yarp.it/yarp_protocol.html
 
     // Send header to select connection type.
     // this header is for fast_tcp, so we don't have to deal with flow control

--- a/example/matlab/simulink/README.txt
+++ b/example/matlab/simulink/README.txt
@@ -8,7 +8,7 @@ The licence of Simulink® Real Time Execution is attached as "license.txt" in th
 
 These three YARP/Simulink examples have been developed by Juan G. Victores
 (http://roboticslab.uc3m.es/roboticslab/persona.php?id_pers=72), licenced as the rest of
-the YARP Repository (http://wiki.icub.org/yarpdoc/index.html) from where this
+the YARP Repository (http://www.yarp.it/index.html) from where this
 source can be downloaded.
 
 Install

--- a/example/port_power/README.TXT
+++ b/example/port_power/README.TXT
@@ -12,6 +12,6 @@ Similarly for ports called:
 
 The examples follow the "Port Power" tutorial.  Do a web search for
 YARP port power, or go to the last known address of the tutorial:
-  http://yarp.it/port_expert.html
+  http://www.yarp.it/port_expert.html
 
 -paulfitz

--- a/scripts/debian/copyright
+++ b/scripts/debian/copyright
@@ -9,7 +9,7 @@ YARP is written and maintained by:
 
 YARP was downloaded here:
 
-  http://wiki.icub.org/yarpdoc/download.html
+  http://www.yarp.it/download.html
 
 YARP ia available by anonymous CVS:
 

--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -524,7 +524,7 @@ std::string RosTypeSearch::readFile(const char *fname) {
 bool RosTypeSearch::fetchFromRos(const std::string& target_file,
                                  const std::string& type_name,
                                  bool find_service) {
-    std::string cmd = std::string(find_service?"rossrv":"rosmsg") + " show -r "+type_name+" > " + target_file + " || rm -f " + type_name;
+    std::string cmd = std::string(find_service?"rossrv":"rosmsg") + " show -r "+type_name+" | install -D /dev/stdin " + target_file + " || rm -f " + type_name;
     if (verbose) {
         fprintf(stderr,"[ros]  %s\n", cmd.c_str());
     }

--- a/src/libYARP_OS/src/TcpFace.cpp
+++ b/src/libYARP_OS/src/TcpFace.cpp
@@ -71,7 +71,7 @@ static void showError(Logger& log) {
     YARP_ERROR(log,"If you do not want to use authentication, please");
     YARP_ERROR(log,"remove this file.");
     YARP_ERROR(log,"If you do want to set up authentication, check:");
-    YARP_ERROR(log,"  http://wiki.icub.org/yarpdoc/yarp_port_auth.html");
+    YARP_ERROR(log,"  http://www.yarp.it/yarp_port_auth.html");
 }
 
 /**

--- a/src/yarplogger-qt/mainwindow.cpp
+++ b/src/yarplogger-qt/mainwindow.cpp
@@ -533,7 +533,7 @@ void MainWindow::on_actionShow_LocalTimestamps_toggled(bool arg1)
 
 void MainWindow::on_actionAbout_QtYarpLogger_triggered()
 {
-    QDesktopServices::openUrl(QUrl("http://wiki.icub.org/yarpdoc/qtyarplogger.html"));
+    QDesktopServices::openUrl(QUrl("http://www.yarp.it/qtyarplogger.html"));
 }
 
 void MainWindow::on_actionSave_Log_triggered(bool checked)

--- a/src/yarpmanager++/src-manager/mainwindow.cpp
+++ b/src/yarpmanager++/src-manager/mainwindow.cpp
@@ -1079,7 +1079,7 @@ void MainWindow::onAbout()
 
 void MainWindow::onHelp()
 {
-    QDesktopServices::openUrl(QUrl("http://wiki.icub.org/yarpdoc/yarpmanager.html"));
+    QDesktopServices::openUrl(QUrl("http://www.yarp.it/yarpmanager.html"));
 }
 
 void MainWindow::onRemoveApplication(QString appName)

--- a/src/yarpmanager-gtk/main_window.cpp
+++ b/src/yarpmanager-gtk/main_window.cpp
@@ -1313,17 +1313,17 @@ void MainWindow::onMenuHelpOnlineHelp()
  #if (GTKMM_MAJOR_VERSION == 2 && GTKMM_MINOR_VERSION >= 16)
     GError *error = NULL;
     gtk_show_uri(gdk_screen_get_default(),
-                 "http://wiki.icub.org/yarpdoc/yarpmanager.html",
+                 "http://www.yarp.it/yarpmanager.html",
                  gtk_get_current_event_time(), &error);
     if(error)
     {
         Gtk::MessageDialog dialog("Cannot open online help!", false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE);
-        dialog.set_secondary_text("http://wiki.icub.org/yarpdoc/yarpmanager.html");
+        dialog.set_secondary_text("http://www.yarp.it/yarpmanager.html");
         dialog.run();
     }
 #else
     Gtk::MessageDialog dialog("Please visit the following link.", false, Gtk::MESSAGE_INFO, Gtk::BUTTONS_CLOSE);
-    dialog.set_secondary_text("http://wiki.icub.org/yarpdoc/yarpmanager.html");
+    dialog.set_secondary_text("http://www.yarp.it/yarpmanager.html");
     dialog.run();
 
 #endif

--- a/src/yarpmanager-qt/mainwindow.cpp
+++ b/src/yarpmanager-qt/mainwindow.cpp
@@ -848,7 +848,7 @@ void MainWindow::onAbout()
 
 void MainWindow::onHelp()
 {
-    QDesktopServices::openUrl(QUrl("http://wiki.icub.org/yarpdoc/yarpmanager.html"));
+    QDesktopServices::openUrl(QUrl("http://www.yarp.it/yarpmanager.html"));
 }
 
 void MainWindow::onRemoveApplication(QString appName)


### PR DESCRIPTION
The "| install -D /dev/stdin " solves the problem when the .msg file is in a directory, so the directory is created properly even if the .msg file is part of a customized message created by the user
in its catkin_workspace directory.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/plinioMoreno%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3798890%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-226892770%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-06-17T22%3A05%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3798890%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plinioMoreno%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20this%20work%20on%20windows%3F%20cc%20%40pattacini%20%40randaz81%20%22%2C%20%22created_at%22%3A%20%222016-06-20T09%3A51%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Of%20course%20not%20%3Awink%3A%20%22%2C%20%22created_at%22%3A%20%222016-06-20T09%3A53%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%3Agun%3A%22%2C%20%22created_at%22%3A%20%222016-06-20T10%3A05%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20command%20to%20be%20issued%20in%20that%20line%20is%20%5C%22rosmsg%20show%20....%5C%22%2C%20which%20is%20a%20ROS%20script.%20Since%20ROS%20is%20not%20supported%20for%20windows%20%28see%20%5Bhere%5D%28http%3A//wiki.ros.org/kinetic/Installation%29%29%2C%20that%20part%20of%20the%20code%20will%20not%20work%20on%20windows.%20On%20windows%20what%20you%20can%20do%20is%20to%20search%20for%20the%20message%20on%20the%20web%2C%20using%20the%20%5BfetchFromWeb%5D%28https%3A//github.com/robotology/yarp/blob/master/src/idls/rosmsg/src/RosType.cpp%23L564%29.%5Cr%5Cn%5Cr%5CnThe%20other%20OS%20where%20that%20line%20can%20be%20tested%20is%20OS%20X%2C%20but%20on%20the%20ROS%20side%20is%20experimental.%22%2C%20%22created_at%22%3A%20%222016-06-20T11%3A43%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3798890%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plinioMoreno%22%7D%7D%2C%20%7B%22body%22%3A%20%22Right%2C%20in%20this%20case%20it%20makes%20sense.%20It%20is%20the%20whole%20fetching-from-ros%20part%20that%20should%20not%20be%20built%20on%20windows%2C%20but%20we%20can%20take%20care%20of%20that%20later.%5Cr%5Cn%40plinioMoreno%20Do%20you%20mind%20rebasing%20over%20the%20latest%20%60master%60%20and%20adding%20some%20documentation%20about%20this%20change%20in%20%60doc/release/v2_3_66_1.md%60%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-06-20T12%3A49%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22what%20about%20leveraging%20on%20code%20from%20%60yarpidl_rosmsg%60%20when%20executed%20with%20the%20flag%3A%20%60--web%20true%60%3F%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A14%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20%40drdanz%20I%20forgot%20to%20do%20the%20rebase%20before%20the%20commit%20of%20the%20documentation%20file.%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A51%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3798890%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plinioMoreno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40plinioMoreno%20Something%20went%20wrong%20in%20the%20rebase%2C%20see%20the%20%5C%22Commits%5C%22%20tab%5Cr%5Cnplease%20try%20this%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cngit%20fetch%20origin%5Cr%5Cngit%20rebase%20origin/master%5Cr%5Cngit%20push%20--force%20plinioMoreno%20master%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cn%28assuming%20that%20in%20your%20local%20clone%20%60origin%60%20is%20the%20remote%20name%20for%20%60robotology/yarp%60%20and%20%60plinioMoreno%60%20is%20the%20remote%20name%20for%20%60plinioMoreno/yarp%60%29%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Sorry%2C%20%40drdanz%20I%20forgot%20to%20do%20the%20rebase%20before%20the%20commit%20of%20the%20documentation%20file.%5Cr%5Cn%5Cr%5CnNo%20problem%2C%20just%20try%20again%20%3B%29%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A54%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20sorry%2C%20I%20did%20the%20same%20thing%20twice.%20What%20a%20mess.%22%2C%20%22created_at%22%3A%20%222016-06-20T14%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3798890%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plinioMoreno%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-226892770%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227098448%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227098804%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227101432%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227120041%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227132789%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227138259%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227147838%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227148243%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227148493%22%2C%20%22https%3A//github.com/robotology/yarp/pull/804%23issuecomment-227153065%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/plinioMoreno'><img src='https://avatars.githubusercontent.com/u/3798890?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/804#issuecomment-226892770'>General Comment</a></b>
- <a href='https://github.com/plinioMoreno'><img border=0 src='https://avatars.githubusercontent.com/u/3798890?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Will this work on windows? cc @pattacini @randaz81
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> Of course not :wink:
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :shipit::gun:
- <a href='https://github.com/plinioMoreno'><img border=0 src='https://avatars.githubusercontent.com/u/3798890?v=3' height=16 width=16'></a> The command to be issued in that line is "rosmsg show ....", which is a ROS script. Since ROS is not supported for windows (see [here](http://wiki.ros.org/kinetic/Installation)), that part of the code will not work on windows. On windows what you can do is to search for the message on the web, using the [fetchFromWeb](https://github.com/robotology/yarp/blob/master/src/idls/rosmsg/src/RosType.cpp#L564).
The other OS where that line can be tested is OS X, but on the ROS side is experimental.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Right, in this case it makes sense. It is the whole fetching-from-ros part that should not be built on windows, but we can take care of that later.
@plinioMoreno Do you mind rebasing over the latest `master` and adding some documentation about this change in `doc/release/v2_3_66_1.md`?
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> what about leveraging on code from `yarpidl_rosmsg` when executed with the flag: `--web true`?
- <a href='https://github.com/plinioMoreno'><img border=0 src='https://avatars.githubusercontent.com/u/3798890?v=3' height=16 width=16'></a> Sorry, @drdanz I forgot to do the rebase before the commit of the documentation file.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @plinioMoreno Something went wrong in the rebase, see the "Commits" tab
please try this:
```
git fetch origin
git rebase origin/master
git push --force plinioMoreno master
```
(assuming that in your local clone `origin` is the remote name for `robotology/yarp` and `plinioMoreno` is the remote name for `plinioMoreno/yarp`)
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> > Sorry, @drdanz I forgot to do the rebase before the commit of the documentation file.
No problem, just try again ;)
- <a href='https://github.com/plinioMoreno'><img border=0 src='https://avatars.githubusercontent.com/u/3798890?v=3' height=16 width=16'></a> I'm sorry, I did the same thing twice. What a mess.


<a href='https://www.codereviewhub.com/robotology/yarp/pull/804?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/804?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/804?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/804'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>