### PR TITLE
Implement OpenCV C++ API in opencv_grabber device

### DIFF
--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -218,7 +218,8 @@ bool OpenCVGrabber::getImage(ImageOf<PixelRgb> & image) {
 
     // Must have a capture object
     if (!m_cap.isOpened()) {
-        image.zero(); return false;
+        image.zero();
+        return false;
     }
 
     // Grab and retrieve a frame
@@ -232,42 +233,29 @@ bool OpenCVGrabber::getImage(ImageOf<PixelRgb> & image) {
     }
 
     if (frame.empty()) {
-        image.zero(); return false;
-    }
-    
-    if (!m_transpose && !m_flip_x && !m_flip_y)
-    {
-        return sendImage(frame, image);
+        image.zero();
+        return false;
     }
 
-    cv::Mat frame_out;
     if (m_transpose)
     {
-        cv::transpose(frame, frame_out);
-    }
-    else
-    {
-        frame_out = frame;
+        cv::transpose(frame, frame);
     }
 
     if (m_flip_x && m_flip_y)
     {
-        cv::flip(frame, frame_out, -1);
+        cv::flip(frame, frame, -1);
     }
-    else
+    else if (m_flip_x)
     {
-        if (m_flip_x)
-        {
-            cv::flip(frame, frame_out, 0);
-        }
-        else if (m_flip_y)
-        {
-            cv::flip(frame, frame_out, 1);
-        }
+        cv::flip(frame, frame, 0);
     }
-    bool ret = sendImage(frame_out, image);
+    else if (m_flip_y)
+    {
+        cv::flip(frame, frame, 1);
+    }
 
-    return ret;
+    return sendImage(frame, image);
 }
 
 

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -14,12 +14,6 @@
  */
 
 
-// This define prevents Yarp from declaring its own copy of IplImage
-// which OpenCV provides as well. Since Yarp's Image class depends on
-// IplImage, we need to define this, then include the OpenCV headers
-// before Yarp's.
-#define YARP_CVTYPES_H_
-
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -33,14 +27,10 @@
 #include <yarp/sig/Image.h>
 
 #include <stdio.h>
+#include <string.h> // memcpy
 
-#ifdef YARP2_WINDOWS
-#include <cv.h>
-#include <highgui.h>
-#else
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
-#endif
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 
 #include <OpenCVGrabber.h>
 
@@ -66,14 +56,7 @@ using namespace yarp::dev;
 
 #define DBG if (0)
 
-#ifndef CV_CAP_ANY
-#define CV_CAP_ANY (-1)
-#endif
-
 bool OpenCVGrabber::open(Searchable & config) {
-    // Release any previously allocated resources, just in case
-    close();
-
     m_saidSize = false;
     m_saidResize = false;
     m_transpose = false;
@@ -87,8 +70,8 @@ bool OpenCVGrabber::open(Searchable & config) {
     if (fromFile) {
 
         // Try to open a capture object for the file
-        m_capture = (void*)cvCaptureFromAVI(file.c_str());
-        if (0 == m_capture) {
+        m_cap.open(file.c_str());
+        if (!m_cap.isOpened()) {
             yError("Unable to open file '%s' for capture!", file.c_str());
             return false;
         }
@@ -105,14 +88,9 @@ bool OpenCVGrabber::open(Searchable & config) {
                          Value(CV_CAP_ANY), 
                          "if present, read from camera identified by this index").asInt();
 
-        if (camera_idx == -1)
-        {
-            yError() << "You are using an old, deprcated C-API cvCaptureFromCAM. Code should be fixed to use opencv VideoCapture class. In the meanwhile you have to relaunch the grabber with option --camera <id_of_the_camera>";
-        }
-
         // Try to open a capture object for the first camera
-        m_capture = (void*)cvCaptureFromCAM(camera_idx);
-        if (0 == m_capture) {
+        m_cap.open(camera_idx);
+        if (!m_cap.isOpened()) {
             yError("Unable to open camera for capture!");
             return false;
         }
@@ -123,8 +101,7 @@ bool OpenCVGrabber::open(Searchable & config) {
 
         if ( config.check("framerate","if present, specifies desired camera device framerate") ) {
             double m_fps = config.check("framerate", Value(-1)).asDouble();
-            cvSetCaptureProperty((CvCapture*)m_capture,
-                                 CV_CAP_PROP_FPS,m_fps);
+            m_cap.set(CV_CAP_PROP_FPS, m_fps);
         }
 
         if (config.check("flip_x", "if present, flip the image along the x-axis"))         m_flip_x = true;
@@ -138,28 +115,22 @@ bool OpenCVGrabber::open(Searchable & config) {
     if (config.check("width","if present, specifies desired image width")) {
         m_w = config.check("width", Value(-1)).asInt();
         if (!fromFile && m_w>0) {
-            cvSetCaptureProperty((CvCapture*)m_capture,
-                                 CV_CAP_PROP_FRAME_WIDTH, m_w);
+            m_cap.set(CV_CAP_PROP_FRAME_WIDTH, m_w);
         }
     } else {
-        m_w = (int)cvGetCaptureProperty((CvCapture*)m_capture,
-                                        CV_CAP_PROP_FRAME_WIDTH);
+        m_w = (int)m_cap.get(CV_CAP_PROP_FRAME_WIDTH);
     }
 
     if (config.check("height","if present, specifies desired image height")) {
         m_h = config.check("height", Value(-1)).asInt();
         if (!fromFile && m_h>0) {
-            cvSetCaptureProperty((CvCapture*)m_capture,
-                                 CV_CAP_PROP_FRAME_HEIGHT, m_h);
+            m_cap.set(CV_CAP_PROP_FRAME_HEIGHT, m_w);
         }
     } else {
-        m_h = (int)cvGetCaptureProperty((CvCapture*)m_capture,
-                                        CV_CAP_PROP_FRAME_HEIGHT);
+        m_w = (int)m_cap.get(CV_CAP_PROP_FRAME_HEIGHT);
     }
 
-
     // Ignore capture properties - they are unreliable
-    // yDebug("Capture properties: %ld x %ld pixels @ %lf frames/sec.", m_w, m_h, cvGetCaptureProperty(m_capture, CV_CAP_PROP_FPS));
 
     yInfo("OpenCVGrabber opened");
     // Success!
@@ -181,13 +152,10 @@ bool OpenCVGrabber::open(Searchable & config) {
  * the device will be unusable after this function is called.
  */
 bool OpenCVGrabber::close() {
-    // Release the capture object, the pointer should be set null
-    if (0 != m_capture) cvReleaseCapture((CvCapture**)(&m_capture));
-    if (0 != m_capture) {
-        m_capture = 0; return false;
-    } else return true;
+    // Resources will be automatically deinitialized in VideoCapture
+    // destructor
+    return true;
 }
-
 
 
 /**
@@ -201,32 +169,26 @@ bool OpenCVGrabber::close() {
  * returned, the image will be resized to the dimensions used by
  * the grabber, but all pixels will be zeroed.
  */
-bool OpenCVGrabber::sendImage(IplImage* iplFrame, ImageOf<PixelRgb> & image)
+bool OpenCVGrabber::sendImage(const cv::Mat & frame, ImageOf<PixelRgb> & image)
 {
     // Resize the output image, this should not result in new
     // memory allocation if the image is already the correct size
-    image.resize(iplFrame->width, iplFrame->height);
+    image.resize(frame.cols, frame.rows);
 
     if (!m_saidSize) {
         yDebug("Received image of size %dx%d\n", image.width(), image.height());
         m_saidSize = true;
     }
 
-    // Get an IplImage, the Yarp Image owns the memory pointed to
-    IplImage * iplImage = (IplImage*)image.getIplImage();
     // create the timestamp
     m_laststamp.update();
 
-    // Copy the captured image to the output image, flipping it if
-    // the coordinate origin is not the top left
-    if (IPL_ORIGIN_TL == iplFrame->origin)
-        cvCopy(iplFrame, iplImage, 0);
-    else
-        cvFlip(iplFrame, iplImage, 0);
+    // Convert to RGB color space
+    cv::Mat frame_rgb;
+    cv::cvtColor(frame, frame_rgb, cv::COLOR_BGR2RGB);
 
-    if (iplFrame->channelSeq[0] == 'B') {
-        cvCvtColor(iplImage, iplImage, CV_BGR2RGB);
-    }
+    // Copy the captured image to the output image
+    memcpy(image.getRawImage(), frame_rgb.data, sizeof(unsigned char) * frame_rgb.rows * frame_rgb.cols * frame_rgb.channels());
 
     if (m_w <= 0) {
         m_w = image.width();
@@ -246,7 +208,7 @@ bool OpenCVGrabber::sendImage(IplImage* iplFrame, ImageOf<PixelRgb> & image)
         }
     }
 
-    DBG yDebug("%d by %d %s image\n", image.width(), image.height(), iplFrame->channelSeq);
+    DBG yDebug("%d by %d image\n", image.width(), image.height());
 
     return true;
 
@@ -254,62 +216,56 @@ bool OpenCVGrabber::sendImage(IplImage* iplFrame, ImageOf<PixelRgb> & image)
 
 bool OpenCVGrabber::getImage(ImageOf<PixelRgb> & image) {
 
-    //yTrace("-->getImage123");
-
     // Must have a capture object
-    if (0 == m_capture) {
+    if (!m_cap.isOpened()) {
         image.zero(); return false;
     }
 
-    //yTrace("-->HERE1");
-    // Grab and retrieve a frame, OpenCV owns the returned image
-    IplImage * iplFrame = cvQueryFrame((CvCapture*)m_capture);
-    //yTrace("-->HERE2");
+    // Grab and retrieve a frame
+    cv::Mat frame;
+    m_cap.read(frame);
 
-    if (0 == iplFrame && m_loop) {
+    if (frame.empty() && m_loop) {
         bool ok = open(m_config);
         if (!ok) return false;
-        iplFrame = cvQueryFrame((CvCapture*)m_capture);
+        m_cap.read(frame);
     }
 
-    if (0 == iplFrame) {
+    if (frame.empty()) {
         image.zero(); return false;
     }
     
-    if (m_transpose == false && m_flip_x == false && m_flip_y == false)
+    if (!m_transpose && !m_flip_x && !m_flip_y)
     {
-        return sendImage(iplFrame, image);
+        return sendImage(frame, image);
     }
 
-    IplImage * iplFrame_out;
+    cv::Mat frame_out;
     if (m_transpose)
     {
-        iplFrame_out = cvCreateImage(cvSize(iplFrame->height, iplFrame->width), iplFrame->depth, iplFrame->nChannels);
-        cvTranspose(iplFrame, iplFrame_out);
+        cv::transpose(frame, frame_out);
     }
     else
     {
-        iplFrame_out = cvCreateImage(cvSize(iplFrame->width, iplFrame->height), iplFrame->depth, iplFrame->nChannels);
-        cvCopy(iplFrame, iplFrame_out);
+        frame_out = frame;
     }
 
     if (m_flip_x && m_flip_y)
     {
-        cvFlip(iplFrame_out, 0, -1);
+        cv::flip(frame, frame_out, -1);
     }
     else
     {
         if (m_flip_x)
         {
-            cvFlip(iplFrame_out, 0, 0);
+            cv::flip(frame, frame_out, 0);
         }
         else if (m_flip_y)
         {
-            cvFlip(iplFrame_out, 0, 1);
+            cv::flip(frame, frame_out, 1);
         }
     }
-    bool ret = sendImage(iplFrame_out, image);
-    cvReleaseImage(&iplFrame_out);
+    bool ret = sendImage(frame_out, image);
 
     return ret;
 }

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -6,8 +6,8 @@
  */
 
 
-#ifndef OpenCVGrabber_INC
-#define OpenCVGrabber_INC
+#ifndef YARP_OPENCV_GRABBER_DEVICE_OPENCVGRABBER_H
+#define YARP_OPENCV_GRABBER_DEVICE_OPENCVGRABBER_H
 
 /*
  * A Yarp 2 frame grabber device driver using OpenCV to implement
@@ -31,14 +31,7 @@ namespace yarp {
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/PreciselyTimed.h>
 
-#ifdef YARP2_WINDOWS
-#include <cv.h>
-#include <highgui.h>
-#else
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
-#endif
-
+#include <opencv2/highgui/highgui.hpp>
 
 #include <OpenCVGrabber.h>
 
@@ -62,7 +55,7 @@ public:
      *
      */
     OpenCVGrabber() : IFrameGrabberImage(), DeviceDriver(),
-                      m_w(0), m_h(0), m_capture(0) { ; }
+                      m_w(0), m_h(0), m_cap() { ; }
 
     /** Destroy an OpenCV image grabber. */
     virtual ~OpenCVGrabber() { ; }
@@ -74,7 +67,7 @@ public:
     virtual bool close();
 
     virtual bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb> & image);
-    virtual bool sendImage(IplImage* iplFrame, yarp::sig::ImageOf<yarp::sig::PixelRgb> & image);
+    virtual bool sendImage(const cv::Mat & frame, yarp::sig::ImageOf<yarp::sig::PixelRgb> & image);
 
 
     /** Get the height of images a grabber produces.
@@ -89,7 +82,7 @@ public:
     * Implements the IPreciselyTimed interface.
     * @return the yarp::os::Stamp of the last image acquired
     */
-    inline virtual yarp::os::Stamp getLastInputStamp() {return m_laststamp; }
+    inline virtual yarp::os::Stamp getLastInputStamp() { return m_laststamp; }
 
 protected:
 
@@ -98,24 +91,24 @@ protected:
     /** Height of the images a grabber produces. */
     int m_h;
 
-    /** Whether to loop or not */
+    /** Whether to loop or not. */
     bool m_loop;
 
     bool m_saidSize;
     bool m_saidResize;
 
-    /* reading from file or camera */
+    /** Whether reading from file or camera. */
     bool fromFile;
 
-    /** Opaque OpenCV structure for image capture. */
-    void * m_capture;
+    /** OpenCV image capture object. */
+    cv::VideoCapture m_cap;
 
     /* optional image modifiers */
     bool m_transpose;
     bool m_flip_x;
     bool m_flip_y;
 
-    /** Saved copy of the device configuration */
+    /** Saved copy of the device configuration. */
     yarp::os::Property m_config;
 
     yarp::os::Stamp m_laststamp;
@@ -131,4 +124,4 @@ protected:
 */
 
 
-#endif
+#endif // YARP_OPENCV_GRABBER_DEVICE_OPENCVGRABBER_H


### PR DESCRIPTION
This PR was motivated by recent experiments with opencv_grabber on my PC - unfruitful as the device was constantly producing empty ("black") images when acquired through the onboard webcam. Further tests focusing on the data acquisition part (no YARP involved, just a simple main routine) revealed that the webcam actually works with OpenCV, but its interface had to be upgraded to C++. This changeset aims to replace the obsolete C API (see 85ef904). Thanks to @jgvictores for his help in identifying the problem.

Tested on:
* Windows 10, OpenCV 3.2.0 (VS 2015 x32)
* Windows 10, OpenCV 2.3.1 (VS 2015 x32)
* Ubuntu 16.04 x64, OpenCV 3.2.0
* Ubuntu 16.04 x64, OpenCV 2.3.1: compiles successfully, although the camera cannot be opened (neither could it with current C API)

OpenCV 2.3.1 is the minimum required version for the current YARP release according to [this table](http://wiki.icub.org/index.php?title=YARP_Supported_Distributions&oldid=22063#Supported_releases).