### PR TITLE
Drop compatibility with YARP 2.1.2

### DIFF
--- a/doc/release/v2_3_68.md
+++ b/doc/release/v2_3_68.md
@@ -34,6 +34,11 @@ Important Changes
   * Added `ConnectionReader::setParentConnectionReader` method. This method
     should be used by `Carriers` that reimplement `modifyIncomingData` and that
     return a ConnectionReader that is not the same as the one in input.
+* `PortCore` now uses the "new" version of the protocol for signalling to
+  suppress the reply. This was expected since YARP 2.1.2, but it was never
+  applied. Both versions of the protocol are accepted in input, unless
+  `YARP_NO_DEPRECATED` is enabled, in this case YARP it is not compatible with
+  previous releases since only the new version is recognized.
 
 ### YARP_sig
 

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -236,17 +236,32 @@ void PortCoreInputUnit::run() {
         case 'D':
         case 'd':
             {
+                bool suppressed = false;
+
+                // this will be the new way to signal that
+                // replies are not expected.
                 if (key=='D') {
                     ip->suppressReply();
                 }
 
                 ConstString env = cmd.getText();
-                if (env.length()>2) {
-                    //YARP_ERROR(Logger::get(),
-                    //"***** received an envelope! [%s]", env.c_str());
-                    ConstString env2 = env.substr(2,env.length());
-                    man.setEnvelope(env2);
-                    ip->setEnvelope(env2);
+                if (env.length()>1) {
+                    if (!suppressed) {
+                        // This is the backwards-compatible
+                        // method for signalling replies are
+                        // not expected.  To be used until
+                        // YARP 2.1.2 is a "long time ago".
+                        if (env[1]=='o') {
+                            ip->suppressReply();
+                        }
+                    }
+                    if (env.length()>2) {
+                        //YARP_ERROR(Logger::get(),
+                        //"***** received an envelope! [%s]", env.c_str());
+                        ConstString env2 = env.substr(2,env.length());
+                        man.setEnvelope(env2);
+                        ip->setEnvelope(env2);
+                    }
                 }
                 if (localReader) {
                     localReader->read(br);

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -236,32 +236,17 @@ void PortCoreInputUnit::run() {
         case 'D':
         case 'd':
             {
-                bool suppressed = false;
-
-                // this will be the new way to signal that
-                // replies are not expected.
                 if (key=='D') {
                     ip->suppressReply();
                 }
 
                 ConstString env = cmd.getText();
-                if (env.length()>1) {
-                    if (!suppressed) {
-                        // This is the backwards-compatible
-                        // method for signalling replies are
-                        // not expected.  To be used until
-                        // YARP 2.1.2 is a "long time ago".
-                        if (env[1]=='o') {
-                            ip->suppressReply();
-                        }
-                    }
-                    if (env.length()>2) {
-                        //YARP_ERROR(Logger::get(),
-                        //"***** received an envelope! [%s]", env.c_str());
-                        ConstString env2 = env.substr(2,env.length());
-                        man.setEnvelope(env2);
-                        ip->setEnvelope(env2);
-                    }
+                if (env.length()>2) {
+                    //YARP_ERROR(Logger::get(),
+                    //"***** received an envelope! [%s]", env.c_str());
+                    ConstString env2 = env.substr(2,env.length());
+                    man.setEnvelope(env2);
+                    ip->setEnvelope(env2);
                 }
                 if (localReader) {
                     localReader->read(br);

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -236,15 +236,13 @@ void PortCoreInputUnit::run() {
         case 'D':
         case 'd':
             {
-                bool suppressed = false;
-
-                // this will be the new way to signal that
-                // replies are not expected.
                 if (key=='D') {
                     ip->suppressReply();
                 }
 
                 ConstString env = cmd.getText();
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.68
+                bool suppressed = false;
                 if (env.length()>1) {
                     if (!suppressed) {
                         // This is the backwards-compatible
@@ -263,6 +261,15 @@ void PortCoreInputUnit::run() {
                         ip->setEnvelope(env2);
                     }
                 }
+#else // YARP_NO_DEPRECATED
+                if (env.length()>2) {
+                    //YARP_ERROR(Logger::get(),
+                    //"***** received an envelope! [%s]", env.c_str());
+                    ConstString env2 = env.substr(2,env.length());
+                    man.setEnvelope(env2);
+                    ip->setEnvelope(env2);
+                }
+#endif // YARP_NO_DEPRECATED
                 if (localReader) {
                     localReader->read(br);
                     if (!br.isActive()) { done = true; break; }

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -273,38 +273,16 @@ bool PortCoreOutputUnit::sendHelper() {
                     buf.addToHeader();
 
                     if (cachedEnvelope!="") {
-                        // this will be the new way to signal that replies
-                        // are not expected
-                        //PortCommand pc('\0', ConstString(suppressReply?"D ":"d ") +
-                        //             cachedEnvelope);
-                        //pc.writeBlock(buf);
-
-                        // This is the backwards-compatible method.
-                        // To be used until YARP 2.1.2 is a "long time ago".
                         if (cachedEnvelope=="__ADMIN") {
                             PortCommand pc('a', "");
                             pc.write(buf);
                         } else {
-                            PortCommand pc('\0', ConstString(suppressReply?"do ":"d ") +
-                                        cachedEnvelope);
+                            PortCommand pc('\0', ConstString(suppressReply ? "D " : "d ") + cachedEnvelope);
                             pc.write(buf);
                         }
-
                     } else {
-                        // this will be the new way to signal that replies
-                        // are not expected
-                        //PortCommand pc(suppressReply?'D':'d',"");
-                        //pc.writeBlock(buf);
-
-                        // This is the backwards-compatible method.
-                        // To be used until YARP 2.1.2 is a "long time ago".
-                        if (suppressReply) {
-                            PortCommand pc('\0', "do");
-                            pc.write(buf);
-                        } else {
-                            PortCommand pc('d', "");
-                            pc.write(buf);
-                        }
+                        PortCommand pc(suppressReply ? 'D' : 'd', "");
+                        pc.write(buf);
                     }
                 }
             }
@@ -414,6 +392,3 @@ void *PortCoreOutputUnit::takeTracker() {
 bool PortCoreOutputUnit::isBusy() {
     return sending;
 }
-
-
-


### PR DESCRIPTION
YARP 2.1.2 is now a "long time ago"...

I'm not sure about this, but this might break compatibility at protocol level between `master` and `devel` because by default, the output part, still writes using the old protocol.
I believe it is time to get rid of this part of the code, but if you think it is not ok to do so I can probably change the `PortCoreOutputUnit` now (so that `devel` "writes" using the new protocol but "reads" both), that should keep the compatibility with `master`, and  later remove the `PortCoreInputUnit` part.