### PR TITLE
YARP_OS: Move Carriers out of the impl namespace

### DIFF
--- a/conf/template/yarp_plugin_carrier.cpp.in
+++ b/conf/template/yarp_plugin_carrier.cpp.in
@@ -5,7 +5,7 @@
  */
 
 #include <yarp/os/api.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/SharedLibraryClass.h>
 #include <@YARPPLUG_INCLUDE@>
 
@@ -17,12 +17,10 @@
 #  define YARP_PLUGIN_EXPORT YARP_HELPER_DLL_EXPORT
 #endif
 
-using namespace yarp::os;
-using namespace yarp::os::impl;
 
 #ifdef YARP_STATIC_PLUGIN
 YARP_PLUGIN_EXPORT void add_owned_@YARPPLUG_NAME@(const char *owner) {
-    yarp::os::impl::Carriers::addCarrierPrototype(new @YARPPLUG_TYPE@);
+    yarp::os::Carriers::addCarrierPrototype(new @YARPPLUG_TYPE@);
 }
 #endif
 

--- a/doc/carrier_expert.dox
+++ b/doc/carrier_expert.dox
@@ -68,7 +68,7 @@ system match those used to compile YARP.
 You should skim the documentation of the following classes:
 
  \li yarp::os::Carrier
- \li yarp::os::impl::Carriers
+ \li yarp::os::Carriers
  \li yarp::os::InputStream
  \li yarp::os::OutputStream
  \li yarp::os::TwoWayStream
@@ -78,7 +78,7 @@ You'll be able to include them in your code as follows:
 
 \code
 #include <yarp/os/Carrier.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/TwoWayStream.h>
 #include <yarp/os/InputStream.h>
 #include <yarp/os/OutputStream.h>
@@ -137,7 +137,7 @@ The key steps are:
  our class by overriding yarp::os::Carrier::getName.
 
  \li At the start of our program, we register an instance of that class
- in a call to yarp::os::impl::Carriers::addCarrierPrototype.
+ in a call to yarp::os::Carriers::addCarrierPrototype.
 
 Having taken those steps, we can make connections using our new carrier
 (called "test" in the example code):
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
 So there isn't much to it to just insert a call to
 Carriers::addCarrierPrototype in there.  Otherwise, to put
 the new carrier in the YARP library proper, do a little pattern-matching
-in the constructor for the yarp::os::impl::Carriers class
+in the constructor for the yarp::os::Carriers class
 at src/libYARP_OS/src/Carriers.cpp.
 
 

--- a/doc/release/v2_3_68.md
+++ b/doc/release/v2_3_68.md
@@ -64,6 +64,7 @@ Bug Fixes
 * `yarp::os::Node` now handles correctly multiple publishers and subscribers on
   the same topic. The limit on YARP is that only one publisher and one
   subscriber can be registered on the same node using the same topic.
+* The `Carriers` class was moved outside of the impl namespace (#402).
 
 ### GUIs
 

--- a/doc/yarp_build_structure.dox
+++ b/doc/yarp_build_structure.dox
@@ -595,7 +595,7 @@ the following variables are defined:
 @section yarp_build_structure_template_carrier conf/template/yarp_plugin_carrier.cpp.in
 
 A snippet of code to add a carrier plugin.  We make an instance of the carrier
-class, and pass it to a global yarp::os::impl::Carriers object.  The
+class, and pass it to a global yarp::os::Carriers object.  The
 code is contained in a function called add_FOO() where FOO is the name
 of the carrier.
 

--- a/example/carrier/carrier_human.cpp
+++ b/example/carrier/carrier_human.cpp
@@ -8,7 +8,7 @@
 #include <yarp/os/all.h>
 
 #include <yarp/os/impl/Carrier.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/Bytes.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/impl/NetType.h>

--- a/example/carrier/carrier_stub.cpp
+++ b/example/carrier/carrier_stub.cpp
@@ -8,7 +8,7 @@
 #include <yarp/os/all.h>
 
 #include <yarp/os/impl/Carrier.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/impl/TextCarrier.h>
 
 using namespace yarp::os;

--- a/src/carriers/CMakeLists.txt
+++ b/src/carriers/CMakeLists.txt
@@ -10,9 +10,6 @@ if(CREATE_OPTIONAL_CARRIERS)
   get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
   include_directories(${YARP_OS_INCLUDE_DIRS})
 
-  # This is required until Carriers is in the impl namespace, see also #402
-  include_directories(${ACE_INCLUDE_DIRS})
-
   add_subdirectory(wire_rep_utils)
 
   include(YarpPlugin)

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -13,6 +13,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/BufferedPort.h
                  include/yarp/os/Bytes.h
                  include/yarp/os/Carrier.h
+                 include/yarp/os/Carriers.h
                  include/yarp/os/Clock.h
                  include/yarp/os/Connection.h
                  include/yarp/os/ConnectionReader.h
@@ -141,7 +142,6 @@ set(YARP_OS_IMPL_HDRS include/yarp/os/impl/ACELockImpl.h
                       include/yarp/os/impl/AuthHMAC.h
                       include/yarp/os/impl/BottleImpl.h
                       include/yarp/os/impl/BufferedConnectionWriter.h
-                      include/yarp/os/impl/Carriers.h
                       include/yarp/os/impl/Companion.h
                       include/yarp/os/impl/CXX11LockImpl.h
                       include/yarp/os/impl/CXX11SemaphoreImpl.h

--- a/src/libYARP_OS/include/yarp/os/Carriers.h
+++ b/src/libYARP_OS/include/yarp/os/Carriers.h
@@ -16,13 +16,10 @@
 #include <yarp/os/Carrier.h>
 #include <yarp/os/Bottle.h>
 
-#include <yarp/os/impl/PlatformVector.h>
 
 namespace yarp {
     namespace os {
-        namespace impl {
-            class Carriers;
-        }
+        class Carriers;
     }
 }
 
@@ -32,7 +29,7 @@ namespace yarp {
  * This is the starting point for creating connections
  * between ports.
  */
-class YARP_OS_impl_API yarp::os::impl::Carriers
+class YARP_OS_API yarp::os::Carriers
 {
 public:
 
@@ -110,15 +107,10 @@ public:
     static Bottle listCarriers();
 
 private:
-    PlatformVector<Carrier *> delegates;
-
     Carriers();
 
-    static Carriers *yarp_carriers_instance;
-
-    Carrier *chooseCarrier(const ConstString * name, const Bytes * header,
-                           bool load_if_needed = true,
-                           bool return_template = false);
+    class Private;
+    Private * const mPriv;
 };
 
 

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -10,7 +10,7 @@
 
 #include <yarp/os/impl/ThreadImpl.h>
 #include <yarp/os/impl/SemaphoreImpl.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/Contactable.h>
 #include <yarp/os/Contact.h>
 #include <yarp/os/impl/PortManager.h>

--- a/src/libYARP_OS/include/yarp/os/impl/Protocol.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Protocol.h
@@ -12,7 +12,7 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/ConstString.h>
 #include <yarp/os/TwoWayStream.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 #include <yarp/os/NetType.h>
 #include <yarp/os/ShiftStream.h>

--- a/src/libYARP_OS/src/Carriers.cpp
+++ b/src/libYARP_OS/src/Carriers.cpp
@@ -6,7 +6,7 @@
  */
 
 
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/TcpFace.h>
 #include <yarp/os/impl/FakeFace.h>
@@ -25,100 +25,38 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/Protocol.h>
 #include <yarp/os/YarpPlugin.h>
+#include <yarp/os/impl/PlatformVector.h>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
 
-Carriers *Carriers::yarp_carriers_instance = NULL;
 
-static bool matchCarrier(const Bytes *header, Bottle& code) {
-    int at = 0;
-    bool success = true;
-    bool done = false;
-    for (int i=0; i<code.size() && !done; i++) {
-        Value& v = code.get(i);
-        if (v.isString()) {
-            ConstString str = v.asString();
-            for (int j=0; j<(int)str.length(); j++) {
-                if ((int)header->length()<=at) {
-                    success = false;
-                    done = true;
-                    break;
-                }
-                if (str[j] != header->get()[at]) {
-                    success = false;
-                    done = true;
-                    break;
-                }
-                at++;
-            }
-        } else {
-            at++;
-        }
-    }
-    return success;
-}
 
-static bool checkForCarrier(const Bytes *header, Searchable& group) {
-    Bottle code = group.findGroup("code").tail();
-    if (code.size()==0) return false;
-    if (matchCarrier(header,code)) {
-        ConstString name = group.find("name").asString();
-        if (NetworkBase::registerCarrier(name.c_str(),NULL)) {
-            return true;
-        }
-    }
-    return false;
-}
+class Carriers::Private
+{
+public:
+    static Carriers* yarp_carriers_instance;
 
-static bool scanForCarrier(const Bytes *header) {
-    YARP_SPRINTF0(Logger::get(),
-                  debug,
-                  "Scanning for a carrier by header.");
-    YarpPluginSelector selector;
-    selector.scan();
-    Bottle lst = selector.getSelectedPlugins();
-    for (int i=0; i<lst.size(); i++) {
-        if (checkForCarrier(header,lst.get(i))) {
-            return true;
-        }
-    }
-    return false;
-}
+    PlatformVector<Carrier*> delegates;
 
-Carriers::Carriers() {
-    delegates.push_back(new HttpCarrier());
-    delegates.push_back(new NameserCarrier());
-    delegates.push_back(new LocalCarrier());
-#ifdef YARP_HAS_ACE
-    //delegates.push_back(new ShmemCarrier(1));
-    delegates.push_back(new ShmemCarrier(2)); // new Alessandro version
-#endif
-    delegates.push_back(new TcpCarrier());
-    delegates.push_back(new TcpCarrier(false));
-#ifdef YARP_HAS_ACE
-    delegates.push_back(new McastCarrier());
-#endif
-    delegates.push_back(new UdpCarrier());
-    delegates.push_back(new TextCarrier());
-    delegates.push_back(new TextCarrier(true));
-}
+    Carrier* chooseCarrier(const ConstString* name,
+                           const Bytes* header,
+                           bool load_if_needed = true,
+                           bool return_template = false);
 
-Carriers::~Carriers() {
-    clear();
-}
+    static bool matchCarrier(const Bytes *header, Bottle& code);
+    static bool checkForCarrier(const Bytes *header, Searchable& group);
+    static bool scanForCarrier(const Bytes *header);
+};
 
-void Carriers::clear() {
-    PlatformVector<Carrier *>& lst = delegates;
-    for (unsigned int i=0; i<lst.size(); i++) {
-        delete lst[i];
-    }
-    lst.clear();
-}
+Carriers* Carriers::Private::yarp_carriers_instance = NULL;
 
-Carrier *Carriers::chooseCarrier(const ConstString *name, const Bytes *header,
-                                 bool load_if_needed,
-                                 bool return_template) {
+
+Carrier* Carriers::Private::chooseCarrier(const ConstString *name,
+                                          const Bytes *header,
+                                          bool load_if_needed,
+                                          bool return_template)
+{
     ConstString s;
     if (name!=NULL) {
         s = *name;
@@ -129,7 +67,7 @@ Carrier *Carriers::chooseCarrier(const ConstString *name, const Bytes *header,
             name = &s;
         }
     }
-    for (size_t i=0; i<(size_t)delegates.size(); i++) {
+    for (size_t i = 0; i < delegates.size(); i++) {
         Carrier& c = *delegates[i];
         bool match = false;
         if (name!=NULL) {
@@ -155,12 +93,12 @@ Carrier *Carriers::chooseCarrier(const ConstString *name, const Bytes *header,
             // let's try to register it, and see if a dll is found.
             if (NetworkBase::registerCarrier(name->c_str(),NULL)) {
                 // We made progress, let's try again...
-                return Carriers::chooseCarrier(name,header,false);
+                return Carriers::Private::chooseCarrier(name,header,false);
             }
         } else {
             if (scanForCarrier(header)) {
                 // We made progress, let's try again...
-                return Carriers::chooseCarrier(name,header,true);
+                return Carriers::Private::chooseCarrier(name,header,true);
             }
         }
     }
@@ -195,21 +133,119 @@ Carrier *Carriers::chooseCarrier(const ConstString *name, const Bytes *header,
 }
 
 
-Carrier *Carriers::chooseCarrier(const ConstString& name) {
-    return getInstance().chooseCarrier(&name,NULL);
+
+bool Carriers::Private::matchCarrier(const Bytes *header, Bottle& code)
+{
+    int at = 0;
+    bool success = true;
+    bool done = false;
+    for (int i=0; i<code.size() && !done; i++) {
+        Value& v = code.get(i);
+        if (v.isString()) {
+            ConstString str = v.asString();
+            for (int j=0; j<(int)str.length(); j++) {
+                if ((int)header->length()<=at) {
+                    success = false;
+                    done = true;
+                    break;
+                }
+                if (str[j] != header->get()[at]) {
+                    success = false;
+                    done = true;
+                    break;
+                }
+                at++;
+            }
+        } else {
+            at++;
+        }
+    }
+    return success;
 }
 
-Carrier *Carriers::getCarrierTemplate(const ConstString& name) {
-    return getInstance().chooseCarrier(&name,NULL,true,true);
+bool Carriers::Private::checkForCarrier(const Bytes *header, Searchable& group)
+{
+    Bottle code = group.findGroup("code").tail();
+    if (code.size()==0) return false;
+    if (matchCarrier(header,code)) {
+        ConstString name = group.find("name").asString();
+        if (NetworkBase::registerCarrier(name.c_str(),NULL)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Carriers::Private::scanForCarrier(const Bytes *header)
+{
+    YARP_SPRINTF0(Logger::get(),
+                  debug,
+                  "Scanning for a carrier by header.");
+    YarpPluginSelector selector;
+    selector.scan();
+    Bottle lst = selector.getSelectedPlugins();
+    for (int i=0; i<lst.size(); i++) {
+        if (checkForCarrier(header,lst.get(i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Carriers::Carriers() :
+        mPriv(new Private)
+{
+    mPriv->delegates.push_back(new HttpCarrier());
+    mPriv->delegates.push_back(new NameserCarrier());
+    mPriv->delegates.push_back(new LocalCarrier());
+#ifdef YARP_HAS_ACE
+    //mPriv->delegates.push_back(new ShmemCarrier(1));
+    mPriv->delegates.push_back(new ShmemCarrier(2)); // new Alessandro version
+#endif
+    mPriv->delegates.push_back(new TcpCarrier());
+    mPriv->delegates.push_back(new TcpCarrier(false));
+#ifdef YARP_HAS_ACE
+    mPriv->delegates.push_back(new McastCarrier());
+#endif
+    mPriv->delegates.push_back(new UdpCarrier());
+    mPriv->delegates.push_back(new TextCarrier());
+    mPriv->delegates.push_back(new TextCarrier(true));
+}
+
+Carriers::~Carriers()
+{
+    clear();
+    delete mPriv;
+}
+
+void Carriers::clear()
+{
+    PlatformVector<Carrier*>& lst = mPriv->delegates;
+    for (unsigned int i=0; i<lst.size(); i++) {
+        delete lst[i];
+    }
+    lst.clear();
+}
+
+Carrier *Carriers::chooseCarrier(const ConstString& name)
+{
+    return getInstance().mPriv->chooseCarrier(&name,NULL);
+}
+
+Carrier *Carriers::getCarrierTemplate(const ConstString& name)
+{
+    return getInstance().mPriv->chooseCarrier(&name,NULL,true,true);
 }
 
 
-Carrier *Carriers::chooseCarrier(const Bytes& bytes) {
-    return getInstance().chooseCarrier(NULL,&bytes);
+Carrier *Carriers::chooseCarrier(const Bytes& bytes)
+{
+    return getInstance().mPriv->chooseCarrier(NULL,&bytes);
 }
 
 
-Face *Carriers::listen(const Contact& address) {
+Face *Carriers::listen(const Contact& address)
+{
     // for now, only TcpFace exists - otherwise would need to manage
     // multiple possibilities
     Face *face = NULL;
@@ -228,44 +264,50 @@ Face *Carriers::listen(const Contact& address) {
 }
 
 
-OutputProtocol *Carriers::connect(const Contact& address) {
+OutputProtocol *Carriers::connect(const Contact& address)
+{
     TcpFace tcpFace;
     return tcpFace.write(address);
 }
 
 
-bool Carriers::addCarrierPrototype(Carrier *carrier) {
-    getInstance().delegates.push_back(carrier);
+bool Carriers::addCarrierPrototype(Carrier *carrier)
+{
+    getInstance().mPriv->delegates.push_back(carrier);
     return true;
 }
 
 
-bool Carrier::reply(ConnectionState& proto, SizedWriter& writer) {
+bool Carrier::reply(ConnectionState& proto, SizedWriter& writer)
+{
     writer.write(proto.os());
     return proto.os().isOk();
 }
 
-Carriers& Carriers::getInstance() {
-    if (yarp_carriers_instance == NULL) {
-        yarp_carriers_instance = new Carriers();
-        yAssert(yarp_carriers_instance!=NULL);
+Carriers& Carriers::getInstance()
+{
+    if (Private::yarp_carriers_instance == NULL) {
+        Private::yarp_carriers_instance = new Carriers();
+        yAssert(Private::yarp_carriers_instance!=NULL);
     }
-    return *yarp_carriers_instance;
+    return *Private::yarp_carriers_instance;
 }
 
 
-void Carriers::removeInstance() {
-    if (yarp_carriers_instance != NULL) {
-        delete yarp_carriers_instance;
-        yarp_carriers_instance = NULL;
+void Carriers::removeInstance()
+{
+    if (Private::yarp_carriers_instance != NULL) {
+        delete Private::yarp_carriers_instance;
+        Private::yarp_carriers_instance = NULL;
     }
 }
 
 
-Bottle Carriers::listCarriers() {
+Bottle Carriers::listCarriers()
+{
     Bottle lst;
-    PlatformVector<Carrier *>& delegates = getInstance().delegates;
-    for (size_t i=0; i<(size_t)delegates.size(); i++) {
+    PlatformVector<Carrier*>& delegates = getInstance().mPriv->delegates;
+    for (size_t i = 0; i < delegates.size(); i++) {
         Carrier& c = *delegates[i];
         lst.addString(c.getName());
     }

--- a/src/libYARP_OS/src/Companion.cpp
+++ b/src/libYARP_OS/src/Companion.cpp
@@ -17,7 +17,7 @@
 #include <yarp/os/Name.h>
 #include <yarp/os/Os.h>
 
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 #include <yarp/os/impl/PortCore.h>

--- a/src/libYARP_OS/src/NameSpace.cpp
+++ b/src/libYARP_OS/src/NameSpace.cpp
@@ -7,7 +7,7 @@
 
 #include <yarp/os/NameSpace.h>
 #include <yarp/os/OutputProtocol.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -23,7 +23,7 @@
 
 #include <yarp/os/InputStream.h>
 #include <yarp/os/OutputProtocol.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 #include <yarp/os/Route.h>

--- a/tests/libYARP_OS/PortCoreTest.cpp
+++ b/tests/libYARP_OS/PortCoreTest.cpp
@@ -7,7 +7,7 @@
 
 #include <yarp/os/impl/PortCore.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/impl/Carriers.h>
+#include <yarp/os/Carriers.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/Companion.h>


### PR DESCRIPTION
Fixes #402

This will allow to create carriers as plugins in separate packages.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/877?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/877'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>