### PR TITLE
RangeFinder2DWrapper: added internal subdevice spawn and attach

### DIFF
--- a/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -47,7 +47,8 @@ Rangefinder2DWrapper::Rangefinder2DWrapper() : RateThread(DEFAULT_THREAD_PERIOD)
     maxAngle    = 0;
     minDistance = 0;
     maxDistance = 0;
-    resolution = 0;
+    resolution  = 0;
+    isDeviceOwned = false;
 }
 
 Rangefinder2DWrapper::~Rangefinder2DWrapper()
@@ -511,6 +512,27 @@ bool Rangefinder2DWrapper::open(yarp::os::Searchable &config)
         return false;
     }
 
+    if(config.check("subdevice"))
+    {
+        Property       p;
+        PolyDriverList driverlist;
+        p.fromString(config.toString(), false);
+        p.put("device", config.find("subdevice").asString());
+
+        if(!driver.open(p) || !driver.isValid())
+        {
+            yError() << "RangeFinder2DWrapper: failed to open subdevice.. check params";
+            return false;
+        }
+
+        driverlist.push(&driver, "1");
+        if(!attachAll(driverlist))
+        {
+            yError() << "RangeFinder2DWrapper: failed to open subdevice.. check params";
+            return false;
+        }
+        isDeviceOwned = true;
+    }
     return true;
 }
 

--- a/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
+++ b/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
@@ -78,6 +78,7 @@ public:
 
 private:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
+    yarp::dev::PolyDriver driver;
     yarp::os::ConstString partName;
     yarp::os::ConstString streamingPortName;
     yarp::os::ConstString rpcPortName;
@@ -91,6 +92,7 @@ private:
     double minAngle, maxAngle;
     double minDistance, maxDistance;
     double resolution;
+    bool   isDeviceOwned;
 
     bool checkROSParams(yarp::os::Searchable &config);
     bool initialize_ROS();


### PR DESCRIPTION
RangeFinder2DWrapper can now create his own device trough the --subdevice parameter 