### PR TITLE
RGBDbugfix

### DIFF
--- a/src/devices/depthCamera/depthCameraDriver.cpp
+++ b/src/devices/depthCamera/depthCameraDriver.cpp
@@ -754,6 +754,15 @@ bool depthCameraDriver::setIntrinsic(Property& intrinsic, const intrinsicParams&
     }
 
     intrinsic.put("retificationMatrix", Value(mat.toString()));
+
+    intrinsic.put("distortionModel", "plumb_bob");
+    intrinsic.put("k1", values.distortionModel.k1);
+    intrinsic.put("k2", values.distortionModel.k2);
+    intrinsic.put("t1", values.distortionModel.t1);
+    intrinsic.put("t2", values.distortionModel.t2);
+    intrinsic.put("k3", values.distortionModel.k3);
+
+    intrinsic.put("stamp", yarp::os::Time::now());
     return true;
 }
 

--- a/src/devices/depthCamera/depthCameraDriver.cpp
+++ b/src/devices/depthCamera/depthCameraDriver.cpp
@@ -420,8 +420,8 @@ bool depthCameraDriver::parseIntrinsic(const Searchable& config, const string& g
         }
     }
 
-    realparam.first = "focalLenghtX";       realparam.second = &params.focalLenghtX;    realParams.push_back(realparam);
-    realparam.first = "focalLenghtY";       realparam.second = &params.focalLenghtY;    realParams.push_back(realparam);
+    realparam.first = "focalLengthX";       realparam.second = &params.focalLengthX;    realParams.push_back(realparam);
+    realparam.first = "focalLengthY";       realparam.second = &params.focalLengthY;    realParams.push_back(realparam);
     realparam.first = "principalPointX";    realparam.second = &params.principalPointX; realParams.push_back(realparam);
     realparam.first = "principalPointY";    realparam.second = &params.principalPointY; realParams.push_back(realparam);
     for(i = 0; i < realParams.size(); i++)
@@ -740,8 +740,8 @@ bool depthCameraDriver::setRgbMirroring(bool mirror)
 
 bool depthCameraDriver::setIntrinsic(Property& intrinsic, const intrinsicParams& values)
 {
-    intrinsic.put("focalLenghtX",       values.focalLenghtX);
-    intrinsic.put("focalLenghtY",       values.focalLenghtY);
+    intrinsic.put("focalLengthX",       values.focalLengthX);
+    intrinsic.put("focalLengthY",       values.focalLengthY);
     intrinsic.put("principalPointX",    values.principalPointX);
     intrinsic.put("principalPointY",    values.principalPointY);
     Bottle mat;

--- a/src/devices/depthCamera/depthCameraDriver.h
+++ b/src/devices/depthCamera/depthCameraDriver.h
@@ -52,8 +52,8 @@ struct intrinsicParams
     yarp::sig::Matrix retificationMatrix;
     double            principalPointX;
     double            principalPointY;
-    double            focalLenghtX;
-    double            focalLenghtY;
+    double            focalLengthX;
+    double            focalLengthY;
     plum_bob          distortionModel;
 };
 
@@ -169,8 +169,8 @@ private:
  * |                              | same as 'SETTINGS' group | -              |    Read only    | -              |   -           |   Alternative to SETTING group   | Parameters here are alternative to the SETTING group                                   |                                                                       |
  * |  RGB_INTRINSIC_PARAMETERS    |      -              | group               |                 | -              |   -           |   Yes                            | Description of rgb camera visual parameters                                            |                                                                       |
  * |                              | retificationMatrix  | 4x4 double matrix   |                 | -              |   -           |   Yes                            |                                                                                        |                                                                       |
- * |                              |   focalLenghtX      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
- * |                              |   focalLenghtY      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
+ * |                              |   focalLengthX      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
+ * |                              |   focalLengthY      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  principalPointX    | double              |                 | pixel          |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  principalPointY    | double              |                 | pixel          |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  distortionModel    | string              |                 | -              |   -           |   Yes                            |  Reference to group of parameters describing the distortion model of the camera, example 'rgbDistortionModelGroup'       | This is only another group's name to be searched for in the config file   |
@@ -183,8 +183,8 @@ private:
  * |                              |   k3                | double              |                 | -              |   -           |   Yes                            |                                                                                        |                                                                       |
  * |  DEPTH_INTRINSIC_PARAMETERS  |      -              | group               |                 | -              |   -           |   Yes                            | Description of depth camera visual parameters                                          |                                                                       |
  * |                              | retificationMatrix  | 4x4 double matrix   |                 | -              |   -           |   Yes                            |                                                                                        |                                                                       |
- * |                              |   focalLenghtX      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
- * |                              |   focalLenghtY      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
+ * |                              |   focalLengthX      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
+ * |                              |   focalLengthY      | double              |                 | mm             |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  principalPointX    | double              |                 | pixel          |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  principalPointY    | double              |                 | pixel          |   -           |   Yes                            |                                                                                        |                                                                       |
  * |                              |  distortionModel    | string              |                 | -              |   -           |   Yes                            |  Reference to group of parameters describing the distortion model of the camera, example 'depthDistortionModelGroup' | This is only another group's name to be searched for in the config file    |
@@ -219,8 +219,8 @@ clipPlanes (0.4 4.5)
 
 [RGB_INTRINSIC_PARAMETERS]
 retificationMatrix      (0.99824 0.0182436 -0.0564274 -0.0654844 -0.0165694 0.999413 0.0299975 0.0 0.0569415 -0.0290098 0.997956 0.00113543 0.0 0.0 0.0 1.0)
-focalLenghtX            1.0
-focalLenghtY            2.0
+focalLengthX            1.0
+focalLengthY            2.0
 principalPointX         256.0
 principalPointY         128.0
 distortionModel         rgb_distortion
@@ -235,8 +235,8 @@ k3                      5.0
 
 [DEPTH_INTRINSIC_PARAMETERS]
 retificationMatrix      (0.99824 0.0182436 -0.0564274 -0.0654844 -0.0165694 0.999413 0.0299975 2.80857e-05 0.0569415 -0.0290098 0.997956 0.00113543 0.0 0.0 0.0 1.0)
-focalLenghtX            1.0
-focalLenghtY            2.0
+focalLengthX            1.0
+focalLengthY            2.0
 principalPointX         256.0
 principalPointY         128.0
 distortionModel         depth_distortion

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -639,14 +639,11 @@ void RGBDSensorWrapper::shallowCopyImages(const ImageOf<PixelFloat>& src, ImageO
 
 
 
-void RGBDSensorWrapper::deepCopyImages
-(
-    const yarp::sig::FlexImage& src, 
-    sensor_msgs_Image&          dest, 
-    const string&               frame_id, 
-    const TickTime&             timeStamp, 
-    const unsigned int          seq
-)
+void RGBDSensorWrapper::deepCopyImages(const yarp::sig::FlexImage& src, 
+                                       sensor_msgs_Image&          dest, 
+                                       const string&               frame_id, 
+                                       const TickTime&             timeStamp, 
+                                       const UInt&                 seq)
 {
     dest.data.resize(src.getRawImageSize());
     dest.width           = src.width();
@@ -660,19 +657,19 @@ void RGBDSensorWrapper::deepCopyImages
     dest.is_bigendian    = 0;
 }
 
-void RGBDSensorWrapper::deepCopyImages
-(
-    const DepthImage&  src,
-    sensor_msgs_Image& dest,
-    const string&      frame_id,
-    const TickTime&    timeStamp,
-    const unsigned int seq
-)
+void RGBDSensorWrapper::deepCopyImages(const DepthImage&  src,
+                                       sensor_msgs_Image& dest,
+                                       const string&      frame_id,
+                                       const TickTime&    timeStamp,
+                                       const UInt&        seq)
 {
     dest.data.resize(src.getRawImageSize());
+    
     dest.width           = src.width();
     dest.height          = src.height();
+    
     memcpy(dest.data.data(), src.getRawImage(), src.getRawImageSize());
+    
     dest.encoding        = yarp2RosPixelCode(src.getPixelCode());
     dest.step            = src.getRowSize();
     dest.header.frame_id = frame_id;

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -143,6 +143,8 @@ private:
     typedef yarp::os::BufferedPort<yarp::sig::FlexImage> ImagePortType;
     typedef yarp::os::Publisher<sensor_msgs_Image>       ImageTopicType;
     typedef yarp::os::Publisher<sensor_msgs_CameraInfo>  DepthTopicType;
+    typedef unsigned int                                 UInt;
+
 
     template <class T>
     struct param
@@ -170,7 +172,7 @@ private:
     std::string           nodeName, depthTopicName, colorTopicName, dInfoTopicName, cInfoTopicName, rosFrameId;
     yarp::sig::FlexImage  colorImage;
     DepthImage            depthImage;
-    unsigned int          nodeSeq;
+    UInt                  nodeSeq;
                                             
     // It should be possible to attach this  guy to more than one port, try to see what
     // will happen when receiving 2 calls at the same time (receive one calls while serving
@@ -182,7 +184,7 @@ private:
 
     // Image data specs
     // int hDim, vDim;
-    int                            rate;
+    UInt                           rate;
     std::string                    sensorId;
     yarp::dev::IRGBDSensor*        sensor_p;
     IRGBDSensor::RGBDSensor_status sensorStatus;
@@ -215,13 +217,13 @@ private:
                         sensor_msgs_Image&          dest,
                         const std::string&          frame_id,
                         const TickTime&             timeStamp,
-                        const unsigned int          seq);
+                        const UInt&                 seq);
 
     void deepCopyImages(const DepthImage&           src,
                         sensor_msgs_Image&          dest,
                         const std::string&          frame_id,
                         const TickTime&             timeStamp,
-                        const unsigned int          seq);
+                        const UInt&                 seq);
 
     bool setCamInfo(sensor_msgs_CameraInfo&         cameraInfo,
                     const std::string&              frame_id,

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -145,6 +145,7 @@ private:
     typedef yarp::os::Publisher<sensor_msgs_CameraInfo>  DepthTopicType;
     typedef unsigned int                                 UInt;
 
+    enum SensorType{COLOR_SENSOR, DEPTH_SENSOR};
 
     template <class T>
     struct param
@@ -227,7 +228,8 @@ private:
 
     bool setCamInfo(sensor_msgs_CameraInfo&         cameraInfo,
                     const std::string&              frame_id,
-                    const unsigned int&             seq);
+                    const UInt&                     seq,
+                    const SensorType&               sensorType);
 
     static std::string yarp2RosPixelCode(int code);
 


### PR DESCRIPTION
-
-camInfo params for ros interoperation
-typo correction
-yarp::os::Node add "/" at the beginning of the name if not present.