### PR TITLE
Fix resizing of output matrices in SVD

### DIFF
--- a/src/libYARP_math/include/yarp/math/SVD.h
+++ b/src/libYARP_math/include/yarp/math/SVD.h
@@ -27,9 +27,11 @@ namespace yarp
         * @param U output M-by-K orthogonal matrix
         * @param S output K-dimensional vector containing the diagonal entries of the diagonal matrix S
         * @param V output N-by-K orthogonal matrix
+        *
+        * @note If U, S, V do not have the expected sizes they are resized automatically.
+        *
         * @note The routine computes the \a thin version of the SVD. Mathematically, the \a full SVD is 
         *       defined with U and V as square orthogonal matrices and S as an M-by-N diagonal matrix.
-        *       If U, S, V do not have the expected sizes they are resized automatically.
         *
         * @note When libYARP_math is compiled with GSL backend, this
         *       function uses the Golub-Reinsch SVD algorithm.
@@ -43,6 +45,8 @@ namespace yarp
         /**
         * Perform SVD decomposition on a MxN matrix (for M >= N) (defined in SVD.h).
         *
+        * @note If U, S, V do not have the expected sizes they are resized automatically.
+        *
         * @note When libYARP_math is compiled with GSL backend, this
         *       function uses the Modified Golub-Reinsch SVD algorithm (fast for M>>N)
         *       When compiled with Eigen backend, this function uses the Jacobi SVD algorithm.
@@ -55,6 +59,8 @@ namespace yarp
         /**
         * Perform SVD decomposition on a matrix using the Jacobi method (defined in SVD.h). The Jacobi method
         * can compute singular values to higher relative accuracy than Golub-Reinsch algorithms.
+        *
+        * @note If U, S, V do not have the expected sizes they are resized automatically.
         *
         * @note For both Eigen and GSL backends, the Jacobi algorithm is used in this function.
         */

--- a/src/libYARP_math/src/eigen/eigen_SVD.cpp
+++ b/src/libYARP_math/src/eigen/eigen_SVD.cpp
@@ -32,8 +32,13 @@ void yarp::math::SVDJacobi(const Matrix &in, Matrix &U, Vector &S, Matrix &V)
 {
     Eigen::JacobiSVD< Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> > svd(toEigen(in), Eigen::ComputeThinU | Eigen::ComputeThinV);
 
+    U.resize(svd.matrixU().rows(),svd.matrixU().cols());
     toEigen(U) = svd.matrixU();
+
+    S.resize(svd.singularValues().size());
     toEigen(S) = svd.singularValues();
+
+    V.resize(svd.matrixV().rows(),svd.matrixV().cols());
     toEigen(V) = svd.matrixV();
 
     return;

--- a/tests/libYARP_math/svdTest.cpp
+++ b/tests/libYARP_math/svdTest.cpp
@@ -83,6 +83,25 @@ public:
         }
     }
 
+    void svdCheckResizeOfOutputMatrices()
+    {
+        report(0,"checking that SVD resizes the output matrices");
+
+        int m=6, n=5;
+        Matrix U, V;
+        Vector s;
+
+        Matrix M = Rand::matrix(m,n)*100;
+
+        SVD(M, U, s, V);
+
+        checkEqual(U.rows(), m, "Number of Rows of U matrix is correct");
+        checkEqual(U.cols(), n, "Number of Cols of U matrix is correct");
+        checkEqual(s.size(), n, "Size of s vector is correct");
+        checkEqual(V.rows(), n, "Number of Rows of V matrix is correct");
+        checkEqual(V.cols(), n, "Number of Cols of V matrix is correct");
+    }
+
     void svdFat()
     {
         report(0,"checking SVD of fat matrix");
@@ -258,6 +277,7 @@ public:
     virtual void runTests() 
     {
         svd();
+        svdCheckResizeOfOutputMatrices();
         svdFat();
         pInv();
         pInvFat();


### PR DESCRIPTION
Fix https://github.com/robotology/yarp/issues/1062 .
@drdanz What is the best strategy to bring this to devel? The file containing the fix has been merged with another fail, so probably merging forward will fail. 