### PR TITLE
imuBosch_BNO055: Disable when YARP_math is not available and fix include dirs

### DIFF
--- a/src/modules/imuBosch_BNO055/CMakeLists.txt
+++ b/src/modules/imuBosch_BNO055/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Alberto Cardellino
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-if(NOT WIN32)
+if(NOT WIN32 AND CREATE_LIB_MATH)
   if(COMPILE_DEVICE_LIBRARY)
     yarp_prepare_device(imuBosch_BNO055
                         TYPE yarp::dev::BoschIMU
@@ -17,9 +17,11 @@ if(NOT WIN32)
     get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
     get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
     get_property(YARP_dev_INCLUDE_DIRS TARGET YARP_dev PROPERTY INCLUDE_DIRS)
+    get_property(YARP_math_INCLUDE_DIRS TARGET YARP_math PROPERTY INCLUDE_DIRS)
     include_directories(${YARP_OS_INCLUDE_DIRS}
                         ${YARP_sig_INCLUDE_DIRS}
-                        ${YARP_dev_INCLUDE_DIRS})
+                        ${YARP_dev_INCLUDE_DIRS}
+                        ${YARP_math_INCLUDE_DIRS})
     yarp_add_plugin(imuBosch_BNO055 imuBosch_BNO055.cpp
                                     imuBosch_BNO055.h)
     target_link_libraries(imuBosch_BNO055 YARP_OS


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/yarp/pull/887?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/yarp/pull/887'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>