### PR TITLE
[yarpmanager] Unify viewModule and viewApplication, fix #1007

### DIFF
--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -470,14 +470,7 @@ void MainWindow::viewModule(yarp::manager::Module *module)
 void MainWindow::viewApplication(yarp::manager::Application *app,bool editingMode)
 {
     for(int i=0;i<ui->mainTabs->count();i++){
-        GenericViewWidget *w = (GenericViewWidget *)ui->mainTabs->widget(i);
-        if(w->getType() ==  yarp::manager::APPLICATION){
-            ApplicationViewWidget *a = (ApplicationViewWidget *)w;
-            if(a->getAppName() == app->getName()){
-                ui->mainTabs->setCurrentIndex(i);
-                return;
-            }
-        }else if(ui->mainTabs->tabText(i) == app->getName()){
+        if(ui->mainTabs->tabText(i) == app->getName()){
             ui->mainTabs->setCurrentIndex(i);
             return;
         }


### PR DESCRIPTION
Hi,
This fixes #1007. Previously it didn't work as `a->getAppName()` returns `""` (which should be fixed as well I guess).
Now, the same logic as in `viewModule` and `viewResource` is being used to correctly only being able to open an application once.

Best, Tobi