### PR TITLE
YARP_OS/PortCoreOutputUnit: small fixes

### DIFF
--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -234,8 +234,8 @@ Route PortCoreOutputUnit::getRoute() {
 
 bool PortCoreOutputUnit::sendHelper() {
     bool replied = false;
-    bool done = false;
     if (op!=NULL) {
+        bool done = false;
         BufferedConnectionWriter buf(op->getConnection().isTextMode(),
                                      op->getConnection().isBareMode());
         if (cachedReader!=NULL) {

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -313,6 +313,9 @@ bool PortCoreOutputUnit::sendHelper() {
         if (!done) {
             if (op->getConnection().isActive()) {
                 replied = op->write(buf);
+                if(replied && op->getSender().modifiesReply()) {
+                    cachedReader = &op->getSender().modifyReply(*cachedReader);
+                }
             }
             if (!op->isOk()) {
                 done = true;
@@ -330,10 +333,6 @@ bool PortCoreOutputUnit::sendHelper() {
         }
     }
 
-    // Another check for op!=NULL is required as closeBasic() might set op=NULL
-    if(op!=NULL && replied && op->getSender().modifiesReply()) {
-            cachedReader = &op->getSender().modifyReply(*cachedReader);
-    }
 
     return replied;
 }


### PR DESCRIPTION
* Move variable declaration inside the if where it is used (see [#866](https://github.com/robotology/yarp/pull/866#issuecomment-240074850)).
* Modify reply right after receiving it instead of (CC @apaikan). The extra `op!=NULL` check added by #866 was removed, since it makes no sense here (CC @Tobias-Fischer).
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/Tobias-Fischer%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/yarp/pull/871%23issuecomment-240111268%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-08-16T14%3A03%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/robotology/yarp/pull/871%23issuecomment-240111268%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/Tobias-Fischer'><img src='https://avatars.githubusercontent.com/u/5497832?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/robotology/yarp/pull/871?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/yarp/pull/871?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/871'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>