### PR TITLE
[yarprobotinterface] closeDevices reversed order

### DIFF
--- a/src/yarprobotinterface/Robot.cpp
+++ b/src/yarprobotinterface/Robot.cpp
@@ -141,7 +141,7 @@ bool RobotInterface::Robot::Private::openDevices()
 bool RobotInterface::Robot::Private::closeDevices()
 {
     bool ret = true;
-    for (RobotInterface::DeviceList::iterator it = devices.begin(); it != devices.end(); ++it) {
+    for (RobotInterface::DeviceList::reverse_iterator it = devices.rbegin(); it != devices.rend(); ++it) {
         RobotInterface::Device &device = *it;
 
         // yDebug() << device;


### PR DESCRIPTION
It is usually a good practice to free resources in the reverse order of the one used to acquired them.
Probably this code won't affect any devices, but I think it may avoid future issues.

cc @drdanz @randaz81 @traversaro 