### PR TITLE
Add overload function of ResourceFinder::setDefaultContext()

### DIFF
--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -39,6 +39,9 @@ Important Changes
 #### YARP_OS
 
 * The `i` command is now enabled only in `Debug` and `DebugFull` builds.
+* The following commands have been marked as _deprecated_ and will be removed in future version of YARP:
+  * in `yarp::os::ResourceFinder`
+    * `bool setContext(const char* contextName)`
 
 #### YARP_dev
 
@@ -122,11 +125,14 @@ New Features
 
 #### YARP_OS
 
-* The following methods were added to the `yarp::os::Publisher` class
+* The following methods were added to the `yarp::os::Publisher` class:
   * `virtual void onRead (T &datum)`
   * `void useCallback (TypedReaderCallback< T > &callback)`
   * `void useCallback()`
   * `void disableCallback()`
+
+* The following overload method is added to the `yarp::os::ResourceFinder` class:
+  * `bool setDefaultContext(const yarp::os::ConstString& contextName)`
 
 #### YARP_dev
 

--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -121,6 +121,18 @@ public:
      */
     bool configure(int argc, char *argv[], bool skipFirstArgument = true);
 
+    /**
+     * Sets the context for the current ResourceFinder object.
+     *
+     * A context is a folder collecting configuration files and data that may be
+     * used to configure modules at runtime.
+     * When the resource finder is configured with a specific contextName,
+     * contexts/<context-name> is added to the search path in which the
+     * initial configuration file and any additional files are sought.
+     *
+     * @param contextName The name of the context
+     * @return true on success, false otherwise
+     */
     bool setDefaultContext(const char *contextName) {
         clearContext();
         return addContext(contextName);

--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -126,14 +126,17 @@ public:
         return addContext(contextName);
     }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
      *
      * Deprecated name for setDefaultContext
      *
+     * @deprecated since YARP 2.3.70
      */
-    bool setContext(const char *contextName) {
+    YARP_DEPRECATED bool setContext(const char *contextName) {
         return setDefaultContext(contextName);
     }
+#endif // YARP_NO_DEPRECATED
 
     /**
      *

--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -139,6 +139,11 @@ public:
     }
 
     /**
+     * Sets the context for the current ResourceFinder object.
+     *
+     * @param contextName The name of the context
+     * @return true on success, false otherwise
+     *
      * @see setDefaultContext(const char *contextName)
      */
     bool setDefaultContext(const yarp::os::ConstString& contextName) {

--- a/src/libYARP_OS/include/yarp/os/ResourceFinder.h
+++ b/src/libYARP_OS/include/yarp/os/ResourceFinder.h
@@ -138,6 +138,13 @@ public:
         return addContext(contextName);
     }
 
+    /**
+     * @see setDefaultContext(const char *contextName)
+     */
+    bool setDefaultContext(const yarp::os::ConstString& contextName) {
+        return setDefaultContext(contextName.c_str());
+    }
+
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
      *

--- a/tests/libYARP_OS/ResourceFinderTest.cpp
+++ b/tests/libYARP_OS/ResourceFinderTest.cpp
@@ -658,6 +658,24 @@ public:
 
         {
             ResourceFinder rf;
+            ConstString contextName = "my_app";
+            rf.setDefaultContext(contextName);
+            rf.setDefaultConfigFile("my_app.ini");
+            rf.configure(0,NULL);
+            checkEqual(rf.find("magic_number").asInt(),1000,"my_app.ini found as default config file");
+        }
+
+        {
+            ResourceFinder rf;
+            ConstString contextName = "my_app";
+            rf.setDefaultContext(contextName.c_str());
+            rf.setDefaultConfigFile("my_app.ini");
+            rf.configure(0,NULL);
+            checkEqual(rf.find("magic_number").asInt(),1000,"my_app.ini found as default config file");
+        }
+
+        {
+            ResourceFinder rf;
             rf.setDefaultContext("shadowtest");
             rf.setDefaultConfigFile("shadow.ini");
             rf.configure(0,NULL);


### PR DESCRIPTION
This PR add an overload function of `ResourceFinder::setDefaultContext()` which now accepts a `yarp::os::ConstString` as input type parameter.

As a plus, this PR adds:

1. `YARP_DEPRECATED` suffix to `ResourceFinder::setContext()` which is documented as deprecated, but wasn't properly appointed in the code;
2. proper **documentation** for each implementation of `ResourceFinder::setDefaultContext()`;
3. **two new test** to cover all the above-mentioned modifications.