### PR TITLE
Fixes #621: Add check for NULL to fix potential segfault

### DIFF
--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -322,15 +322,16 @@ bool PortCoreOutputUnit::sendHelper() {
         if (buf.dropRequested()) {
             done = true;
         }
-    }
-    if (done) {
-        closeBasic();
-        finished = true;
-        closing = true;
-        setDoomed();
+        if (done) {
+            closeBasic();
+            closing = true;
+            finished = true;
+            setDoomed();
+        }
     }
 
-    if(replied && op->getSender().modifiesReply()) {
+    // Another check for op!=NULL is required as closeBasic() might set op=NULL
+    if(op!=NULL && replied && op->getSender().modifiesReply()) {
             cachedReader = &op->getSender().modifyReply(*cachedReader);
     }
 


### PR DESCRIPTION
This fixes #621. The addition of `op!=NULL` is the actual fix; moving `if(done) { ... }` up in the other protected area is just clean-up (and does not change the logic). 

I've written a small comment in the code, as just moving the `if(replied ...)` up in the other protected area is not enough. The call to `closeBasic` might set `op=NULL`, and thus there is another check required whether `op!=NULL`.

I had this running for ~16 hours without crash.

Would be great if you could merge @drdanz.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/866?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/866'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>