### PR TITLE
Use reentrant version of get_host_addr

### DIFF
--- a/src/libYARP_OS/src/NameConfig.cpp
+++ b/src/libYARP_OS/src/NameConfig.cpp
@@ -237,9 +237,10 @@ String NameConfig::getHostName(bool prefer_loopback, String seed) {
 #ifdef YARP_HAS_ACE
     ACE_INET_Addr *ips = NULL;
     size_t count = 0;
+    char hostAddress[256];
     if (ACE::get_ip_interfaces(count,ips)>=0) {
         for (size_t i=0; i<count; i++) {
-            ConstString ip = ips[i].get_host_addr();
+            ConstString ip = ips[i].get_host_addr(hostAddress, 256);
 #else
     int family, s;
     char hostname[NI_MAXHOST]; hostname[NI_MAXHOST-1] = '\0';

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -79,8 +79,12 @@ void SocketTwoWayStream::updateAddresses() {
     ACE_INET_Addr local, remote;
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);
-    localAddress = Contact(local.get_host_addr(),local.get_port_number());
-    remoteAddress = Contact(remote.get_host_addr(),remote.get_port_number());
+    char localHostAddress[256];
+    char remoteHostAddress[256];
+    local.get_host_addr(localHostAddress, 256);
+    remote.get_host_addr(remoteHostAddress, 256);
+    localAddress = Contact(localHostAddress,local.get_port_number());
+    remoteAddress = Contact(remoteHostAddress,remote.get_port_number());
 #else
     stream.set_option (IPPROTO_TCP, TCP_NODELAY, &one,
                        sizeof(int));
@@ -95,7 +99,7 @@ void SocketTwoWayStream::updateAddresses() {
     } else {
         YARP_ERROR(Logger::get(),"ipv6 address type not propagated without ACE");
     }
-#endif    
+#endif
 }
 
 bool SocketTwoWayStream::setTypeOfService(int tos) {


### PR DESCRIPTION
Fixes several race conditions reported by valgrind.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/831?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/831'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>