### PR TITLE
Fix valgrind test when ACE is not used

### DIFF
--- a/src/libYARP_OS/src/NameConfig.cpp
+++ b/src/libYARP_OS/src/NameConfig.cpp
@@ -319,6 +319,8 @@ ConstString NameConfig::getHostName(bool prefer_loopback, ConstString seed) {
         }
 #ifdef YARP_HAS_ACE
         delete[] ips;
+#else
+        freeifaddrs(ifaddr);
 #endif
     }
 


### PR DESCRIPTION
When looking at the Travis output for https://github.com/robotology/yarp/pull/828, I noticed that the `serversql::server_test::Valgrind::MemCheck` is failing when ACE is not used. This should fix it.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/841%23issuecomment-236968147%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/841%23issuecomment-236968147%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40Tobias-Fischer%20The%20patch%20looks%20good%20to%20me%2C%20Thanks%21%5Cr%5CnThis%20kind%20of%20patches%20belong%20to%20the%20%60master%60%20branch%20%28small%20bugfix%2C%20no%20API/ABI%20change%29...%20I%27m%20merging%20this%20and%20then%20I%20will%20cherry-pick%20the%20commit%20in%20master.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-02T16%3A54%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/841#issuecomment-236968147'>General Comment</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer The patch looks good to me, Thanks!
This kind of patches belong to the `master` branch (small bugfix, no API/ABI change)... I'm merging this and then I will cherry-pick the commit in master.


<a href='https://www.codereviewhub.com/robotology/yarp/pull/841?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/841?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/841'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>