### PR TITLE
Show/Hide window menu  for Yarpmanager++ 

### DIFF
--- a/src/yarpmanager++/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager++/src-manager/applicationviewwidget.cpp
@@ -14,6 +14,7 @@
 #include <QMenu>
 #include <QFileDialog>
 #include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/manager/localbroker.h>
 #include "yscopewindow.h"
 #include <QTreeWidgetItem>
@@ -108,9 +109,11 @@ ApplicationViewWidget::ApplicationViewWidget(yarp::manager::Application *app,
     builderWindowContainer->addDockWidget(Qt::TopDockWidgetArea,builderWidget);
     builder = YarpBuilderLib::getBuilder(this->app,lazyManager,&safeManager,editingMode);
     builderWidget->setWidget(builder);
-
-    builderWidget->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+    //builderWidget->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+    builderWidget->setFeatures(QDockWidget::NoDockWidgetFeatures);
     connect(builderWidget,SIGNAL(topLevelChanged(bool)),this,SLOT(onBuilderFloatChanged(bool)));
+
+    //builderWidget->pos()
 
     if (!editingMode) {
         //builder->addAction(modRunAction);
@@ -147,7 +150,8 @@ ApplicationViewWidget::ApplicationViewWidget(yarp::manager::Application *app,
         builder->addConnectionsAction(conn1SeparatorAction);
 
         ui->splitter->setStretchFactor(0,50);
-        ui->splitter->setStretchFactor(1,10);
+        ui->splitter->setStretchFactor(1,10);       
+        showBuilderWindows(*m_pConfig);
 
         connect(builder,SIGNAL(refreshApplication()),
                 this,SLOT(onRefreshApplication()),Qt::DirectConnection);
@@ -161,7 +165,6 @@ ApplicationViewWidget::ApplicationViewWidget(yarp::manager::Application *app,
 
     builder->load();
     builderToolBar = builder->getToolBar();
-
 }
 
 bool ApplicationViewWidget::save()
@@ -211,7 +214,7 @@ bool ApplicationViewWidget::isBuilderFloating()
 
 void ApplicationViewWidget::onBuilderFloatChanged(bool floating)
 {
-
+    /*
     if (floating) {
         builderWindowFloating(floating);
         builder->addToolBar();
@@ -221,7 +224,7 @@ void ApplicationViewWidget::onBuilderFloatChanged(bool floating)
         builderToolBar = builder->getToolBar();
         builderWindowFloating(floating);
     }
-
+    */
 }
 
 /*! \brief Create the context menu for the modules tree. */
@@ -2114,4 +2117,24 @@ QTreeWidgetItem* ApplicationViewWidget::getModRowByID(int id, QTreeWidgetItem *p
 
 void ApplicationViewWidget::closeManager() {
     safeManager.close();
+}
+
+
+void ApplicationViewWidget::showBuilderWindows(yarp::os::Property& proprty) {
+    if(editingMode)
+        return;
+    int w1 = width()/2.0;
+    int w2 = width()/2.0;
+    if(!proprty.check("showBuilder") && proprty.check("showManager")) {
+        w1 = width();
+        w2 = 0;
+    }
+    else if(proprty.check("showBuilder") && !proprty.check("showManager")) {
+        w1 = 0;
+        w2 = width();
+    }
+    QList<int> ss;
+    ss.push_back(w1);
+    ss.push_back(w2);
+    ui->splitter->setSizes(ss);
 }

--- a/src/yarpmanager++/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager++/src-manager/applicationviewwidget.h
@@ -74,6 +74,7 @@ public:
 
     bool isEditingMode();
 
+    void showBuilderWindows(yarp::os::Property& proprty);
 
 private:
     bool getConRowByID(int id, int *row);

--- a/src/yarpmanager++/src-manager/mainwindow.cpp
+++ b/src/yarpmanager++/src-manager/mainwindow.cpp
@@ -117,12 +117,14 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionSave,SIGNAL(triggered()),this,SLOT(onSave()));
     connect(ui->actionHelp,SIGNAL(triggered()),this,SLOT(onHelp()));
     connect(ui->actionAbout,SIGNAL(triggered()),this,SLOT(onAbout()));
-
+    connect(ui->action_Builder_Window, SIGNAL(triggered()),this, SLOT(onViewBuilderWindows()));
+    connect(ui->action_Manager_Window, SIGNAL(triggered()),this, SLOT(onViewBuilderWindows()));
 
     connect(this,SIGNAL(selectItem(QString)),ui->entitiesTree,SLOT(onSelectItem(QString)));
 
     onTabChangeItem(-1);
 
+    ui->action_Manager_Window->setChecked(true);
 
 }
 
@@ -481,6 +483,16 @@ void MainWindow::viewApplication(yarp::manager::Application *app,bool editingMod
         }
     }
 
+    if(ui->action_Builder_Window->isChecked())
+        config.put("showBuilder", true);
+    else
+        config.unput("showBuilder");
+
+    if(ui->action_Manager_Window->isChecked())
+        config.put("showManager", true);
+    else
+        config.unput("showManager");
+
     ApplicationViewWidget *w = new ApplicationViewWidget(app,&lazyManager,&config,editingMode,ui->mainTabs);
     connect(w,SIGNAL(logError(QString)),this,SLOT(onLogError(QString)));
     connect(w,SIGNAL(logWarning(QString)),this,SLOT(onLogWarning(QString)));
@@ -715,11 +727,11 @@ void MainWindow::onLogMessage(QString msg)
 
 void MainWindow::onBuilderWindowFloating(bool floating)
 {
+    /*
     if(builderToolBar){
         removeToolBar(builderToolBar);
         builderToolBar = NULL;
     }
-
     if(!floating){
         GenericViewWidget *w = (GenericViewWidget*)ui->mainTabs->widget(ui->mainTabs->currentIndex());
         if(w && w->getType() == yarp::manager::APPLICATION){
@@ -731,6 +743,7 @@ void MainWindow::onBuilderWindowFloating(bool floating)
             }
         }
     }
+    */
 }
 
 /*! \brief Called when a tab has been pressed
@@ -771,6 +784,7 @@ void MainWindow::onTabChangeItem(int index)
             ui->actionSave_As->setEnabled(false);
         }
 
+        /*
         if(builderToolBar){
             removeToolBar(builderToolBar);
             builderToolBar = NULL;
@@ -784,7 +798,7 @@ void MainWindow::onTabChangeItem(int index)
         if(aw->isBuilderFloating()){
             aw->showBuilder(true);
         }
-
+    */
         if(prevWidget && prevWidget != w){
             if(prevWidget->getType() == yarp::manager::APPLICATION){
                 ApplicationViewWidget *aw = (ApplicationViewWidget*)prevWidget;
@@ -810,10 +824,12 @@ void MainWindow::onTabChangeItem(int index)
         ui->actionStop->setEnabled(false);
         ui->actionKill->setEnabled(false);
 
+        /*
         if(builderToolBar){
             removeToolBar(builderToolBar);
             builderToolBar = NULL;
         }
+        */
 
 //        if(w){
 //            BuilderWindow *b = (BuilderWindow*)ui->mainTabs->widget(index);
@@ -1121,3 +1137,27 @@ void MainWindow::onReopenResource(QString resName,QString fileName)
     lazyManager.addResource(fileName.toLatin1().data());
     syncApplicationList();
 }
+
+void MainWindow::onViewBuilderWindows() {
+    if(ui->action_Builder_Window->isChecked())
+        config.put("showBuilder", true);
+    else
+        config.unput("showBuilder");
+
+    if(ui->action_Manager_Window->isChecked())
+        config.put("showManager", true);
+    else
+        config.unput("showManager");
+
+    for(int i=0;i<ui->mainTabs->count();i++){
+        GenericViewWidget *w = (GenericViewWidget*)ui->mainTabs->widget(i);
+        yAssert(w);
+        if(w->getType() == yarp::manager::APPLICATION){
+            ApplicationViewWidget *aw = ((ApplicationViewWidget*)w);
+            yAssert(aw);
+            aw->showBuilderWindows(config);
+        }
+    }
+}
+
+

--- a/src/yarpmanager++/src-manager/mainwindow.h
+++ b/src/yarpmanager++/src-manager/mainwindow.h
@@ -85,6 +85,7 @@ private slots:
     void onAbout();
     void onBuilderWindowFloating(bool);
     void onWizardError(QString);
+    void onViewBuilderWindows();
 
     void onModified(bool);
 

--- a/src/yarpmanager++/src-manager/mainwindow.ui
+++ b/src/yarpmanager++/src-manager/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>YARP module manager</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="res.qrc">
+   <iconset resource="../../yarplogger/res.qrc">
     <normaloff>:/logo.svg</normaloff>:/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -221,7 +221,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>25</height>
+     <height>19</height>
     </rect>
    </property>
    <property name="nativeMenuBar">
@@ -280,9 +280,17 @@
     <addaction name="actionHelp"/>
     <addaction name="actionAbout"/>
    </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="action_Builder_Window"/>
+    <addaction name="action_Manager_Window"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuManage"/>
+   <addaction name="menu_View"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
@@ -309,7 +317,7 @@
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionNew_Application">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/run22.svg</normaloff>:/run22.svg</iconset>
    </property>
    <property name="text">
@@ -318,7 +326,7 @@
   </action>
   <action name="actionNew_Module">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/module22.svg</normaloff>:/module22.svg</iconset>
    </property>
    <property name="text">
@@ -327,7 +335,7 @@
   </action>
   <action name="actionNew_Resource">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/computer22.svg</normaloff>:/computer22.svg</iconset>
    </property>
    <property name="text">
@@ -336,7 +344,7 @@
   </action>
   <action name="actionOpen_File">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/file-new.svg</normaloff>:/file-new.svg</iconset>
    </property>
    <property name="text">
@@ -345,7 +353,7 @@
   </action>
   <action name="actionClose">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/close.svg</normaloff>:/close.svg</iconset>
    </property>
    <property name="text">
@@ -357,7 +365,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -369,7 +377,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -378,7 +386,7 @@
   </action>
   <action name="actionImport_Files">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/folder-new.svg</normaloff>:/folder-new.svg</iconset>
    </property>
    <property name="text">
@@ -387,7 +395,7 @@
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/close.svg</normaloff>:/close.svg</iconset>
    </property>
    <property name="text">
@@ -396,7 +404,7 @@
   </action>
   <action name="actionSelect_All">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/select-all.svg</normaloff>:/select-all.svg</iconset>
    </property>
    <property name="text">
@@ -405,7 +413,7 @@
   </action>
   <action name="actionExport_Graph">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/uml-app.svg</normaloff>:/uml-app.svg</iconset>
    </property>
    <property name="text">
@@ -414,7 +422,7 @@
   </action>
   <action name="actionRun">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/play.svg</normaloff>:/play.svg</iconset>
    </property>
    <property name="text">
@@ -423,7 +431,7 @@
   </action>
   <action name="actionStop">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/stop.svg</normaloff>:/stop.svg</iconset>
    </property>
    <property name="text">
@@ -432,7 +440,7 @@
   </action>
   <action name="actionKill">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/kill.svg</normaloff>:/kill.svg</iconset>
    </property>
    <property name="text">
@@ -441,7 +449,7 @@
   </action>
   <action name="actionConnect">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/connect.svg</normaloff>:/connect.svg</iconset>
    </property>
    <property name="text">
@@ -450,7 +458,7 @@
   </action>
   <action name="actionDisconnect">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/disconnect.svg</normaloff>:/disconnect.svg</iconset>
    </property>
    <property name="text">
@@ -459,7 +467,7 @@
   </action>
   <action name="actionRefresh_Status">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/refresh.svg</normaloff>:/refresh.svg</iconset>
    </property>
    <property name="text">
@@ -468,7 +476,7 @@
   </action>
   <action name="actionHelp">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/help.svg</normaloff>:/help.svg</iconset>
    </property>
    <property name="text">
@@ -477,11 +485,27 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset resource="res.qrc">
+    <iconset resource="res_manager.qrc">
      <normaloff>:/info.svg</normaloff>:/info.svg</iconset>
    </property>
    <property name="text">
     <string>About</string>
+   </property>
+  </action>
+  <action name="action_Builder_Window">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Builder Window</string>
+   </property>
+  </action>
+  <action name="action_Manager_Window">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Manager Window</string>
    </property>
   </action>
  </widget>
@@ -499,7 +523,9 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="res.qrc"/>
+  <include location="../../yarpdataplayer/src/RC/res.qrc"/>
+  <include location="../../yarplogger/res.qrc"/>
+  <include location="res_manager.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
This pull request adds the show/hide menu to the yarpmanager++ to enable/disable the builder or manager windows. 

By default the builder windows is set to hidden. 