### PR TITLE
fixes narrowing conversion error

### DIFF
--- a/src/libYARP_OS/src/AbstractCarrier.cpp
+++ b/src/libYARP_OS/src/AbstractCarrier.cpp
@@ -217,9 +217,9 @@ bool AbstractCarrier::defaultSendIndex(ConnectionState& proto, SizedWriter& writ
 {
     writeYarpInt(10,proto);
     int len = (int)writer.length();
-    char lens[] = { (char)len, 1,
-                    -1, -1, -1, -1,
-                    -1, -1, -1, -1 };
+    char lens[] = { (char)len, (char)1,
+                    (char)-1, (char)-1, (char)-1, (char)-1,
+                    (char)-1, (char)-1, (char)-1, (char)-1 };
     Bytes b(lens,10);
     OutputStream& os = proto.os();
     os.write(b);


### PR DESCRIPTION
Fixes the following error on Jetson TK1 (arm64 architecture):

`/usr/local/src/robot/yarp/src/libYARP_OS/src/AbstractCarrier.cpp:222:36: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]`
