### PR TITLE
Fixed missing include in IEncoders.h

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -84,6 +84,7 @@ Bug Fixes
   parser in IVisualParamsImpl.
 * Fixed ControlBoardRemapper not returning an error on malformed axesNames.
 * `IControlLimits2Raw` now inherits publicly from IControlLimitsRaw.
+* Fixed missing include of `yarp/dev/api.h` in `IEncoders.h` (#1127)
 
 #### YARP_math
 

--- a/src/libYARP_dev/include/yarp/dev/IEncoders.h
+++ b/src/libYARP_dev/include/yarp/dev/IEncoders.h
@@ -8,6 +8,7 @@
 #define YARP_DEV_IENCODERS_H
 
 #include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {


### PR DESCRIPTION
If somebody includes only `IEncoders.h` than  `YARP_dev_API` is not defined.


Thanks @claudia-lat