### PR TITLE
fixing #837 setting QT_DEVICE_PIXEL_RATIO = auto for some guis. 

### DIFF
--- a/src/yarpdataplayer-qt/src/main.cpp
+++ b/src/yarpdataplayer-qt/src/main.cpp
@@ -24,6 +24,7 @@ using namespace yarp::os;
 
 int main(int argc, char *argv[])
 {
+    qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("auto"));
     QApplication a(argc, argv);
 
     Network yarp;

--- a/src/yarpmotorgui-qt/main.cpp
+++ b/src/yarpmotorgui-qt/main.cpp
@@ -53,6 +53,7 @@ static void sighandler(int sig) {
 
 int main(int argc, char *argv[])
 {
+    qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("auto"));
     QApplication a(argc, argv);
 
     //YARP_REGISTER_DEVICES(icubmod)

--- a/src/yarpview-qt/src/main.cpp
+++ b/src/yarpview-qt/src/main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
         }
     }
 
+    qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("auto"));
     QApplication app(argc, argv);
     QVariant retVal;
 


### PR DESCRIPTION
Not touching yarpscope because it already works fine and yarpmanager++ because this settings badly affects the graphical representation of the applications.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/pattacini%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/839%23issuecomment-236445698%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-07-31T17%3A54%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/839%23issuecomment-236445698%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/pattacini'><img src='https://avatars.githubusercontent.com/u/3738070?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/robotology/yarp/pull/839?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/839?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/839'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>