### PR TITLE
Set RPATH for Python bindings

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -238,6 +238,28 @@ if(CREATE_PYTHON)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/yarp.py
             DESTINATION ${PYTHON_INSTDIR})
   endif()
+
+  set(_CMAKE_INSTALL_PYTHONDIR "${PYTHON_INSTDIR}")
+  set(CMAKE_INSTALL_PYTHONDIR ${_CMAKE_INSTALL_PYTHONDIR} CACHE PATH "python bindings (${_CMAKE_INSTALL_PYTHONDIR})")
+  mark_as_advanced(CMAKE_INSTALL_PYTHONDIR)
+  if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_PYTHONDIR})
+    set(CMAKE_INSTALL_FULL_PYTHONDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_PYTHONDIR}")
+  else()
+    set(CMAKE_INSTALL_FULL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR}")
+  endif()
+
+  # Update RPATH
+  if(NOT CMAKE_SKIP_RPATH AND NOT CMAKE_SKIP_INSTALL_RPATH)
+    file(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_FULL_PYTHONDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
+    get_target_property(_current_rpath "${target_name}" INSTALL_RPATH)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      list(APPEND _current_rpath "@loader_path/${_rel_path}")
+    else()
+      list(APPEND _current_rpath "\$ORIGIN/${_rel_path}")
+    endif()
+    set_target_properties("_${target_name}" PROPERTIES INSTALL_RPATH "${_current_rpath}")
+  endif()
+
   install(TARGETS _${target_name}
           DESTINATION ${PYTHON_INSTDIR})
 


### PR DESCRIPTION
Following up the discussion in https://github.com/robotology/yarp/commit/86b118c91fa3c84b22a43597db5c2ebde4dd362f this PR sets the RPATH to the python bindings.
Would be great if you have a look @drdanz 