### PR TITLE
Fix thread return value when C++11 compilation is activated

### DIFF
--- a/doc/release/v2_3_66_2.md
+++ b/doc/release/v2_3_66_2.md
@@ -11,6 +11,7 @@ Important Changes
 
 Bug Fixes
 ---------
+* Fixed join() return values of threads when C++11 compilation is activated (macro PLATFORM_THREAD_JOIN).
 
 ### GUIs
 

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformThread.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformThread.h
@@ -15,7 +15,7 @@
 #  define Platform_thread_t size_t
 #  define PLATFORM_THREAD_SELF() std::hash<std::thread::id>()(std::this_thread::get_id())
 #  define PLATFORM_THREAD_RETURN unsigned
-#  define PLATFORM_THREAD_JOIN(x) ([](std::thread& y) { if (!y.joinable()) return false; y.join(); return true; }(x))
+#  define PLATFORM_THREAD_JOIN(x) ([](std::thread& y) { if (!y.joinable()) return -1; y.join(); return 0; }(x))
 #elif defined(YARP_HAS_ACE)
 #  include <ace/Thread.h>
 #  include <ace/Sched_Params.h>

--- a/tests/libYARP_OS/ThreadTest.cpp
+++ b/tests/libYARP_OS/ThreadTest.cpp
@@ -284,39 +284,43 @@ public:
     }
 
     void testSync() {
-        report(0,"testing cross-thread synchronization...");
+        report(0, "testing cross-thread synchronization...");
+
         int tct = ThreadImpl::getCount();
-        Thread1 bozo(*this);
-        Thread1 bozo2(*this);
-        Thread2 burper(*this);
+        Thread1    bozo(*this);
+        Thread1    bozo2(*this);
+        Thread2    burper(*this);
         ThreadImpl t1(&bozo);
         ThreadImpl t2(&bozo2);
-        report(0,"starting threads ...");
+        report(0, "starting threads ...");
         burper.start();
         t1.start();
         Time::delay(0.05);
         t2.start();
-        checkEqual(ThreadImpl::getCount(),tct+3,"thread count");
-        t1.join();
-        t2.join();
+        checkEqual(ThreadImpl::getCount(), tct+3, "thread count");
+        checkEqual(t1.join(), 0, "thread t1 joined succesfully");
+        checkEqual(t2.join(), 0, "thread t1 joined succesfully");
         burper.close();
-        burper.join();
-        report(0,"... done threads");
-        checkEqual(expectCount,gotCount,"thread event counts");
-        checkEqual(true,expectCount==11,"thread event counts");
+        checkEqual(burper.join(), 0, "thread burper joined succesfully");
+        report(0, "... done threads");
+        checkEqual(expectCount, gotCount, "thread event counts");
+        checkEqual(true, expectCount==11, "thread event counts");
+
+        report(0, "done");
     }
 
     void testStartVersusStop() {
-        report(0,"testing start/stop");
-        Thread3 t;
-        checkTrue(!t.isRunning(),"not active");
-        t.start();
-        checkTrue(t.isRunning(),"active");
-        t.stop();
-        checkTrue(!t.isRunning(),"not active");
+        report(0, "testing start/stop");
 
+        Thread3 t;
+        checkTrue(!t.isRunning(), "not active");
+        checkTrue(t.start(),      "t started succefully");
+        checkTrue(t.isRunning(),  "t is active");
+        checkTrue(t.stop(),       "t stopped succefully");
+        checkTrue(!t.isRunning(), "not active");
         checkTrue(t.onStopCalled, "onStop was called");
-        report(0,"done");
+
+        report(0, "done");
     }
 
     void testInitAndRelease()
@@ -436,7 +440,7 @@ public:
         ThreadDelay t(0.1,true);
         checkTrue(t.active,"flag starts out ok");
         t.start();
-        t.join(1);
+        checkEqual(t.join(1), 0, "thread t joined succesfully before 1 second timeout");
         checkTrue(t.active,"timeout join returns before thread stops");
         t.hold = false;
         t.stop();


### PR DESCRIPTION
This is a dedicated PR that follows PR #943.

The 3 commits address 2 issues:

- Fix/Align the join() return value of YARP threads when C++11 compilation is activated. In particular, the return value is aligned with the one used by ACE and pthread threads (even though, as pointed out by @drdanz, `EINVAL` should be used as return value in place of -1, but the requirement is a value different from 0 and -1 is the same used by ACE.)
- Improve tests for YARP thread. The return values of join() calls are now tested.