### PR TITLE
IControlLimits2Raw inherit publicly from IControlLimitsRaw

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/IControlLimits2.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlLimits2.h
@@ -60,7 +60,7 @@ public:
  * Interface for control devices, commands to get/set position and veloity limits
  * in encoder coordinates
  */
-class yarp::dev::IControlLimits2Raw: yarp::dev::IControlLimitsRaw
+class yarp::dev::IControlLimits2Raw: public yarp::dev::IControlLimitsRaw
 {
 public:
     /**


### PR DESCRIPTION
`IControlLimits2Raw` inherit publicly from `IControlLimitsRaw`, similar to other interfaces; allows b/w compatibility viewing `IControlLimitsRaw`.

Default `private`inheritance looked more like a bug/typo than something really intentional.

