### PR TITLE
Implement scheduling priority methods for C++11

### DIFF
--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -362,10 +362,10 @@ int ThreadImpl::setPriority(int priority, int policy) {
         YARP_ERROR(Logger::get(),"Cannot set priority with C++11");
 #elif defined(YARP_HAS_ACE) // Use ACE API
         return ACE_Thread::setprio(hid, priority, policy);
-#elif defined(UNIX) // Use the POSIX syscalls
+#elif defined(__unix__) // Use the POSIX syscalls
         struct sched_param thread_param;
         thread_param.sched_priority = priority;
-        int ret pthread_setschedparam(hid, policy, &thread_param);
+        int ret = pthread_setschedparam(hid, policy, &thread_param);
         return (ret != 0) ? -1 : 0;
 #else
         YARP_ERROR(Logger::get(),"Cannot set priority without ACE");
@@ -382,11 +382,12 @@ int ThreadImpl::getPriority() {
         YARP_ERROR(Logger::get(),"Cannot get priority with C++11");
 #elif defined(YARP_HAS_ACE) // Use ACE API
         ACE_Thread::getprio(hid, prio);
-#elif defined(UNIX) // Use the POSIX syscalls
+#elif defined(__unix__) // Use the POSIX syscalls
         struct sched_param thread_param;
         int policy;
-        if(pthread_getschedparam(hid, &policy, &thread_param) == 0)
-            prio = thread_param.priority;
+        if(pthread_getschedparam(hid, &policy, &thread_param) == 0) {
+            prio = thread_param.sched_priority;
+        }
 #else
         YARP_ERROR(Logger::get(),"Cannot read priority without ACE");
 #endif
@@ -403,10 +404,11 @@ int ThreadImpl::getPolicy() {
 #elif defined(YARP_HAS_ACE) // Use ACE API
         int prio;
         ACE_Thread::getprio(hid, prio, policy);
-#elif defined(UNIX) // Use the POSIX syscalls
+#elif defined(__unix__) // Use the POSIX syscalls
         struct sched_param thread_param;
-        if(pthread_getschedparam(hid, &policy, &thread_param) != 0)
+        if(pthread_getschedparam(hid, &policy, &thread_param) != 0) {
             policy = defaultPolicy;
+        }
 #else
         YARP_ERROR(Logger::get(),"Cannot read scheduling policy without ACE");
 #endif
@@ -428,7 +430,7 @@ void ThreadImpl::yield() {
     std::this_thread::yield();
 #elif defined(YARP_HAS_ACE) // Use ACE API
     ACE_Thread::yield();
-#elif defined(UNIX) // Use the POSIX syscalls
+#elif defined(__unix__) // Use the POSIX syscalls
     pthread_yield();
 #else
     YARP_ERROR(Logger::get(),"Cannot yield thread without ACE");

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -17,6 +17,12 @@
 
 #include <stdlib.h>
 
+#if defined(YARP_HAS_CXX11)
+#  if defined(YARP_HAS_ACE)
+#    include <ace/Thread.h> // For using ACE_hthread_t as native_handle
+#  endif
+#endif
+
 #if defined(__linux__) // Use the POSIX syscalls for the gettid()
     #include <sys/syscall.h>
     #include <unistd.h>
@@ -358,8 +364,24 @@ int ThreadImpl::setPriority(int priority, int policy) {
     if (active && priority!=-1) {
 
 #if defined(YARP_HAS_CXX11)
-        // FIXME Use std::thread::native_handle()
-        YARP_ERROR(Logger::get(),"Cannot set priority with C++11");
+#  if defined(YARP_HAS_ACE)
+        if (std::is_same<std::thread::native_handle_type, ACE_hthread_t>::value) {
+            return ACE_Thread::setprio(hid.native_handle(), priority, policy);
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot set priority without ACE");
+        }
+#  elif defined(__unix__)
+        if (std::is_same<std::thread::native_handle_type, pthread_t>::value) {
+            struct sched_param thread_param;
+            thread_param.sched_priority = priority;
+            int ret = pthread_setschedparam(hid.native_handle(), policy, &thread_param);
+            return (ret != 0) ? -1 : 0;
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot set priority without ACE");
+        }
+#  else
+        YARP_ERROR(Logger::get(),"Cannot set priority without ACE");
+#  endif
 #elif defined(YARP_HAS_ACE) // Use ACE API
         return ACE_Thread::setprio(hid, priority, policy);
 #elif defined(__unix__) // Use the POSIX syscalls
@@ -378,8 +400,25 @@ int ThreadImpl::getPriority() {
     int prio = defaultPriority;
     if (active) {
 #if defined(YARP_HAS_CXX11)
-        // FIXME Use std::thread::native_handle()
-        YARP_ERROR(Logger::get(),"Cannot get priority with C++11");
+#  if defined(YARP_HAS_ACE)
+        if (std::is_same<std::thread::native_handle_type, ACE_hthread_t>::value) {
+            ACE_Thread::getprio(hid.native_handle(), prio);
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot get priority without ACE");
+        }
+#  elif defined(__unix__)
+        if (std::is_same<std::thread::native_handle_type, pthread_t>::value) {
+            struct sched_param thread_param;
+            int policy;
+            if(pthread_getschedparam(hid.native_handle(), &policy, &thread_param) == 0) {
+                prio = thread_param.sched_priority;
+            }
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot get priority without ACE");
+        }
+#  else
+        YARP_ERROR(Logger::get(),"Cannot get priority without ACE");
+#  endif
 #elif defined(YARP_HAS_ACE) // Use ACE API
         ACE_Thread::getprio(hid, prio);
 #elif defined(__unix__) // Use the POSIX syscalls
@@ -399,8 +438,25 @@ int ThreadImpl::getPolicy() {
     int policy = defaultPolicy;
     if (active) {
 #if defined(YARP_HAS_CXX11)
-        // FIXME Use std::thread::native_handle()
-        YARP_ERROR(Logger::get(),"Cannot get scheduling policy with C++11");
+#  if defined(YARP_HAS_ACE)
+        if (std::is_same<std::thread::native_handle_type, ACE_hthread_t>::value) {
+            int prio;
+            ACE_Thread::getprio(hid.native_handle(), prio, policy);
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot get scheduling policy without ACE");
+        }
+#  elif defined(__unix__)
+        if (std::is_same<std::thread::native_handle_type, pthread_t>::value) {
+            struct sched_param thread_param;
+            if(pthread_getschedparam(hid.native_handle(), &policy, &thread_param) != 0) {
+                policy = defaultPolicy;
+            }
+        } else {
+            YARP_ERROR(Logger::get(),"Cannot get scheduling policy without ACE");
+        }
+#  else
+        YARP_ERROR(Logger::get(),"Cannot get scheduling policy without ACE");
+#  endif
 #elif defined(YARP_HAS_ACE) // Use ACE API
         int prio;
         ACE_Thread::getprio(hid, prio, policy);


### PR DESCRIPTION
* **Fix scheduling priority methods on UNIX without ACE**

  These methods are currently implemented in an `#if defined(UNIX)` that is actually never built (and this is obvious because the code inside is missing an `=` and therefore it is broken. The correct macro is `__unix__`.

* **Implement scheduling priority methods for C++11**

  These methods are at the moment not implemented without C++11. Using [std::thread::native_handle](http://en.cppreference.com/w/cpp/thread/thread/native_handle) allow us to get a handle depending on the implementation and to use it either with ACE or with pthread.

Note: this is currently untested on windows with `YARP_EXPERIMENTAL_CXX11` enabled + ACE. It would be really useful if someone could at least try and see if it builds, since I'm not sure if the native handle is the same in this case. CC @pattacini, @randaz81.
