### PR TITLE
Fix SIGPIPE errors when running tests with gdb

### DIFF
--- a/doc/release/v2_3_66_1.md
+++ b/doc/release/v2_3_66_1.md
@@ -48,6 +48,7 @@ Bug Fixes
   other platforms (#633)
 * `yarp plugin` command now works with `SKIP_ACE` enabled.
 * Fixed UDP and MCAST on macOS (#637)
+* Fixed SIGPIPE when closing input port before output ports.
 
 
 ### YARP_DEV

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -373,7 +373,6 @@ void PortCore::closeMain() {
             if (unit!=NULL) {
                 if (unit->isInput()) {
                     if (!unit->isDoomed()) {
-                        unit->interrupt();
                         Route r = unit->getRoute();
                         String s = r.getFromName();
                         if (s.length()>=1) {

--- a/tests/libYARP_OS/NetworkTest.cpp
+++ b/tests/libYARP_OS/NetworkTest.cpp
@@ -78,6 +78,11 @@ public:
             p.reply(b2);
         }
     }
+
+    virtual void onStop() {
+        p.interrupt();
+        p.close();
+    }
 };
 
 class NetworkTest : public UnitTest {


### PR DESCRIPTION
* **OS/PortCore: do not interrupt input unit in closeMain**

  When an input port is deleted, all the ports connected to this port should be disconnected first. Therefore a message is sent to these ports, and these perform the actual disconnection. The real disconnection is executed after sending a final message on the socket.

  The interrupt() call removed by this patch closes the socket internally, therefore when the final message is sent by the output port, the output socket is broken, hence the SIGPIPE.

  Removing the interrupt here does not seem to have side effects, since the socket is closed later, when the message arrives.


* **NetworkTest: Interrupt and close the port when the SlowResponder thread is stopped**

  This fixes the SIGPIPE crash with gdb