### PR TITLE
Improved Custom positions support for yarpmotorgui

### DIFF
--- a/doc/cmd_yarpmotorgui.dox
+++ b/doc/cmd_yarpmotorgui.dox
@@ -52,15 +52,37 @@ yarpmotorgui --from yarpmotorgui.ini
 By default yarpmotorgui starts using the file yarpmotorgui.ini
 in $ICUB_ROOT/app/default.
 
-An home position can be optionally defined in the supplied file.
-This home position is specified using a group [part_zero] (e.g. [head_zero])
-containing the home position and velocity  that will be commanded when the home
-button is pressed:
+Home positions are obtained directly by the robot as specified in the Calibrator 
+settings of the robot.
+It is nevertheless possible to specify custom configurations which can be executed by the corresponding menu action in the "Custom positions" submenu (present in both the Global Joints commands menu and in the single part Commands menu).
+A (multiple) custom position can be defined in the yarpmotorgui configuration file with the following syntax:
 \code
-[head_zero]
-PositionZero      0.0        0.0      0.0       0.0        0.0        0.0
-VelocityZero     10.0       10.0     10.0      10.0       10.0       10.0
+[customPosition_{CUSTOM_POSITION_NAME}]
+{FULL_ROBOT_PART_NAME}_Position   0             0             0                  0             0             0            
+{FULL_ROBOT_PART_NAME}_Velocity                10            10            10                10            10            10            
 \endcode
+
+where {CUSTOM_POSITION_NAME} is the unique name associated to the custom configuration and
+{FULL_ROBOT_PART_NAME} is the name which fully specifies the robot part, e.g. "/icub/torso".
+Note that both Position and Velocity elements must be present, and the number of joints must match the the number of axes for the part.
+The following is an example of custom configuration
+
+\code
+[customPosition_OnChair]
+/icub/head_Position            0             0             0   	      0	            0  	       0      
+/icub/head_Velocity            10            10            10            10            10         10
+/icub/torso_Position           0             0             0                
+/icub/torso_Velocity           10            10            10             
+/icub/left_arm_Position      -90.00         11.0000       80.00         15.00         0.00          0.00          0.00            
+/icub/left_arm_Velocity       10            10            10            10            10            10            10         
+/icub/right_arm_Position      -90.00         11.0000       80.00         15.00        -0.00          0.00         -0.00            
+/icub/right_arm_Velocity       10            10            10            10            10            10            10         
+/icub/right_leg_Position      84.00         12            0            -87.00         0.00          0         
+/icub/right_leg_Velocity      10            10            10            10            10            10         
+/icub/left_leg_Position            84.00         12            0            -87.00         0.00          0 
+/icub/left_leg_Velocity            10            10            10            10            10            10         
+\endcode
+
 
 A set of calibration parameters can be optionally defined in the
 supplied file. These calibration parameters follow the same standard

--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -202,10 +202,11 @@ New Features
   of robot parts.
 * New button "idle all parts".
 * New button "execute script1/2".
-* New button "goto to custom position1/2".
+* `yarpmotorgui` now enforces the correct "go to home" behaviour:
+  * home is asked to the robot, and, as a consequence, the "Home" button will apply the robot home position as specified by the `Calibrator`, see [this comment in QA#108](https://github.com/robotology/QA/issues/108#issuecomment-214743789)
+  * added possibility to specified custom positions in the configuration file. These positions can be executed by newly introduced "Custom positions" submenus. Syntax is described in the `yarpmotorgui` documentation. [#1160](https://github.com/robotology/yarp/pull/1160)
 * Added CurrentPid tab in yarpmotorgui.
 * Added new control mode widgets to handle current and pwm control modes.
-
 
 #### `yarpmanager`
 

--- a/src/yarpmotorgui/main.cpp
+++ b/src/yarpmotorgui/main.cpp
@@ -65,16 +65,16 @@ int main(int argc, char *argv[])
     bool           ret;
     int            appRet;
     QApplication   a(argc, argv);
-    ResourceFinder finder;
-    Bottle         pParts;
-    QStringList    enabledParts;
-    vector<bool>   enabled;
-    MainWindow     w;
-
+    ResourceFinder &finder = ResourceFinder::getResourceFinderSingleton();
     //retrieve information for the list of parts
     finder.setVerbose();
     finder.setDefaultConfigFile("yarpmotorgui.ini");
     finder.configure(argc, argv);
+    
+    Bottle         pParts;
+    QStringList    enabledParts;
+    vector<bool>   enabled;
+    MainWindow     w;
 
     qRegisterMetaType<Pid>("Pid");
     qRegisterMetaType<SequenceItem>("SequenceItem");

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -24,6 +24,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QFileDialog>
+#include <QShortcut>
 #include <map>
 #include <cstdlib>
 #include <yarp/os/LogStream.h>
@@ -123,15 +124,23 @@ MainWindow::MainWindow(QWidget *parent) :
         //If there are customPositions create a submenu item
         QMenu *customPositionsMenu = globalMenuCommands->addMenu(QIcon(":/home.svg"), "Custom positions");
 
+        unsigned keyIndex = 0;
         for (std::map<std::string, yarp::os::Bottle>::const_iterator it(customPositions.begin()); it != customPositions.end(); ++it) {
+
             QAction *newAction = customPositionsMenu->addAction(("Move all parts to " + it->first).c_str());
             m_customPositionsAllParts.push_back(newAction);
             //
             const yarp::os::Bottle &position = it->second;
 
+            // Adding shortcut (to only the first 9 sequences)
+            if (keyIndex < 9) {
+                QKeySequence shortcut(Qt::CTRL + Qt::META + (Qt::Key_1 + keyIndex++));
+                newAction->setShortcut(shortcut);
+                newAction->setShortcutContext(Qt::ApplicationShortcut);
+            }
+
             //copy position in the lambda
             connect(newAction, &QAction::triggered, this, [this, position]{onHomeAllPartsToCustomPosition(position); });
-
         }
     }
 
@@ -207,12 +216,19 @@ MainWindow::MainWindow(QWidget *parent) :
         //If there are customPositions create a submenu item
         QMenu *customPositionsMenu = m_currentPartMenu->addMenu(QIcon(":/home.svg"), "Custom positions");
 
+        unsigned keyIndex = 0;
         for (std::map<std::string, yarp::os::Bottle>::const_iterator it(customPositions.begin()); it != customPositions.end(); ++it) {
             QAction *newAction = customPositionsMenu->addAction(("Move all joints of this part to " + it->first).c_str());
             m_customPositionsSinglePartToolbar.push_back(newAction);
             //
             const yarp::os::Bottle &position = it->second;
 
+            // Adding shortcut (to only the first 9 sequences)
+            if (keyIndex < 9) {
+                QKeySequence shortcut(Qt::CTRL + Qt::ALT + Qt::META + (Qt::Key_1 + keyIndex++));
+                newAction->setShortcut(shortcut);
+                newAction->setShortcutContext(Qt::ApplicationShortcut);
+            }
             //copy position in the lambda
             connect(newAction, &QAction::triggered, this, [this, position]{onHomeSinglePartToCustomPosition(position); });
             

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include <map>
 #include <cstdlib>
 #include <yarp/os/LogStream.h>
+#include <yarp/os/ResourceFinder.h>
 
 #define TREEMODE_OK     1
 #define TREEMODE_WARN   2
@@ -89,8 +90,51 @@ MainWindow::MainWindow(QWidget *parent) :
     globalMenuCommands->addAction(m_idleAllParts);
     globalMenuCommands->addAction(m_runAllParts);
     globalMenuCommands->addAction(m_homeAllParts);
-    m_customPosition1AllParts = globalMenuCommands->addAction(QIcon(":/home.svg"), "Move all parts to custom position 1");
-    m_customPosition2AllParts = globalMenuCommands->addAction(QIcon(":/home.svg"), "Move all parts to custom position 2");
+    //Looking for custom positions in the config file
+    yarp::os::ResourceFinder &finder = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    //Positions have the following form: "customPosition_{NAME_OF_CUSTOM_POSITION}"
+    //To iterate on all groups, transform the finder into Bottle
+    yarp::os::Bottle ini(finder.toString().c_str());
+
+    std::map<std::string, yarp::os::Bottle> customPositions;
+
+    for (int index = 0; index < ini.size(); ++index) {
+        //Look for groups starting with "customPosition_"
+        yarp::os::Value item = ini.get(index);
+        if (!item.isList()) continue;
+        yarp::os::Bottle *subElement = item.asList();
+        //At least two elements and first should be string
+        if (!subElement
+            || subElement->size() < 2
+            || !subElement->get(0).isString())
+            continue;
+        //get first element
+        std::string key = subElement->get(0).asString();
+        std::string pattern = "customPosition_";
+        size_t subStringPosition = key.find(pattern);
+        if (subStringPosition != 0) continue; //not starting or not found
+
+        std::string customPositionName = key.substr(pattern.size());
+        customPositions.insert(std::map<std::string, yarp::os::Bottle>::value_type(customPositionName, subElement->tail()));
+    }
+
+    m_customPositionsAllParts.reserve(customPositions.size());
+    if (customPositions.size() > 0) {
+        //If there are customPositions create a submenu item
+        QMenu *customPositionsMenu = globalMenuCommands->addMenu(QIcon(":/home.svg"), "Custom positions");
+
+        for (std::map<std::string, yarp::os::Bottle>::const_iterator it(customPositions.begin()); it != customPositions.end(); ++it) {
+            QAction *newAction = customPositionsMenu->addAction(("Move all parts to " + it->first).c_str());
+            m_customPositionsAllParts.push_back(newAction);
+            //
+            const yarp::os::Bottle &position = it->second;
+
+            //copy position in the lambda
+            connect(newAction, &QAction::triggered, this, [this, position]{onHomeAllPartsToCustomPosition(position); });
+
+        }
+    }
+
     globalMenuCommands->addSeparator();
     globalMenuCommands->addAction(m_script1);
     globalMenuCommands->addAction(m_script2);
@@ -111,9 +155,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(m_script1, SIGNAL(triggered()), this, SLOT(onExecuteScript1()));
     connect(m_script2, SIGNAL(triggered()), this, SLOT(onExecuteScript2()));
-
-    connect(m_customPosition1AllParts, &QAction::triggered, this, [this]{onHomeAllPartsToCustomPosition("_customPosition1"); });
-    connect(m_customPosition2AllParts, &QAction::triggered, this, [this]{onHomeAllPartsToCustomPosition("_customPosition2"); });
 
     //addToolBarBreak();
 
@@ -136,8 +177,19 @@ MainWindow::MainWindow(QWidget *parent) :
     m_idleSinglePart = m_partToolBar->addAction(QIcon(":/idle.svg"), "Idle all joints of this part");
     m_calibSinglePart = m_partToolBar->addAction(QIcon(":/images/calibrate.png"), "Calibrate all joints of this part");
     m_homeSinglePart = m_partToolBar->addAction(QIcon(":/home.svg"), "Home all joints of this part");
-    m_customPosition1SinglePart = m_partToolBar->addAction(QIcon(":/home.svg"), "Move all joints of this part to custom position 1");
-    m_customPosition2SinglePart = m_partToolBar->addAction(QIcon(":/home.svg"), "Move all joints of this part to custom position 2");
+
+    m_customPositionsSinglePartToolbar.reserve(customPositions.size());
+    if (customPositions.size() > 0) {
+        for (std::map<std::string, yarp::os::Bottle>::const_iterator it(customPositions.begin()); it != customPositions.end(); ++it) {
+            QAction *newAction = m_partToolBar->addAction(QIcon(":/home.svg"), ("Move all joints of this part to "  + it->first).c_str());
+            m_customPositionsSinglePartToolbar.push_back(newAction);
+            //
+            const yarp::os::Bottle &position = it->second;
+
+            //copy position in the lambda
+            connect(newAction, &QAction::triggered, this, [this, position]{onHomeSinglePartToCustomPosition(position); });
+        }
+    }
 
     addToolBar(m_partToolBar);
 
@@ -149,13 +201,30 @@ MainWindow::MainWindow(QWidget *parent) :
     m_currentPartMenu->addAction(m_homeSinglePart);
     m_currentPartMenu->addAction(m_idleSinglePart);
 
+    m_customPositionsSinglePart.reserve(customPositions.size());
+    if (customPositions.size() > 0) {
+
+        //If there are customPositions create a submenu item
+        QMenu *customPositionsMenu = m_currentPartMenu->addMenu(QIcon(":/home.svg"), "Custom positions");
+
+        for (std::map<std::string, yarp::os::Bottle>::const_iterator it(customPositions.begin()); it != customPositions.end(); ++it) {
+            QAction *newAction = customPositionsMenu->addAction(("Move all joints of this part to " + it->first).c_str());
+            m_customPositionsSinglePartToolbar.push_back(newAction);
+            //
+            const yarp::os::Bottle &position = it->second;
+
+            //copy position in the lambda
+            connect(newAction, &QAction::triggered, this, [this, position]{onHomeSinglePartToCustomPosition(position); });
+            
+        }
+    }
+
+
     connect(openSequenceAction,SIGNAL(triggered()),this,SLOT(onOpenSequenceTab()));
     connect(m_runSinglePart, SIGNAL(triggered()), this, SLOT(onRunSinglePart()));
     connect(m_idleSinglePart, SIGNAL(triggered()), this, SLOT(onIdleSinglePart()));
     connect(m_homeSinglePart, SIGNAL(triggered()), this, SLOT(onHomeSinglePart()));
     connect(m_calibSinglePart, SIGNAL(triggered()), this, SLOT(onCalibSinglePart()));
-    connect(m_customPosition1SinglePart, &QAction::triggered, this, [this]{onHomeSinglePartToCustomPosition("_customPosition1"); });
-    connect(m_customPosition2SinglePart, &QAction::triggered, this, [this]{onHomeSinglePartToCustomPosition("_customPosition2"); });
 
     QMenu *windows = m_ui->menuBar->addMenu("View");
     QAction *viewGlobalToolbar = windows->addAction("Global Commands Toolbar");
@@ -719,7 +788,7 @@ void MainWindow::onHomeAllParts()
     }
 }
 
-void MainWindow::onHomeAllPartsToCustomPosition(std::string suffix)
+void MainWindow::onHomeAllPartsToCustomPosition(const yarp::os::Bottle& positionElement)
 {
     if (QMessageBox::question(this, "Question", "Do you really want to home all parts?") != QMessageBox::Yes){
         return;
@@ -737,12 +806,11 @@ void MainWindow::onHomeAllPartsToCustomPosition(std::string suffix)
         {
             continue;
         }
-
-        bool done = part->homeToCustomPosition(suffix);
+        part->homeToCustomPosition(positionElement);
     }
 }
 
-void MainWindow::onHomeSinglePartToCustomPosition(std::string suffix)
+void MainWindow::onHomeSinglePartToCustomPosition(const yarp::os::Bottle& positionElement)
 {
     if (QMessageBox::question(this, "Question", "Do you really want to home all joints of this part?") != QMessageBox::Yes){
         return;
@@ -758,7 +826,7 @@ void MainWindow::onHomeSinglePartToCustomPosition(std::string suffix)
         return;
     }
 
-    part->homeToCustomPosition(suffix);
+    part->homeToCustomPosition(positionElement);
 }
 
 void MainWindow::onIdleSinglePart()

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -24,6 +24,8 @@
 #include "partitem.h"
 #include "sliderOptions.h"
 
+#include <vector>
+
 namespace Ui {
 class MainWindow;
 }
@@ -72,10 +74,9 @@ private:
     QAction *m_idleAllParts;
     QAction *m_runAllParts;
     QAction *m_homeAllParts;
-    QAction *m_customPosition1AllParts;
-    QAction *m_customPosition2AllParts;
-    QAction *m_customPosition1SinglePart;
-    QAction *m_customPosition2SinglePart;
+    std::vector<QAction *> m_customPositionsAllParts;
+    std::vector<QAction *> m_customPositionsSinglePart;
+    std::vector<QAction *> m_customPositionsSinglePartToolbar;
     QAction *openSequenceAction;
     QAction *m_runSinglePart;
     QAction *m_calibSinglePart;
@@ -107,8 +108,8 @@ private slots:
     void onIdleSinglePart();
     void onHomeSinglePart();
     void onHomeAllParts();
-    void onHomeSinglePartToCustomPosition(std::string suffix);
-    void onHomeAllPartsToCustomPosition(std::string suffix);
+    void onHomeSinglePartToCustomPosition(const yarp::os::Bottle& positionElement);
+    void onHomeAllPartsToCustomPosition(const yarp::os::Bottle& positionElement);
     void onCalibSinglePart();
     void onGoAll();
     void onExecuteScript1();

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -71,7 +71,7 @@ public:
     void idlePart();
     bool homeJoint(int joint);
     bool homePart();
-    bool homeToCustomPosition(std::string suffix);
+    bool homeToCustomPosition(const yarp::os::Bottle& positionElement);
     void calibratePart();
     bool checkAndGo();
     void stopSequence();


### PR DESCRIPTION
Changed custom positions support in the motorgui.
To implement this change I needed to change the .ini syntax regarding the custom positions (which was anyway new and never pushed to master).

The proposed changes have the following impact on the use of the motorgui:
- the number of custom positions is no more hardcoded. This means that it is possible to not specify any custom positions (and no options are shown in the menus) or to add a variable number of positions.
- the custom positions are now named instead of numbered. This simplifies the executions of custom positions if more then one are specified in the ini file.
- Added also the menu option in the single part menubar menu.

For @robotology/codyco-developers this means that it is now possible to have a single ini file with the most often used configurations.

See this screenshots for an example:

<img width="857" alt="screen shot 2017-04-02 at 12 14 16" src="https://cloud.githubusercontent.com/assets/2189180/24586500/d95134c6-17a2-11e7-8f68-aab9dc36fd26.png">

<img width="577" alt="screen shot 2017-04-02 at 12 14 27" src="https://cloud.githubusercontent.com/assets/2189180/24586501/df7b61f0-17a2-11e7-9ad6-fbc9247cf0d0.png">

Updated also release notes and changed the `yarpmotorgui` doxygen documentation section regarding the home position to document the new .ini syntax

cc @randaz81 
cc @DanielePucci @gabrielenava @traversaro  