### PR TITLE
fixes segfault when publishing a ros message including a null vector

### DIFF
--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -449,7 +449,8 @@ bool RosTypeCodeGenYarp::writeField(bool bare, const RosField& field) {
                     fprintf(out,"    connection.appendInt(%s.size());\n",
                             field.rosName.c_str());
                 }
-                fprintf(out,"    connection.appendExternalBlock((char*)&%s[0],sizeof(%s)*%s.size());\n",
+                fprintf(out,"    if (%s.size()>0) {connection.appendExternalBlock((char*)&%s[0],sizeof(%s)*%s.size());}\n",
+                        field.rosName.c_str(), 
                         field.rosName.c_str(),
                         t.yarpType.c_str(),
                         field.rosName.c_str());


### PR DESCRIPTION
fixes segfault when publishing a ros message including a null vector