### PR TITLE
Fix for issue #832 and further related improvements

### DIFF
--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -214,13 +214,17 @@ bool PolyDriver::coreOpen(yarp::os::Searchable& prop) {
     if (prop.check("device",part)) {
         str = part->toString().c_str();
     }
+
+#ifndef YARP_NO_DEPRECATE // since yarp 2.3.70
     Bottle bot(str.c_str());
     if (bot.size()>1) {
-        // this wasn't a device name, but some codes -- rearrange
+		yWarning("Passing 'device' parameter with a list of parameters as value is deprecated. This might be an internal bug. If you didn't do it please report an issue at https://github.com/robotology/yarp");
+		// this wasn't a device name, but some codes -- rearrange
         p.fromString(str.c_str());
         str = p.find("device").asString().c_str();
         config = &p;
     }
+#endif
 
     DeviceDriver *driver = NULL;
 

--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -215,7 +215,7 @@ bool PolyDriver::coreOpen(yarp::os::Searchable& prop) {
         str = part->toString().c_str();
     }
 
-#ifndef YARP_NO_DEPRECATE // since yarp 2.3.70
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     Bottle bot(str.c_str());
     if (bot.size()>1) {
         // this wasn't a device name, but some codes -- rearrange

--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -218,8 +218,8 @@ bool PolyDriver::coreOpen(yarp::os::Searchable& prop) {
 #ifndef YARP_NO_DEPRECATE // since yarp 2.3.70
     Bottle bot(str.c_str());
     if (bot.size()>1) {
-		yWarning("Passing 'device' parameter with a list of parameters as value is deprecated. This might be an internal bug. If you didn't do it please report an issue at https://github.com/robotology/yarp");
-		// this wasn't a device name, but some codes -- rearrange
+        // this wasn't a device name, but some codes -- rearrange
+        yWarning("Passing 'device' parameter with a list of parameters as value is deprecated. This might be an internal bug. If you didn't do it please report an issue at https://github.com/robotology/yarp");
         p.fromString(str.c_str());
         str = p.find("device").asString().c_str();
         config = &p;

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -82,7 +82,7 @@ public:
     inline yarp::os::Semaphore* lst_sem() const { return &driver->threadListSemaphore; }
 
     inline bool isValid() const { return drv()->isValid(); }
-	inline bool open() { return drv()->open(paramsAsProperty().toString()); }
+	inline bool open() { return drv()->open(paramsAsProperty()); }
     inline bool close() { return drv()->close(); }
 
     inline void registerThread(yarp::os::Thread *thread) const

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -82,7 +82,7 @@ public:
     inline yarp::os::Semaphore* lst_sem() const { return &driver->threadListSemaphore; }
 
     inline bool isValid() const { return drv()->isValid(); }
-	inline bool open() { return drv()->open(paramsAsProperty()); }
+    inline bool open() { return drv()->open(paramsAsProperty()); }
     inline bool close() { return drv()->close(); }
 
     inline void registerThread(yarp::os::Thread *thread) const
@@ -130,32 +130,32 @@ public:
     {
         ParamList p = RobotInterface::mergeDuplicateGroups(params);
    
-		yarp::os::Property prop;
-		prop.put("device",type);
+        yarp::os::Property prop;
+        prop.put("device",type);
 
-		for (RobotInterface::ParamList::const_iterator it = p.begin(); it != p.end(); ++it) {
-			const RobotInterface::Param &param = *it;
+        for (RobotInterface::ParamList::const_iterator it = p.begin(); it != p.end(); ++it) {
+            const RobotInterface::Param &param = *it;
 
-			// check if parentheses are balanced
-			std::string stringFormatValue = param.value();
-			int counter = 0;
-			for (int i = 0; i < stringFormatValue.size() && counter >= 0; i++){
-				if (stringFormatValue[i] == '('){
-					counter++;
-				} else if (stringFormatValue[i] == ')'){
-					counter--;
-				}
-			}
-			if (counter != 0){
-				yWarning() << "Parentheses not balanced for param " << param.name();
-			}
+            // check if parentheses are balanced
+            std::string stringFormatValue = param.value();
+            int counter = 0;
+            for (int i = 0; i < stringFormatValue.size() && counter >= 0; i++){
+                if (stringFormatValue[i] == '('){
+                    counter++;
+                } else if (stringFormatValue[i] == ')'){
+                    counter--;
+                }
+            }
+            if (counter != 0){
+                yWarning() << "Parentheses not balanced for param " << param.name();
+            }
 
-			yarp::os::Value value;
-			value.fromString(param.value().c_str());
-			prop.put(param.name(),value);
-		}
+            yarp::os::Value value;
+            value.fromString(param.value().c_str());
+            prop.put(param.name(),value);
+            }
 
-		return prop;
+        return prop;
     }
 
     std::string name;

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -82,7 +82,7 @@ public:
     inline yarp::os::Semaphore* lst_sem() const { return &driver->threadListSemaphore; }
 
     inline bool isValid() const { return drv()->isValid(); }
-    inline bool open() { return drv()->open(paramsAsProperty()); }
+    inline bool open() { yarp::os::Property p = paramsAsProperty(); return drv()->open(p); }
     inline bool close() { return drv()->close(); }
 
     inline void registerThread(yarp::os::Thread *thread) const

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -129,7 +129,7 @@ public:
     yarp::os::Property paramsAsProperty() const
     {
         ParamList p = RobotInterface::mergeDuplicateGroups(params);
-   
+
         yarp::os::Property prop;
         prop.put("device",type);
 

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -139,7 +139,7 @@ public:
             // check if parentheses are balanced
             std::string stringFormatValue = param.value();
             int counter = 0;
-            for (int i = 0; i < stringFormatValue.size() && counter >= 0; i++){
+            for (size_t i = 0; i < stringFormatValue.size() && counter >= 0; i++){
                 if (stringFormatValue[i] == '('){
                     counter++;
                 } else if (stringFormatValue[i] == ')'){

--- a/src/yarprobotinterface/Param.cpp
+++ b/src/yarprobotinterface/Param.cpp
@@ -105,6 +105,8 @@ bool RobotInterface::Param::isGroup() const
 yarp::os::Property RobotInterface::Param::toProperty() const
 {
     yarp::os::Property p;
-    p.put(mPriv->name.c_str(), mPriv->value.c_str());
+	yarp::os::Value v;
+	v.fromString(mPriv->value.c_str());
+    p.put(mPriv->name.c_str(), v);
     return p;
 }

--- a/src/yarprobotinterface/Param.cpp
+++ b/src/yarprobotinterface/Param.cpp
@@ -105,8 +105,8 @@ bool RobotInterface::Param::isGroup() const
 yarp::os::Property RobotInterface::Param::toProperty() const
 {
     yarp::os::Property p;
-	yarp::os::Value v;
-	v.fromString(mPriv->value.c_str());
+    yarp::os::Value v;
+    v.fromString(mPriv->value.c_str());
     p.put(mPriv->name.c_str(), v);
     return p;
 }


### PR DESCRIPTION
I made the following changes:

- With respect to the issue #832, now a warning is printed if parenthesis are not balanced.
- I noticed that, in a parameter's value, when parenthesis are not balanced (or in general when the syntax of the value is not respected), also other parameters may be affected (that is they might not be stored in the `Property` object). This is due to the fact that before creating the `Property `object an intermediate string representation is used. I got rid of this (apparently useless) intermediate step, so that when the syntax of a value is not respected, only the related parameter will be corrupted.
-  In `PolyDriver.cpp` I added a warning when in a `Property` object there are two 'device' parameters nested one in the other (one is part of the value of the other). This situation was currently managed applying a workaround, that is now ignored when `YARP_NO_DEPRECATE` is enabled.
- In `Param.cpp` the `toProperty()` now parses the value before putting it in the `Property `object.

