### PR TITLE
Try to fix NodeTest race condition

### DIFF
--- a/src/libYARP_serversql/src/NameServiceOnTriples.cpp
+++ b/src/libYARP_serversql/src/NameServiceOnTriples.cpp
@@ -582,6 +582,7 @@ bool NameServiceOnTriples::apply(yarp::os::Bottle& cmd,
     ConstString key = cmd.get(0).toString();
     ConstString prefix = " * ";
 
+    access.wait();
     if (key=="register") {
         lastRegister = cmd.get(1).asString().c_str();
     } else if (key=="set") {
@@ -596,6 +597,7 @@ bool NameServiceOnTriples::apply(yarp::os::Bottle& cmd,
                prefix.c_str(),
                cmd.toString().c_str());
     }
+    access.post();
 
     TripleSource& mem = *db;
     //mem.begin();

--- a/src/libYARP_serversql/src/NameServiceOnTriples.h
+++ b/src/libYARP_serversql/src/NameServiceOnTriples.h
@@ -20,7 +20,8 @@
  * State information for a single name server operation on a database.
  *
  */
-class NameTripleState {
+class NameTripleState
+{
 public:
     yarp::os::Bottle& cmd;
     yarp::os::Bottle& reply;
@@ -30,18 +31,19 @@ public:
     bool bottleMode;
     bool nestedMode;
 
-    NameTripleState(yarp::os::Bottle& cmd, 
-                    yarp::os::Bottle& reply, 
-                    yarp::os::Bottle& event, 
+    NameTripleState(yarp::os::Bottle& cmd,
+                    yarp::os::Bottle& reply,
+                    yarp::os::Bottle& event,
                     const yarp::os::Contact& remote,
-                    TripleSource& mem) : cmd(cmd), 
-                                         reply(reply), 
-                                         event(event), 
-                                         remote(remote),
-                                         mem(mem)
+                    TripleSource& mem) :
+            cmd(cmd),
+            reply(reply),
+            event(event),
+            remote(remote),
+            mem(mem),
+            bottleMode(false),
+            nestedMode(false)
     {
-        bottleMode = false;
-        nestedMode = false;
     }
 };
 
@@ -50,45 +52,53 @@ public:
  * An implementation of name service operators on a triple store.
  *
  */
-class NameServiceOnTriples : public yarp::name::NameService {
+class NameServiceOnTriples : public yarp::name::NameService
+{
 private:
     TripleSource *db;
     Allocator *alloc;
     Subscriber *subscriber;
     std::string lastRegister;
     yarp::os::Contact serverContact;
-    yarp::os::Semaphore mutex, access;
+    yarp::os::Semaphore mutex;
+    yarp::os::Semaphore access;
     bool gonePublic;
     bool silent;
     yarp::os::NameSpace *delegate;
 public:
-    NameServiceOnTriples() : mutex(1), access(1) {
-        db = 0 /*NULL*/;
-        alloc = 0 /*NULL*/;
-        lastRegister = "";
-        subscriber = NULL;
-        gonePublic = false;
-        silent = false;
-        delegate = 0 /*NULL*/;
+    NameServiceOnTriples() :
+            db(NULL),
+            alloc(NULL),
+            subscriber(NULL),
+            lastRegister(""),
+            mutex(1),
+            access(1),
+            gonePublic(false),
+            silent(false),
+            delegate(NULL)
+    {
     }
 
     void open(TripleSource *db,
               Allocator *alloc,
-              const yarp::os::Contact& serverContact) {
+              const yarp::os::Contact& serverContact)
+    {
         this->db = db;
         this->alloc = alloc;
         this->serverContact = serverContact;
     }
 
-    void setSubscriber(Subscriber *subscriber) {
+    void setSubscriber(Subscriber *subscriber)
+    {
         this->subscriber = subscriber;
     }
 
-    void setSilent(bool flag) {
+    void setSilent(bool flag)
+    {
         this->silent = flag;
     }
 
-    yarp::os::Contact query(const yarp::os::ConstString& portName, 
+    yarp::os::Contact query(const yarp::os::ConstString& portName,
                             NameTripleState& act,
                             const yarp::os::ConstString& prefix,
                             bool nested = false);
@@ -117,12 +127,13 @@ public:
 
     bool cmdHelp(NameTripleState& act);
 
-    virtual bool apply(yarp::os::Bottle& cmd, 
-                       yarp::os::Bottle& reply, 
+    virtual bool apply(yarp::os::Bottle& cmd,
+                       yarp::os::Bottle& reply,
                        yarp::os::Bottle& event,
                        const yarp::os::Contact& remote);
 
-    virtual void goPublic() {
+    virtual void goPublic()
+    {
         gonePublic = true;
     }
 
@@ -130,11 +141,13 @@ public:
 
     void unlock();
 
-    void setDelegate(yarp::os::NameSpace *delegate) {
+    void setDelegate(yarp::os::NameSpace *delegate)
+    {
         this->delegate = delegate;
     }
 
-    yarp::os::NameSpace *getDelegate() {
+    yarp::os::NameSpace *getDelegate()
+    {
         return delegate;
     }
 };

--- a/src/libYARP_serversql/src/NameServiceOnTriples.h
+++ b/src/libYARP_serversql/src/NameServiceOnTriples.h
@@ -57,12 +57,12 @@ private:
     Subscriber *subscriber;
     std::string lastRegister;
     yarp::os::Contact serverContact;
-    yarp::os::Semaphore mutex;
+    yarp::os::Semaphore mutex, access;
     bool gonePublic;
     bool silent;
     yarp::os::NameSpace *delegate;
 public:
-    NameServiceOnTriples() : mutex(1) {
+    NameServiceOnTriples() : mutex(1), access(1) {
         db = 0 /*NULL*/;
         alloc = 0 /*NULL*/;
         lastRegister = "";


### PR DESCRIPTION
`YARP_serversql/NameServiceOnTriples`: Protect concurrent access to internal variables using a mutex

Fixes several race conditions reported by valgrind

Might fix #374 

CC @Tobias-Fischer
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/860%23discussion_r73843846%22%2C%20%22https%3A//github.com/robotology/yarp/pull/860%23issuecomment-238182507%22%2C%20%22https%3A//github.com/robotology/yarp/pull/860%23discussion_r73850323%22%2C%20%22https%3A//github.com/robotology/yarp/pull/860%23issuecomment-238213020%22%2C%20%22https%3A//github.com/robotology/yarp/pull/860%23issuecomment-238221280%22%2C%20%22https%3A//github.com/robotology/yarp/pull/860%23issuecomment-238221454%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/860%23issuecomment-238182507%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27ll%20let%20the%20test%20run%20for%20a%20couple%20of%20hours%20and%20report%20whether%20it%20runs%20fine.%22%2C%20%22created_at%22%3A%20%222016-08-08T09%3A12%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20I%27ve%20run%20it%20locally%20for%20a%20few%20hours%20with%20no%20crashes%2C%20any%20crash%20on%20your%20side%3F%20Otherwise%20I%27m%20merging%20this...%22%2C%20%22created_at%22%3A%20%222016-08-08T11%3A47%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20crashes%20here%20for%203%20or%204%20hours%20..%20Go%20ahead%20and%20merge%20I%27d%20say%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-08-08T12%3A30%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-08T12%3A31%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e6da8fe6c4d002971c0e210ed920ccb665bc147d%20src/libYARP_serversql/src/NameServiceOnTriples.h%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/860%23discussion_r73843846%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20might%20be%20a%20good%20chance%20to%20also%20use%20proper%20initializers%20for%20the%20other%20attributes%20..%22%2C%20%22created_at%22%3A%20%222016-08-08T09%3A11%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%5Cr%5CnDone%2C%20thanks%22%2C%20%22created_at%22%3A%20%222016-08-08T09%3A59%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/libYARP_serversql/src/NameServiceOnTriples.h%3AL57-69%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull e6da8fe6c4d002971c0e210ed920ccb665bc147d src/libYARP_serversql/src/NameServiceOnTriples.h 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/860#discussion_r73843846'>File: src/libYARP_serversql/src/NameServiceOnTriples.h:L57-69</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> This might be a good chance to also use proper initializers for the other attributes ..
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :+1:
Done, thanks
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/860#issuecomment-238182507'>General Comment</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> I'll let the test run for a couple of hours and report whether it runs fine.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @Tobias-Fischer I've run it locally for a few hours with no crashes, any crash on your side? Otherwise I'm merging this...
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> No crashes here for 3 or 4 hours .. Go ahead and merge I'd say :)


<a href='https://www.codereviewhub.com/robotology/yarp/pull/860?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/860?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/860'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>