### PR TITLE
Fix segfault while closing yarp modules

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_OS/include/yarp/os/impl/LogForwarder.h
@@ -20,16 +20,15 @@ namespace os {
 
 #define MAX_STRING_SIZE 255
 
-class YARP_OS_API LogForwarderDestroyer;
 class YARP_OS_API LogForwarder
 {
     public:
         static LogForwarder* getInstance();
+        static void clearInstance();
         void forward (std::string message);
     protected:
         LogForwarder();
         ~LogForwarder();
-        friend class LogForwarderDestroyer;
     private:
         static yarp::os::Semaphore *sem;
         char logPortName[MAX_STRING_SIZE];
@@ -38,17 +37,6 @@ class YARP_OS_API LogForwarder
         LogForwarder(LogForwarder const&){};
         LogForwarder& operator=(LogForwarder const&){return *this;}; //@@@checkme
         static LogForwarder* instance;
-        static LogForwarderDestroyer destroyer;
-};
-
-class  YARP_OS_API LogForwarderDestroyer
-{
-    public:
-        LogForwarderDestroyer(LogForwarder * = 0);
-        ~LogForwarderDestroyer();
-        void SetSingleton(LogForwarder *s);
-    private:
-        LogForwarder* singleton;
 };
 
 }

--- a/src/libYARP_OS/src/LogForwarder.cpp
+++ b/src/libYARP_OS/src/LogForwarder.cpp
@@ -12,7 +12,6 @@
 #include <yarp/os/Log.h>
 
 yarp::os::LogForwarder* yarp::os::LogForwarder::instance = YARP_NULLPTR;
-yarp::os::LogForwarderDestroyer yarp::os::LogForwarder::destroyer;
 yarp::os::Semaphore *yarp::os::LogForwarder::sem = YARP_NULLPTR;
 
 yarp::os::LogForwarder* yarp::os::LogForwarder::getInstance()
@@ -20,9 +19,16 @@ yarp::os::LogForwarder* yarp::os::LogForwarder::getInstance()
     if (!instance)
     {
         instance = new LogForwarder;
-        destroyer.SetSingleton(instance);
     }
     return instance;
+};
+
+void yarp::os::LogForwarder::clearInstance()
+{
+    if (instance)
+    {
+        delete instance;
+    };
 };
 
 void yarp::os::LogForwarder::forward (std::string message)
@@ -43,7 +49,10 @@ void yarp::os::LogForwarder::forward (std::string message)
 
 yarp::os::LogForwarder::LogForwarder()
 {
-    yarp::os::NetworkBase::initMinimum();
+    // I believe this guy, which is called by a yDebug() or similar, should be always called after
+    // yarp::os::Network has already been initialized, therefore calling initMinimum here is not required.
+    // It should not harm, but I prefer to avoid it if possible
+//     yarp::os::NetworkBase::initMinimum();
     sem = new yarp::os::Semaphore(1);
     yAssert(sem);
     outputPort =0;
@@ -79,24 +88,6 @@ yarp::os::LogForwarder::~LogForwarder()
     sem->post();
     delete sem;
     sem = YARP_NULLPTR;
-    yarp::os::NetworkBase::finiMinimum();
+//     yarp::os::NetworkBase::finiMinimum();
 };
-
-yarp::os::LogForwarderDestroyer::LogForwarderDestroyer(LogForwarder *s)
-{
-    singleton = s;
-}
-
-yarp::os::LogForwarderDestroyer::~LogForwarderDestroyer()
-{
-    if (singleton)
-    {
-        delete singleton;
-    }
-}
-
-void yarp::os::LogForwarderDestroyer::SetSingleton(LogForwarder *s)
-{
-    singleton = s;
-}
 

--- a/src/libYARP_init/src/CustomInit.cpp
+++ b/src/libYARP_init/src/CustomInit.cpp
@@ -29,9 +29,13 @@ extern "C" void yarpCustomInit() {
 #endif
 }
 
+#include <yarp/os/impl/LogForwarder.h>
+
 extern "C" int __yarp_is_initialized;
 
-extern "C" void yarpCustomFini() {
+extern "C" void yarpCustomFini()
+{
+    yarp::os::LogForwarder::clearInstance();
 }
 
 yarp::os::Network::Network() {


### PR DESCRIPTION
This issue fix the destruction of logForwarder causing segfault in closure of any yarp application.
