### PR TITLE
Yarpmanager to load sub-folders by default

### DIFF
--- a/src/yarpmanager/src-manager/main.cpp
+++ b/src/yarpmanager/src-manager/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     }
 
     if(!config.check("load_subfolders")){
-        config.put("load_subfolders", "no");
+        config.put("load_subfolders", "yes");
     }
 
     if(!config.check("watchdog")){


### PR DESCRIPTION
I found myself more comfortable having `yarpmanager` to load applications also from sub-folders **by default**.

This way, the usual path `~/.local/share/yarp/applications` can have a tree of sub-folders without impacting `yarpmanager`.

As of now, in fact, to make `yarpmanager` deal with the above configuration, we have to create a context containing the proper option.

cc @Tobias-Fischer @clement-moulin-frier 