### PR TITLE
Yarp view autosize

### DIFF
--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -31,7 +31,7 @@ Rectangle {
     property string version: "2.0"
 
     signal changeWindowSize(int w, int h)
-    signal synch(bool check);
+    signal synchRate(bool check);
     signal setName(string name)
 
 
@@ -54,11 +54,24 @@ Rectangle {
         }
 
         onSynch:{
-            synch(check);
+            synchRate(check);
         }
 
         onSetName:{
             setName(name)
+        }
+
+        onWidthChanged:{
+            //console.log("onWidthChanged")
+        }
+
+        onHeightChanged:{
+            //console.log("onHeightChanged")
+        }
+
+        onSizeChanged:{
+            //console.log("onSizeChanged")
+            setOriginalSize()
         }
     }
 
@@ -166,6 +179,10 @@ Rectangle {
 
     function synchToDisplay(checked){
         yarpViewCore.synchToDisplay(checked)
+    }
+
+    function synchSize(checked){
+        yarpViewCore.synchSize(checked)
     }
 
     function saveSingleImage(checked){

--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -32,6 +32,7 @@ Rectangle {
 
     signal changeWindowSize(int w, int h)
     signal synchRate(bool check);
+    signal autosize(bool check);
     signal setName(string name)
 
 
@@ -53,10 +54,14 @@ Rectangle {
             }
         }
 
-        onSynch:{
+        onSynchRate:{
             synchRate(check);
         }
 
+        onAutosize:{
+            autosize(check);
+        }
+        
         onSetName:{
             setName(name)
         }
@@ -177,12 +182,12 @@ Rectangle {
         setIntervalDlg.visibility = Window.Windowed
     }
 
-    function synchToDisplay(checked){
-        yarpViewCore.synchToDisplay(checked)
+    function synchDisplayPeriod(checked){
+        yarpViewCore.synchDisplayPeriod(checked)
     }
 
-    function synchSize(checked){
-        yarpViewCore.synchSize(checked)
+    function synchDisplaySize(checked){
+        yarpViewCore.synchDisplaySize(checked)
     }
 
     function saveSingleImage(checked){

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -19,8 +19,8 @@ MenuBar {
     signal freeze(bool checked)
     signal setOriginalSize()
     signal setOriginalAspectRatio()
-    signal synchToDisplay(bool checked)
-    signal synchSize(bool checked)
+    signal synchDisplayPeriod(bool checked)
+    signal synchDisplaySize(bool checked)
     signal changeRefreshInterval()
     signal saveSingleImage(bool checked)
     signal saveSetImages(bool checked)
@@ -33,7 +33,14 @@ MenuBar {
         }
     }
 
-
+    function enableAutosize(check){
+        if(check === true){
+            autosizeItem.checked = true
+        }else{
+            autosizeItem.checked = false
+        }
+    }
+    
     Menu {
 
         title: "File"
@@ -83,14 +90,14 @@ MenuBar {
                    text: "Synch display"
                    checkable: true
                    onTriggered: {
-                       synchToDisplay(synchItem.checked)
+                       synchDisplayPeriod(synchItem.checked)
                    }}
         MenuSeparator{}
-        MenuItem { id: synchSizeItem
-                   text: "Synch size"
+        MenuItem { id: autosizeItem
+                   text: "Auto resize"
                    checkable: true
                    onTriggered: {
-                       synchSize(synchSizeItem.checked)
+                       synchDisplaySize(autosizeItem.checked)
                    }}
         MenuSeparator{}
         MenuItem { text: "Change refresh interval"

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -20,6 +20,7 @@ MenuBar {
     signal setOriginalSize()
     signal setOriginalAspectRatio()
     signal synchToDisplay(bool checked)
+    signal synchSize(bool checked)
     signal changeRefreshInterval()
     signal saveSingleImage(bool checked)
     signal saveSetImages(bool checked)
@@ -83,6 +84,13 @@ MenuBar {
                    checkable: true
                    onTriggered: {
                        synchToDisplay(synchItem.checked)
+                   }}
+        MenuSeparator{}
+        MenuItem { id: synchSizeItem
+                   text: "Synch size"
+                   checkable: true
+                   onTriggered: {
+                       synchSize(synchSizeItem.checked)
                    }}
         MenuSeparator{}
         MenuItem { text: "Change refresh interval"

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -24,6 +24,10 @@ QtYARPView::QtYARPView(QQuickItem *parent):
 
     connect(&sigHandler,SIGNAL(sendFps(double,double,double,double,double,double)),
             this, SLOT(onSendFps(double,double,double,double,double,double)));
+
+    connect(&videoProducer,SIGNAL(resizeWindowRequest()),
+            this, SLOT(onWindowSizeChangeRequested()));
+
     createObjects();
 }
 
@@ -82,11 +86,20 @@ int QtYARPView::windowHeight()
 
 /*! \brief Synchs the video stream to the display.
  *
- *  \param check a bool parameter that enbales or disables the synch option
+ *  \param check a bool parameter that enables or disables the synch option
  */
 void QtYARPView::synchToDisplay(bool check)
 {
     sigHandler.synchToDisplay(check);
+}
+
+/*! \brief Synchs the size of the window with the size of the video stream.
+*
+*  \param check a bool parameter that enables or disables the synch option
+*/
+void QtYARPView::synchSize(bool check)
+{
+    sigHandler.synchSize(check);
 }
 
 /*! \brief Changes the refresh interval.
@@ -287,9 +300,13 @@ void QtYARPView::setOptions(yarp::os::Searchable& options) {
     }
     if (options.check("synch"))
     {
-        _options.synch=true;
+        _options.synchRate=true;
         synchToDisplay(true);
-        synch(true);
+        synchRate(true);
+    }
+    if (options.check("synchSize"))
+    {
+       _options.synchSize = true;
     }
 }
 
@@ -414,7 +431,8 @@ void QtYARPView::saveOptFile(char *fileName)
     optFile.write((QString("Height %d\n").arg(_options.windHeight)).toLatin1().data());
     optFile.write((QString("OutputEnables %d\n").arg(_options.outputEnabled)).toLatin1().data());
     optFile.write((QString("SaveOptions %d\n").arg(_options.saveOnExit)).toLatin1().data());
-    optFile.write((QString("synch %d\n").arg(_options.synch)).toLatin1().data());
+    optFile.write((QString("synchRate %d\n").arg(_options.synchRate)).toLatin1().data());
+    optFile.write((QString("synchSize %d\n").arg(_options.synchSize)).toLatin1().data());
     optFile.close();
 }
 
@@ -438,5 +456,13 @@ void QtYARPView::clickCoords(int x,int y)
 
     } else {
         qDebug("I would send a position, but there's no image for scaling");
+    }
+}
+
+void QtYARPView::onWindowSizeChangeRequested()
+{
+    if (sigHandler.getSynchSizeMode())
+    {
+        emit sizeChanged();
     }
 }

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -36,8 +36,8 @@ QtYARPView::~QtYARPView()
     closePorts();
     deleteObjects();
 
-    if (_options.saveOnExit != 0){
-        saveOptFile(_options.fileName);
+    if (_options.m_saveOnExit != 0){
+        saveOptFile(_options.m_fileName);
     }
 }
 
@@ -62,25 +62,25 @@ QObject *QtYARPView::getVideoProducer()
 /*! \brief Returns the x position from the options.*/
 int QtYARPView::posX()
 {
-    return _options.posX;
+    return _options.m_posX;
 }
 
 /*! \brief Returns the y position from the options.*/
 int QtYARPView::posY()
 {
-    return _options.posY;
+    return _options.m_posY;
 }
 
 /*! \brief Returns the width from the options.*/
 int QtYARPView::windowWidth()
 {
-    return _options.windWidth;
+    return _options.m_windWidth;
 }
 
 /*! \brief Returns the height from the options.*/
 int QtYARPView::windowHeight()
 {
-    return _options.windHeight;
+    return _options.m_windHeight;
 }
 
 
@@ -88,18 +88,18 @@ int QtYARPView::windowHeight()
  *
  *  \param check a bool parameter that enables or disables the synch option
  */
-void QtYARPView::synchToDisplay(bool check)
+void QtYARPView::synchDisplayPeriod(bool check)
 {
-    sigHandler.synchToDisplay(check);
+    sigHandler.synchDisplayPeriod(check);
 }
 
 /*! \brief Synchs the size of the window with the size of the video stream.
 *
 *  \param check a bool parameter that enables or disables the synch option
 */
-void QtYARPView::synchSize(bool check)
+void QtYARPView::synchDisplaySize(bool check)
 {
-    sigHandler.synchSize(check);
+    sigHandler.synchDisplaySize(check);
 }
 
 /*! \brief Changes the refresh interval.
@@ -189,7 +189,7 @@ void QtYARPView::onSendFps(double portAvg, double portMin, double portMax,
 */
 int QtYARPView::refreshInterval()
 {
-    return _options.refreshTime;
+    return _options.m_refreshTime;
 }
 
 
@@ -256,57 +256,59 @@ void QtYARPView::setOptions(yarp::os::Searchable& options) {
     // switch to subsections if available
     yarp::os::Value *val;
     if (options.check("PortName",val)||options.check("name",val)) {
-        qsnprintf(_options.portName, 256, "%s", val->asString().c_str());
+        qsnprintf(_options.m_portName, 256, "%s", val->asString().c_str());
         qDebug("%s", val->asString().c_str());
     }
     if (options.check("NetName",val)||options.check("n",val)) {
-        qsnprintf(_options.networkName, 256, "%s", val->asString().c_str());
+        qsnprintf(_options.m_networkName, 256, "%s", val->asString().c_str());
     }
     if (options.check("OutPortName",val)||options.check("out",val)) {
-        qsnprintf(_options.outPortName, 256, "%s", val->asString().c_str());
+        qsnprintf(_options.m_outPortName, 256, "%s", val->asString().c_str());
     }
     if (options.check("OutNetName",val)||options.check("neto",val)) {
-        qsnprintf(_options.outNetworkName, 256, "%s", val->asString().c_str());
+        qsnprintf(_options.m_outNetworkName, 256, "%s", val->asString().c_str());
     }
     if (options.check("RefreshTime",val)||options.check("p",val)) {
-        _options.refreshTime = val->asInt();
-        sigHandler.changeRefreshInterval(_options.refreshTime);
+        _options.m_refreshTime = val->asInt();
+        sigHandler.changeRefreshInterval(_options.m_refreshTime);
         refreshIntervalChanged();
     }
     if (options.check("PosX",val)||options.check("x",val)) {
-        _options.posX = val->asInt();
+        _options.m_posX = val->asInt();
         posXChanged();
     }
     if (options.check("PosY",val)||options.check("y",val)) {
-        _options.posY = val->asInt();
+        _options.m_posY = val->asInt();
         posYChanged();
     }
     if (options.check("Width",val)||options.check("w",val)) {
-        _options.windWidth = val->asInt();
+        _options.m_windWidth = val->asInt();
         widthChanged();
     }
     if (options.check("Height",val)||options.check("h",val)) {
-        _options.windHeight = val->asInt();
+        _options.m_windHeight = val->asInt();
         heightChanged();
     }
     if (options.check("OutputEnabled",val)) {
-        _options.outputEnabled = val->asInt();
+        _options.m_outputEnabled = val->asInt();
     }
     if (options.check("out",val)) {
-        _options.outputEnabled = true;
+        _options.m_outputEnabled = true;
     }
     if (options.check("SaveOptions",val)||options.check("saveoptions",val)) {
-        _options.outputEnabled = val->asInt();
+        _options.m_outputEnabled = val->asInt();
     }
     if (options.check("synch"))
     {
-        _options.synchRate=true;
-        synchToDisplay(true);
+        _options.m_synchRate=true;
+        synchDisplayPeriod(true);
         synchRate(true);
     }
-    if (options.check("synchSize"))
+    if (options.check("autosize"))
     {
-       _options.synchSize = true;
+        _options.m_autosize = true;
+        synchDisplaySize(true);
+        autosize(true);
     }
 }
 
@@ -321,6 +323,7 @@ void QtYARPView::printHelp()
     qDebug("  --h: height of the window");
     qDebug("  --p: refresh time [ms]");
     qDebug("  --synch: synchronous display, every image received by the input port is displayed");
+    qDebug("  --autosize: the display automatically resizes on every new frame");
     qDebug("  --out: output port name (no default is given, if this option is not specified the port is not created)");
     qDebug("  --neto: output network");
     qDebug("  --neti: input network");
@@ -333,25 +336,26 @@ void QtYARPView::printHelp()
 void QtYARPView::setOptionsToDefault()
 {
     // Options defaults
-    _options.refreshTime = 100;
-    qsnprintf(_options.portName, 256, "%s","/yarpview/img:i");
-    qsnprintf(_options.networkName, 256, "%s", "default");
-    qsnprintf(_options.outPortName, 256, "%s","/yarpview/o:point");
-    qsnprintf(_options.outNetworkName, 256, "%s", "default");
-    _options.outputEnabled = 0;
-    _options.windWidth = 300;
-    _options.windHeight = 300;
-    _options.posX = 100;
-    _options.posY = 100;
-    qsnprintf(_options.fileName, 256, "%s","yarpview.conf");
-    _options.saveOnExit = 0;
+    _options.m_refreshTime = 100;
+    qsnprintf(_options.m_portName, 256, "%s","/yarpview/img:i");
+    qsnprintf(_options.m_networkName, 256, "%s", "default");
+    qsnprintf(_options.m_outPortName, 256, "%s","/yarpview/o:point");
+    qsnprintf(_options.m_outNetworkName, 256, "%s", "default");
+    _options.m_outputEnabled = 0;
+    _options.m_windWidth = 300;
+    _options.m_windHeight = 300;
+    _options.m_posX = 100;
+    _options.m_posY = 100;
+    _options.m_autosize = false;
+    qsnprintf(_options.m_fileName, 256, "%s","yarpview.conf");
+    _options.m_saveOnExit = 0;
 
     posXChanged();
     posYChanged();
     widthChanged();
     heightChanged();
 
-    sigHandler.changeRefreshInterval(_options.refreshTime);
+    sigHandler.changeRefreshInterval(_options.m_refreshTime);
     refreshIntervalChanged();
 }
 
@@ -364,7 +368,7 @@ bool QtYARPView::openPorts()
     bool ret = false;
 
     ptr_inputPort->setReadOnly();
-    ret= ptr_inputPort->open(_options.portName);
+    ret= ptr_inputPort->open(_options.m_portName);
     setName(ptr_inputPort->getName().c_str());
 
     if (!ret){
@@ -372,10 +376,10 @@ bool QtYARPView::openPorts()
         return false;
     }
 
-    if (_options.outputEnabled == 1){
+    if (_options.m_outputEnabled == 1){
         _pOutPort = new yarp::os::BufferedPort<yarp::os::Bottle>;
-        qDebug("Registering port %s on network %s...", _options.outPortName, _options.outNetworkName);
-        bool ok = _pOutPort->open(_options.outPortName);
+        qDebug("Registering port %s on network %s...", _options.m_outPortName, _options.m_outNetworkName);
+        bool ok = _pOutPort->open(_options.m_outPortName);
         if (ok) {
             qDebug("Port registration succeed!");
         }
@@ -395,13 +399,13 @@ void QtYARPView::closePorts()
 
     ptr_inputPort->close();
 
-    if (_options.outputEnabled == 1 && _pOutPort){
+    if (_options.m_outputEnabled == 1 && _pOutPort){
         _pOutPort->close();
         bool ok = true;
         if  (ok)
-            qDebug("Port %s unregistration succeed!\n", _options.outPortName);
+            qDebug("Port %s unregistration succeed!\n", _options.m_outPortName);
         else
-            qDebug("ERROR: Port %s unregistration failed.\n", _options.outPortName);
+            qDebug("ERROR: Port %s unregistration failed.\n", _options.m_outPortName);
         delete _pOutPort;
         _pOutPort = NULL;
     }
@@ -420,19 +424,19 @@ void QtYARPView::saveOptFile(char *fileName)
         qDebug("ERROR: Impossible to save to option file.");
         return;
     }
-    optFile.write((QString("PortName %1\n").arg(_options.portName)).toLatin1().data());
-    optFile.write((QString("NetName %1\n").arg(_options.networkName)).toLatin1().data());
-    optFile.write((QString("OutPortName %1\n").arg(_options.outPortName)).toLatin1().data());
-    optFile.write((QString("OutNetName %s\n").arg(_options.outNetworkName)).toLatin1().data());
-    optFile.write((QString("RefreshTime %d\n").arg(_options.refreshTime)).toLatin1().data());
-    optFile.write((QString("PosX %d\n").arg(_options.posX)).toLatin1().data());
-    optFile.write((QString("PosY %d\n").arg(_options.posY)).toLatin1().data());
-    optFile.write((QString("Width %d\n").arg(_options.windWidth)).toLatin1().data());
-    optFile.write((QString("Height %d\n").arg(_options.windHeight)).toLatin1().data());
-    optFile.write((QString("OutputEnables %d\n").arg(_options.outputEnabled)).toLatin1().data());
-    optFile.write((QString("SaveOptions %d\n").arg(_options.saveOnExit)).toLatin1().data());
-    optFile.write((QString("synchRate %d\n").arg(_options.synchRate)).toLatin1().data());
-    optFile.write((QString("synchSize %d\n").arg(_options.synchSize)).toLatin1().data());
+    optFile.write((QString("PortName %1\n").arg(_options.m_portName)).toLatin1().data());
+    optFile.write((QString("NetName %1\n").arg(_options.m_networkName)).toLatin1().data());
+    optFile.write((QString("OutPortName %1\n").arg(_options.m_outPortName)).toLatin1().data());
+    optFile.write((QString("OutNetName %s\n").arg(_options.m_outNetworkName)).toLatin1().data());
+    optFile.write((QString("RefreshTime %d\n").arg(_options.m_refreshTime)).toLatin1().data());
+    optFile.write((QString("PosX %d\n").arg(_options.m_posX)).toLatin1().data());
+    optFile.write((QString("PosY %d\n").arg(_options.m_posY)).toLatin1().data());
+    optFile.write((QString("Width %d\n").arg(_options.m_windWidth)).toLatin1().data());
+    optFile.write((QString("Height %d\n").arg(_options.m_windHeight)).toLatin1().data());
+    optFile.write((QString("OutputEnables %d\n").arg(_options.m_outputEnabled)).toLatin1().data());
+    optFile.write((QString("SaveOptions %d\n").arg(_options.m_saveOnExit)).toLatin1().data());
+    optFile.write((QString("synchRate %d\n").arg(_options.m_synchRate)).toLatin1().data());
+    optFile.write((QString("autosize %d\n").arg(_options.m_autosize)).toLatin1().data());
     optFile.close();
 }
 
@@ -461,7 +465,7 @@ void QtYARPView::clickCoords(int x,int y)
 
 void QtYARPView::onWindowSizeChangeRequested()
 {
-    if (sigHandler.getSynchSizeMode())
+    if (sigHandler.getAutosizeMode())
     {
         emit sizeChanged();
     }

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -42,7 +42,8 @@ struct mOptions
     char			outPortName[256];
     char			outNetworkName[256];
     int				outputEnabled;
-    bool            synch;
+    bool            synchRate;
+    bool            synchSize;
 };
 typedef struct mOptions pgmOptions;
 
@@ -71,6 +72,7 @@ public:
 
     Q_INVOKABLE void freeze(bool check);
     Q_INVOKABLE void synchToDisplay(bool check);
+    Q_INVOKABLE void synchSize(bool check);
     Q_INVOKABLE void changeRefreshInterval(int);
     Q_INVOKABLE void saveFrame();
     Q_INVOKABLE void setFileName(QUrl url);
@@ -118,12 +120,14 @@ signals:
     void posYChanged();
     void widthChanged();
     void heightChanged();
+    void sizeChanged();
     void sendPortFps(QString avg, QString min, QString max);
     void sendDisplayFps(QString avg, QString min, QString max);
-    void synch(bool check);
+    void synchRate(bool check);
     void setName(QString name);
 private slots:
     void onSendFps(double portAvg, double portMin, double portMax, double dispAvg, double dispMin, double dispMax);
+    void onWindowSizeChangeRequested();
 };
 
 #endif // QTYARPVIEW_H

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -30,20 +30,20 @@
 */
 struct mOptions
 {
-    unsigned int	refreshTime;
-    char			portName[256];
-    char			networkName[256];
-    int				windWidth;
-    int				windHeight;
-    int				posX;
-    int				posY;
-    char			fileName[256];
-    int				saveOnExit;
-    char			outPortName[256];
-    char			outNetworkName[256];
-    int				outputEnabled;
-    bool            synchRate;
-    bool            synchSize;
+    unsigned int    m_refreshTime;
+    char            m_portName[256];
+    char            m_networkName[256];
+    int             m_windWidth;
+    int             m_windHeight;
+    int             m_posX;
+    int             m_posY;
+    char            m_fileName[256];
+    int             m_saveOnExit;
+    char            m_outPortName[256];
+    char            m_outNetworkName[256];
+    int             m_outputEnabled;
+    bool            m_synchRate;
+    bool            m_autosize;
 };
 typedef struct mOptions pgmOptions;
 
@@ -71,8 +71,8 @@ public:
     ~QtYARPView();
 
     Q_INVOKABLE void freeze(bool check);
-    Q_INVOKABLE void synchToDisplay(bool check);
-    Q_INVOKABLE void synchSize(bool check);
+    Q_INVOKABLE void synchDisplayPeriod(bool check);
+    Q_INVOKABLE void synchDisplaySize(bool check);
     Q_INVOKABLE void changeRefreshInterval(int);
     Q_INVOKABLE void saveFrame();
     Q_INVOKABLE void setFileName(QUrl url);
@@ -124,6 +124,7 @@ signals:
     void sendPortFps(QString avg, QString min, QString max);
     void sendDisplayFps(QString avg, QString min, QString max);
     void synchRate(bool check);
+    void autosize(bool check);
     void setName(QString name);
 private slots:
     void onSendFps(double portAvg, double portMin, double portMax, double dispAvg, double dispMin, double dispMax);

--- a/src/yarpview/plugin/signalhandler.cpp
+++ b/src/yarpview/plugin/signalhandler.cpp
@@ -18,10 +18,11 @@ SignalHandler::SignalHandler(QObject *parent) :
     QObject(parent),timer(this)
 {
 
-    saveSetFrameMode = false;
-    saveCurrentFrameMode = false;
-    freezeMode = false;
-    synchMode = false;
+    b_saveSetFrameMode = false;
+    b_saveCurrentFrameMode = false;
+    b_freezeMode = false;
+    b_synchRateMode = false;
+    b_synchSizeMode = false;
     defaultNameCounter = 0;
     customNameCounter = 0;
     framesetCounter = 0;
@@ -81,7 +82,7 @@ void SignalHandler::sendVideoFrame(QVideoFrame f)
 {
     portFps.update();
 
-    if(synchMode){
+    if(b_synchRateMode){
         displayFps.update();
         internalSendFrame(f);
     }else{
@@ -94,15 +95,15 @@ void SignalHandler::sendVideoFrame(QVideoFrame f)
 
     }
 
-    if(saveCurrentFrameMode){
-        saveCurrentFrameMode = false;
+    if(b_saveCurrentFrameMode){
+        b_saveCurrentFrameMode = false;
         f.map(QAbstractVideoBuffer::ReadOnly);
         QImage img = QImage(f.bits(),f.width(),f.height(),QImage::Format_RGB32);
         f.unmap();
         saveFrame(img);
     }
 
-    if(saveSetFrameMode){
+    if(b_saveSetFrameMode){
         f.map(QAbstractVideoBuffer::ReadOnly);
         QImage img = QImage(f.bits(),f.width(),f.height(),QImage::Format_RGB32);
         f.unmap();
@@ -120,7 +121,7 @@ void SignalHandler::sendVideoFrame(QVideoFrame f)
  */
 void SignalHandler::internalReceiveFrame(QVideoFrame f)
 {
-    if(!freezeMode){
+    if(!b_freezeMode){
         sendFrame(&f);
     }
 }
@@ -131,8 +132,8 @@ void SignalHandler::internalReceiveFrame(QVideoFrame f)
  */
 void SignalHandler::synchToDisplay(bool check)
 {
-    synchMode = check;
-    if(synchMode){
+    b_synchRateMode = check;
+    if(b_synchRateMode){
         if(timer.isActive()){
             timer.stop();
         }
@@ -143,13 +144,27 @@ void SignalHandler::synchToDisplay(bool check)
     }
 }
 
+/*! \brief Enable/Disable the synch size mode.
+*
+*  \param check
+*/
+void SignalHandler::synchSize(bool check)
+{
+    b_synchSizeMode = check;
+}
+
+bool SignalHandler::getSynchSizeMode()
+{
+    return b_synchSizeMode;
+}
+
 /*! \brief Enable/Disable the freeze mode.
  *
  *  \param check
  */
 void SignalHandler::freeze(bool check)
 {
-    freezeMode = check;
+    b_freezeMode = check;
 }
 
 /*! \brief Sets the refresh interval.
@@ -175,7 +190,7 @@ void SignalHandler::onTimerElapsed()
  */
 void SignalHandler::saveCurrentFrame()
 {
-    saveCurrentFrameMode = true;
+    b_saveCurrentFrameMode = true;
 }
 
 /*! \brief Sets the filename used for saving a video frame.
@@ -278,7 +293,7 @@ void SignalHandler::checkCustomNameCounterCount(QString file)
  */
 void SignalHandler::setFileNames(QUrl url)
 {
-    if(saveSetFrameMode == false)
+    if(b_saveSetFrameMode == false)
         this->fileNames = url.toLocalFile();
 }
 
@@ -286,13 +301,13 @@ void SignalHandler::setFileNames(QUrl url)
 void SignalHandler::startDumpFrames()
 {
     framesetCounter = 0;
-    saveSetFrameMode = true;
+    b_saveSetFrameMode = true;
 }
 
 /*! \brief Stops the Dump frame modality (Save frame set).*/
 void SignalHandler::stopDumpFrames()
 {
-    saveSetFrameMode = false;
+    b_saveSetFrameMode = false;
 }
 
 

--- a/src/yarpview/plugin/signalhandler.cpp
+++ b/src/yarpview/plugin/signalhandler.cpp
@@ -22,7 +22,7 @@ SignalHandler::SignalHandler(QObject *parent) :
     b_saveCurrentFrameMode = false;
     b_freezeMode = false;
     b_synchRateMode = false;
-    b_synchSizeMode = false;
+    b_autosizeMode = false;
     defaultNameCounter = 0;
     customNameCounter = 0;
     framesetCounter = 0;
@@ -130,7 +130,7 @@ void SignalHandler::internalReceiveFrame(QVideoFrame f)
  *
  *  \param check
  */
-void SignalHandler::synchToDisplay(bool check)
+void SignalHandler::synchDisplayPeriod(bool check)
 {
     b_synchRateMode = check;
     if(b_synchRateMode){
@@ -148,14 +148,14 @@ void SignalHandler::synchToDisplay(bool check)
 *
 *  \param check
 */
-void SignalHandler::synchSize(bool check)
+void SignalHandler::synchDisplaySize(bool check)
 {
-    b_synchSizeMode = check;
+    b_autosizeMode = check;
 }
 
-bool SignalHandler::getSynchSizeMode()
+bool SignalHandler::getAutosizeMode()
 {
-    return b_synchSizeMode;
+    return b_autosizeMode;
 }
 
 /*! \brief Enable/Disable the freeze mode.

--- a/src/yarpview/plugin/signalhandler.h
+++ b/src/yarpview/plugin/signalhandler.h
@@ -33,6 +33,7 @@ public:
 
     void sendVideoFrame(QVideoFrame);
     void synchToDisplay(bool check);
+    void synchSize(bool check);
     void changeRefreshInterval(int ineterval);
     void freeze(bool check);
     void saveCurrentFrame();
@@ -40,6 +41,7 @@ public:
     void setFileNames(QUrl url);
     void startDumpFrames();
     void stopDumpFrames();
+    bool getSynchSizeMode();
 
 private:
     void saveFrame(QImage);
@@ -66,10 +68,11 @@ private:
     FpsStats displayFps;
     QString fileName;
     QString fileNames;
-    bool saveSetFrameMode;
-    bool saveCurrentFrameMode;
-    bool freezeMode;
-    bool synchMode;
+    bool b_saveSetFrameMode;
+    bool b_saveCurrentFrameMode;
+    bool b_freezeMode;
+    bool b_synchRateMode;
+    bool b_synchSizeMode;
     QVideoFrame frame;
     QMutex mutex;
     QTimer timer;

--- a/src/yarpview/plugin/signalhandler.h
+++ b/src/yarpview/plugin/signalhandler.h
@@ -32,8 +32,8 @@ public:
     ~SignalHandler();
 
     void sendVideoFrame(QVideoFrame);
-    void synchToDisplay(bool check);
-    void synchSize(bool check);
+    void synchDisplayPeriod(bool check);
+    void synchDisplaySize(bool check);
     void changeRefreshInterval(int ineterval);
     void freeze(bool check);
     void saveCurrentFrame();
@@ -41,7 +41,7 @@ public:
     void setFileNames(QUrl url);
     void startDumpFrames();
     void stopDumpFrames();
-    bool getSynchSizeMode();
+    bool getAutosizeMode();
 
 private:
     void saveFrame(QImage);
@@ -72,7 +72,7 @@ private:
     bool b_saveCurrentFrameMode;
     bool b_freezeMode;
     bool b_synchRateMode;
-    bool b_synchSizeMode;
+    bool b_autosizeMode;
     QVideoFrame frame;
     QMutex mutex;
     QTimer timer;

--- a/src/yarpview/plugin/videoproducer.cpp
+++ b/src/yarpview/plugin/videoproducer.cpp
@@ -20,8 +20,10 @@ VideoProducer::VideoProducer(QObject *parent) :
 
 VideoProducer::~VideoProducer()
 {
-    if(m_format){
+    if(m_format)
+    {
         delete m_format;
+        m_format = 0;
     }
 }
 
@@ -79,25 +81,30 @@ void VideoProducer::onNewVideoContentReceived(QVideoFrame *frame)
 {
     if (m_surface){
         if(m_surface->isActive() && (m_format->frameWidth() != frame->size().width() ||
-                                     m_format->frameHeight() != frame->size().height())){
+                                     m_format->frameHeight() != frame->size().height()))
+        {
             m_surface->stop();
             delete m_format;
             m_format = NULL;
         }
 
-        if(!m_surface->isActive()){
+        if (!m_surface->isActive())
+        {
             QSize s = frame->size();
             QVideoFrame::PixelFormat f = frame->pixelFormat();
-            m_format = new QVideoSurfaceFormat(s,f);
-            
+            m_format = new QVideoSurfaceFormat(s, f);
 
             bool b = m_surface->start(*m_format);
-            if(b){
-                qDebug("Surface STARTED! Dimensions: %dx%d -- PixelFormat: %d",s.width(),s.height(),(int)f);
-            }else{
+            if (b)
+            {
+                qDebug("Surface STARTED! Dimensions: %dx%d -- PixelFormat: %d", s.width(), s.height(), (int)f);
+            }
+            else
+            {
                 qDebug("Surface START ERROR");
                 delete m_format;
             }
+            emit resizeWindowRequest();
         }
     }
 

--- a/src/yarpview/plugin/videoproducer.h
+++ b/src/yarpview/plugin/videoproducer.h
@@ -42,6 +42,7 @@ private:
     QVideoSurfaceFormat *m_format;
 
 signals:
+    void resizeWindowRequest();
 
 public slots:
     void onNewVideoContentReceived(QVideoFrame *frame);

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -97,6 +97,10 @@ ApplicationWindow {
             vSurface.synchToDisplay(checked)
         }
 
+        onSynchSize:{
+            vSurface.synchSize(checked)
+        }
+
         onSaveSingleImage:{
             vSurface.saveSingleImage(checked)
         }

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -64,7 +64,12 @@ ApplicationWindow {
             window.width = w
             window.height = h
         }
-        onSynch:{
+        onAutosize:{
+            if(menu !== undefined){
+                menu.enableAutosize(check)
+            }
+        }
+        onSynchRate:{
             if(menu !== undefined){
                 menu.enableSynch(check)
             }
@@ -93,12 +98,12 @@ ApplicationWindow {
             vSurface.changeRefreshInterval()
         }
 
-        onSynchToDisplay:{
-            vSurface.synchToDisplay(checked)
+        onSynchDisplayPeriod:{
+            vSurface.synchDisplayPeriod(checked)
         }
 
-        onSynchSize:{
-            vSurface.synchSize(checked)
+        onSynchDisplaySize:{
+            vSurface.synchDisplaySize(checked)
         }
 
         onSaveSingleImage:{

--- a/src/yarpview/src/qml/QtYARPView/mainCompact.qml
+++ b/src/yarpview/src/qml/QtYARPView/mainCompact.qml
@@ -54,9 +54,14 @@ ApplicationWindow {
             window.width = w
             window.height = h
         }
-        onSynch:{
+        onSynchRate:{
             if(menu !== undefined){
                 menu.enableSynch(check)
+            }
+        }
+        onAutosize:{
+            if(menu !== undefined){
+                menu.enableAutosize(check)
             }
         }
         onSetName:{


### PR DESCRIPTION
added --autosize option
added menu item which allows the main yarpview window to automatically resize to the new frame size when a video stream width/height is time-variant.  

tested with:
yarpdev --device test_grabber -mode size