### PR TITLE
Remote control board remapper

### DIFF
--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -149,7 +149,8 @@ set(YARP_devices_SRCS   src/modules/AnalogWrapper/AnalogWrapper.cpp
                         src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
                         src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.cpp
                         src/modules/ControlBoardRemapper/ControlBoardRemapper.cpp
-                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp)
+                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+                        src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.cpp)
 if (CREATE_LIB_MATH)
   list(APPEND YARP_devices_SRCS src/modules/FrameTransformClient/FrameTransformClient.cpp
                                 src/modules/FrameTransformServer/FrameTransformServer.cpp)
@@ -164,7 +165,8 @@ set(YARP_devices_HDRS   src/modules/AnalogWrapper/AnalogWrapper.h
                         src/modules/ControlBoardWrapper/ControlBoardWrapper.h
                         src/modules/VirtualAnalogWrapper/VirtualAnalogWrapper.h
                         src/modules/ControlBoardRemapper/ControlBoardRemapper.h
-                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.h)
+                        src/modules/ControlBoardRemapper/ControlBoardRemapperHelpers.h
+                        src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h)
 if (CREATE_LIB_MATH)
   list(APPEND YARP_devices_SRCS src/modules/FrameTransformClient/FrameTransformClient.h
                                 src/modules/FrameTransformServer/FrameTransformServer.h)

--- a/src/libYARP_dev/src/PopulateDrivers.cpp
+++ b/src/libYARP_dev/src/PopulateDrivers.cpp
@@ -41,6 +41,7 @@ extern DriverCreator *createRangefinder2DClient();
 extern DriverCreator *createRGBDSensorWrapper();
 extern DriverCreator *createRGBDSensorClient();
 extern DriverCreator *createControlBoardRemapper();
+extern DriverCreator *createRemoteControlBoardRemapper();
 
 #ifdef WITH_YARPMATH
 extern DriverCreator *createFrameTransformServer();
@@ -98,6 +99,7 @@ void Drivers::init() {
     add(createRGBDSensorWrapper());
     add(createRGBDSensorClient());
     add(createControlBoardRemapper());
+    add(createRemoteControlBoardRemapper());
 
 #ifdef WITH_YARPMATH
     add(createFrameTransformServer());

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "RemoteControlBoardRemapper.h"
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/LockGuard.h>
+
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <cassert>
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace std;
+
+// needed for the driver factory.
+DriverCreator *createRemoteControlBoardRemapper()
+{
+    return new DriverCreatorOf<yarp::dev::RemoteControlBoardRemapper>
+            ("remotecontrolboardremapper", "controlboardwrapper2", "yarp::dev::RemoteControlBoardRemapper");
+}
+
+RemoteControlBoardRemapper::RemoteControlBoardRemapper()
+{
+}
+
+RemoteControlBoardRemapper::~RemoteControlBoardRemapper()
+{
+}
+
+void RemoteControlBoardRemapper::closeAllRemoteControlBoards()
+{
+    for(size_t ctrlBrd=0; ctrlBrd < m_remoteControlBoardDevices.size(); ctrlBrd++)
+    {
+        if( m_remoteControlBoardDevices[ctrlBrd] )
+        {
+            m_remoteControlBoardDevices[ctrlBrd]->close();
+            delete m_remoteControlBoardDevices[ctrlBrd];
+            m_remoteControlBoardDevices[ctrlBrd] = 0;
+        }
+    }
+
+    m_remoteControlBoardDevices.resize(0);
+}
+
+
+bool RemoteControlBoardRemapper::close()
+{
+    bool ret = true;
+
+    bool ok = ControlBoardRemapper::detachAll();
+
+    ret = ret && ok;
+
+    ok = ControlBoardRemapper::close();
+
+    ret = ret && ok;
+
+    closeAllRemoteControlBoards();
+
+    return ret;
+}
+
+bool RemoteControlBoardRemapper::open(Searchable& config)
+{
+    Property prop;
+    prop.fromString(config.toString().c_str());
+
+    std::string localPortPrefix;
+    std::vector<std::string> remoteControlBoardsPorts;
+
+    // Check if the required parameters  are found
+    if( prop.check("localPortPrefix") && prop.find("localPortPrefix").isString() )
+    {
+        localPortPrefix = prop.find("localPortPrefix").asString().c_str();
+    }
+    else
+    {
+       yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"localPortPrefix\" should be a string\n";
+       return false;
+    }
+
+    Bottle *remoteControlBoards=prop.find("remoteControlBoards").asList();
+    if(remoteControlBoards==0)
+    {
+       yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"remoteControlBoards\" should be followed by a list\n";
+       return false;
+    }
+
+    remoteControlBoardsPorts.resize(remoteControlBoards->size());
+    for(int ax=0; ax < remoteControlBoards->size(); ax++)
+    {
+        remoteControlBoardsPorts[ax] = remoteControlBoards->get(ax).asString().c_str();
+    }
+
+    // Parameters loaded, open all the remote controlboards
+    m_remoteControlBoardDevices.resize(remoteControlBoardsPorts.size(),0);
+
+    PolyDriverList remoteControlBoardsList;
+
+    for(size_t ctrlBrd=0; ctrlBrd < remoteControlBoardsPorts.size(); ctrlBrd++ )
+    {
+        std::string remote = remoteControlBoardsPorts[ctrlBrd];
+        // Note: as local parameter we use localPortPrefix+remoteOfTheReportControlBoard
+        std::string local = localPortPrefix+remote;
+
+        Property options;
+        options.put("device", "remote_controlboard");
+        options.put("local", local);
+        options.put("remote", remote);
+
+        m_remoteControlBoardDevices[ctrlBrd] = new PolyDriver();
+
+        bool ok = m_remoteControlBoardDevices[ctrlBrd]->open(options);
+        
+        if( !ok || !(m_remoteControlBoardDevices[ctrlBrd]->isValid()) )
+        {
+            yError() << "RemoteControlBoardRemapper: error opening remote_controlboard with remote \"" << remote << "\", opening the device failed.";
+            closeAllRemoteControlBoards();
+            return false;
+        }
+
+        // We use the remote name of the remote_controlboard as the key for it, in absense of anything better
+        remoteControlBoardsList.push((m_remoteControlBoardDevices[ctrlBrd]),remote.c_str());
+    }
+
+    // Device opened, now we open the ControlBoardRemapper and then we call attachAll
+    bool ok = ControlBoardRemapper::open(prop);
+
+    if( !ok )
+    {
+        yError() << "RemoteControlBoardRemapper: error opening the controlboardremapper device, opening the device failed.";
+        ControlBoardRemapper::close();
+        closeAllRemoteControlBoards();
+        return false;
+    }
+
+    // If open went ok, we now call attachAll
+    ok = ControlBoardRemapper::attachAll(remoteControlBoardsList);
+
+    if( !ok )
+    {
+        yError() << "RemoteControlBoardRemapper: error calling attachAll in the controlboardremapper device, opening the device failed.";
+        ControlBoardRemapper::close();
+        closeAllRemoteControlBoards();
+        return false;
+    }
+
+    // All went ok, return true
+    // TODO: close devices that are not actually used by the remapper
+    return true;
+}
+

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.cpp
@@ -83,15 +83,15 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
     }
     else
     {
-       yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"localPortPrefix\" should be a string\n";
-       return false;
+        yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"localPortPrefix\" should be a string.";
+        return false;
     }
 
     Bottle *remoteControlBoards=prop.find("remoteControlBoards").asList();
     if(remoteControlBoards==0)
     {
-       yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"remoteControlBoards\" should be followed by a list\n";
-       return false;
+        yError() <<"RemoteControlBoardRemapper: Error parsing parameters: \"remoteControlBoards\" should be followed by a list.";
+        return false;
     }
 
     remoteControlBoardsPorts.resize(remoteControlBoards->size());
@@ -100,7 +100,17 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
         remoteControlBoardsPorts[ax] = remoteControlBoards->get(ax).asString().c_str();
     }
 
+    // Load the REMOTE_CONTROLBOARD_OPTIONS, containg any additional option to pass to the remote control boards
+    Property remoteControlBoardsOptions;
+
+    Bottle & optionsGroupBot = prop.findGroup("REMOTE_CONTROLBOARD_OPTIONS");
+    if( !(optionsGroupBot.isNull()) )
+    {
+        remoteControlBoardsOptions.fromString(optionsGroupBot.toString());
+    }
+
     // Parameters loaded, open all the remote controlboards
+
     m_remoteControlBoardDevices.resize(remoteControlBoardsPorts.size(),0);
 
     PolyDriverList remoteControlBoardsList;
@@ -111,7 +121,7 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
         // Note: as local parameter we use localPortPrefix+remoteOfTheReportControlBoard
         std::string local = localPortPrefix+remote;
 
-        Property options;
+        Property options = remoteControlBoardsOptions;
         options.put("device", "remote_controlboard");
         options.put("local", local);
         options.put("remote", remote);
@@ -119,7 +129,7 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
         m_remoteControlBoardDevices[ctrlBrd] = new PolyDriver();
 
         bool ok = m_remoteControlBoardDevices[ctrlBrd]->open(options);
-        
+
         if( !ok || !(m_remoteControlBoardDevices[ctrlBrd]->isValid()) )
         {
             yError() << "RemoteControlBoardRemapper: error opening remote_controlboard with remote \"" << remote << "\", opening the device failed.";

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
@@ -1,0 +1,136 @@
+/*
+* Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+* Author: Lorenzo Natale, Silvio Traversaro
+* CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+*/
+
+#ifndef YARP_DEV_REMOTECONTROLBOARDREMAPPER_REMOTECONTROLBOARDREMAPPER_H
+#define YARP_DEV_REMOTECONTROLBOARDREMAPPER_REMOTECONTROLBOARDREMAPPER_H
+
+#include <yarp/dev/PolyDriver.h>
+
+#include "ControlBoardRemapper.h"
+
+
+namespace yarp {
+namespace dev {
+
+
+/**
+ *  @ingroup dev_impl_wrapper
+ *
+ * \section RemoteControlBoardRemapper
+ * A device that takes a list of axes from multiple controlboards, a list
+ * of remote controlboards in which this axes are located, that is opening
+ * all the remote controlboards but is exposing them
+ *
+ *
+ *  Parameters required by this device are:
+ * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
+ * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+ * | axesNames      |      -         | vector of strings  | -   |   -           | Yes          | Ordered list of the axes that are part of the remapped device.    |       |
+ * | remoteControlBoards |     -      | vector of strings  | -   |   -           | Yes          | List of remote prefix used by the remote controlboards.           | The element of this list are then passed as "remote" parameter to the RemoteControlBoard device. |
+ * | localPortPrefix |     -         | string             | -   |   -           | Yes          | All ports opened by this device will start with this prefix       |       |
+ *
+ * All the passed remote controlboards are opened, and then the axesNames and the opened device are
+ * passed to the ControlBoardRemapper device. If different axes
+ * in two attached controlboard have the same name, the behaviour of this device is undefined.
+ *
+ *
+ * Configuration file using .ini format.
+ *
+ * \code{.unparsed}
+ *  device remotecontrolboardremapper
+ *  axesNames (torso_pitch torso_roll torso_yaw neck_pitch neck_roll neck_yaw)
+ *  remoteControlBoards (/icub/torso /icub/head)
+ *
+ * ...
+ * \endcode
+ *
+ * Configuration of the device from C++ code.
+ * \code{.cpp}
+ *   Property options;
+ *   options.put("device","remotecontrolboardremapper");
+ *   Bottle axesNames;
+ *   Bottle & axesList = axesNames.addList();
+ *   axesList.addString("torso_pitch");
+ *   axesList.addString("torso_roll");
+ *   axesList.addString("torso_yaw");
+ *   axesList.addString("neck_pitch");
+ *   axesList.addString("neck_roll");
+ *   axesList.addString("neck_yaw");
+ *   options.put("axesNames",axesNames.get(0))
+ *
+ *   Bottle remoteControlBoards;
+ *   Bottle & remoteControlBoardsList = remoteControlBoards.addList();
+ *   remoteControlBoardsList.addString("/icub/torso");
+ *   remoteControlBoardsList.addString("/icub/head");
+ *   options.put("remoteControlBoards",remoteControlBoards.get(0));
+ *
+ *   options.put("localPortPrefix",/test");
+ *
+ *   // Actually open the device
+ *   PolyDriver robotDevice(options);
+ *
+ *   // Use it as  you would use any controlboard device
+ *   // ...
+ * \endcode
+ *
+ *
+ *
+ * \section Caveat
+ * By design, the RemoteControlBoardRemapper is more limited with respect to a true RemoteControlBoard.
+ * Known limitations include:
+ *   * If some axes belong to a coupled mechanics, all the axes should be added to the RemoteControlBoardRemapper.
+ *     If only an axis of a coupled mechanics is added to the remapper, the semantic of the coupled mechanics
+ *     in the underlyng implementation could create confusing behaviour. For example, changing the control mode
+ *     of an axis in a coupled mechanism could change the control mode of the other coupled axes, even if the
+ *     other coupled axes are not part of the remapped controlboard.
+ *   * The debug methods provided by IRemoteVariables are not supported by the RemoteControlBoardRemapper .
+ *
+ */
+
+class RemoteControlBoardRemapper : public ControlBoardRemapper
+{
+private:
+    /**
+     * List of remote_controlboard devices opened by the RemoteControlBoardRemapper device.
+     */
+    std::vector<PolyDriver*> m_remoteControlBoardDevices;
+
+
+    // Close all opened remote controlboards
+    void closeAllRemoteControlBoards();
+
+public:
+    /**
+    * Constructor.
+    */
+    RemoteControlBoardRemapper();
+
+    virtual ~RemoteControlBoardRemapper();
+
+    /**
+     * Default open() method.
+     * @return always false since initialization requires parameters.
+     */
+    virtual bool open() { return false; }
+
+   /**
+     * Open the device driver.
+     * @param prop is a Searchable object which contains the parameters.
+     * Allowed parameters are described in the class documentation.
+     */
+    virtual bool open(yarp::os::Searchable &prop);
+
+    /**
+     * Close the device driver by deallocating all resources and closing ports.
+     * @return true if successful or false otherwise.
+     */
+    virtual bool close();
+};
+
+}
+}
+
+#endif

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
@@ -29,9 +29,9 @@ namespace dev {
  * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | axesNames      |      -         | vector of strings  | -   |   -           | Yes          | Ordered list of the axes that are part of the remapped device.    |       |
- * | remoteControlBoards |     -      | vector of strings  | -   |   -           | Yes          | List of remote prefix used by the remote controlboards.           | The element of this list are then passed as "remote" parameter to the RemoteControlBoard device. |
+ * | remoteControlBoards |     -     | vector of strings  | -   |   -           | Yes          | List of remote prefix used by the remote controlboards.           | The element of this list are then passed as "remote" parameter to the RemoteControlBoard device. |
  * | localPortPrefix |     -         | string             | -   |   -           | Yes          | All ports opened by this device will start with this prefix       |       |
- *
+ * | REMOTE_CONTROLBOARD_OPTIONS | - | group              | -   |   -           | No           | Options that will be passed directly to the remote_controlboard devices | |
  * All the passed remote controlboards are opened, and then the axesNames and the opened device are
  * passed to the ControlBoardRemapper device. If different axes
  * in two attached controlboard have the same name, the behaviour of this device is undefined.
@@ -43,6 +43,10 @@ namespace dev {
  *  device remotecontrolboardremapper
  *  axesNames (torso_pitch torso_roll torso_yaw neck_pitch neck_roll neck_yaw)
  *  remoteControlBoards (/icub/torso /icub/head)
+ *
+ *  [REMOTE_CONTROLBOARD_OPTIONS]
+ *  writeStrict on
+ *  
  *
  * ...
  * \endcode

--- a/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
+++ b/src/libYARP_dev/src/modules/ControlBoardRemapper/RemoteControlBoardRemapper.h
@@ -46,7 +46,7 @@ namespace dev {
  *
  *  [REMOTE_CONTROLBOARD_OPTIONS]
  *  writeStrict on
- *  
+ *
  *
  * ...
  * \endcode
@@ -72,6 +72,9 @@ namespace dev {
  *   options.put("remoteControlBoards",remoteControlBoards.get(0));
  *
  *   options.put("localPortPrefix",/test");
+ *
+ *   Property & remoteControlBoardsOpts = options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
+ *   remoteControlBoardsOpts.put("writeStrict","on");
  *
  *   // Actually open the device
  *   PolyDriver robotDevice(options);

--- a/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/modules/RemoteControlBoard/RemoteControlBoard.cpp
@@ -253,7 +253,19 @@ YARP_DISABLE_DEPRECATED_WARNING
 /**
 * @ingroup dev_impl_wrapper
 *
-* The client side of the control board, connects to a ServerControlBoard.
+* The client side of the control board, connects to a remote controlboard using the YARP network.
+*
+* This device communicates using the YARP ports opened the yarp::dev::ControlBoardWrapper device
+* to use a device exposing controlboard method even from a different process (or even computer)
+* from the one that opened the controlboard device.
+*
+*  Parameters required by this device are:
+* | Parameter name | SubParameter   | Type    | Units | Default Value | Required     | Description                       | Notes |
+* |:--------------:|:--------------:|:-------:|:-----:|:-------------:|:-----------: |:---------------------------------:|:-----:|
+* | remote         |       -        | string  | -     |   -           | Yes          | Prefix of the port to which to connect.  |       |
+* | local          |       -        | string  | -     |   -           | Yes          | Port prefix of the port openend by this device.  |       |
+* | writeStrict    |       -        | string  | -     | See note      | No           |                                   |       |
+*
 */
 class yarp::dev::RemoteControlBoard :
     public IPidControl,

--- a/src/modules/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/modules/fakeMotionControl/fakeMotionControl.cpp
@@ -90,6 +90,41 @@ bool FakeMotionControl::extractGroup(Bottle &input, Bottle &out, const std::stri
     return true;
 }
 
+void FakeMotionControl::resizeBuffers()
+{
+    pos.resize(_njoints);
+    dpos.resize(_njoints);
+    vel.resize(_njoints);
+    speed.resize(_njoints);
+    acc.resize(_njoints);
+    loc.resize(_njoints);
+    amp.resize(_njoints);
+
+    current.resize(_njoints);
+    nominalCurrent.resize(_njoints);
+    maxCurrent.resize(_njoints);
+    peakCurrent.resize(_njoints);
+    pwm.resize(_njoints);
+    pwmLimit.resize(_njoints);
+    supplyVoltage.resize(_njoints);
+
+    pos.zero();
+    dpos.zero();
+    vel.zero();
+    speed.zero();
+    acc.zero();
+    loc.zero();
+    amp.zero();
+
+    current.zero();
+    nominalCurrent.zero();
+    maxCurrent.zero();
+    peakCurrent.zero();
+
+    pwm.zero();
+    pwmLimit.zero();
+    supplyVoltage.zero();
+}
 
 bool FakeMotionControl::alloc(int nj)
 {
@@ -155,7 +190,7 @@ bool FakeMotionControl::alloc(int nj)
     _calibrated = allocAndCheck<bool>(nj);
 //     _cacheImpedance = allocAndCheck<eOmc_impedance_t>(nj);
 
-    //debug purpose
+    resizeBuffers();
 
     return true;
 }
@@ -244,36 +279,8 @@ FakeMotionControl::FakeMotionControl() :
     verbose = VERY_VERBOSE;
     _njoints = 2;
     opened = false;
-    pos.resize(_njoints);
-    dpos.resize(_njoints);
-    vel.resize(_njoints);
-    speed.resize(_njoints);
-    acc.resize(_njoints);
-    loc.resize(_njoints);
-    amp.resize(_njoints);
 
-    current.resize(_njoints);
-    nominalCurrent.resize(_njoints);
-    maxCurrent.resize(_njoints);
-    peakCurrent.resize(_njoints);
-    pwm.resize(_njoints);
-    pwmLimit.resize(_njoints);
-    supplyVoltage.resize(_njoints);
-
-    pos.zero();
-    dpos.zero();
-    vel.zero();
-    speed.zero();
-    acc.zero();
-    loc.zero();
-    amp.zero();
-
-    current.zero();
-    maxCurrent.zero();
-    peakCurrent.zero();
-    pwm.zero();
-    pwmLimit.zero();
-    supplyVoltage.zero();
+    resizeBuffers();
 
     _controlModes = NULL;
     _interactMode = NULL;
@@ -1801,6 +1808,8 @@ bool FakeMotionControl::getEncodersRaw(double *encs)
 
 bool FakeMotionControl::getEncoderSpeedRaw(int j, double *sp)
 {
+    // To avoid returning uninitialized memory, we set the encoder speed to 0
+    *sp = 0.0;
     return true;
 }
 
@@ -1816,6 +1825,9 @@ bool FakeMotionControl::getEncoderSpeedsRaw(double *spds)
 
 bool FakeMotionControl::getEncoderAccelerationRaw(int j, double *acc)
 {
+    // To avoid returning uninitialized memory, we set the encoder acc to 0
+    *acc = 0.0;
+
     return true;
 }
 
@@ -1891,8 +1903,8 @@ bool FakeMotionControl::resetMotorEncodersRaw()
 
 bool FakeMotionControl::getMotorEncoderRaw(int m, double *value)
 {
-    bool ret = false;
-    return ret;
+    *value = 0.0;
+    return true;
 }
 
 bool FakeMotionControl::getMotorEncodersRaw(double *encs)
@@ -1908,6 +1920,7 @@ bool FakeMotionControl::getMotorEncodersRaw(double *encs)
 
 bool FakeMotionControl::getMotorEncoderSpeedRaw(int m, double *sp)
 {
+    *sp = 0.0;
     return true;
 }
 
@@ -1923,6 +1936,7 @@ bool FakeMotionControl::getMotorEncoderSpeedsRaw(double *spds)
 
 bool FakeMotionControl::getMotorEncoderAccelerationRaw(int m, double *acc)
 {
+    *acc = 0.0;
     return true;
 }
 

--- a/src/modules/fakeMotionControl/fakeMotionControl.h
+++ b/src/modules/fakeMotionControl/fakeMotionControl.h
@@ -236,7 +236,16 @@ public:
 
     virtual bool initialised();
 
+    /**
+     * Allocated buffers.
+     */
     bool alloc(int njoints);
+
+    /**
+     * Resize previously allocated buffers.
+     */
+    void resizeBuffers();
+
     bool init(void);
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.65

--- a/tests/libYARP_OS/PropertyTest.cpp
+++ b/tests/libYARP_OS/PropertyTest.cpp
@@ -607,6 +607,11 @@ check $x $y\n\
         psub.put("y",2);
         checkEqual(p.find("x").asInt(),1,"basic int");
         checkEqual(p.findGroup("psub").find("y").asInt(),2,"nested int");
+        Property pCopy = p;
+        checkEqual(pCopy.toString(),p.toString(),"test if addGroup works fine with Property copy assigment");
+        Property pCopy2;
+        pCopy2 = p;
+        checkEqual(pCopy.toString(),p.toString(),"test if addGroup works fine with Property copy operator");
     }
 
     virtual void runTests() {

--- a/tests/libYARP_dev/ControlBoardRemapperTest.cpp
+++ b/tests/libYARP_dev/ControlBoardRemapperTest.cpp
@@ -295,6 +295,8 @@ public:
 
         pRemoteRemapper.put("localPortPrefix","/test/remoteControlBoardRemapper");
 
+        Property & opts = pRemoteRemapper.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
+        opts.put("writeStrict","on");
 
         ok = ddRemoteRemapper.open(pRemoteRemapper);
         checkTrue(ok,"remotecontrolboardremapper open reported successful, testing it");

--- a/tests/libYARP_dev/ControlBoardRemapperTest.cpp
+++ b/tests/libYARP_dev/ControlBoardRemapperTest.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <yarp/os/impl/UnitTest.h>
+#include <yarp/os/Time.h>
 
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IControlMode2.h>
@@ -37,19 +38,142 @@ const char *fmcC_file_content   =  "device fakeMotionControl\n"
                                   "\n"
                                   "AxisName \"axisC1\" \"axisC2\" \"axisC3\" \"axisC4\"  \n";
 
+const char *wrapperA_file_content   = "device controlboardwrapper2\n"
+                                      "name /testRemapperRobot/a\n"
+                                      "period 10\n"
+                                      "networks (net_a)\n"
+                                      "joints 2\n"
+                                      "net_a 0 1 0 1\n";
+
+const char *wrapperB_file_content   = "device controlboardwrapper2\n"
+                                      "name /testRemapperRobot/b\n"
+                                      "period 10\n"
+                                      "networks (net_b)\n"
+                                      "joints 3\n"
+                                      "net_b 0 2 0 2\n";
+
+const char *wrapperC_file_content   = "device controlboardwrapper2\n"
+                                      "name /testRemapperRobot/c\n"
+                                      "period 10\n"
+                                      "networks (net_c)\n"
+                                      "joints 4\n"
+                                      "net_c 0 3 0 3\n";
+
+
+
+
 
 class ControlBoardRemapperTest : public UnitTest
 {
 public:
     virtual ConstString getName() { return "ControlBoardRemapperTest"; }
 
+    void checkRemapper(yarp::dev::PolyDriver & ddRemapper, int rand, size_t nrOfRemappedAxes)
+    {
+        IPositionControl2 *pos = NULL;
+        bool ok = ddRemapper.view(pos);
+        checkTrue(ok, "interface position correctly opened");
+        int axes = 0;
+        ok = pos->getAxes(&axes);
+        checkTrue(ok, "getAxes returned correctly");
+        checkEqual(axes, nrOfRemappedAxes, "remapper seems functional");
+
+        IPositionDirect *posdir = 0;
+        ok = ddRemapper.view(posdir);
+        checkTrue(ok, "direct position interface correctly opened");
+
+        IEncoders * encs = 0;
+        ok = ddRemapper.view(encs);
+        checkTrue(ok, "encoders interface correctly opened");
+
+        IControlMode2 *ctrlmode = NULL;
+        ok = ddRemapper.view(ctrlmode);
+        checkTrue(ok, "control mode interface correctly opened");
+
+        // Vector used for setting/getting data from the controlboard
+        std::vector<double> setPosition(nrOfRemappedAxes,-10),
+                            setRefSpeeds(nrOfRemappedAxes,-15),
+                            readedPosition(nrOfRemappedAxes,-20),
+                            readedEncoders(nrOfRemappedAxes,-30);
+
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            setPosition[i]  = i*100.0+50.0 + rand;
+            setRefSpeeds[i] = i*10.0+5 + rand;
+            readedPosition[i] = -100 + rand;
+        }
+
+        // Set the control mode in position direct
+        std::vector<int>    settedControlMode(nrOfRemappedAxes,VOCAB_CM_POSITION_DIRECT);
+        std::vector<int>    readedControlMode(nrOfRemappedAxes,VOCAB_CM_POSITION);
+
+        ok = ctrlmode->setControlModes(settedControlMode.data());
+        checkTrue(ok, "setControlModes correctly called");
+
+        // Check that the readed control mode is actually position direct
+        // Let's try 10 times because if the remapper is using some remotecontrolboards,
+        // it is possible that this return false if it is called before the first message
+        // has been received from the controlboardwrapper
+        ok = false;
+        for(int wait=0; wait < 10 && !ok; wait++)
+        {
+            ok = ctrlmode->getControlModes(readedControlMode.data());
+            yarp::os::Time::delay(0.001);
+        }
+
+        checkTrue(ok, "getControlModes correctly called");
+
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            checkEqual(settedControlMode[i],readedControlMode[i],"Setted control mode and readed control mode match");
+        }
+
+        // Test position direct methods
+
+        // Set position
+        ok = posdir->setPositions(setPosition.data());
+        checkTrue(ok, "setPositions correctly called");
+
+        // Set also the speeds in the mean time, so we are sure that we don't get
+        // spurios successful set/get of position because of intermediate buffers
+        ok = pos->setRefSpeeds(setRefSpeeds.data());
+        checkTrue(ok, "setRefSpeeds correctly called");
+
+        // Wait some time to make sure that the vector has been correctly propagated
+        // back and forth
+        yarp::os::Time::delay(0.1);
+
+        // Read position
+        ok = posdir->getRefPositions(readedPosition.data());
+        checkTrue(ok, "getRefPositions correctly called");
+
+        // Check that the two vector match
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            checkEqual(setPosition[i],readedPosition[i],"Setted position and readed ref position match");
+        }
+
+        // Do a similar test for the encoders
+        // in fakeMotionControl their value is the one setted with setPosition
+        ok = encs->getEncoders(readedEncoders.data());
+        checkTrue(ok, "getEncoders correctly called");
+
+        // Check that the two vector match
+        for(size_t i=0; i < nrOfRemappedAxes; i++)
+        {
+            checkEqual(setPosition[i],readedEncoders[i],"Setted position and readed encoders match");
+        }
+    }
+
     void testControlBoardRemapper() {
         report(0,"\ntest the controlboard remapper");
 
-        // We first allocate three fakeMotionControl boards,
-        // that we will remap using the remapper
+        // We first allocate three fakeMotionControl boards
+        // and their wrappers that we will remap using the remapper
         std::vector<PolyDriver *> fmcbs;
+        std::vector<PolyDriver *> wrappers;
         fmcbs.resize(3);
+        wrappers.resize(3);
 
         std::vector<int> fmcbsSizes;
         fmcbsSizes.push_back(2);
@@ -60,6 +184,11 @@ public:
         fmcbsNames.push_back("fakeControlBoardA");
         fmcbsNames.push_back("fakeControlBoardB");
         fmcbsNames.push_back("fakeControlBoardC");
+
+        std::vector<std::string> wrapperNetworks;
+        wrapperNetworks.push_back("net_a");
+        wrapperNetworks.push_back("net_b");
+        wrapperNetworks.push_back("net_c");
 
 
         for(int i=0; i < 3; i++)
@@ -76,6 +205,7 @@ public:
             result = fmcbs[i]->open(p);
             checkTrue(result, "fakeMotionControlBoard open reported successful");
 
+
             if(result)
             {
                 IPositionControl *pos = NULL;
@@ -85,8 +215,29 @@ public:
                 pos->getAxes(&axes);
                 checkEqual(axes, fmcbsSizes[i], "fakeMotionControlBoard seems functional");
             }
+
+            // Open the wrapper
+            wrappers[i] = new PolyDriver();
+
+            if(i==0) { p.fromConfig(wrapperA_file_content); }
+            if(i==1) { p.fromConfig(wrapperB_file_content); }
+            if(i==2) { p.fromConfig(wrapperC_file_content); }
+
+            result = wrappers[i]->open(p);
+            checkTrue(result, "controlboardwrapper2 open reported successful");
+
+            yarp::dev::IMultipleWrapper *iwrap = 0;
+            result = wrappers[i]->view(iwrap);
+            checkTrue(result, "interface for multiple wrapper correctly opened for the controlboardwrapper2");
+
+            PolyDriverList pdList;
+            pdList.push(fmcbs[i],wrapperNetworks[i].c_str());
+
+            result = iwrap->attachAll(pdList);
+            checkTrue(result, "controlboardwrapper2 attached successfully to the device");
         }
 
+        // Open the controlboardremapper
         PolyDriver ddRemapper;
         Property pRemapper;
         pRemapper.put("device","controlboardremapper");
@@ -117,99 +268,54 @@ public:
 
         ok = imultwrap->attachAll(fmcList);
 
-        checkTrue(ok, "attachAll successful");
+        checkTrue(ok, "attachAll for controlboardremapper successful");
 
-        IPositionControl2 *pos = NULL;
-        ok = ddRemapper.view(pos);
-        checkTrue(ok, "interface position correctly opened");
-        int axes = 0;
-        ok = pos->getAxes(&axes);
-        checkTrue(ok, "getAxes returned correctly");
-        checkEqual(axes, 6, "remapper seems functional");
+        // Test the controlboardremapper
+        checkRemapper(ddRemapper,200,nrOfRemappedAxes);
 
-        IPositionDirect *posdir = 0;
-        ok = ddRemapper.view(posdir);
-        checkTrue(ok, "direct position interface correctly opened");
+        // Open the remotecontrolboardremapper
+        PolyDriver ddRemoteRemapper;
+        Property pRemoteRemapper;
+        pRemoteRemapper.put("device","remotecontrolboardremapper");
+        pRemoteRemapper.addGroup("axesNames");
+        Bottle & remoteAxesList = pRemoteRemapper.findGroup("axesNames").addList();
+        remoteAxesList.addString("axisA1");
+        remoteAxesList.addString("axisB1");
+        remoteAxesList.addString("axisC1");
+        remoteAxesList.addString("axisB3");
+        remoteAxesList.addString("axisC3");
+        remoteAxesList.addString("axisA2");
 
-        IEncoders * encs = 0;
-        ok = ddRemapper.view(encs);
-        checkTrue(ok, "encoders interface correctly opened");
+        Bottle remoteControlBoards;
+        Bottle & remoteControlBoardsList = remoteControlBoards.addList();
+        remoteControlBoardsList.addString("/testRemapperRobot/a");
+        remoteControlBoardsList.addString("/testRemapperRobot/b");
+        remoteControlBoardsList.addString("/testRemapperRobot/c");
+        pRemoteRemapper.put("remoteControlBoards",remoteControlBoards.get(0));
 
-        IControlMode2 *ctrlmode = NULL;
-        ok = ddRemapper.view(ctrlmode);
-        checkTrue(ok, "control mode interface correctly opened");
-
-        // Vector used for setting/getting data from the controlboard
-        std::vector<double> setPosition(nrOfRemappedAxes,-10),
-                            setRefSpeeds(nrOfRemappedAxes,-15),
-                            readedPosition(nrOfRemappedAxes,-20),
-                            readedEncoders(nrOfRemappedAxes,-30);
-
-        for(size_t i=0; i < nrOfRemappedAxes; i++)
-        {
-            setPosition[i]  = i*100.0+50.0;
-            setRefSpeeds[i] = i*10.0+5;
-            readedPosition[i] = -100;
-        }
-
-        // Set the control mode in position direct
-        std::vector<int>    settedControlMode(nrOfRemappedAxes,VOCAB_CM_POSITION_DIRECT);
-        std::vector<int>    readedControlMode(nrOfRemappedAxes,VOCAB_CM_POSITION);
-
-        ok = ctrlmode->setControlModes(settedControlMode.data());
-        checkTrue(ok, "setControlModes correctly called");
-
-        // Check that the readed control mode is actually position direct
-        ok = ctrlmode->getControlModes(readedControlMode.data());
-        checkTrue(ok, "getControlModes correctly called");
-
-        for(size_t i=0; i < nrOfRemappedAxes; i++)
-        {
-            checkEqual(settedControlMode[i],readedControlMode[i],"Setted control mode and readed control mode match");
-        }
-
-        // Test position direct methods
-
-        // Set position
-        ok = posdir->setPositions(setPosition.data());
-        checkTrue(ok, "setPositions correctly called");
-
-        // Set also the speeds in the mean time, so we are sure that we don't get
-        // spurios successful set/get of position because of intermediate buffers
-        ok = pos->setRefSpeeds(setRefSpeeds.data());
-        checkTrue(ok, "setRefSpeeds correctly called");
-
-        // Read position
-        ok = posdir->getRefPositions(readedPosition.data());
-        checkTrue(ok, "getRefPositions correctly called");
+        pRemoteRemapper.put("localPortPrefix","/test/remoteControlBoardRemapper");
 
 
-        // Check that the two vector match
-        for(size_t i=0; i < nrOfRemappedAxes; i++)
-        {
-            checkEqual(setPosition[i],readedPosition[i],"Setted position and readed ref position match");
-        }
+        ok = ddRemoteRemapper.open(pRemoteRemapper);
+        checkTrue(ok,"remotecontrolboardremapper open reported successful, testing it");
 
-        // Do a similar test for the encoders
-        // in fakeMotionControl their value is the one setted with setPosition
-        ok = encs->getEncoders(readedEncoders.data());
-        checkTrue(ok, "getEncoders correctly called");
-
-        // Check that the two vector match
-        for(size_t i=0; i < nrOfRemappedAxes; i++)
-        {
-            checkEqual(setPosition[i],readedEncoders[i],"Setted position and readed encoders match");
-        }
-
+        // Test the remotecontrolboardremapper
+        checkRemapper(ddRemoteRemapper,100,nrOfRemappedAxes);
 
         // Close devices
         imultwrap->detachAll();
         ddRemapper.close();
+        ddRemoteRemapper.close();
 
         for(int i=0; i < 3; i++)
         {
+            wrappers[i]->close();
+            delete wrappers[i];
+            wrappers[i] = 0;
+
             fmcbs[i]->close();
             delete fmcbs[i];
+            fmcbs[i] = 0;
         }
     }
 


### PR DESCRIPTION
Add the new `remotecontrolboardremapper` device, rationale for its use can be found in the class documentation https://github.com/robotology/yarp/compare/devel...traversaro:RemoteControlBoardRemapper?expand=1#diff-2ce8be34020e8c21cfd98d56050157a4R22 and in https://github.com/robotology/yarp/pull/746 .

Tests of the `controlboardremapper` device have been modified to test also the `remotecontorlboardmapper`  . 

Documentation of the `remote_controlboard` has been also added for consistency : https://github.com/robotology/yarp/commit/f5e88f2b1c7be0862f747f9d9ba68635d92dad53 .
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-238487668%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-238822697%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-238943211%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-239009277%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-239384104%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-239391500%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-239406262%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-240053949%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-240054398%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-240054909%22%2C%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-240055002%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/861%23issuecomment-238487668%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20are%20various%20compilation%20failures%20in%20Travis%2C%20but%20apparently%20they%20also%20%20occur%20in%20the%20%60master%60/%60devel%60%20branches%2C%20so%20they%20are%20not%20directly%20related%20to%20this%20PR.%20%22%2C%20%22created_at%22%3A%20%222016-08-09T08%3A29%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40traversaro%20the%20build%20should%20be%20fixed%2C%20can%20you%20please%20rebase%20the%20branch%3F%22%2C%20%22created_at%22%3A%20%222016-08-10T10%3A05%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60Valgrind%60%20build%20on%20Travis%20catched%20a%20valid%20leak%2C%20apparently%3A%20https%3A//travis-ci.org/traversaro/yarp/jobs/151172548%20%20.%20%22%2C%20%22created_at%22%3A%20%222016-08-10T17%3A36%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22Finally%20Valgrind%20tests%20were%20useful%21%20%3Atada%3A%22%2C%20%22created_at%22%3A%20%222016-08-10T21%3A24%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Debugging%20the%20issue%20on%20%60Ubuntu%2016.04%60%20rather%20then%20%60Ubuntu%2014.04%60%20used%20in%20%60Travis%60%2C%20I%20got%20the%20following%20leaks%3A%20%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%3D%3D17000%3D%3D%20HEAP%20SUMMARY%3A%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20%20in%20use%20at%20exit%3A%2072%2C736%20bytes%20in%202%20blocks%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20total%20heap%20usage%3A%20658%2C430%20allocs%2C%20658%2C428%20frees%2C%20119%2C016%2C174%20bytes%20allocated%5Cr%5Cn%3D%3D17000%3D%3D%20%5Cr%5Cn%3D%3D17000%3D%3D%20Thread%201%3A%5Cr%5Cn%3D%3D17000%3D%3D%2032%20bytes%20in%201%20blocks%20are%20still%20reachable%20in%20loss%20record%201%20of%202%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20at%200x4C2FB55%3A%20calloc%20%28in%20/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x7A5C626%3A%20_dlerror_run%20%28/build/glibc-GKVZIf/glibc-2.23/dlfcn/dlerror.c%3A141%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x7A5BFA0%3A%20dlopen%40%40GLIBC_2.2.5%20%28/build/glibc-GKVZIf/glibc-2.23/dlfcn/dlopen.c%3A87%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x67A24EB%3A%20ACE_DLL_Handle%3A%3Aopen%28char%20const%2A%2C%20int%2C%20void%2A%2C%20ACE_Fixed_Stack%3CACE_String_Base%3Cchar%3E%2C%2010ul%3E%2A%29%20%28in%20/usr/lib/libACE-6.3.3.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x67A2A57%3A%20ACE_DLL_Manager%3A%3Aopen_dll%28char%20const%2A%2C%20int%2C%20void%2A%2C%20ACE_Fixed_Stack%3CACE_String_Base%3Cchar%3E%2C%2010ul%3E%2A%29%20%28in%20/usr/lib/libACE-6.3.3.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x67604EA%3A%20ACE_DLL%3A%3Aopen_i%28char%20const%2A%2C%20int%2C%20bool%2C%20void%2A%29%20%28in%20/usr/lib/libACE-6.3.3.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x5AE164C%3A%20yarp%3A%3Aos%3A%3ASharedLibrary%3A%3Aopen%28char%20const%2A%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x5AE1E09%3A%20yarp%3A%3Aos%3A%3ASharedLibraryFactory%3A%3Aopen%28char%20const%2A%2C%20char%20const%2A%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x5AFB245%3A%20yarp%3A%3Aos%3A%3AYarpPluginSettings%3A%3Asubopen%28yarp%3A%3Aos%3A%3ASharedLibraryFactory%26%2C%20yarp%3A%3Aos%3A%3AConstString%20const%26%2C%20yarp%3A%3Aos%3A%3AConstString%20const%26%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x5AFCB00%3A%20yarp%3A%3Aos%3A%3AYarpPluginSettings%3A%3Aopen%28yarp%3A%3Aos%3A%3ASharedLibraryFactory%26%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x4F24CAF%3A%20DriversHelper%3A%3Aload%28char%20const%2A%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_dev.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x4F26074%3A%20yarp%3A%3Adev%3A%3ADrivers%3A%3Afind%28char%20const%2A%29%20%28in%20/home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_dev.so.2.3.67.1%29%5Cr%5Cn%3D%3D17000%3D%3D%20%5Cr%5Cn%3D%3D17000%3D%3D%2072%2C704%20bytes%20in%201%20blocks%20are%20still%20reachable%20in%20loss%20record%202%20of%202%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20at%200x4C2DB8F%3A%20malloc%20%28in%20/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x5DF8EFF%3A%20%3F%3F%3F%20%28in%20/usr/lib/x86_64-linux-gnu/libstdc%2B%2B.so.6.0.21%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x40104E9%3A%20call_init.part.0%20%28/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c%3A72%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x40105FA%3A%20call_init%20%28/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c%3A30%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x40105FA%3A%20_dl_init%20%28/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c%3A120%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x4000CF9%3A%20%3F%3F%3F%20%28in%20/lib/x86_64-linux-gnu/ld-2.23.so%29%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200x3%3A%20%3F%3F%3F%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200xFFEFFFFAA%3A%20%3F%3F%3F%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200xFFEFFFFF5%3A%20%3F%3F%3F%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200xFFEFFFFFD%3A%20%3F%3F%3F%5Cr%5Cn%3D%3D17000%3D%3D%20%20%20%20by%200xFFF000008%3A%20%3F%3F%3F%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%5Cr%5Cn%23%23%2032%20bytes%20%5C%22leak%5C%22%5Cr%5CnThe%2032%20bytes%20leaks%20is%20probably%20the%20one%20detected%20by%20Travis.%20This%20is%20a%20known%20bug%20in%20%60dlopen%60%2C%20see%20for%20example%20%5B2%5D.%20On%20debian%20system%20a%20suppression%20for%20this%20error%20can%20be%20found%20in%20%60/usr/lib/valgrind/debian.supp%60%2C%20but%20that%20suppression%20files%20is%20not%20used%20by%20default%2C%20as%20the%20only%20file%20that%20is%20used%20by%20default%20by%20valgrind%20is%20%60/usr/lib/valgrind/default.supp%60.%20%5Cr%5Cn%5Cr%5Cn%23%23%2072%2C704%20bytes%20%5C%22leak%5C%22%5Cr%5CnThe%2072%2C704%20loss%20record%20is%20a%20known%20area%20of%20memory%20that%20is%20not%20freed%20in%20gcc%205.1.%20%5B1%5D%5Cr%5Cn%23%23%20Proposed%20solution%5Cr%5CnI%20think%20it%20make%20sense%20to%20add%20it%20to%20a%20YARP-specific%20Valgrind%20suppression%20file%20to%20suppress%20this%20errors.%20%5Cr%5Cn%40drdanz%20what%20do%20you%20think%3F%20If%20you%20give%20me%20the%20green%20light%20on%20this%20I%20can%20add%20it%20and%20integrate%20it%20with%20CMake%20test%20logic.%20%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5B1%5D%20%3A%20https%3A//gcc.gnu.org/bugzilla/show_bug.cgi%3Fid%3D68704%5Cr%5Cn%5B2%5D%20%3A%20https%3A//bugs.debian.org/cgi-bin/bugreport.cgi%3Fbug%3D700899%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-12T07%3A55%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22Even%20by%20suppressing%20the%20leak%20errors%2C%20I%20still%20have%20problem%20of%20not%20initialized%20memory.%20%5Cr%5CnTo%20clarify%20%3A%20all%20this%20issues%20have%20not%20been%20introduced%20by%20this%20PR%2C%20but%20this%20PR%20introduces%20a%20test%20that%20for%20the%20first%20time%20tests%20the%20%60RemoteControlBoard%60%20and%20the%20%60ControlBoardWrapper%60%20classes%2C%20and%20all%20the%20code%20that%20they%20use.%20%22%2C%20%22created_at%22%3A%20%222016-08-12T08%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20turns%20out%20that%20the%20actual%20problem%20reported%20by%20Valgrind%20was%20a%20problem%20of%20not%20initialized%20memory%20in%20%60fakeMotionControl%60%2C%20solved%20in%20%20https%3A//github.com/robotology/yarp/pull/861/commits/403683f0cc4bcd647a3c6d67d4f5818b851371be%20.%20%20%5Cr%5Cn%5Cr%5CnThe%20leaks%20reported%20by%20Valgrind%20are%20not%20considered%20%5C%22errors%5C%22%2C%20so%20the%20test%20are%20working%20fine%2C%20i.e.%20we%20don%27t%20need%20the%20suppression%20file.%20Given%20that%20I%20wrote%20it%2C%20I%20will%20copy%20and%20paste%20it%20here%20in%20case%20someone%20ever%20needs%20it%3A%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%23%20Valgrind%20suppression%20file%20for%20YARP%5Cr%5Cn%23%20Useful%20to%20suppress%20Valgrind%20errors%20related%20to%20bugs%20in%20third-party%20projects%5Cr%5Cn%5Cr%5Cn%23%20See%20https%3A//bugs.debian.org/cgi-bin/bugreport.cgi%3Fbug%3D700899%5Cr%5Cn%7B%5Cr%5Cn%20%20dlopen%28%29%20with%20-lpthread%20see%20https%3A//bugs.debian.org/cgi-bin/bugreport.cgi%3Fbug%3D700899%5Cr%5Cn%20%20Memcheck%3ALeak%5Cr%5Cn%20%20fun%3Acalloc%5Cr%5Cn%20%20fun%3A_dlerror_run%5Cr%5Cn%20%20fun%3Adlopen%40%40GLIBC_2.2.5%5Cr%5Cn%7D%5Cr%5Cn%5Cr%5Cn%23%20See%20%20https%3A//gcc.gnu.org/bugzilla/show_bug.cgi%3Fid%3D68704%5Cr%5Cn%7B%5Cr%5Cn%20%20%20gcc%20not%20freed%20buffer%20see%20https%3A//gcc.gnu.org/bugzilla/show_bug.cgi%3Fid%3D68704%5Cr%5Cn%20%20%20Memcheck%3ALeak%5Cr%5Cn%20%20%20match-leak-kinds%3A%20reachable%5Cr%5Cn%20%20%20fun%3Amalloc%5Cr%5Cn%20%20%20obj%3A/usr/lib/x86_64-linux-gnu/libstdc%2B%2B.so.6.0.21%5Cr%5Cn%20%20%20fun%3Acall_init.part.0%5Cr%5Cn%20%20%20fun%3Acall_init%5Cr%5Cn%20%20%20fun%3A_dl_init%5Cr%5Cn%20%20%20obj%3A/lib/x86_64-linux-gnu/ld-2.23.so%5Cr%5Cn%20%20%20obj%3A%2A%5Cr%5Cn%20%20%20obj%3A%2A%5Cr%5Cn%20%20%20obj%3A%2A%5Cr%5Cn%20%20%20obj%3A%2A%5Cr%5Cn%20%20%20obj%3A%2A%5Cr%5Cn%7D%5Cr%5Cn%7E%7E%7E%22%2C%20%22created_at%22%3A%20%222016-08-12T09%3A49%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-16T09%3A36%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-08-16T09%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20I%20merge%3F%22%2C%20%22created_at%22%3A%20%222016-08-16T09%3A40%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%2C%20I%27ll%20go%20on%20and%20merge%20this%2C%20even%20if%20I%27m%20not%20a%20%60YARP_dev%60%20expert%2C%20since%20everyone%20is%20on%20holiday...%22%2C%20%22created_at%22%3A%20%222016-08-16T09%3A40%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/drdanz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/drdanz'><img src='https://avatars.githubusercontent.com/u/1100056?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/861#issuecomment-238487668'>General Comment</a></b>
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> There are various compilation failures in Travis, but apparently they also  occur in the `master`/`devel` branches, so they are not directly related to this PR.
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @traversaro the build should be fixed, can you please rebase the branch?
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> `Valgrind` build on Travis catched a valid leak, apparently: https://travis-ci.org/traversaro/yarp/jobs/151172548  .
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Finally Valgrind tests were useful! :tada:
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Debugging the issue on `Ubuntu 16.04` rather then `Ubuntu 14.04` used in `Travis`, I got the following leaks:
~~~
==17000== HEAP SUMMARY:
==17000==     in use at exit: 72,736 bytes in 2 blocks
==17000==   total heap usage: 658,430 allocs, 658,428 frees, 119,016,174 bytes allocated
==17000==
==17000== Thread 1:
==17000== 32 bytes in 1 blocks are still reachable in loss record 1 of 2
==17000==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17000==    by 0x7A5C626: _dlerror_run (/build/glibc-GKVZIf/glibc-2.23/dlfcn/dlerror.c:141)
==17000==    by 0x7A5BFA0: dlopen@@GLIBC_2.2.5 (/build/glibc-GKVZIf/glibc-2.23/dlfcn/dlopen.c:87)
==17000==    by 0x67A24EB: ACE_DLL_Handle::open(char const*, int, void*, ACE_Fixed_Stack<ACE_String_Base<char>, 10ul>*) (in /usr/lib/libACE-6.3.3.so)
==17000==    by 0x67A2A57: ACE_DLL_Manager::open_dll(char const*, int, void*, ACE_Fixed_Stack<ACE_String_Base<char>, 10ul>*) (in /usr/lib/libACE-6.3.3.so)
==17000==    by 0x67604EA: ACE_DLL::open_i(char const*, int, bool, void*) (in /usr/lib/libACE-6.3.3.so)
==17000==    by 0x5AE164C: yarp::os::SharedLibrary::open(char const*) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1)
==17000==    by 0x5AE1E09: yarp::os::SharedLibraryFactory::open(char const*, char const*) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1)
==17000==    by 0x5AFB245: yarp::os::YarpPluginSettings::subopen(yarp::os::SharedLibraryFactory&, yarp::os::ConstString const&, yarp::os::ConstString const&) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1)
==17000==    by 0x5AFCB00: yarp::os::YarpPluginSettings::open(yarp::os::SharedLibraryFactory&) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_OS.so.2.3.67.1)
==17000==    by 0x4F24CAF: DriversHelper::load(char const*) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_dev.so.2.3.67.1)
==17000==    by 0x4F26074: yarp::dev::Drivers::find(char const*) (in /home/traversaro/src/codyco-superbuild/build/external/YARP/lib/libYARP_dev.so.2.3.67.1)
==17000==
==17000== 72,704 bytes in 1 blocks are still reachable in loss record 2 of 2
==17000==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17000==    by 0x5DF8EFF: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==17000==    by 0x40104E9: call_init.part.0 (/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c:72)
==17000==    by 0x40105FA: call_init (/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c:30)
==17000==    by 0x40105FA: _dl_init (/build/glibc-GKVZIf/glibc-2.23/elf/dl-init.c:120)
==17000==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==17000==    by 0x3: ???
==17000==    by 0xFFEFFFFAA: ???
==17000==    by 0xFFEFFFFF5: ???
==17000==    by 0xFFEFFFFFD: ???
==17000==    by 0xFFF000008: ???
~~~
## 32 bytes "leak"
The 32 bytes leaks is probably the one detected by Travis. This is a known bug in `dlopen`, see for example [2]. On debian system a suppression for this error can be found in `/usr/lib/valgrind/debian.supp`, but that suppression files is not used by default, as the only file that is used by default by valgrind is `/usr/lib/valgrind/default.supp`.
## 72,704 bytes "leak"
The 72,704 loss record is a known area of memory that is not freed in gcc 5.1. [1]
## Proposed solution
I think it make sense to add it to a YARP-specific Valgrind suppression file to suppress this errors.
@drdanz what do you think? If you give me the green light on this I can add it and integrate it with CMake test logic.
[1] : https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68704
[2] : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Even by suppressing the leak errors, I still have problem of not initialized memory.
To clarify : all this issues have not been introduced by this PR, but this PR introduces a test that for the first time tests the `RemoteControlBoard` and the `ControlBoardWrapper` classes, and all the code that they use.
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> It turns out that the actual problem reported by Valgrind was a problem of not initialized memory in `fakeMotionControl`, solved in  https://github.com/robotology/yarp/pull/861/commits/403683f0cc4bcd647a3c6d67d4f5818b851371be .
The leaks reported by Valgrind are not considered "errors", so the test are working fine, i.e. we don't need the suppression file. Given that I wrote it, I will copy and paste it here in case someone ever needs it:
~~~
# Valgrind suppression file for YARP
# Useful to suppress Valgrind errors related to bugs in third-party projects
# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
{
dlopen() with -lpthread see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
Memcheck:Leak
fun:calloc
fun:_dlerror_run
fun:dlopen@@GLIBC_2.2.5
}
# See  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68704
{
gcc not freed buffer see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68704
Memcheck:Leak
match-leak-kinds: reachable
fun:malloc
obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
fun:call_init.part.0
fun:call_init
fun:_dl_init
obj:/lib/x86_64-linux-gnu/ld-2.23.so
obj:*
obj:*
obj:*
obj:*
obj:*
}
~~~
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Can I merge?
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> LGTM, I'll go on and merge this, even if I'm not a `YARP_dev` expert, since everyone is on holiday...


<a href='https://www.codereviewhub.com/robotology/yarp/pull/861?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/861?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/861?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/861'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>