### PR TITLE
Several Improvements for ROS Compatibility

### DIFF
--- a/doc/release/v2_3_68.md
+++ b/doc/release/v2_3_68.md
@@ -19,8 +19,13 @@ Important Changes
     to allow this).
   * The byConfig() method is now deprecated. fromConfig() should be used
     instead.
-  * The toURI() method now accepts an includeCarrier parameter (true by
+  * The Contact::toURI() method now accepts an includeCarrier parameter (true by
     default) to simplify the generation of the URI without the carrier.
+    Moreover the string returned always end with a `/` character.
+  * ROS integration was heavily improved and it is now possible to register
+    one `Publisher` and one `Subscriber` on the same `Node` using the same
+    topic, and to use tools like `roswtf` and `rqt`.
+    If you are using YARP with ROS, upgrading is strongly recommended.
 
 ### CMake Modules
 
@@ -48,7 +53,17 @@ Bug Fixes
 
 * Fixed some cases of connections leaving a streaming connection pending.
 * Support dynamic plugins when YARP is built without ACE.
-* Fixed several possible race conditions in `yarp::os::Thread`
+* Fixed several possible race conditions in `yarp::os::Thread`.
+* `getBusInfo` ROS command was implemented.
+* `getMasterUri` ROS command was implemented.
+* `getPid` ROS command was fixed and now returns just one integer instead of a
+  vector.
+* The right caller_id is returned by `PortCore` for `publisherUpdate` and
+  `requestTopic` ROS commands.
+* The right caller_id is returned by the tcpros carrier.
+* `yarp::os::Node` now handles correctly multiple publishers and subscribers on
+  the same topic. The limit on YARP is that only one publisher and one
+  subscriber can be registered on the same node using the same topic.
 
 ### GUIs
 
@@ -69,11 +84,12 @@ New Features
   containing macros to check if a specific feature is available.
 * Added method `yarp::os::Thread::yield()` that reschedules the execution of
   current thread, allowing other threads to run.
+* Added method `yarp::os::Contactable::resetReporter()` to remove the
+  `PortReport` set by `setReporter()`.
 
 ### YARP_math
 
 * Added the `yarp::math::FrameTransform` class.
-
 
 ### YARP_dev
 

--- a/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
+++ b/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
@@ -130,7 +130,8 @@ bool TcpRosCarrier::sendHeader(ConnectionState& proto) {
     if (message_definition!="") {
         header.data["message_definition"] = message_definition;
     }
-    header.data["callerid"] = proto.getRoute().getFromName().c_str();
+    NestedContact nc(proto.getRoute().getFromName());
+    header.data["callerid"] = nc.getNodeName();
     header.data["persistent"] = "1";
     string header_serial = header.writeHeader();
     string header_len(4,'\0');
@@ -268,7 +269,8 @@ bool TcpRosCarrier::expectSenderSpecifier(ConnectionState& proto) {
     // Let's just ignore everything that is sane and holy, and
     // send the same header right back.
     // **UPDATE** Oh, ok, let's modify the callerid.  Begrudgingly.
-    header.data["callerid"] = proto.getRoute().getToName().c_str();
+    NestedContact nc(proto.getRoute().getToName());
+    header.data["callerid"] = nc.getNodeName().c_str();
 
     string header_serial = header.writeHeader();
     string header_len(4,'\0');

--- a/src/libYARP_OS/include/yarp/os/AbstractContactable.h
+++ b/src/libYARP_OS/include/yarp/os/AbstractContactable.h
@@ -109,6 +109,10 @@ public:
         return asPort().setReporter(reporter);
     }
 
+    virtual void resetReporter() {
+        return asPort().resetReporter();
+    }
+
     virtual bool isWriting() {
         return asPort().isWriting();
     }

--- a/src/libYARP_OS/include/yarp/os/BufferedPort.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort.h
@@ -328,6 +328,11 @@ public:
         port.setReporter(reporter);
     }
 
+    // documented in Contactable
+    virtual void resetReporter() {
+        port.resetReporter();
+    }
+
     // documented in TypedReader
     virtual void *acquire() {
         return reader.acquire();

--- a/src/libYARP_OS/include/yarp/os/Contactable.h
+++ b/src/libYARP_OS/include/yarp/os/Contactable.h
@@ -206,6 +206,11 @@ public:
      */
     virtual void setReporter(PortReport& reporter) = 0;
 
+    /**
+     * Remove the callback which is called upon any future connections and
+     * disconnections to/from the port.
+     */
+    virtual void resetReporter() = 0;
 
     /**
      * Report whether the port is currently writing data.

--- a/src/libYARP_OS/include/yarp/os/Port.h
+++ b/src/libYARP_OS/include/yarp/os/Port.h
@@ -190,6 +190,9 @@ public:
     // documented in Contactable
     virtual void setReporter(PortReport& reporter);
 
+    // documented in Contactable
+    virtual void resetReporter();
+
     /**
      *
      * Turn on/off "admin" mode.  With admin mode on, messages

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -392,6 +392,11 @@ public:
     void setReportCallback(yarp::os::PortReport *reporter);
 
     /**
+     * Reset the callback to be notified of changes in port status.
+     */
+    void resetReportCallback();
+
+    /**
      * Process an administrative message.
      */
     bool adminBlock(yarp::os::ConnectionReader& reader, void *id,

--- a/src/libYARP_OS/src/Contact.cpp
+++ b/src/libYARP_OS/src/Contact.cpp
@@ -329,6 +329,7 @@ ConstString Contact::toURI(bool includeCarrier) const
         result += mPriv->hostname;
         result += ":";
         result += NetType::toString(mPriv->port);
+        result += "/";
     }
     return result;
 }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -181,6 +181,7 @@ class yarp::os::Node::Helper : public PortReader
 {
 public:
     std::map<ConstString,NodeItem> by_part_name;
+    std::map<ConstString,ROSReport*> report_items;
     std::multimap<ConstString,NodeItem> by_category;
     std::map<Contactable*,NodeItem> name_cache;
     Port port;
@@ -391,6 +392,10 @@ void yarp::os::Node::Helper::add(Contactable& contactable)
     }
     prepare(name);
     item.contactable = &contactable;
+    ROSReport* rep = new ROSReport();
+    item.contactable->setReporter(*rep);
+
+    report_items[item.nc.getNestedName()] = rep;
     name_cache[&contactable] = item;
     by_part_name[item.nc.getNestedName()] = item;
     by_category.insert(std::pair<ConstString,NodeItem>(item.nc.getCategory(),item));
@@ -405,6 +410,7 @@ void yarp::os::Node::Helper::remove(Contactable& contactable)
 {
     NodeItem item = name_cache[&contactable];
     name_cache.erase(&contactable);
+    report_items.erase(item.nc.getNestedName());
     by_part_name.erase(item.nc.getNestedName());
     by_category.erase(item.nc.getCategory());
 }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -437,6 +437,7 @@ void yarp::os::Node::Helper::add(Contactable& contactable)
 
     mutex.lock();
     name_cache[&contactable] = item;
+    by_part_name.insert(std::pair<ConstString,NodeItem>(item.nc.getNestedName(),item));
     by_category.insert(std::pair<ConstString,NodeItem>(item.nc.getCategory(),item));
     mutex.unlock();
 }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -233,6 +233,7 @@ public:
             Contactable *c = name_cache.begin()->first;
             if (c) {
                 mutex.unlock();
+                c->resetReporter();
                 c->interrupt();
                 c->close();
                 mutex.lock();

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -434,21 +434,28 @@ void yarp::os::Node::Helper::add(Contactable& contactable)
     }
     prepare(name);
     item.contactable = &contactable;
+
+    mutex.lock();
     name_cache[&contactable] = item;
     by_category.insert(std::pair<ConstString,NodeItem>(item.nc.getCategory(),item));
+    mutex.unlock();
 }
 
 void yarp::os::Node::Helper::update(Contactable& contactable)
 {
+    mutex.lock();
     NodeItem item = name_cache[&contactable];
+    mutex.unlock();
 }
 
 void yarp::os::Node::Helper::remove(Contactable& contactable)
 {
+    mutex.lock();
     NodeItem item = name_cache[&contactable];
     name_cache.erase(&contactable);
     by_part_name.erase(item.nc.getNestedName());
     by_category.erase(item.nc.getCategory());
+    mutex.unlock();
 }
 
 std::vector<Contact> yarp::os::Node::Helper::query(const ConstString& name, const ConstString& category)
@@ -464,7 +471,6 @@ std::vector<Contact> yarp::os::Node::Helper::query(const ConstString& name, cons
 #endif
         }
     }
-
     mutex.unlock();
 
     return contacts;
@@ -557,36 +563,27 @@ Node::~Node()
 
 void Node::add(Contactable& contactable)
 {
-    mPriv->mutex.lock();
     mPriv->add(contactable);
-    mPriv->mutex.unlock();
 }
 
 void Node::update(Contactable& contactable)
 {
-    mPriv->mutex.lock();
     mPriv->update(contactable);
-    mPriv->mutex.unlock();
 }
 
 void Node::remove(Contactable& contactable)
 {
-    mPriv->mutex.lock();
     mPriv->remove(contactable);
-    mPriv->mutex.unlock();
 }
 
 Contact Node::query(const ConstString& name, const ConstString& category)
 {
-    mPriv->mutex.lock();
     std::vector<Contact> contacts = mPriv->query(name,category);
-    mPriv->mutex.unlock();
     if (contacts.size() >= 1) {
         return contacts.at(0);
     }
     return Contact();
 }
-
 
 void Node::interrupt()
 {

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -228,6 +228,11 @@ public:
                 }
             }
         }
+        for (std::map<ConstString,ROSReport*>::iterator it = report_items.begin(); it != report_items.end(); it++) {
+            delete it->second;
+        }
+        report_items.clear();
+
         mutex.unlock();
         port.interrupt();
     }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -19,6 +19,7 @@
 #include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/NameClient.h>
 
+#include <algorithm>
 #include <vector>
 #include <list>
 #include <map>

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -267,7 +267,8 @@ public:
         na.success();
     }
 
-    void getBusInfo(NodeArgs& na) {
+    void getBusInfo(NodeArgs& na)
+    {
         mutex.lock();
         unsigned int opaque_id = 1;
         for (std::map<ConstString,NodeItem>::iterator it = by_part_name.begin(); it != by_part_name.end(); it++) {
@@ -297,7 +298,8 @@ public:
 
     void getMasterUri(NodeArgs& na)
     {
-        na.reply.fromString("hmm");
+        na.reply.addString(NetworkBase::getEnvironment("ROS_MASTER_URI"));
+        na.success();
     }
 
     void shutdown(NodeArgs& na)

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -454,8 +454,20 @@ void yarp::os::Node::Helper::remove(Contactable& contactable)
     mutex.lock();
     NodeItem item = name_cache[&contactable];
     name_cache.erase(&contactable);
-    by_part_name.erase(item.nc.getNestedName());
-    by_category.erase(item.nc.getCategory());
+    ConstString nestedName = item.nc.getNestedName();
+    for (std::multimap<ConstString, NodeItem>::iterator it = by_part_name.begin(); it != by_part_name.end(); ++it) {
+        if (it->first == nestedName && it->second.contactable->where().toString() == contactable.where().toString()) {
+            by_part_name.erase(it);
+            break;
+        }
+    }
+    ConstString category = item.nc.getCategory();
+    for (std::multimap<ConstString, NodeItem>::iterator it = by_category.begin(); it != by_category.end(); ++it) {
+        if (it->first == category && it->second.contactable->where().toString() == contactable.where().toString()) {
+            by_category.erase(it);
+            break;
+        }
+    }
     mutex.unlock();
 }
 

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -41,14 +41,9 @@ public:
             Contact c;
             if (info.incoming) {
                 c = RosNameSpace::rosify(nic.queryName(info.sourceName));
-
-            } else {
-                c = RosNameSpace::rosify(nic.queryName(info.targetName));
-            }
-
-            if (info.incoming) {
                 incomingURIs.insert(std::make_pair(info.portName, c.toURI()));
             } else {
+                c = RosNameSpace::rosify(nic.queryName(info.targetName));
                 outgoingURIs.insert(std::make_pair(info.portName, c.toURI()));
             }
         }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -9,7 +9,6 @@
 #include <yarp/conf/compiler.h>
 #include <yarp/os/Node.h>
 #include <yarp/os/Mutex.h>
-#include <yarp/os/LogStream.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/NestedContact.h>
 #include <yarp/os/Port.h>

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -405,6 +405,7 @@ public:
 
 void yarp::os::Node::Helper::prepare(const ConstString& name)
 {
+    mutex.lock();
     if (port.getName()=="") {
         port.setReader(*this);
         Property *prop = port.acquireProperties(false);
@@ -415,6 +416,7 @@ void yarp::os::Node::Helper::prepare(const ConstString& name)
         port.open(name);
         this->name = port.getName();
     }
+    mutex.unlock();
 }
 
 void yarp::os::Node::Helper::add(Contactable& contactable)
@@ -605,7 +607,5 @@ Contact Node::where()
 
 void Node::prepare(const ConstString& name)
 {
-    mPriv->mutex.lock();
     mPriv->prepare(name);
-    mPriv->mutex.unlock();
 }

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -460,6 +460,8 @@ void yarp::os::Node::Helper::remove(Contactable& contactable)
 {
     NodeItem item = name_cache[&contactable];
     name_cache.erase(&contactable);
+    contactable.resetReporter();
+    delete report_items[item.nc.getNestedName()];
     report_items.erase(item.nc.getNestedName());
     by_part_name.erase(item.nc.getNestedName());
     by_category.erase(item.nc.getCategory());

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 iCub Facility
+ * Copyright (C) 2013 iCub Facility
  * Authors: Paul Fitzpatrick, Tobias Fischer
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -267,9 +267,31 @@ public:
         na.success();
     }
 
-    void getBusInfo(NodeArgs& na)
-    {
-        na.reply.addList();
+    void getBusInfo(NodeArgs& na) {
+        mutex.lock();
+        unsigned int opaque_id = 1;
+        for (std::map<ConstString,NodeItem>::iterator it = by_part_name.begin(); it != by_part_name.end(); it++) {
+            NodeItem& item = it->second;
+            if (!(item.isSubscriber() || item.isPublisher())) continue;
+            item.update();
+            Bottle& lst = na.reply.addList();
+            item.contactable->getReport(*report_items.at(it->first));
+            if(item.isSubscriber()) {
+                if(report_items.at(it->first)->sourceURI=="") continue;
+                lst.addInt(opaque_id); // connectionId
+                lst.addString(report_items.at(it->first)->sourceURI);
+                lst.addString("i");
+            } else if(item.isPublisher()) {
+                if(report_items.at(it->first)->targetURI=="") continue;
+                lst.addInt(opaque_id); // connectionId
+                lst.addString(report_items.at(it->first)->targetURI);
+                lst.addString("o");
+            }
+            lst.addString("TCPROS");
+            lst.addString(toRosName(item.nc.getNestedName()));
+            opaque_id++;
+        }
+        mutex.unlock();
         na.success();
     }
 

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -270,7 +270,7 @@ public:
             lst.addInt(opaque_id); // connectionId
             lst.addString(it->second);
             lst.addString("o");
-            lst.addString((it->second != "/yarp/node" ? "TCPROS" : "YARP"));
+            lst.addString("TCPROS");
             NestedContact nc(it->first);
             lst.addString(toRosName(nc.getNestedName()));
             opaque_id++;
@@ -281,7 +281,7 @@ public:
             lst.addInt(opaque_id); // connectionId
             lst.addString(it->second);
             lst.addString("i");
-            lst.addString((it->second != "/yarp/node" ? "TCPROS" : "YARP"));
+            lst.addString("TCPROS");
             NestedContact nc(it->first);
             lst.addString(toRosName(nc.getNestedName()));
             opaque_id++;

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2013 iCub Facility
- * Authors: Paul Fitzpatrick
+ * Copyright (C) 2016 iCub Facility
+ * Authors: Paul Fitzpatrick, Tobias Fischer
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *
  */

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -9,9 +9,12 @@
 #include <yarp/conf/compiler.h>
 #include <yarp/os/Node.h>
 #include <yarp/os/Mutex.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/NestedContact.h>
 #include <yarp/os/Port.h>
+#include <yarp/os/PortReport.h>
+#include <yarp/os/PortInfo.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/RosNameSpace.h>
 #include <yarp/os/impl/PlatformStdlib.h>
@@ -23,8 +26,38 @@
 using namespace yarp::os;
 using namespace yarp::os::impl;
 
-static ConstString toRosName(const ConstString& str)
-{
+class ROSReport : public PortReport {
+public:
+    std::string sourceURI;
+    std::string targetURI;
+
+    ROSReport() {
+    }
+
+    virtual void report(const PortInfo& info) {
+        NameClient& nic = NameClient::getNameClient();
+
+        std::string sourceTmp = nic.queryName(info.sourceName).toURI();
+        if(sourceTmp!="") {
+            sourceURI = sourceTmp + "/";
+            std::string toreplace = "xmlrpc://";
+            size_t source_pos = sourceURI.find(toreplace);
+            if(source_pos!=std::string::npos)
+                sourceURI.replace(source_pos, toreplace.length(), "http://");
+        }
+
+        std::string targetTmp = nic.queryName(info.targetName).toURI();
+        if(targetTmp!="") {
+            targetURI = targetTmp + "/";
+            std::string toreplace = "xmlrpc://";
+            size_t target_pos = targetURI.find(toreplace);
+            if(target_pos!=std::string::npos)
+                targetURI.replace(target_pos, toreplace.length(), "http://");
+        }
+    }
+};
+
+static ConstString toRosName(const ConstString& str) {
     return RosNameSpace::toRosName(str);
 }
 

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -547,6 +547,12 @@ void Port::setReporter(PortReport& reporter) {
 }
 
 
+void Port::resetReporter() {
+    PortCoreAdapter& core = IMPL();
+    core.resetReportCallback();
+}
+
+
 void Port::setAdminMode(bool adminMode) {
     if (adminMode) {
         Bottle b("__ADMIN");

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1175,6 +1175,11 @@ void PortCore::setReportCallback(yarp::os::PortReport *reporter) {
    stateMutex.post();
 }
 
+void PortCore::resetReportCallback() {
+    stateMutex.wait();
+    eventReporter = NULL;
+    stateMutex.post();
+}
 
 void PortCore::report(const PortInfo& info) {
     // We are in the context of one of the input or output threads,

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1967,7 +1967,8 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                         YARP_SPRINTF1(log,debug,"ROS ADD %s", pub.c_str());
                         Bottle req, reply;
                         req.addString("requestTopic");
-                        req.addString("dummy_id");
+                        NestedContact nc(getName());
+                        req.addString(nc.getNodeName().c_str());
                         req.addString(topic);
                         Bottle& lst = req.addList();
                         Bottle& sublst = lst.addList();
@@ -2049,7 +2050,8 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
             YARP_SPRINTF1(log,debug,"requestTopic! --> %s",
                           cmd.toString().c_str());
             result.addInt(1);
-            result.addString("dummy_id");
+            NestedContact nc(getName());
+            result.addString(nc.getNodeName().c_str());
             Bottle& lst = result.addList();
             Contact addr = getAddress();
             lst.addString("TCPROS");

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2026,7 +2026,6 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                 stateMutex.wait();
                                 PortCoreUnit *unit = new PortCoreInputUnit(*this,
                                                                            getNextIndex(),
-
                                                                            ip,
                                                                            true);
                                 yAssert(unit!=NULL);

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -100,7 +100,7 @@ void PortCoreInputUnit::run() {
         setMode();
         getOwner().reportUnit(this,true);
 
-            ConstString msg = ConstString("Receiving input from ") +
+        ConstString msg = ConstString("Receiving input from ") +
             route.getFromName() + " to " + route.getToName() +
             " using " +
             route.getCarrierName();
@@ -117,7 +117,7 @@ void PortCoreInputUnit::run() {
 
         // Report the new connection
         PortInfo info;
-        info.message = msg.c_str();
+        info.message = msg;
         info.tag = yarp::os::PortInfo::PORTINFO_CONNECTION;
         info.incoming = true;
         info.created = true;

--- a/src/libYARP_OS/src/RosNameSpace.cpp
+++ b/src/libYARP_OS/src/RosNameSpace.cpp
@@ -99,7 +99,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString("registerService");
-            cmd.addString(toRosNodeName(nc.toString()));
+            cmd.addString(toRosNodeName(nc.getNodeName()));
             cmd.addString(toRosName(nc.getNestedName()));
             Contact rosrpc = contact;
             rosrpc.setCarrier("rosrpc");
@@ -119,7 +119,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString((cat=="+")?"registerPublisher":"registerSubscriber");
-            cmd.addString(toRosNodeName(nc.toString()));
+            cmd.addString(toRosNodeName(nc.getNodeName()));
             cmd.addString(toRosName(nc.getNestedName()));
             ConstString typ = nc.getTypeNameStar();
             if (typ!="*"&&typ!="") {
@@ -251,7 +251,7 @@ Contact RosNameSpace::unregisterAdvanced(const ConstString& name, NameStore *sto
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString("unregisterService");
-            cmd.addString(toRosNodeName(nc.toString()));
+            cmd.addString(toRosNodeName(nc.getNodeName()));
             cmd.addString(nc.getNestedName());
             cmd.addString(c.toURI());
             bool ok = NetworkBase::write(getNameServerContact(),
@@ -261,7 +261,7 @@ Contact RosNameSpace::unregisterAdvanced(const ConstString& name, NameStore *sto
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString((cat=="+")?"unregisterPublisher":"unregisterSubscriber");
-            cmd.addString(toRosNodeName(nc.toString()));
+            cmd.addString(toRosNodeName(nc.getNodeName()));
             cmd.addString(nc.getNestedName());
             Contact c;
             if (store) {

--- a/src/libYARP_OS/src/RosNameSpace.cpp
+++ b/src/libYARP_OS/src/RosNameSpace.cpp
@@ -99,7 +99,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString("registerService");
-            cmd.addString(toRosNodeName(nc.getNodeName()));
+            cmd.addString(toRosNodeName(nc.toString()));
             cmd.addString(toRosName(nc.getNestedName()));
             Contact rosrpc = contact;
             rosrpc.setCarrier("rosrpc");
@@ -119,7 +119,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString((cat=="+")?"registerPublisher":"registerSubscriber");
-            cmd.addString(toRosNodeName(nc.getNodeName()));
+            cmd.addString(toRosNodeName(nc.toString()));
             cmd.addString(toRosName(nc.getNestedName()));
             ConstString typ = nc.getTypeNameStar();
             if (typ!="*"&&typ!="") {
@@ -251,7 +251,7 @@ Contact RosNameSpace::unregisterAdvanced(const ConstString& name, NameStore *sto
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString("unregisterService");
-            cmd.addString(toRosNodeName(nc.getNodeName()));
+            cmd.addString(toRosNodeName(nc.toString()));
             cmd.addString(nc.getNestedName());
             cmd.addString(c.toURI());
             bool ok = NetworkBase::write(getNameServerContact(),
@@ -261,7 +261,7 @@ Contact RosNameSpace::unregisterAdvanced(const ConstString& name, NameStore *sto
             Bottle cmd, reply;
             cmd.clear();
             cmd.addString((cat=="+")?"unregisterPublisher":"unregisterSubscriber");
-            cmd.addString(toRosNodeName(nc.getNodeName()));
+            cmd.addString(toRosNodeName(nc.toString()));
             cmd.addString(nc.getNestedName());
             Contact c;
             if (store) {

--- a/src/libYARP_OS/src/RosNameSpace.cpp
+++ b/src/libYARP_OS/src/RosNameSpace.cpp
@@ -111,7 +111,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
                 Nodes& nodes = NameClient::getNameClient().getNodes();
                 c = rosify(nodes.getParent(contact.getName()));
             }
-            cmd.addString(c.toString());
+            cmd.addString(c.toString() + "/");
             bool ok = NetworkBase::write(getNameServerContact(),
                                          cmd, reply);
             if (!ok) return Contact();
@@ -140,7 +140,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
                 c = rosify(nodes.getParent(contact.getName()));
             }
             //Contact c = rosify(contact);
-            cmd.addString(c.toString());
+            cmd.addString(c.toString() + "/");
             bool ok = NetworkBase::write(getNameServerContact(),
                                          cmd, reply);
             if (!ok) {

--- a/src/libYARP_OS/src/RosNameSpace.cpp
+++ b/src/libYARP_OS/src/RosNameSpace.cpp
@@ -111,7 +111,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
                 Nodes& nodes = NameClient::getNameClient().getNodes();
                 c = rosify(nodes.getParent(contact.getName()));
             }
-            cmd.addString(c.toString() + "/");
+            cmd.addString(c.toURI());
             bool ok = NetworkBase::write(getNameServerContact(),
                                          cmd, reply);
             if (!ok) return Contact();
@@ -140,7 +140,7 @@ Contact RosNameSpace::registerAdvanced(const Contact& contact, NameStore *store)
                 c = rosify(nodes.getParent(contact.getName()));
             }
             //Contact c = rosify(contact);
-            cmd.addString(c.toString() + "/");
+            cmd.addString(c.toURI());
             bool ok = NetworkBase::write(getNameServerContact(),
                                          cmd, reply);
             if (!ok) {

--- a/tests/libYARP_OS/ContactTest.cpp
+++ b/tests/libYARP_OS/ContactTest.cpp
@@ -27,7 +27,7 @@ public:
         report(0, "checking string representation");
         Contact address("tcp", "127.0.0.1", 10000);
         ConstString txt = address.toURI();
-        checkEqual(txt, "tcp://127.0.0.1:10000", "string rep example");
+        checkEqual(txt, "tcp://127.0.0.1:10000/", "string rep example");
     }
 
     virtual void testCopy()
@@ -37,7 +37,7 @@ public:
         Contact address2;
         address2 = address;
         ConstString txt = address2.toURI();
-        checkEqual(txt, "tcp://127.0.0.1:10000", "string rep example");
+        checkEqual(txt, "tcp://127.0.0.1:10000/", "string rep example");
 
         Contact inv1;
         address2 = inv1;


### PR DESCRIPTION
See #826
Main contribution is the proper implementation of getBusInfo, which provides a connection list to ROS. It's not yet implemented for services.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233291252%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233294365%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233294536%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233296950%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233302452%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233307189%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233308153%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233310502%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233319298%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233335300%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233335940%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233336657%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233423953%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233579091%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233625804%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233679805%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233683757%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233890953%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233917898%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234273080%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234291459%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234339326%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234349688%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234398288%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234564928%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-234907222%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-235564997%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-235567885%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-235570458%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-235944304%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236181367%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236523170%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236539542%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236540328%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236567360%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236575166%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236589939%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236593461%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236627282%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236640509%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236641770%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236656996%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236706773%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236708493%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71039573%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71040350%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71071743%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71206946%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71233646%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71233737%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71678162%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71679028%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71687525%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71687632%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71716507%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71723564%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71891438%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73009766%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010016%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010424%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010727%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010807%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010938%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73012206%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73012448%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73012487%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73013192%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73013229%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065726%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065729%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065731%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065735%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065736%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73065738%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236730175%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236834311%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236882721%22%2C%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-236901734%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23issuecomment-233291252%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Rebased%20over%20latest%20%60devel%60%20since%20the%20builds%20were%20failing%20due%20to%20the%20issue%20in%20%60Contact%60%22%2C%20%22created_at%22%3A%20%222016-07-18T10%3A09%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20The%20patch%20looks%20good%2C%20thanks%21%5Cr%5Cn%5Cr%5CnI%27m%20just%20not%20sure%20about%20the%20reason%20why%20the%20%5C%22Use%20full%20name%20when%20%28un-%29registering%20publisher%20with%20ROS%5C%22%20commit%20is%20required%2C%20can%20you%20explain%20it%20to%20me%3F%5Cr%5Cn%5Cr%5CnAlso%20I%20think%20you%20are%20leaking%20the%20%60ROSReport%2A%60%2C%20I%20don%27t%20see%20the%20%60delete%60%20and%20%60Contactable%60%20destructor%20does%20not%20delete%20it.%22%2C%20%22created_at%22%3A%20%222016-07-18T10%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20%40Tobias-Fischer%21%22%2C%20%22created_at%22%3A%20%222016-07-18T10%3A27%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40drdanz%2C%5Cr%5Cnregarding%20the%20%5C%22full%20name%5C%22%20commit.%20I%20have%20no%20idea%20about%20the%20internals%2C%20but%20this%20is%20what%20happens%20if%20the%20commit%20is%20not%20applied%3A%5Cr%5Cn%60%60%60%5Cr%5CnWARNING%20The%20following%20nodes%20are%20unexpectedly%20connected%3A%5Cr%5Cn%20%2A%20/rostopic_23303_1468838229656-%3E/chatter-%40/yarp/listener%20%28/chatter%29%5Cr%5Cn%20%2A%20unknown%20%28http%3A//icubunicorn%3A43247/%29-%3E/rosout%20%28/rosout%29%5Cr%5Cn%60%60%60%5Cr%5CnAfter%20applying%20the%20commit%2C%20%60roswtf%60%20does%20not%20complain%20anymore.%20I%20guess%20that%20there%20is%20a%20non-consistency%20with%20some%20of%20the%20values%20yarp%20sends%20to%20ROS%20via%20the%20Slave%20API%20if%20the%20commit%20is%20not%20applied.%20However%20I%20did%20not%20investigate%20further%20as%20the%20commit%20fixes%20it%20nicely.%22%2C%20%22created_at%22%3A%20%222016-07-18T10%3A42%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Regarding%20the%20memory%20leak%3A%20I%20now%20delete%20the%20objects%20which%20are%20being%20created%20in%20the%20destructor.%20However%2C%20I%20am%20afraid%20there%20is%20still%20a%20memory%20leak%20elsewhere.%20The%20object%20should%20also%20be%20deleted%20within%20%60void%20yarp%3A%3Aos%3A%3ANode%3A%3AHelper%3A%3Aremove%60%2C%20however%20if%20I%20do%20this%2C%20we%20encounter%20a%20segfault%20later%20on%2C%20as%20the%20%60report%60%20method%20is%20still%20being%20called%20on%20an%20object%20which%20cannot%20be%20dereferenced.%5Cr%5CnI%20think%20what%20we%20need%20is%20a%20%60resetReporter%60%20method%2C%20which%20resets%20the%20%60eventReporter%60%20to%20%60NULL%60.%20What%20do%20you%20think%20%40drdanz%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T11%3A16%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20Have%20you%20tried%20if%20%60item.contactable-%3EsetReporter%28NULL%29%3B%60%20works%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T11%3A45%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40drdanz%20Yes%20I%20tried.%20It%20doesn%27t%20because%20of%20the%20protection%20in%20https%3A//github.com/robotology/yarp/blob/master/src/libYARP_OS/src/PortCore.cpp%23L1168-L1174%5Cr%5CnI%27d%20rather%20not%20touch%20this%2C%20who%20knows%20what%20other%20things%20would%20be%20affected%20by%20removing%20the%20protection%20against%20%60NULL%60.%22%2C%20%22created_at%22%3A%20%222016-07-18T11%3A51%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20After%20applying%20the%20commit%2C%20roswtf%20does%20not%20complain%20anymore.%5Cr%5Cn%5Cr%5CnI%20see...%20That%20looks%20weird%20though%2C%20since%20these%20are%20the%20implementations%20of%20the%20methods%3A%5Cr%5Cn%5Cr%5Cn%5B%60toString%28%29%60%5D%28https%3A//github.com/robotology/yarp/blob/master/src/libYARP_OS/include/yarp/os/NestedContact.h%23L72-L74%29%5Cr%5Cn%60%60%60%5Cr%5Cnreturn%20nestedName%20%2B%20category%20%2B%20%5C%22%40%5C%22%20%2B%20nodeName%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5B%60getNodeName%28%29%60%5D%28https%3A//github.com/robotology/yarp/blob/master/src/libYARP_OS/include/yarp/os/NestedContact.h%23L47-L49%29%5Cr%5Cn%60%60%60%5Cr%5Cnreturn%20nodeName%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnPerhaps%20the%20%60NestedContact%60%20is%20created%20with%20the%20wrong%20%60nodeName%60%3F%5Cr%5Cn%5Cr%5CnCan%20you%20tell%20me%20what%20is%20the%20output%20of%20%60getNestedContact%28%29%60%20and%20%60toString%28%29%60%20for%20the%20example%20above%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T12%3A05%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22About%20the%20%60setReporter%60%20method%2C%20I%20think%20that%20%28but%20I%20might%20be%20wrong%20here%29%2C%20since%20you%20are%20using%20%60getReport%28%29%60%2C%20you%20don%27t%20really%20need%20to%20set%20them%2C%20also%20because%20the%20user%20might%20be%20setting%20a%20custom%20one.%5Cr%5Cn%5Cr%5CnHave%20a%20look%20at%20the%20%5B%60Contactable%3A%3AgetReport%28%29%60%5D%28http%3A//yarp.it/classyarp_1_1os_1_1Contactable.html%23a88686f32c69de4146a5b1d99e4a5dc76%29%20and%20%5B%60Contactable%3A%3AsetReporter%28%29%60%5D%28http%3A//yarp.it/classyarp_1_1os_1_1Contactable.html%23a5fbef3de0f5483dd6458f97a24069444%29%20methods%20documentation.%5Cr%5Cn%5Cr%5CnAlso%20I%20think%20you%20don%27t%20need%20to%20store%20them%20and%20delete%20them%20later%2C%20you%20can%20just%20create%20a%20new%20one%20whenever%20is%20needed%2C%20have%20a%20look%20at%20how%20the%20class%20%60MyReport%60%20is%20used%20in%20%5B%60PortTest.cpp%60%5D%28https%3A//github.com/robotology/yarp/blob/master/tests/libYARP_OS/PortTest.cpp%23L929-L930%29.%5Cr%5Cn%5Cr%5Cn%5Cr%5CnThis%20considered%2C%20I%20think%20that%20the%20%60resetReporter%28%29%60%20method%20makes%20sense%2C%20the%20code%20does%20not%20consider%20at%20all%20that%20the%20%60eventReporter%60%20might%20be%20deleted%20before%20the%20%60Port%60%22%2C%20%22created_at%22%3A%20%222016-07-18T12%3A51%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%5Cr%5Cnregarding%20%60toString%60%20vs%20%60getNestedContact%60%3A%5Cr%5CnExample%20for%20%60toString%60%3A%20/chatter-%40/yarp/listener%5Cr%5CnExample%20for%20%60getNestedContact%60%3A%20/chatter%5Cr%5CnExample%20for%20%60getNodeName%60%3A%20/yarp/listener%22%2C%20%22created_at%22%3A%20%222016-07-18T13%3A55%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Regarding%20%60getReport%60%3A%20Good%20tip%2C%20that%20works%20nicely.%20See%20https%3A//github.com/robotology/yarp/pull/828/commits/4f6c68ef91e3fdb4e71d2e86be372f4d14e6aba9%5Cr%5CnI%27ll%20leave%20it%20up%20to%20you%20guys%20to%20implement%20the%20%60resetReporter%28%29%60%2C%20probably%20this%20should%20be%20done%20separately%20from%20this%20PR%20anyways.%22%2C%20%22created_at%22%3A%20%222016-07-18T13%3A57%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Think%20this%20looks%20pretty%20good%20now%2C%20I%27d%20be%20happy%20for%20it%20to%20be%20merged.%22%2C%20%22created_at%22%3A%20%222016-07-18T14%3A00%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-07-18T18%3A56%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Don%27t%20merge%20yet%2C%20it%20seems%20like%20there%27s%20still%20some%20issues%20in%20more%20complex%20cases.%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A29%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Okay%20cool%2C%20now%20everything%20should%20work%20nicely.%20I%20needed%20to%20go%20back%20to%20using%20%60setReportCallback%28%29%60%20as%20%60getReport%60%20only%20reports%20the%20last%20connection.%20Now%20I%20keep%20track%20of%20the%20connections%20in%20a%20%60std%3A%3Avector%60%2C%20and%20report%20them%20all.%20To%20get%20rid%20of%20the%20memory%20leak%2C%20I%20introduce%20a%20%60resetReportCallback%28%29%60%20method%20and%20implement%20it%20where%20needed%20in%20the%20various%20classes.%5Cr%5CnThis%20now%20works%20nicely%20in%20a%20%5C%22real-world%5C%22%20scenario%20with%20tens%20of%20connections.%20Previously%20I%20only%20performed%20tests%20on%20a%20toy%20example.%22%2C%20%22created_at%22%3A%20%222016-07-19T13%3A04%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Greate%20%40Tobias-Fischer%2C%20maybe%20with%20this%20fix%20we%20will%20see%20yarp%20%27node%27%20in%20rqt%20node%20graph%21%21%20%5Cr%5CnIt%27d%20be%20pretty%20cool%22%2C%20%22created_at%22%3A%20%222016-07-19T15%3A58%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40barbalberto%2C%20yes%2C%20they%20are%20shown%20in%20rqt_graph%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-07-19T16%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20no%20idea%20why%20the%20%60NodeTest%60%20fails%20in%20two%20of%20the%20Travis%20builds.%20Do%20you%20have%20the%20chance%20to%20investigate%20this%20%40drdanz%3F%5Cr%5CnLooking%20at%20the%20%60NodeTest%60%2C%20I%20noticed%20that%20%60Publisher%60%20and%20%60Subscriber%60%20are%20defined%20within%20the%20test%20rather%20than%20including%20%60yarp/os/Publisher.h%60%20/%20%60yarp/os/Subscriber.h%60.%20Is%20there%20any%20reason%20for%20this%3F%22%2C%20%22created_at%22%3A%20%222016-07-20T08%3A52%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Seems%20like%20https%3A//github.com/robotology/yarp/pull/828/commits/9a0996e0295324d84ac7b9b9f1ef305cade21ed3%20fixed%20the%20problem.%20Now%20finally%20ready%20to%20merge%3F%21%3F%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-07-20T10%3A58%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20I%20just%20rebased%20over%20latest%20devel%20to%20check%20if%20travis%20and%20appveyor%20complain.%20I%20messed%20up%20with%20devel%2C%20therefore%20everything%20was%20failing.%22%2C%20%22created_at%22%3A%20%222016-07-21T14%3A35%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20I%27m%20on%20vacation%20now%20and%20won%27t%20have%20time%20to%20look%20into%20it.%20What%20do%20you%20propose%3F%22%2C%20%22created_at%22%3A%20%222016-07-21T15%3A33%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%2C%20I%27ll%20have%20a%20look%20at%20the%20reporter%20internals%2C%20perhaps%20it%20would%20make%20sense%20to%20allow%20more%20than%20one%20reporter%2C%20so%20that%20instead%20of%20replacing%20current%20reporter%2C%20setReporter%20will%20add%20one%20reporter%20and%20all%20of%20them%20could%20be%20called%20when%20there%20is%20an%20event.%22%2C%20%22created_at%22%3A%20%222016-07-21T18%3A20%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unfortunately%20I%20just%20found%20another%20issue...%5Cr%5Cn%5Cr%5CnWithout%20the%20patch%20yarp%20nodes%20are%20seen%20by%20ros%20as%20a%20node%20using%20%60rosnode%20list%60%2C%20using%20the%20patch%20it%20lists%20publisher%20and%20subscribers%20names%20%28i.e.%20%60/yarp/foo%2B%40/yarp/node%60%2C%20but%20not%20%60/yarp/node%60%29%2C%20and%20there%20is%20one%20separate%20node%20for%20each%20publisher/subscriber.%5Cr%5CnI%20think%20this%20is%20related%20to%20the%20%60toString%28%29%60%20vs.%20%60getNodeName%28%29%60%20issue.%20I%20will%20investigate%20more%20tomorrow.%22%2C%20%22created_at%22%3A%20%222016-07-21T18%3A56%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20yes%20I%27m%20aware%20that%20each%20connection%20is%20listed%20as%20separate%20note.%20And%20yes%2C%20it%20does%20have%20to%20do%20with%20the%20change%20to%20use%20toString%28%29.%20If%20you%20want%20to%20go%20back%20to%20getNodeName%28%29%2C%20we%27ll%20have%20to%20find%20out%20which%20other%20place%20needs%20the%20same%20change%2C%20so%20that%20the%20publisher/subscriber%20reports%20the%20proper%20names%20back%20to%20ROS.%22%2C%20%22created_at%22%3A%20%222016-07-21T22%3A04%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20I%20should%20have%20fixed%20the%20%60toString%28%29%60/%60getNodeName%28%29%60%20issue...%20I%20reverted%20your%20change%20and%20fixed%20the%20%60caller_id%60%20in%20the%20requests.%5Cr%5CnIf%20you%20manage%20to%20test%20it%2C%20let%20me%20know%20if%20this%20works%20for%20you...%22%2C%20%22created_at%22%3A%20%222016-07-22T14%3A50%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22About%20the%20%60setReporter%28%29%60%20issue%2C%20I%20haven%27t%20found%20a%20proper%20fix%20yet.%20Anyway%20I%20believe%20that%20%60getReport%28%29%60%20should%20report%20all%20the%20active%20connections%2C%20if%20it%20doesn%27t%20there%20is%20a%20problem%20in%20this%20function.%20I%20had%20a%20quick%20look%20at%20the%20%60PortCore%3A%3Adescribe%60%20method%20%28that%20is%20called%20by%20%60getReport%60%29%20and%20apparently%20it%20should%20report%20all%20the%20connections%2C%20the%20%60PortReport%3A%3Areport%28%29%60%20method%20is%20called%203%20times%20inside%20the%20method.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-25T09%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20I%20think%20you%27re%20right.%20The%20%60getReport%28%29%60%20method%20should%20do%20the%20job%2C%20if%20we%20call%20it%20with%20an%20instance%20of%20the%20newly%20introduced%20%60ROSReport%60%2C%20all%20should%20work%20nicely.%20I%27ll%20try%20on%20Monday.%20%5Cr%5CnThen%20we%20don%27t%20need%20the%20%60setReporter%28%29%60%20anymore.%20%5Cr%5Cn%5Cr%5CnI%27ll%20also%20check%20your%20changes%20regarding%20the%20%60caller_id%60%2C%20thanks%20for%20the%20fix%21%22%2C%20%22created_at%22%3A%20%222016-07-27T12%3A01%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20A%20quick%20update%2C%20I%20fixed%20several%20other%20issues%2C%20reverted%20to%20getReport%2C%20and%20some%20more%2C%20I%20will%20update%20the%20branch%20tomorrow...%22%2C%20%22created_at%22%3A%20%222016-07-27T12%3A17%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22By%20the%20way%2C%20I%20used%20this%20setup%20for%20testing%2C%20%60rosgraph%60%20produces%20the%20correct%20graph%2C%20and%20%60roswtf%60%20does%20not%20complain%20%3Av%3A%20%5Cr%5Cn%5Cr%5Cn%21%5Brosgraph%5D%28https%3A//cloud.githubusercontent.com/assets/1100056/17175119/fd8a85ec-5405-11e6-92bc-d62ef290650f.png%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-27T12%3A29%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Rebased%20the%20branch%20and%20added%20several%20fixes...%5Cr%5CnThere%20is%20still%20one%20thing%20missing%2C%20the%20%60RosNameSpace%3A%3Arosify%28%29%60%20method%20should%20be%20changed%20to%20return%20the%20hostname%20instead%20of%20the%20ip%20address.%20After%20changing%20that%2C%20%60roswtf%60%20does%20not%20complain%20anymore%2C%20and%20all%20the%20connections%20are%20properly%20displayed%20in%20%60rqt%60.%5Cr%5Cn%5Cr%5CnAlso%20I%20believe%20that%20there%20is%20some%20new%20leak%20when%20closing%20the%20ports%20because%20when%20I%20stop%20my%20program%20my%20system%20suddenly%20slows%20down.%5Cr%5CnI%20will%20try%20to%20fix%20these%20issues%20next%20week%22%2C%20%22created_at%22%3A%20%222016-07-28T16%3A12%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20leak%20%28that%20was%20actually%20a%20deadlock%20not%20a%20leak%29%2C%20should%20be%20fixed%20now...%20the%20last%20thing%20to%20fix%20is%20the%20%60rosify%28%29%60%20method%2C%20then%20I%27m%20very%20happy%20to%20merge%20this.%22%2C%20%22created_at%22%3A%20%222016-07-29T13%3A34%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40drdanz%2C%20thanks%20for%20all%20the%20fixes%21%20It%20looks%20much%20cleaner%20now.%20Can%20I%20help%20regarding%20the%20change%20in%20the%20%60rosify%60%20method%3F%22%2C%20%22created_at%22%3A%20%222016-08-01T08%3A45%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%2B1%22%2C%20%22created_at%22%3A%20%222016-08-01T09%3A59%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22PS%3A%20It%20seems%20like%20the%20%60NodeTest%60%20is%20stalling%20..%20any%20idea%20why%3F%22%2C%20%22created_at%22%3A%20%222016-08-01T10%3A02%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20yes%2C%20the%20%60NodeTest%60%20was%20stalling%20because%20I%20forgot%20to%20add%20one%20line%20to%20the%20patch%20%3A-1%3A%20%5Cr%5CnIt%20was%20hidden%20in%20the%20middle%20of%20the%20debug%20output%20I%20added%20for%20testing...%5Cr%5Cn%5Cr%5CnAbout%20the%20ip-%3Ehostname%20conversion%2C%20I%27m%20trying%20to%20find%20a%20portable%20solution%20that%20does%20not%20take%20a%20lot%20of%20time%2C%20because%20it%20is%20going%20to%20be%20called%20a%20lot...%20Also%20I%20want%20to%20skip%20it%20for%20hostnames%20and%20I%20would%20like%20it%20to%20work%20for%20both%20IPv4%20and%20IPv6.%20And%20also%20I%20think%20we%20just%20need%20the%20hostname%2C%20and%20not%20the%20FQDN.%20Suggestions%20are%20welcome.%20%3Asmile%3A.%5Cr%5Cn%5Cr%5CnThere%20is%20also%20yet%20another%20issue%20that%20I%20want%20to%20check%20before%20merging%2C%20I%20think%20that%20%60yarp%3A%3Aos%3A%3ANode%3A%3AHelper%3A%3Aremove%60%20is%20removing%20more%20contacts%20than%20it%20should...%20But%20that%27s%20the%20last%20one%2C%20I%20promise%21%20%3Alaughing%3A%20%22%2C%20%22created_at%22%3A%20%222016-08-01T12%3A29%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Regarding%20the%20ip-%3Ehostname%20..%20I%27m%20afraid%20I%27m%20not%20an%20expert%20in%20these%20regards%2C%20so%20I%27ll%20leave%20that%20up%20to%20you%20%3B-%29.%5Cr%5Cn%5Cr%5CnRegarding%20the%20%60remove%28%29%60%3A%20Indeed%2C%20I%20guess%20it%20does%20remove%20more%20contacts%20than%20it%20should.%20As%20it%20is%20erases%20elements%20of%20a%20%60multimap%60%20by%20key%2C%20all%20contacts%20with%20the%20same%20key%20are%20removed.%20Rather%20than%20this%20behavior%2C%20I%20guess%20only%20one%20specific%20%60Contactable%60%20should%20be%20removed%20%28by%20iterator%29.%20Is%20there%20a%20way%20to%20compare%20%60Contactable%60%20objects%20such%20that%20the%20specific%20instance%20can%20be%20found%3F%20Then%20we%20can%20erase%20by%20iterator%20rather%20than%20by%20key.%5Cr%5Cn%5Cr%5CnRegarding%20the%20fix%3A%20It%20seems%20like%20it%27s%20still%20stalling%20in%20the%20appveyor%20debug%20configuration.%20Weird%20..%22%2C%20%22created_at%22%3A%20%222016-08-01T13%3A07%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unfortunately%20the%20%60NodeTest%60%20is%20still%20hanging%20for%20some%20obscure%20reason%20on%20Appveyor%20in%20Debug%20configurations...%5Cr%5Cn%5Cr%5Cn%40Tobias-Fischer%20perhaps%20something%20like%20this%20could%20work%2C%20but%20I%20didn%27t%20test%20it%20yet%5Cr%5Cn%5Cr%5Cn%60%60%60c%2B%2B%5Cr%5Cn%20%20%20%20ConstString%20nestedName%20%3D%20item.nc.getNestedName%28%29%3B%5Cr%5Cn%20%20%20%20for%20%28std%3A%3Amultimap%3CConstString%2C%20NodeItem%3E%3A%3Aiterator%20it%20%3D%20by_part_name.begin%28%29%3B%20it%20%21%3D%20by_part_name.end%28%29%3B%20%2B%2Bit%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20if%20%28it-%3Efirst%20%3D%3D%20nestedName%20%26%26%20it-%3Esecond.contactable%20%3D%3D%20contactable%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20by_part_name.erase%28it%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%20%20%20%20for%20%28std%3A%3Amultimap%3CConstString%2C%20NodeItem%3E%3A%3Aiterator%20it%20%3D%20by_category.begin%28%29%3B%20it%20%21%3D%20by_category.end%28%29%3B%20%2B%2Bit%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20if%20%28it-%3Efirst%20%3D%3D%20nestedName%20%26%26%20it-%3Esecond.contactable%20%3D%3D%20contactable%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20by_category.erase%28it%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnI%20don%27t%20know%20if%20%60Contactable%3A%3Aoperator%3D%3D%28%29%60%20is%20implemented%20though%2C%20perhaps%20we%20need%20more...%5Cr%5CnIf%20you%20want%20to%20take%20care%20about%20this%2C%20I%27ll%20just%20focus%20on%20the%20ip-%3Ehostname%20conversion...%22%2C%20%22created_at%22%3A%20%222016-08-01T14%3A05%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20%60Contactable%3A%3Aoperator%3D%3D%28%29%60%20is%20not%20implemented.%20Do%20you%20think%20%60it-%3Esecond.contactable.where%28%29.toString%28%29%20%3D%3D%20contactable.where%28%29.toString%28%29%60%20would%20do%20the%20job%3F%20%5Cr%5Cn%5Cr%5CnAlso%2C%20I%20guess%20the%20above%20should%20check%20for%20%60it-%3Efirst%20%3D%3D%20category%60%20in%20the%20case%20of%20the%20%60by_category%60%20multimap%20%28where%20%60category%20%3D%20item.nc.getCategory%28%29%60%29.%5Cr%5Cn%5Cr%5CnSo%20my%20proposal%3A%5Cr%5Cn%5Cr%5Cn%60%60%60c%2B%2B%5Cr%5Cn%20%20%20%20ConstString%20nestedName%20%3D%20item.nc.getNestedName%28%29%3B%5Cr%5Cn%20%20%20%20ConstString%20category%20%3D%20item.nc.getCategory%28%29%3B%5Cr%5Cn%5Cr%5Cn%20%20%20%20for%20%28std%3A%3Amultimap%3CConstString%2C%20NodeItem%3E%3A%3Aiterator%20it%20%3D%20by_part_name.begin%28%29%3B%20it%20%21%3D%20by_part_name.end%28%29%3B%20%2B%2Bit%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20if%20%28it-%3Efirst%20%3D%3D%20nestedName%20%26%26%20it-%3Esecond.contactable.where%28%29.toString%28%29%20%3D%3D%20contactable.where%28%29.toString%28%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20by_part_name.erase%28it%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%20%20%20%20for%20%28std%3A%3Amultimap%3CConstString%2C%20NodeItem%3E%3A%3Aiterator%20it%20%3D%20by_category.begin%28%29%3B%20it%20%21%3D%20by_category.end%28%29%3B%20%2B%2Bit%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20if%20%28it-%3Efirst%20%3D%3D%20category%20%26%26%20it-%3Esecond.contactable.where%28%29.toString%28%29%20%3D%3D%20contactable.where%28%29.toString%28%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20by_category.erase%28it%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-08-01T14%3A18%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20The%20%60Contactable%3A%3Aoperator%3D%3D%28%29%60%20is%20not%20implemented.%20Do%20you%20think%20%60it-%3Esecond.contactable.where%28%29.toString%28%29%20%3D%3D%20contactable.where%28%29.toString%28%29%60%20would%20do%20the%20job%3F%20%5Cr%5Cn%5Cr%5Cn%3A%2B1%3A%5Cr%5Cn%5Cr%5Cn%3E%20Also%2C%20I%20guess%20the%20above%20should%20check%20for%20%60it-%3Efirst%20%3D%3D%20category%60%20in%20the%20case%20of%20the%20%60by_category%60%20multimap%20%28where%20%60category%20%3D%20item.nc.getCategory%28%29%60%29.%20%5Cr%5Cn%5Cr%5CnRight%2C%20sorry%2C%20copy%20and%20paste%20distracted%20me%21%5Cr%5Cn%5Cr%5CnJust%20pushed%20a%20commit%20fixing%20%60Helper%3A%3Aremove%60...%20just%20the%20conversion%20ip-%3Ehostname%20is%20left.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A09%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20quite%20sure%20why%20https%3A//github.com/robotology/yarp/pull/828/commits/5fbce405bc30a915748bb9ddddb164f6995eeca8%20and%20https%3A//github.com/robotology/yarp/pull/828/commits/605c175b132ce9e37d4575622fc92214936d01e8%20show%20up%20in%20this%20PR.%20Does%20the%20branch%20need%20to%20be%20rebased%20properly%20before%20merging%3F%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A57%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%27m%20not%20quite%20sure%20why%205fbce40%20and%20605c175%20show%20up%20in%20this%20PR.%20Does%20the%20branch%20need%20to%20be%20rebased%20properly%20before%20merging%3F%5Cr%5Cn%5Cr%5CnMy%20fault%2C%20sorry...%20I%20just%20rebased%20the%20branch%22%2C%20%22created_at%22%3A%20%222016-08-01T17%3A02%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Renamed%20and%20added%20%5BWIP%5D%20to%20the%20name%2C%20to%20remind%20that%20it%20is%20not%20ready%20yet%29%22%2C%20%22created_at%22%3A%20%222016-08-01T17%3A58%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20found%20out%20that%20%60roswtf%60%20does%20not%20complain%20if%20we%20pass%20an%20ip%20address%20and%20that%20address%20is%20in%20the%20/etc/hosts%20file%21%5Cr%5CnI%20probably%20wasted%20a%20lot%20of%20time%20trying%20to%20reverse%20the%20ip%20address%2C%20and%20that%27s%20not%20necessary%20%3Aboom%3A%5Cr%5CnI%27ll%20keep%20investigating%20tomorrow%2C%20but%20perhaps%20this%20patch%20is%20finally%20ready%20to%20be%20merged...%22%2C%20%22created_at%22%3A%20%222016-08-01T21%3A02%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40drdanz%2C%20can%27t%20we%20just%20use%20the%20hostname%20of%20the%20%60contactable%60%20as%20I%20implemented%20it%20in%20the%20first%20place%3F%20%3A%29%5Cr%5CnOr%20in%20other%20words%2C%20the%20current%20implementation%20should%20be%20fine%2C%20isn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222016-08-01T21%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20think%20so%2C%20but%20I%20just%20want%20to%20be%20sure%20that%20everything%20works%20on%20more%20than%20one%20machine%2C%20until%20now%20I%20tested%20everything%20on%20just%20one%20host.%20I%20will%20make%20the%20tests%20tomorrow%2C%20If%2C%20as%20I%20expect%2C%20everything%20works%2C%20assuming%20that%20AppVeyor%20and%20Travis%20are%20ok%2C%20I%20will%20merge%20it.%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A42%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20I%27ve%20had%20a%20look%20at%20the%20AppVeyor%20history%20and%20checked%20which%20commit%20might%20cause%20the%20debug%20build%20to%20stall.%20As%20far%20as%20I%20can%20tell%2C%20it%20seems%20to%20be%20this%20one%3A%20https%3A//ci.appveyor.com/project/robotology/yarp/build/appveyor.863%20%28https%3A//github.com/robotology/yarp/commit/f088baa7f51ef4c8928f6f7c7f1bc08aad6702c8%29%5Cr%5CnThe%20previous%20build%20was%20fine%3A%20https%3A//ci.appveyor.com/project/robotology/yarp/build/appveyor.860%22%2C%20%22created_at%22%3A%20%222016-08-02T08%3A11%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20indeed%21%20The%20issue%20was%20in%20devel%2C%20and%20it%20should%20be%20fixed%20now%20%28see%20%5Bbuild%20920%5D%28https%3A//ci.appveyor.com/project/robotology/yarp/build/appveyor.920%29%29.%20Thanks%20for%20noticing%20it%21%5Cr%5Cn%5Cr%5CnI%20added%20one%20part%20of%20the%20ip-%3Ehostname%20conversion%20anyway%2C%20only%20for%20local%20addresses%2C%20that%20means%20that%20only%20%60yarpserver%60%20will%20return%20the%20ip%2C%20all%20the%20modules%20should%20use%20the%20local%20hostname.%5Cr%5Cn%5Cr%5CnI%27m%20merging%20this%20as%20soon%20as%20the%20tests%20are%20completed.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-02T11%3A57%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-08-02T13%3A20%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200893950cc9ecd712008b598ca6a103cbc10ac717%20src/libYARP_OS/src/Node.cpp%20141%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010424%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20sure%20whether%20the%20following%20two%20%60for%60%20loops%20should%20also%20be%20protected%20by%20the%20mutex.%20I%20guess%20so%2C%20otherwise%20the%20%60report%60%20might%20change%20while%20iterating%20over%20it.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A40%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20it%20is%20required%20here%2C%20since%20we%20are%20populating%20%60report%60%20using%20%60getReport%28%29%60%20%28in%20the%20mutex%29%20that%20is%20called%20once%20for%20each%20connection.%20After%20report%20is%20populated%2C%20we%20iterate%20over%20%60report.outgoingURIs%60%20and%20then%20over%20%60report.incomingURIs%60%2C%20because%2C%20from%20what%20I%20saw%2C%20ROS%20returns%20the%20all%20outgoing%20connections%20first%2C%20and%20then%20all%20the%20incoming%20ones.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A51%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20this%20is%20very%20true%21%20Didn%27t%20think%20carefully%20that%20only%20%60getReport%60%20can%20change%20the%20%60report%60.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A53%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL241-411%22%7D%2C%20%22Pull%200893950cc9ecd712008b598ca6a103cbc10ac717%20src/libYARP_OS/src/Node.cpp%2097%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010938%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40drdanz%20I%20think%20we%20should%20move%20the%20%60mutex.lock%28%29%60%20and%20%60mutex.unlock%28%29%60%20also%20in%20the%20helper%20class%20for%20the%20%60prepare%28%29%60%20method%2C%20just%20to%20be%20consistent.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A43%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A53%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A57%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL230-237%22%7D%2C%20%22Pull%207f31fdc72148142e20514ce5b2622534a064cb8e%20src/libYARP_OS/src/Node.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71071743%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20am%20not%20sure%20whether%20the%20%60toURI%60%20method%20should%20return%20a%20%5C%22/%5C%22%20at%20the%20end%20by%20default.%22%2C%20%22created_at%22%3A%20%222016-07-16T20%3A56%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20know%2C%20I%27ll%20trust%20you%20on%20this...%20%3Awink%3A%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-18T21%3A28%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-07-18T21%3A29%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL25-63%22%7D%2C%20%22Pull%20325dcf4e5f6237bfc2f073a9b4f25e5d9dca7a2a%20src/libYARP_OS/src/Node.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71039573%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20not%20use%20LogStream%20in%20YARP_OS%20port%20related%20classes.%20Since%20log%20generated%20by%20yDebug%20etc.%20can%20be%20forwarded%20to%20the%20logger%20using%20a%20port%2C%20it%20is%20better%20for%20now%20to%20avoid%20using%20them%20around%20these%20classes%2C%20as%20this%20might%20cause%20recursive%20loops...%5Cr%5CnUnfortunately%20we%20have%20a%20lots%20of%20logging%20methods%20around%20the%20YARP%20code...%20One%20day%20we%20will%20make%20disappear%20them%20all%20and%20leave%20only%20one%2C%20but%20for%20now%20have%20a%20look%20at%20what%20is%20already%20used%20in%20the%20class%20and%20use%20the%20same...%22%2C%20%22created_at%22%3A%20%222016-07-15T20%3A55%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20rest%20of%20the%20review%20on%20Monday%20%3Awink%3A%22%2C%20%22created_at%22%3A%20%222016-07-15T21%3A01%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-07-18T18%3A57%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL9-21%22%7D%2C%20%22Pull%209a0996e0295324d84ac7b9b9f1ef305cade21ed3%20src/libYARP_OS/src/Node.cpp%20157%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71679028%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40Tobias-Fischer%20I%27m%20just%20worried%20that%20someone%20could%20call%20%60setReporter%28%29%60%20and%20replace%20the%20%60ROSReport%60%20with%20a%20custom%20one.%20If%20this%20happens%2C%20then%20the%20ROS%20Node%20will%20no%20longer%20work...%20I%20don%27t%20know%20if%20the%20%60Contactable%26%20contactable%60%20is%20accessible%20in%20some%20way%20from%20outside%2C%20though.%20Do%20you%20know%20if%20this%20is%20possible%3F%22%2C%20%22created_at%22%3A%20%222016-07-21T10%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20sure%20..%20However%20I%20think%20it%27s%20not%20possible.%5Cr%5CnThe%20contactable%20is%20stored%20in%20%60name_cache%60%20of%20%60yarp%3A%3Aos%3A%3ANode%3A%3AHelper%60%2C%20which%20is%20a%20public%20attribute.%20However%2C%20the%20helper%20is%20owned%20by%20an%20instance%20of%20%20%60yarp%3A%3Aos%3A%3ANode%60%2C%20which%20does%20not%20allow%20access%20to%20the%20helper%2C%20and%20thus%20not%20to%20the%20contactable%20either.%20So%20the%20only%20places%20to%20access%20the%20contactable%20are%20within%20the%20helper%20class%20and%20the%20%60Node%60%20class.%22%2C%20%22created_at%22%3A%20%222016-07-21T11%3A19%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20Unfortunately%2C%20after%20investigating%20a%20little%20bit%2C%20this%20works%20and%20it%20will%20mess%20up%20with%20the%20node%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20sub%20%3D%20new%20yarp%3A%3Aos%3A%3ASubscriber%3Cstd_msgs%3A%3AString%3E%28%29%3B%5Cr%5Cn%20%20%20%20if%20%28%21sub-%3Etopic%28%5C%22/yarp/foo%5C%22%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20yError%28%29%20%3C%3C%20%5C%22Failed%20to%20create%20subscriber%20to%20/yarp/foo%5C%5Cn%5C%22%3B%5Cr%5Cn%20%20%20%20%20%20%20%20return%20-1%3B%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%20%20%20%20MyReport%20report%3B%5Cr%5Cn%20%20%20%20sub-%3EasPort%28%29.setReporter%28report%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-07-21T15%3A06%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL436-446%22%7D%2C%20%22Pull%209a0996e0295324d84ac7b9b9f1ef305cade21ed3%20src/libYARP_OS/src/Node.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r71678162%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20year%20here%20should%20not%20be%20changed...%22%2C%20%22created_at%22%3A%20%222016-07-21T09%3A57%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20it%20back%2C%20didn%27t%20know%20that%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-21T11%3A20%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-07-21T14%3A32%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-07-22T14%3A51%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL1-7%22%7D%2C%20%22Pull%200893950cc9ecd712008b598ca6a103cbc10ac717%20src/libYARP_OS/src/Node.cpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73010016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40drdanz%20I%20think%20it%27s%20nicer%20to%20merge%20the%20two%20if-else%20constructs%20into%20one.%20Are%20you%20happy%20with%20that%3F%20Will%20do%20in%20this%20case.%5Cr%5Cn%60%60%60c%2B%2B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20if%20%28info.incoming%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20c%20%3D%20RosNameSpace%3A%3Arosify%28nic.queryName%28info.sourceName%29%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20incomingURIs.insert%28std%3A%3Amake_pair%28info.portName%2C%20c.toURI%28%29%29%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20c%20%3D%20RosNameSpace%3A%3Arosify%28nic.queryName%28info.targetName%29%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20outgoingURIs.insert%28std%3A%3Amake_pair%28info.portName%2C%20c.toURI%28%29%29%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A37%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A42%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A58%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL12-62%22%7D%2C%20%22Pull%200893950cc9ecd712008b598ca6a103cbc10ac717%20src/libYARP_OS/src/Node.cpp%20148%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/828%23discussion_r73009766%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40drdanz%20I%20think%20this%20needs%20a%20comment%20why%20there%20is%20the%20special%20case%20for%20%60/yarp/node%60.%20Not%20sure%20where%20this%20comes%20from.%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A35%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22wooops%2C%20thanks%2C%20that%20was%20debugging%20stuff%2C%20I%20totally%20forgot%20about%20that%21%22%2C%20%22created_at%22%3A%20%222016-08-01T16%3A42%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-01T22%3A36%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_OS/src/Node.cpp%3AL241-411%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/drdanz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/drdanz'><img src='https://avatars.githubusercontent.com/u/1100056?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 325dcf4e5f6237bfc2f073a9b4f25e5d9dca7a2a src/libYARP_OS/src/Node.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r71039573'>File: src/libYARP_OS/src/Node.cpp:L9-21</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Please do not use LogStream in YARP_OS port related classes. Since log generated by yDebug etc. can be forwarded to the logger using a port, it is better for now to avoid using them around these classes, as this might cause recursive loops...
Unfortunately we have a lots of logging methods around the YARP code... One day we will make disappear them all and leave only one, but for now have a look at what is already used in the class and use the same...
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> The rest of the review on Monday :wink:
- [x] <a href='#crh-comment-Pull 7f31fdc72148142e20514ce5b2622534a064cb8e src/libYARP_OS/src/Node.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r71071743'>File: src/libYARP_OS/src/Node.cpp:L25-63</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> I am not sure whether the `toURI` method should return a "/" at the end by default.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> I don't know, I'll trust you on this... :wink:
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#issuecomment-233291252'>General Comment</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Rebased over latest `devel` since the builds were failing due to the issue in `Contact`
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer The patch looks good, thanks!
I'm just not sure about the reason why the "Use full name when (un-)registering publisher with ROS" commit is required, can you explain it to me?
Also I think you are leaking the `ROSReport*`, I don't see the `delete` and `Contactable` destructor does not delete it.
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> Thanks @Tobias-Fischer!
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi @drdanz,
regarding the "full name" commit. I have no idea about the internals, but this is what happens if the commit is not applied:
```
WARNING The following nodes are unexpectedly connected:
* /rostopic_23303_1468838229656->/chatter-@/yarp/listener (/chatter)
* unknown (http://icubunicorn:43247/)->/rosout (/rosout)
```
After applying the commit, `roswtf` does not complain anymore. I guess that there is a non-consistency with some of the values yarp sends to ROS via the Slave API if the commit is not applied. However I did not investigate further as the commit fixes it nicely.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Regarding the memory leak: I now delete the objects which are being created in the destructor. However, I am afraid there is still a memory leak elsewhere. The object should also be deleted within `void yarp::os::Node::Helper::remove`, however if I do this, we encounter a segfault later on, as the `report` method is still being called on an object which cannot be dereferenced.
I think what we need is a `resetReporter` method, which resets the `eventReporter` to `NULL`. What do you think @drdanz?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer Have you tried if `item.contactable->setReporter(NULL);` works?
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @drdanz Yes I tried. It doesn't because of the protection in https://github.com/robotology/yarp/blob/master/src/libYARP_OS/src/PortCore.cpp#L1168-L1174
I'd rather not touch this, who knows what other things would be affected by removing the protection against `NULL`.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> > After applying the commit, roswtf does not complain anymore.
I see... That looks weird though, since these are the implementations of the methods:
[`toString()`](https://github.com/robotology/yarp/blob/master/src/libYARP_OS/include/yarp/os/NestedContact.h#L72-L74)
```
return nestedName + category + "@" + nodeName;
```
[`getNodeName()`](https://github.com/robotology/yarp/blob/master/src/libYARP_OS/include/yarp/os/NestedContact.h#L47-L49)
```
return nodeName;
```
Perhaps the `NestedContact` is created with the wrong `nodeName`?
Can you tell me what is the output of `getNestedContact()` and `toString()` for the example above?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> About the `setReporter` method, I think that (but I might be wrong here), since you are using `getReport()`, you don't really need to set them, also because the user might be setting a custom one.
Have a look at the [`Contactable::getReport()`](http://yarp.it/classyarp_1_1os_1_1Contactable.html#a88686f32c69de4146a5b1d99e4a5dc76) and [`Contactable::setReporter()`](http://yarp.it/classyarp_1_1os_1_1Contactable.html#a5fbef3de0f5483dd6458f97a24069444) methods documentation.
Also I think you don't need to store them and delete them later, you can just create a new one whenever is needed, have a look at how the class `MyReport` is used in [`PortTest.cpp`](https://github.com/robotology/yarp/blob/master/tests/libYARP_OS/PortTest.cpp#L929-L930).
This considered, I think that the `resetReporter()` method makes sense, the code does not consider at all that the `eventReporter` might be deleted before the `Port`
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi,
regarding `toString` vs `getNestedContact`:
Example for `toString`: /chatter-@/yarp/listener
Example for `getNestedContact`: /chatter
Example for `getNodeName`: /yarp/listener
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Regarding `getReport`: Good tip, that works nicely. See https://github.com/robotology/yarp/pull/828/commits/4f6c68ef91e3fdb4e71d2e86be372f4d14e6aba9
I'll leave it up to you guys to implement the `resetReporter()`, probably this should be done separately from this PR anyways.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Think this looks pretty good now, I'd be happy for it to be merged.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Don't merge yet, it seems like there's still some issues in more complex cases.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Okay cool, now everything should work nicely. I needed to go back to using `setReportCallback()` as `getReport` only reports the last connection. Now I keep track of the connections in a `std::vector`, and report them all. To get rid of the memory leak, I introduce a `resetReportCallback()` method and implement it where needed in the various classes.
This now works nicely in a "real-world" scenario with tens of connections. Previously I only performed tests on a toy example.
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> Greate @Tobias-Fischer, maybe with this fix we will see yarp 'node' in rqt node graph!!
It'd be pretty cool
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi @barbalberto, yes, they are shown in rqt_graph :+1:
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> I have no idea why the `NodeTest` fails in two of the Travis builds. Do you have the chance to investigate this @drdanz?
Looking at the `NodeTest`, I noticed that `Publisher` and `Subscriber` are defined within the test rather than including `yarp/os/Publisher.h` / `yarp/os/Subscriber.h`. Is there any reason for this?
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Seems like https://github.com/robotology/yarp/pull/828/commits/9a0996e0295324d84ac7b9b9f1ef305cade21ed3 fixed the problem. Now finally ready to merge?!? :+1:
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer I just rebased over latest devel to check if travis and appveyor complain. I messed up with devel, therefore everything was failing.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi, I'm on vacation now and won't have time to look into it. What do you propose?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> I'm not sure, I'll have a look at the reporter internals, perhaps it would make sense to allow more than one reporter, so that instead of replacing current reporter, setReporter will add one reporter and all of them could be called when there is an event.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Unfortunately I just found another issue...
Without the patch yarp nodes are seen by ros as a node using `rosnode list`, using the patch it lists publisher and subscribers names (i.e. `/yarp/foo+@/yarp/node`, but not `/yarp/node`), and there is one separate node for each publisher/subscriber.
I think this is related to the `toString()` vs. `getNodeName()` issue. I will investigate more tomorrow.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi, yes I'm aware that each connection is listed as separate note. And yes, it does have to do with the change to use toString(). If you want to go back to getNodeName(), we'll have to find out which other place needs the same change, so that the publisher/subscriber reports the proper names back to ROS.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer I should have fixed the `toString()`/`getNodeName()` issue... I reverted your change and fixed the `caller_id` in the requests.
If you manage to test it, let me know if this works for you...
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> About the `setReporter()` issue, I haven't found a proper fix yet. Anyway I believe that `getReport()` should report all the active connections, if it doesn't there is a problem in this function. I had a quick look at the `PortCore::describe` method (that is called by `getReport`) and apparently it should report all the connections, the `PortReport::report()` method is called 3 times inside the method.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi, I think you're right. The `getReport()` method should do the job, if we call it with an instance of the newly introduced `ROSReport`, all should work nicely. I'll try on Monday.
Then we don't need the `setReporter()` anymore.
I'll also check your changes regarding the `caller_id`, thanks for the fix!
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer A quick update, I fixed several other issues, reverted to getReport, and some more, I will update the branch tomorrow...
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> By the way, I used this setup for testing, `rosgraph` produces the correct graph, and `roswtf` does not complain :v:
![rosgraph](https://cloud.githubusercontent.com/assets/1100056/17175119/fd8a85ec-5405-11e6-92bc-d62ef290650f.png)
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Rebased the branch and added several fixes...
There is still one thing missing, the `RosNameSpace::rosify()` method should be changed to return the hostname instead of the ip address. After changing that, `roswtf` does not complain anymore, and all the connections are properly displayed in `rqt`.
Also I believe that there is some new leak when closing the ports because when I stop my program my system suddenly slows down.
I will try to fix these issues next week
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> The leak (that was actually a deadlock not a leak), should be fixed now... the last thing to fix is the `rosify()` method, then I'm very happy to merge this.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi @drdanz, thanks for all the fixes! It looks much cleaner now. Can I help regarding the change in the `rosify` method?
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> +1
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> PS: It seems like the `NodeTest` is stalling .. any idea why?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer yes, the `NodeTest` was stalling because I forgot to add one line to the patch :-1:
It was hidden in the middle of the debug output I added for testing...
About the ip->hostname conversion, I'm trying to find a portable solution that does not take a lot of time, because it is going to be called a lot... Also I want to skip it for hostnames and I would like it to work for both IPv4 and IPv6. And also I think we just need the hostname, and not the FQDN. Suggestions are welcome. :smile:.
There is also yet another issue that I want to check before merging, I think that `yarp::os::Node::Helper::remove` is removing more contacts than it should... But that's the last one, I promise! :laughing:
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Regarding the ip->hostname .. I'm afraid I'm not an expert in these regards, so I'll leave that up to you ;-).
Regarding the `remove()`: Indeed, I guess it does remove more contacts than it should. As it is erases elements of a `multimap` by key, all contacts with the same key are removed. Rather than this behavior, I guess only one specific `Contactable` should be removed (by iterator). Is there a way to compare `Contactable` objects such that the specific instance can be found? Then we can erase by iterator rather than by key.
Regarding the fix: It seems like it's still stalling in the appveyor debug configuration. Weird ..
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Unfortunately the `NodeTest` is still hanging for some obscure reason on Appveyor in Debug configurations...
@Tobias-Fischer perhaps something like this could work, but I didn't test it yet
```c++
ConstString nestedName = item.nc.getNestedName();
for (std::multimap<ConstString, NodeItem>::iterator it = by_part_name.begin(); it != by_part_name.end(); ++it) {
if (it->first == nestedName && it->second.contactable == contactable) {
by_part_name.erase(it);
break;
}
}
for (std::multimap<ConstString, NodeItem>::iterator it = by_category.begin(); it != by_category.end(); ++it) {
if (it->first == nestedName && it->second.contactable == contactable) {
by_category.erase(it);
break;
}
}
```
I don't know if `Contactable::operator==()` is implemented though, perhaps we need more...
If you want to take care about this, I'll just focus on the ip->hostname conversion...
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> The `Contactable::operator==()` is not implemented. Do you think `it->second.contactable.where().toString() == contactable.where().toString()` would do the job?
Also, I guess the above should check for `it->first == category` in the case of the `by_category` multimap (where `category = item.nc.getCategory()`).
So my proposal:
```c++
ConstString nestedName = item.nc.getNestedName();
ConstString category = item.nc.getCategory();
for (std::multimap<ConstString, NodeItem>::iterator it = by_part_name.begin(); it != by_part_name.end(); ++it) {
if (it->first == nestedName && it->second.contactable.where().toString() == contactable.where().toString()) {
by_part_name.erase(it);
break;
}
}
for (std::multimap<ConstString, NodeItem>::iterator it = by_category.begin(); it != by_category.end(); ++it) {
if (it->first == category && it->second.contactable.where().toString() == contactable.where().toString()) {
by_category.erase(it);
break;
}
}
```
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> > The `Contactable::operator==()` is not implemented. Do you think `it->second.contactable.where().toString() == contactable.where().toString()` would do the job?
:+1:
> Also, I guess the above should check for `it->first == category` in the case of the `by_category` multimap (where `category = item.nc.getCategory()`).
Right, sorry, copy and paste distracted me!
Just pushed a commit fixing `Helper::remove`... just the conversion ip->hostname is left.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> I'm not quite sure why https://github.com/robotology/yarp/pull/828/commits/5fbce405bc30a915748bb9ddddb164f6995eeca8 and https://github.com/robotology/yarp/pull/828/commits/605c175b132ce9e37d4575622fc92214936d01e8 show up in this PR. Does the branch need to be rebased properly before merging?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> > I'm not quite sure why 5fbce40 and 605c175 show up in this PR. Does the branch need to be rebased properly before merging?
My fault, sorry... I just rebased the branch
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> (Renamed and added [WIP] to the name, to remind that it is not ready yet)
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> I just found out that `roswtf` does not complain if we pass an ip address and that address is in the /etc/hosts file!
I probably wasted a lot of time trying to reverse the ip address, and that's not necessary :boom:
I'll keep investigating tomorrow, but perhaps this patch is finally ready to be merged...
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi @drdanz, can't we just use the hostname of the `contactable` as I implemented it in the first place? :)
Or in other words, the current implementation should be fine, isn't it?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Yes, I think so, but I just want to be sure that everything works on more than one machine, until now I tested everything on just one host. I will make the tests tomorrow, If, as I expect, everything works, assuming that AppVeyor and Travis are ok, I will merge it.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi, I've had a look at the AppVeyor history and checked which commit might cause the debug build to stall. As far as I can tell, it seems to be this one: https://ci.appveyor.com/project/robotology/yarp/build/appveyor.863 (https://github.com/robotology/yarp/commit/f088baa7f51ef4c8928f6f7c7f1bc08aad6702c8)
The previous build was fine: https://ci.appveyor.com/project/robotology/yarp/build/appveyor.860
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer indeed! The issue was in devel, and it should be fixed now (see [build 920](https://ci.appveyor.com/project/robotology/yarp/build/appveyor.920)). Thanks for noticing it!
I added one part of the ip->hostname conversion anyway, only for local addresses, that means that only `yarpserver` will return the ip, all the modules should use the local hostname.
I'm merging this as soon as the tests are completed.
- [x] <a href='#crh-comment-Pull 9a0996e0295324d84ac7b9b9f1ef305cade21ed3 src/libYARP_OS/src/Node.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r71678162'>File: src/libYARP_OS/src/Node.cpp:L1-7</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> The year here should not be changed...
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Changed it back, didn't know that :)
- [x] <a href='#crh-comment-Pull 9a0996e0295324d84ac7b9b9f1ef305cade21ed3 src/libYARP_OS/src/Node.cpp 157'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r71679028'>File: src/libYARP_OS/src/Node.cpp:L436-446</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer I'm just worried that someone could call `setReporter()` and replace the `ROSReport` with a custom one. If this happens, then the ROS Node will no longer work... I don't know if the `Contactable& contactable` is accessible in some way from outside, though. Do you know if this is possible?
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> I am not sure .. However I think it's not possible.
The contactable is stored in `name_cache` of `yarp::os::Node::Helper`, which is a public attribute. However, the helper is owned by an instance of  `yarp::os::Node`, which does not allow access to the helper, and thus not to the contactable either. So the only places to access the contactable are within the helper class and the `Node` class.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer Unfortunately, after investigating a little bit, this works and it will mess up with the node:
```
sub = new yarp::os::Subscriber<std_msgs::String>();
if (!sub->topic("/yarp/foo")) {
yError() << "Failed to create subscriber to /yarp/foo\n";
return -1;
}
MyReport report;
sub->asPort().setReporter(report);
```
- [x] <a href='#crh-comment-Pull 0893950cc9ecd712008b598ca6a103cbc10ac717 src/libYARP_OS/src/Node.cpp 148'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r73009766'>File: src/libYARP_OS/src/Node.cpp:L241-411</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @drdanz I think this needs a comment why there is the special case for `/yarp/node`. Not sure where this comes from.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> wooops, thanks, that was debugging stuff, I totally forgot about that!
- [x] <a href='#crh-comment-Pull 0893950cc9ecd712008b598ca6a103cbc10ac717 src/libYARP_OS/src/Node.cpp 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r73010016'>File: src/libYARP_OS/src/Node.cpp:L12-62</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @drdanz I think it's nicer to merge the two if-else constructs into one. Are you happy with that? Will do in this case.
```c++
if (info.incoming) {
c = RosNameSpace::rosify(nic.queryName(info.sourceName));
incomingURIs.insert(std::make_pair(info.portName, c.toURI()));
} else {
c = RosNameSpace::rosify(nic.queryName(info.targetName));
outgoingURIs.insert(std::make_pair(info.portName, c.toURI()));
}
```
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Done
- [x] <a href='#crh-comment-Pull 0893950cc9ecd712008b598ca6a103cbc10ac717 src/libYARP_OS/src/Node.cpp 141'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r73010424'>File: src/libYARP_OS/src/Node.cpp:L241-411</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Not sure whether the following two `for` loops should also be protected by the mutex. I guess so, otherwise the `report` might change while iterating over it.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> I don't think it is required here, since we are populating `report` using `getReport()` (in the mutex) that is called once for each connection. After report is populated, we iterate over `report.outgoingURIs` and then over `report.incomingURIs`, because, from what I saw, ROS returns the all outgoing connections first, and then all the incoming ones.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Yep, this is very true! Didn't think carefully that only `getReport` can change the `report`.
- [x] <a href='#crh-comment-Pull 0893950cc9ecd712008b598ca6a103cbc10ac717 src/libYARP_OS/src/Node.cpp 97'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/828#discussion_r73010938'>File: src/libYARP_OS/src/Node.cpp:L230-237</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @drdanz I think we should move the `mutex.lock()` and `mutex.unlock()` also in the helper class for the `prepare()` method, just to be consistent.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Done


<a href='https://www.codereviewhub.com/robotology/yarp/pull/828?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/828?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/828?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/828'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>