### PR TITLE
Fix UDP and MCAST on macOS

### DIFF
--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -28,7 +28,7 @@ Bug Fixes
 * Fixed bug in `yarprun` currently occuring only on macOS, but potentially on
   other platforms (#633)
 * `yarp plugin` command now works with `SKIP_ACE` enabled.
-
+* Fixed UDP and MCAST on macOS (#637)
 
 ### YARP_DEV
 

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -489,7 +489,12 @@ bool DgramTwoWayStream::openMcast(const Contact& group,
     localHandle = ACE_INET_Addr((u_short)(localAddress.getPort()),
                                 (ACE_UINT32)INADDR_ANY);
 
-    ACE_SOCK_Dgram_Mcast *dmcast = new ACE_SOCK_Dgram_Mcast;
+    ACE_SOCK_Dgram_Mcast::options mcastOptions = ACE_SOCK_Dgram_Mcast::DEFOPTS;
+#ifdef __APPLE__
+    mcastOptions = static_cast<ACE_SOCK_Dgram_Mcast::options>(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO | ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
+#endif
+
+    ACE_SOCK_Dgram_Mcast *dmcast = new ACE_SOCK_Dgram_Mcast(mcastOptions);
     dgram = dmcast;
     mgram = dmcast;
     yAssert(dgram!=NULL);
@@ -544,9 +549,13 @@ bool DgramTwoWayStream::join(const Contact& group, bool sender,
         //return;
     }
 
-    ACE_SOCK_Dgram_Mcast *dmcast = new ACE_SOCK_Dgram_Mcast;
 
-    //possible flags: ((ACE_SOCK_Dgram_Mcast::options)(ACE_SOCK_Dgram_Mcast::OPT_NULLIFACE_ALL | ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_YES));
+    ACE_SOCK_Dgram_Mcast::options mcastOptions = ACE_SOCK_Dgram_Mcast::DEFOPTS;
+#ifdef __APPLE__
+    mcastOptions = static_cast<ACE_SOCK_Dgram_Mcast::options>(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO | ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
+#endif
+
+    ACE_SOCK_Dgram_Mcast *dmcast = new ACE_SOCK_Dgram_Mcast(mcastOptions);
 
     dgram = dmcast;
     mgram = dmcast;

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -33,6 +33,8 @@
 #endif
 
 #include <yarp/os/Time.h>
+#include <cerrno>
+#include <cstring>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -173,6 +175,95 @@ bool DgramTwoWayStream::open(const Contact& local, const Contact& remote) {
 }
 
 void DgramTwoWayStream::allocate(int readSize, int writeSize) {
+#ifdef __APPLE__
+    //These are only as another default. We should modify the method to return bool
+    //and fail if we cannot read the socket size.
+    
+    int _read_size = READ_SIZE+CRC_SIZE;
+    int _write_size = WRITE_SIZE+CRC_SIZE;
+
+    int socketSendBufferSize = -1;
+    int socketRecvBufferSize = -1;
+
+#ifdef YARP_HAS_ACE
+    //Defaults to socket size
+    if (dgram) {
+        int len = sizeof(_read_size);
+        int result = dgram->get_option(SOL_SOCKET, SO_SNDBUF, &_write_size, &len);
+        if (result < 0) {
+            YARP_ERROR(Logger::get(), String("Failed to read buffer size from SNDBUF socket with error: ") +
+                       String(strerror(errno)));
+        }
+        socketSendBufferSize = _write_size;
+
+        result = dgram->get_option(SOL_SOCKET, SO_RCVBUF, &_read_size, &len);
+        if (result < 0) {
+            YARP_ERROR(Logger::get(), String("Failed to read buffer size from RCVBUF socket with error: ") +
+                       String(strerror(errno)));
+        }
+        socketRecvBufferSize = _read_size;
+    }
+#else
+    socklen_t len = sizeof(_read_size);
+    int result = getsockopt(dgram_sockfd, SOL_SOCKET, SO_SNDBUF, &_write_size, &len);
+    if (result < 0) {
+        YARP_ERROR(Logger::get(), String("Failed to read buffer size from SNDBUF socket with error: ") +
+                   String(strerror(errno)));
+    }
+    socketSendBufferSize = _write_size;
+
+    result = getsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF, &_read_size, &len);
+    if (result < 0) {
+        YARP_ERROR(Logger::get(), String("Failed to read buffer size from RCVBUF socket with error: ") +
+                   String(strerror(errno)));
+    }
+    socketRecvBufferSize = _read_size;
+#endif
+
+    ConstString _env_dgram = NetworkBase::getEnvironment("YARP_DGRAM_SIZE");
+    ConstString _env_mode = "";
+    if (multiMode) {
+        _env_mode = NetworkBase::getEnvironment("YARP_MCAST_SIZE");
+    } else {
+        _env_mode = NetworkBase::getEnvironment("YARP_UDP_SIZE");
+    }
+    if ( _env_mode!="") {
+        _env_dgram = _env_mode;
+    }
+    if (_env_dgram!="") {
+        int sz = NetType::toInt(_env_dgram);
+        if (sz!=0) {
+            _read_size = _write_size = sz;
+        }
+        YARP_INFO(Logger::get(),String("Datagram packet size set to ") +
+                  NetType::toString(_read_size));
+    }
+    if (readSize!=0) {
+        _read_size = readSize;
+        YARP_INFO(Logger::get(),String("Datagram read size reset to ") +
+                  NetType::toString(_read_size));
+    }
+    if (writeSize!=0) {
+        _write_size = writeSize;
+        YARP_INFO(Logger::get(),String("Datagram write size reset to ") +
+                  NetType::toString(_write_size));
+    }
+    readBuffer.allocate(_read_size);
+    writeBuffer.allocate(_write_size);
+    readAt = 0;
+    readAvail = 0;
+    writeAvail = CRC_SIZE;
+    //happy = true;
+    pct = 0;
+
+    if (_read_size < socketRecvBufferSize && socketRecvBufferSize != -1) {
+        YARP_WARN(Logger::get(), "RECV buffer size smaller than socket RECV size. Errors can occur during reading");
+    }
+    if (_write_size > socketSendBufferSize && socketSendBufferSize != -1) {
+        YARP_WARN(Logger::get(), "SND buffer size bigger than socket SND size. Errors can occur during writing");
+    }
+
+#else
     int _read_size = READ_SIZE+CRC_SIZE;
     int _write_size = WRITE_SIZE+CRC_SIZE;
 
@@ -211,10 +302,83 @@ void DgramTwoWayStream::allocate(int readSize, int writeSize) {
     writeAvail = CRC_SIZE;
     //happy = true;
     pct = 0;
+#endif
 }
 
 
 void DgramTwoWayStream::configureSystemBuffers() {
+#ifdef __APPLE__
+    //By default use system buffer size.
+    //These can be overwritten by environment variables
+    //Generic variable
+    ConstString socketBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
+    //Specific read
+    ConstString socketReadBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_RECV_BUFFER_SIZE");
+    //Specific write
+    ConstString socketSendBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_SND_BUFFER_SIZE");
+
+    int readBufferSize = -1;
+    if (socketReadBufferSize != "") {
+        readBufferSize = NetType::toInt(socketReadBufferSize);
+    } else if (socketBufferSize != "") {
+        readBufferSize = NetType::toInt(socketBufferSize);
+    }
+
+    int writeBufferSize = -1;
+    if (socketSendBufferSize != "") {
+        writeBufferSize = NetType::toInt(socketSendBufferSize);
+    } else if (socketBufferSize != "") {
+        writeBufferSize = NetType::toInt(socketBufferSize);
+    }
+
+    if (readBufferSize > 0) {
+        int actualReadSize = -1;
+
+#ifdef YARP_HAS_ACE
+        int intSize = sizeof(readBufferSize);
+        int setResult = dgram->set_option(SOL_SOCKET, SO_RCVBUF,
+                                          (void*)&readBufferSize, intSize);
+
+        int getResult = dgram->get_option(SOL_SOCKET, SO_RCVBUF,
+                                          (void*)&actualReadSize, &intSize);
+#else
+        socklen_t intSize = sizeof(readBufferSize);
+        int setResult = setsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF,
+                                   (void*)&readBufferSize, intSize);
+        int getResult = getsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF,
+                                   (void *) &actualReadSize, &intSize);
+#endif
+        if (setResult < 0 || getResult < 0 || readBufferSize != actualReadSize) {
+            bufferAlertNeeded = true;
+            bufferAlerted = false;
+            YARP_WARN(Logger::get(), "Failed to set RECV socket buffer to desired size. Actual: " + NetType::toString(actualReadSize) + ", Desired: " + NetType::toString(readBufferSize));
+        }
+    }
+    if (writeBufferSize > 0) {
+        int actualWriteSize = -1;
+#ifdef YARP_HAS_ACE
+        int intSize = sizeof(writeBufferSize);
+        int setResult = dgram->set_option(SOL_SOCKET, SO_SNDBUF,
+                                          (void*)&writeBufferSize, intSize);
+        int getResult = dgram->get_option(SOL_SOCKET, SO_SNDBUF,
+                                          (void*)&actualWriteSize, &intSize);
+#else
+        socklen_t intSize = sizeof(readBufferSize);
+        int setResult = setsockopt(dgram_sockfd, SOL_SOCKET, SO_SNDBUF,
+                                   (void*)&writeBufferSize, intSize);
+        int getResult = getsockopt(dgram_sockfd, SOL_SOCKET, SO_SNDBUF,
+                                   (void *) &actualWriteSize, &intSize);
+#endif
+        if (setResult < 0 || getResult < 0 || writeBufferSize != actualWriteSize) {
+            bufferAlertNeeded = true;
+            bufferAlerted = false;
+            YARP_WARN(Logger::get(), "Failed to set SND socket buffer to desired size. Actual: " + NetType::toString(actualWriteSize) + ", Desired: " + NetType::toString(writeBufferSize));
+        }
+    }
+
+
+
+#else
     // ask for more buffer space for udp/mcast
 
     ConstString _dgram_buffer_size = NetworkBase::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
@@ -227,6 +391,8 @@ void DgramTwoWayStream::configureSystemBuffers() {
     int window_size = window_size_desired;
 #ifdef YARP_HAS_ACE
     int result = dgram->set_option(SOL_SOCKET, SO_RCVBUF,
+                                   (char *) &window_size, sizeof(window_size));
+    dgram->set_option(SOL_SOCKET, SO_SNDBUF,
                                    (char *) &window_size, sizeof(window_size));
 #else
     int result = setsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF,
@@ -250,6 +416,7 @@ void DgramTwoWayStream::configureSystemBuffers() {
     }
     YARP_DEBUG(Logger::get(),
                String("Warning: buffer size set to ")+ NetType::toString(window_size) + String(", you requested ") + NetType::toString(window_size_desired));
+#endif
 }
 
 
@@ -762,9 +929,9 @@ void DgramTwoWayStream::flush() {
             } while (now-first<0.001);
         }
 
-        if (len<0) {
+        if (len < 0) {
             happy = false;
-            YARP_DEBUG(Logger::get(),"DGRAM failed to write");
+            YARP_DEBUG(Logger::get(), "DGRAM failed to send message with error: " + String(strerror(errno)));
             return;
         }
         writeAt += len;


### PR DESCRIPTION
Fixes #637 

This PR fixes UDP and MCAST on macOS.

**UDP**
Currently the updated code is included in an `#ifdef __APPLE__` so other OSes should not see any changes in UDP.
Anyway, as discussed with @apaikan probably we should trust more the kernel engineers of the various OSes and their choice for socket buffers.
In the current macOS implementation thus, the default for the socket buffers are taken from the operating system configuration. Nevertheless they can be overwritten by environment variables.

What about a test (both of compilation and performance) also on other OSes (i.e. Linux and Windows). In this case a manual intervention is needed as the `#ifdef` block should be substituted the older block

**MCAST**
[Related issue on ACE](https://github.com/DOCGroup/ACE_TAO/issues/281)

It seems that the ACE defaults for MCAST are not suited to macOS (at least on modern hardware and software). I overwritten the defaults in case macOS is used.

@drdanz what do you think of putting in the release notes the corresponding issue if present?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-238479914%22%2C%20%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-238597499%22%2C%20%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-238795285%22%2C%20%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-240055476%22%2C%20%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-240686826%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/862%23issuecomment-238479914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22WIP%20flag%20waiting%20for%20some%20updates%20in%20the%20ACE%20issue.%22%2C%20%22created_at%22%3A%20%222016-08-09T07%3A52%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%2C%20%7B%22body%22%3A%20%22Todo%20to%20self%3A%20remove%20%28or%20check%29%20error%20messages%20in%20the%20code.%22%2C%20%22created_at%22%3A%20%222016-08-09T15%3A50%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%2C%20%7B%22body%22%3A%20%22Travis%20is%20successful%20%28on%20the%20PR%29.%5Cr%5CnRebasing%20to%20master%20and%20removing%20the%20spurious%20%60std%3A%3Acerr%60%20I%20left%20in%20the%20code%22%2C%20%22created_at%22%3A%20%222016-08-10T08%3A08%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40francesco-romano%20Any%20news%20about%20the%20ACE%20issue%3F%22%2C%20%22created_at%22%3A%20%222016-08-16T09%3A43%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40drdanz%20nope..%20%5Cud83d%5Cude22%20%22%2C%20%22created_at%22%3A%20%222016-08-18T10%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/862#issuecomment-238479914'>General Comment</a></b>
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> WIP flag waiting for some updates in the ACE issue.
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> Todo to self: remove (or check) error messages in the code.
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> Travis is successful (on the PR).
Rebasing to master and removing the spurious `std::cerr` I left in the code
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> @francesco-romano Any news about the ACE issue?
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> @drdanz nope.. 😢


<a href='https://www.codereviewhub.com/robotology/yarp/pull/862?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/862?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/862'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>