### PR TITLE
Add viewIAnalogSensor and IAnalogSensor.h to bindings (yarp.i)

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -442,6 +442,7 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IImpedanceControl.h>
 %include <yarp/dev/IVelocityControl.h>
 %include <yarp/dev/IOpenLoopControl.h>
+%include <yarp/dev/IAnalogSensor.h>
 
 #if !defined(SWIGCHICKEN) && !defined(SWIGALLEGROCL)
   %template(DVector) std::vector<double>;
@@ -768,6 +769,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 
     yarp::dev::IOpenLoopControl *viewIOpenLoopControl() {
             yarp::dev::IOpenLoopControl *result;
+        self->view(result);
+        return result;
+    }
+
+    yarp::dev::IAnalogSensor *viewIAnalogSensor() {
+        yarp::dev::IAnalogSensor *result;
         self->view(result);
         return result;
     }


### PR DESCRIPTION
Here's a small patch to include the `IAnalogSensor` interface in the bindings (via `yarp.i`).

A small working example using `getChannel()` and `read()` is [here](https://github.com/roboticslab-uc3m/teo-body/blob/0ca3b9fb55d868f972ddfa562f6fcca140d844ae/example/python/exampleRemoteJr3.py), tested with:
- One of the four 6 channel ports of a [Jr3 F/T sensor](https://github.com/roboticslab-uc3m/teo-body/tree/0ca3b9fb55d868f972ddfa562f6fcca140d844ae/libraries/BodyYarp/Jr3) device.
- An instance of: `yarpdev --device fakeAnalogSensor --period 20 --name /jr3/ch0:o`
