### PR TITLE
 Fix bug in ControlBoardRemapper on malformed axesNames

### DIFF
--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -378,7 +378,16 @@ bool ControlBoardRemapper::attachAllUsingAxesNames(const PolyDriverList& polylis
     // the couple subControlBoard, axis in subControlBoard
     for(size_t l=0; l < axesNames.size(); l++)
     {
-        axisLocation loc = axesLocationMap[axesNames[l]];
+        std::map<std::string, axisLocation>::iterator it = axesLocationMap.find(axesNames[l]);
+        if( it == axesLocationMap.end() )
+        {
+            yError() <<"ControlBoardRemapper: axis " << axesNames[l]
+                     <<" specified in axesNames was not found in the axes of the controlboards "
+                     <<"passed to attachAll, attachAll failed. ";
+            return false;
+        }
+
+        axisLocation loc = it->second;
         std::string key = loc.subDeviceKey;
 
         if(std::find(subControlBoardsKeys.begin(), subControlBoardsKeys.end(), key) == subControlBoardsKeys.end())


### PR DESCRIPTION
If axesNames contains a name of an axis that is not contained in the controlboards passed to attachAll,
attachAll did not return any error. It will now with this bugfix. The PR also includes test that will catch similar bugs in the future. 