### PR TITLE
Control board message Optimization - Update protocol number

### DIFF
--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (C) 2009 RobotCub Consortium
- * Author: Lorenzo Natale
+ * Author: Lorenzo Natale, Alberto Cardellino
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
 #include "ControlBoardWrapper.h"
 #include "StreamingMessagesParser.h"
 #include "RPCMessagesParser.h"
+#include "../msgs/yarp/include/jointData.h"
 #include <iostream>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
@@ -885,16 +886,16 @@ void ControlBoardWrapper::run()
         yarp_struct.controlMode.resize(controlledJoints);
         yarp_struct.interactionMode.resize(controlledJoints);
 
-        yarp_struct.jointPosition_isValid       = getEncoders(yarp_struct.jointPosition.data());
-        yarp_struct.jointVelocity_isValid       = getEncoderSpeeds(yarp_struct.jointVelocity.data());
-        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.data());
-        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.data());
-        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
-        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
-        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.data());
-        yarp_struct.pidOutput_isValid           = getOutputs(yarp_struct.pidOutput.data());
-        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.data());
-        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.data());
+        yarp_struct.jointPosition_isValid       = getEncoders(yarp_struct.jointPosition.getFirst());
+        yarp_struct.jointVelocity_isValid       = getEncoderSpeeds(yarp_struct.jointVelocity.getFirst());
+        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.getFirst());
+        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.getFirst());
+        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.getFirst());
+        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.getFirst());
+        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.getFirst());
+        yarp_struct.pidOutput_isValid           = getOutputs(yarp_struct.pidOutput.getFirst());
+        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.getFirst());
+        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.getFirst());
 
         extendedOutputStatePort.setEnvelope(time);
         extendedOutputState_buffer.write();
@@ -3320,13 +3321,14 @@ bool ControlBoardWrapper::disableAmp(int j)
         return false;
 
     // Use the newer interface if available, otherwise fallback on the old one.
-    if(p->iMode2) {
+    if(p->iMode2)
         return p->iMode2->setControlMode(off+p->base, VOCAB_CM_IDLE);
-    }
-    if (p->pos) {
-        return p->amp->disableAmp(off+p->base);
-    }
-    return false;
+    else
+        if (p->pos)
+        {
+            return p->amp->disableAmp(off+p->base);
+        }
+        return false;
 }
 
 bool ControlBoardWrapper::getAmpStatus(int *st)

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -3316,19 +3316,24 @@ bool ControlBoardWrapper::disableAmp(int j)
     int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
     int subIndex=device.lut[j].deviceEntry;
 
+    bool ret = true;
     yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
     if (!p)
         return false;
 
     // Use the newer interface if available, otherwise fallback on the old one.
     if(p->iMode2)
-        return p->iMode2->setControlMode(off+p->base, VOCAB_CM_IDLE);
+    {
+        ret = p->iMode2->setControlMode(off+p->base, VOCAB_CM_IDLE);
+    }
     else
+    {
         if (p->pos)
-        {
-            return p->amp->disableAmp(off+p->base);
-        }
-        return false;
+            ret = p->amp->disableAmp(off+p->base);
+        else
+            ret = false;
+    }
+    return ret;
 }
 
 bool ControlBoardWrapper::getAmpStatus(int *st)

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 iCub Facility - Istituto Italiano di Tecnologia
- * Author: Lorenzo Natale
+ * Author: Lorenzo Natale, Alberto Cardellino
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -52,7 +52,7 @@
 #endif
 
 #define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 6
+#define PROTOCOL_VERSION_MINOR 7
 #define PROTOCOL_VERSION_TWEAK 0
 
 /*

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2878,7 +2878,7 @@ public:
         double localArrivalTime=0.0;
 
         extendedPortMutex.wait();
-        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.controlMode.data(), lastStamp, localArrivalTime);
+        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.controlMode.getFirst(), lastStamp, localArrivalTime);
         if(ret)
         {
             for (int i = 0; i < n_joint; i++)
@@ -3177,7 +3177,7 @@ public:
         double localArrivalTime=0.0;
 
         extendedPortMutex.wait();
-        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.interactionMode.data(), lastStamp, localArrivalTime);
+        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.interactionMode.getFirst(), lastStamp, localArrivalTime);
         if(ret)
         {
             for (int i = 0; i < n_joints; i++)

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 RobotCub Consortium
- * Authors: Giorgio Metta, Lorenzo Natale, Paul Fitzpatrick
+ * Authors: Giorgio Metta, Lorenzo Natale, Paul Fitzpatrick, Alberto Cardellino
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -29,7 +29,7 @@
 #include <stateExtendedReader.hpp>
 
 #define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 6
+#define PROTOCOL_VERSION_MINOR 7
 #define PROTOCOL_VERSION_TWEAK 0
 
 using namespace yarp::os;

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -183,42 +183,42 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
         {
             case VOCAB_ENCODERS:
                 ret = last.jointPosition_isValid;
-                std::copy(last.jointPosition.begin(), last.jointPosition.end(), data);
+                memcpy(data, last.jointPosition.getFirst(), last.jointPosition.size() * last.jointPosition.getElementSize() );
             break;
 
             case VOCAB_ENCODER_SPEEDS:
                 ret = last.jointVelocity_isValid;
-                std::copy(last.jointVelocity.begin(), last.jointVelocity.end(), data);
+                memcpy(data, last.jointVelocity.getFirst(), last.jointVelocity.size() * last.jointVelocity.getElementSize() );
             break;
 
             case VOCAB_ENCODER_ACCELERATIONS:
                 ret = last.jointAcceleration_isValid;
-                std::copy(last.jointAcceleration.begin(), last.jointAcceleration.end(), data);
+                memcpy(data, last.jointAcceleration.getFirst(), last.jointAcceleration.size() * last.jointAcceleration.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODERS:
                 ret = last.motorPosition_isValid;
-                std::copy(last.motorPosition.begin(), last.motorPosition.end(), data);
+                memcpy(data, last.motorPosition.getFirst(), last.motorPosition.size() * last.motorPosition.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODER_SPEEDS:
                 ret = last.motorVelocity_isValid;
-                std::copy(last.motorVelocity.begin(), last.motorVelocity.end(), data);
+                memcpy(data, last.motorVelocity.getFirst(), last.motorVelocity.size() * last.motorVelocity.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODER_ACCELERATIONS:
                 ret = last.motorAcceleration_isValid;
-                std::copy(last.motorAcceleration.begin(), last.motorAcceleration.end(), data);
+                memcpy(data, last.motorAcceleration.getFirst(), last.motorAcceleration.size() * last.motorAcceleration.getElementSize() );
             break;
 
             case VOCAB_TRQS:
                 ret = last.torque_isValid;
-                std::copy(last.torque.begin(), last.torque.end(), data);
+                memcpy(data, last.torque.getFirst(), last.torque.size() * last.torque.getElementSize() );
             break;
 
             case VOCAB_OUTPUTS:
                 ret = last.pidOutput_isValid;
-                std::copy(last.pidOutput.begin(), last.pidOutput.end(), data);
+                memcpy(data, last.pidOutput.getFirst(), last.pidOutput.size() * last.pidOutput.getElementSize() );
             break;
 
             default:
@@ -244,12 +244,12 @@ bool StateExtendedInputPort::getLastVector(int field, int* data, Stamp& stamp, d
         {
             case VOCAB_CM_CONTROL_MODES:
                 ret = last.controlMode_isValid;
-                std::copy(last.controlMode.begin(), last.controlMode.end(), data);
+                memcpy(data, last.controlMode.getFirst(), last.controlMode.size() * last.controlMode.getElementSize());
             break;
 
             case VOCAB_INTERACTION_MODES:
                 ret = last.interactionMode_isValid;
-                std::copy(last.interactionMode.begin(), last.interactionMode.end(), data);
+                memcpy(data, last.interactionMode.getFirst(), last.interactionMode.size() * last.interactionMode.getElementSize());
             break;
 
             default:

--- a/src/libYARP_dev/src/devices/msgs/yarp/include/jointData.h
+++ b/src/libYARP_dev/src/devices/msgs/yarp/include/jointData.h
@@ -6,6 +6,7 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/sig/Vector.h>
 
 class jointData;
 
@@ -13,25 +14,25 @@ class jointData;
 class jointData : public yarp::os::idl::WirePortable {
 public:
   // Fields
-  std::vector<double>  jointPosition;
+  yarp::sig::VectorOf<double> jointPosition;
   bool jointPosition_isValid;
-  std::vector<double>  jointVelocity;
+  yarp::sig::VectorOf<double> jointVelocity;
   bool jointVelocity_isValid;
-  std::vector<double>  jointAcceleration;
+  yarp::sig::VectorOf<double> jointAcceleration;
   bool jointAcceleration_isValid;
-  std::vector<double>  motorPosition;
+  yarp::sig::VectorOf<double> motorPosition;
   bool motorPosition_isValid;
-  std::vector<double>  motorVelocity;
+  yarp::sig::VectorOf<double> motorVelocity;
   bool motorVelocity_isValid;
-  std::vector<double>  motorAcceleration;
+  yarp::sig::VectorOf<double> motorAcceleration;
   bool motorAcceleration_isValid;
-  std::vector<double>  torque;
+  yarp::sig::VectorOf<double> torque;
   bool torque_isValid;
-  std::vector<double>  pidOutput;
+  yarp::sig::VectorOf<double> pidOutput;
   bool pidOutput_isValid;
-  std::vector<int32_t>  controlMode;
+  yarp::sig::VectorOf<int> controlMode;
   bool controlMode_isValid;
-  std::vector<int32_t>  interactionMode;
+  yarp::sig::VectorOf<int> interactionMode;
   bool interactionMode_isValid;
 
   // Default constructor
@@ -39,7 +40,7 @@ public:
   }
 
   // Constructor with field values
-  jointData(const std::vector<double> & jointPosition,const bool jointPosition_isValid,const std::vector<double> & jointVelocity,const bool jointVelocity_isValid,const std::vector<double> & jointAcceleration,const bool jointAcceleration_isValid,const std::vector<double> & motorPosition,const bool motorPosition_isValid,const std::vector<double> & motorVelocity,const bool motorVelocity_isValid,const std::vector<double> & motorAcceleration,const bool motorAcceleration_isValid,const std::vector<double> & torque,const bool torque_isValid,const std::vector<double> & pidOutput,const bool pidOutput_isValid,const std::vector<int32_t> & controlMode,const bool controlMode_isValid,const std::vector<int32_t> & interactionMode,const bool interactionMode_isValid) : jointPosition(jointPosition), jointPosition_isValid(jointPosition_isValid), jointVelocity(jointVelocity), jointVelocity_isValid(jointVelocity_isValid), jointAcceleration(jointAcceleration), jointAcceleration_isValid(jointAcceleration_isValid), motorPosition(motorPosition), motorPosition_isValid(motorPosition_isValid), motorVelocity(motorVelocity), motorVelocity_isValid(motorVelocity_isValid), motorAcceleration(motorAcceleration), motorAcceleration_isValid(motorAcceleration_isValid), torque(torque), torque_isValid(torque_isValid), pidOutput(pidOutput), pidOutput_isValid(pidOutput_isValid), controlMode(controlMode), controlMode_isValid(controlMode_isValid), interactionMode(interactionMode), interactionMode_isValid(interactionMode_isValid) {
+  jointData(const yarp::sig::VectorOf<double>& jointPosition,const bool jointPosition_isValid,const yarp::sig::VectorOf<double>& jointVelocity,const bool jointVelocity_isValid,const yarp::sig::VectorOf<double>& jointAcceleration,const bool jointAcceleration_isValid,const yarp::sig::VectorOf<double>& motorPosition,const bool motorPosition_isValid,const yarp::sig::VectorOf<double>& motorVelocity,const bool motorVelocity_isValid,const yarp::sig::VectorOf<double>& motorAcceleration,const bool motorAcceleration_isValid,const yarp::sig::VectorOf<double>& torque,const bool torque_isValid,const yarp::sig::VectorOf<double>& pidOutput,const bool pidOutput_isValid,const yarp::sig::VectorOf<int>& controlMode,const bool controlMode_isValid,const yarp::sig::VectorOf<int>& interactionMode,const bool interactionMode_isValid) : jointPosition(jointPosition), jointPosition_isValid(jointPosition_isValid), jointVelocity(jointVelocity), jointVelocity_isValid(jointVelocity_isValid), jointAcceleration(jointAcceleration), jointAcceleration_isValid(jointAcceleration_isValid), motorPosition(motorPosition), motorPosition_isValid(motorPosition_isValid), motorVelocity(motorVelocity), motorVelocity_isValid(motorVelocity_isValid), motorAcceleration(motorAcceleration), motorAcceleration_isValid(motorAcceleration_isValid), torque(torque), torque_isValid(torque_isValid), pidOutput(pidOutput), pidOutput_isValid(pidOutput_isValid), controlMode(controlMode), controlMode_isValid(controlMode_isValid), interactionMode(interactionMode), interactionMode_isValid(interactionMode_isValid) {
   }
 
   // Copy constructor
@@ -228,16 +229,9 @@ public:
       group--;
       if (group==0&&is_dirty) communicate();
     }
-    void set_jointPosition(const std::vector<double> & jointPosition) {
+    void set_jointPosition(const yarp::sig::VectorOf<double>& jointPosition) {
       will_set_jointPosition();
       obj->jointPosition = jointPosition;
-      mark_dirty_jointPosition();
-      communicate();
-      did_set_jointPosition();
-    }
-    void set_jointPosition(int index, const double elem) {
-      will_set_jointPosition();
-      obj->jointPosition[index] = elem;
       mark_dirty_jointPosition();
       communicate();
       did_set_jointPosition();
@@ -249,16 +243,9 @@ public:
       communicate();
       did_set_jointPosition_isValid();
     }
-    void set_jointVelocity(const std::vector<double> & jointVelocity) {
+    void set_jointVelocity(const yarp::sig::VectorOf<double>& jointVelocity) {
       will_set_jointVelocity();
       obj->jointVelocity = jointVelocity;
-      mark_dirty_jointVelocity();
-      communicate();
-      did_set_jointVelocity();
-    }
-    void set_jointVelocity(int index, const double elem) {
-      will_set_jointVelocity();
-      obj->jointVelocity[index] = elem;
       mark_dirty_jointVelocity();
       communicate();
       did_set_jointVelocity();
@@ -270,16 +257,9 @@ public:
       communicate();
       did_set_jointVelocity_isValid();
     }
-    void set_jointAcceleration(const std::vector<double> & jointAcceleration) {
+    void set_jointAcceleration(const yarp::sig::VectorOf<double>& jointAcceleration) {
       will_set_jointAcceleration();
       obj->jointAcceleration = jointAcceleration;
-      mark_dirty_jointAcceleration();
-      communicate();
-      did_set_jointAcceleration();
-    }
-    void set_jointAcceleration(int index, const double elem) {
-      will_set_jointAcceleration();
-      obj->jointAcceleration[index] = elem;
       mark_dirty_jointAcceleration();
       communicate();
       did_set_jointAcceleration();
@@ -291,16 +271,9 @@ public:
       communicate();
       did_set_jointAcceleration_isValid();
     }
-    void set_motorPosition(const std::vector<double> & motorPosition) {
+    void set_motorPosition(const yarp::sig::VectorOf<double>& motorPosition) {
       will_set_motorPosition();
       obj->motorPosition = motorPosition;
-      mark_dirty_motorPosition();
-      communicate();
-      did_set_motorPosition();
-    }
-    void set_motorPosition(int index, const double elem) {
-      will_set_motorPosition();
-      obj->motorPosition[index] = elem;
       mark_dirty_motorPosition();
       communicate();
       did_set_motorPosition();
@@ -312,16 +285,9 @@ public:
       communicate();
       did_set_motorPosition_isValid();
     }
-    void set_motorVelocity(const std::vector<double> & motorVelocity) {
+    void set_motorVelocity(const yarp::sig::VectorOf<double>& motorVelocity) {
       will_set_motorVelocity();
       obj->motorVelocity = motorVelocity;
-      mark_dirty_motorVelocity();
-      communicate();
-      did_set_motorVelocity();
-    }
-    void set_motorVelocity(int index, const double elem) {
-      will_set_motorVelocity();
-      obj->motorVelocity[index] = elem;
       mark_dirty_motorVelocity();
       communicate();
       did_set_motorVelocity();
@@ -333,16 +299,9 @@ public:
       communicate();
       did_set_motorVelocity_isValid();
     }
-    void set_motorAcceleration(const std::vector<double> & motorAcceleration) {
+    void set_motorAcceleration(const yarp::sig::VectorOf<double>& motorAcceleration) {
       will_set_motorAcceleration();
       obj->motorAcceleration = motorAcceleration;
-      mark_dirty_motorAcceleration();
-      communicate();
-      did_set_motorAcceleration();
-    }
-    void set_motorAcceleration(int index, const double elem) {
-      will_set_motorAcceleration();
-      obj->motorAcceleration[index] = elem;
       mark_dirty_motorAcceleration();
       communicate();
       did_set_motorAcceleration();
@@ -354,16 +313,9 @@ public:
       communicate();
       did_set_motorAcceleration_isValid();
     }
-    void set_torque(const std::vector<double> & torque) {
+    void set_torque(const yarp::sig::VectorOf<double>& torque) {
       will_set_torque();
       obj->torque = torque;
-      mark_dirty_torque();
-      communicate();
-      did_set_torque();
-    }
-    void set_torque(int index, const double elem) {
-      will_set_torque();
-      obj->torque[index] = elem;
       mark_dirty_torque();
       communicate();
       did_set_torque();
@@ -375,16 +327,9 @@ public:
       communicate();
       did_set_torque_isValid();
     }
-    void set_pidOutput(const std::vector<double> & pidOutput) {
+    void set_pidOutput(const yarp::sig::VectorOf<double>& pidOutput) {
       will_set_pidOutput();
       obj->pidOutput = pidOutput;
-      mark_dirty_pidOutput();
-      communicate();
-      did_set_pidOutput();
-    }
-    void set_pidOutput(int index, const double elem) {
-      will_set_pidOutput();
-      obj->pidOutput[index] = elem;
       mark_dirty_pidOutput();
       communicate();
       did_set_pidOutput();
@@ -396,16 +341,9 @@ public:
       communicate();
       did_set_pidOutput_isValid();
     }
-    void set_controlMode(const std::vector<int32_t> & controlMode) {
+    void set_controlMode(const yarp::sig::VectorOf<int>& controlMode) {
       will_set_controlMode();
       obj->controlMode = controlMode;
-      mark_dirty_controlMode();
-      communicate();
-      did_set_controlMode();
-    }
-    void set_controlMode(int index, const int32_t elem) {
-      will_set_controlMode();
-      obj->controlMode[index] = elem;
       mark_dirty_controlMode();
       communicate();
       did_set_controlMode();
@@ -417,16 +355,9 @@ public:
       communicate();
       did_set_controlMode_isValid();
     }
-    void set_interactionMode(const std::vector<int32_t> & interactionMode) {
+    void set_interactionMode(const yarp::sig::VectorOf<int>& interactionMode) {
       will_set_interactionMode();
       obj->interactionMode = interactionMode;
-      mark_dirty_interactionMode();
-      communicate();
-      did_set_interactionMode();
-    }
-    void set_interactionMode(int index, const int32_t elem) {
-      will_set_interactionMode();
-      obj->interactionMode[index] = elem;
       mark_dirty_interactionMode();
       communicate();
       did_set_interactionMode();
@@ -438,61 +369,61 @@ public:
       communicate();
       did_set_interactionMode_isValid();
     }
-    const std::vector<double> & get_jointPosition() {
+    const yarp::sig::VectorOf<double>& get_jointPosition() {
       return obj->jointPosition;
     }
     bool get_jointPosition_isValid() {
       return obj->jointPosition_isValid;
     }
-    const std::vector<double> & get_jointVelocity() {
+    const yarp::sig::VectorOf<double>& get_jointVelocity() {
       return obj->jointVelocity;
     }
     bool get_jointVelocity_isValid() {
       return obj->jointVelocity_isValid;
     }
-    const std::vector<double> & get_jointAcceleration() {
+    const yarp::sig::VectorOf<double>& get_jointAcceleration() {
       return obj->jointAcceleration;
     }
     bool get_jointAcceleration_isValid() {
       return obj->jointAcceleration_isValid;
     }
-    const std::vector<double> & get_motorPosition() {
+    const yarp::sig::VectorOf<double>& get_motorPosition() {
       return obj->motorPosition;
     }
     bool get_motorPosition_isValid() {
       return obj->motorPosition_isValid;
     }
-    const std::vector<double> & get_motorVelocity() {
+    const yarp::sig::VectorOf<double>& get_motorVelocity() {
       return obj->motorVelocity;
     }
     bool get_motorVelocity_isValid() {
       return obj->motorVelocity_isValid;
     }
-    const std::vector<double> & get_motorAcceleration() {
+    const yarp::sig::VectorOf<double>& get_motorAcceleration() {
       return obj->motorAcceleration;
     }
     bool get_motorAcceleration_isValid() {
       return obj->motorAcceleration_isValid;
     }
-    const std::vector<double> & get_torque() {
+    const yarp::sig::VectorOf<double>& get_torque() {
       return obj->torque;
     }
     bool get_torque_isValid() {
       return obj->torque_isValid;
     }
-    const std::vector<double> & get_pidOutput() {
+    const yarp::sig::VectorOf<double>& get_pidOutput() {
       return obj->pidOutput;
     }
     bool get_pidOutput_isValid() {
       return obj->pidOutput_isValid;
     }
-    const std::vector<int32_t> & get_controlMode() {
+    const yarp::sig::VectorOf<int>& get_controlMode() {
       return obj->controlMode;
     }
     bool get_controlMode_isValid() {
       return obj->controlMode_isValid;
     }
-    const std::vector<int32_t> & get_interactionMode() {
+    const yarp::sig::VectorOf<int>& get_interactionMode() {
       return obj->interactionMode;
     }
     bool get_interactionMode_isValid() {

--- a/src/libYARP_dev/src/devices/msgs/yarp/src/jointData.cpp
+++ b/src/libYARP_dev/src/devices/msgs/yarp/src/jointData.cpp
@@ -2,42 +2,19 @@
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #include <jointData.h>
+#include <yarp/os/Time.h>
 
 bool jointData::read_jointPosition(yarp::os::idl::WireReader& reader) {
-  {
-    jointPosition.clear();
-    uint32_t _size0;
-    yarp::os::idl::WireState _etype3;
-    reader.readListBegin(_etype3, _size0);
-    jointPosition.resize(_size0);
-    uint32_t _i4;
-    for (_i4 = 0; _i4 < _size0; ++_i4)
-    {
-      if (!reader.readDouble(jointPosition[_i4])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(jointPosition)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_jointPosition(yarp::os::idl::WireReader& reader) {
-  {
-    jointPosition.clear();
-    uint32_t _size5;
-    yarp::os::idl::WireState _etype8;
-    reader.readListBegin(_etype8, _size5);
-    jointPosition.resize(_size5);
-    uint32_t _i9;
-    for (_i9 = 0; _i9 < _size5; ++_i9)
-    {
-      if (!reader.readDouble(jointPosition[_i9])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(jointPosition)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -56,40 +33,16 @@ bool jointData::nested_read_jointPosition_isValid(yarp::os::idl::WireReader& rea
   return true;
 }
 bool jointData::read_jointVelocity(yarp::os::idl::WireReader& reader) {
-  {
-    jointVelocity.clear();
-    uint32_t _size10;
-    yarp::os::idl::WireState _etype13;
-    reader.readListBegin(_etype13, _size10);
-    jointVelocity.resize(_size10);
-    uint32_t _i14;
-    for (_i14 = 0; _i14 < _size10; ++_i14)
-    {
-      if (!reader.readDouble(jointVelocity[_i14])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(jointVelocity)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_jointVelocity(yarp::os::idl::WireReader& reader) {
-  {
-    jointVelocity.clear();
-    uint32_t _size15;
-    yarp::os::idl::WireState _etype18;
-    reader.readListBegin(_etype18, _size15);
-    jointVelocity.resize(_size15);
-    uint32_t _i19;
-    for (_i19 = 0; _i19 < _size15; ++_i19)
-    {
-      if (!reader.readDouble(jointVelocity[_i19])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(jointVelocity)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -108,40 +61,16 @@ bool jointData::nested_read_jointVelocity_isValid(yarp::os::idl::WireReader& rea
   return true;
 }
 bool jointData::read_jointAcceleration(yarp::os::idl::WireReader& reader) {
-  {
-    jointAcceleration.clear();
-    uint32_t _size20;
-    yarp::os::idl::WireState _etype23;
-    reader.readListBegin(_etype23, _size20);
-    jointAcceleration.resize(_size20);
-    uint32_t _i24;
-    for (_i24 = 0; _i24 < _size20; ++_i24)
-    {
-      if (!reader.readDouble(jointAcceleration[_i24])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(jointAcceleration)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_jointAcceleration(yarp::os::idl::WireReader& reader) {
-  {
-    jointAcceleration.clear();
-    uint32_t _size25;
-    yarp::os::idl::WireState _etype28;
-    reader.readListBegin(_etype28, _size25);
-    jointAcceleration.resize(_size25);
-    uint32_t _i29;
-    for (_i29 = 0; _i29 < _size25; ++_i29)
-    {
-      if (!reader.readDouble(jointAcceleration[_i29])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(jointAcceleration)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -160,40 +89,16 @@ bool jointData::nested_read_jointAcceleration_isValid(yarp::os::idl::WireReader&
   return true;
 }
 bool jointData::read_motorPosition(yarp::os::idl::WireReader& reader) {
-  {
-    motorPosition.clear();
-    uint32_t _size30;
-    yarp::os::idl::WireState _etype33;
-    reader.readListBegin(_etype33, _size30);
-    motorPosition.resize(_size30);
-    uint32_t _i34;
-    for (_i34 = 0; _i34 < _size30; ++_i34)
-    {
-      if (!reader.readDouble(motorPosition[_i34])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(motorPosition)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_motorPosition(yarp::os::idl::WireReader& reader) {
-  {
-    motorPosition.clear();
-    uint32_t _size35;
-    yarp::os::idl::WireState _etype38;
-    reader.readListBegin(_etype38, _size35);
-    motorPosition.resize(_size35);
-    uint32_t _i39;
-    for (_i39 = 0; _i39 < _size35; ++_i39)
-    {
-      if (!reader.readDouble(motorPosition[_i39])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(motorPosition)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -212,40 +117,16 @@ bool jointData::nested_read_motorPosition_isValid(yarp::os::idl::WireReader& rea
   return true;
 }
 bool jointData::read_motorVelocity(yarp::os::idl::WireReader& reader) {
-  {
-    motorVelocity.clear();
-    uint32_t _size40;
-    yarp::os::idl::WireState _etype43;
-    reader.readListBegin(_etype43, _size40);
-    motorVelocity.resize(_size40);
-    uint32_t _i44;
-    for (_i44 = 0; _i44 < _size40; ++_i44)
-    {
-      if (!reader.readDouble(motorVelocity[_i44])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(motorVelocity)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_motorVelocity(yarp::os::idl::WireReader& reader) {
-  {
-    motorVelocity.clear();
-    uint32_t _size45;
-    yarp::os::idl::WireState _etype48;
-    reader.readListBegin(_etype48, _size45);
-    motorVelocity.resize(_size45);
-    uint32_t _i49;
-    for (_i49 = 0; _i49 < _size45; ++_i49)
-    {
-      if (!reader.readDouble(motorVelocity[_i49])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(motorVelocity)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -264,40 +145,16 @@ bool jointData::nested_read_motorVelocity_isValid(yarp::os::idl::WireReader& rea
   return true;
 }
 bool jointData::read_motorAcceleration(yarp::os::idl::WireReader& reader) {
-  {
-    motorAcceleration.clear();
-    uint32_t _size50;
-    yarp::os::idl::WireState _etype53;
-    reader.readListBegin(_etype53, _size50);
-    motorAcceleration.resize(_size50);
-    uint32_t _i54;
-    for (_i54 = 0; _i54 < _size50; ++_i54)
-    {
-      if (!reader.readDouble(motorAcceleration[_i54])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(motorAcceleration)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_motorAcceleration(yarp::os::idl::WireReader& reader) {
-  {
-    motorAcceleration.clear();
-    uint32_t _size55;
-    yarp::os::idl::WireState _etype58;
-    reader.readListBegin(_etype58, _size55);
-    motorAcceleration.resize(_size55);
-    uint32_t _i59;
-    for (_i59 = 0; _i59 < _size55; ++_i59)
-    {
-      if (!reader.readDouble(motorAcceleration[_i59])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(motorAcceleration)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -316,40 +173,16 @@ bool jointData::nested_read_motorAcceleration_isValid(yarp::os::idl::WireReader&
   return true;
 }
 bool jointData::read_torque(yarp::os::idl::WireReader& reader) {
-  {
-    torque.clear();
-    uint32_t _size60;
-    yarp::os::idl::WireState _etype63;
-    reader.readListBegin(_etype63, _size60);
-    torque.resize(_size60);
-    uint32_t _i64;
-    for (_i64 = 0; _i64 < _size60; ++_i64)
-    {
-      if (!reader.readDouble(torque[_i64])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(torque)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_torque(yarp::os::idl::WireReader& reader) {
-  {
-    torque.clear();
-    uint32_t _size65;
-    yarp::os::idl::WireState _etype68;
-    reader.readListBegin(_etype68, _size65);
-    torque.resize(_size65);
-    uint32_t _i69;
-    for (_i69 = 0; _i69 < _size65; ++_i69)
-    {
-      if (!reader.readDouble(torque[_i69])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(torque)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -368,40 +201,16 @@ bool jointData::nested_read_torque_isValid(yarp::os::idl::WireReader& reader) {
   return true;
 }
 bool jointData::read_pidOutput(yarp::os::idl::WireReader& reader) {
-  {
-    pidOutput.clear();
-    uint32_t _size70;
-    yarp::os::idl::WireState _etype73;
-    reader.readListBegin(_etype73, _size70);
-    pidOutput.resize(_size70);
-    uint32_t _i74;
-    for (_i74 = 0; _i74 < _size70; ++_i74)
-    {
-      if (!reader.readDouble(pidOutput[_i74])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(pidOutput)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_pidOutput(yarp::os::idl::WireReader& reader) {
-  {
-    pidOutput.clear();
-    uint32_t _size75;
-    yarp::os::idl::WireState _etype78;
-    reader.readListBegin(_etype78, _size75);
-    pidOutput.resize(_size75);
-    uint32_t _i79;
-    for (_i79 = 0; _i79 < _size75; ++_i79)
-    {
-      if (!reader.readDouble(pidOutput[_i79])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(pidOutput)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -420,40 +229,16 @@ bool jointData::nested_read_pidOutput_isValid(yarp::os::idl::WireReader& reader)
   return true;
 }
 bool jointData::read_controlMode(yarp::os::idl::WireReader& reader) {
-  {
-    controlMode.clear();
-    uint32_t _size80;
-    yarp::os::idl::WireState _etype83;
-    reader.readListBegin(_etype83, _size80);
-    controlMode.resize(_size80);
-    uint32_t _i84;
-    for (_i84 = 0; _i84 < _size80; ++_i84)
-    {
-      if (!reader.readI32(controlMode[_i84])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(controlMode)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_controlMode(yarp::os::idl::WireReader& reader) {
-  {
-    controlMode.clear();
-    uint32_t _size85;
-    yarp::os::idl::WireState _etype88;
-    reader.readListBegin(_etype88, _size85);
-    controlMode.resize(_size85);
-    uint32_t _i89;
-    for (_i89 = 0; _i89 < _size85; ++_i89)
-    {
-      if (!reader.readI32(controlMode[_i89])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(controlMode)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -472,40 +257,16 @@ bool jointData::nested_read_controlMode_isValid(yarp::os::idl::WireReader& reade
   return true;
 }
 bool jointData::read_interactionMode(yarp::os::idl::WireReader& reader) {
-  {
-    interactionMode.clear();
-    uint32_t _size90;
-    yarp::os::idl::WireState _etype93;
-    reader.readListBegin(_etype93, _size90);
-    interactionMode.resize(_size90);
-    uint32_t _i94;
-    for (_i94 = 0; _i94 < _size90; ++_i94)
-    {
-      if (!reader.readI32(interactionMode[_i94])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.read(interactionMode)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
 bool jointData::nested_read_interactionMode(yarp::os::idl::WireReader& reader) {
-  {
-    interactionMode.clear();
-    uint32_t _size95;
-    yarp::os::idl::WireState _etype98;
-    reader.readListBegin(_etype98, _size95);
-    interactionMode.resize(_size95);
-    uint32_t _i99;
-    for (_i99 = 0; _i99 < _size95; ++_i99)
-    {
-      if (!reader.readI32(interactionMode[_i99])) {
-        reader.fail();
-        return false;
-      }
-    }
-    reader.readListEnd();
+  if (!reader.readNested(interactionMode)) {
+    reader.fail();
+    return false;
   }
   return true;
 }
@@ -554,27 +315,11 @@ bool jointData::read(yarp::os::ConnectionReader& connection) {
 }
 
 bool jointData::write_jointPosition(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointPosition.size()))) return false;
-    std::vector<double> ::iterator _iter100;
-    for (_iter100 = jointPosition.begin(); _iter100 != jointPosition.end(); ++_iter100)
-    {
-      if (!writer.writeDouble((*_iter100))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(jointPosition)) return false;
   return true;
 }
 bool jointData::nested_write_jointPosition(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointPosition.size()))) return false;
-    std::vector<double> ::iterator _iter101;
-    for (_iter101 = jointPosition.begin(); _iter101 != jointPosition.end(); ++_iter101)
-    {
-      if (!writer.writeDouble((*_iter101))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(jointPosition)) return false;
   return true;
 }
 bool jointData::write_jointPosition_isValid(yarp::os::idl::WireWriter& writer) {
@@ -586,27 +331,11 @@ bool jointData::nested_write_jointPosition_isValid(yarp::os::idl::WireWriter& wr
   return true;
 }
 bool jointData::write_jointVelocity(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointVelocity.size()))) return false;
-    std::vector<double> ::iterator _iter102;
-    for (_iter102 = jointVelocity.begin(); _iter102 != jointVelocity.end(); ++_iter102)
-    {
-      if (!writer.writeDouble((*_iter102))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(jointVelocity)) return false;
   return true;
 }
 bool jointData::nested_write_jointVelocity(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointVelocity.size()))) return false;
-    std::vector<double> ::iterator _iter103;
-    for (_iter103 = jointVelocity.begin(); _iter103 != jointVelocity.end(); ++_iter103)
-    {
-      if (!writer.writeDouble((*_iter103))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(jointVelocity)) return false;
   return true;
 }
 bool jointData::write_jointVelocity_isValid(yarp::os::idl::WireWriter& writer) {
@@ -618,27 +347,11 @@ bool jointData::nested_write_jointVelocity_isValid(yarp::os::idl::WireWriter& wr
   return true;
 }
 bool jointData::write_jointAcceleration(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointAcceleration.size()))) return false;
-    std::vector<double> ::iterator _iter104;
-    for (_iter104 = jointAcceleration.begin(); _iter104 != jointAcceleration.end(); ++_iter104)
-    {
-      if (!writer.writeDouble((*_iter104))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(jointAcceleration)) return false;
   return true;
 }
 bool jointData::nested_write_jointAcceleration(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(jointAcceleration.size()))) return false;
-    std::vector<double> ::iterator _iter105;
-    for (_iter105 = jointAcceleration.begin(); _iter105 != jointAcceleration.end(); ++_iter105)
-    {
-      if (!writer.writeDouble((*_iter105))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(jointAcceleration)) return false;
   return true;
 }
 bool jointData::write_jointAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
@@ -650,27 +363,11 @@ bool jointData::nested_write_jointAcceleration_isValid(yarp::os::idl::WireWriter
   return true;
 }
 bool jointData::write_motorPosition(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorPosition.size()))) return false;
-    std::vector<double> ::iterator _iter106;
-    for (_iter106 = motorPosition.begin(); _iter106 != motorPosition.end(); ++_iter106)
-    {
-      if (!writer.writeDouble((*_iter106))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(motorPosition)) return false;
   return true;
 }
 bool jointData::nested_write_motorPosition(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorPosition.size()))) return false;
-    std::vector<double> ::iterator _iter107;
-    for (_iter107 = motorPosition.begin(); _iter107 != motorPosition.end(); ++_iter107)
-    {
-      if (!writer.writeDouble((*_iter107))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(motorPosition)) return false;
   return true;
 }
 bool jointData::write_motorPosition_isValid(yarp::os::idl::WireWriter& writer) {
@@ -682,27 +379,11 @@ bool jointData::nested_write_motorPosition_isValid(yarp::os::idl::WireWriter& wr
   return true;
 }
 bool jointData::write_motorVelocity(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorVelocity.size()))) return false;
-    std::vector<double> ::iterator _iter108;
-    for (_iter108 = motorVelocity.begin(); _iter108 != motorVelocity.end(); ++_iter108)
-    {
-      if (!writer.writeDouble((*_iter108))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(motorVelocity)) return false;
   return true;
 }
 bool jointData::nested_write_motorVelocity(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorVelocity.size()))) return false;
-    std::vector<double> ::iterator _iter109;
-    for (_iter109 = motorVelocity.begin(); _iter109 != motorVelocity.end(); ++_iter109)
-    {
-      if (!writer.writeDouble((*_iter109))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(motorVelocity)) return false;
   return true;
 }
 bool jointData::write_motorVelocity_isValid(yarp::os::idl::WireWriter& writer) {
@@ -714,27 +395,11 @@ bool jointData::nested_write_motorVelocity_isValid(yarp::os::idl::WireWriter& wr
   return true;
 }
 bool jointData::write_motorAcceleration(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorAcceleration.size()))) return false;
-    std::vector<double> ::iterator _iter110;
-    for (_iter110 = motorAcceleration.begin(); _iter110 != motorAcceleration.end(); ++_iter110)
-    {
-      if (!writer.writeDouble((*_iter110))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(motorAcceleration)) return false;
   return true;
 }
 bool jointData::nested_write_motorAcceleration(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(motorAcceleration.size()))) return false;
-    std::vector<double> ::iterator _iter111;
-    for (_iter111 = motorAcceleration.begin(); _iter111 != motorAcceleration.end(); ++_iter111)
-    {
-      if (!writer.writeDouble((*_iter111))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(motorAcceleration)) return false;
   return true;
 }
 bool jointData::write_motorAcceleration_isValid(yarp::os::idl::WireWriter& writer) {
@@ -746,27 +411,11 @@ bool jointData::nested_write_motorAcceleration_isValid(yarp::os::idl::WireWriter
   return true;
 }
 bool jointData::write_torque(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(torque.size()))) return false;
-    std::vector<double> ::iterator _iter112;
-    for (_iter112 = torque.begin(); _iter112 != torque.end(); ++_iter112)
-    {
-      if (!writer.writeDouble((*_iter112))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(torque)) return false;
   return true;
 }
 bool jointData::nested_write_torque(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(torque.size()))) return false;
-    std::vector<double> ::iterator _iter113;
-    for (_iter113 = torque.begin(); _iter113 != torque.end(); ++_iter113)
-    {
-      if (!writer.writeDouble((*_iter113))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(torque)) return false;
   return true;
 }
 bool jointData::write_torque_isValid(yarp::os::idl::WireWriter& writer) {
@@ -778,27 +427,11 @@ bool jointData::nested_write_torque_isValid(yarp::os::idl::WireWriter& writer) {
   return true;
 }
 bool jointData::write_pidOutput(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(pidOutput.size()))) return false;
-    std::vector<double> ::iterator _iter114;
-    for (_iter114 = pidOutput.begin(); _iter114 != pidOutput.end(); ++_iter114)
-    {
-      if (!writer.writeDouble((*_iter114))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(pidOutput)) return false;
   return true;
 }
 bool jointData::nested_write_pidOutput(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_DOUBLE, static_cast<uint32_t>(pidOutput.size()))) return false;
-    std::vector<double> ::iterator _iter115;
-    for (_iter115 = pidOutput.begin(); _iter115 != pidOutput.end(); ++_iter115)
-    {
-      if (!writer.writeDouble((*_iter115))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(pidOutput)) return false;
   return true;
 }
 bool jointData::write_pidOutput_isValid(yarp::os::idl::WireWriter& writer) {
@@ -810,27 +443,11 @@ bool jointData::nested_write_pidOutput_isValid(yarp::os::idl::WireWriter& writer
   return true;
 }
 bool jointData::write_controlMode(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_INT, static_cast<uint32_t>(controlMode.size()))) return false;
-    std::vector<int32_t> ::iterator _iter116;
-    for (_iter116 = controlMode.begin(); _iter116 != controlMode.end(); ++_iter116)
-    {
-      if (!writer.writeI32((*_iter116))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(controlMode)) return false;
   return true;
 }
 bool jointData::nested_write_controlMode(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_INT, static_cast<uint32_t>(controlMode.size()))) return false;
-    std::vector<int32_t> ::iterator _iter117;
-    for (_iter117 = controlMode.begin(); _iter117 != controlMode.end(); ++_iter117)
-    {
-      if (!writer.writeI32((*_iter117))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(controlMode)) return false;
   return true;
 }
 bool jointData::write_controlMode_isValid(yarp::os::idl::WireWriter& writer) {
@@ -842,27 +459,11 @@ bool jointData::nested_write_controlMode_isValid(yarp::os::idl::WireWriter& writ
   return true;
 }
 bool jointData::write_interactionMode(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_INT, static_cast<uint32_t>(interactionMode.size()))) return false;
-    std::vector<int32_t> ::iterator _iter118;
-    for (_iter118 = interactionMode.begin(); _iter118 != interactionMode.end(); ++_iter118)
-    {
-      if (!writer.writeI32((*_iter118))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.write(interactionMode)) return false;
   return true;
 }
 bool jointData::nested_write_interactionMode(yarp::os::idl::WireWriter& writer) {
-  {
-    if (!writer.writeListBegin(BOTTLE_TAG_INT, static_cast<uint32_t>(interactionMode.size()))) return false;
-    std::vector<int32_t> ::iterator _iter119;
-    for (_iter119 = interactionMode.begin(); _iter119 != interactionMode.end(); ++_iter119)
-    {
-      if (!writer.writeI32((*_iter119))) return false;
-    }
-    if (!writer.writeListEnd()) return false;
-  }
+  if (!writer.writeNested(interactionMode)) return false;
   return true;
 }
 bool jointData::write_interactionMode_isValid(yarp::os::idl::WireWriter& writer) {
@@ -1054,7 +655,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       if (!reader.readString(field)) return false;
       if (field=="jointPosition") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  jointPosition")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> jointPosition")) return false;
       }
       if (field=="jointPosition_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1062,7 +663,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="jointVelocity") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  jointVelocity")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> jointVelocity")) return false;
       }
       if (field=="jointVelocity_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1070,7 +671,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="jointAcceleration") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  jointAcceleration")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> jointAcceleration")) return false;
       }
       if (field=="jointAcceleration_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1078,7 +679,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="motorPosition") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  motorPosition")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> motorPosition")) return false;
       }
       if (field=="motorPosition_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1086,7 +687,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="motorVelocity") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  motorVelocity")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> motorVelocity")) return false;
       }
       if (field=="motorVelocity_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1094,7 +695,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="motorAcceleration") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  motorAcceleration")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> motorAcceleration")) return false;
       }
       if (field=="motorAcceleration_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1102,7 +703,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="torque") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  torque")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> torque")) return false;
       }
       if (field=="torque_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1110,7 +711,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="pidOutput") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<double>  pidOutput")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<double> pidOutput")) return false;
       }
       if (field=="pidOutput_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1118,7 +719,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="controlMode") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<int32_t>  controlMode")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<int> controlMode")) return false;
       }
       if (field=="controlMode_isValid") {
         if (!writer.writeListHeader(1)) return false;
@@ -1126,7 +727,7 @@ bool jointData::Editor::read(yarp::os::ConnectionReader& connection) {
       }
       if (field=="interactionMode") {
         if (!writer.writeListHeader(1)) return false;
-        if (!writer.writeString("std::vector<int32_t>  interactionMode")) return false;
+        if (!writer.writeString("yarp::sig::VectorOf<int> interactionMode")) return false;
       }
       if (field=="interactionMode_isValid") {
         if (!writer.writeListHeader(1)) return false;


### PR DESCRIPTION
Reduce message size of controlboardwrapper stateExt:o of nearly 30% and
writing time by nearly half by using yarp vector instead of std::vector in idl.

btw idl shall generate optimized code also when using std::vector... but that's another matter.