### PR TITLE
Bindings: Properly define TypedReaderCallbackSound

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -577,7 +577,7 @@ typedef yarp::os::BufferedPort<Sound> BufferedPortSound;
 %template(BufferedPortImageInt) yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelInt> >;
 
 %template(TypedReaderSound) yarp::os::TypedReader<yarp::sig::Sound >;
-%template(TypedReaderCallbackImageMono) yarp::os::TypedReaderCallback<yarp::sig::Sound>;
+%template(TypedReaderCallbackSound) yarp::os::TypedReaderCallback<yarp::sig::Sound>;
 %template(BufferedPortSound) yarp::os::BufferedPort<yarp::sig::Sound >;
 
 // Add getPixel and setPixel methods to access float values

--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -58,6 +58,11 @@ Bug Fixes
 * The script executed by RosTypeSearch::fetchFromRos now supports the creation
   of .msg files in a non-existing directory.
 
+### Bindings
+
+* Properly define TypedReaderCallbackSound (Fixes TypedReaderCallbackImageMono
+  redefinition).
+
 
 Contributors
 ------------


### PR DESCRIPTION
Fixes TypedReaderCallbackImageMono redefinition.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/830?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/830'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>