### PR TITLE
Import RTF-YARP library and fixture managers from RTF

### DIFF
--- a/cmake/YarpDescribe.cmake
+++ b/cmake/YarpDescribe.cmake
@@ -35,6 +35,7 @@ foreach(lib ${YARP_LIBS})
   if(NOT "${lib}" MATCHES "carrier$" AND
      NOT "${lib}" MATCHES "^yarp_" AND
      NOT "${lib}" MATCHES "^YARP_priv" AND
+     NOT "${lib}" MATCHES "rtf_fixturemanager_" AND
      NOT "${lib}" STREQUAL "yarpcar" AND
      NOT "${lib}" STREQUAL "yarpmod" AND
      NOT "${lib}" STREQUAL "YARP_wire_rep_utils" AND
@@ -42,7 +43,8 @@ foreach(lib ${YARP_LIBS})
      NOT "${lib}" STREQUAL "YARP_logger" AND
      NOT "${lib}" STREQUAL "YARP_serversql" AND
      NOT "${lib}" STREQUAL "YARP_gsl" AND
-     NOT "${lib}" STREQUAL "YARP_eigen")
+     NOT "${lib}" STREQUAL "YARP_eigen" AND
+     NOT "${lib}" STREQUAL "YARP_rtf")
     list(APPEND YARP_LIBRARIES YARP::${lib})
   endif()
 endforeach()

--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -320,6 +320,10 @@ else()
   endif()
 endif()
 
+set(RTF_REQUIRED_VERSION 1.1.0.1)
+find_package(RTF ${RTF_REQUIRED_VERSION} QUIET)
+checkbuildandset_dependency(RTF)
+
 find_package(SQLite QUIET)
 checkbuildandset_dependency(SQLite)
 
@@ -427,6 +431,7 @@ checkandset_dependency(OpenNI2)
 message(STATUS "I have found the following libraries:")
 print_dependency(YCM)
 print_dependency(ACE)
+print_dependency(RTF)
 print_dependency(SQLite)
 print_dependency(Eigen3)
 print_dependency(TinyXML)
@@ -467,6 +472,7 @@ check_optional_dependency(CREATE_GUIS Qt5)
 check_optional_dependency(CREATE_YARPSCOPE QCustomPlot)
 check_optional_dependency(CREATE_YARPLASERSCANNERGUI OpenCV)
 check_optional_dependency(YARP_COMPILE_BINDINGS SWIG)
+check_optional_dependency(YARP_COMPILE_RTF_ADDONS RTF)
 
 
 #########################################################################

--- a/cmake/YarpOptions.cmake
+++ b/cmake/YarpOptions.cmake
@@ -123,6 +123,12 @@ mark_as_advanced(YARP_COMPILE_EXECUTABLES)
 
 
 #########################################################################
+# Add the option to build Robot Testing Framework addons
+option(YARP_COMPILE_RTF_ADDONS "Compile Robot Testing Framework addons." OFF)
+mark_as_advanced(YARP_COMPILE_RTF_ADDONS)
+
+
+#########################################################################
 # Disable unmaintained stuff unless explicitly enabled by the user.
 
 option(YARP_COMPILE_UNMAINTAINED "Enable unmaintained components" OFF)

--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -13,7 +13,8 @@ Important Changes
 * A compiler supporting C++11 is now required.
 * CMake 3.0 or newer is now required.
 * Optional dependency on YCM now requires version 0.3.1 (devel) or later.
-
+* [Robot Testing Framework (RTF)](https://github.com/robotology/robot-testing/)
+  1.1.0.1 is now an optional dependency.
 
 ### CMake Modules
 
@@ -77,6 +78,7 @@ Important Changes
 * The `TestFrameGrabber` was removed from libYARP_dev and it is now an optional
   plugin.
 
+
 New Features
 ------------
 
@@ -84,6 +86,15 @@ New Features
 
 * `YarpPlugin`
   * Add QUIET/VERBOSE arguments and YarpPlugin_QUIET/VERBOSE variables.
+
+
+### Libraries
+
+* New library `libYARP_rtf` to simplify the creation of unit tests using the
+  [Robot Testing Framework (RTF)](https://github.com/robotology/robot-testing/)
+  and YARP. This is a slightly modified version of the RTF_YARP_utilities
+  library in RTF 1.0.
+  It can be enabled with the option `YARP_COMPILE_RTF_ADDONS`.
 
 
 ### GUIs
@@ -130,6 +141,18 @@ New Features
 * TestFrameGrabber now implements the interface yarp::dev::IRgbVisualParams
   for parsing rgb camera parameters.
 * Added getRgbResolution and getRgbSupportedConfigurations in the interface IRgbVisualParams
+
+
+### RTF Plugins
+
+* The `yarpmanager` RTF Fixture Managers was imported from
+  robotology/robot-testing, and allows one to start a fixture using yarpmanager.
+  It can be enabled with the option `YARP_COMPILE_RTF_ADDONS`.
+
+* The `yarpplugin` RTF Fixture Managers was imported from robotology/icub-tests
+  (Originally YarpPluginFixture), and allows one to check if a yarp plugin is
+  available.
+  It can be enabled with the option `YARP_COMPILE_RTF_ADDONS`.
 
 
 Bug Fixes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,11 @@ if(YARP_COMPILE_EXECUTABLES)
     add_subdirectory(yarplaserscannergui)
 endif()
 
+# Robot Testing Framework addons
+if(YARP_COMPILE_RTF_ADDONS)
+  add_subdirectory(libYARP_rtf)
+  add_subdirectory(rtf-plugins)
+endif()
 
 # unmaintained stuff
 add_subdirectory(libyarpc)

--- a/src/libYARP_rtf/CMakeLists.txt
+++ b/src/libYARP_rtf/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
     add_library(RTF_yarp_utility SHARED ${folder_source} ${folder_header} )
 endif()
 
-target_link_libraries(RTF_yarp_utility ${YARP_LIBRARIES})
+target_link_libraries(RTF_yarp_utility ${RTF_LIBS} ${YARP_LIBRARIES})
 
 
 # We already added the header files within the parent CMakeLists

--- a/src/libYARP_rtf/CMakeLists.txt
+++ b/src/libYARP_rtf/CMakeLists.txt
@@ -1,0 +1,55 @@
+#  Sharedlib++
+#  Copyright: (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+#  Authors: Ali Paikan <ali.paikan@gmail.com>
+#
+#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+#
+
+cmake_minimum_required(VERSION 2.8.9)
+
+project(RTF_yarp_utility)
+
+find_package(YARP REQUIRED)
+
+get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
+
+get_property(RTF_LIBS GLOBAL PROPERTY RTF_LIBS)
+get_property(RTF_INTERNAL_INCLUDE_DIRS GLOBAL PROPERTY RTF_INTERNAL_INCLUDE_DIRS)
+get_property(RTF_INTERNAL_LIBS GLOBAL PROPERTY RTF_INTERNAL_LIBS)
+
+# Create the library
+file(GLOB folder_source *.cpp)
+file(GLOB_RECURSE folder_header ../include/rtf/yarp/*.h)
+source_group("Source Files" FILES ${folder_source})
+source_group("Header Files" FILES ${folder_header})
+
+include_directories(${RTF_TREE_INCLUDE_DIRS}
+                    ${RTF_INTERNAL_INCLUDE_DIRS}
+                    ../include/rtf/yarp
+                    ${YARP_INCLUDE_DIRS})
+
+if(WIN32)
+    add_library(RTF_yarp_utility STATIC ${folder_source} ${folder_header} )
+else()
+    add_library(RTF_yarp_utility SHARED ${folder_source} ${folder_header} )
+endif()
+
+target_link_libraries(RTF_yarp_utility ${YARP_LIBRARIES})
+
+
+# We already added the header files within the parent CMakeLists
+# choose which header files should be installed
+#set(RTF_YARP_HDRS ../include/rtf/yarp/YarpTestAsserter.h)
+#set_property(TARGET RTF_yarp_utility PROPERTY PUBLIC_HEADER ${RTF_YARP_HDRS})
+
+install(TARGETS RTF_yarp_utility
+        EXPORT RTF
+        COMPONENT runtime
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/rtf/yarp)
+
+set_property(GLOBAL APPEND PROPERTY RTF_LIBS RTF_yarp_utility)
+set_property(TARGET RTF_yarp_utility PROPERTY INCLUDE_DIRS ${RTF_TREE_INCLUDE_DIRS})
+

--- a/src/libYARP_rtf/CMakeLists.txt
+++ b/src/libYARP_rtf/CMakeLists.txt
@@ -1,55 +1,47 @@
-#  Sharedlib++
-#  Copyright: (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
-#  Authors: Ali Paikan <ali.paikan@gmail.com>
-#
-#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
-#
-
-cmake_minimum_required(VERSION 2.8.9)
-
-project(RTF_yarp_utility)
-
-find_package(YARP REQUIRED)
-
-get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
-
-get_property(RTF_LIBS GLOBAL PROPERTY RTF_LIBS)
-get_property(RTF_INTERNAL_INCLUDE_DIRS GLOBAL PROPERTY RTF_INTERNAL_INCLUDE_DIRS)
-get_property(RTF_INTERNAL_LIBS GLOBAL PROPERTY RTF_INTERNAL_LIBS)
-
-# Create the library
-file(GLOB folder_source *.cpp)
-file(GLOB_RECURSE folder_header ../include/rtf/yarp/*.h)
-source_group("Source Files" FILES ${folder_source})
-source_group("Header Files" FILES ${folder_header})
-
-include_directories(${RTF_TREE_INCLUDE_DIRS}
-                    ${RTF_INTERNAL_INCLUDE_DIRS}
-                    ../include/rtf/yarp
-                    ${YARP_INCLUDE_DIRS})
-
-if(WIN32)
-    add_library(RTF_yarp_utility STATIC ${folder_source} ${folder_header} )
-else()
-    add_library(RTF_yarp_utility SHARED ${folder_source} ${folder_header} )
-endif()
-
-target_link_libraries(RTF_yarp_utility ${RTF_LIBS} ${YARP_LIBRARIES})
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 
-# We already added the header files within the parent CMakeLists
-# choose which header files should be installed
-#set(RTF_YARP_HDRS ../include/rtf/yarp/YarpTestAsserter.h)
-#set_property(TARGET RTF_yarp_utility PROPERTY PUBLIC_HEADER ${RTF_YARP_HDRS})
+project(YARP_rtf)
 
-install(TARGETS RTF_yarp_utility
-        EXPORT RTF
+
+set(YARP_rtf_HDRS include/yarp/rtf/JointsPosMotion.h
+                  include/yarp/rtf/TestAsserter.h
+                  include/yarp/rtf/TestCase.h)
+
+set(YARP_rtf_SRCS src/JointsPosMotion.cpp
+                  src/TestAsserter.cpp
+                  src/TestCase.cpp)
+
+
+source_group("Source Files" FILES ${YARP_rtf_SRCS})
+source_group("Header Files" FILES ${YARP_rtf_HDRS})
+
+set_property(GLOBAL APPEND PROPERTY YARP_TREE_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
+get_property(YARP_TREE_INCLUDE_DIRS GLOBAL PROPERTY YARP_TREE_INCLUDE_DIRS)
+
+include_directories(${YARP_TREE_INCLUDE_DIRS})
+include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
+
+add_library(YARP_rtf ${YARP_rtf_SRCS} ${YARP_rtf_HDRS})
+add_library(YARP::YARP_rtf ALIAS YARP_rtf)
+
+target_link_libraries(YARP_rtf PUBLIC RTF::RTF
+                               PRIVATE YARP::YARP_OS
+                                       YARP::YARP_sig
+                                       YARP::YARP_init
+                                       YARP::YARP_dev)
+
+set_property(TARGET YARP_rtf PROPERTY PUBLIC_HEADER ${YARP_rtf_HDRS})
+
+install(TARGETS YARP_rtf
+        EXPORT YARP
         COMPONENT runtime
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/rtf/yarp)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/yarp/rtf)
 
-set_property(GLOBAL APPEND PROPERTY RTF_LIBS RTF_yarp_utility)
-set_property(TARGET RTF_yarp_utility PROPERTY INCLUDE_DIRS ${RTF_TREE_INCLUDE_DIRS})
-
+set_property(GLOBAL APPEND PROPERTY YARP_LIBS YARP_rtf)
+set_property(TARGET YARP_rtf PROPERTY INCLUDE_DIRS ${YARP_TREE_INCLUDE_DIRS})

--- a/src/libYARP_rtf/include/yarp/rtf/JointsPosMotion.h
+++ b/src/libYARP_rtf/include/yarp/rtf/JointsPosMotion.h
@@ -1,121 +1,120 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2015 iCub Facility
- * Authors: Valentina Gaggero
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Valentina Gaggero <valentina.gaggero@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#ifndef _JOINTSPOSMOVE_H_
-#define _JOINTSPOSMOVE_H_
+#ifndef YARP_RTF_JOINTSPOSMOVE_H
+#define YARP_RTF_JOINTSPOSMOVE_H
 
-#include <string>
-#include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/PolyDriver.h>
+#include <yarp/rtf/api.h>
 #include <yarp/sig/Vector.h>
+#include <yarp/dev/PolyDriver.h>
+#include <string>
+
+namespace yarp {
+namespace rtf {
 
 /**
  * \brief The JointPosMotion class is used
  * has been created to simplify and speed up development of tests
  * that controls joints in position.
  */
-namespace RTF {
-    namespace YARP {
-
-class jointsPosMotion{
+class YARP_rtf_API jointsPosMotion {
 public:
     //jointsPosMotion();
 
     /**
-     * Creates an object for control joints specified in @jlist.
+     * @brief Creates an object for control joints specified in @jlist.
+     *
      * Sets default speed used in position control.
+     *
      * Tolerance and timeout will be initialized with default values
-     * (tolerance=1.0 deg  timeout=5 sec)
+     * (tolerance=1.0 deg, timeout=5 sec)
+     *
      * @param polydriver: pointer to polydriver used to manage joints
      * @param jlist: list of joints
      */
-    jointsPosMotion(yarp::dev::PolyDriver *polydriver, yarp::sig::Vector &jlist);
+    jointsPosMotion(yarp::dev::PolyDriver *polydriver,
+                    yarp::sig::Vector &jlist);
 
     virtual ~jointsPosMotion();
 
     /**
-     * Sets tolerance used to check if a joint is in position
+     * @brief Sets tolerance used to check if a joint is in position.
+     *
      * @param tolerance
-     * @return: -
      */
     void setTolerance(double tolerance);
 
     /**
-     * Sets timeout
+     * @brief Sets timeout.
+     *
      * @param timeout in seconds
-     * @return: -
      */
     void setTimeout(double timeout);
 
     /**
-     * Sets speed of each joint used in position control
-     * @param vector of speed. The vector must have size equal to @jlist in costructor.
-     * @return: -
+     * @brief Sets speed of each joint used in position control.
+     *
+     * @param vector of speed. The vector must have size equal to @jlist in
+     *               costructor.
      */
     void setSpeed(yarp::sig::Vector &speedlist);
 
     /**
-     * Sets all joints in position control mode and checks if all are in position control mode
-     * waiting timeout seconds. (The value of timeout can be default or configured by setTimeout function)
+     * @brief Sets all joints in position control mode and checks if all are in
+     * position control mode waiting timeout seconds.
+     *
+     * The value of timeout can be default or configured by setTimeout function.
+     *
      * @return: true if all joints are in position, false otherwise
      */
     bool setAndCheckPosControlMode();
 
 
     /**
-     * Moves joint @j in position @pos and checks if joint reaches target within tolerance range
-     * in maximun timeout seconds.
+     * @brief Moves joint @a j in position @a pos and checks if joint reaches
+     * target within tolerance range in maximun timeout seconds.
+     *
      * @param j: joint
      * @param pos: target position
-     * @param reached_pos: if not null, in output will contain the reached position
+     * @param reached_pos: if not null, in output will contain the reached
+     *                     position
      * @return: true if the joint has reached target position, false otherwise.
      */
-    bool goToSingle(int j, double pos, double *reached_pos=NULL);
+    bool goToSingle(int j,
+                    double pos,
+                    double *reached_pos = YARP_NULLPTR);
 
     /**
-     * Moves joints in corrisponding positions specified by @positions and
-     * checks if all joints reach its target within tolerance range in maximun timeout seconds.
+     * @brief Moves joints in corrisponding positions specified by
+     * @a positions and checks if all joints reach its target within tolerance
+     * range in maximun timeout seconds.
+     *
      * @param positions: vector of target positions
-     * @param reached_pos: if not null, in output will contain the reached position of each joint
+     * @param reached_pos: if not null, in output will contain the reached
+     *                     position of each joint
      * @return: true if each joint has reached its target, false otherwise.
      */
-    bool goTo(yarp::sig::Vector positions, yarp::sig::Vector *reached_pos=NULL);
+    bool goTo(yarp::sig::Vector positions,
+              yarp::sig::Vector *reached_pos = YARP_NULLPTR);
 
     /**
-     * Checks if joint @j has reached its limit withi tollerance range.
+     * @brief Checks if joint @a j has reached its limit within tollerance
+     *        range.
+     *
+     * @param j: joint to check.
      * @return: true if joint is on limit, false otherwise.
      */
     bool checkJointLimitsReached(int j);
 
-
-
 private:
-    int getIndexOfJoint(int j);
-    void readJointsLimits(void);
-    void init(yarp::dev::PolyDriver *polydriver);
-    yarp::sig::Vector jointsList;
-    yarp::sig::Vector encoders;
-    yarp::sig::Vector speed;
-    yarp::sig::Vector max_lims;
-    yarp::sig::Vector min_lims;
-    double tolerance;
-    double timeout;
-    int    n_joints;
-
-    yarp::dev::PolyDriver        *dd;
-    yarp::dev::IPositionControl2 *ipos;
-    yarp::dev::IControlMode2     *icmd;
-    yarp::dev::IInteractionMode  *iimd;
-    yarp::dev::IEncoders         *ienc;
-    yarp::dev::IControlLimits    *ilim;
-
+    class Private;
+    Private * const mPriv;
 };
-}
-}
-#endif //_JOINTSPOSMOVE_H_
+
+} // namespace rtf
+} // namespace yarp
+
+#endif // YARP_RTF_JOINTSPOSMOVE_H

--- a/src/libYARP_rtf/include/yarp/rtf/JointsPosMotion.h
+++ b/src/libYARP_rtf/include/yarp/rtf/JointsPosMotion.h
@@ -1,0 +1,121 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Valentina Gaggero
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _JOINTSPOSMOVE_H_
+#define _JOINTSPOSMOVE_H_
+
+#include <string>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/sig/Vector.h>
+
+/**
+ * \brief The JointPosMotion class is used
+ * has been created to simplify and speed up development of tests
+ * that controls joints in position.
+ */
+namespace RTF {
+    namespace YARP {
+
+class jointsPosMotion{
+public:
+    //jointsPosMotion();
+
+    /**
+     * Creates an object for control joints specified in @jlist.
+     * Sets default speed used in position control.
+     * Tolerance and timeout will be initialized with default values
+     * (tolerance=1.0 deg  timeout=5 sec)
+     * @param polydriver: pointer to polydriver used to manage joints
+     * @param jlist: list of joints
+     */
+    jointsPosMotion(yarp::dev::PolyDriver *polydriver, yarp::sig::Vector &jlist);
+
+    virtual ~jointsPosMotion();
+
+    /**
+     * Sets tolerance used to check if a joint is in position
+     * @param tolerance
+     * @return: -
+     */
+    void setTolerance(double tolerance);
+
+    /**
+     * Sets timeout
+     * @param timeout in seconds
+     * @return: -
+     */
+    void setTimeout(double timeout);
+
+    /**
+     * Sets speed of each joint used in position control
+     * @param vector of speed. The vector must have size equal to @jlist in costructor.
+     * @return: -
+     */
+    void setSpeed(yarp::sig::Vector &speedlist);
+
+    /**
+     * Sets all joints in position control mode and checks if all are in position control mode
+     * waiting timeout seconds. (The value of timeout can be default or configured by setTimeout function)
+     * @return: true if all joints are in position, false otherwise
+     */
+    bool setAndCheckPosControlMode();
+
+
+    /**
+     * Moves joint @j in position @pos and checks if joint reaches target within tolerance range
+     * in maximun timeout seconds.
+     * @param j: joint
+     * @param pos: target position
+     * @param reached_pos: if not null, in output will contain the reached position
+     * @return: true if the joint has reached target position, false otherwise.
+     */
+    bool goToSingle(int j, double pos, double *reached_pos=NULL);
+
+    /**
+     * Moves joints in corrisponding positions specified by @positions and
+     * checks if all joints reach its target within tolerance range in maximun timeout seconds.
+     * @param positions: vector of target positions
+     * @param reached_pos: if not null, in output will contain the reached position of each joint
+     * @return: true if each joint has reached its target, false otherwise.
+     */
+    bool goTo(yarp::sig::Vector positions, yarp::sig::Vector *reached_pos=NULL);
+
+    /**
+     * Checks if joint @j has reached its limit withi tollerance range.
+     * @return: true if joint is on limit, false otherwise.
+     */
+    bool checkJointLimitsReached(int j);
+
+
+
+private:
+    int getIndexOfJoint(int j);
+    void readJointsLimits(void);
+    void init(yarp::dev::PolyDriver *polydriver);
+    yarp::sig::Vector jointsList;
+    yarp::sig::Vector encoders;
+    yarp::sig::Vector speed;
+    yarp::sig::Vector max_lims;
+    yarp::sig::Vector min_lims;
+    double tolerance;
+    double timeout;
+    int    n_joints;
+
+    yarp::dev::PolyDriver        *dd;
+    yarp::dev::IPositionControl2 *ipos;
+    yarp::dev::IControlMode2     *icmd;
+    yarp::dev::IInteractionMode  *iimd;
+    yarp::dev::IEncoders         *ienc;
+    yarp::dev::IControlLimits    *ilim;
+
+};
+}
+}
+#endif //_JOINTSPOSMOVE_H_

--- a/src/libYARP_rtf/include/yarp/rtf/TestAsserter.h
+++ b/src/libYARP_rtf/include/yarp/rtf/TestAsserter.h
@@ -1,0 +1,78 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _YARPTESTASSERTER_H_
+#define _YARPTESTASSERTER_H_
+
+#include <yarp/sig/Vector.h>
+
+namespace RTF {
+    namespace YARP {
+        class YarpTestAsserter;
+    }
+}
+
+
+/**
+ * \brief The Yarp Test Asserter class is used to throw exception or to report messages/failures
+ * to a TestResult.
+ */
+class RTF::YARP::YarpTestAsserter {
+
+public:
+    /**
+     * Element-wise compare two vectors to determine if they are approximately equal, according to asymmetric thresholds that specify lower and upper bound.
+     * Both thresholds are assumed to be positive.
+     * @param left: left operand
+     * @param right: right operand
+     * @param l_thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors. It specifies the low bound of the interval.
+     * @param h_thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors. It specifies the upper bound of the interval.
+     * @param lenght: specifies the lengths of all vectors
+     * @return: the result of the comparison
+     */
+    static bool isApproxEqual(const double *left, const double *right,
+                       const double *l_thresholds, const double *h_thresholds,
+                       int lenght);
+
+    /**
+     * Element-wise compare two vectors to determine if they are approximately equal, according to a threshold. The threshold is assumed to be positive.
+     * @param left: left operand
+     * @param right: right operand
+     * @param thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors
+     * @param lenght: specifies the lengths of all vectors
+     * @return: the result of comparison
+     */
+    static bool isApproxEqual(const double *left, const double *right,
+                       const double *thresholds, int lenght);
+
+    /**
+     * Element-wise compare two vectors to determine if they are approximately equal, according to a threshold. The threshold is assumed to be positive.
+     * @param left: left operand
+     * @param right: right operand
+     * @param thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors
+     * @return: the result of comparison
+     */
+    static bool isApproxEqual(const yarp::sig::Vector &left,
+                       const yarp::sig::Vector &right,
+                       const yarp::sig::Vector &thresholds);
+
+    /**
+     * Compare two scalars to determine if they are approximately equal, according to asymmetric thresholds that specify upper and lower bound.
+     * @param left: left operand
+     * @param right: right operand
+     * @param l_th: lower bound of interval for comparison
+     * @param h_th: upper bound of interval for comparison
+     * @return: the result of comparison
+     */
+    static bool isApproxEqual(double left, double right,
+                       double l_th, double h_th);
+};
+
+#endif //_YARPTESTASSERTER_H_
+

--- a/src/libYARP_rtf/include/yarp/rtf/TestAsserter.h
+++ b/src/libYARP_rtf/include/yarp/rtf/TestAsserter.h
@@ -1,78 +1,107 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2015 iCub Facility
- * Authors: Ali Paikan
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Ali Paikan <ali.paikan@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#ifndef _YARPTESTASSERTER_H_
-#define _YARPTESTASSERTER_H_
+#ifndef YARP_RTF_YARPTESTASSERTER_H
+#define YARP_RTF_YARPTESTASSERTER_H
 
+#include <yarp/rtf/api.h>
 #include <yarp/sig/Vector.h>
 
-namespace RTF {
-    namespace YARP {
-        class YarpTestAsserter;
-    }
-}
-
+namespace yarp {
+namespace rtf {
 
 /**
- * \brief The Yarp Test Asserter class is used to throw exception or to report messages/failures
- * to a TestResult.
+ * @brief The yarp::rtf::TestAsserter class is used to throw exception or to
+ * report messages/failures to a TestResult.
  */
-class RTF::YARP::YarpTestAsserter {
-
+class YARP_rtf_API TestAsserter
+{
 public:
+    explicit TestAsserter();
+    virtual ~TestAsserter();
+
     /**
-     * Element-wise compare two vectors to determine if they are approximately equal, according to asymmetric thresholds that specify lower and upper bound.
+     * Element-wise compare two vectors to determine if they are approximately
+     * equal, according to asymmetric thresholds that specify lower and upper
+     * bound.
+     *
      * Both thresholds are assumed to be positive.
      * @param left: left operand
      * @param right: right operand
-     * @param l_thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors. It specifies the low bound of the interval.
-     * @param h_thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors. It specifies the upper bound of the interval.
+     * @param l_thresholds: a vector of thresholds whose elements are used when
+     *                      checking equality of corresponding elements of the
+     *                      left and right vectors. It specifies the low bound
+     *                      of the interval.
+     * @param h_thresholds: a vector of thresholds whose elements are used when
+     *                      checking equality of corresponding elements of the
+     *                      left and right vectors. It specifies the upper bound
+     *                      of the interval.
      * @param lenght: specifies the lengths of all vectors
      * @return: the result of the comparison
      */
-    static bool isApproxEqual(const double *left, const double *right,
-                       const double *l_thresholds, const double *h_thresholds,
-                       int lenght);
+    static bool isApproxEqual(const double *left,
+                              const double *right,
+                              const double *l_thresholds,
+                              const double *h_thresholds,
+                              int lenght);
 
     /**
-     * Element-wise compare two vectors to determine if they are approximately equal, according to a threshold. The threshold is assumed to be positive.
+     * Element-wise compare two vectors to determine if they are approximately
+     * equal, according to a threshold. The threshold is assumed to be positive.
+     *
      * @param left: left operand
      * @param right: right operand
-     * @param thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors
+     * @param thresholds: a vector of thresholds whose elements are used when
+     *                    checking equality of corresponding elements of the
+     *                    left and right vectors
      * @param lenght: specifies the lengths of all vectors
      * @return: the result of comparison
      */
-    static bool isApproxEqual(const double *left, const double *right,
-                       const double *thresholds, int lenght);
+    static bool isApproxEqual(const double *left,
+                              const double *right,
+                              const double *thresholds,
+                              int lenght);
 
     /**
-     * Element-wise compare two vectors to determine if they are approximately equal, according to a threshold. The threshold is assumed to be positive.
+     * Element-wise compare two vectors to determine if they are approximately
+     * equal, according to a threshold. The threshold is assumed to be positive.
+     *
      * @param left: left operand
      * @param right: right operand
-     * @param thresholds: a vector of thresholds whose elements are used when checking equality of corresponding elements of the left and right vectors
+     * @param thresholds: a vector of thresholds whose elements are used when
+     *                    checking equality of corresponding elements of the
+     *                    left and right vectors
      * @return: the result of comparison
      */
     static bool isApproxEqual(const yarp::sig::Vector &left,
-                       const yarp::sig::Vector &right,
-                       const yarp::sig::Vector &thresholds);
+                              const yarp::sig::Vector &right,
+                              const yarp::sig::Vector &thresholds);
 
     /**
-     * Compare two scalars to determine if they are approximately equal, according to asymmetric thresholds that specify upper and lower bound.
+     * Compare two scalars to determine if they are approximately equal,
+     * according to asymmetric thresholds that specify upper and lower bound.
+     *
      * @param left: left operand
      * @param right: right operand
      * @param l_th: lower bound of interval for comparison
      * @param h_th: upper bound of interval for comparison
      * @return: the result of comparison
      */
-    static bool isApproxEqual(double left, double right,
-                       double l_th, double h_th);
+    static bool isApproxEqual(double left,
+                              double right,
+                              double l_th,
+                              double h_th);
+
+private:
+    class Private;
+    Private * const mPriv;
 };
 
-#endif //_YARPTESTASSERTER_H_
 
+} // namespace rtf
+} // namespace yarp
+
+#endif // YARP_RTF_YARPTESTASSERTER_H

--- a/src/libYARP_rtf/include/yarp/rtf/TestCase.h
+++ b/src/libYARP_rtf/include/yarp/rtf/TestCase.h
@@ -12,9 +12,9 @@
 
 #include <string>
 #include <cstring>
-#include <TestCase.h>
-#include <TestAssert.h>
-#include <Arguments.h>
+#include <rtf/TestCase.h>
+#include <rtf/TestAssert.h>
+#include <rtf/Arguments.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/ResourceFinder.h>

--- a/src/libYARP_rtf/include/yarp/rtf/TestCase.h
+++ b/src/libYARP_rtf/include/yarp/rtf/TestCase.h
@@ -77,7 +77,7 @@ public:
             }
             RTF_ASSERT_ERROR_IF(cfgfile.size(),
                                 RTF::Asserter::format("Cannot find configuration file %s", cfgfile.c_str()));
-
+            RTF_TEST_REPORT(RTF::Asserter::format("Loading configuration from %s", cfgfile.c_str()));
             // update the properties with environment
             property.fromConfigFile(cfgfile.c_str(), envprop);
         }

--- a/src/libYARP_rtf/include/yarp/rtf/TestCase.h
+++ b/src/libYARP_rtf/include/yarp/rtf/TestCase.h
@@ -1,96 +1,48 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2015 iCub Facility
- * Authors: Ali Paikan
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Ali Paikan <ali.paikan@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#ifndef _YARPTESTCASE_H_
-#define _YARPTESTCASE_H_
+#ifndef YARP_RTF_YARPTESTCASE_H
+#define YARP_RTF_YARPTESTCASE_H
 
-#include <string>
-#include <cstring>
-#include <rtf/TestCase.h>
-#include <rtf/TestAssert.h>
-#include <rtf/Arguments.h>
-#include <yarp/os/Network.h>
+#include <yarp/rtf/api.h>
 #include <yarp/os/Property.h>
-#include <yarp/os/ResourceFinder.h>
+#include <rtf/TestCase.h>
+#include <string>
+
+namespace yarp {
+namespace rtf {
 
 /**
- * @brief The YarpTestCase is a helper class to facilitate
- * laoding the tests settings which are developed for YARP/iCub.
+ * @brief The YarpTestCase is a helper class to facilitate loading the tests
+ * settings which are developed for YARP.
+ *
  * The class simply looks for test configuration file given using "--from"
  * paramter to the test case and loads it into a yarp::os::Property object.
+ *
  * If any environment property is given using "testrunner -e" or using
- * <environment></environment> tag within suit XML file, that will be used to
+ * \<environment> \</environment> tag within suit XML file, that will be used to
  * updated the properties from the main config file.
- * Please see the example folder for how to develope a simple test plugin for iCub/Yarp.
+ *
+ * Please see RTF example folder for how to develop a simple test plugin for
+ * YARP.
  */
-class YarpTestCase : public RTF::TestCase {
+class YARP_rtf_API TestCase : public RTF::TestCase {
 public:
-    YarpTestCase(std::string name)
-        : RTF::TestCase(name) { }
+    TestCase(std::string name);
+    virtual ~TestCase();
 
-    bool setup(int argc, char** argv) {
-        // check yarp network
-        yarp.setVerbosity(-1);
-        RTF_ASSERT_ERROR_IF(yarp.checkNetwork(),
-                            "YARP network does not seem to be available, is the yarp server accessible?");
-
-        // loading environment properties by parsing the string value
-        // from getEnvironment().
-        std::string strEnv = getEnvironment();
-        yarp::os::Property envprop;
-        envprop.fromArguments(strEnv.c_str());
-        bool useSuitContext = envprop.check("context");
-
-        // load the config file and update the environment if available
-        // E.g., "--from mytest.ini"
-        yarp::os::ResourceFinder rf;
-        rf.setVerbose(false);
-        if(useSuitContext)
-            rf.setDefaultContext(envprop.find("context").asString().c_str());
-        else
-            rf.setDefaultContext("RobotTesting");
-        rf.configure(argc, argv);
-        yarp::os::Property property;
-
-        if(rf.check("from")) {
-
-            std::string cfgname = rf.find("from").asString();
-            RTF_ASSERT_ERROR_IF(cfgname.size(),
-                                "Empty value was set for the '--from' property");
-
-            // loading configuration file indicated by --from
-            std::string cfgfile = rf.findFileByName(cfgname.c_str());
-
-            bool useTestContext = rf.check("context");
-
-            // if the config file cannot be found from default context or
-            // there is not any context, use the robotname environment as context
-            if(!useSuitContext && !useTestContext && !cfgfile.size() && envprop.check("robotname")) {
-                rf.setContext(envprop.find("robotname").asString().c_str());
-                cfgfile = rf.findFileByName(cfgname.c_str());
-            }
-            RTF_ASSERT_ERROR_IF(cfgfile.size(),
-                                RTF::Asserter::format("Cannot find configuration file %s", cfgfile.c_str()));
-            RTF_TEST_REPORT(RTF::Asserter::format("Loading configuration from %s", cfgfile.c_str()));
-            // update the properties with environment
-            property.fromConfigFile(cfgfile.c_str(), envprop);
-        }
-        else
-            property.fromString(rf.toString().c_str());
-
-        return setup(property);
-    }
-
-    virtual bool setup(yarp::os::Property& property) {return false;}
+    bool setup(int argc, char** argv);
+    virtual bool setup(yarp::os::Property& property);
 
 private:
-    yarp::os::Network yarp;
+    class Private;
+    Private * const mPriv;
 };
 
-#endif //_YARPTESTCASE_H_
+} // namespace rtf
+} // namespace yarp
+
+#endif // YARP_RTF_YARPTESTCASE_H

--- a/src/libYARP_rtf/include/yarp/rtf/api.h
+++ b/src/libYARP_rtf/include/yarp/rtf/api.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_RTF_API_H
+#define YARP_RTF_API_H
+
+#include <yarp/conf/api.h>
+#ifndef YARP_rtf_API
+#  ifdef YARP_rtf_EXPORTS
+#    define YARP_rtf_API YARP_EXPORT
+#    define YARP_rtf_EXTERN YARP_EXPORT_EXTERN
+#  else
+#    define YARP_rtf_API YARP_IMPORT
+#    define YARP_rtf_EXTERN YARP_IMPORT_EXTERN
+#  endif
+#  define YARP_rtf_DEPRECATED_API YARP_DEPRECATED_API
+#  define YARP_rtf_DEPRECATED_API_MSG(X) YARP_DEPRECATED_API_MSG(X)
+#endif
+
+#endif // YARP_RTF_API_H

--- a/src/libYARP_rtf/src/JointsPosMotion.cpp
+++ b/src/libYARP_rtf/src/JointsPosMotion.cpp
@@ -103,6 +103,7 @@ bool jointsPosMotion::setAndCheckPosControlMode()
 
     }
 
+    return true;
 }
 
 void jointsPosMotion::setTimeout(double timeout){timeout = timeout;}

--- a/src/libYARP_rtf/src/JointsPosMotion.cpp
+++ b/src/libYARP_rtf/src/JointsPosMotion.cpp
@@ -1,28 +1,49 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2015 iCub Facility
- * Authors: Valentina Gaggero
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Valentina Gaggero <valentina.gaggero@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#include <math.h>
-#include <rtf/TestAssert.h>
+#include <yarp/rtf/JointsPosMotion.h>
+
 #include <yarp/os/Time.h>
-#include <rtf/yarp/JointsPosMotion.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PolyDriver.h>
 
-using namespace RTF;
-using namespace RTF::YARP;
-using namespace yarp::os;
-using namespace yarp::dev;
+#include <rtf/TestAssert.h>
 
+#include <cmath>
 
+using yarp::dev::VOCAB_IM_STIFF;
 
-//jointsPosMotion::jointsPosMotion(){}
-void jointsPosMotion::init(yarp::dev::PolyDriver *polydriver)
+class yarp::rtf::jointsPosMotion::Private
 {
+public:
+    void init(yarp::dev::PolyDriver *polydriver);
+    size_t getIndexOfJoint(int j);
+    void readJointsLimits(void);
 
+    yarp::sig::Vector jointsList;
+    yarp::sig::Vector encoders;
+    yarp::sig::Vector speed;
+    yarp::sig::Vector max_lims;
+    yarp::sig::Vector min_lims;
+    double tolerance;
+    double timeout;
+    size_t n_joints;
+
+    yarp::dev::PolyDriver        *dd;
+    yarp::dev::IPositionControl2 *ipos;
+    yarp::dev::IControlMode2     *icmd;
+    yarp::dev::IInteractionMode  *iimd;
+    yarp::dev::IEncoders         *ienc;
+    yarp::dev::IControlLimits    *ilim;
+};
+
+
+void yarp::rtf::jointsPosMotion::Private::init(yarp::dev::PolyDriver *polydriver)
+{
     jointsList = 0;
     n_joints = 0;
     encoders = 0;
@@ -32,51 +53,76 @@ void jointsPosMotion::init(yarp::dev::PolyDriver *polydriver)
     timeout = 5.0;
 
     dd = polydriver;
-    RTF_ASSERT_ERROR_IF(dd->isValid(),"Unable to open device driver");
-    RTF_ASSERT_ERROR_IF(dd->view(ienc),"Unable to open encoders interface");
-    RTF_ASSERT_ERROR_IF(dd->view(ipos),"Unable to open position interface");
-    RTF_ASSERT_ERROR_IF(dd->view(icmd),"Unable to open control mode interface");
-    RTF_ASSERT_ERROR_IF(dd->view(iimd),"Unable to open interaction mode interface");
-    RTF_ASSERT_ERROR_IF(dd->view(ilim),"Unable to open limits interface");
+    RTF_ASSERT_ERROR_IF(dd->isValid(), "Unable to open device driver");
+    RTF_ASSERT_ERROR_IF(dd->view(ienc), "Unable to open encoders interface");
+    RTF_ASSERT_ERROR_IF(dd->view(ipos), "Unable to open position interface");
+    RTF_ASSERT_ERROR_IF(dd->view(icmd), "Unable to open control mode interface");
+    RTF_ASSERT_ERROR_IF(dd->view(iimd), "Unable to open interaction mode interface");
+    RTF_ASSERT_ERROR_IF(dd->view(ilim), "Unable to open limits interface");
+}
+
+
+size_t yarp::rtf::jointsPosMotion::Private::getIndexOfJoint(int j)
+{
+    for(size_t i = 0; i < n_joints; i++) {
+        if(jointsList[i] == j) {
+            return i;
+        }
+    }
+    return jointsList.size()+1;
+}
+
+
+void yarp::rtf::jointsPosMotion::Private::readJointsLimits(void)
+{
+    max_lims.resize(n_joints);
+    min_lims.resize(n_joints);
+    for (size_t i = 0; i < n_joints; i++) {
+        ilim->getLimits((int)jointsList[i], &min_lims[i], &max_lims[i]);
+    }
 
 }
 
 
-jointsPosMotion::jointsPosMotion(yarp::dev::PolyDriver *polydriver, yarp::sig::Vector &jlist)
+
+yarp::rtf::jointsPosMotion::jointsPosMotion(yarp::dev::PolyDriver *polydriver, yarp::sig::Vector &jlist) :
+        mPriv(new Private)
 {
-    init(polydriver);
+    mPriv->init(polydriver);
 
-    n_joints = jlist.size();
-    jointsList.resize(n_joints);
-    jointsList = jlist;
+    mPriv->n_joints = jlist.size();
+    mPriv->jointsList.resize(mPriv->n_joints);
+    mPriv->jointsList = jlist;
 
-    encoders.resize(n_joints); encoders.zero();
-    speed = yarp::sig::Vector(n_joints, 10.0);
+    mPriv->encoders.resize(mPriv->n_joints); mPriv->encoders.zero();
+    mPriv->speed = yarp::sig::Vector(mPriv->n_joints, 10.0);
 
     //send default speed
-    for (unsigned int i=0; i<n_joints; i++)
-    {
-        ipos->setRefSpeed((int)jointsList[i],speed[i]);
+    for (size_t i = 0; i < mPriv->n_joints; i++) {
+        mPriv->ipos->setRefSpeed((int)mPriv->jointsList[i], mPriv->speed[i]);
     }
-    readJointsLimits();
-
-}
-
-jointsPosMotion::~jointsPosMotion()
-{
-   // if (dd) {delete dd; dd =0;}
+    mPriv->readJointsLimits();
 }
 
 
-void jointsPosMotion::setTolerance(double tolerance) {tolerance = tolerance;}
 
-
-bool jointsPosMotion::setAndCheckPosControlMode()
+yarp::rtf::jointsPosMotion::~jointsPosMotion()
 {
-    for (unsigned int i=0; i<jointsList.size(); i++)
-    {
-        icmd->setControlMode((int)jointsList[i],VOCAB_CM_POSITION);
-        iimd->setInteractionMode((int)jointsList[i],VOCAB_IM_STIFF);
+    delete mPriv;
+}
+
+
+void yarp::rtf::jointsPosMotion::setTolerance(double tolerance)
+{
+    mPriv->tolerance = tolerance;
+}
+
+
+bool yarp::rtf::jointsPosMotion::setAndCheckPosControlMode()
+{
+    for (size_t i = 0; i < mPriv->jointsList.size(); i++) {
+        mPriv->icmd->setControlMode((int)mPriv->jointsList[i], VOCAB_CM_POSITION);
+        mPriv->iimd->setInteractionMode((int)mPriv->jointsList[i], VOCAB_IM_STIFF);
         yarp::os::Time::delay(0.010);
     }
 
@@ -84,18 +130,19 @@ bool jointsPosMotion::setAndCheckPosControlMode()
     yarp::dev::InteractionModeEnum imode;
     double time_started = yarp::os::Time::now();
 
-    while (1)
-    {
-        int ok=0;
-        for (unsigned int i=0; i<n_joints; i++)
-        {
-            icmd->getControlMode ((int)jointsList[i],&cmode);
-            iimd->getInteractionMode((int)jointsList[i],&imode);
-            if (cmode==VOCAB_CM_POSITION && imode==VOCAB_IM_STIFF) ok++;
+    while (1) {
+        size_t ok = 0;
+        for (size_t i = 0; i < mPriv->n_joints; i++) {
+            mPriv->icmd->getControlMode ((int)mPriv->jointsList[i], &cmode);
+            mPriv->iimd->getInteractionMode((int)mPriv->jointsList[i], &imode);
+            if (cmode == VOCAB_CM_POSITION && imode == VOCAB_IM_STIFF) {
+                ok++;
+            }
         }
-        if (ok==n_joints) break;
-        if (yarp::os::Time::now()-time_started > timeout)
-        {
+        if (ok == mPriv->n_joints) {
+            break;
+        }
+        if (yarp::os::Time::now() - time_started > mPriv->timeout) {
             RTF_ASSERT_ERROR("Unable to set control mode/interaction mode");
         }
 
@@ -106,48 +153,41 @@ bool jointsPosMotion::setAndCheckPosControlMode()
     return true;
 }
 
-void jointsPosMotion::setTimeout(double timeout){timeout = timeout;}
 
-int jointsPosMotion::getIndexOfJoint(int j)
+void yarp::rtf::jointsPosMotion::setTimeout(double timeout)
 {
-    for(int i=0; i<n_joints; i++)
-    {
-        if(jointsList[i] == j)
-            return i;
-    }
-    return jointsList.size()+1;
-}
-
-void jointsPosMotion::setSpeed(yarp::sig::Vector &speedlist)
-{
-    RTF_ASSERT_ERROR_IF((speedlist.size() != jointsList.size()), "speed list has a different size of joint list");
-    speed = speedlist;
-    for (unsigned int i=0; i<n_joints; i++)
-    {
-        ipos->setRefSpeed((int)jointsList[i],speed[i]);
-    }
+    mPriv->timeout = timeout;
 }
 
 
 
-bool jointsPosMotion::goToSingle(int j, double pos, double *reached_pos)
+void yarp::rtf::jointsPosMotion::setSpeed(yarp::sig::Vector &speedlist)
 {
-    int i = getIndexOfJoint(j);
-    RTF_ASSERT_ERROR_IF(i<n_joints, "cannot move a joint not in list.");
+    RTF_ASSERT_ERROR_IF((speedlist.size() != mPriv->jointsList.size()), "Speed list has a different size of joint list");
+    mPriv->speed = speedlist;
+    for (size_t i = 0; i < mPriv->n_joints; i++) {
+        mPriv->ipos->setRefSpeed((int)mPriv->jointsList[i], mPriv->speed[i]);
+    }
+}
 
-    ipos->positionMove((int)jointsList[i],pos);
-    double tmp=0;
+
+bool yarp::rtf::jointsPosMotion::goToSingle(int j, double pos, double *reached_pos)
+{
+    size_t i = mPriv->getIndexOfJoint(j);
+    RTF_ASSERT_ERROR_IF(i < mPriv->n_joints, "Cannot move a joint not in list.");
+
+    mPriv->ipos->positionMove((int)mPriv->jointsList[i], pos);
+    double tmp = 0;
 
     double time_started = yarp::os::Time::now();
     bool ret = true;
-    while (1)
-    {
-        ienc->getEncoder((int)jointsList[i],&tmp);
-        if (fabs(tmp-pos)<tolerance)
+    while (1) {
+        mPriv->ienc->getEncoder((int)mPriv->jointsList[i], &tmp);
+        if (fabs(tmp-pos)<mPriv->tolerance) {
             break;
+        }
 
-        if (yarp::os::Time::now()-time_started > timeout)
-        {
+        if (yarp::os::Time::now()-time_started > mPriv->timeout) {
             ret  = false;
             break;
         }
@@ -155,77 +195,61 @@ bool jointsPosMotion::goToSingle(int j, double pos, double *reached_pos)
         yarp::os::Time::delay(0.2);
     }
 
-    if(reached_pos != NULL)
-    {
+    if(reached_pos != YARP_NULLPTR) {
         *reached_pos = tmp;
     }
     return(ret);
 }
 
 
-bool jointsPosMotion::goTo(yarp::sig::Vector positions, yarp::sig::Vector *reached_pos)
+bool yarp::rtf::jointsPosMotion::goTo(yarp::sig::Vector positions, yarp::sig::Vector *reached_pos)
 {
-    for (unsigned int i=0; i<n_joints; i++)
-    {
-        ipos->positionMove((int)jointsList[i],positions[i]);
+    for (unsigned int i=0; i<mPriv->n_joints; i++) {
+        mPriv->ipos->positionMove((int)mPriv->jointsList[i], positions[i]);
     }
 
     double time_started = yarp::os::Time::now();
-    yarp::sig::Vector tmp(n_joints);tmp.zero();
+    yarp::sig::Vector tmp(mPriv->n_joints);tmp.zero();
     bool ret = true;
 
-    while (1)
-    {
-        int in_position=0;
-        for (unsigned int i=0; i<n_joints; i++)
-        {
-            ienc->getEncoder((int)jointsList[i],&tmp[i]);
-            if (fabs(tmp[i]-positions[i])<tolerance)
+    while (1) {
+        size_t in_position = 0;
+        for (size_t i = 0; i < mPriv->n_joints; i++) {
+            mPriv->ienc->getEncoder((int)mPriv->jointsList[i], &tmp[i]);
+            if (fabs(tmp[i]-positions[i])<mPriv->tolerance)
                 in_position++;
         }
-        if (in_position==n_joints)
+        if (in_position == mPriv->n_joints)
             break;
 
-        if (yarp::os::Time::now()-time_started > timeout)
-        {
+        if (yarp::os::Time::now()-time_started > mPriv->timeout) {
             ret = false;
             break;
         }
         yarp::os::Time::delay(0.2);
     }
 
-    if(reached_pos != NULL)
-    {
-        reached_pos->resize(n_joints);
+    if(reached_pos != YARP_NULLPTR) {
+        reached_pos->resize(mPriv->n_joints);
         *reached_pos = tmp;
     }
     return(ret);
 }
 
-void jointsPosMotion::readJointsLimits(void)
+
+
+bool yarp::rtf::jointsPosMotion::checkJointLimitsReached(int j)
 {
-    max_lims.resize(n_joints);
-    min_lims.resize(n_joints);
-    for (int i=0; i <n_joints; i++)
-    {
-        ilim->getLimits((int)jointsList[i],&min_lims[i],&max_lims[i]);
-    }
+    size_t i = mPriv->getIndexOfJoint(j);
 
-}
-
-
-bool jointsPosMotion::checkJointLimitsReached(int j)
-{
-    int i = getIndexOfJoint(j);
-
-    RTF_ASSERT_ERROR_IF(i<n_joints, "cannot move a joint not in list.");
+    RTF_ASSERT_ERROR_IF(i < mPriv->n_joints, "Cannot move a joint not in list.");
 
     double enc=0;
-    ienc->getEncoder((int)jointsList[i],&enc);
-    if (fabs(enc-max_lims[i]) < tolerance ||
-         fabs(enc-min_lims[i]) < tolerance )
+    mPriv->ienc->getEncoder((int)mPriv->jointsList[i], &enc);
+    if (fabs(enc-mPriv->max_lims[i]) < mPriv->tolerance ||
+            fabs(enc-mPriv->min_lims[i]) < mPriv->tolerance ) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
-

--- a/src/libYARP_rtf/src/JointsPosMotion.cpp
+++ b/src/libYARP_rtf/src/JointsPosMotion.cpp
@@ -1,0 +1,230 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Valentina Gaggero
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <math.h>
+#include <rtf/TestAssert.h>
+#include <yarp/os/Time.h>
+#include <rtf/yarp/JointsPosMotion.h>
+
+using namespace RTF;
+using namespace RTF::YARP;
+using namespace yarp::os;
+using namespace yarp::dev;
+
+
+
+//jointsPosMotion::jointsPosMotion(){}
+void jointsPosMotion::init(yarp::dev::PolyDriver *polydriver)
+{
+
+    jointsList = 0;
+    n_joints = 0;
+    encoders = 0;
+    speed = 0;
+
+    tolerance = 1.0;
+    timeout = 5.0;
+
+    dd = polydriver;
+    RTF_ASSERT_ERROR_IF(dd->isValid(),"Unable to open device driver");
+    RTF_ASSERT_ERROR_IF(dd->view(ienc),"Unable to open encoders interface");
+    RTF_ASSERT_ERROR_IF(dd->view(ipos),"Unable to open position interface");
+    RTF_ASSERT_ERROR_IF(dd->view(icmd),"Unable to open control mode interface");
+    RTF_ASSERT_ERROR_IF(dd->view(iimd),"Unable to open interaction mode interface");
+    RTF_ASSERT_ERROR_IF(dd->view(ilim),"Unable to open limits interface");
+
+}
+
+
+jointsPosMotion::jointsPosMotion(yarp::dev::PolyDriver *polydriver, yarp::sig::Vector &jlist)
+{
+    init(polydriver);
+
+    n_joints = jlist.size();
+    jointsList.resize(n_joints);
+    jointsList = jlist;
+
+    encoders.resize(n_joints); encoders.zero();
+    speed = yarp::sig::Vector(n_joints, 10.0);
+
+    //send default speed
+    for (unsigned int i=0; i<n_joints; i++)
+    {
+        ipos->setRefSpeed((int)jointsList[i],speed[i]);
+    }
+    readJointsLimits();
+
+}
+
+jointsPosMotion::~jointsPosMotion()
+{
+   // if (dd) {delete dd; dd =0;}
+}
+
+
+void jointsPosMotion::setTolerance(double tolerance) {tolerance = tolerance;}
+
+
+bool jointsPosMotion::setAndCheckPosControlMode()
+{
+    for (unsigned int i=0; i<jointsList.size(); i++)
+    {
+        icmd->setControlMode((int)jointsList[i],VOCAB_CM_POSITION);
+        iimd->setInteractionMode((int)jointsList[i],VOCAB_IM_STIFF);
+        yarp::os::Time::delay(0.010);
+    }
+
+    int cmode;
+    yarp::dev::InteractionModeEnum imode;
+    double time_started = yarp::os::Time::now();
+
+    while (1)
+    {
+        int ok=0;
+        for (unsigned int i=0; i<n_joints; i++)
+        {
+            icmd->getControlMode ((int)jointsList[i],&cmode);
+            iimd->getInteractionMode((int)jointsList[i],&imode);
+            if (cmode==VOCAB_CM_POSITION && imode==VOCAB_IM_STIFF) ok++;
+        }
+        if (ok==n_joints) break;
+        if (yarp::os::Time::now()-time_started > timeout)
+        {
+            RTF_ASSERT_ERROR("Unable to set control mode/interaction mode");
+        }
+
+        yarp::os::Time::delay(0.2);
+
+    }
+
+}
+
+void jointsPosMotion::setTimeout(double timeout){timeout = timeout;}
+
+int jointsPosMotion::getIndexOfJoint(int j)
+{
+    for(int i=0; i<n_joints; i++)
+    {
+        if(jointsList[i] == j)
+            return i;
+    }
+    return jointsList.size()+1;
+}
+
+void jointsPosMotion::setSpeed(yarp::sig::Vector &speedlist)
+{
+    RTF_ASSERT_ERROR_IF((speedlist.size() != jointsList.size()), "speed list has a different size of joint list");
+    speed = speedlist;
+    for (unsigned int i=0; i<n_joints; i++)
+    {
+        ipos->setRefSpeed((int)jointsList[i],speed[i]);
+    }
+}
+
+
+
+bool jointsPosMotion::goToSingle(int j, double pos, double *reached_pos)
+{
+    int i = getIndexOfJoint(j);
+    RTF_ASSERT_ERROR_IF(i<n_joints, "cannot move a joint not in list.");
+
+    ipos->positionMove((int)jointsList[i],pos);
+    double tmp=0;
+
+    double time_started = yarp::os::Time::now();
+    bool ret = true;
+    while (1)
+    {
+        ienc->getEncoder((int)jointsList[i],&tmp);
+        if (fabs(tmp-pos)<tolerance)
+            break;
+
+        if (yarp::os::Time::now()-time_started > timeout)
+        {
+            ret  = false;
+            break;
+        }
+
+        yarp::os::Time::delay(0.2);
+    }
+
+    if(reached_pos != NULL)
+    {
+        *reached_pos = tmp;
+    }
+    return(ret);
+}
+
+
+bool jointsPosMotion::goTo(yarp::sig::Vector positions, yarp::sig::Vector *reached_pos)
+{
+    for (unsigned int i=0; i<n_joints; i++)
+    {
+        ipos->positionMove((int)jointsList[i],positions[i]);
+    }
+
+    double time_started = yarp::os::Time::now();
+    yarp::sig::Vector tmp(n_joints);tmp.zero();
+    bool ret = true;
+
+    while (1)
+    {
+        int in_position=0;
+        for (unsigned int i=0; i<n_joints; i++)
+        {
+            ienc->getEncoder((int)jointsList[i],&tmp[i]);
+            if (fabs(tmp[i]-positions[i])<tolerance)
+                in_position++;
+        }
+        if (in_position==n_joints)
+            break;
+
+        if (yarp::os::Time::now()-time_started > timeout)
+        {
+            ret = false;
+            break;
+        }
+        yarp::os::Time::delay(0.2);
+    }
+
+    if(reached_pos != NULL)
+    {
+        reached_pos->resize(n_joints);
+        *reached_pos = tmp;
+    }
+    return(ret);
+}
+
+void jointsPosMotion::readJointsLimits(void)
+{
+    max_lims.resize(n_joints);
+    min_lims.resize(n_joints);
+    for (int i=0; i <n_joints; i++)
+    {
+        ilim->getLimits((int)jointsList[i],&min_lims[i],&max_lims[i]);
+    }
+
+}
+
+
+bool jointsPosMotion::checkJointLimitsReached(int j)
+{
+    int i = getIndexOfJoint(j);
+
+    RTF_ASSERT_ERROR_IF(i<n_joints, "cannot move a joint not in list.");
+
+    double enc=0;
+    ienc->getEncoder((int)jointsList[i],&enc);
+    if (fabs(enc-max_lims[i]) < tolerance ||
+         fabs(enc-min_lims[i]) < tolerance )
+        return true;
+    else
+        return false;
+}
+

--- a/src/libYARP_rtf/src/TestAsserter.cpp
+++ b/src/libYARP_rtf/src/TestAsserter.cpp
@@ -1,58 +1,75 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2015 iCub Facility
- * Authors: Ali Paikan
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Ali Paikan <ali.paikan@iit.it>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#include <math.h>
+#include <yarp/rtf/TestAsserter.h>
+#include <yarp/sig/Vector.h>
 #include <rtf/TestAssert.h>
-#include <rtf/yarp/YarpTestAsserter.h>
-
-using namespace yarp::sig;
-using namespace RTF;
-using namespace RTF::YARP;
+#include <cmath>
 
 
-bool YarpTestAsserter::isApproxEqual(const double *left, const double *right,
-                              const double *thresholds, int lenght)
+class yarp::rtf::TestAsserter::Private
+{
+};
+
+yarp::rtf::TestAsserter::TestAsserter() :
+        mPriv(new Private)
+{
+}
+
+yarp::rtf::TestAsserter::~TestAsserter()
+{
+    delete mPriv;
+}
+
+bool yarp::rtf::TestAsserter::isApproxEqual(const double *left,
+                                            const double *right,
+                                            const double *thresholds,
+                                            int lenght)
 {
     return isApproxEqual(left, right, thresholds, thresholds, lenght);
 }
 
-bool YarpTestAsserter::isApproxEqual(const double *left, const double *right,
-                              const double *l_thresholds, const double *h_thresholds,
-                              int lenght)
+bool yarp::rtf::TestAsserter::isApproxEqual(const double *left,
+                                            const double *right,
+                                            const double *l_thresholds,
+                                            const double *h_thresholds,
+                                            int lenght)
 {
-    bool reached=true;
-    for(int j=0; j<lenght; j++)
+    bool reached = true;
+    for(int j = 0; j < lenght; j++)
     {
-        if (left[j]<(right[j]-fabs(l_thresholds[j])) || left[j]>(right[j]+fabs(h_thresholds[j])))
+        if (left[j]<(right[j]-fabs(l_thresholds[j])) || left[j]>(right[j]+fabs(h_thresholds[j]))) {
             reached=false;
+        }
     }
     return reached;
 }
 
 
-bool YarpTestAsserter::isApproxEqual(const Vector &left,
-                              const Vector &right,
-                              const Vector &thresholds)
+bool yarp::rtf::TestAsserter::isApproxEqual(const yarp::sig::Vector &left,
+                                            const yarp::sig::Vector &right,
+                                            const yarp::sig::Vector &thresholds)
 {
-    if (left.size()!=right.size() && right.size()!=thresholds.size()) {
-            RTF_ASSERT_ERROR("YarpTestAsserter::isApproxEqual : vectors must have same size!");
-            return false;
+    if (left.size() != right.size() && right.size() != thresholds.size()) {
+        RTF_ASSERT_ERROR("yarp::rtf::TestAsserter::isApproxEqual : vectors must have same size!");
+        return false;
     }
     return isApproxEqual(left.data(), right.data(), thresholds.data(), left.size());
 }
 
-bool YarpTestAsserter::isApproxEqual(double left, double right, double l_th, double h_th)
+bool yarp::rtf::TestAsserter::isApproxEqual(double left,
+                                            double right,
+                                            double l_th,
+                                            double h_th)
 {
 
-    if (left>=right-fabs(l_th) && left<=right+fabs(h_th))
+    if (left >= right - fabs(l_th) && left <= right + fabs(h_th)) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
 

--- a/src/libYARP_rtf/src/TestAsserter.cpp
+++ b/src/libYARP_rtf/src/TestAsserter.cpp
@@ -1,0 +1,58 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <math.h>
+#include <rtf/TestAssert.h>
+#include <rtf/yarp/YarpTestAsserter.h>
+
+using namespace yarp::sig;
+using namespace RTF;
+using namespace RTF::YARP;
+
+
+bool YarpTestAsserter::isApproxEqual(const double *left, const double *right,
+                              const double *thresholds, int lenght)
+{
+    return isApproxEqual(left, right, thresholds, thresholds, lenght);
+}
+
+bool YarpTestAsserter::isApproxEqual(const double *left, const double *right,
+                              const double *l_thresholds, const double *h_thresholds,
+                              int lenght)
+{
+    bool reached=true;
+    for(int j=0; j<lenght; j++)
+    {
+        if (left[j]<(right[j]-fabs(l_thresholds[j])) || left[j]>(right[j]+fabs(h_thresholds[j])))
+            reached=false;
+    }
+    return reached;
+}
+
+
+bool YarpTestAsserter::isApproxEqual(const Vector &left,
+                              const Vector &right,
+                              const Vector &thresholds)
+{
+    if (left.size()!=right.size() && right.size()!=thresholds.size()) {
+            RTF_ASSERT_ERROR("YarpTestAsserter::isApproxEqual : vectors must have same size!");
+            return false;
+    }
+    return isApproxEqual(left.data(), right.data(), thresholds.data(), left.size());
+}
+
+bool YarpTestAsserter::isApproxEqual(double left, double right, double l_th, double h_th)
+{
+
+    if (left>=right-fabs(l_th) && left<=right+fabs(h_th))
+        return true;
+    else
+        return false;
+}
+

--- a/src/libYARP_rtf/src/TestCase.cpp
+++ b/src/libYARP_rtf/src/TestCase.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
+ * Authors: Ali Paikan <ali.paikan@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <yarp/rtf/TestCase.h>
+
+#include <rtf/Arguments.h>
+#include <rtf/TestAssert.h>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include <cstring>
+
+
+class yarp::rtf::TestCase::Private
+{
+public:
+    yarp::os::Network yarp;
+};
+
+
+yarp::rtf::TestCase::TestCase(std::string name) :
+        RTF::TestCase(name),
+        mPriv(new Private)
+{
+}
+
+yarp::rtf::TestCase::~TestCase()
+{
+    delete mPriv;
+}
+
+
+bool yarp::rtf::TestCase::setup(int argc, char** argv)
+{
+    // check yarp network
+    mPriv->yarp.setVerbosity(-1);
+    RTF_ASSERT_ERROR_IF(mPriv->yarp.checkNetwork(),
+                        "YARP network does not seem to be available, is the yarp server accessible?");
+
+    // loading environment properties by parsing the string value
+    // from getEnvironment().
+    std::string strEnv = getEnvironment();
+    yarp::os::Property envprop;
+    envprop.fromArguments(strEnv.c_str());
+    bool useSuitContext = envprop.check("context");
+
+    // load the config file and update the environment if available
+    // E.g., "--from mytest.ini"
+    yarp::os::ResourceFinder rf;
+    rf.setVerbose(false);
+    if(useSuitContext) {
+        rf.setDefaultContext(envprop.find("context").asString().c_str());
+    } else {
+        rf.setDefaultContext("RobotTesting");
+    }
+    rf.configure(argc, argv);
+    yarp::os::Property property;
+
+    if(rf.check("from")) {
+
+        std::string cfgname = rf.find("from").asString();
+        RTF_ASSERT_ERROR_IF(cfgname.size(),
+                            "Empty value was set for the '--from' property");
+
+        // loading configuration file indicated by --from
+        std::string cfgfile = rf.findFileByName(cfgname.c_str());
+
+        bool useTestContext = rf.check("context");
+
+        // if the config file cannot be found from default context or
+        // there is not any context, use the robotname environment as context
+        if(!useSuitContext && !useTestContext && !cfgfile.size() && envprop.check("robotname")) {
+            rf.setContext(envprop.find("robotname").asString().c_str());
+            cfgfile = rf.findFileByName(cfgname.c_str());
+        }
+        RTF_ASSERT_ERROR_IF(cfgfile.size(),
+                            RTF::Asserter::format("Cannot find configuration file %s", cfgfile.c_str()));
+        RTF_TEST_REPORT(RTF::Asserter::format("Loading configuration from %s", cfgfile.c_str()));
+        // update the properties with environment
+        property.fromConfigFile(cfgfile.c_str(), envprop);
+    } else {
+        property.fromString(rf.toString().c_str());
+    }
+
+    return setup(property);
+}
+
+bool yarp::rtf::TestCase::setup(yarp::os::Property& property)
+{
+    return false;
+}

--- a/src/middleware/yarp/include/YarpTestCase.h
+++ b/src/middleware/yarp/include/YarpTestCase.h
@@ -11,6 +11,7 @@
 #define _YARPTESTCASE_H_
 
 #include <string>
+#include <cstring>
 #include <TestCase.h>
 #include <TestAssert.h>
 #include <Arguments.h>
@@ -33,8 +34,8 @@ public:
     YarpTestCase(std::string name)
         : RTF::TestCase(name) { }
 
-    bool setup(int argc, char** argv) {        
-        // check yarp network        
+    bool setup(int argc, char** argv) {
+        // check yarp network
         yarp.setVerbosity(-1);
         RTF_ASSERT_ERROR_IF(yarp.checkNetwork(),
                             "YARP network does not seem to be available, is the yarp server accessible?");

--- a/src/middleware/yarp/include/YarpTestCase.h
+++ b/src/middleware/yarp/include/YarpTestCase.h
@@ -1,0 +1,97 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _YARPTESTCASE_H_
+#define _YARPTESTCASE_H_
+
+#include <string>
+#include <TestCase.h>
+#include <TestAssert.h>
+#include <Arguments.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/ResourceFinder.h>
+
+/**
+ * @brief The YarpTestCase is a helper class to facilitate
+ * laoding the tests settings which are developed for YARP/iCub.
+ * The class simply looks for test configuration file given using "--from"
+ * paramter to the test case and loads it into a yarp::os::Property object.
+ * If any environment property is given using "testrunner -e" or using
+ * <environment></environment> tag within suit XML file, that will be used to
+ * updated the properties from the main config file.
+ * Please see the example folder for how to develope a simple test plugin for iCub/Yarp.
+ */
+class YarpTestCase : public RTF::TestCase {
+public:
+    YarpTestCase(std::string name)
+        : RTF::TestCase(name) { }
+
+    bool setup(int argc, char** argv) {        
+        // check yarp network        
+        yarp.setVerbosity(-1);
+        RTF_ASSERT_ERROR_IF(yarp.checkNetwork(),
+                            "YARP network does not seem to be available, is the yarp server accessible?");
+
+        // load the config file and update the environment if available
+        // E.g., "--from mytest.ini"
+        yarp::os::ResourceFinder rf;
+        rf.setVerbose(false);
+        rf.setDefaultContext("RobotTesting");
+        rf.configure(argc, argv);
+        yarp::os::Property property;
+
+        std::string strEnv = getEnvironment();
+        if(rf.check("from") && strEnv.size()) {
+
+            std::string cfgname = rf.find("from").asString();
+            RTF_ASSERT_ERROR_IF(cfgname.size(),
+                                "Empty value was set for the '--from' property");
+
+            // loading environment properties by parsing the string value
+            // from getEnvironment().
+            yarp::os::Property envprop;
+            char* szenv = new char[strEnv.size()+1];
+            strcpy(szenv, strEnv.c_str());
+            int argc = 0;
+            char** argv = new char*[128]; // maximum 128
+            RTF::Arguments::parse(szenv, &argc, argv);
+            argv[argc]=0;
+            envprop.fromCommand(argc, argv, false);
+            delete [] szenv;
+            delete [] argv;
+
+            // loading configuration file indicated by --from
+            std::string cfgfile = rf.findFileByName(cfgname.c_str());
+
+            // if the config file cannot be found from default context or
+            // there is not any context, use the robotname environment as context
+            if(!cfgfile.size() && envprop.check("robotname")) {
+                rf.setContext(envprop.find("robotname").asString().c_str());
+                cfgfile = rf.findFileByName(cfgname.c_str());
+            }
+            RTF_ASSERT_ERROR_IF(cfgfile.size(),
+                                RTF::Asserter::format("Cannot find configuratio file %s", cfgfile.c_str()));
+
+            // update the properties with environment
+            property.fromConfigFile(cfgfile.c_str(), envprop);
+        }
+        else
+            property.fromString(rf.toString().c_str());
+
+        return setup(property);
+    }
+
+    virtual bool setup(yarp::os::Property& property) {return false;}
+
+private:
+    yarp::os::Network yarp;
+};
+
+#endif //_YARPTESTCASE_H_

--- a/src/rtf-plugins/CMakeLists.txt
+++ b/src/rtf-plugins/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+add_subdirectory(fixture-managers)

--- a/src/rtf-plugins/fixture-managers/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+add_subdirectory(yarpmanager)
+add_subdirectory(yarpplugin)

--- a/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
@@ -1,0 +1,40 @@
+#  RTF
+#  Copyright: (C) 2015 Ali Paikan
+#  Authors: Ali Paikan <ali.paikan@gmail.com>
+#
+#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+#
+
+
+cmake_minimum_required(VERSION 2.8.9)
+set(PROJECTNAME yarpmanager)
+project(${PROJECTNAME})
+
+find_package(YARP REQUIRED)
+
+get_property(RTF_LIBS GLOBAL PROPERTY RTF_LIBS)
+get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
+
+
+include_directories(${CMAKE_SOURCE_DIR}
+                    ${RTF_TREE_INCLUDE_DIRS}
+                    ${YARP_INCLUDE_DIRS})
+
+message(STATUS "YARP_LIBRARIES: " ${YARP_LIBRARIES})
+
+message(STATUS "RTF_LIBRARIES: " ${RTF_LIBS})
+
+link_libraries(${RTF_LIBS}
+               ${YARP_LIBRARIES}
+               YARP::YARP_manager)
+
+add_library(${PROJECTNAME} MODULE YarpFixManager.h
+                                  YarpFixManager.cpp)
+install(TARGETS ${PROJECTNAME}
+        EXPORT ${PROJECTNAME}
+        COMPONENT runtime
+        LIBRARY DESTINATION lib)
+
+
+
+

--- a/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
@@ -1,38 +1,27 @@
-#  RTF
-#  Copyright: (C) 2015 Ali Paikan
-#  Authors: Ali Paikan <ali.paikan@gmail.com>
-#
-#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
-#
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 
-cmake_minimum_required(VERSION 2.8.9)
-set(PROJECTNAME yarpmanager)
-project(${PROJECTNAME})
+project(rtf_fixturemanager_yarpmanager)
 
-find_package(YARP REQUIRED)
+get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
+get_property(YARP_manager_INCLUDE_DIRS TARGET YARP_manager PROPERTY INCLUDE_DIRS)
 
-get_property(RTF_LIBS GLOBAL PROPERTY RTF_LIBS)
-get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
+include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
+include_directories(${YARP_OS_INCLUDE_DIRS}
+                    ${YARP_manager_INCLUDE_DIRS})
 
+add_library(rtf_fixturemanager_yarpmanager MODULE YarpFixManager.h
+                                                  YarpFixManager.cpp)
+set_property(TARGET rtf_fixturemanager_yarpmanager PROPERTY PREFIX "")
+set_property(TARGET rtf_fixturemanager_yarpmanager PROPERTY OUTPUT_NAME yarpmanager)
 
-include_directories(${CMAKE_SOURCE_DIR}
-                    ${RTF_TREE_INCLUDE_DIRS}
-                    ${YARP_INCLUDE_DIRS})
+target_link_libraries(rtf_fixturemanager_yarpmanager PRIVATE RTF::RTF
+                                                             YARP::YARP_OS
+                                                             YARP::YARP_manager)
 
-set(CMAKE_SHARED_MODULE_PREFIX "")
-
-link_libraries(${RTF_LIBS}
-               ${YARP_LIBRARIES}
-               YARP::YARP_manager)
-
-add_library(${PROJECTNAME} MODULE YarpFixManager.h
-                                  YarpFixManager.cpp)
-install(TARGETS ${PROJECTNAME}
-        EXPORT ${PROJECTNAME}
-        COMPONENT runtime
-        LIBRARY DESTINATION lib)
-
-
-
-
+yarp_install(TARGETS rtf_fixturemanager_yarpmanager
+             EXPORT YARP
+             COMPONENT runtime
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rtf)

--- a/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
@@ -20,9 +20,7 @@ include_directories(${CMAKE_SOURCE_DIR}
                     ${RTF_TREE_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-message(STATUS "YARP_LIBRARIES: " ${YARP_LIBRARIES})
-
-message(STATUS "RTF_LIBRARIES: " ${RTF_LIBS})
+set(CMAKE_SHARED_MODULE_PREFIX "")
 
 link_libraries(${RTF_LIBS}
                ${YARP_LIBRARIES}

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -81,7 +81,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
     szerror = getLogger()->getLastError();
     RTF_ASSERT_ERROR_IF(ret,
                         "yarpmanager cannot setup the fixture because " +
-                        std::string((szerror) ? szerror : ""));
+                        std::string(getLogger()->getFormatedErrorString()));
     return true;
 }
 

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -44,7 +44,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
         yarp::os::ResourceFinder rf;
         rf.setVerbose(false);
         rf.setDefaultContext("RobotTesting");
-        rf.configure("", argc, argv, false);
+        rf.configure(argc, argv, false);
 
         RTF_ASSERT_ERROR_IF(rf.check("fixture"),
                             "No application xml file is set (add --fixture yourfixture.xml)");

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -62,11 +62,12 @@ bool YarpFixManager::setup(int argc, char** argv) {
         enableRestrictedMode();
 
         // load the fixture (application xml)
-        char szAppName[] = "fixture";
-        ret = addApplication(appfile.c_str(), szAppName);
+        char szAppName[255];
+        ret = addApplication(appfile.c_str(), szAppName, 254);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (addApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
+
         ret = loadApplication(szAppName);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (loadApplication) cannot setup the fixture because " +

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -1,0 +1,117 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <Plugin.h>
+#include <yarp/manager/utility.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/ResourceFinder.h>
+
+#include "YarpFixManager.h"
+
+using namespace RTF;
+using namespace yarp::os;
+using namespace yarp::manager;
+
+PREPARE_FIXTURE_PLUGIN(YarpFixManager)
+
+YarpFixManager::YarpFixManager()
+    : initialized(false) { }
+
+YarpFixManager::~YarpFixManager() {
+        tearDown();
+}
+
+
+bool YarpFixManager::setup(int argc, char** argv) {
+    RTF_FIXTURE_REPORT("yarpmanager is setuping the fixture...");
+    bool ret;
+    const char* szerror;
+    if(!initialized) {
+        // check yarp network
+        yarp.setVerbosity(-1);
+        RTF_ASSERT_ERROR_IF(yarp.checkNetwork(),
+                            "YARP network does not seem to be available, is the yarp server accessible?");
+
+        // load the config file and update the environment if available
+        // E.g., "--application myapp.xml"
+        yarp::os::ResourceFinder rf;
+        rf.setVerbose(false);
+        rf.setDefaultContext("RobotTesting");
+        rf.configure("", argc, argv, false);
+
+        RTF_ASSERT_ERROR_IF(rf.check("fixture"),
+                            "No application xml file is set (add --fixture yourfixture.xml)");
+
+        fixtureName = rf.find("fixture").asString();
+        std::string appfile = rf.findFileByName(std::string("fixtures/"+fixtureName).c_str());
+        RTF_ASSERT_ERROR_IF(appfile.size(),
+                            RTF::Asserter::format("yarpmanager cannot find apllication file %s. Is it in the 'fixtures' folder?",
+                                                  fixtureName.c_str()));
+
+        // enable restricted mode to ensure all the modules
+        // is running and enable watchdog to monitor the modules.
+        enableWatchDog();
+        enableAutoConnect();
+        enableRestrictedMode();
+
+        // load the fixture (application xml)
+        char szAppName[] = "fixture";
+        ret = addApplication(appfile.c_str(), szAppName);
+        szerror = getLogger()->getLastError();
+        RTF_ASSERT_ERROR_IF(ret,
+                            "yarpmanager cannot setup the fixture because " +
+                            std::string((szerror) ? szerror : ""));
+        ret = loadApplication(szAppName);
+        szerror = getLogger()->getLastError();
+        RTF_ASSERT_ERROR_IF(ret,
+                            "yarpmanager cannot setup the fixture because " +
+                            std::string((szerror) ? szerror : ""));
+        initialized = true;
+    }
+
+    //run the modules and connect
+    ret = run();
+    szerror = getLogger()->getLastError();
+    RTF_ASSERT_ERROR_IF(ret,
+                        "yarpmanager cannot setup the fixture because " +
+                        std::string((szerror) ? szerror : ""));
+    return true;
+}
+
+void YarpFixManager::tearDown() {
+    RTF_FIXTURE_REPORT("yarpmanager is tearing down the fixture...");
+    bool ret = stop();
+    if(!ret)
+        ret = kill();
+    const char* szerror = getLogger()->getLastError();
+    RTF_ASSERT_ERROR_IF(ret,
+                        "yarpmanager cannot teardown the fixture because " +
+                        std::string((szerror) ? szerror : ""));    
+}
+
+
+void YarpFixManager::onExecutableFailed(void* which) {
+    Executable* exe = (Executable*) which;
+    RTF_ASSERT_ERROR_IF(exe!=NULL, "Executable is null!");
+    TestMessage msg(Asserter::format("Fixture %s collapsed", fixtureName.c_str()),
+                    Asserter::format("Module %s is failed!", exe->getCommand()),
+                    RTF_SOURCEFILE(), RTF_SOURCELINE());
+    getDispatcher()->fixtureCollapsed(msg);
+}
+
+void YarpFixManager::onCnnFailed(void* which) {
+    Connection* cnn = (Connection*) which;
+    RTF_ASSERT_ERROR_IF(cnn!=NULL, "Connection is null!");
+    TestMessage msg(Asserter::format("Fixture %s collapsed", fixtureName.c_str()),
+                    Asserter::format("Connection %s - %s is failed!",
+                                     cnn->from(), cnn->to()),
+                    RTF_SOURCEFILE(), RTF_SOURCELINE());
+    getDispatcher()->fixtureCollapsed(msg);
+}

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -64,23 +64,20 @@ bool YarpFixManager::setup(int argc, char** argv) {
         // load the fixture (application xml)
         char szAppName[] = "fixture";
         ret = addApplication(appfile.c_str(), szAppName);
-        szerror = getLogger()->getLastError();
         RTF_ASSERT_ERROR_IF(ret,
-                            "yarpmanager cannot setup the fixture because " +
-                            std::string((szerror) ? szerror : ""));
+                            "yarpmanager (addApplication) cannot setup the fixture because " +
+                            std::string(getLogger()->getFormatedErrorString()));
         ret = loadApplication(szAppName);
-        szerror = getLogger()->getLastError();
         RTF_ASSERT_ERROR_IF(ret,
-                            "yarpmanager cannot setup the fixture because " +
-                            std::string((szerror) ? szerror : ""));
+                            "yarpmanager (loadApplication) cannot setup the fixture because " +
+                            std::string(getLogger()->getFormatedErrorString()));
         initialized = true;
     }
 
     //run the modules and connect
     ret = run();
-    szerror = getLogger()->getLastError();
     RTF_ASSERT_ERROR_IF(ret,
-                        "yarpmanager cannot setup the fixture because " +
+                        "yarpmanager (run) cannot setup the fixture because " +
                         std::string(getLogger()->getFormatedErrorString()));
     return true;
 }

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -7,7 +7,7 @@
  *
  */
 
-#include <Plugin.h>
+#include <rtf/dll/Plugin.h>
 #include <yarp/manager/utility.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
@@ -93,7 +93,7 @@ void YarpFixManager::tearDown() {
     const char* szerror = getLogger()->getLastError();
     RTF_ASSERT_ERROR_IF(ret,
                         "yarpmanager cannot teardown the fixture because " +
-                        std::string((szerror) ? szerror : ""));    
+                        std::string((szerror) ? szerror : ""));
 }
 
 

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -32,7 +32,6 @@ YarpFixManager::~YarpFixManager() {
 bool YarpFixManager::setup(int argc, char** argv) {
     RTF_FIXTURE_REPORT("yarpmanager is setuping the fixture...");
     bool ret;
-    const char* szerror;
     if(!initialized) {
         // check yarp network
         yarp.setVerbosity(-1);

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
@@ -1,14 +1,11 @@
-// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
-
 /*
  * Copyright (C) 2015 iCub Facility
  * Authors: Ali Paikan
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
-#ifndef _YarpFixManager_H_
-#define _YarpFixManager_H_
+#ifndef YARP_RTF_PLUGINS_YARPMANAGER_YARPFIXMANAGER_H
+#define YARP_RTF_PLUGINS_YARPMANAGER_YARPFIXMANAGER_H
 
 #include <yarp/os/Network.h>
 #include <yarp/manager/manager.h>
@@ -53,4 +50,4 @@ private:
     std::string fixtureName;
 };
 
-#endif //_YarpFixManager_H_
+#endif // YARP_RTF_PLUGINS_YARPMANAGER_YARPFIXMANAGER_H

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
@@ -12,9 +12,9 @@
 
 #include <yarp/os/Network.h>
 #include <yarp/manager/manager.h>
-#include <FixtureManager.h>
-#include <TestSuit.h>
-#include <TestAssert.h>
+#include <rtf/FixtureManager.h>
+#include <rtf/TestSuit.h>
+#include <rtf/TestAssert.h>
 
 // define a helper macro for fixture message reporting
 #define RTF_FIXTURE_REPORT(message)\

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.h
@@ -1,0 +1,56 @@
+// -*- mode:C++ { } tab-width:4 { } c-basic-offset:4 { } indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef _YarpFixManager_H_
+#define _YarpFixManager_H_
+
+#include <yarp/os/Network.h>
+#include <yarp/manager/manager.h>
+#include <FixtureManager.h>
+#include <TestSuit.h>
+#include <TestAssert.h>
+
+// define a helper macro for fixture message reporting
+#define RTF_FIXTURE_REPORT(message)\
+    if(dynamic_cast<RTF::FixtureManager*>(this) == 0) {\
+        RTF_ASSERT_ERROR("RTF_FIXTURE_REPORT is called outside a FixtureManager!"); }\
+    if(dynamic_cast<RTF::TestSuit*>(getDispatcher()) == 0) {\
+        RTF_ASSERT_ERROR("RTF_FIXTURE_REPORT cannot get any TestSuit instance from dispacher!"); }\
+    RTF::Asserter::report(RTF::TestMessage("reports",\
+                                            message,\
+                                            RTF_SOURCEFILE(),\
+                                            RTF_SOURCELINE()),\
+                                            dynamic_cast<RTF::TestSuit*>(getDispatcher()))
+
+class YarpFixManager : public RTF::FixtureManager,
+        yarp::manager::Manager {
+public:
+
+    YarpFixManager();
+    virtual ~YarpFixManager();
+
+    virtual bool setup(int argc, char** argv);
+
+    virtual void tearDown();
+
+protected:
+    //virtual void onExecutableStart(void* which);
+    //virtual void onExecutableStop(void* which);
+    //virtual void onExecutableDied(void* which);
+    //virtual void onCnnStablished(void* which);
+    virtual void onExecutableFailed(void* which);
+    virtual void onCnnFailed(void* which);
+
+private:
+    bool initialized;
+    yarp::os::Network yarp;
+    std::string fixtureName;
+};
+
+#endif //_YarpFixManager_H_

--- a/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
@@ -1,35 +1,29 @@
-# Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
-# Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
-# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+# Copyright: (C) 2016, 2017 iCub Facility - Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 2.8.9)
+project(rtf_fixturemanager_yarpplugin)
 
-# set the project name
-set(PROJECTNAME YarpPluginFixture)
-project(${PROJECTNAME})
+get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
+get_property(YARP_dev_INCLUDE_DIRS TARGET YARP_dev PROPERTY INCLUDE_DIRS)
+get_property(YARP_dev_INCLUDE_DIRS TARGET YARP_rtf PROPERTY INCLUDE_DIRS)
 
-# add the required cmake packages
-find_package(RTF)
-find_package(RTF COMPONENTS DLL)
-find_package(YARP)
+include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
+include_directories(${YARP_OS_INCLUDE_DIRS}
+                    ${YARP_dev_INCLUDE_DIRS}
+                    ${YARP_rtf_INCLUDE_DIRS})
 
-# add include directories
-include_directories(${CMAKE_SOURCE_DIR}
-                    ${RTF_INCLUDE_DIRS}
-                    ${YARP_INCLUDE_DIRS}
-                    ${YARP_HELPERS_INCLUDE_DIR})
+add_library(rtf_fixturemanager_yarpplugin MODULE YarpPluginFixture.h
+                                                 YarpPluginFixture.cpp)
+set_property(TARGET rtf_fixturemanager_yarpplugin PROPERTY PREFIX "")
+set_property(TARGET rtf_fixturemanager_yarpplugin PROPERTY OUTPUT_NAME yarpplugin)
 
-# add required libraries 
-link_libraries(${RTF_LIBRARIES}
-               ${YARP_LIBRARIES})
+target_link_libraries(rtf_fixturemanager_yarpplugin RTF::RTF
+                                                    YARP::YARP_OS
+                                                    YARP::YARP_dev
+                                                    YARP::YARP_rtf)
 
-# add the source codes to build the plugin library
-add_library(${PROJECTNAME} MODULE YarpPluginFixture.h
-                                  YarpPluginFixture.cpp)
-
-# set the installation options
-install(TARGETS ${PROJECTNAME}
-        EXPORT ${PROJECTNAME}
-        COMPONENT runtime
-        LIBRARY DESTINATION lib)
-
+yarp_install(TARGETS rtf_fixturemanager_yarpplugin
+             EXPORT YARP
+             COMPONENT runtime
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rtf)

--- a/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+# Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+cmake_minimum_required(VERSION 2.8.9)
+
+# set the project name
+set(PROJECTNAME YarpPluginFixture)
+project(${PROJECTNAME})
+
+# add the required cmake packages
+find_package(RTF)
+find_package(RTF COMPONENTS DLL)
+find_package(YARP)
+
+# add include directories
+include_directories(${CMAKE_SOURCE_DIR}
+                    ${RTF_INCLUDE_DIRS}
+                    ${YARP_INCLUDE_DIRS}
+                    ${YARP_HELPERS_INCLUDE_DIR})
+
+# add required libraries 
+link_libraries(${RTF_LIBRARIES}
+               ${YARP_LIBRARIES})
+
+# add the source codes to build the plugin library
+add_library(${PROJECTNAME} MODULE YarpPluginFixture.h
+                                  YarpPluginFixture.cpp)
+
+# set the installation options
+install(TARGETS ${PROJECTNAME}
+        EXPORT ${PROJECTNAME}
+        COMPONENT runtime
+        LIBRARY DESTINATION lib)
+

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
@@ -1,0 +1,59 @@
+/*
+*  Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+* Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+* CopyPolicy: Released under the terms of the GNU GPL v2.0.
+*/
+
+#include <cstdio>
+#include <ctime>
+#include <rtf/dll/Plugin.h>
+#include "YarpPluginFixture.h"
+#include <yarp/os/Property.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/dev/Drivers.h>
+
+using namespace std;
+using namespace RTF;
+using namespace yarp::os;
+using namespace yarp::dev;
+
+PREPARE_FIXTURE_PLUGIN(YarpPluginFixture)
+
+bool YarpPluginFixture::setup(int argc, char** argv) {
+    yInfo()<<"YarpPluginFixture: setupping fixture...";
+    // do the setup here
+
+    Property prop;
+    prop.fromCommand(argc, argv, false);
+    if(!prop.check("devices")) {
+        yError()<<"YarpPluginFixture: missing 'devices' param.";
+        return false;
+    }
+    devices = prop.findGroup("devices");
+    if(devices.isNull())
+    {
+        yError()<<"YarpPluginFixture: not found devices parameter";
+        return false;
+    }
+    bool res=true;
+
+    for(int i=1;i<devices.size();i++)
+    {
+        if(Drivers::factory().find(devices.get(i).asString().c_str())==NULL)
+        {
+            yError()<<"Unable to find"<<devices.get(i).asString()<<"amonge the available devices";
+            res=false;
+        }
+    }
+
+    return res;
+}
+
+bool YarpPluginFixture::check() {
+    // in this case check it is not necessary
+    return true;
+}
+
+void YarpPluginFixture::tearDown() {
+    yInfo()<<"YarpPluginFixture: tearing down the fixture...";
+}

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
@@ -7,12 +7,13 @@
 #include <cstdio>
 #include <ctime>
 #include <rtf/dll/Plugin.h>
+#include <rtf/TestAssert.h>
+#include <rtf/yarp/YarpTestCase.h>
 #include "YarpPluginFixture.h"
 #include <yarp/os/Property.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/dev/Drivers.h>
 #include <yarp/os/YarpPlugin.h>
-#include <yarp/os/ResourceFinder.h>
 
 using namespace std;
 using namespace RTF;
@@ -37,10 +38,11 @@ bool YarpPluginFixture::scanPlugins(ConstString name){
 bool YarpPluginFixture::setup(int argc, char** argv) {
     if(argc<=1)
     {
-        yError()<<"Please specify --devices and/or --plugins parameters";
+        //RTF::RTF_FIXTURE_REPORT();
+        RTF_ASSERT_ERROR("YarpPluginFixture: Please specify --devices and/or --plugins parameters");
         return false;
     }
-    yInfo()<<"YarpPluginFixture: setupping fixture...";
+    RTF_FIXTURE_REPORT("YarpPluginFixture: setupping fixture...");
     bool resDev=true, resPlug=true;
     Property prop;
     prop.fromCommand(argc, argv, false);
@@ -49,21 +51,21 @@ bool YarpPluginFixture::setup(int argc, char** argv) {
         devices = prop.findGroup("devices");
         if(devices.isNull())
         {
-            yError()<<"YarpPluginFixture: not found devices parameter";
+            RTF_ASSERT_ERROR("YarpPluginFixture: not found devices parameter");
             resDev=false;
         }
         for(int i=1;i<devices.size();i++)
         {
             if(Drivers::factory().find(devices.get(i).asString().c_str())==NULL)
             {
-                yError()<<"YarpPluginFixture: Unable to find"<<devices.get(i).asString()<<"among the available devices";
+                RTF_ASSERT_ERROR("YarpPluginFixture: Unable to find "+ devices.get(i).asString() +" among the available devices");
                 resDev=false;
             }
         }
     }
     else
     {
-        yWarning()<<"YarpPluginFixture: missing 'devices' param. Probably not required skipping this check. Trying with 'plugins' param...";
+        RTF_FIXTURE_REPORT("YarpPluginFixture: missing 'devices' param. Probably not required skipping this check. Trying with 'plugins' param...");
     }
 
     if(prop.check("plugins"))
@@ -71,20 +73,20 @@ bool YarpPluginFixture::setup(int argc, char** argv) {
         plugins = prop.findGroup("plugins");
         if(plugins.isNull())
         {
-            yError()<<"YarpPluginFixture: not found plugins parameter";
+            RTF_ASSERT_ERROR("YarpPluginFixture: not found plugins parameter");
             resPlug=false;
         }
         for(int i=1;i<plugins.size();i++)
         {
             if(!scanPlugins(plugins.get(i).asString())){
-                yError()<<"YarpPluginFixture: Unable to find"<<plugins.get(i).asString()<<"among the available plugins";
+                RTF_ASSERT_ERROR("YarpPluginFixture: Unable to find "+plugins.get(i).asString()+" among the available plugins");
                 resPlug=false;
             }
         }
     }
     else
     {
-        yWarning()<<"YarpPluginFixture: missing 'plugins' param. Probably not required skipping this check...";
+        RTF_FIXTURE_REPORT("YarpPluginFixture: missing 'plugins' param. Probably not required skipping this check...");
         resPlug=prop.check("devices");
     }
 
@@ -98,5 +100,4 @@ bool YarpPluginFixture::check() {
 }
 
 void YarpPluginFixture::tearDown() {
-    yInfo()<<"YarpPluginFixture: tearing down the fixture...";
 }

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
@@ -1,19 +1,20 @@
 /*
-*  Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
-* Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
-* CopyPolicy: Released under the terms of the GNU GPL v2.0.
-*/
+ * Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Authors: Nicolò Genesio <nicolo.genesio@iit.it>
+ * Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "YarpPluginFixture.h"
 
 #include <cstdio>
 #include <ctime>
 #include <rtf/dll/Plugin.h>
 #include <rtf/TestAssert.h>
-#include <rtf/yarp/YarpTestCase.h>
-#include "YarpPluginFixture.h"
 #include <yarp/os/Property.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/dev/Drivers.h>
 #include <yarp/os/YarpPlugin.h>
+#include <yarp/dev/Drivers.h>
+#include <yarp/rtf/TestCase.h>
 
 using namespace std;
 using namespace RTF;

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -33,6 +33,7 @@ public:
 private:
     yarp::os::Bottle devices;
     yarp::os::Bottle plugins;
+    yarp::os::Bottle carriers;
 };
 
 #endif // YARP_RTF_PLUGINS_YARPPLUGIN_YARPPLUGINFIXTURE_H

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -9,7 +9,20 @@
 #define _YARP_PLUGIN_FIXTURE_H_
 
 #include <rtf/FixtureManager.h>
+#include <rtf/Asserter.h>
 #include <yarp/os/Bottle.h>
+
+// define a helper macro for fixture message reporting
+#define RTF_FIXTURE_REPORT(message)\
+    if(dynamic_cast<RTF::FixtureManager*>(this) == 0) {\
+        RTF_ASSERT_ERROR("RTF_FIXTURE_REPORT is called outside a FixtureManager!"); }\
+    if(dynamic_cast<RTF::TestSuit*>(getDispatcher()) == 0) {\
+        RTF_ASSERT_ERROR("RTF_FIXTURE_REPORT cannot get any TestSuit instance from dispacher!"); }\
+    RTF::Asserter::report(RTF::TestMessage("reports",\
+                                            message,\
+                                            RTF_SOURCEFILE(),\
+                                            RTF_SOURCELINE()),\
+                                            dynamic_cast<RTF::TestSuit*>(getDispatcher()))
 
 class YarpPluginFixture : public RTF::FixtureManager {
 public:

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -29,11 +29,12 @@ public:
     virtual bool setup(int argc, char** argv);
     virtual bool check();
     virtual void tearDown();
-    bool scanPlugins(yarp::os::ConstString name);
 private:
     yarp::os::Bottle devices;
     yarp::os::Bottle plugins;
+    yarp::os::Bottle portmonitors;
     yarp::os::Bottle carriers;
+    bool scanPlugins(yarp::os::ConstString name, yarp::os::ConstString type="");
 };
 
 #endif // YARP_RTF_PLUGINS_YARPPLUGIN_YARPPLUGINFIXTURE_H

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -16,8 +16,10 @@ public:
     virtual bool setup(int argc, char** argv);
     virtual bool check();
     virtual void tearDown();
+    bool scanPlugins(yarp::os::ConstString name);
 private:
     yarp::os::Bottle devices;
+    yarp::os::Bottle plugins;
 };
 
 #endif //_YARP_PLUGIN_FIXTURE_H_

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -1,12 +1,12 @@
 /*
-* Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
-* Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
-* CopyPolicy: Released under the terms of the GNU GPL v2.0.
-*/
+ * Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+ * Authors: Nicolò Genesio <nicolo.genesio@iit.it>
+ * Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
 
 
-#ifndef _YARP_PLUGIN_FIXTURE_H_
-#define _YARP_PLUGIN_FIXTURE_H_
+#ifndef YARP_RTF_PLUGINS_YARPPLUGIN_YARPPLUGINFIXTURE_H
+#define YARP_RTF_PLUGINS_YARPPLUGIN_YARPPLUGINFIXTURE_H
 
 #include <rtf/FixtureManager.h>
 #include <rtf/Asserter.h>
@@ -35,4 +35,4 @@ private:
     yarp::os::Bottle plugins;
 };
 
-#endif //_YARP_PLUGIN_FIXTURE_H_
+#endif // YARP_RTF_PLUGINS_YARPPLUGIN_YARPPLUGINFIXTURE_H

--- a/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/YarpPluginFixture.h
@@ -1,0 +1,23 @@
+/*
+* Copyright: (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+* Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+* CopyPolicy: Released under the terms of the GNU GPL v2.0.
+*/
+
+
+#ifndef _YARP_PLUGIN_FIXTURE_H_
+#define _YARP_PLUGIN_FIXTURE_H_
+
+#include <rtf/FixtureManager.h>
+#include <yarp/os/Bottle.h>
+
+class YarpPluginFixture : public RTF::FixtureManager {
+public:
+    virtual bool setup(int argc, char** argv);
+    virtual bool check();
+    virtual void tearDown();
+private:
+    yarp::os::Bottle devices;
+};
+
+#endif //_YARP_PLUGIN_FIXTURE_H_


### PR DESCRIPTION
* New library `libYARP_rtf` to simplify the creation of unit tests using the [Robot Testing Framework (RTF)](https://github.com/robotology/robot-testing/) and YARP. This is a slightly modified version of the `RTF_YARP_utilities` library in RTF 1.0.
* The `yarpmanager` RTF Fixture Managers was imported from robotology/robot-testing, and allows one to start a fixture using yarpmanager.
* The `yarpplugin` RTF Fixture Managers was imported from robotology/icub-tests (Originally YarpPluginFixture), and allows one to check if a yarp plugin is available.

All these can be enabled with the option `YARP_COMPILE_RTF_ADDONS` and require RTF from `devel` branch
