### PR TITLE
Add a brief doxygen doc to AnalogWrapper

### DIFF
--- a/src/libYARP_dev/src/modules/AnalogWrapper/AnalogWrapper.h
+++ b/src/libYARP_dev/src/modules/AnalogWrapper/AnalogWrapper.h
@@ -59,6 +59,8 @@ namespace yarp{
 /**
  *  @ingroup dev_impl_wrapper
  *
+ * \brief Device that expose an AnalogSensor (using the IAnalogSensor interface) on the YARP or ROS network.
+ * 
  * \section analogWrapper_parameter Description of input parameters
  *
  *  It reads the data from an analog sensor and sends them on one or more ports.


### PR DESCRIPTION
To avoid the missing "More..." link in http://www.yarp.it/classyarp_1_1dev_1_1AnalogWrapper.html .
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/883?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/883'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>