### PR TITLE
yarpmotorgui: Added QlineEdit box to display openloop output.

### DIFF
--- a/src/yarpmotorgui-qt/jointitem.cpp
+++ b/src/yarpmotorgui-qt/jointitem.cpp
@@ -1099,6 +1099,9 @@ void JointItem::setOpenLoop(double openLoopValue)
     }
     if(ui->stackedWidget->currentIndex() == OPENLOOP){
         updateSliderOpenloop(openLoopValue);
+        QString sVal;
+        sVal = QString("%L1").arg(openLoopValue, 0, 'f', 3);
+        ui->editOpenLoopOutput->setText(sVal);
     }
 }
 

--- a/src/yarpmotorgui-qt/jointitem.ui
+++ b/src/yarpmotorgui-qt/jointitem.ui
@@ -2,24 +2,27 @@
 <ui version="4.0">
  <class>JointItem</class>
  <widget class="QWidget" name="JointItem">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>290</width>
-    <height>218</height>
+    <width>329</width>
+    <height>240</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>290</width>
-    <height>218</height>
+    <height>240</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>329</width>
-    <height>218</height>
+    <height>240</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -253,7 +256,7 @@ QSlider::groove:horizontal:disabled {
  }</string>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>6</number>
         </property>
         <widget class="QWidget" name="pageIdle">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -1603,72 +1606,6 @@ QSlider::groove:horizontal:disabled {
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox_10">
-            <property name="title">
-             <string>Position</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_15">
-             <property name="leftMargin">
-              <number>2</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>2</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="widget_21" native="true">
-               <layout class="QHBoxLayout" name="horizontalLayout_13">
-                <property name="spacing">
-                 <number>2</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_21">
-                  <property name="text">
-                   <string>Encoder:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="editOpenLoopCurrentPos">
-                  <property name="styleSheet">
-                   <string notr="true">background-color: rgb(255, 255, 255);</string>
-                  </property>
-                  <property name="readOnly">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_posUnits_7">
-                  <property name="text">
-                   <string>deg</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
            <widget class="QWidget" name="widget_22" native="true">
             <layout class="QGridLayout" name="gridLayout_6">
              <property name="leftMargin">
@@ -1677,44 +1614,14 @@ QSlider::groove:horizontal:disabled {
              <property name="rightMargin">
               <number>2</number>
              </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_trqTitle_7">
+             <item row="3" column="2">
+              <widget class="QLabel" name="label_velUnits_7">
                <property name="text">
-                <string>Torque:</string>
+                <string>deg/s</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="editOpenLoopTorque">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="label_trqUnits_7">
-               <property name="text">
-                <string>Nm</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="labelSpeed10">
-               <property name="text">
-                <string>Speed:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
+             <item row="3" column="1">
               <widget class="QLineEdit" name="editOpenLoopSpeed">
                <property name="maximumSize">
                 <size>
@@ -1730,10 +1637,81 @@ QSlider::groove:horizontal:disabled {
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
-              <widget class="QLabel" name="label_velUnits_7">
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_trqTitle_7">
                <property name="text">
-                <string>deg/s</string>
+                <string>Torque:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLineEdit" name="editOpenLoopTorque">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">background-color: rgb(255, 255, 255);</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QLabel" name="label_trqUnits_7">
+               <property name="text">
+                <string>Nm</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="labelSpeed10">
+               <property name="text">
+                <string>Speed:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_21">
+               <property name="text">
+                <string>Encoder:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="editOpenLoopCurrentPos">
+               <property name="styleSheet">
+                <string notr="true">background-color: rgb(255, 255, 255);</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QLabel" name="label_posUnits_7">
+               <property name="text">
+                <string>deg</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Output:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="editOpenLoopOutput"/>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Units</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
This fixes issue #630
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/851?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/851'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>