### PR TITLE
RGBDSensorWrapper time stamp' dt == 0 fixed

### DIFF
--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -165,7 +165,7 @@ RGBDSensorWrapper::RGBDSensorWrapper(): RateThread(DEFAULT_THREAD_PERIOD),
     isSubdeviceOwned = false;
     verbose          = 4;
     sensorStatus     = IRGBDSensor::RGBD_SENSOR_NOT_READY;
-    forceInfoSync    = false;
+    forceInfoSync    = true;
 }
 
 RGBDSensorWrapper::~RGBDSensorWrapper()
@@ -795,6 +795,22 @@ bool RGBDSensorWrapper::writeData()
     {
         return false;
     }
+
+    static Stamp oldColorStamp = Stamp(0, 0);
+    static Stamp oldDepthStamp = Stamp(0, 0);
+
+    if (colorStamp.getTime() - oldColorStamp.getTime() > 0 == false)
+    {
+        return true;
+    }
+
+    if (depthStamp.getTime() - oldDepthStamp.getTime() > 0 == false)
+    {
+        return true;
+    }
+
+    oldDepthStamp = depthStamp;
+    oldColorStamp = colorStamp;
 
     if (use_YARP)
     {


### PR DESCRIPTION
prevent RGBDSensorWrapper from posting camera_info with different sequence number but same time stamp on rostopic.