### PR TITLE
Fix the bundle folder to be named "<target>.app.app"

### DIFF
--- a/cmake/YarpOSXUtilities.cmake
+++ b/cmake/YarpOSXUtilities.cmake
@@ -99,6 +99,12 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
     # Enable bundle creation
     set_target_properties(${_target_dest} PROPERTIES MACOSX_BUNDLE ON)
 
+    # Force OUTPUT_NAME to be the same as original (.app is appended automatically)
+    get_property(_output_name_set TARGET ${_target_orig} PROPERTY OUTPUT_NAME SET)
+    if(NOT _output_name_set)
+      set_target_properties(${_target_dest} PROPERTIES OUTPUT_NAME ${_target_orig})
+    endif()
+
     # Set icon for the bundle
     if (DEFINED _DADB_APP_ICON)
       get_filename_component(_filename "${_DADB_APP_ICON}" NAME)

--- a/cmake/YarpOSXUtilities.cmake
+++ b/cmake/YarpOSXUtilities.cmake
@@ -11,7 +11,6 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
  if(APPLE)
     set(_options )
     set(_oneValueArgs TARGET_ORIG
-                      TARGET_DEST
                       APP_ICON
                       INSTALL_DESTINATION
                       INSTALL_COMPONENT)
@@ -26,12 +25,7 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
       message(FATAL_ERROR "TARGET_ORIG is required")
     endif()
     set(_target_orig ${_DADB_TARGET_ORIG})
-
-    if(NOT DEFINED _DADB_TARGET_DEST)
-      set(_target_dest ${_target_orig}.app)
-    else()
-      set(_target_dest ${_DADB_TARGET_DEST})
-    endif()
+    set(_target_dest ${_target_orig}.app)
 
     if(DEFINED _DADB_INSTALL_COMPONENT AND NOT DEFINED _DADB_INSTALL_DESTINATION)
       message(FATAL_ERROR "INSTALL_COMPONENT cannot be used without INSTALL_DESTINATION")

--- a/cmake/YarpOSXUtilities.cmake
+++ b/cmake/YarpOSXUtilities.cmake
@@ -10,7 +10,7 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
 
  if(APPLE)
     set(_options )
-    set(_oneValueArgs TARGET_ORIG
+    set(_oneValueArgs TARGET
                       APP_ICON
                       INSTALL_DESTINATION
                       INSTALL_COMPONENT)
@@ -21,10 +21,10 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
                                 "${_multiValueArgs}"
                                 "${ARGN}")
 
-    if(NOT DEFINED _DADB_TARGET_ORIG)
-      message(FATAL_ERROR "TARGET_ORIG is required")
+    if(NOT DEFINED _DADB_TARGET)
+      message(FATAL_ERROR "TARGET is required")
     endif()
-    set(_target_orig ${_DADB_TARGET_ORIG})
+    set(_target_orig ${_DADB_TARGET})
     set(_target_dest ${_target_orig}.app)
 
     if(DEFINED _DADB_INSTALL_COMPONENT AND NOT DEFINED _DADB_INSTALL_DESTINATION)

--- a/src/yarpbatterygui/CMakeLists.txt
+++ b/src/yarpbatterygui/CMakeLists.txt
@@ -54,7 +54,6 @@ if(CREATE_YARPBATTERYGUI)
   install(TARGETS yarpbatterygui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpbatterygui
-                                    TARGET_DEST yarpbatterygui.app
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpbatterygui/CMakeLists.txt
+++ b/src/yarpbatterygui/CMakeLists.txt
@@ -53,7 +53,7 @@ if(CREATE_YARPBATTERYGUI)
 
   install(TARGETS yarpbatterygui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpbatterygui
+  yarp_osx_duplicate_and_add_bundle(TARGET yarpbatterygui
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpdataplayer/CMakeLists.txt
+++ b/src/yarpdataplayer/CMakeLists.txt
@@ -99,7 +99,7 @@ if(CREATE_YARPDATAPLAYER)
 
   install(TARGETS yarpdataplayer COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpdataplayer
+  yarp_osx_duplicate_and_add_bundle(TARGET yarpdataplayer
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpdataplayer/CMakeLists.txt
+++ b/src/yarpdataplayer/CMakeLists.txt
@@ -100,7 +100,6 @@ if(CREATE_YARPDATAPLAYER)
   install(TARGETS yarpdataplayer COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpdataplayer
-                                    TARGET_DEST yarpdataplayer.app
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarplaserscannergui/CMakeLists.txt
+++ b/src/yarplaserscannergui/CMakeLists.txt
@@ -57,7 +57,6 @@ if(CREATE_YARPLASERSCANNERGUI)
   install(TARGETS yarplaserscannergui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarplaserscannergui
-                                    TARGET_DEST yarplaserscannergui.app
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarplaserscannergui/CMakeLists.txt
+++ b/src/yarplaserscannergui/CMakeLists.txt
@@ -56,7 +56,7 @@ if(CREATE_YARPLASERSCANNERGUI)
 
   install(TARGETS yarplaserscannergui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarplaserscannergui
+  yarp_osx_duplicate_and_add_bundle(TARGET yarplaserscannergui
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarplogger/CMakeLists.txt
+++ b/src/yarplogger/CMakeLists.txt
@@ -46,7 +46,6 @@ if(CREATE_YARPLOGGER)
           DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarplogger
-                                    TARGET_DEST yarplogger.app
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarplogger/CMakeLists.txt
+++ b/src/yarplogger/CMakeLists.txt
@@ -45,7 +45,7 @@ if(CREATE_YARPLOGGER)
           COMPONENT utilities
           DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarplogger
+  yarp_osx_duplicate_and_add_bundle(TARGET yarplogger
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpmanager++/CMakeLists.txt
+++ b/src/yarpmanager++/CMakeLists.txt
@@ -128,7 +128,7 @@ if(CREATE_YARPMANAGER_PP)
 
     install(TARGETS yarpmanager++ COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-    yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmanager++
+    yarp_osx_duplicate_and_add_bundle(TARGET yarpmanager++
                                       APP_ICON src-manager/Resources/AppIcon.icns
                                       INSTALL_COMPONENT utilities
                                       INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/yarpmanager++/CMakeLists.txt
+++ b/src/yarpmanager++/CMakeLists.txt
@@ -129,7 +129,6 @@ if(CREATE_YARPMANAGER_PP)
     install(TARGETS yarpmanager++ COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmanager++
-                                      TARGET_DEST yarpmanager++.app
                                       APP_ICON src-manager/Resources/AppIcon.icns
                                       INSTALL_COMPONENT utilities
                                       INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/yarpmanager/CMakeLists.txt
+++ b/src/yarpmanager/CMakeLists.txt
@@ -87,7 +87,6 @@ if(CREATE_YARPMANAGER)
   install(TARGETS yarpmanager COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmanager
-                                    TARGET_DEST yarpmanager.app
                                     APP_ICON Resources/AppIcon.icns
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/yarpmanager/CMakeLists.txt
+++ b/src/yarpmanager/CMakeLists.txt
@@ -86,7 +86,7 @@ if(CREATE_YARPMANAGER)
 
   install(TARGETS yarpmanager COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmanager
+  yarp_osx_duplicate_and_add_bundle(TARGET yarpmanager
                                     APP_ICON Resources/AppIcon.icns
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/yarpmotorgui/CMakeLists.txt
+++ b/src/yarpmotorgui/CMakeLists.txt
@@ -74,7 +74,7 @@ if(CREATE_YARPMOTORGUI)
 
   install(TARGETS yarpmotorgui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmotorgui
+  yarp_osx_duplicate_and_add_bundle(TARGET yarpmotorgui
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
   yarp_install(FILES yarpmotorgui.xml

--- a/src/yarpmotorgui/CMakeLists.txt
+++ b/src/yarpmotorgui/CMakeLists.txt
@@ -75,7 +75,6 @@ if(CREATE_YARPMOTORGUI)
   install(TARGETS yarpmotorgui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpmotorgui
-                                    TARGET_DEST yarpmotorgui.app
                                     INSTALL_COMPONENT utilities
                                     INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
   yarp_install(FILES yarpmotorgui.xml

--- a/src/yarpscope/src/CMakeLists.txt
+++ b/src/yarpscope/src/CMakeLists.txt
@@ -40,7 +40,7 @@ install(TARGETS yarpscope
         COMPONENT utilities
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpscope
+yarp_osx_duplicate_and_add_bundle(TARGET yarpscope
                                   INSTALL_COMPONENT utilities
                                   INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpscope/src/CMakeLists.txt
+++ b/src/yarpscope/src/CMakeLists.txt
@@ -41,7 +41,6 @@ install(TARGETS yarpscope
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpscope
-                                  TARGET_DEST yarpscope.app
                                   INSTALL_COMPONENT utilities
                                   INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/yarpview/src/CMakeLists.txt
+++ b/src/yarpview/src/CMakeLists.txt
@@ -41,7 +41,6 @@ install(TARGETS yarpview
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpview
-                                  TARGET_DEST yarpview.app
                                   APP_ICON icons/AppIcon.icns
                                   INSTALL_COMPONENT utilities
                                   INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/yarpview/src/CMakeLists.txt
+++ b/src/yarpview/src/CMakeLists.txt
@@ -40,7 +40,7 @@ install(TARGETS yarpview
         COMPONENT utilities
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-yarp_osx_duplicate_and_add_bundle(TARGET_ORIG yarpview
+yarp_osx_duplicate_and_add_bundle(TARGET yarpview
                                   APP_ICON icons/AppIcon.icns
                                   INSTALL_COMPONENT utilities
                                   INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
After removing the GTK guis, also the code setting the `OUTPUT_NAME` property for gui targets was removed.
This code was setting the output name for the target `yarpfoo-qt` to `yarpfoo`.
This property was then copied to the bundle copy of the target, i.e. `yarpfoo.app` target had `OUTPUT_NAME` set to `yarpfoo`.
If `OUTPUT_NAME` is not set, it uses the name of the target as the output name, i.e. `yarpfoo.app`

CMake adds automatically `.app` to this name, therefore if `OUTPUT_NAME` is not set, `yarpfoo` copy target gerates a bundle `yarpfoo.app.app`

In this patch, if `OUTPUT_NAME` is not set, it is forced to the name of the original target.

Also the `TARGET_DEST` and `TARGET_ORIG` options are removed and replaced by the `TARGET` option