### PR TITLE
ControlBoardWrapper2 cleanup and small improvment

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
@@ -31,7 +31,6 @@ protected:
     double *temp;
     double *temp2;
     int    *temp_int;
-//     yarp::dev::Pid *fake;
     yarp::dev::Pid *tmpPids;
 
     /**

--- a/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
@@ -31,7 +31,7 @@ protected:
     double *temp;
     double *temp2;
     int    *temp_int;
-    yarp::dev::Pid *fake;
+//     yarp::dev::Pid *fake;
     yarp::dev::Pid *tmpPids;
 
     /**

--- a/src/libYARP_dev/src/TorqueControlImpl.cpp
+++ b/src/libYARP_dev/src/TorqueControlImpl.cpp
@@ -19,6 +19,7 @@ ImplementTorqueControl::ImplementTorqueControl(ITorqueControlRaw *tq)
     iTorqueRaw = tq;
     helper=0;
     temp=0;
+//     fake =0;
     temp2=0;
     temp_int=0;
     tmpPids=0;

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -572,7 +572,7 @@ bool ControlBoardWrapper::openDeferredAttach(Property& prop)
         tmpDevice->setVerbose(_verb);
 
         int axes=top-base+1;
-        if (!tmpDevice->configure(base, top, axes, nets->get(k).asString().c_str()))
+        if (!tmpDevice->configure(base, top, axes, nets->get(k).asString().c_str(), this))
         {
             yError() <<"configure of subdevice ret false";
             return false;
@@ -670,7 +670,7 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     tmpDevice->setVerbose(_verb);
 
     std::string subDevName ((partName + "_" + prop.find("subdevice").asString().c_str()));
-    if (!tmpDevice->configure(base, top, controlledJoints, subDevName) )
+    if (!tmpDevice->configure(base, top, controlledJoints, subDevName, this) )
     {
         yError() <<"configure of subdevice ret false";
         return false;

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -362,6 +362,9 @@ public:
     */
     bool verbose() const { return _verb; }
 
+    /* Return id of this device */
+    yarp::os::ConstString getId() { return partName; };
+
     /**
     * Default open() method.
     * @return always false since initialization requires parameters.

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -54,8 +54,9 @@ SubDevice::SubDevice()
     _subDevVerbose = false;
 }
 
-bool SubDevice::configure(int b, int t, int n, const std::string &key)
+bool SubDevice::configure(int b, int t, int n, const std::string &key, yarp::dev::ControlBoardWrapper *_parent)
 {
+    parent = _parent;
     configuredF=false;
 
     base=b;
@@ -121,6 +122,14 @@ void SubDevice::detach()
 
 bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
 {
+    std::string parentName;
+    if(parent)
+    {
+        parentName = parent->getId();
+    }
+    else
+        parentName = "";
+
     if (id!=k)
         {
             yError()<<"controlBoardWrapper: Wrong device" << k.c_str();
@@ -209,7 +218,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         return false;
     }
 
-    if( ! (vel || vel2) ) // One of the 2 is enough, therefor if both are missing I raise an error
+    if( ! (vel || vel2) ) // One of the 2 is enough, therefore if both are missing I raise an error
     {
         yError("ControlBoarWrapper: neither IVelocityControl nor IVelocityControl2 interface was not found in subdevice. Quitting");
         return false;
@@ -258,6 +267,17 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
     {
         yError("ControlBoarWrapper: check device configuration, number of joints of attached device '%d' less than the one specified during configuration '%d' for %s.", deviceJoints, axes, k.c_str());
         return false;
+    }
+
+    int subdevAxes;
+    if(!pos->getAxes(&subdevAxes))
+    {
+
+        yError() << "ControlBoardWrapper for device <" << parentName << "> attached to subdevice " << k.c_str() << " but it was not ready yet. \n" \
+                 << "Please check the device has been correctly created and all required initialization actions has been performed.";
+                 return false;
+        attachedF=false;
+
     }
 
     int subdevAxes;

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -131,21 +131,21 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         parentName = "";
 
     if (id!=k)
-        {
-            yError()<<"controlBoardWrapper: Wrong device" << k.c_str();
-            return false;
-        }
+    {
+        yError("ControlBoardWrapper for part <%s>: Wrong or unknow device %s. Cannot attach to it.", parentName.c_str(), k.c_str());
+        return false;
+    }
 
     //configure first
     if (!configuredF)
         {
-            yError()<<"controlBoardWrapper: You need to call configure before you can attach any device";
+            yError("ControlBoardWrapper for part <%s>: You need to call configure before you can attach any device", parentName.c_str());
             return false;
         }
 
     if (d==0)
         {
-            yError()<<"controlBoardWrapper: Invalid device (null pointer)";
+            yError("ControlBoardWrapper for part <%s>: Invalid device (null pointer)", parentName.c_str());
             return false;
         }
 
@@ -178,36 +178,36 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         }
     else
         {
-            yError()<<"controlBoardWrapper: Invalid device " << k << " (isValid() returned false)";
+            yError("ControlBoardWrapper for part <%s>: Invalid device %s (isValid() returned false).", parentName.c_str(), k.c_str());
             return false;
         }
 
     if ( ((iMode==0) || (iMode2==0)) && (_subDevVerbose ))
-        yWarning() << "controlBoardWrapper:  Warning iMode not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iMode not valid interface.", parentName.c_str());
 
     if ((iTorque==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iTorque not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iTorque not valid interface.", parentName.c_str());
 
     if ((iImpedance==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iImpedance not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iImpedance not valid interface.", parentName.c_str());
 
     if ((iOpenLoop==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iOpenLoop not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iOpenLoop not valid interface.", parentName.c_str());
 
     if ((iInteract==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iInteractionMode not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iInteractionMode not valid interface.", parentName.c_str());
 
     if ((iMotEnc==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iMotorEncoder not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iMotorEncoder not valid interface.", parentName.c_str());
 
     if ((imotor==0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iMotor not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iMotor not valid interface.", parentName.c_str());
 
     if ((iVar == 0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning iVar not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iRemoteVariable not valid interface.", parentName.c_str());
 
     if ((info == 0) && (_subDevVerbose))
-        yWarning() << "controlBoardWrapper:  Warning info not valid interface";
+        yWarning("ControlBoardWrapper for part <%s>:  Warning iAxisInfo not valid interface.", parentName.c_str());
 
     int deviceJoints=0;
 
@@ -232,7 +232,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
 
     if(!iJntEnc)
     {
-        yError("ControlBoarWrapper: IEncoderTimed interface was not found in subdevice");
+        yError("ControlBoardWrapper for part <%s>: IEncoderTimed interface was not found in subdevice.", parentName.c_str());
         return false;
     }
 
@@ -245,7 +245,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         }
         if(deviceJoints <= 0)
         {
-            yError("ControlBoarWrapper: attached device has an invalid number of joints (%d)", deviceJoints);
+            yError("ControlBoardWrapper for part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
             return false;
         }
     }
@@ -253,19 +253,20 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
     {
         if (!pos2->getAxes(&deviceJoints))
         {
-            yError() << "ControlBoarWrapper: failed to get axes number for subdevice " << k.c_str();
+            yError("ControlBoardWrapper for part <%s>: failed to get axes number for subdevice %s.", parentName.c_str(), k.c_str());
             return false;
         }
         if(deviceJoints <=0)
         {
-            yError("ControlBoarWrapper: attached device has an invalid number of joints (%d)", deviceJoints);
+            yError("ControlBoarWrapper for part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
             return false;
         }
     }
 
     if (deviceJoints<axes)
     {
-        yError("ControlBoarWrapper: check device configuration, number of joints of attached device '%d' less than the one specified during configuration '%d' for %s.", deviceJoints, axes, k.c_str());
+        yError("ControlBoarWrapper for part <%s>: check device configuration, number of joints of attached device '%d' less \
+                than the one specified during configuration '%d' for %s.", parentName.c_str(), deviceJoints, axes, k.c_str());
         return false;
     }
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -281,16 +281,6 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
 
     }
 
-    int subdevAxes;
-    if(!pos->getAxes(&subdevAxes))
-    {
-
-        yError() << "ControlBoardWrapper trying to attach to subdevice " << k.c_str() << " but it was not ready yet. \n" \
-                    << "Please check the device has been correctly created and all required initialization actions has been performed.";
-        attachedF=false;
-        return false;
-    }
-
     attachedF=true;
     return true;
 }

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
@@ -78,6 +78,8 @@ public:
 
     bool configuredF;
 
+    yarp::dev::ControlBoardWrapper   *parent;
+
     yarp::dev::PolyDriver            *subdevice;
     yarp::dev::IPidControl           *pid;
     yarp::dev::IPositionControl      *pos;
@@ -113,7 +115,7 @@ public:
     void detach();
     inline void setVerbose(bool _verbose) {_subDevVerbose = _verbose; }
 
-    bool configure(int base, int top, int axes, const std::string &id);
+    bool configure(int base, int top, int axes, const std::string &id, yarp::dev::ControlBoardWrapper *_parent);
 
     inline void refreshJointEncoders()
     {


### PR DESCRIPTION
removed unused variable
propagate device name to ControlBoardWrapper2 subdevices to have more meaningful error messages