### PR TITLE
YARP_OS/SocketTwoWayStream: Initialize sockaddr structures when SKIP_ACE is enabled

### DIFF
--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -21,6 +21,8 @@ Bug Fixes
 * Use reentrant version of get_host_addr in NameConfig and SocketTwoWayStream
   (fixes a few possible race conditions).
 * Fixed memory leak in NameConfig::getHostName with SKIP_ACE enabled.
+* Fixed "Conditional jump or move depends on uninitialised value" issues
+  reported by `valgrind --memcheck` in SocketTwoWayStream with SKIP_ACE enabled.
 
 
 ### YARP_DEV

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -88,7 +88,10 @@ void SocketTwoWayStream::updateAddresses() {
 #else
     stream.set_option (IPPROTO_TCP, TCP_NODELAY, &one,
                        sizeof(int));
-    struct sockaddr local, remote;
+    struct sockaddr local;
+    struct sockaddr remote;
+    memset(&local, 0, sizeof(local));
+    memset(&remote, 0, sizeof(remote));
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);
     if (local.sa_family == AF_INET) {


### PR DESCRIPTION
Fixed "Conditional jump or move depends on uninitialised value" issues reported by `valgrind --memcheck` in SocketTwoWayStream.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/842?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/842'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>