### PR TITLE
Set and export CMake variables before entering if-guard in YarpInstallationHelpers

### DIFF
--- a/cmake/YarpInstallationHelpers.cmake
+++ b/cmake/YarpInstallationHelpers.cmake
@@ -3,15 +3,8 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 
-## Skip this whole file if it has already been included
-if(COMMAND YARP_CONFIGURE_EXTERNAL_INSTALLATION)
-  return()
-endif()
-
-include(CMakeParseArguments)
+# Needed by yarp_configure_external_installation in caller scope
 include(GNUInstallDirs)
-include(CMakeDependentOption)
-
 
 # Define CMAKE_INSTALL_QMLDIR for installing QML plugins
 if(NOT DEFINED CMAKE_INSTALL_QMLDIR)
@@ -27,6 +20,14 @@ if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_QMLDIR})
 else()
   set(CMAKE_INSTALL_FULL_QMLDIR "${CMAKE_INSTALL_QMLDIR}")
 endif()
+
+## Skip this whole file if it has already been included
+if(COMMAND YARP_CONFIGURE_EXTERNAL_INSTALLATION)
+  return()
+endif()
+
+include(CMakeParseArguments)
+include(CMakeDependentOption)
 
 
 


### PR DESCRIPTION
From the commit description:

> `yarp_configure_external_installation` requires that certain variables are defined on each call (e.g. the ones introduced by [GNUInstallDirs](https://cmake.org/cmake/help/git-master/module/GNUInstallDirs.html)). Keep in mind that CMake macros and functions are visible in the global scope once defined; therefore, one may have included this module in a previous section of the CMake project tree and, as a result, fail to load the entire file due to the presence of the if-guard. If this is the case, and variables like `CMAKE_INSTALL_DATADIR` haven't been set in the cache, `yarp_configure_external_installation` sees empty strings instead and produces absolute paths.

In other words, there is an inconsistency in the expected behaviour of this module. The following lines probably won't yield the desired result if `YarpInstallationHelpers` has been included at an earlier point during the configuration phase (note that other modules call it internally, e.g. `YarpPlugin`):

```cmake
include(YarpInstallationHelpers)
yarp_configure_external_installation(my-context-dir)
yarp_install(FILES file.ini DESTINATION ${MY-CONTEXT-DIR_CONTEXTS_INSTALL_DIR})
```

`MY-CONTEXT-DIR_CONTEXTS_INSTALL_DIR` [resolves](https://github.com/robotology/yarp/blob/cca890b/cmake/YarpInstallationHelpers.cmake#L112) to `/my-context-dir/contexts` if `GNUInstallDirs` wasn't loaded in the same scope.

We've run into this issue at roboticslab-uc3m/openrave-yarp-plugins#20. 