### PR TITLE
yarp::math::NormRand documentation fix

### DIFF
--- a/src/libYARP_math/include/yarp/math/NormRand.h
+++ b/src/libYARP_math/include/yarp/math/NormRand.h
@@ -27,7 +27,7 @@ namespace yarp
 
 
 /**
-* A static class grouping function for uniform random number 
+* A static class grouping function for normal random number 
 * generator. Thread safe.
 *
 * Methods inside this class provides access to a global instance 


### PR DESCRIPTION
This class is for a normal (Gaussian) probability distribution. The documentation was referring to a uniform distribution (which is in yarp::math::Rand).