### PR TITLE
Jointidcheck

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardHelper.h
@@ -146,6 +146,15 @@ public:
         return true;
     }
 
+    inline bool checkAxisId(int id)
+    {
+        if (id >= nj)
+        {
+            return false;
+        }
+        return true;
+    }
+
     inline int toHw(int axis)
     { return axisMap[axis]; }
 

--- a/src/libYARP_dev/src/ControlMode2Impl.cpp
+++ b/src/libYARP_dev/src/ControlMode2Impl.cpp
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementControlMode2::ImplementControlMode2(IControlMode2Raw *r):
 temp_int(NULL),
@@ -62,42 +64,49 @@ bool ImplementControlMode2::uninitialize ()
 
 bool ImplementControlMode2::setPositionMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setPositionModeRaw(k);
 }
 
 bool ImplementControlMode2::setVelocityMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setVelocityModeRaw(k);
 }
 
 bool ImplementControlMode2::setTorqueMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setTorqueModeRaw(k);
 }
 
 bool ImplementControlMode2::setOpenLoopMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setOpenLoopModeRaw(k);
 }
 
 bool ImplementControlMode2::setImpedancePositionMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setImpedancePositionModeRaw(k);
 }
 
 bool ImplementControlMode2::setImpedanceVelocityMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setImpedanceVelocityModeRaw(k);
 }
 
 bool ImplementControlMode2::getControlMode(int j, int *f)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->getControlModeRaw(k, f);
 }
@@ -116,6 +125,7 @@ bool ImplementControlMode2::getControlModes(const int n_joint, const int *joints
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -126,6 +136,7 @@ bool ImplementControlMode2::getControlModes(const int n_joint, const int *joints
 
 bool ImplementControlMode2::setControlMode(const int j, const int mode)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setControlModeRaw(k, mode);
 }
@@ -134,6 +145,7 @@ bool ImplementControlMode2::setControlModes(const int n_joint, const int *joints
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
     return raw->setControlModesRaw(n_joint, temp_int, modes);

--- a/src/libYARP_dev/src/ControlModeImpl.cpp
+++ b/src/libYARP_dev/src/ControlModeImpl.cpp
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementControlMode::ImplementControlMode(IControlModeRaw *r)
 {
@@ -51,42 +53,49 @@ bool ImplementControlMode::uninitialize ()
 
 bool ImplementControlMode::setPositionMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setPositionModeRaw(k);
 }
 
 bool ImplementControlMode::setVelocityMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setVelocityModeRaw(k);
 }
 
 bool ImplementControlMode::setTorqueMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setTorqueModeRaw(k);
 }
 
 bool ImplementControlMode::setOpenLoopMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setOpenLoopModeRaw(k);
 }
 
 bool ImplementControlMode::setImpedancePositionMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setImpedancePositionModeRaw(k);
 }
 
 bool ImplementControlMode::setImpedanceVelocityMode(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->setImpedanceVelocityModeRaw(k);
 }
 
 bool ImplementControlMode::getControlMode(int j, int *f)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return raw->getControlModeRaw(k, f);
 }

--- a/src/libYARP_dev/src/IEncodersTimedImpl.cpp
+++ b/src/libYARP_dev/src/IEncodersTimedImpl.cpp
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ////////////////////////
 // Encoder Interface Timed Implementation
@@ -66,6 +68,7 @@ bool ImplementEncodersTimed::getAxes(int *ax)
 
 bool ImplementEncodersTimed::resetEncoder(int j)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
 
@@ -79,6 +82,7 @@ bool ImplementEncodersTimed::resetEncoders()
 
 bool ImplementEncodersTimed::setEncoder(int j, double val)
 {
+    JOINTIDCHECK
     int k;
     double enc;
 
@@ -96,6 +100,7 @@ bool ImplementEncodersTimed::setEncoders(const double *val)
 
 bool ImplementEncodersTimed::getEncoder(int j, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -123,6 +128,7 @@ bool ImplementEncodersTimed::getEncoders(double *v)
 
 bool ImplementEncodersTimed::getEncoderSpeed(int j, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -148,6 +154,7 @@ bool ImplementEncodersTimed::getEncoderSpeeds(double *v)
 
 bool ImplementEncodersTimed::getEncoderAcceleration(int j, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -173,6 +180,7 @@ bool ImplementEncodersTimed::getEncoderAccelerations(double *v)
 
 bool ImplementEncodersTimed::getEncoderTimed(int j, double *v, double *t)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;

--- a/src/libYARP_dev/src/IInteractionModeImpl.cpp
+++ b/src/libYARP_dev/src/IInteractionModeImpl.cpp
@@ -12,7 +12,8 @@
 #include <yarp/dev/IInteractionModeImpl.h>
 
 using namespace yarp::dev;
-
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementInteractionMode::ImplementInteractionMode(yarp::dev::IInteractionModeRaw *class_p) :
     iInteraction(class_p),
@@ -81,9 +82,11 @@ bool ImplementInteractionMode::getInteractionMode(int axis, yarp::dev::Interacti
 
 bool ImplementInteractionMode::getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
-    for(int i=0; i<n_joints; i++)
-        temp_int[i] = castToMapper(helper)->toHw(joints[i]);
-
+    for (int i = 0; i < n_joints; i++)
+    {
+         MJOINTIDCHECK(i)
+         temp_int[i] = castToMapper(helper)->toHw(joints[i]);
+    }
     return iInteraction->getInteractionModesRaw(n_joints, temp_int, modes);
 }
 
@@ -110,6 +113,7 @@ bool ImplementInteractionMode::setInteractionModes(int n_joints, int *joints, ya
 {
     for(int idx=0; idx<n_joints; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
     return iInteraction->setInteractionModesRaw(n_joints, temp_int, modes);

--- a/src/libYARP_dev/src/IMotorEncodersImpl.cpp
+++ b/src/libYARP_dev/src/IMotorEncodersImpl.cpp
@@ -10,7 +10,8 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
-
+#define JOINTIDCHECK if (m >= castToMapper(helper)->axes()){yError("motor id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 ////////////////////////
 // Encoder Interface Timed Implementation
 ImplementMotorEncoders::ImplementMotorEncoders(IMotorEncodersRaw *y)
@@ -66,6 +67,7 @@ bool ImplementMotorEncoders::getNumberOfMotorEncoders(int *num)
 
 bool ImplementMotorEncoders::resetMotorEncoder(int m)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(m);
 
@@ -79,6 +81,7 @@ bool ImplementMotorEncoders::resetMotorEncoders()
 
 bool ImplementMotorEncoders::setMotorEncoder(int m, const double val)
 {
+    JOINTIDCHECK
     int k;
     double enc;
 
@@ -89,6 +92,7 @@ bool ImplementMotorEncoders::setMotorEncoder(int m, const double val)
 
 bool ImplementMotorEncoders::getMotorEncoderCountsPerRevolution(int m, double* cpr)
 {
+    JOINTIDCHECK
     bool ret;
     int k=castToMapper(helper)->toHw(m);
 
@@ -99,6 +103,7 @@ bool ImplementMotorEncoders::getMotorEncoderCountsPerRevolution(int m, double* c
 
 bool ImplementMotorEncoders::setMotorEncoderCountsPerRevolution(int m, double cpr)
 {
+    JOINTIDCHECK
     int k;
 
     k=castToMapper(helper)->toHw(m);
@@ -115,6 +120,7 @@ bool ImplementMotorEncoders::setMotorEncoders(const double *val)
 
 bool ImplementMotorEncoders::getMotorEncoder(int m, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -142,6 +148,7 @@ bool ImplementMotorEncoders::getMotorEncoders(double *v)
 
 bool ImplementMotorEncoders::getMotorEncoderSpeed(int m, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -167,6 +174,7 @@ bool ImplementMotorEncoders::getMotorEncoderSpeeds(double *v)
 
 bool ImplementMotorEncoders::getMotorEncoderAcceleration(int m, double *v)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;
@@ -192,6 +200,7 @@ bool ImplementMotorEncoders::getMotorEncoderAccelerations(double *v)
 
 bool ImplementMotorEncoders::getMotorEncoderTimed(int m, double *v, double *t)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     bool ret;

--- a/src/libYARP_dev/src/IMotorImpl.cpp
+++ b/src/libYARP_dev/src/IMotorImpl.cpp
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
+#define JOINTIDCHECK if (m >= castToMapper(helper)->axes()){yError("motor id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ////////////////////////
 // Encoder Interface Timed Implementation
@@ -66,6 +68,7 @@ bool ImplementMotor::getNumberOfMotors(int *num)
 
 bool ImplementMotor::getTemperature(int m, double* value)
 {
+    JOINTIDCHECK
     bool ret;
     int k=castToMapper(helper)->toHw(m);
 
@@ -76,6 +79,7 @@ bool ImplementMotor::getTemperature(int m, double* value)
 
 bool ImplementMotor::getTemperatureLimit(int m, double* value)
 {
+    JOINTIDCHECK
     bool ret;
     int k=castToMapper(helper)->toHw(m);
 
@@ -86,6 +90,7 @@ bool ImplementMotor::getTemperatureLimit(int m, double* value)
 
 bool ImplementMotor::setTemperatureLimit(int m, const double value)
 {
+    JOINTIDCHECK
     bool ret;
     int k=castToMapper(helper)->toHw(m);
 
@@ -96,6 +101,7 @@ bool ImplementMotor::setTemperatureLimit(int m, const double value)
 
 bool ImplementMotor::getGearboxRatio(int m, double* value)
 {
+    JOINTIDCHECK
     bool ret;
     int k = castToMapper(helper)->toHw(m);
 
@@ -106,6 +112,7 @@ bool ImplementMotor::getGearboxRatio(int m, double* value)
 
 bool ImplementMotor::setGearboxRatio(int m, const double value)
 {
+    JOINTIDCHECK
     bool ret;
     int k = castToMapper(helper)->toHw(m);
 

--- a/src/libYARP_dev/src/IPositionControl2Impl.cpp
+++ b/src/libYARP_dev/src/IPositionControl2Impl.cpp
@@ -12,6 +12,9 @@
 #include <yarp/os/Log.h>
 
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementPositionControl2::ImplementPositionControl2(IPositionControl2Raw *y) :
     iPosition2(y),
@@ -80,6 +83,7 @@ YARP_WARNING_POP
 
 bool ImplementPositionControl2::positionMove(int j, double ang)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->posA2E(ang, j, enc, k);
@@ -90,6 +94,7 @@ bool ImplementPositionControl2::positionMove(const int n_joint, const int *joint
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->posA2E(refs[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
     return iPosition2->positionMoveRaw(n_joint, temp_int, temp_double);
@@ -104,6 +109,7 @@ bool ImplementPositionControl2::positionMove(const double *refs)
 
 bool ImplementPositionControl2::relativeMove(int j, double delta)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->velA2E(delta, j, enc, k);
@@ -115,6 +121,7 @@ bool ImplementPositionControl2::relativeMove(const int n_joint, const int *joint
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->velA2E(deltas[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
     return iPosition2->relativeMoveRaw(n_joint, temp_int, temp_double);
@@ -128,6 +135,7 @@ bool ImplementPositionControl2::relativeMove(const double *deltas)
 
 bool ImplementPositionControl2::checkMotionDone(int j, bool *flag)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
 
     return iPosition2->checkMotionDoneRaw(k,flag);
@@ -137,6 +145,7 @@ bool ImplementPositionControl2::checkMotionDone(const int n_joint, const int *jo
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -150,6 +159,7 @@ bool ImplementPositionControl2::checkMotionDone(bool *flag)
 
 bool ImplementPositionControl2::setRefSpeed(int j, double sp)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->velA2E_abs(sp, j, enc, k);
@@ -160,6 +170,7 @@ bool ImplementPositionControl2::setRefSpeeds(const int n_joint, const int *joint
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->velA2E_abs(spds[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
 
@@ -175,6 +186,7 @@ bool ImplementPositionControl2::setRefSpeeds(const double *spds)
 
 bool ImplementPositionControl2::setRefAcceleration(int j, double acc)
 {
+    JOINTIDCHECK
     int k;
     double enc;
 
@@ -186,6 +198,7 @@ bool ImplementPositionControl2::setRefAccelerations(const int n_joint, const int
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->accA2E_abs(accs[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
 
@@ -201,6 +214,7 @@ bool ImplementPositionControl2::setRefAccelerations(const double *accs)
 
 bool ImplementPositionControl2::getRefSpeed(int j, double *ref)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     k=castToMapper(helper)->toHw(j);
@@ -216,6 +230,7 @@ bool ImplementPositionControl2::getRefSpeeds(const int n_joint, const int *joint
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -246,6 +261,7 @@ bool ImplementPositionControl2::getRefAccelerations(const int n_joint, const int
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -260,6 +276,7 @@ bool ImplementPositionControl2::getRefAccelerations(const int n_joint, const int
 
 bool ImplementPositionControl2::getRefAcceleration(int j, double *acc)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     k=castToMapper(helper)->toHw(j);
@@ -272,6 +289,7 @@ bool ImplementPositionControl2::getRefAcceleration(int j, double *acc)
 
 bool ImplementPositionControl2::stop(int j)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
 
@@ -282,6 +300,7 @@ bool ImplementPositionControl2::stop(const int n_joint, const int *joints)
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -303,6 +322,7 @@ bool ImplementPositionControl2::getAxes(int *axis)
 
 bool ImplementPositionControl2::getTargetPosition(const int joint, double* ref)
 {
+    PJOINTIDCHECK(joint)
     int k;
     double enc;
     k=castToMapper(helper)->toHw(joint);
@@ -324,6 +344,7 @@ bool ImplementPositionControl2::getTargetPositions(const int n_joint, const int*
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 

--- a/src/libYARP_dev/src/IPositionDirectImpl.cpp
+++ b/src/libYARP_dev/src/IPositionDirectImpl.cpp
@@ -12,6 +12,9 @@
 #include <yarp/os/Log.h>
 
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementPositionDirect::ImplementPositionDirect(IPositionDirectRaw *y) :
     iPDirect(y),
@@ -74,6 +77,7 @@ YARP_WARNING_POP
 
 bool ImplementPositionDirect::setPosition(int j, double ref)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->posA2E(ref, j, enc, k);
@@ -84,7 +88,8 @@ bool ImplementPositionDirect::setPositions(const int n_joint, const int *joints,
 {
     for(int idx=0; idx<n_joint; idx++)
     {
-      castToMapper(helper)->posA2E(refs[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK(idx)
+        castToMapper(helper)->posA2E(refs[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
     return iPDirect->setPositionsRaw(n_joint, temp_int, temp_double);
 }
@@ -98,6 +103,7 @@ bool ImplementPositionDirect::setPositions(const double *refs)
 
 bool ImplementPositionDirect::getRefPosition(const int j, double* ref)
 {
+    JOINTIDCHECK
     int k;
     double tmp;
     k=castToMapper(helper)->toHw(j);
@@ -112,6 +118,7 @@ bool ImplementPositionDirect::getRefPositions(const int n_joint, const int* join
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 

--- a/src/libYARP_dev/src/IVelocityControl2Impl.cpp
+++ b/src/libYARP_dev/src/IVelocityControl2Impl.cpp
@@ -11,6 +11,9 @@
 #include <yarp/dev/ControlBoardHelper.h>
 
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementVelocityControl2::ImplementVelocityControl2(IVelocityControl2Raw *y) :
     iVelocity2(y),
@@ -77,6 +80,7 @@ YARP_WARNING_POP
 
 bool ImplementVelocityControl2::velocityMove(int j, double sp)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->velA2E(sp, j, enc, k);
@@ -87,6 +91,7 @@ bool ImplementVelocityControl2::velocityMove(const int n_joint, const int *joint
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->velA2E(spds[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
     return iVelocity2->velocityMoveRaw(n_joint, temp_int, temp_double);
@@ -100,6 +105,7 @@ bool ImplementVelocityControl2::velocityMove(const double *sp)
 
 bool ImplementVelocityControl2::getRefVelocity(const int j, double* vel)
 {
+    JOINTIDCHECK
     int k;
     double tmp;
     k=castToMapper(helper)->toHw(j);
@@ -119,6 +125,7 @@ bool ImplementVelocityControl2::getRefVelocities(const int n_joint, const int *j
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -133,6 +140,7 @@ bool ImplementVelocityControl2::getRefVelocities(const int n_joint, const int *j
 
 bool ImplementVelocityControl2::setRefAcceleration(int j, double acc)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     castToMapper(helper)->accA2E_abs(acc, j, enc, k);
@@ -143,6 +151,7 @@ bool ImplementVelocityControl2::setRefAccelerations(const int n_joint, const int
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->accA2E_abs(accs[idx], joints[idx], temp_double[idx], temp_int[idx]);
     }
     return iVelocity2->setRefAccelerationsRaw(n_joint, temp_int, temp_double);
@@ -156,6 +165,7 @@ bool ImplementVelocityControl2::setRefAccelerations(const double *accs)
 
 bool ImplementVelocityControl2::getRefAcceleration(int j, double *acc)
 {
+    JOINTIDCHECK
     int k;
     double enc;
     k=castToMapper(helper)->toHw(j);
@@ -168,6 +178,7 @@ bool ImplementVelocityControl2::getRefAccelerations(const int n_joint, const int
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
@@ -191,6 +202,7 @@ bool ImplementVelocityControl2::getRefAccelerations(double *accs)
 
 bool ImplementVelocityControl2::stop(int j)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iVelocity2->stopRaw(k);
@@ -201,6 +213,7 @@ bool ImplementVelocityControl2::stop(const int n_joint, const int *joints)
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
     return iVelocity2->stopRaw(n_joint, temp_int);
@@ -215,6 +228,7 @@ bool ImplementVelocityControl2::stop()
 
 bool ImplementVelocityControl2::setVelPid(int j, const Pid &pid)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iVelocity2->setVelPidRaw(k,pid);
 }
@@ -237,6 +251,7 @@ bool ImplementVelocityControl2::setVelPids(const Pid *pids)
 
 bool ImplementVelocityControl2::getVelPid(int j, Pid *pid)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
 

--- a/src/libYARP_dev/src/ImpedanceControlImpl.cpp
+++ b/src/libYARP_dev/src/ImpedanceControlImpl.cpp
@@ -11,6 +11,8 @@
 #include <yarp/dev/ControlBoardHelper.h>
 
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 /////////////// implement ImplementImpedanceControl
 ImplementImpedanceControl::ImplementImpedanceControl(IImpedanceControlRaw *r)
@@ -53,6 +55,7 @@ bool ImplementImpedanceControl::getAxes(int *axes)
 
 bool ImplementImpedanceControl::setImpedance(int j, double stiffness, double damping)
 {
+    JOINTIDCHECK
     int k;
     double stiff;
     double damp;
@@ -63,6 +66,7 @@ bool ImplementImpedanceControl::setImpedance(int j, double stiffness, double dam
 
 bool ImplementImpedanceControl::getImpedance(int j, double *stiffness, double *damping)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     bool ret=iImpedanceRaw->getImpedanceRaw(k, stiffness, damping);
@@ -76,6 +80,7 @@ bool ImplementImpedanceControl::getImpedance(int j, double *stiffness, double *d
 
 bool ImplementImpedanceControl::setImpedanceOffset(int j, double offset)
 {
+    JOINTIDCHECK
     int k;
     double off;
     castToMapper(helper)->trqN2S(offset,j,off,k);
@@ -84,6 +89,7 @@ bool ImplementImpedanceControl::setImpedanceOffset(int j, double offset)
 
 bool ImplementImpedanceControl::getImpedanceOffset(int j, double *offset)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     bool ret = iImpedanceRaw->getImpedanceOffsetRaw(k, offset);
@@ -93,6 +99,7 @@ bool ImplementImpedanceControl::getImpedanceOffset(int j, double *offset)
 
 bool ImplementImpedanceControl::getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iImpedanceRaw->getCurrentImpedanceLimitRaw(k, min_stiff, max_stiff, min_damp, max_damp);

--- a/src/libYARP_dev/src/OpenLoopControlImpl.cpp
+++ b/src/libYARP_dev/src/OpenLoopControlImpl.cpp
@@ -10,6 +10,9 @@
 #include <iostream>
 
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 /////////////// implement ImplementOpenLoopControl
 ImplementOpenLoopControl::ImplementOpenLoopControl(IOpenLoopControlRaw *r)
@@ -52,6 +55,7 @@ bool ImplementOpenLoopControl::uninitialize ()
 
 bool ImplementOpenLoopControl::setRefOutput(int j, double v)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
 
     return raw->setRefOutputRaw(k, v);
@@ -66,6 +70,7 @@ bool ImplementOpenLoopControl::setRefOutputs(const double *v)
 
 bool ImplementOpenLoopControl::getRefOutput(int j, double *v)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
 
     bool ret = raw->getRefOutputRaw(k, v);
@@ -82,6 +87,7 @@ bool ImplementOpenLoopControl::getRefOutputs(double *v)
 
 bool ImplementOpenLoopControl::getOutput(int j, double *v)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
 
     bool ret = raw->getOutputRaw(k, v);

--- a/src/libYARP_dev/src/TorqueControlImpl.cpp
+++ b/src/libYARP_dev/src/TorqueControlImpl.cpp
@@ -10,6 +10,9 @@
 
 #include <stdio.h>
 using namespace yarp::dev;
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementTorqueControl::ImplementTorqueControl(ITorqueControlRaw *tq)
 {
@@ -77,6 +80,7 @@ YARP_WARNING_POP
 
 bool ImplementTorqueControl::getRefTorque(int j, double *r)
 {
+    JOINTIDCHECK
     int k;
     bool ret;
     double torque;
@@ -88,6 +92,7 @@ bool ImplementTorqueControl::getRefTorque(int j, double *r)
 
 bool ImplementTorqueControl::getBemfParam(int j, double *bemf)
 {
+    JOINTIDCHECK
     int k;
     bool ret;
     k=castToMapper(helper)->toHw(j);
@@ -97,6 +102,7 @@ bool ImplementTorqueControl::getBemfParam(int j, double *bemf)
 
 bool ImplementTorqueControl::setBemfParam(int j, double bemf)
 {
+    JOINTIDCHECK
     int k;
     bool ret;
     k=castToMapper(helper)->toHw(j);
@@ -106,6 +112,7 @@ bool ImplementTorqueControl::setBemfParam(int j, double bemf)
 
 bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->setMotorTorqueParamsRaw(k, params);
@@ -113,6 +120,7 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
 
 bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params)
 {
+    JOINTIDCHECK
   int k=castToMapper(helper)->toHw(j);
   return iTorqueRaw->getMotorTorqueParamsRaw(k, params);
 }
@@ -133,6 +141,7 @@ bool ImplementTorqueControl::setRefTorques(const double *t)
 
 bool ImplementTorqueControl::setRefTorque(int j, double t)
 {
+    JOINTIDCHECK
     int k;
     double sens;
     castToMapper(helper)->trqN2S(t,j,sens,k);
@@ -150,6 +159,7 @@ bool ImplementTorqueControl::setRefTorques(const int n_joint, const int *joints,
 {
     for(int idx=0; idx<n_joint; idx++)
     {
+        MJOINTIDCHECK(idx)
         castToMapper(helper)->trqN2S(t[idx], joints[idx], temp[idx], temp_int[idx]);
     }
     return iTorqueRaw->setRefTorquesRaw(n_joint, temp_int, temp);
@@ -157,6 +167,7 @@ bool ImplementTorqueControl::setRefTorques(const int n_joint, const int *joints,
 
 bool ImplementTorqueControl::getTorque(int j, double *t)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->getTorqueRaw(k, t);
@@ -172,6 +183,7 @@ bool ImplementTorqueControl::getTorqueRanges(double *min, double *max)
 
 bool ImplementTorqueControl::getTorqueRange(int j, double *min, double *max)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->getTorqueRangeRaw(k, min, max);
@@ -179,6 +191,7 @@ bool ImplementTorqueControl::getTorqueRange(int j, double *min, double *max)
 
 bool ImplementTorqueControl::setTorquePid(int j, const Pid &pid)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->setTorquePidRaw(k, pid);
@@ -200,6 +213,7 @@ bool ImplementTorqueControl::setTorquePids(const Pid *pids)
 
 bool ImplementTorqueControl::setTorqueErrorLimit(int j, double limit)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->setTorqueErrorLimitRaw(k, limit);
@@ -207,6 +221,7 @@ bool ImplementTorqueControl::setTorqueErrorLimit(int j, double limit)
 
 bool ImplementTorqueControl::getTorqueErrorLimit(int j, double *limit)
 {
+    JOINTIDCHECK
     int k;
     k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->getTorqueErrorLimitRaw(k, limit);
@@ -220,6 +235,7 @@ bool ImplementTorqueControl::setTorqueErrorLimits(const double *limits)
 
 bool ImplementTorqueControl::getTorqueError(int j, double *err)
 {
+    JOINTIDCHECK
     int k;
     bool ret;
     double temp;
@@ -239,6 +255,7 @@ bool ImplementTorqueControl::getTorqueErrors(double *errs)
 
 bool ImplementTorqueControl::getTorquePidOutput(int j, double *out)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->getTorquePidOutputRaw(k, out);
 }
@@ -252,6 +269,7 @@ bool ImplementTorqueControl::getTorquePidOutputs(double *outs)
 
 bool ImplementTorqueControl::getTorquePid(int j, Pid *pid)
 {
+    JOINTIDCHECK
   int k=castToMapper(helper)->toHw(j);
   return iTorqueRaw->getTorquePidRaw(k, pid);
 }
@@ -281,23 +299,27 @@ bool ImplementTorqueControl::getTorqueErrorLimits(double *limits)
 
 bool ImplementTorqueControl::resetTorquePid(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->resetTorquePidRaw(k);
 }
 
 bool ImplementTorqueControl::disableTorquePid(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->disableTorquePidRaw(k);
 }
 
 bool ImplementTorqueControl::enableTorquePid(int j)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->enableTorquePidRaw(k);
 }
 bool ImplementTorqueControl::setTorqueOffset(int j, double v)
 {
+    JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
     return iTorqueRaw->setTorqueOffsetRaw(k, v);
 }

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -939,7 +939,7 @@ void ControlBoardWrapper::run()
 //
 bool ControlBoardWrapper::setPid(int j, const Pid &p)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -978,7 +978,7 @@ bool ControlBoardWrapper::setPids(const Pid *ps)
 
 bool ControlBoardWrapper::setReference(int j, double ref)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1017,7 +1017,7 @@ bool ControlBoardWrapper::setReferences(const double *refs)
 
 bool ControlBoardWrapper::setErrorLimit(int j, double limit)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1065,7 +1065,7 @@ bool ControlBoardWrapper::setErrorLimits(const double *limits)
 */
 bool ControlBoardWrapper::getError(int j, double *err)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1114,7 +1114,7 @@ bool ControlBoardWrapper::getErrors(double *errs)
 */
 bool ControlBoardWrapper::getOutput(int j, double *out)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1157,7 +1157,7 @@ bool ControlBoardWrapper::getOutputs(double *outs)
 
 bool ControlBoardWrapper::setOffset(int j, double v)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1179,7 +1179,7 @@ bool ControlBoardWrapper::setOffset(int j, double v)
 bool ControlBoardWrapper::getPid(int j, Pid *p)
 {
 //#warning "check for max number of joints!?!?!"
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -1226,7 +1226,7 @@ bool ControlBoardWrapper::getPids(Pid *pids)
 * @return reference value
 */
 bool ControlBoardWrapper::getReference(int j, double *ref) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1270,7 +1270,7 @@ bool ControlBoardWrapper::getReferences(double *refs) {
 * @return success/failure
 */
 bool ControlBoardWrapper::getErrorLimit(int j, double *limit) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1317,7 +1317,7 @@ bool ControlBoardWrapper::getErrorLimits(double *limits) {
 * @return true on success, false on failure.
 */
 bool ControlBoardWrapper::resetPid(int j) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1337,7 +1337,7 @@ bool ControlBoardWrapper::resetPid(int j) {
 * @return true if successful, false on failure
 **/
 bool ControlBoardWrapper::disablePid(int j) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1361,7 +1361,7 @@ bool ControlBoardWrapper::disablePid(int j) {
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::enablePid(int j) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1477,7 +1477,7 @@ YARP_WARNING_POP
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::positionMove(int j, double ref) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1602,7 +1602,7 @@ bool ControlBoardWrapper::positionMove(const int n_joints, const int *joints, co
 
 bool ControlBoardWrapper::getTargetPosition(const int j, double* ref)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1708,7 +1708,7 @@ bool ControlBoardWrapper::getTargetPositions(const int n_joints, const int *join
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::relativeMove(int j, double delta) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1807,7 +1807,7 @@ bool ControlBoardWrapper::relativeMove(const int n_joints, const int *joints, co
 * @return false on failure
 */
 bool ControlBoardWrapper::checkMotionDone(int j, bool *flag) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1915,7 +1915,7 @@ bool ControlBoardWrapper::checkMotionDone(const int n_joints, const int *joints,
 * @return true/false upon success/failure
 */
 bool ControlBoardWrapper::setRefSpeed(int j, double sp) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2045,7 +2045,7 @@ bool ControlBoardWrapper::setRefSpeeds(const int n_joints, const int *joints, co
 * @return true/false upon success/failure
 */
 bool ControlBoardWrapper::setRefAcceleration(int j, double acc) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2177,7 +2177,7 @@ bool ControlBoardWrapper::setRefAccelerations(const int n_joints, const int *joi
  * @return true/false on success or failure
  */
 bool ControlBoardWrapper::getRefSpeed(int j, double *ref) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2303,7 +2303,7 @@ bool ControlBoardWrapper::getRefSpeeds(const int n_joints, const int *joints, do
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::getRefAcceleration(int j, double *acc) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2427,7 +2427,7 @@ bool ControlBoardWrapper::getRefAccelerations(const int n_joints, const int *joi
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::stop(int j) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2522,7 +2522,7 @@ bool ControlBoardWrapper::stop(const int n_joints, const int *joints)
 /* IVelocityControl */
 
 bool ControlBoardWrapper::velocityMove(int j, double v) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2625,7 +2625,7 @@ YARP_WARNING_POP
 /* IEncoders */
 
 bool ControlBoardWrapper::resetEncoder(int j) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2662,7 +2662,7 @@ bool ControlBoardWrapper::resetEncoders() {
 }
 
 bool ControlBoardWrapper::setEncoder(int j, double val) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2699,7 +2699,7 @@ bool ControlBoardWrapper::setEncoders(const double *vals) {
 }
 
 bool ControlBoardWrapper::getEncoder(int j, double *v) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2759,7 +2759,7 @@ bool ControlBoardWrapper::getEncodersTimed(double *encs, double *t) {
 }
 
 bool ControlBoardWrapper::getEncoderTimed(int j, double *v, double *t) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2775,7 +2775,7 @@ bool ControlBoardWrapper::getEncoderTimed(int j, double *v, double *t) {
 }
 
 bool ControlBoardWrapper::getEncoderSpeed(int j, double *sp) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2813,7 +2813,7 @@ bool ControlBoardWrapper::getEncoderSpeeds(double *spds) {
 }
 
 bool ControlBoardWrapper::getEncoderAcceleration(int j, double *acc) {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3277,7 +3277,7 @@ bool ControlBoardWrapper::getNumberOfMotorEncoders(int *num) {
 
 bool ControlBoardWrapper::enableAmp(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3293,7 +3293,7 @@ bool ControlBoardWrapper::enableAmp(int j)
 
 bool ControlBoardWrapper::disableAmp(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3337,7 +3337,7 @@ bool ControlBoardWrapper::getAmpStatus(int *st)
 
 bool ControlBoardWrapper::getAmpStatus(int j, int *v)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3374,7 +3374,7 @@ bool ControlBoardWrapper::getCurrents(double *vals)
 
 bool ControlBoardWrapper::getCurrent(int j, double *val)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3391,7 +3391,7 @@ bool ControlBoardWrapper::getCurrent(int j, double *val)
 
 bool ControlBoardWrapper::setMaxCurrent(int j, double v)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3407,7 +3407,7 @@ bool ControlBoardWrapper::setMaxCurrent(int j, double v)
 
 bool ControlBoardWrapper::getMaxCurrent(int j, double* v)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3563,7 +3563,7 @@ bool ControlBoardWrapper::getPowerSupplyVoltage(int m, double* val)
 
 bool ControlBoardWrapper::setLimits(int j, double min, double max)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3579,7 +3579,7 @@ bool ControlBoardWrapper::setLimits(int j, double min, double max)
 
 bool ControlBoardWrapper::getLimits(int j, double *min, double *max)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3601,7 +3601,7 @@ bool ControlBoardWrapper::getLimits(int j, double *min, double *max)
 
 bool ControlBoardWrapper::setVelLimits(int j, double min, double max)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3617,7 +3617,7 @@ bool ControlBoardWrapper::setVelLimits(int j, double min, double max)
 
 bool ControlBoardWrapper::getVelLimits(int j, double *min, double *max)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     *min=0.0;
@@ -3725,7 +3725,7 @@ bool ControlBoardWrapper::quitPark()
 
 bool ControlBoardWrapper::calibrate(int j, double p)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -3741,7 +3741,7 @@ bool ControlBoardWrapper::calibrate(int j, double p)
 
 bool ControlBoardWrapper::calibrate2(int j, unsigned int ui, double v1, double v2, double v3)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
@@ -3767,7 +3767,7 @@ bool ControlBoardWrapper::setCalibrationParameters(int j, const CalibrationParam
 
 bool ControlBoardWrapper::done(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3797,7 +3797,7 @@ bool ControlBoardWrapper::abortCalibration()
 
 bool ControlBoardWrapper::getAxisName(int j, yarp::os::ConstString& name)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3886,7 +3886,7 @@ bool ControlBoardWrapper::getRefTorques(double *refs)
 bool ControlBoardWrapper::getRefTorque(int j, double *t)
 {
 
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3925,7 +3925,7 @@ bool ControlBoardWrapper::setRefTorques(const double *t)
 
 bool ControlBoardWrapper::setRefTorque(int j, double t)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3989,7 +3989,7 @@ bool ControlBoardWrapper::setRefTorques(const int n_joints, const int *joints, c
 bool ControlBoardWrapper::getBemfParam(int j, double *t)
 {
 
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4005,7 +4005,7 @@ bool ControlBoardWrapper::getBemfParam(int j, double *t)
 
 bool ControlBoardWrapper::setBemfParam(int j, double t)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4021,7 +4021,7 @@ bool ControlBoardWrapper::setBemfParam(int j, double t)
 
 bool ControlBoardWrapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4037,7 +4037,7 @@ bool ControlBoardWrapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorquePar
 
 bool ControlBoardWrapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4053,7 +4053,7 @@ bool ControlBoardWrapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTor
 
 bool ControlBoardWrapper::setTorquePid(int j, const Pid &pid)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4070,7 +4070,7 @@ bool ControlBoardWrapper::setTorquePid(int j, const Pid &pid)
 
 bool ControlBoardWrapper::setImpedance(int j, double stiff, double damp)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4087,7 +4087,7 @@ bool ControlBoardWrapper::setImpedance(int j, double stiff, double damp)
 
 bool ControlBoardWrapper::setImpedanceOffset(int j, double offset)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4104,7 +4104,7 @@ bool ControlBoardWrapper::setImpedanceOffset(int j, double offset)
 
 bool ControlBoardWrapper::getTorque(int j, double *t)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4144,7 +4144,7 @@ bool ControlBoardWrapper::getTorques(double *t)
 
 bool ControlBoardWrapper::getTorqueRange(int j, double *min, double *max)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4206,7 +4206,7 @@ bool ControlBoardWrapper::setTorquePids(const Pid *pids)
 
 bool ControlBoardWrapper::setTorqueErrorLimit(int j, double limit)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4246,7 +4246,7 @@ bool ControlBoardWrapper::setTorqueErrorLimits(const double *limits)
 
 bool ControlBoardWrapper::getTorqueError(int j, double *err)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4286,7 +4286,7 @@ bool ControlBoardWrapper::getTorqueErrors(double *errs)
 
 bool ControlBoardWrapper::getTorquePidOutput(int j, double *out)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4326,7 +4326,7 @@ bool ControlBoardWrapper::getTorquePidOutputs(double *outs)
 
 bool ControlBoardWrapper::getTorquePid(int j, Pid *pid)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4343,7 +4343,7 @@ bool ControlBoardWrapper::getTorquePid(int j, Pid *pid)
 
 bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4360,7 +4360,7 @@ bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
 
 bool ControlBoardWrapper::getImpedanceOffset(int j, double* offset)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4377,7 +4377,7 @@ bool ControlBoardWrapper::getImpedanceOffset(int j, double* offset)
 
 bool ControlBoardWrapper::getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4417,7 +4417,7 @@ bool ControlBoardWrapper::getTorquePids(Pid *pids)
 
 bool ControlBoardWrapper::getTorqueErrorLimit(int j, double *limit)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4457,7 +4457,7 @@ bool ControlBoardWrapper::getTorqueErrorLimits(double *limits)
 
 bool ControlBoardWrapper::resetTorquePid(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4474,7 +4474,7 @@ bool ControlBoardWrapper::resetTorquePid(int j)
 
 bool ControlBoardWrapper::disableTorquePid(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4491,7 +4491,7 @@ bool ControlBoardWrapper::disableTorquePid(int j)
 
 bool ControlBoardWrapper::enableTorquePid(int j)
 {
-     int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+     int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4508,7 +4508,7 @@ bool ControlBoardWrapper::enableTorquePid(int j)
 
 bool ControlBoardWrapper::setTorqueOffset(int j, double v)
 {
-     int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+     int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4525,7 +4525,7 @@ bool ControlBoardWrapper::setTorqueOffset(int j, double v)
 
 bool ControlBoardWrapper::setPositionMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4547,7 +4547,7 @@ bool ControlBoardWrapper::setPositionMode(int j)
 
 bool ControlBoardWrapper::setTorqueMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4569,7 +4569,7 @@ bool ControlBoardWrapper::setTorqueMode(int j)
 
 bool ControlBoardWrapper::setImpedancePositionMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4587,7 +4587,7 @@ bool ControlBoardWrapper::setImpedancePositionMode(int j)
 
 bool ControlBoardWrapper::setImpedanceVelocityMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4604,7 +4604,7 @@ bool ControlBoardWrapper::setImpedanceVelocityMode(int j)
 
 bool ControlBoardWrapper::setVelocityMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4626,7 +4626,7 @@ bool ControlBoardWrapper::setVelocityMode(int j)
 
 bool ControlBoardWrapper::setOpenLoopMode(int j)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4648,7 +4648,7 @@ bool ControlBoardWrapper::setOpenLoopMode(int j)
 
 bool ControlBoardWrapper::getControlMode(int j, int *mode)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4712,7 +4712,7 @@ bool ControlBoardWrapper::getControlModes(const int n_joint, const int *joints, 
 bool ControlBoardWrapper::legacySetControlMode(const int j, const int mode)
 {
     bool ret = true;
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4784,7 +4784,7 @@ bool ControlBoardWrapper::legacySetControlMode(const int j, const int mode)
 bool ControlBoardWrapper::setControlMode(const int j, const int mode)
 {
     bool ret = true;
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4899,7 +4899,7 @@ bool ControlBoardWrapper::setControlModes(int *modes)
 
 bool ControlBoardWrapper::setRefOutput(int j, double v)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4937,7 +4937,7 @@ bool ControlBoardWrapper::setRefOutputs(const double *outs) {
 
 bool ControlBoardWrapper::setPosition(int j, double ref)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5047,7 +5047,7 @@ yarp::os::Stamp ControlBoardWrapper::getLastInputStamp() {
 
 bool ControlBoardWrapper::getRefPosition(const int j, double* ref)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5195,7 +5195,7 @@ bool ControlBoardWrapper::getRefVelocity(const int j, double* vel)
     if(verbose())
         yTrace();
 
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5298,7 +5298,7 @@ bool ControlBoardWrapper::getRefVelocities(const int n_joints, const int* joints
 
 bool ControlBoardWrapper::setVelPid(int j, const Pid &pid)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5338,7 +5338,7 @@ bool ControlBoardWrapper::setVelPids(const Pid *pids)
 bool ControlBoardWrapper::getVelPid(int j, Pid *pid)
 {
     //#warning "check for max number of joints!?!?!"
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5377,7 +5377,7 @@ bool ControlBoardWrapper::getVelPids(Pid *pids)
 
 bool ControlBoardWrapper::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5453,7 +5453,7 @@ bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* mo
 
     for(int j=0; j<controlledJoints; j++)
     {
-        int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+        int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
         int subIndex=device.lut[j].deviceEntry;
 
         yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5472,7 +5472,7 @@ bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* mo
 
 bool ControlBoardWrapper::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5527,7 +5527,7 @@ bool ControlBoardWrapper::setInteractionModes(yarp::dev::InteractionModeEnum* mo
 
     for(int j=0; j<controlledJoints; j++)
     {
-        int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+        int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
         int subIndex=device.lut[j].deviceEntry;
 
         yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5546,7 +5546,7 @@ bool ControlBoardWrapper::setInteractionModes(yarp::dev::InteractionModeEnum* mo
 
 bool ControlBoardWrapper::getRefOutput(int j, double *out)
 {
-    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
+    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -939,7 +939,7 @@ void ControlBoardWrapper::run()
 //
 bool ControlBoardWrapper::setPid(int j, const Pid &p)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -978,7 +978,7 @@ bool ControlBoardWrapper::setPids(const Pid *ps)
 
 bool ControlBoardWrapper::setReference(int j, double ref)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1017,7 +1017,7 @@ bool ControlBoardWrapper::setReferences(const double *refs)
 
 bool ControlBoardWrapper::setErrorLimit(int j, double limit)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1065,7 +1065,7 @@ bool ControlBoardWrapper::setErrorLimits(const double *limits)
 */
 bool ControlBoardWrapper::getError(int j, double *err)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1114,7 +1114,7 @@ bool ControlBoardWrapper::getErrors(double *errs)
 */
 bool ControlBoardWrapper::getOutput(int j, double *out)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1157,7 +1157,7 @@ bool ControlBoardWrapper::getOutputs(double *outs)
 
 bool ControlBoardWrapper::setOffset(int j, double v)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1179,7 +1179,7 @@ bool ControlBoardWrapper::setOffset(int j, double v)
 bool ControlBoardWrapper::getPid(int j, Pid *p)
 {
 //#warning "check for max number of joints!?!?!"
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -1226,7 +1226,7 @@ bool ControlBoardWrapper::getPids(Pid *pids)
 * @return reference value
 */
 bool ControlBoardWrapper::getReference(int j, double *ref) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1270,7 +1270,7 @@ bool ControlBoardWrapper::getReferences(double *refs) {
 * @return success/failure
 */
 bool ControlBoardWrapper::getErrorLimit(int j, double *limit) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1317,7 +1317,7 @@ bool ControlBoardWrapper::getErrorLimits(double *limits) {
 * @return true on success, false on failure.
 */
 bool ControlBoardWrapper::resetPid(int j) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1337,7 +1337,7 @@ bool ControlBoardWrapper::resetPid(int j) {
 * @return true if successful, false on failure
 **/
 bool ControlBoardWrapper::disablePid(int j) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1361,7 +1361,7 @@ bool ControlBoardWrapper::disablePid(int j) {
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::enablePid(int j) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1477,7 +1477,7 @@ YARP_WARNING_POP
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::positionMove(int j, double ref) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1602,7 +1602,7 @@ bool ControlBoardWrapper::positionMove(const int n_joints, const int *joints, co
 
 bool ControlBoardWrapper::getTargetPosition(const int j, double* ref)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1708,7 +1708,7 @@ bool ControlBoardWrapper::getTargetPositions(const int n_joints, const int *join
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::relativeMove(int j, double delta) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1807,7 +1807,7 @@ bool ControlBoardWrapper::relativeMove(const int n_joints, const int *joints, co
 * @return false on failure
 */
 bool ControlBoardWrapper::checkMotionDone(int j, bool *flag) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -1915,7 +1915,7 @@ bool ControlBoardWrapper::checkMotionDone(const int n_joints, const int *joints,
 * @return true/false upon success/failure
 */
 bool ControlBoardWrapper::setRefSpeed(int j, double sp) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2045,7 +2045,7 @@ bool ControlBoardWrapper::setRefSpeeds(const int n_joints, const int *joints, co
 * @return true/false upon success/failure
 */
 bool ControlBoardWrapper::setRefAcceleration(int j, double acc) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2177,7 +2177,7 @@ bool ControlBoardWrapper::setRefAccelerations(const int n_joints, const int *joi
  * @return true/false on success or failure
  */
 bool ControlBoardWrapper::getRefSpeed(int j, double *ref) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2303,7 +2303,7 @@ bool ControlBoardWrapper::getRefSpeeds(const int n_joints, const int *joints, do
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::getRefAcceleration(int j, double *acc) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2427,7 +2427,7 @@ bool ControlBoardWrapper::getRefAccelerations(const int n_joints, const int *joi
 * @return true/false on success/failure
 */
 bool ControlBoardWrapper::stop(int j) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2522,7 +2522,7 @@ bool ControlBoardWrapper::stop(const int n_joints, const int *joints)
 /* IVelocityControl */
 
 bool ControlBoardWrapper::velocityMove(int j, double v) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2625,7 +2625,7 @@ YARP_WARNING_POP
 /* IEncoders */
 
 bool ControlBoardWrapper::resetEncoder(int j) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2662,7 +2662,7 @@ bool ControlBoardWrapper::resetEncoders() {
 }
 
 bool ControlBoardWrapper::setEncoder(int j, double val) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2699,7 +2699,7 @@ bool ControlBoardWrapper::setEncoders(const double *vals) {
 }
 
 bool ControlBoardWrapper::getEncoder(int j, double *v) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2759,7 +2759,7 @@ bool ControlBoardWrapper::getEncodersTimed(double *encs, double *t) {
 }
 
 bool ControlBoardWrapper::getEncoderTimed(int j, double *v, double *t) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2775,7 +2775,7 @@ bool ControlBoardWrapper::getEncoderTimed(int j, double *v, double *t) {
 }
 
 bool ControlBoardWrapper::getEncoderSpeed(int j, double *sp) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -2813,7 +2813,7 @@ bool ControlBoardWrapper::getEncoderSpeeds(double *spds) {
 }
 
 bool ControlBoardWrapper::getEncoderAcceleration(int j, double *acc) {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3277,7 +3277,7 @@ bool ControlBoardWrapper::getNumberOfMotorEncoders(int *num) {
 
 bool ControlBoardWrapper::enableAmp(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3293,7 +3293,7 @@ bool ControlBoardWrapper::enableAmp(int j)
 
 bool ControlBoardWrapper::disableAmp(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3337,7 +3337,7 @@ bool ControlBoardWrapper::getAmpStatus(int *st)
 
 bool ControlBoardWrapper::getAmpStatus(int j, int *v)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3374,7 +3374,7 @@ bool ControlBoardWrapper::getCurrents(double *vals)
 
 bool ControlBoardWrapper::getCurrent(int j, double *val)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3391,7 +3391,7 @@ bool ControlBoardWrapper::getCurrent(int j, double *val)
 
 bool ControlBoardWrapper::setMaxCurrent(int j, double v)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3407,7 +3407,7 @@ bool ControlBoardWrapper::setMaxCurrent(int j, double v)
 
 bool ControlBoardWrapper::getMaxCurrent(int j, double* v)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3563,7 +3563,7 @@ bool ControlBoardWrapper::getPowerSupplyVoltage(int m, double* val)
 
 bool ControlBoardWrapper::setLimits(int j, double min, double max)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3579,7 +3579,7 @@ bool ControlBoardWrapper::setLimits(int j, double min, double max)
 
 bool ControlBoardWrapper::getLimits(int j, double *min, double *max)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3601,7 +3601,7 @@ bool ControlBoardWrapper::getLimits(int j, double *min, double *max)
 
 bool ControlBoardWrapper::setVelLimits(int j, double min, double max)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3617,7 +3617,7 @@ bool ControlBoardWrapper::setVelLimits(int j, double min, double max)
 
 bool ControlBoardWrapper::getVelLimits(int j, double *min, double *max)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     *min=0.0;
@@ -3725,7 +3725,7 @@ bool ControlBoardWrapper::quitPark()
 
 bool ControlBoardWrapper::calibrate(int j, double p)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -3741,7 +3741,7 @@ bool ControlBoardWrapper::calibrate(int j, double p)
 
 bool ControlBoardWrapper::calibrate2(int j, unsigned int ui, double v1, double v2, double v3)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
@@ -3767,7 +3767,7 @@ bool ControlBoardWrapper::setCalibrationParameters(int j, const CalibrationParam
 
 bool ControlBoardWrapper::done(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3797,7 +3797,7 @@ bool ControlBoardWrapper::abortCalibration()
 
 bool ControlBoardWrapper::getAxisName(int j, yarp::os::ConstString& name)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3886,7 +3886,7 @@ bool ControlBoardWrapper::getRefTorques(double *refs)
 bool ControlBoardWrapper::getRefTorque(int j, double *t)
 {
 
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3925,7 +3925,7 @@ bool ControlBoardWrapper::setRefTorques(const double *t)
 
 bool ControlBoardWrapper::setRefTorque(int j, double t)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -3989,7 +3989,7 @@ bool ControlBoardWrapper::setRefTorques(const int n_joints, const int *joints, c
 bool ControlBoardWrapper::getBemfParam(int j, double *t)
 {
 
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4005,7 +4005,7 @@ bool ControlBoardWrapper::getBemfParam(int j, double *t)
 
 bool ControlBoardWrapper::setBemfParam(int j, double t)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4021,7 +4021,7 @@ bool ControlBoardWrapper::setBemfParam(int j, double t)
 
 bool ControlBoardWrapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4037,7 +4037,7 @@ bool ControlBoardWrapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorquePar
 
 bool ControlBoardWrapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4053,7 +4053,7 @@ bool ControlBoardWrapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTor
 
 bool ControlBoardWrapper::setTorquePid(int j, const Pid &pid)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4070,7 +4070,7 @@ bool ControlBoardWrapper::setTorquePid(int j, const Pid &pid)
 
 bool ControlBoardWrapper::setImpedance(int j, double stiff, double damp)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4087,7 +4087,7 @@ bool ControlBoardWrapper::setImpedance(int j, double stiff, double damp)
 
 bool ControlBoardWrapper::setImpedanceOffset(int j, double offset)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4104,7 +4104,7 @@ bool ControlBoardWrapper::setImpedanceOffset(int j, double offset)
 
 bool ControlBoardWrapper::getTorque(int j, double *t)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4144,7 +4144,7 @@ bool ControlBoardWrapper::getTorques(double *t)
 
 bool ControlBoardWrapper::getTorqueRange(int j, double *min, double *max)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4206,7 +4206,7 @@ bool ControlBoardWrapper::setTorquePids(const Pid *pids)
 
 bool ControlBoardWrapper::setTorqueErrorLimit(int j, double limit)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4246,7 +4246,7 @@ bool ControlBoardWrapper::setTorqueErrorLimits(const double *limits)
 
 bool ControlBoardWrapper::getTorqueError(int j, double *err)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4286,7 +4286,7 @@ bool ControlBoardWrapper::getTorqueErrors(double *errs)
 
 bool ControlBoardWrapper::getTorquePidOutput(int j, double *out)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4326,7 +4326,7 @@ bool ControlBoardWrapper::getTorquePidOutputs(double *outs)
 
 bool ControlBoardWrapper::getTorquePid(int j, Pid *pid)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4343,7 +4343,7 @@ bool ControlBoardWrapper::getTorquePid(int j, Pid *pid)
 
 bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4360,7 +4360,7 @@ bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
 
 bool ControlBoardWrapper::getImpedanceOffset(int j, double* offset)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4377,7 +4377,7 @@ bool ControlBoardWrapper::getImpedanceOffset(int j, double* offset)
 
 bool ControlBoardWrapper::getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4417,7 +4417,7 @@ bool ControlBoardWrapper::getTorquePids(Pid *pids)
 
 bool ControlBoardWrapper::getTorqueErrorLimit(int j, double *limit)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4457,7 +4457,7 @@ bool ControlBoardWrapper::getTorqueErrorLimits(double *limits)
 
 bool ControlBoardWrapper::resetTorquePid(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4474,7 +4474,7 @@ bool ControlBoardWrapper::resetTorquePid(int j)
 
 bool ControlBoardWrapper::disableTorquePid(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4491,7 +4491,7 @@ bool ControlBoardWrapper::disableTorquePid(int j)
 
 bool ControlBoardWrapper::enableTorquePid(int j)
 {
-     int off=device.lut[j].offset;
+     int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4508,7 +4508,7 @@ bool ControlBoardWrapper::enableTorquePid(int j)
 
 bool ControlBoardWrapper::setTorqueOffset(int j, double v)
 {
-     int off=device.lut[j].offset;
+     int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4525,7 +4525,7 @@ bool ControlBoardWrapper::setTorqueOffset(int j, double v)
 
 bool ControlBoardWrapper::setPositionMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4547,7 +4547,7 @@ bool ControlBoardWrapper::setPositionMode(int j)
 
 bool ControlBoardWrapper::setTorqueMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4569,7 +4569,7 @@ bool ControlBoardWrapper::setTorqueMode(int j)
 
 bool ControlBoardWrapper::setImpedancePositionMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4587,7 +4587,7 @@ bool ControlBoardWrapper::setImpedancePositionMode(int j)
 
 bool ControlBoardWrapper::setImpedanceVelocityMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4604,7 +4604,7 @@ bool ControlBoardWrapper::setImpedanceVelocityMode(int j)
 
 bool ControlBoardWrapper::setVelocityMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4626,7 +4626,7 @@ bool ControlBoardWrapper::setVelocityMode(int j)
 
 bool ControlBoardWrapper::setOpenLoopMode(int j)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4648,7 +4648,7 @@ bool ControlBoardWrapper::setOpenLoopMode(int j)
 
 bool ControlBoardWrapper::getControlMode(int j, int *mode)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4712,7 +4712,7 @@ bool ControlBoardWrapper::getControlModes(const int n_joint, const int *joints, 
 bool ControlBoardWrapper::legacySetControlMode(const int j, const int mode)
 {
     bool ret = true;
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4784,7 +4784,7 @@ bool ControlBoardWrapper::legacySetControlMode(const int j, const int mode)
 bool ControlBoardWrapper::setControlMode(const int j, const int mode)
 {
     bool ret = true;
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4899,7 +4899,7 @@ bool ControlBoardWrapper::setControlModes(int *modes)
 
 bool ControlBoardWrapper::setRefOutput(int j, double v)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -4937,7 +4937,7 @@ bool ControlBoardWrapper::setRefOutputs(const double *outs) {
 
 bool ControlBoardWrapper::setPosition(int j, double ref)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5047,7 +5047,7 @@ yarp::os::Stamp ControlBoardWrapper::getLastInputStamp() {
 
 bool ControlBoardWrapper::getRefPosition(const int j, double* ref)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5195,7 +5195,7 @@ bool ControlBoardWrapper::getRefVelocity(const int j, double* vel)
     if(verbose())
         yTrace();
 
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5298,7 +5298,7 @@ bool ControlBoardWrapper::getRefVelocities(const int n_joints, const int* joints
 
 bool ControlBoardWrapper::setVelPid(int j, const Pid &pid)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5338,7 +5338,7 @@ bool ControlBoardWrapper::setVelPids(const Pid *pids)
 bool ControlBoardWrapper::getVelPid(int j, Pid *pid)
 {
     //#warning "check for max number of joints!?!?!"
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5377,7 +5377,7 @@ bool ControlBoardWrapper::getVelPids(Pid *pids)
 
 bool ControlBoardWrapper::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5453,7 +5453,7 @@ bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* mo
 
     for(int j=0; j<controlledJoints; j++)
     {
-        int off=device.lut[j].offset;
+        int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
         int subIndex=device.lut[j].deviceEntry;
 
         yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5472,7 +5472,7 @@ bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* mo
 
 bool ControlBoardWrapper::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *s=device.getSubdevice(subIndex);
@@ -5527,7 +5527,7 @@ bool ControlBoardWrapper::setInteractionModes(yarp::dev::InteractionModeEnum* mo
 
     for(int j=0; j<controlledJoints; j++)
     {
-        int off=device.lut[j].offset;
+        int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
         int subIndex=device.lut[j].deviceEntry;
 
         yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
@@ -5546,7 +5546,7 @@ bool ControlBoardWrapper::setInteractionModes(yarp::dev::InteractionModeEnum* mo
 
 bool ControlBoardWrapper::getRefOutput(int j, double *out)
 {
-    int off=device.lut[j].offset;
+    int off; try{off = device.lut.at(j).offset;} catch(out_of_range e){yError() << "joint number out of bound"; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73398075%22%2C%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73477945%22%2C%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73479875%22%2C%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73483347%22%2C%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73486888%22%2C%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73490120%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%201cb2164c2e107aa529a8fa227764b4b5d13999f9%20src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/845%23discussion_r73398075%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aerydna%20is%20there%20any%20specific%20reason%20why%20you%20make%20use%20of%20%60try%60%2B%60catch%60%20construct%3F%20Checking%20directly%20against%20the%20buffer%20overflow%20should%20be%20preferable%20in%20my%20opinion.%22%2C%20%22created_at%22%3A%20%222016-08-03T18%3A53%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20idea%20is%20that%20we%20are%20checking%20for%20something%20that%20should%20never%20occour%20in%20normal%20usage%5Cr%5CnIn%20thise%20case%2C%20the%20try/catch%20mechanism%20is%20more%20efficent%20than%20a%20double%20%60if%28%29%60%20%20%28double%20because%20we%20need%20to%20check%202%20bounds%29.%5Cr%5Cn%5Cr%5CnExceptions%20are%20slower%20than%20normal%20%60if%28%29%60%20code%20only%20when%20actually%20thrown%2C%20which%20is%20rare%20and%20anyway%20better%20than%20a%20segfault%20%3A-%29%5Cr%5Cnhttp%3A//stackoverflow.com/questions/13835817/are-exceptions-in-c-really-slow%22%2C%20%22created_at%22%3A%20%222016-08-04T07%3A59%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20the%20%60vector%3A%3Aat%60%20method%20is%20implemented%20with%20two%20%60if%60%2C%20so%20I%20fail%20to%20see%20the%20efficiency%20gain%20coming%20from%20using%20the%20exception.%20%20%5Cr%5CnFurthermore%20for%20this%20kind%20of%20behavior%20profiling%20is%20the%20only%20way%20of%20actually%20knowing%20the%20speed%20of%20the%20code%2C%20and%20typically%20results%20are%20quite%20counterintuitive.%20%22%2C%20%22created_at%22%3A%20%222016-08-04T08%3A15%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22My%20point%20is%20that%20it%20can%20be%20equal%20or%20better%20than%20if%2C%20not%20worse.%20Then%20how%20much%20depends%20on%20the%20implementation%20of%20%60.at%28%29%60%20vs%20%60if%60%20and%20compilers.%5Cr%5CnThis%20is%20not%20a%20matter%20of%20profiling%20nor%20optimization%2C%20the%20question%20was%20%5C%22%20why%20%60try%60%20instead%20of%20%60if%60%3F%5C%22%20The%20answer%20is%20that%20in%20this%20case%20it%20can%20only%20be%20equal%20or%20better.%22%2C%20%22created_at%22%3A%20%222016-08-04T08%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4061020%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/barbalberto%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20defining%20%60better%60%20we%20include%20also%20readability%20of%20the%20code%2C%20and%20I%20think%20that%20some%20good%20old%20plain%20%60if%60%20would%20be%20much%20more%20easier%20to%20read.%20%5Cr%5Cn%5Cr%5CnIf%20instead%20we%20are%20only%20interested%20in%20time%20complexity%2C%20I%20am%20not%20sure%20at%20all%20that%20the%20%60.at%28%29%60%20based%20implementation%20is%20always%20better%20w.r.t.%20to%20time%20complexity.%20%5Cr%5Cn%5Cr%5CnAn%20example%20in%20which%20it%20could%20be%20much%20worse%20is%20if%20%60.at%28%29%60%20is%20not%20be%20proper%20inlined%20by%20the%20compiler%20%28and%20modern%20compilers%20are%20not%20magically%20always%20taking%20the%20right%20decision%20with%20respect%20to%20inlining%2C%20despite%20popular%20belief%29.%20In%20that%20case%2C%20just%20getting%20the%20code%20for%20%60.at%28%29%60%20could%20create%20an%20%60L1%60%20cache%20miss%2C%20that%20for%20sure%20would%20be%20much%20more%20costly%20that%20a%20simple%20%60if%60%20comparison%20between%20integers%20present%20in%20the%20register%20or%20the%20cache.%20%5Cr%5Cn%5Cr%5CnI%20am%20not%20saying%20that%20this%20would%20happen%20for%20sure%2C%20but%20just%20claiming%20that%20we%20can%20understand%20which%20one%20of%20the%20two%20constucts%20is%20faster%20on%20modern%20systems%20is%20totally%20unrealistic%20%28and%20probably%20performance%20is%20not%20a%20big%20problem%20anyway%20in%20this%20case%29.%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-04T09%3A04%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tend%20to%20agree%20with%20%40traversaro%20also%20because%20of%20my%20mindset%20%3Asmile%3A%3A%20I%20always%20go%20for%20basic%20standard%20constructs%20when%20possible%20rather%20than%20using%20fancy%20solutions%2C%20unless%20they%20bring%20solid%20improvements%2C%20but%20here%20two%20%60if%60%27s%20among%20integers%20cost%20practically%20%600%60.%5Cr%5Cn%5Cr%5CnHowever%2C%20if%20we%20wanna%20stick%20to%20%60try%60%2B%60catch%60%20I%20think%20it%27d%20be%20worth%20arranging%20the%20code%20in%20several%20lines%20to%20improve%20readability%20and/or%20perhaps%20resort%20to%20macros.%22%2C%20%22created_at%22%3A%20%222016-08-04T09%3A26%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp%3AL939-946%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 1cb2164c2e107aa529a8fa227764b4b5d13999f9 src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/845#discussion_r73398075'>File: src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp:L939-946</a></b>
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @aerydna is there any specific reason why you make use of `try`+`catch` construct? Checking directly against the buffer overflow should be preferable in my opinion.
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> The idea is that we are checking for something that should never occour in normal usage
In thise case, the try/catch mechanism is more efficent than a double `if()`  (double because we need to check 2 bounds).
Exceptions are slower than normal `if()` code only when actually thrown, which is rare and anyway better than a segfault :-)
http://stackoverflow.com/questions/13835817/are-exceptions-in-c-really-slow
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> But the `vector::at` method is implemented with two `if`, so I fail to see the efficiency gain coming from using the exception.
Furthermore for this kind of behavior profiling is the only way of actually knowing the speed of the code, and typically results are quite counterintuitive.
- <a href='https://github.com/barbalberto'><img border=0 src='https://avatars.githubusercontent.com/u/4061020?v=3' height=16 width=16'></a> My point is that it can be equal or better than if, not worse. Then how much depends on the implementation of `.at()` vs `if` and compilers.
This is not a matter of profiling nor optimization, the question was " why `try` instead of `if`?" The answer is that in this case it can only be equal or better.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> If defining `better` we include also readability of the code, and I think that some good old plain `if` would be much more easier to read.
If instead we are only interested in time complexity, I am not sure at all that the `.at()` based implementation is always better w.r.t. to time complexity.
An example in which it could be much worse is if `.at()` is not be proper inlined by the compiler (and modern compilers are not magically always taking the right decision with respect to inlining, despite popular belief). In that case, just getting the code for `.at()` could create an `L1` cache miss, that for sure would be much more costly that a simple `if` comparison between integers present in the register or the cache.
I am not saying that this would happen for sure, but just claiming that we can understand which one of the two constucts is faster on modern systems is totally unrealistic (and probably performance is not a big problem anyway in this case).
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> I tend to agree with @traversaro also because of my mindset :smile:: I always go for basic standard constructs when possible rather than using fancy solutions, unless they bring solid improvements, but here two `if`'s among integers cost practically `0`.
However, if we wanna stick to `try`+`catch` I think it'd be worth arranging the code in several lines to improve readability and/or perhaps resort to macros.


<a href='https://www.codereviewhub.com/robotology/yarp/pull/845?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/845?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/845'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>