### PR TITLE
Analog wrapper harmonize params

### DIFF
--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -234,7 +234,10 @@ void AnalogWrapper::removeHandlers()
     for(unsigned int i=0; i<handlers.size(); i++)
     {
         if (handlers[i]!=YARP_NULLPTR)
+        {
             delete handlers[i];
+            handlers[i] = YARP_NULLPTR;
+        }
     }
     handlers.clear();
 }
@@ -887,6 +890,7 @@ bool AnalogWrapper::close()
     {
         subDeviceOwned->close();
         delete subDeviceOwned;
+        subDeviceOwned = YARP_NULLPTR;
     }
 
     if(rosNode!=YARP_NULLPTR) {

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -880,10 +880,14 @@ bool AnalogWrapper::close()
         RateThread::stop();
     }
 
-    //RateThread::stop();
-
     detachAll();
     removeHandlers();
+
+    if(subDeviceOwned)
+    {
+        subDeviceOwned->close();
+        delete subDeviceOwned;
+    }
 
     if(rosNode!=YARP_NULLPTR) {
         rosNode->interrupt();

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -483,13 +483,13 @@ bool AnalogWrapper::checkROSParams(Searchable &config)
     else if (rosMsgType == "sensor_msgs/JointState")
     {
         yInfo() << sensorId << "ROS_msgType is " << rosMsgType;
-        if (!rosGroup.check("joint_names"))
+        if (!rosGroup.check("jointNames"))
         {
-            yError() << sensorId << " cannot find some ros parameters";
+            yError() << sensorId << " missing 'jointNames' parameter needed when broadcasting 'sensor_msgs/JointState' message type";
             useROS = ROS_config_error;
             return false;
         }
-        yarp::os::Bottle& jnam =rosGroup.findGroup("joint_names");
+        yarp::os::Bottle& jnam =rosGroup.findGroup("jointNames");
         int joint_names_size = jnam.size()-1;
         for (int i = 0; i < joint_names_size; i++)
         {
@@ -795,7 +795,7 @@ void AnalogWrapper::run()
 
                     if (data_size != ros_joint_names.size())
                     {
-                        yDebug() << "Invalid ros_joint_names size:" << data_size << "!=" << ros_joint_names.size();
+                        yDebug() << "Invalid jointNames size:" << data_size << "!=" << ros_joint_names.size();
                     }
                     else
                     {


### PR DESCRIPTION
-Change ROS param from `joint_names` to `jointNames` like the controlBoardWrapper. Old name is deprecated, but still accepted. A warning message will be displayed.

- Add call to subdevice close 