### PR TITLE
RosTypeMsg_bounds_fix

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -103,6 +103,10 @@ Bug Fixes
 
 * Devices are now closed in the reverse order as they are created.
 
+#### yarpidl_rosmsg
+
+* Fixed an out-of-bounds error if an array contained in a ros message has size ==0
+
 ### GUIs
 
 #### yarpmanager

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -313,7 +313,7 @@ bool RosTypeCodeGenYarp::readField(bool bare, const RosField& field) {
                         t.yarpReader.c_str());
                 fprintf(out,"    }\n");
             } else {
-                fprintf(out,"    if (!connection.expectBlock((char*)&%s[0],sizeof(%s)*%s)) return false;\n",
+                fprintf(out,"    if (len > 0 && !connection.expectBlock((char*)&%s[0],sizeof(%s)*%s)) return false;\n",
                         field.rosName.c_str(),
                         t.yarpType.c_str(),
                         len.c_str());


### PR DESCRIPTION
fixes an out-of-bounds error if an array contained in a ros message has size ==0