### PR TITLE
Remote control board: remove single port compatibility

### DIFF
--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -11,6 +11,10 @@ Important Changes
 * YARP_math can no longer be built using GSL. The `CREATE_LIB_MATH_USING_GSL`
   option was removed. Only Eigen is supported. `FindGSL.cmake` is no longer
   installed.
+* 31/12/2016: `RemoteControlBoard` device is no longer compatible with `ControlBoardWrapper2`
+  devices that does not have the `stateExt:o` port. This change was introduced in
+  30/07/2014 and back compatibility was mainteined up to now. `state:o` port in the
+  wrapper is still available for encoder reading.
 
 
 New Features

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -52,8 +52,8 @@
 #endif
 
 #define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 5
-#define PROTOCOL_VERSION_TWEAK 1
+#define PROTOCOL_VERSION_MINOR 6
+#define PROTOCOL_VERSION_TWEAK 0
 
 /*
  * To optimize memory allocation, for group of joints we can have one mem reserver for rpc port

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -30,8 +30,8 @@
 #include <stateExtendedReader.hpp>
 
 #define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 5
-#define PROTOCOL_VERSION_TWEAK 1
+#define PROTOCOL_VERSION_MINOR 6
+#define PROTOCOL_VERSION_TWEAK 0
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -3549,10 +3549,9 @@ public:
             return true;
 
         // protocol did not match
-        yError("expecting protocol %d %d %d, but remotecontrolboard returned protocol version %d %d %d\n",
+        yError("expecting protocol %d %d %d, but the device we are connectin to has protocol version %d %d %d\n",
                         PROTOCOL_VERSION_MAJOR, PROTOCOL_VERSION_MINOR, PROTOCOL_VERSION_TWEAK,
                         protocolVersion.major, protocolVersion.minor, protocolVersion.tweak);
-
 
         bool ret;
         if (ignore)

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -3393,7 +3393,7 @@ public:
             return true;
 
         // protocol did not match
-        yError("expecting protocol %d %d %d, but the device we are connectin to has protocol version %d %d %d\n",
+        yError("expecting protocol %d %d %d, but the device we are connecting to has protocol version %d %d %d\n",
                         PROTOCOL_VERSION_MAJOR, PROTOCOL_VERSION_MINOR, PROTOCOL_VERSION_TWEAK,
                         protocolVersion.major, protocolVersion.minor, protocolVersion.tweak);
 

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.hpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.hpp
@@ -58,7 +58,7 @@ public:
 
     StateExtendedInputPort();
 
-    inline void resetStat();
+    void resetStat();
     void init(int numberOfJoints);
 
     using yarp::os::BufferedPort<jointData>::onRead;


### PR DESCRIPTION
This PR remove the backward compatibility of the remote control board with wrapper that has ONLY the state:o port.

This device is therefore expecting the wrapper to have the stateExt:o port, which was introduced in 30/07/2014.
