### PR TITLE
Fixes yarprun (at least on macOS)

### DIFF
--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -24,6 +24,7 @@ Bug Fixes
 * Fixed "Conditional jump or move depends on uninitialised value" issues
   reported by `valgrind --memcheck` in SocketTwoWayStream with SKIP_ACE enabled.
 * Added implementation of SystemInfo for macOS.
+* Fixed bug in `yarprun` currently occuring only on macOS, but potentially on other platforms (#633)
 
 
 ### YARP_DEV

--- a/src/libYARP_OS/src/Run.cpp
+++ b/src/libYARP_OS/src/Run.cpp
@@ -1192,11 +1192,9 @@ int yarp::os::Run::server()
 
         if (mBraveZombieHunter)
         {
-            //ZombieHunterThread *p=mBraveZombieHunter;
-            //mBraveZombieHunter=NULL;
-            //p->stop();
-            //delete p;
             mBraveZombieHunter->stop();
+            delete mBraveZombieHunter;
+            mBraveZombieHunter = 0;
         }
 
         delete mProcessVector;
@@ -2500,7 +2498,10 @@ int yarp::os::Run::executeCmdAndStdio(yarp::os::Bottle& msg,yarp::os::Bottle& re
         CLOSE(pipe_cmd_to_stdout[WRITE_TO_PIPE]);
         CLOSE(pipe_child_to_parent[READ_FROM_PIPE]);
 
-        cleanBeforeExec();
+        //Why removing vectors and stop threads?
+        //exec* never returns and memory is claimed by the system
+        //furthermore after fork() only the thread which called fork() is forked!
+        //            cleanBeforeExec();
 
         //signal(SIGPIPE,SIG_DFL);
 
@@ -2574,7 +2575,10 @@ int yarp::os::Run::executeCmdAndStdio(yarp::os::Bottle& msg,yarp::os::Bottle& re
             CLOSE(pipe_cmd_to_stdout[WRITE_TO_PIPE]);
             CLOSE(pipe_child_to_parent[READ_FROM_PIPE]);
 
-            cleanBeforeExec();
+            //Why removing vectors and stop threads?
+            //exec* never returns and memory is claimed by the system
+            //furthermore after fork() only the thread which called fork() is forked!
+            //            cleanBeforeExec();
 
             //signal(SIGPIPE,SIG_DFL);
 
@@ -2718,7 +2722,10 @@ int yarp::os::Run::executeCmdAndStdio(yarp::os::Bottle& msg,yarp::os::Bottle& re
                     strcat(cwd_arg_str[0],"/");
                     strcat(cwd_arg_str[0],arg_str[0]);
 
-                    cleanBeforeExec();
+                    //Why removing vectors and stop threads?
+                    //exec* never returns and memory is claimed by the system
+                    //furthermore after fork() only the thread which called fork() is forked!
+                    //            cleanBeforeExec();
 
                     ret=execvp(cwd_arg_str[0],cwd_arg_str);
 
@@ -2728,7 +2735,10 @@ int yarp::os::Run::executeCmdAndStdio(yarp::os::Bottle& msg,yarp::os::Bottle& re
 
                 if (ret==YARPRUN_ERROR)
                 {
-                    cleanBeforeExec();
+                    //Why removing vectors and stop threads?
+                    //exec* never returns and memory is claimed by the system
+                    //furthermore after fork() only the thread which called fork() is forked!
+                    //            cleanBeforeExec();
 
                     ret=execvp(arg_str[0],arg_str);
                 }
@@ -2919,7 +2929,10 @@ int yarp::os::Run::executeCmdStdout(yarp::os::Bottle& msg,yarp::os::Bottle& resu
         CLOSE(pipe_cmd_to_stdout[WRITE_TO_PIPE]);
         CLOSE(pipe_child_to_parent[READ_FROM_PIPE]);
 
-        cleanBeforeExec();
+        //Why removing vectors and stop threads?
+        //exec* never returns and memory is claimed by the system
+        //furthermore after fork() only the thread which called fork() is forked!
+        //            cleanBeforeExec();
 
         //signal(SIGPIPE,SIG_DFL);
 
@@ -3061,7 +3074,10 @@ int yarp::os::Run::executeCmdStdout(yarp::os::Bottle& msg,yarp::os::Bottle& resu
                     strcat(cwd_arg_str[0],"/");
                     strcat(cwd_arg_str[0],arg_str[0]);
 
-                    cleanBeforeExec();
+                    //Why removing vectors and stop threads?
+                    //exec* never returns and memory is claimed by the system
+                    //furthermore after fork() only the thread which called fork() is forked!
+                    //            cleanBeforeExec();
 
                     ret=execvp(cwd_arg_str[0],cwd_arg_str);
 
@@ -3071,7 +3087,10 @@ int yarp::os::Run::executeCmdStdout(yarp::os::Bottle& msg,yarp::os::Bottle& resu
 
                 if (ret==YARPRUN_ERROR)
                 {
-                    cleanBeforeExec();
+                    //Why removing vectors and stop threads?
+                    //exec* never returns and memory is claimed by the system
+                    //furthermore after fork() only the thread which called fork() is forked!
+                    //            cleanBeforeExec();
 
                     ret=execvp(arg_str[0],arg_str);
                 }
@@ -3272,7 +3291,10 @@ int yarp::os::Run::userStdio(yarp::os::Bottle& msg,yarp::os::Bottle& result)
 
         REDIRECT_TO(STDERR_FILENO,pipe_child_to_parent[WRITE_TO_PIPE]);
 
-        cleanBeforeExec();
+        //Why removing vectors and stop threads?
+        //exec* never returns and memory is claimed by the system
+        //furthermore after fork() only the thread which called fork() is forked!
+        //            cleanBeforeExec();
 
         //signal(SIGHUP,rwSighupHandler);
 
@@ -3435,8 +3457,7 @@ int yarp::os::Run::executeCmd(yarp::os::Bottle& msg,yarp::os::Bottle& result)
         {
             char* szenv = new char[msg.find("env").asString().length()+1];
             strcpy(szenv,msg.find("env").asString().c_str());
-            putenv(szenv); // putenv doesn't make copy of the string
-            //delete [] szenv;
+            putenv(szenv); // putenv becomes owner of the string. DO NOT RELEASE it
         }
 
         if (msg.check("workdir"))
@@ -3480,7 +3501,10 @@ int yarp::os::Run::executeCmd(yarp::os::Bottle& msg,yarp::os::Bottle& result)
             strcat(cwd_arg_str[0],"/");
             strcat(cwd_arg_str[0],arg_str[0]);
 
-            cleanBeforeExec();
+            //Why removing vectors and stop threads?
+            //exec* never returns and memory is claimed by the system
+            //furthermore after fork() only the thread which called fork() is forked!
+//            cleanBeforeExec();
 
             ret=execvp(cwd_arg_str[0],cwd_arg_str);
 
@@ -3490,8 +3514,10 @@ int yarp::os::Run::executeCmd(yarp::os::Bottle& msg,yarp::os::Bottle& result)
 
         if (ret==YARPRUN_ERROR)
         {
-            cleanBeforeExec();
-
+            //Why removing vectors and stop threads?
+            //exec* never returns and memory is claimed by the system
+            //furthermore after fork() only the thread which called fork() is forked!
+            //            cleanBeforeExec();
             ret=execvp(arg_str[0],arg_str);
         }
 


### PR DESCRIPTION
Symptom  of the problem was the following uncaught exception:
```
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: thread::join failed: No such process
```

Details of the problem:

> The problem is that the join was called on a thread object in a process different from the one which created it.
> This happened because of calls to `fork()`.
> 
> In particular we have to be careful when we call `fork()`: all the memory is duplicated but only one thread (the one calling `fork()`) survives.
> In general it can be very dangerous to fork in a multithread application. It is only safe to call exec* as soon as possible after the fork. At that point the whole memory is substituted with the executed process.
> 
> To fix this issue I decided to completely remove the calls to `cleanBeforeExec` (which now is no more used, and probably should be removed).
> In case exec* succeeds the function never returns. In case it fails, the process exit some statements after.

This fixes #633

(Honestly I don't understand how it worked on linux, as the Zombie thread does not exist in the child process, and the exception is correct)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-239206958%22%2C%20%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-239374720%22%2C%20%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-240389253%22%2C%20%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-240641636%22%2C%20%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-240647803%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/865%23issuecomment-239206958%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ok%22%2C%20%22created_at%22%3A%20%222016-08-11T16%3A01%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4729270%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ale-git%22%7D%7D%2C%20%7B%22body%22%3A%20%22Of%20course%20before%20merging%20we%20must%20test%20it%20also%20on%20the%20robot%20cluster..%22%2C%20%22created_at%22%3A%20%222016-08-12T06%3A56%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20since%20the%20zombie%20hunter%20thread%20isn%27t%20duplicated%20in%20the%20child%20process%2C%20we%20can%20get%20rid%20of%20the%20cleanBeforeExec%28%29.%20Though%20multithreading%20and%20fork%28%29%20is%20a%20tricky%20environment%2C%20the%20zombie%20hunter%20thread%20isn%27t%20sharing%20any%20mutex%20with%20the%20fork%28%29%20calling%20thread%2C%20so%20yarprun%20should%20be%20safe%20the%20same.%22%2C%20%22created_at%22%3A%20%222016-08-17T11%3A52%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4729270%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ale-git%22%7D%7D%2C%20%7B%22body%22%3A%20%22Tested%20on%20the%20%60iCubGenova01%60%20cluster%20by%20using%20%20the%20%60CalibCameras%60%20application%20of%20the%20yarpmanager%20which%20launches%20processes%20on%20both%20pc104%20and%20on%20the%20robot%20laptops.%5Cr%5Cn%5Cr%5CnIf%20this%20test%20is%20sufficient%2C%20I%20think%20we%20can%20merge.%5Cr%5CnBTW%3A%20I%20update%20now%20the%20Release%20Notes.%22%2C%20%22created_at%22%3A%20%222016-08-18T07%3A07%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%2C%20%7B%22body%22%3A%20%22Rebased%20to%20master.%5Cr%5CnForgot%20to%20add%20the%20skip%20ci%20flags%20%5Cud83d%5Cude22%20%22%2C%20%22created_at%22%3A%20%222016-08-18T07%3A41%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2189180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/francesco-romano%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/yarp/pull/865#issuecomment-239206958'>General Comment</a></b>
- <a href='https://github.com/ale-git'><img border=0 src='https://avatars.githubusercontent.com/u/4729270?v=3' height=16 width=16'></a> ok
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> Of course before merging we must test it also on the robot cluster..
- <a href='https://github.com/ale-git'><img border=0 src='https://avatars.githubusercontent.com/u/4729270?v=3' height=16 width=16'></a> Ok, since the zombie hunter thread isn't duplicated in the child process, we can get rid of the cleanBeforeExec(). Though multithreading and fork() is a tricky environment, the zombie hunter thread isn't sharing any mutex with the fork() calling thread, so yarprun should be safe the same.
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> Tested on the `iCubGenova01` cluster by using  the `CalibCameras` application of the yarpmanager which launches processes on both pc104 and on the robot laptops.
If this test is sufficient, I think we can merge.
BTW: I update now the Release Notes.
- <a href='https://github.com/francesco-romano'><img border=0 src='https://avatars.githubusercontent.com/u/2189180?v=3' height=16 width=16'></a> Rebased to master.
Forgot to add the skip ci flags 😢


<a href='https://www.codereviewhub.com/robotology/yarp/pull/865?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/865?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/865'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>