### PR TITLE
Setting modules' environment variables within application XML file

### DIFF
--- a/src/libYARP_OS/src/Run.cpp
+++ b/src/libYARP_OS/src/Run.cpp
@@ -9,6 +9,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/RunProcManager.h>
+#include <yarp/os/impl/SplitString.h>
 #include <yarp/os/SystemInfo.h>
 #include <yarp/os/SystemInfoSerializer.h>
 
@@ -1775,8 +1776,11 @@ int yarp::os::Run::executeCmdAndStdio(Bottle& msg,Bottle& result)
     yarp::os::ConstString cstrEnvName;
     if(msg.check("env"))
     {
-        lstrcpy(lpNew, (LPTCH) msg.find("env").asString().c_str());
-        lpNew += lstrlen(lpNew) + 1;
+        yarp::os::impl::SplitString ss(msg.find("env").asString().c_str(), ';');
+        for(int i=0; i<ss.size(); i++) {
+            lstrcpy(lpNew, (LPTCH) ss.get(i));
+            lpNew += lstrlen(lpNew) + 1;
+        }
     }
 
     // closing env block
@@ -2676,9 +2680,12 @@ int yarp::os::Run::executeCmdAndStdio(yarp::os::Bottle& msg,yarp::os::Bottle& re
 
                 if(msg.check("env"))
                 {
-                    char* szenv = new char[msg.find("env").asString().length()+1];
-                    strcpy(szenv,msg.find("env").asString().c_str());
-                    putenv(szenv); // putenv doesn't make copy of the string
+                    yarp::os::impl::SplitString ss(msg.find("env").asString().c_str(), ';');
+                    for(int i=0; i<ss.size(); i++) {
+                        char* szenv = new char[strlen(ss.get(i))+1];
+                        strcpy(szenv, ss.get(i));
+                        putenv(szenv); // putenv doesn't make copy of the string
+                    }
                     //delete [] szenv;
                 }
 
@@ -3028,9 +3035,12 @@ int yarp::os::Run::executeCmdStdout(yarp::os::Bottle& msg,yarp::os::Bottle& resu
 
                 if(msg.check("env"))
                 {
-                    char* szenv = new char[msg.find("env").asString().length()+1];
-                    strcpy(szenv,msg.find("env").asString().c_str());
-                    putenv(szenv); // putenv doesn't make copy of the string
+                    yarp::os::impl::SplitString ss(msg.find("env").asString().c_str(), ';');
+                    for(int i=0; i<ss.size(); i++) {
+                        char* szenv = new char[strlen(ss.get(i))+1];
+                        strcpy(szenv, ss.get(i));
+                        putenv(szenv); // putenv doesn't make copy of the string
+                    }
                     //delete [] szenv;
                 }
 
@@ -3457,9 +3467,12 @@ int yarp::os::Run::executeCmd(yarp::os::Bottle& msg,yarp::os::Bottle& result)
 
         if (msg.check("env"))
         {
-            char* szenv = new char[msg.find("env").asString().length()+1];
-            strcpy(szenv,msg.find("env").asString().c_str());
-            putenv(szenv); // putenv becomes owner of the string. DO NOT RELEASE it
+            yarp::os::impl::SplitString ss(msg.find("env").asString().c_str(), ';');
+            for(int i=0; i<ss.size(); i++) {
+                char* szenv = new char[strlen(ss.get(i))+1];
+                strcpy(szenv, ss.get(i));
+                putenv(szenv); // putenv doesn't make copy of the string
+            }
         }
 
         if (msg.check("workdir"))

--- a/src/libYARP_manager/include/yarp/manager/application.h
+++ b/src/libYARP_manager/include/yarp/manager/application.h
@@ -175,6 +175,7 @@ public:
     void setStdio(const char* szStdio) { if(szStdio) strStdio = szStdio; }
     void setBroker(const char* szBroker) { if(szBroker) strBroker = szBroker; }
     void setPrefix(const char* szPrefix) {if(szPrefix) strPrefix = szPrefix; }
+    void setEnvironemnt(const char* szEnv) {if(szEnv) strEnvironemnt = szEnv; }
     void setTag(const char* szTag) {if(szTag) strTag = szTag; }
     void setDisplay(const char* szDisplay) {if(szDisplay) strDisplay = szDisplay;}
 
@@ -186,6 +187,7 @@ public:
     const char* getStdio(void) { return strStdio.c_str(); }
     const char* getBroker(void) { return strBroker.c_str(); }
     const char* getPrefix(void) { return strPrefix.c_str(); }
+    const char* getEnvironment(void) { return strEnvironemnt.c_str(); }
     const char* getTag(void) { return strTag.c_str(); }
     const char* getDisplay() { return strDisplay.c_str(); }
 
@@ -222,6 +224,7 @@ private:
     string strStdio;
     string strBroker;
     string strPrefix;
+    string strEnvironemnt;
     string strDisplay;
     int iRank;
     ResourceContainer resources;

--- a/src/libYARP_manager/include/yarp/manager/module.h
+++ b/src/libYARP_manager/include/yarp/manager/module.h
@@ -125,6 +125,7 @@ public:
     void setStdio(const char* szStdio) { if(szStdio) strStdio = szStdio; }
     void setBroker(const char* szBroker) { if(szBroker) strBroker = szBroker; }
     void setPrefix(const char* szPrefix) { if(szPrefix) strPrefix = szPrefix; }
+    void setEnvironemnt(const char* szEnv) {if(szEnv) strEnvironemnt = szEnv; }
     void setBasePrefix(const char* szPrefix) { if(szPrefix) strBasePrefix = szPrefix; }
     void setNeedDeployer(bool need) { bNeedDeployer = need; }
     void setDisplay(const char* szDisplay) {if(szDisplay) strDisplay = szDisplay;}
@@ -143,6 +144,7 @@ public:
     const char* getStdio(void) { return strStdio.c_str(); }
     const char* getBroker(void) { return strBroker.c_str(); }
     const char* getPrefix(void) { return strPrefix.c_str(); }
+    const char* getEnvironment(void) { return strEnvironemnt.c_str(); }
     const char* getBasePrefix(void) { return strBasePrefix.c_str(); }
     const char* getDisplay() { return strDisplay.c_str(); }
 
@@ -213,6 +215,7 @@ private:
     string strBroker;
     bool bNeedDeployer;
     string strPrefix;
+    string strEnvironemnt;
     string strBasePrefix;
     double wait;
     string strDisplay;

--- a/src/libYARP_manager/src/application.cpp
+++ b/src/libYARP_manager/src/application.cpp
@@ -26,6 +26,7 @@ ModuleInterface::ModuleInterface(Module* module)
     strStdio = module->strStdio;
     strBroker = module->strBroker;
     strPrefix = module->strPrefix;
+    strEnvironemnt = module->strEnvironemnt;
     iRank = module->iRank;
     strTag = module->getLabel();
     strDisplay = module->getDisplay();

--- a/src/libYARP_manager/src/kbase.cpp
+++ b/src/libYARP_manager/src/kbase.cpp
@@ -1109,6 +1109,8 @@ bool KnowledgeBase::updateModule(Module* module, ModuleInterface* imod )
         module->setWorkDir(imod->getWorkDir());
     if(strlen(imod->getDisplay()))
         module->setDisplay(imod->getDisplay());
+    if(strlen(imod->getEnvironment()))
+        module->setEnvironemnt(imod->getEnvironment());
     module->setPostExecWait(imod->getPostExecWait());
     module->setModelBase(imod->getModelBase());
 

--- a/src/libYARP_manager/src/localbroker.cpp
+++ b/src/libYARP_manager/src/localbroker.cpp
@@ -7,6 +7,7 @@
  */
 
 
+#include <yarp/os/impl/SplitString.h>
 #include <yarp/manager/localbroker.h>
 
 #include <csignal>
@@ -658,8 +659,11 @@ int LocalBroker::ExecuteCmd(void)
     yarp::os::ConstString cstrEnvName;
     if(strEnv.size())
     {
-        lstrcpy(lpNew, (LPTCH) strEnv.c_str());
-        lpNew += lstrlen(lpNew) + 1;
+        yarp::os::impl::SplitString ss(strEnv.c_str(), ';');
+        for(int i=0; i<ss.size(); i++) {
+            lstrcpy(lpNew, (LPTCH) ss.get(i));
+            lpNew += lstrlen(lpNew) + 1;
+        }
     }
 
     // closing env block
@@ -892,12 +896,15 @@ int LocalBroker::ExecuteCmd(void)
         int nargs = 0;
         char **szarg = new char*[C_MAXARGS + 1];
         parseArguments(szcmd, &nargs, szarg);
-        szarg[nargs]=0;
+        szarg[nargs]=0;                
         if(strEnv.size())
         {
-            char* szenv = new char[strEnv.size()+1];
-            strcpy(szenv,strEnv.c_str());
-            putenv(szenv);
+            yarp::os::impl::SplitString ss(strEnv.c_str(), ';');
+            for(int i=0; i<ss.size(); i++) {
+                char* szenv = new char[strlen(ss.get(i))+1];
+                strcpy(szenv,ss.get(i));
+                putenv(szenv);
+            }
             //delete szenv;
         }
 
@@ -914,7 +921,7 @@ int LocalBroker::ExecuteCmd(void)
                 close(pipe_child_to_parent[WRITE_TO_PIPE]);
                 delete [] szcmd;
                 delete [] szarg;
-                exit(ret);
+                ::exit(ret);
             }
         }
 
@@ -953,7 +960,7 @@ int LocalBroker::ExecuteCmd(void)
         close(pipe_child_to_parent[WRITE_TO_PIPE]);
         delete [] szcmd;
         delete [] szarg;
-        exit(ret);
+        ::exit(ret);
     }
 
     if (IS_PARENT_OF(pid_cmd))

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -6,7 +6,6 @@
  *  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-
 #include <yarp/manager/manager.h>
 #include <yarp/manager/yarpbroker.h>
 #include <yarp/manager/localbroker.h>
@@ -290,6 +289,7 @@ bool Manager::prepare(bool silent)
         exe->setPostExecWait((*itr)->getPostExecWait());
         string env = string("YARP_PORT_PREFIX=") +
                         string((*itr)->getPrefix());
+        env = env + ";" + (*itr)->getEnvironment();
         exe->setEnv(env.c_str());
 
         /**

--- a/src/libYARP_manager/src/module.cpp
+++ b/src/libYARP_manager/src/module.cpp
@@ -61,6 +61,7 @@ void Module::swap(const Module &mod)
     strBroker = mod.strBroker;
     bNeedDeployer = mod.bNeedDeployer;
     strPrefix = mod.strPrefix;
+    strEnvironemnt = mod.strEnvironemnt;
     strBasePrefix = mod.strBasePrefix;
     strDisplay = mod.strDisplay;
     modOwner = mod.modOwner;    
@@ -228,6 +229,7 @@ void Module::clear(void)
     strStdio.clear();
     strBroker.clear();
     strPrefix.clear();
+    strEnvironemnt.clear();
     strBasePrefix.clear();
     strDisplay.clear();
     for(ResourcePIterator itr = resources.begin();

--- a/src/libYARP_manager/src/xmlapploader.cpp
+++ b/src/libYARP_manager/src/xmlapploader.cpp
@@ -316,6 +316,9 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                 if((element = (TiXmlElement*) mod->FirstChild("prefix")))
                     module.setPrefix(element->GetText());
 
+                if((element = (TiXmlElement*) mod->FirstChild("environment")))
+                    module.setEnvironemnt(element->GetText());
+
                 if((element = (TiXmlElement*) mod->FirstChild("display")))
                     module.setDisplay(element->GetText());
 


### PR DESCRIPTION
This pull request  (as requested by  :notes: @randaz81) allows to set the multiple environment variables for each single module within the application xml file. example below: 

```xml
    <module>
        <name>mymodule</name>
        <node>localhost</node>
        <prefix>/test</prefix>
        <environment>VAR1=value1;VAR2=value2</environment>
    </module>
```
the `mymodule` will receive the flowing variables in its local environment-variables set: 

```ini
...
YARP_PORT_PREFIX=/test
VAR1=value1
VAR2=value2
```
  
