### PR TITLE
Deprecate yarp::os::Value::operator==(const char *alt)

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Value.h
+++ b/src/libYARP_OS/include/yarp/os/Value.h
@@ -276,6 +276,16 @@ public:
         return asString() != alt;
     }
 
+    bool operator==(const int alt) const
+    {
+        return asInt() == alt;
+    }
+
+    bool operator!=(const int alt) const
+    {
+        return asInt() != alt;
+    }
+
     /**
      * Set value to correspond to a textual representation.
      * For example if str="10" then the value will be an integer,

--- a/tests/libYARP_OS/ValueTest.cpp
+++ b/tests/libYARP_OS/ValueTest.cpp
@@ -235,6 +235,11 @@ public:
             checkTrue((v1!=v2), "(blob) operator!= ok");
             checkTrue((v1!=*(reinterpret_cast<const int*>(v2.asBlob()))), "(blob) value ok");
         }
+
+        {
+            Value v(0);
+            checkTrue(v == 0, "equivalence with integer literal ok");
+        }
     }
 
     virtual void runTests() {


### PR DESCRIPTION
fixes #1028.
`<yarp::os::Value> == <literal integer>` calls the `const char*` comparison overload (often resulting in a segfault). new `int` comparison overload has been added with relative test.