### PR TITLE
libYARP_dev : document clearly the removal of two deprecated parameters

### DIFF
--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -9,6 +9,23 @@ A (partial) list of bug fixed and issues resolved in this release can be found
 Important Changes
 -----------------
 
+### YARP_dev
+
+* The `analogServer` device (implemented in `yarp::dev::AnalogWrapper` has removed
+  the supporte for the `deviceId` parameter, that has been
+  deprecated since 2014. Invalid configuration files of the form:
+~~~
+robotName icub
+deviceId left_arm
+~~~
+  can be updated with the valid:
+~~~
+name /icub/left_arm/analog:o
+~~~
+
+* The `controlboardwrapper2` device (implemented in `yarp::dev::ControlBoardWrapper` has removed
+  the supported for the `threadrate` parameter, that has been deprecated since 2014.
+  Invalid configuration files of the form `threadrate 10` can be update with the valid form `period 10`.
 
 Bug Fixes
 ---------

--- a/src/libYARP_dev/src/modules/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/modules/AnalogWrapper/AnalogWrapper.cpp
@@ -484,7 +484,7 @@ bool AnalogWrapper::open(yarp::os::Searchable &config)
 
     if (config.check("deviceId"))
     {
-        yError() << "lAnalogWrapper: the parameter 'deviceId' has been deprecated, please use parameter 'name' instead. \n"
+        yError() << "AnalogServer: the parameter 'deviceId' has been removed, please use parameter 'name' instead. \n"
             << "e.g. In the FT wrapper configuration files of your robot, replace '<param name=""deviceId""> left_arm </param>' \n"
             << "with '/icub/left_arm/analog:o' ";
         return false;

--- a/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -409,7 +409,7 @@ bool ControlBoardWrapper::open(Searchable& config)
     // check FIRST for deprecated parameter
     if(prop.check("threadrate"))
     {
-        yError() << " *** ControlBoardWrapper2 is using DEPRECATED parameter 'threadrate', use 'period' instead ***";
+        yError() << " *** ControlBoardWrapper2 is using removed parameter 'threadrate', use 'period' instead ***";
         return false;
     }
 


### PR DESCRIPTION
The removal of some parameters deprecated for a long time is causing some confusion when updating some robots simulated in Gazebo. Reformulated the error message to be clearer and update the release notes (the 2.3.66.1 one because we already released 2.3.66).