### PR TITLE
CMakeLists.txt ported to new OpenNI2 variables

### DIFF
--- a/src/devices/depthCamera/CMakeLists.txt
+++ b/src/devices/depthCamera/CMakeLists.txt
@@ -4,16 +4,16 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 if(WIN32)
-find_path(OPENNI2_INCLUDE_LOCAL NAMES OpenNI.h HINTS $ENV{OPENNI2_DIR}/Include)
-find_library(OPENNI2_LIBRARY NAMES OpenNI2 libOpenNI2 HINTS $ENV{OPENNI2_DIR}/Lib $ENV{OPENNI2_DIR}/Redist)
+find_path(OpenNI2_INCLUDE_LOCAL NAMES OpenNI.h HINTS $ENV{OpenNI2_DIR}/Include)
+find_library(OpenNI2_LIBRARY NAMES OpenNI2 libOpenNI2 HINTS $ENV{OpenNI2_DIR}/Lib $ENV{OpenNI2_DIR}/Redist)
 else(WIN32)
-find_path(OPENNI2_INCLUDE_LOCAL NAMES OpenNI.h HINTS $ENV{OPENNI2_DIR}/include)
-find_library(OPENNI2_LIBRARY NAMES OpenNI2 libOpenNI2 HINTS $ENV{OPENNI2_DIR}/lib $ENV{OPENNI2_DIR}/redist)
+find_path(OpenNI2_INCLUDE_LOCAL NAMES OpenNI.h HINTS $ENV{OpenNI2_DIR}/include)
+find_library(OpenNI2_LIBRARY NAMES OpenNI2 libOpenNI2 HINTS $ENV{OpenNI2_DIR}/lib $ENV{OpenNI2_DIR}/redist)
 endif(WIN32)
-if(OPENNI2_INCLUDE_LOCAL AND OPENNI2_LIBRARY)
-  set(OPENNI2_FOUND TRUE)
+if(OpenNI2_INCLUDE_LOCAL AND OpenNI2_LIBRARY)
+  set(OpenNI2_FOUND TRUE)
 else()
-  set(OPENNI2_FOUND FALSE)
+  set(OpenNI2_FOUND FALSE)
 endif()
 
 
@@ -22,7 +22,7 @@ yarp_prepare_plugin(depthCamera
                     TYPE                 yarp::dev::depthCameraDriver
                     INCLUDE              depthCameraDriver.h
                     EXTRA_CONFIG WRAPPER=RGBDSensorWrapper
-                    DEPENDS              "CREATE_DEVICE_LIBRARY_MODULES;OPENNI2_FOUND")
+                    DEPENDS              "CREATE_DEVICE_LIBRARY_MODULES;OpenNI2_FOUND")
 
 if(ENABLE_depthCamera)
 
@@ -32,14 +32,14 @@ if(ENABLE_depthCamera)
   get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
   get_property(YARP_dev_INCLUDE_DIRS TARGET YARP_dev PROPERTY INCLUDE_DIRS)
 
-  include_directories(SYSTEM ${OPENNI2_INCLUDE_LOCAL})
+  include_directories(SYSTEM ${OpenNI2_INCLUDE_LOCAL})
   include_directories(${YARP_OS_INCLUDE_DIRS}
                       ${YARP_sig_INCLUDE_DIRS}
                       ${YARP_dev_INCLUDE_DIRS})
 
   yarp_add_plugin(yarp_depthCamera depthCameraDriver.cpp depthCameraDriver.h depthCameraImpl.hpp)
   
-  target_link_libraries(yarp_depthCamera YARP_OS YARP_sig YARP_dev ${OPENNI2_LIBRARY})
+  target_link_libraries(yarp_depthCamera YARP_OS YARP_sig YARP_dev ${OpenNI2_LIBRARY})
 
   yarp_install(TARGETS     yarp_depthCamera
                EXPORT      YARP


### PR DESCRIPTION
This change is necessary for fixing [ycm/#111](https://github.com/robotology/ycm/pull/111).