### PR TITLE
JoypadControlServer: Fix -Wmismatched-tags warnings

### DIFF
--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
@@ -13,8 +13,8 @@ namespace yarp
     {
         namespace JoypadControl
         {
-            class                       LoopablePort;
-            template <typename T> class JoyPort;
+            struct                       LoopablePort;
+            template <typename T> struct JoyPort;
         }
     }
 }


### PR DESCRIPTION
@aerydna I'm not sure whether you prefer to keep them as `struct`s and therefore change the forward declaration like I did in this path, or if you'd prefer to change them to `class`...