### PR TITLE
Port core port info

### DIFF
--- a/doc/release/v2_3_68.md
+++ b/doc/release/v2_3_68.md
@@ -140,6 +140,9 @@ New Features
   They also return now:
   * `(connectionless 1)` when the connection is connectionless (i.e. udp).
   * `(push 0)` when the connection is not push (i.e. mjpeg).
+* Improved Portcore `[prop] [get] $portname` command.
+  It also returns now some more information about the port in this form:
+  `(port ((is_input [0|1]) (is_output [0|1]) (is_rpc [0|1]) (type "[type]")))`
 * Improved compiler detection and added <yarp/conf/compiler.h> header
   containing macros to check if a specific feature is available.
 * Added method `yarp::os::Thread::yield()` that reschedules the execution of

--- a/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
@@ -43,8 +43,6 @@ private:
     SemaphoreImpl readBlock;
     PortReaderCreator *recReadCreator;
     int recWaitAfterSend;
-    Type typ;
-    bool checkedType;
     bool usedForRead;
     bool usedForWrite;
     bool usedForRpc;
@@ -60,7 +58,6 @@ public:
 
     PortCoreAdapter(Port& owner);
     void openable();
-    void checkType(PortReader& reader);
     void alertOnRead();
     void alertOnWrite();
     void alertOnRpc();
@@ -85,8 +82,6 @@ public:
     int checkWaitAfterSend();
     bool isOpened();
     void setOpen(bool opened);
-    Type getType();
-    void promiseType(const Type& typ);
     void includeNodeInName(bool flag);
 };
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2119,6 +2119,18 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                     Property& platform_prop = platform.addDict();
                                     platform_prop.put("os", pinfo.name);
                                     platform_prop.put("hostname", address.getHost());
+
+                                    int f = getFlags();
+                                    bool is_input = (f & PORTCORE_IS_INPUT);
+                                    bool is_output = (f & PORTCORE_IS_OUTPUT);
+                                    bool is_rpc = (f & PORTCORE_IS_RPC);
+                                    Bottle& port = result.addList();
+                                    port.addString("port");
+                                    Property& port_prop = port.addDict();
+                                    port_prop.put("is_input", is_input);
+                                    port_prop.put("is_output", is_output);
+                                    port_prop.put("is_rpc", is_rpc);
+                                    port_prop.put("type", getType().getName());
                                 }
                                 else {
                                     for (unsigned int i=0; i<units.size(); i++) {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2086,8 +2086,8 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                 {
                     Property *p = acquireProperties(false);
                     if (p) {
-                        if (!cmd.get(2).isNull()) {                            
-                            // request: "prop get /portname"                            
+                        if (!cmd.get(2).isNull()) {
+                            // request: "prop get /portname"
                             ConstString portName = cmd.get(2).asString();
                             bool bFound = false;
                             if((portName.size() > 0) && (portName[0] == '/')) {
@@ -2097,7 +2097,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                     result.clear();
                                     Bottle& sched = result.addList();
                                     sched.addString("sched");
-                                    Property& sched_prop = sched.addDict();                                    
+                                    Property& sched_prop = sched.addDict();
                                     sched_prop.put("tid", (int)this->getTid());
                                     sched_prop.put("priority", this->getPriority());
                                     sched_prop.put("policy", this->getPolicy());
@@ -2130,7 +2130,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                                 bFound = true;
                                                 int priority = unit->getPriority();
                                                 int policy = unit->getPolicy();
-                                                int tos = getTypeOfService(unit);                                                
+                                                int tos = getTypeOfService(unit);
                                                 int tid = (int) unit->getTid();
                                                 result.clear();
                                                 Bottle& sched = result.addList();

--- a/src/libYARP_OS/src/PortCoreAdapter.cpp
+++ b/src/libYARP_OS/src/PortCoreAdapter.cpp
@@ -27,7 +27,6 @@ yarp::os::impl::PortCoreAdapter::PortCoreAdapter(Port& owner) :
         produce(0), consume(0), readBlock(1),
         recReadCreator(YARP_NULLPTR),
         recWaitAfterSend(-1),
-        checkedType(false),
         usedForRead(false),
         usedForWrite(false),
         usedForRpc(false),
@@ -48,16 +47,6 @@ void yarp::os::impl::PortCoreAdapter::openable()
     closed = false;
     opened = true;
     stateMutex.post();
-}
-
-void yarp::os::impl::PortCoreAdapter::checkType(PortReader& reader)
-{
-    if (!checkedType) {
-        if (!typ.isValid()) {
-            typ = reader.getReadType();
-        }
-        checkedType = true;
-    }
 }
 
 void yarp::os::impl::PortCoreAdapter::alertOnRead()
@@ -335,21 +324,6 @@ bool yarp::os::impl::PortCoreAdapter::isOpened()
 void yarp::os::impl::PortCoreAdapter::setOpen(bool opened)
 {
     this->opened = opened;
-}
-
-yarp::os::Type yarp::os::impl::PortCoreAdapter::getType()
-{
-    stateMutex.wait();
-    Type t = typ;
-    stateMutex.post();
-    return t;
-}
-
-void yarp::os::impl::PortCoreAdapter::promiseType(const Type& typ)
-{
-    stateMutex.wait();
-    this->typ = typ;
-    stateMutex.post();
 }
 
 void yarp::os::impl::PortCoreAdapter::includeNodeInName(bool flag)


### PR DESCRIPTION
This allows to query the port and to get information about the type of the port (whether it is an input, output or rpc port) and the message type accepted/produced by the port (if set). For example:

```
>>prop get /yarp/bar+@/foo process
Response: (sched ((policy -1) (priority -1) (tid 19689))) (process ((arguments foo) (name "./test-yarp-node") (pid 19647) (policy 0) (priority 0))) (platform ((hostname "xxx.xxx.xxx.xxx") (os Linux))) (port ((is_input 0) (is_output 1) (is_rpc 0) (type "std_msgs/String")))
```

Now contains this information `(port ((is_input 0) (is_output 1) (is_rpc 0) (type "std_msgs/String")))`

@apaikan I think it would be nice to have this information in `yarpviz`