### PR TITLE
[YARP_OS] Fix memory leak in Property::fromArgs

### DIFF
--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -803,7 +803,6 @@ public:
         char** szarg = new char*[128 + 1];  // maximum 128 arguments
         char* szcmd = new char[strlen(command)+1];
         strcpy(szcmd, command);
-        szarg = new char*[128 + 1];
         int nargs = 0;
         parseArguments(szcmd, &nargs, szarg, 128);
         szarg[nargs]=0;


### PR DESCRIPTION
`szarg` was allocated twice.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/818?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/818'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>