### PR TITLE
Ensure that after yarp::sig::VectorOf<T>::resize(), the constructor operator for the new objects is called

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -59,6 +59,11 @@ Bug Fixes
 
 * fixed typo preventing successful compilation on linux/mac with C++11 enabled.
 
+#### YARP_sig
+
+* Ensure that after yarp::sig::VectorOf::resize(), the constructor operator
+  for the new objects is called.
+
 #### YARP_dev
 
 * Added warning when loading a plugin with a wrong library parameter (#975).

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -169,21 +169,23 @@ public:
 
     virtual void resize(size_t size)
     {
-        // T def = (T)0;
-        // resize(size, def);
+        size_t prev_len = len;
         bytes.allocateOnNeed(size*sizeof(T),size*sizeof(T));
         bytes.setUsed(size*sizeof(T));
         _updatePointers();
+        for (size_t i = prev_len; i < size; i++) {
+            new (&((*this)[i])) T(); // non-allocating placement operator new
+        }
     }
 
     void resize(size_t size, const T&def)
     {
-        /*
         bytes.allocateOnNeed(size*sizeof(T),size*sizeof(T));
         bytes.setUsed(size*sizeof(T));
-        _updatePointers(); */
-        resize(size);
-        for (size_t i=0; i<size; i++) { (*this)[i] = def; }
+        _updatePointers();
+        for (size_t i = 0; i < size; i++) {
+            new (&((*this)[i])) T(def); // non-allocating placement operator new
+        }
     }
 
     inline void push_back (const T &elem)


### PR DESCRIPTION
The `yarp::sig::VectorOf<T>::resize()` allocates memory for new objects, but the constructor is never called.
This means that one can resize a vector, and then access the new elements, that are not initialized, but it cannot call the constructor on them leading to several types of errors (for example the valgrind errors on `devel` are caused by this).
