### PR TITLE
Fix valgrind issues in NameConfig.cpp

### DIFF
--- a/src/libYARP_OS/src/NameConfig.cpp
+++ b/src/libYARP_OS/src/NameConfig.cpp
@@ -319,10 +319,11 @@ String NameConfig::getHostName(bool prefer_loopback, String seed) {
         }
 #ifdef YARP_HAS_ACE
         delete[] ips;
-#else
-        freeifaddrs(ifaddr);
 #endif
     }
+#ifndef YARP_HAS_ACE
+    freeifaddrs(ifaddr);
+#endif
 
     return result.c_str();
 }


### PR DESCRIPTION
See https://github.com/robotology/yarp/pull/844 (https://github.com/robotology/yarp/pull/843 can't be reopened as branch was force-pushed).
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/846?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/846'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>