### PR TITLE
TestFrameGrabberTest: update for testing new functionalities

### DIFF
--- a/src/devices/test_grabber/TestFrameGrabber.cpp
+++ b/src/devices/test_grabber/TestFrameGrabber.cpp
@@ -306,8 +306,8 @@ void TestFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>&
     if (background.width()>0) {
         image.copy(background);
     } else {
-        image.zero();
         image.resize(w,h);
+        image.zero();
     }
     switch (mode) {
     case VOCAB_BALL:


### PR DESCRIPTION
This PR updates the `TestFrameGrabberTest` for testing the new functionalities introduced in `IRgbVisualParams` .
These changes triggers a non-deterministic uninitialised memory valgrind error : 
```
==18615== Thread 7:
==18615== Syscall param write(buf) points to uninitialised byte(s)
==18615== at 0x62DB72D: ??? (/build/eglibc-oGUzwX/eglibc-2.19/io/../sysdeps/unix/syscall-template.S:81)
==18615== by 0x6652D08: ACE::send_n_i(int, void const*, unsigned long, unsigned long*) (in /usr/lib/libACE-6.0.3.so)
==18615== by 0x4EDD17C: yarp::os::impl::SocketTwoWayStream::write(yarp::os::Bytes const&) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4EA2AE3: yarp::os::impl::BufferedConnectionWriter::write(yarp::os::OutputStream&) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4E93B07: yarp::os::AbstractCarrier::write(yarp::os::ConnectionState&, yarp::os::SizedWriter&) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4F75B4A: yarp::os::impl::Protocol::write(yarp::os::SizedWriter&) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4F52A20: yarp::os::impl::PortCoreOutputUnit::sendHelper() (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4F53954: yarp::os::impl::PortCoreOutputUnit::run() (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4FC7A94: theExecutiveBranch(void*) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x5D57C2F: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22)
==18615== by 0x6930183: start_thread (/build/eglibc-oGUzwX/eglibc-2.19/nptl/pthread_create.c:312)
==18615== by 0x62EA37C: clone (/build/eglibc-oGUzwX/eglibc-2.19/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:111)
==18615== Address 0xc2092be is 30 bytes inside a block of size 230,408 alloc'd
==18615== at 0x4C2B800: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18615== by 0x5AAE1A0: iplAllocateImage(_IplImage*, int, int) (in /home/travis/build/robotology/yarp/build/lib/libYARP_sig.so.2.3.69.5)
==18615== by 0x5AA64C4: ImageStorage::_alloc() (in /home/travis/build/robotology/yarp/build/lib/libYARP_sig.so.2.3.69.5)
==18615== by 0x5AA749E: yarp::sig::Image::resize(int, int) (in /home/travis/build/robotology/yarp/build/lib/libYARP_sig.so.2.3.69.5)
==18615== by 0x7EB664D: yarp::dev::TestFrameGrabber::createTestImage(yarp::sig::ImageOfyarp::sig::PixelRgb&) (in /home/travis/build/robotology/yarp/build/lib/yarp/yarp_test_grabber.so)
==18615== by 0x7EB6EC3: yarp::dev::TestFrameGrabber::getImage(yarp::sig::ImageOfyarp::sig::PixelRgb&) (in /home/travis/build/robotology/yarp/build/lib/yarp/yarp_test_grabber.so)
==18615== by 0x55099C5: yarp::dev::DataWriter<yarp::sig::ImageOfyarp::sig::PixelRgb >::run() (in /home/travis/build/robotology/yarp/build/lib/libYARP_dev.so.2.3.69.5)
==18615== by 0x4F7B214: RateThreadCallbackAdapter::run() (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x4FC7A94: theExecutiveBranch(void*) (in /home/travis/build/robotology/yarp/build/lib/libYARP_OS.so.2.3.69.5)
==18615== by 0x5D57C2F: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22)
==18615== by 0x6930183: start_thread (/build/eglibc-oGUzwX/eglibc-2.19/nptl/pthread_create.c:312)
==18615== by 0x62EA37C: clone (/build/eglibc-oGUzwX/eglibc-2.19/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:111)
==18615==
```

Please review code.