### PR TITLE
New broken test

### DIFF
--- a/tests/libYARP_OS/NodeTest.cpp
+++ b/tests/libYARP_OS/NodeTest.cpp
@@ -52,6 +52,14 @@ public:
 
 private:
 
+    void wrongNamePort()
+    {
+        report(0, "trying to open a port without '/' after Node creation.");
+        Node n("/mynode");
+        BufferedPort<Bottle> p;
+        checkFalse(p.open("nameWithoutSlash+"), "open port with wrong name should fail");
+    }
+
     void parseName(const ConstString& arg,
                    const ConstString& node,
                    const ConstString& nested,
@@ -257,6 +265,11 @@ void NodeTest::typePropTest() {
 
 void NodeTest::runTests() {
     NetworkBase::setLocalMode(true);
+
+#ifdef BROKEN_TEST
+    wrongNamePort();
+#endif
+
     parseNameTest();
     basicNodeTest();
     basicNodesTest();


### PR DESCRIPTION
adds a broken test regarding wrong effect misleading port name after ros node creation. see issue #1037