### PR TITLE
Improvements for portability issues and c++11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -145,3 +145,6 @@ notifications:
   - provider: Slack
     incoming_webhook:
       secure: y4pfqod7KJ2iS3k3TbRPSpZ17uNnIPWIWgH79GirKA3xJfIcbvNhB/+mpBbClSXspVaFuPDr19gFj7aBGmoLBhR1DIXAzPDoYonYYpEZdF4=
+
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/cmake/YarpSystemCheck.cmake
+++ b/cmake/YarpSystemCheck.cmake
@@ -127,10 +127,6 @@ else()
   endif()
 endif()
 
-set(YARP_HAVE_SYS_TYPES_H ${HAVE_SYS_TYPES_H})
-set(YARP_HAVE_STDDEF_H ${HAVE_STDDEF_H})
-check_include_file_cxx(cstddef YARP_HAVE_CSTDDEF)
-
 
 #########################################################################
 # Set up compile flags
@@ -222,6 +218,7 @@ else()
     yarp_check_and_append_cxx_compiler_flag(WANTED_WARNING_FLAGS "-Wmicrosoft-exists")
     yarp_check_and_append_cxx_compiler_flag(WANTED_WARNING_FLAGS "-Wstatic-inline-explicit-instantiation")
     yarp_check_and_append_cxx_compiler_flag(WANTED_WARNING_FLAGS "-Wmisleading-indentation")
+    yarp_check_and_append_cxx_compiler_flag(WANTED_WARNING_FLAGS "-Wtautological-compare")
 
     ## Unwanted warning flags ##
     unset(UNWANTED_WARNING_FLAGS)
@@ -352,9 +349,15 @@ endif()
 
 
 #########################################################################
-# Try to locate execinfo.h
-check_include_files(execinfo.h YARP_HAS_EXECINFO)
+# Try to locate some system headers
 
+check_include_files(execinfo.h YARP_HAS_EXECINFO_H)
+check_include_files(sys/wait.h YARP_HAS_SYS_WAIT_H)
+check_include_files(sys/types.h YARP_HAS_SYS_TYPES_H)
+check_include_files(sys/prctl.h YARP_HAS_SYS_PRCTL_H)
+check_include_files(sys/signal.h YARP_HAS_SIGNAL_H)
+check_include_files(sys/signal.h YARP_HAS_SYS_SIGNAL_H)
+check_include_files(netdb.h YARP_HAS_NETDB_H)
 
 #########################################################################
 # Translate the names of some YARP options, for yarp_config_options.h.in

--- a/cmake/template/yarp_conf_numeric.h.in
+++ b/cmake/template/yarp_conf_numeric.h.in
@@ -7,70 +7,27 @@
 #ifndef YARP_CONFIG_NUMERIC_H
 #define YARP_CONFIG_NUMERIC_H
 
-#cmakedefine YARP_HAVE_SYS_TYPES_H
-#cmakedefine YARP_HAVE_STDDEF_H
-#cmakedefine YARP_HAVE_CSTDDEF
+#cmakedefine YARP_HAS_SYS_TYPES_H
 
-
-#ifdef YARP_HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#if defined(YARP_HAS_SYS_TYPES_H)
+# include <sys/types.h>
 #endif
 
-#ifdef YARP_HAVE_CSTDDEF
-#  include <cstddef>
-#elif defined YARP_HAVE_STDDEF_H
-#  include <stddef.h>
-#endif
-
-#ifdef YARP_INT8
-#undef YARP_INT8
-#endif
-
-#ifdef YARP_INT16
-#undef YARP_INT16
-#endif
-
-#ifdef YARP_INT32
-#undef YARP_INT32
-#endif
-
-#ifdef YARP_INT64
-#undef YARP_INT64
-#endif
-
-#ifdef YARP_FLOAT32
-#undef YARP_FLOAT32
-#endif
-
-#ifdef YARP_FLOAT64
-#undef YARP_FLOAT64
-#endif
-
-#ifdef YARP_BIG_ENDIAN
-#undef YARP_BIG_ENDIAN
-#endif
-
-#ifdef YARP_LITTLE_ENDIAN
-#undef YARP_LITTLE_ENDIAN
-#endif
-
-#ifdef YARP_SSIZE_T
-#undef YARP_SSIZE_T
-#endif
+#include <cstddef>
 
 #define YARP_INT8 signed char
-#define YARP_INT16 ${YARP_INT16}
-#define YARP_INT32 ${YARP_INT32}
-#define YARP_INT64 ${YARP_INT64}
-#define YARP_FLOAT32 ${YARP_FLOAT32}
-#define YARP_FLOAT64 ${YARP_FLOAT64}
+#define YARP_INT16 @YARP_INT16@
+#define YARP_INT32 @YARP_INT32@
+#define YARP_INT64 @YARP_INT64@
+#define YARP_FLOAT32 @YARP_FLOAT32@
+#define YARP_FLOAT64 @YARP_FLOAT64@
 
-#define YARP_INT32_FMT "${YARP_INT32_FMT}"
-#define YARP_INT64_FMT "${YARP_INT64_FMT}"
+#define YARP_INT32_FMT "@YARP_INT32_FMT@"
+#define YARP_INT64_FMT "@YARP_INT64_FMT@"
 
 #cmakedefine YARP_BIG_ENDIAN
 #cmakedefine YARP_LITTLE_ENDIAN
 
-#define YARP_SSIZE_T ${YARP_SSIZE_T}
+#define YARP_SSIZE_T @YARP_SSIZE_T@
 
 #endif

--- a/cmake/template/yarp_conf_system.h.in
+++ b/cmake/template/yarp_conf_system.h.in
@@ -31,9 +31,16 @@
 #cmakedefine ACE_ADDR_HAS_LOOPBACK_METHOD
 #cmakedefine ACE_HAS_STRING_HASH
 
-#cmakedefine YARP_HAS_EXECINFO
+#cmakedefine YARP_HAS_EXECINFO_H
+#cmakedefine YARP_HAS_SYS_WAIT_H
+#cmakedefine YARP_HAS_SYS_TYPES_H
+#cmakedefine YARP_HAS_SYS_PRCTL_H
+#cmakedefine YARP_HAS_SIGNAL_H
+#cmakedefine YARP_HAS_SYS_SIGNAL_H
+#cmakedefine YARP_HAS_NETDB_H
 
-#define YARP_POINTER_SIZE ${YARP_POINTER_SIZE}
+
+#define YARP_POINTER_SIZE @YARP_POINTER_SIZE@
 
 
 ///@{

--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -31,17 +31,23 @@ Important Changes
 
 * `YarpInstallationHelpers`
   *  A new command `yarp_configure_plugins_installation` has been introduced to
-     simplify installation of YARP plugins when `yarp_configure_external_installation`
-     is not invoked.
+     simplify installation of YARP plugins when
+     `yarp_configure_external_installation` is not invoked.
 
 ### Libraries
+
+* A lot of refactoring was performed in order to improve c++11 usage and to
+  simplify porting to other platforms without ACE
 
 #### YARP_OS
 
 * The `i` command is now enabled only in `Debug` and `DebugFull` builds.
-* The following commands have been marked as _deprecated_ and will be removed in future version of YARP:
-  * in `yarp::os::ResourceFinder`
-    * `bool setContext(const char* contextName)`
+* The following commands have been marked as _deprecated_ and will be removed in
+  future version of YARP:
+  * `yarp::os::exit()`
+  * `yarp::os::abort()`
+  * `yarp::os::signal()`
+  * `yarp::os::ResourceFinder::setContext(const char* contextName)`
 
 #### YARP_dev
 
@@ -69,8 +75,8 @@ Important Changes
 
 #### `RobotDescriptionClient`
 
-* Added new device `RobotDescriptionClient`. User module can ask a list of registered
-  devices using the iRobotDescription interface.
+* Added new device `RobotDescriptionClient`. User module can ask a list of
+  registered devices using the iRobotDescription interface.
 
 #### `RemoteControlBoard`
 
@@ -105,8 +111,8 @@ Important Changes
 
 #### `ServerGrabber`
 
-* Added new device `ServerGrabber` to handle one or two camera devices in function
-  of the configuration.
+* Added new device `ServerGrabber` to handle one or two camera devices in
+  function of the configuration.
 
 New Features
 ------------
@@ -127,12 +133,14 @@ New Features
 
 #### YARP_OS
 
+* The following methods were added to the `yarp::os` namespace:
+  * `char* yarp::os::getcwd(char *buf, size_t size)`
+  * `int yarp::os::fork(void)`
 * The following methods were added to the `yarp::os::Publisher` class:
   * `virtual void onRead (T &datum)`
   * `void useCallback (TypedReaderCallback< T > &callback)`
   * `void useCallback()`
   * `void disableCallback()`
-
 * The following overload method is added to the `yarp::os::ResourceFinder` class:
   * `bool setDefaultContext(const yarp::os::ConstString& contextName)`
 

--- a/example/ace_check/Semaphore.cpp
+++ b/example/ace_check/Semaphore.cpp
@@ -10,8 +10,8 @@
 Semaphore::Semaphore(int initialCount) {
     implementation = new SemaphoreImpl(initialCount);
     if (implementation==NULL) {
-        ACE_OS::printf("Could not allocate thread, exitting\n");
-        ACE_OS::exit(1);
+        printf("Could not allocate thread, exiting\n");
+        exit(1);
     }
 }
 

--- a/example/ace_check/Thread.cpp
+++ b/example/ace_check/Thread.cpp
@@ -37,8 +37,8 @@ public:
 Thread::Thread() {
     implementation = new ThreadCallbackAdapter(*this);
     if (implementation==NULL) {
-        ACE_OS::printf("Could not allocate thread, exitting\n");
-        ACE_OS::exit(1);
+        printf("Could not allocate thread, exiting\n");
+        exit(1);
     }
 }
 

--- a/example/ace_check/ThreadImpl.cpp
+++ b/example/ace_check/ThreadImpl.cpp
@@ -18,7 +18,7 @@ static unsigned __stdcall theExecutiveBranch (void *args)
     unsigned theExecutiveBranch (void *args)
 #endif
 {
-    ACE_OS::signal(SIGPIPE, SIG_IGN);
+    signal(SIGPIPE, SIG_IGN);
 
     ThreadImpl *thread = (ThreadImpl *)args;
     thread->run();

--- a/example/ace_check/timers/main.cpp
+++ b/example/ace_check/timers/main.cpp
@@ -7,10 +7,10 @@
 
 // Test timing on your system, this affects
 // the precision with which you can schedule
-// periodic thread. It boils down to 
+// periodic thread. It boils down to
 // - how precise are timers
 // - how precise is Sleep()
-// 
+//
 // In general this depends on:
 // - hardware
 // - frequency of the scheduler, in Windows
@@ -19,12 +19,12 @@
 // compile the kernel (default values have been changed
 // from 100Hz, to 1000Hz and now seems back to 250Hz).
 //
-// With scheduler at 1kHz, expected performances 
+// With scheduler at 1kHz, expected performances
 // should around +/- 1-2ms, or better.
-// 
+//
 // March 2008 -- Lorenzo Natale
 
-#include <math.h>
+#include <cmath>
 
 #include <ace/ACE.h>
 #include <ace/High_Res_Timer.h>
@@ -47,7 +47,7 @@ int main()
     ACE_Time_Value sleep;
     ACE_Time_Value elapsed;
     double avErrors[wTimes];
-    
+
     int i,k;
 
     for(i=0;i<wTimes;i++)
@@ -61,9 +61,9 @@ int main()
                 {
                     req=sleepT[k];
                     sleep.msec(sleepT[k]);
-                    
+
                     now1 = ACE_OS::gettimeofday ();
-                    
+
                     //ACE_OS::sleep(sleep);
                     usleep(sleep.sec()*1000000+sleep.usec()-1000);
 

--- a/example/ace_check/timers/precise-test.cpp
+++ b/example/ace_check/timers/precise-test.cpp
@@ -5,14 +5,14 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-// Example code to test timers in Linux (and ACE), 
+// Example code to test timers in Linux (and ACE),
 // run as sudo.
-// 
+//
 // Plug oscilloscope to the parallel port (any data bit),
 // you should see a square wave, compare the length of
 // the "high" level with th measure from the timer.
-// 
-// Test show that gettimeofday() is precise enough to 
+//
+// Test show that gettimeofday() is precise enough to
 // deal with the precision of the scheduler. RTSC
 // seem less precise, but this could be hw dependent.
 // Also RTSC could be more precise with short delays
@@ -24,7 +24,7 @@
 //
 // March 2008 -- Lorenzo Natale
 
-#include <math.h>
+#include <cmath>
 
 #include <ace/ACE.h>
 #include <sys/time.h>
@@ -40,7 +40,7 @@
 
 //this is the clock of your cpu, check /proc/cpuinfo
 const int SLEEP=40;
-#define CLOCK_TICKS 1663 
+#define CLOCK_TICKS 1663
 #define PARALLEL_PORT 0x378
 
 int main()
@@ -52,11 +52,11 @@ int main()
     if (ioperm(base, 1, 1))
         {
             fprintf(stderr, "Could not get the port at %x\n", base);
-            
+
         }
     ACE_hrtime_t usecs;
     ACE_Time_Value sleep;
-    
+
     int i;
     for(i=0;i<times;i++)
         {
@@ -73,7 +73,7 @@ int main()
 
             // RTSC(stop);
             outb(0x0, base);
-                        
+
             gettimeofday(&tv2,0);
 
             // wait some time

--- a/example/carrier/carrier_human.cpp
+++ b/example/carrier/carrier_human.cpp
@@ -329,7 +329,7 @@ int main(int argc, char *argv[]) {
         yInfo() << "Please run in two terminals as:\n";
         yInfo() << "  carrier_human --server\n";
         yInfo() << "  carrier_human --client\n";
-        yarp::os::exit(1);
+        std::exit(1);
     }
 
     std::string mode = argv[1];

--- a/example/dev/audio_test.cpp
+++ b/example/dev/audio_test.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <yarp/os/all.h>
 

--- a/example/game/game_client/main.cpp
+++ b/example/game/game_client/main.cpp
@@ -72,10 +72,10 @@ public:
         printf("Connecting...\n");
 
         Logger::get().setVerbosity(-1);
-    
+
         // we'll be sending messages to the game (and getting responses)
         Network::connect(p.getName(),"/game");
-    
+
         // there are occasional messages broadcast from the game to us
         Network::connect("/game",p.getName(),"mcast");
 
@@ -99,9 +99,9 @@ public:
                 prep = prep + "*";
             }
         }
-        cprintf("%s\n%s\n%s\n", 
+        cprintf("%s\n%s\n%s\n",
                 pad("").c_str(),
-                pad(prep).c_str(), 
+                pad(prep).c_str(),
                 pad(broadcast).c_str());
         broadcastMutex.post();
         int i;
@@ -118,8 +118,8 @@ public:
                 char buf[256];
                 ConstString playerName = player->get(0).asString();
                 if (strlen(playerName.c_str())<40) {
-                    ACE_OS::sprintf(buf,"PLAYER %s is at (%d,%d) with lifeforce %d", 
-                                    playerName.c_str(), 
+                    sprintf(buf,"PLAYER %s is at (%d,%d) with lifeforce %d",
+                                    playerName.c_str(),
                                     location.get(1).asInt(),
                                     location.get(2).asInt(),
                                     life.asInt());
@@ -130,7 +130,7 @@ public:
         for (int j=players.size(); j<=5; j++) {
             cprintf("%s\n", pad(String("")).c_str());
         }
-    
+
         gotoxy(xx,yy);
         mutex.post();
     }
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
     signal(SIGTERM,stop);
     signal(SIGPIPE,stop);
 #endif
-  
+
     mainloop();
 
     return 0;

--- a/example/game/game_server/Thing.h
+++ b/example/game/game_server/Thing.h
@@ -7,7 +7,7 @@
 #ifndef THING_H
 #define THING_H
 
-#include <math.h>
+#include <cmath>
 #include <string.h>
 
 #include <ace/OS.h>
@@ -30,7 +30,7 @@ public:
     static Thing NOTHING;
 
     void set(ID n_x, ID n_y, ID n_id = -1);
-  
+
     void setID(ID n_id) { id = n_id; }
 
 
@@ -46,20 +46,20 @@ public:
     void applyMove();
 
     bool isAlive() {
-        return lifetime != 0; 
+        return lifetime != 0;
     }
 
     bool isBullet() {
         return lifetime >=0;
     }
-  
+
     void setLifetime (int lt) {
         lifetime = lt;
     }
- 
+
     void update() {
 
-        if( lifetime > 0) { 
+        if( lifetime > 0) {
             lifetime--;
         }
         applyMove();
@@ -67,7 +67,7 @@ public:
     }
 
 
-    void setName(const char *txt) { 
+    void setName(const char *txt) {
         ACE_OS::strncpy(name,txt,sizeof(name));
         for (unsigned int i=0; i<ACE_OS::strlen(name); i++) {
             char ch = name[i];

--- a/example/matrix/gsl_example.cpp
+++ b/example/matrix/gsl_example.cpp
@@ -13,7 +13,7 @@
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_blas.h>
 
-//#include <gsl/gsl_math.h>
+//#include <gsl/gsl_cmath>
 //#include <gsl/gsl_chebyshev.h>
 
 #include <yarp/sig/Matrix.h>
@@ -29,7 +29,7 @@ int main(int argc, const char **argv)
     v2=1;
 
     double r;
-    gsl_blas_ddot((gsl_vector *)(v1.getGslVector()), 
+    gsl_blas_ddot((gsl_vector *)(v1.getGslVector()),
                   (gsl_vector *)(v2.getGslVector()), &r);
 
     printf("Res vector: %lf\n", r);
@@ -49,15 +49,15 @@ int main(int argc, const char **argv)
     //gsl_matrix_view A2 = gsl_matrix_view_array(m2.data(), 3, 2);
     //gsl_matrix_view A3 = gsl_matrix_view_array(m3.data(), 2, 2);
 
-    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 
-        1.0, 
-        (const gsl_matrix *) m1.getGslMatrix(), 
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans,
+        1.0,
+        (const gsl_matrix *) m1.getGslMatrix(),
         (const gsl_matrix *) m2.getGslMatrix(),
-        0.0, 
+        0.0,
         (gsl_matrix *) m3.getGslMatrix());
 
     printf("Result: (%s)", m3.toString().c_str());
 
-    return 0; 
+    return 0;
 }
 

--- a/example/portmonitor/ascii_image/AsciiImage.cpp
+++ b/example/portmonitor/ascii_image/AsciiImage.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include <yarp/sig/Image.h>
 #include "AsciiImage.h"
@@ -20,7 +20,7 @@ static char available[] = {' ', '`', '.', '~', '+', 'I', 'X', 'O', '8', '%', 'W'
 
 bool AsciiImageMonitorObject::create(const yarp::os::Property& options)
 {
-   printf("created!\n"); 
+   printf("created!\n");
    return true;
 }
 
@@ -29,7 +29,7 @@ void AsciiImageMonitorObject::destroy(void)
     printf("destroyed!\n");
 }
 
-bool AsciiImageMonitorObject::setparam(const yarp::os::Property& params) 
+bool AsciiImageMonitorObject::setparam(const yarp::os::Property& params)
 {
     return false;
 }
@@ -40,7 +40,7 @@ bool AsciiImageMonitorObject::getparam(yarp::os::Property& params)
 }
 
 bool AsciiImageMonitorObject::accept(yarp::os::Things& thing)
-{   
+{
     ImageOf<PixelRgb>* img = thing.cast_as< ImageOf<PixelRgb> >();
     if(img == NULL) {
         printf("AsciiImageMonitorObject: expected type ImageOf<PixelRgb> but got wrong data type!\n");

--- a/example/profiling/port_latency.cpp
+++ b/example/profiling/port_latency.cpp
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <yarp/os/all.h>
 
-#include <math.h>
+#include <cmath>
 
 #include <stdlib.h>
 #include <time.h>
@@ -15,13 +15,13 @@
 using namespace yarp::os;
 
 // Port latency, basic test.
-// Send a sequence of message to a port. Test the 
+// Send a sequence of message to a port. Test the
 // time it takes for the message to be received.
 // Compute average.
 //
 // Time only makes sense if server and client run
 // on the same machine.
-// 
+//
 // Lorenzo Natale May 2008
 //
 // Added paralell port code August 2008.
@@ -83,7 +83,7 @@ public:
 
     double inline get()
     { return datum; }
-    
+
     void inline set(double v)
     {  datum=v; }
 
@@ -107,7 +107,7 @@ public:
             unsigned int rnd=rand();
             payload[k]=rnd; //paranoid
         }
-        
+
     }
 
     unsigned int getPayloadSize()
@@ -245,7 +245,7 @@ public:
     {
         port.close();
     }
-}; 
+};
 
 int server(double server_wait, const std::string &name, unsigned int payload)
 {
@@ -282,7 +282,7 @@ int client(int nframes, std::string &name)
     portName="/profiling/client/";
     portName+=name;
     portName+="/port:o";
-    
+
     reader.outPort.open(portName.c_str());
 
     while( (reader.count<nframes) || forever)
@@ -307,7 +307,7 @@ int client(int nframes, std::string &name)
 
     stdLatency=sqrt(stdLatency);
 
-    fprintf(stderr, "Received: %d average latency %.3lf +/- %.5lf [ms]\n", 
+    fprintf(stderr, "Received: %d average latency %.3lf +/- %.5lf [ms]\n",
             reader.count, averageLatency, stdLatency);
     return 0;
 }

--- a/src/carriers/bayer_carrier/BayerCarrier.cpp
+++ b/src/carriers/bayer_carrier/BayerCarrier.cpp
@@ -8,8 +8,8 @@
 #include "BayerCarrier.h"
 
 #include <yarp/sig/ImageDraw.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 #ifndef USE_LIBDC1394
 extern "C" {
@@ -23,7 +23,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 // can't seem to do ipl/opencv/yarp style end-of-row padding
-void setDcImage(yarp::sig::Image& yimg, dc1394video_frame_t *dc, 
+void setDcImage(yarp::sig::Image& yimg, dc1394video_frame_t *dc,
                 int filter) {
     if (!dc) return;
     dc->image = (unsigned char *) yimg.getRawImage();

--- a/src/carriers/human_carrier/HumanStream.cpp
+++ b/src/carriers/human_carrier/HumanStream.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <string.h>
+#include <cstring>
 #include "HumanStream.h"
 
 YARP_SSIZE_T HumanStream::read(const Bytes& b) {

--- a/src/carriers/human_carrier/HumanStream.h
+++ b/src/carriers/human_carrier/HumanStream.h
@@ -5,12 +5,12 @@
  *
  */
 
-#include <stdio.h>
 #include <yarp/os/all.h>
 #include <yarp/os/Carrier.h>
 
 #include <iostream>
 #include <string>
+#include <cstdio>
 
 using namespace yarp::os;
 

--- a/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
@@ -6,7 +6,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 
 /*
@@ -14,7 +14,7 @@
   unconditionally defining INT32 to be "long".  This needs to
   be worked around.  Work around begins...
  */
-#ifdef WIN32
+#if defined(_WIN32)
 #define INT32 long  // jpeg's definition
 #define QGLOBAL_H 1
 #endif
@@ -32,7 +32,7 @@ extern "C" {
 #pragma warning (pop)
 #endif
 
-#ifdef WIN32
+#if defined(_WIN32)
 #undef INT32
 #undef QGLOBAL_H
 #endif

--- a/src/carriers/mjpeg_carrier/MjpegCarrier.h
+++ b/src/carriers/mjpeg_carrier/MjpegCarrier.h
@@ -12,7 +12,7 @@
 #include <yarp/os/NetType.h>
 #include "MjpegStream.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace yarp {
     namespace os {

--- a/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
@@ -5,9 +5,15 @@
  *
  */
 
-#include <stdio.h>
+#include "MjpegDecompression.h"
 
-#ifdef WIN32
+#include <yarp/os/Log.h>
+#include <yarp/sig/Image.h>
+
+#include <csetjmp>
+#include <cstdio>
+
+#if defined(_WIN32)
 #define INT32 long  // jpeg's definition
 #define QGLOBAL_H 1
 #endif
@@ -25,16 +31,11 @@ extern "C" {
 #pragma warning (pop)
 #endif
 
-#ifdef WIN32
+#if defined(_WIN32)
 #undef INT32
 #undef QGLOBAL_H
 #endif
 
-#include <setjmp.h>
-
-#include <yarp/os/Log.h>
-#include <yarp/sig/Image.h>
-#include "MjpegDecompression.h"
 
 using namespace yarp::os;
 using namespace yarp::sig;
@@ -206,7 +207,7 @@ MjpegDecompression::~MjpegDecompression() {
 }
 
 
-bool MjpegDecompression::decompress(const yarp::os::Bytes& data, 
+bool MjpegDecompression::decompress(const yarp::os::Bytes& data,
                                     yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) {
     MjpegDecompressionHelper& helper = HELPER(system_resource);
     return helper.decompress(data, image);

--- a/src/carriers/mjpeg_carrier/MjpegStream.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegStream.cpp
@@ -5,14 +5,15 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
 #include "MjpegStream.h"
 #include "MjpegDecompression.h"
 
 #include <yarp/os/Log.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/ImageNetworkHeader.h>
+
+#include <cstdio>
+#include <cstring>
 
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/carriers/mpi_carrier/include/yarp/os/MpiBcastStream.h
+++ b/src/carriers/mpi_carrier/include/yarp/os/MpiBcastStream.h
@@ -9,7 +9,7 @@
 #define YARP_MPIBCASTSTREAM
 
 #include <yarp/os/MpiStream.h>
-#include <string.h>
+#include <cstring>
 
 #define CMD_JOIN -1
 #define CMD_DISCONNECT -2

--- a/src/carriers/mpi_carrier/src/MpiBcastCarrier.cpp
+++ b/src/carriers/mpi_carrier/src/MpiBcastCarrier.cpp
@@ -86,7 +86,7 @@ ElectionOf<yarp::os::PeerRecord<MpiBcastCarrier> >& MpiBcastCarrier::getCaster()
         yarp::os::NetworkBase::unlock();
         if (caster==NULL) {
             yError("No memory for MpiBcastCarrier::caster");
-            exit(1);
+            std::exit(1);
         }
     } else {
         yarp::os::NetworkBase::unlock();

--- a/src/carriers/mpi_carrier/src/MpiComm.cpp
+++ b/src/carriers/mpi_carrier/src/MpiComm.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/NetType.h>
 #include <mpi.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 
 using namespace yarp::os;

--- a/src/carriers/priority_carrier/PriorityCarrier.h
+++ b/src/carriers/priority_carrier/PriorityCarrier.h
@@ -8,7 +8,7 @@
 #ifndef PRIORITYCARRIER_INC
 #define PRIORITYCARRIER_INC
 
-#include <math.h>
+#include <cmath>
 #include <yarp/os/ModifyingCarrier.h>
 #include <yarp/os/Election.h>
 #include <yarp/os/NullConnectionReader.h>
@@ -45,12 +45,12 @@ public:
     virtual ~PriorityGroup() {}
     virtual bool acceptIncomingData(yarp::os::ConnectionReader& reader,
                                     PriorityCarrier *source);
-    bool recalculate(double t); 
+    bool recalculate(double t);
 
 public:
-    yarp::sig::Matrix InvA;         // the inverse of matrix (I-A) in the equation y(t) = [(I-A)^(-1) * B] .*x(t) 
+    yarp::sig::Matrix InvA;         // the inverse of matrix (I-A) in the equation y(t) = [(I-A)^(-1) * B] .*x(t)
     yarp::sig::Matrix B;            // matrix of biases B in the equation y(t) = [(I-A)^(-1) * B] .*x(t)
-    yarp::sig::Matrix Y;            // matrix y(t) 
+    yarp::sig::Matrix Y;            // matrix y(t)
     yarp::sig::Matrix X;            // matrix x(t)
     //yarp::os::Semaphore semDebug;   // this semaphor is used only when debug mode is active
                                     // to control the access to matrices from debug thread

--- a/src/carriers/tcpros_carrier/RosHeader.cpp
+++ b/src/carriers/tcpros_carrier/RosHeader.cpp
@@ -7,8 +7,8 @@
 
 #include "RosHeader.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <yarp/os/Bytes.h>
 #include <yarp/os/NetType.h>
 

--- a/src/carriers/tcpros_carrier/RosLookup.cpp
+++ b/src/carriers/tcpros_carrier/RosLookup.cpp
@@ -7,7 +7,7 @@
 
 #include "RosLookup.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace yarp::os;
 
@@ -100,7 +100,7 @@ bool RosLookup::lookupTopic(const ConstString& name) {
     portnum = portnum2.asInt();
     protocol = "tcpros";
     if (verbose) {
-        printf("topic %s available at %s:%d\n", name.c_str(), 
+        printf("topic %s available at %s:%d\n", name.c_str(),
                hostname.c_str(), portnum);
     }
     return true;

--- a/src/carriers/tcpros_carrier/RosLookup.h
+++ b/src/carriers/tcpros_carrier/RosLookup.h
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/all.h>
 
 #include <tcpros_carrier_api.h>

--- a/src/carriers/tcpros_carrier/TcpRosStream.cpp
+++ b/src/carriers/tcpros_carrier/TcpRosStream.cpp
@@ -7,9 +7,9 @@
 
 #include "TcpRosStream.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 #include <yarp/os/NetType.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Bottle.h>

--- a/src/carriers/tcpros_carrier/yarpros.cpp
+++ b/src/carriers/tcpros_carrier/yarpros.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/all.h>
 #include "RosSlave.h"
 #include "RosLookup.h"

--- a/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
+++ b/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
@@ -4,9 +4,9 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
+#include <cstdio>
+#include <cstring>
+#include <cmath>
 #include <algorithm>
 #include <yarp/sig/Image.h>
 #include <yarp/os/LogStream.h>

--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
@@ -3,7 +3,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *
  */
- 
+
  /*
  * Yarp Driver for Dynamixel AX-12, controlled using USB to Dynamixel Adapter
  * The default IDs for the motors are for Kaspar robot. As different robots would have different settings,
@@ -12,10 +12,10 @@
  * SENSORINDEX 16 101 116 132 102 117 133 103 118 134 107 119 135 106 104 105 108
  * This needs to be done by running configure(), before opening the device
  *
- * As it is using libftdi library, it is not possible to identify a device by specifying the serial port number, such as 
+ * As it is using libftdi library, it is not possible to identify a device by specifying the serial port number, such as
  * /dev/ttyUSB0
- * Instead, this driver requires precise information of the ftdi device, such as the dynamixel usb manufacture id, serial number, etc. See class FtdiDeviceSettings for details. 
- * 
+ * Instead, this driver requires precise information of the ftdi device, such as the dynamixel usb manufacture id, serial number, etc. See class FtdiDeviceSettings for details.
+ *
  * The motor does not support Torque control, but provide torque feedback. Therefore, several functions
  * have been implemented for such purpose, though not very rigorous.
  *
@@ -32,20 +32,20 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 
-#include <ace/OS_NS_stdio.h>
+#include <ace/OS_NS_cstdio>
 #include <ace/Vector_T.h>
 
-#include <stdio.h> 
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <cmath>
-#include <string.h>
+#include <cstring>
 #include <ftdi.h>
 //#include <libftdi/ftdi.h>
 #include <usb.h>
 #include <iostream>
 #include <ace/DEV_Connector.h>
 #include <ace/TTY_IO.h>
-#include <ace/OS_NS_stdio.h>
+#include <ace/OS_NS_cstdio>
 #include <yarp/os/Time.h>
 
 #include <yarp/os/Semaphore.h>
@@ -172,7 +172,7 @@ public:
 
     /** Open device
         Opens and configures the device.
-      
+
         @param config Config file containing string pairs for parameters
         @return true on success
      */
@@ -180,14 +180,14 @@ public:
 
     /** Close device
         Closes the device and shuts down connection.
-      
+
         @return true on success
      */
     virtual bool close(void);
 
     /** Configure device online
         Configures parts of the device that can be configures online.
-      
+
         @param config Config file containing string pairs for parameters
         @return true on success
      */
@@ -197,7 +197,7 @@ public:
         Send an instruction to a device of given ID. The instruction has to be a byte arry containing
         the AX12 instruction code beginning with the instruction, the address and the parameters.
         Header and checksum are written automatically.
-      
+
         @param id The hex id of the device to be contacted
         @param inst Byte array containing the instruction body (instruction, address, parameters)
         @return The content of the return packet of the device
@@ -206,7 +206,7 @@ public:
 
     /** Read parameter from motor
         Requests the value of a parameter from motor.
-      
+
         @param id The id of the device to be contacted
         @param param encodes address in control table and size of parameter (2 Bytes => address + 100, 1 byte => address)
         @return value if read successful or -1

--- a/src/devices/SDLJoypad/SDLJoypad.cpp
+++ b/src/devices/SDLJoypad/SDLJoypad.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "SDLJoypad.h"
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/LogStream.h>
 
 

--- a/src/devices/SerialServoBoard/SerialServoBoard.cpp
+++ b/src/devices/SerialServoBoard/SerialServoBoard.cpp
@@ -12,8 +12,8 @@
 
 #include <yarp/dev/SerialInterfaces.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 
 //TODO: check limits of operation (range of angles)?

--- a/src/devices/SerialServoBoard/SerialServoBoard.h
+++ b/src/devices/SerialServoBoard/SerialServoBoard.h
@@ -9,9 +9,9 @@
 
 #include <yarp/dev/SerialInterfaces.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define round(x) ((x)>=0?(int)((x)+0.5):(int)((x)-0.5))
 #define FABS(x) (x>=0?x:-x)
@@ -125,12 +125,12 @@ public:
         dd.open(conf);
         if (!dd.isValid()) {
             printf("Failed to create and configure a device\n");
-            exit(1);
+            std::exit(1);
         }
 
         if (!dd.view(serial)) {
             printf("Failed to view device through IGPUDevice interface\n");
-            exit(1);
+            std::exit(1);
         }
 
 

--- a/src/devices/cuda/CUDADeviceDriver.cpp
+++ b/src/devices/cuda/CUDADeviceDriver.cpp
@@ -3,8 +3,8 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <GL/glew.h>
 #include <GL/gl.h>

--- a/src/devices/depthCamera/depthCameraDriver.cpp
+++ b/src/devices/depthCamera/depthCameraDriver.cpp
@@ -1,4 +1,4 @@
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include <yarp/os/Value.h>
 
@@ -412,10 +412,10 @@ bool depthCameraDriver::setParams(const Bottle& settings, const Bottle& descript
         bool mirrorOk;
         Value& v = m_cameraDescription->depthMirroring.val[0];
         mirrorOk = false;
-        
+
         if(!v.isBool() )
             settingErrorMsg("Param " + m_cameraDescription->depthMirroring.name + " is not a bool as it should be.", ret);
-        
+
         for (int t = 0; t < 5; t++)
         {
             yarp::os::Time::delay(0.5);
@@ -509,7 +509,7 @@ bool depthCameraDriver::parseIntrinsic(const Searchable& config, const string& g
 bool depthCameraDriver::open(Searchable& config)
 {
     bool ret = true;
-    
+
     if(!config.check("SETTINGS"))
     {
         yError() << "depthCameraDriver: missing SETTINGS section on the configuration file";
@@ -634,7 +634,7 @@ int depthCameraDriver::getRgbHeight()
 }
 
 int depthCameraDriver::getRgbWidth()
-{    
+{
     if(m_cameraDescription->rgbRes.isDescription)
     {
         return m_cameraDescription->rgbRes.val.at(0).asInt();

--- a/src/devices/dimax_u2c/DimaxU2C.cpp
+++ b/src/devices/dimax_u2c/DimaxU2C.cpp
@@ -4,7 +4,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/all.h>
 #include <yarp/sig/all.h>
 
@@ -20,7 +20,7 @@ DimaxU2C::DimaxU2C():
     //printf("Construct Servo object\n");
     servos = new Servo();
     if (!servos) {
-        ACE_OS::fprintf(stderr,"DimaxU2C: Failed to create a Servo object\n");
+        fprintf(stderr,"DimaxU2C: Failed to create a Servo object\n");
     }
 }
 
@@ -67,7 +67,7 @@ bool DimaxU2C::open(yarp::os::Searchable& config) {
         servos->init();
         return true;
     } else {
-        ACE_OS::fprintf(stderr,"DimaxU2C: No Servo object created\n");
+        fprintf(stderr,"DimaxU2C: No Servo object created\n");
         return false;
     }
     return true;

--- a/src/devices/dimax_u2c/i2cbridge.h
+++ b/src/devices/dimax_u2c/i2cbridge.h
@@ -35,7 +35,7 @@ typedef void*       HANDLE;
 #define INVALID_HANDLE_VALUE ((HANDLE)(-1))
 #endif
 
-#ifdef WIN32
+#if defined(_WIN32)
 //#include <windows.h>
 //#include <winbase.inl>
 //#include <windef.h>

--- a/src/devices/fakeLaser/fakeLaser.cpp
+++ b/src/devices/fakeLaser/fakeLaser.cpp
@@ -3,18 +3,20 @@
 * Author: Marco Randazzo <marco.randazzo@iit.it>
 * CopyPolicy: Released under the terms of the GPLv2 or later, see GPL.TXT
 */
- 
-#include <fakeLaser.h>
+
+#define _USE_MATH_DEFINES
+
+#include "fakeLaser.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
 #include <iostream>
-#include <string.h>
-#include <stdlib.h>
 #include <limits>
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <cstring>
+#include <cstdlib>
+#include <cmath>
 
 //#define LASER_DEBUG
 #ifndef DEG2RAD
@@ -49,7 +51,7 @@ bool FakeLaser::open(yarp::os::Searchable& config)
 
     sensorsNum = (int)((max_angle-min_angle)/resolution);
     laser_data.resize(sensorsNum);
-    
+
     yInfo("Starting debug mode");
     yInfo("max_dist %f, min_dist %f", max_distance, min_distance);
     yInfo("max_angle %f, min_angle %f", max_angle, min_angle);
@@ -171,7 +173,7 @@ bool FakeLaser::getDeviceStatus(Device_status &status)
     mutex.wait();
     status = device_status;
     mutex.post();
-    return true; 
+    return true;
 }
 
 bool FakeLaser::threadInit()
@@ -179,7 +181,7 @@ bool FakeLaser::threadInit()
 #ifdef LASER_DEBUG
     yDebug("FakeLaser:: thread initialising...\n");
     yDebug("... done!\n");
-#endif 
+#endif
 
     return true;
 }
@@ -191,7 +193,7 @@ void FakeLaser::run()
     double t      = yarp::os::Time::now();
     static double t_orig = yarp::os::Time::now();
     double size = (t - (t_orig));
-    
+
     static int test_count = 0;
     static int test = 0;
 

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/LogStream.h>
@@ -28,7 +28,7 @@ using namespace yarp::os::impl;
 void FakeMotionControl::run() {
     if (lifetime>=0) {
         Time::delay(lifetime);
-        yarp::os::exit(0);
+        std::exit(0);
     }
 }
 

--- a/src/devices/fakebot/FakeBot.cpp
+++ b/src/devices/fakebot/FakeBot.cpp
@@ -164,7 +164,7 @@ bool FakeBot::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) {
 void FakeBot::run() {
     if (lifetime>=0) {
         Time::delay(lifetime);
-        yarp::os::exit(0);
+        std::exit(0);
     }
 }
 

--- a/src/devices/ffmpeg/FfmpegGrabber.cpp
+++ b/src/devices/ffmpeg/FfmpegGrabber.cpp
@@ -12,7 +12,7 @@
 
 #include "ffmpeg_api.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #define ERROR_PROBLEM
 

--- a/src/devices/ffmpeg/FfmpegWriter.cpp
+++ b/src/devices/ffmpeg/FfmpegWriter.cpp
@@ -40,7 +40,7 @@
 
 #include "ffmpeg_api.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -51,10 +51,10 @@ using namespace yarp::sig::file;
 
 //#define OMIT_AUDIO
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cmath>
 
 #ifndef M_PI
 #define M_PI 3.1415926535897931

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -3,15 +3,15 @@
 // CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <termios.h> // terminal io (serial port) interface
 #include <fcntl.h>   // File control definitions
-#include <errno.h>   // Error number definitions
+#include <cerrno>   // Error number definitions
 #include <arpa/inet.h>
 #include <iostream>
-#include <string.h>
-#include <math.h>
+#include <cstring>
+#include <cmath>
 
 #include <yarp/os/Time.h>
 #include <yarp/os/LogStream.h>

--- a/src/devices/jrkerr/nmccom.cpp
+++ b/src/devices/jrkerr/nmccom.cpp
@@ -15,7 +15,7 @@ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WAR
 //---------------------------------------------------------------------------
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "nmccom.h"
 //#include "picio.h"
@@ -156,7 +156,7 @@ SERVOMOD *p;
 //char mess[40];
 
 InitVars( jrsendcmd);
-  
+
 jrsendcmd->ComPort = SioOpen( portname, baudrate);    //Open with default rate of 19200
 if ( jrsendcmd->ComPort == INVALID_HANDLE_VALUE) return 0;
 
@@ -451,7 +451,7 @@ return jrsendcmd->mod[addr].groupleader;
 //    }
 if ( jrsendcmd->ComPort!=INVALID_HANDLE_VALUE && jrsendcmd->ComPort!=NULL) NmcHardReset(0xFF, jrsendcmd);
 
-jrsendcmd->nummod = 0;    
+jrsendcmd->nummod = 0;
 SioClose( jrsendcmd->ComPort);
 }
 //---------------------------------------------------------------------------

--- a/src/devices/jrkerr/picservo.cpp
+++ b/src/devices/jrkerr/picservo.cpp
@@ -14,7 +14,7 @@ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WAR
 ============================================ */
 //---------------------------------------------------------------------------
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "sio_util.h"
 #include "nmccom.h"
@@ -643,7 +643,7 @@ for (i=0; i<poffset; i++)
 
 ServoClearBits(addr);  //Clear any position errors
 
-for (i=127; i<=maxpwm; i++)    
+for (i=127; i<=maxpwm; i++)
   {
   ServoLoadTraj(addr, 0x88, 0, 0, 0, (byte)i);  //ramp up PWM to 255
   if ( (NmcGetStat(addr) & POS_ERR) )     //check if power still there

--- a/src/devices/jrkerr/sio_util.cpp
+++ b/src/devices/jrkerr/sio_util.cpp
@@ -13,7 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WAR
 
 ============================================ */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "sio_util.h"
 //---------------------------------------------------------------------------

--- a/src/devices/kinect/OpenNI/KinectYarpDeviceServerLib/KinectSkeletonTracker.h
+++ b/src/devices/kinect/OpenNI/KinectYarpDeviceServerLib/KinectSkeletonTracker.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <string>
-#include <time.h>
+#include <ctime>
 #include <iostream>
 
 // Headers for OpenNI

--- a/src/devices/kinect/OpenNI/TEST/GLWindow.h
+++ b/src/devices/kinect/OpenNI/TEST/GLWindow.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/sig/Matrix.h>
 #include <yarp/sig/Vector.h>
 #include <GL/glut.h>

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -4,6 +4,8 @@
 * CopyPolicy: Released under the terms of the GPLv2 or later, see GPL.TXT
 */
 
+#define _USE_MATH_DEFINES
+
 #include <laserFromDepth.h>
 
 #include <yarp/os/Time.h>
@@ -12,12 +14,11 @@
 #include <yarp/os/LockGuard.h>
 #include <yarp/os/ResourceFinder.h>
 #include <iostream>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <limits>
 
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 
@@ -87,7 +88,7 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     }
 
     Time::turboBoost();
-   
+
     Property prop;
     if(!config.check("RGBD_SENSOR_CLIENT"))
     {
@@ -96,7 +97,7 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     }
     prop.fromString(config.findGroup("RGBD_SENSOR_CLIENT").toString());
     prop.put("device", "RGBDSensorClient");
-  
+
     driver.open(prop);
     if (!driver.isValid())
     {

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -8,17 +8,18 @@
 // *** THIS FILE IS CURRENTLY UNDER DEVELOPMENT / DEBUG ***
 // ********************************************************
 
+#define _USE_MATH_DEFINES
+
 #include <laserHokuyo.h>
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <iostream>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <limits>
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 //#define LASER_DEBUG
 

--- a/src/devices/laserHokuyo/laserHokuyo.h
+++ b/src/devices/laserHokuyo/laserHokuyo.h
@@ -11,7 +11,7 @@
 #ifndef LASERHOKUYO_THREAD_H
 #define LASERHOKUYO_THREAD_H
 
-//#include <stdio.h>
+//#include <cstdio>
 #include <string>
 
 #include <yarp/os/RateThread.h>
@@ -30,7 +30,7 @@ class laserHokuyo : public RateThread, public yarp::dev::IRangefinder2D, public 
 protected:
     PolyDriver driver;
     ISerialDevice *pSerial;
-   
+
     yarp::os::Semaphore mutex;
 
     int cardId;
@@ -59,7 +59,7 @@ protected:
 
     Laser_mode_type laser_mode;
 
-    struct sensor_property_struct 
+    struct sensor_property_struct
     {
         std::string MODL;
         int DMIN;
@@ -76,7 +76,7 @@ protected:
 public:
     laserHokuyo(int period=20) : RateThread(period),mutex(1)
     {}
-    
+
 
     ~laserHokuyo()
     {

--- a/src/devices/meiMotionControl/MEIMotionControl.cpp
+++ b/src/devices/meiMotionControl/MEIMotionControl.cpp
@@ -38,7 +38,7 @@ using namespace yarp::dev;
 
 bool NOT_IMPLEMENTED_YET(const char *txt)
 {
-    ACE_OS::fprintf(stderr, "%s not yet implemented for MEIMotionControl\n", txt);
+    fprintf(stderr, "%s not yet implemented for MEIMotionControl\n", txt);
 
     return false;
 }
@@ -49,7 +49,7 @@ bool NOT_IMPLEMENTED_YET(const char *txt)
 
 MEIMotionControlParameters::MEIMotionControlParameters(int nj)
 {
-	
+
 
 		_zeros = new double[nj];
 		_signs = new int[nj];
@@ -69,12 +69,12 @@ MEIMotionControlParameters::MEIMotionControlParameters(int nj)
 		nj= _BabybotArm::_nj;
 
 		int i;
-		for(i = 0; i<_njoints; i++) 
+		for(i = 0; i<_njoints; i++)
 		{
 			_zeros[i]			= _BabybotArm::_zeros[i];
 			_axis_map[i]		= _BabybotArm::_axis_map[i];
 			_signs[i]			= _BabybotArm::_signs[i];
-			_encoderToAngles[i] = _BabybotArm::_encoders[i]*_BabybotArm::_encWheels[i];		
+			_encoderToAngles[i] = _BabybotArm::_encoders[i]*_BabybotArm::_encWheels[i];
 			_fwdCouple[i]		= _BabybotArm::_fwdCouple[i];
 			_stiffPID[i]		= _BabybotArm::_stiffPID[i];
 			_maxDAC[i]			= _BabybotArm::_maxDAC[i];
@@ -204,7 +204,7 @@ void MEIMotionControlParameters::_realloc(int nj)
 		if (_maxDAC != NULL)			delete [] _maxDAC;
 		if (_limitsMax != NULL)			delete [] _limitsMax;
 		if (_limitsMin != NULL)			delete [] _limitsMin;
-		
+
 		_zeros				= new double [nj];
 		_signs				= new int [nj];
 		_axis_map			= new int [nj];
@@ -237,7 +237,7 @@ public:
 	bool read ();
 
 	inline int getJoints (void) const { return _Rnjoints; }
-	
+
 public:
 	enum { MEI_TIMEOUT = 20, MEI_POLLING_INTERVAL = 10 };
 
@@ -267,14 +267,14 @@ public:
 		double *_RfwdCouple;
 		double *_RfwdCoupleC;
 		double *_RinvCouple;
-		double *_RmaxDAC;		
+		double *_RmaxDAC;
 		double *_R16bit_oldpos;
 		double *_RposHome;			//10 double
 
 		double *_Rref_acc;
 		double *_Rref_speeds;
 		double *_Rref_positions;
-		
+
 		short *_Revents;
 
 		int16 *_Rwinding;			/// counting how many times the encoder wraps up.
@@ -288,12 +288,12 @@ public:
 		int _Rpolling_interval;						/// thread polling interval.
 		int _Rspeed;								/// speed of the bus.
 		int _RnetworkN;								/// network number.
-	
 
 
 
 
-	unsigned char _Rmy_address;					/// 
+
+	unsigned char _Rmy_address;					///
 };
 
 MEIResources::MEIResources ()
@@ -321,7 +321,7 @@ MEIResources::MEIResources ()
 
 
 
-	//here it is better to put a value which can change depending on the number of robot-joints- 
+	//here it is better to put a value which can change depending on the number of robot-joints-
 	MEIMotionControlParameters param(6);
 
 	initialize(param);
@@ -333,15 +333,15 @@ MEIResources::MEIResources ()
 }
 
 
-MEIResources::~MEIResources () 
-{ 
-//	uninitialize(); 
+MEIResources::~MEIResources ()
+{
+//	uninitialize();
 }
 
 bool MEIResources::initialize (const MEIMotionControlParameters& parms)
 {
 		_Rnjoints = parms._njoints;
-		
+
 
 		_RlimitsMax			= new double[_Rnjoints];
 		_RlimitsMin			= new double[_Rnjoints];
@@ -359,17 +359,17 @@ bool MEIResources::initialize (const MEIMotionControlParameters& parms)
 		_Raxis_map			= new int[_Rnjoints];
 		_Rinv_axis_map		= new int[_Rnjoints];		//3 int
 
-		_Rwinding			= new int16[_Rnjoints];		
+		_Rwinding			= new int16[_Rnjoints];
 		_Revents			= new short[4];				//2short
 
 		_Rref_acc           = new double[_Rnjoints];
 		_Rref_speeds		= new double[_Rnjoints];
 		_Rref_positions		= new double[_Rnjoints];
 
-	
+
 	for (int i = 0; i<parms._njoints; i++)
 	{
-		
+
 		_Rzeros[i] = parms._zeros[i];
 		_Rsigns[i] = parms._signs[i];
 		_Raxis_map[i] = parms._axis_map[i];
@@ -383,8 +383,8 @@ bool MEIResources::initialize (const MEIMotionControlParameters& parms)
 		_RlimitsMax[i] = parms._limitsMax[i];
 		_RlimitsMin[i] = parms._limitsMin[i];
 		_Rref_acc[i] = 0;
-		_Rref_speeds[i] = 0;	
-		_Rref_positions[i] = 0;	
+		_Rref_speeds[i] = 0;
+		_Rref_positions[i] = 0;
 	}
 
 
@@ -429,7 +429,7 @@ inline MEIResources& RES(void *res) { return *(MEIResources *)res; }
 
 
 
-MEIMotionControl::MEIMotionControl() : 
+MEIMotionControl::MEIMotionControl() :
     ImplementPositionControl<MEIMotionControl, IPositionControl>(this),
 	ImplementVelocityControl<MEIMotionControl, IVelocityControl>(this),
     ImplementPidControl<MEIMotionControl, IPidControl>(this),
@@ -470,11 +470,11 @@ bool MEIMotionControl::open (const MEIMotionControlParameters &params)
 			printf("\n I AM NOT ABLE TO INITIALIZE THE RESOURCES!!!\n");
             return false;
         }
-		
+
 
     ImplementPositionControl<MEIMotionControl, IPositionControl>::
         initialize(params._njoints, params._axis_map, params._encoderToAngles , params._zeros);
-    
+
     ImplementVelocityControl<MEIMotionControl, IVelocityControl>::
         initialize(params._njoints, params._axis_map, params._encoderToAngles, params._zeros);
 
@@ -503,10 +503,10 @@ bool MEIMotionControl::open (const MEIMotionControlParameters &params)
 	{
 		int error;
 		char buffer[MAX_ERROR_LEN];
-		error = dsp_init(r.MEIPORT);	
+		error = dsp_init(r.MEIPORT);
 		rc = dsp_reset();				// reset
 		if (error)
-			{	
+			{
 				error_msg(error, buffer);
 				printf("Value: %d Message: %s", error, buffer);
 				return false;
@@ -523,7 +523,7 @@ bool MEIMotionControl::open (const MEIMotionControlParameters &params)
 
 	//set the input port and the output port
 	//set_io is needed for anable the amplifiers
-	//check 
+	//check
 	int set0 = init_io(0, IO_INPUT);
 	int set1 = init_io(1, IO_OUTPUT);
 	int set3 = set_io(1,0);
@@ -540,27 +540,27 @@ bool MEIMotionControl::open (const MEIMotionControlParameters &params)
 
 
 bool MEIMotionControl::open(yarp::os::Searchable& config) {
-	
+
 	bool fromfileflag=false;
-	Searchable& p = config;	
+	Searchable& p = config;
 	MEIResources& r = RES (system_resources);
 
-    if (!p.check("GENERAL","section for general motor control parameters")) 
+    if (!p.check("GENERAL","section for general motor control parameters"))
 	{
         fprintf(stderr, "Cannot understand configuration parameters\n");
 		printf("\nI am going to load parameters from file\n");
         fromfileflag=true;
 	}
 
-	
+
 	if (fromfileflag==true)
 	{
 		Property robot;
 
-	
+
 		//take data from file
 		robot.fromConfigFile("MEIconfig.txt");
-		if (!robot.check("GENERAL")) 
+		if (!robot.check("GENERAL"))
 		{
 			printf("Cannot understand config file\n");
 			return false;
@@ -575,7 +575,7 @@ bool MEIMotionControl::open(yarp::os::Searchable& config) {
 
 	_filter_coeffs = new int16* [params._njoints];
 	ACE_ASSERT (_filter_coeffs != NULL);
-	
+
 	for(i = 0; i < params._njoints; i++)
 	{
 		_filter_coeffs[i] = new int16 [r.COEFFICIENTS];
@@ -603,7 +603,7 @@ bool MEIMotionControl::open(yarp::os::Searchable& config) {
         printf("Signs does not have the right number of entries\n");
         return false;
     }
-    
+
 	for (i = 1; i < params._njoints+1; i++) params._stiffPID[i-1] = xtmp.get(i).asInt();
 
 	xtmp = robot.findGroup("GENERAL").findGroup("MaxDAC","a list of MaxDAC values");
@@ -634,9 +634,9 @@ bool MEIMotionControl::open(yarp::os::Searchable& config) {
     for(j=0;j<params._njoints;j++)
         {
             char tmp[80];
-            sprintf(tmp, "Pid%d", j); 
+            sprintf(tmp, "Pid%d", j);
             xtmp = robot.findGroup("PIDS").findGroup(tmp);
-			
+
 			_filter_coeffs[j][r.DF_P]			= params._pids[j].kp = xtmp.get(1).asInt();
 			_filter_coeffs[j][r.DF_I]			= params._pids[j].ki = xtmp.get(2).asInt();
 			_filter_coeffs[j][r.DF_D]			= params._pids[j].kd = xtmp.get(3).asInt();
@@ -651,7 +651,7 @@ bool MEIMotionControl::open(yarp::os::Searchable& config) {
 			params._pids[j].kp = (double)_filter_coeffs[j][r.DF_P];
             params._pids[j].kd = (double)_filter_coeffs[j][r.DF_D];
             params._pids[j].ki = (double)_filter_coeffs[j][r.DF_I];
-    
+
             params._pids[j].max_int		= (double)_filter_coeffs[j][r.DF_I_LIMIT]	;
 			params._pids[j].offset		= (double)_filter_coeffs[j][r.DF_OFFSET];
             params._pids[j].max_output	= (double)_filter_coeffs[j][r.DF_DAC_LIMIT];
@@ -678,7 +678,7 @@ bool MEIMotionControl::open(yarp::os::Searchable& config) {
 
 	fromfileflag=false;
 
-	
+
 ////////////////////////////////////////////////////end new
 return open(params);
 }
@@ -695,7 +695,7 @@ else
     Bottle& xtmp = p.findGroup("MaxDAC");
 	ACE_ASSERT (xtmp.size() == nj+1);
 
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		params._maxDAC[i-1] = xtmp.get(i).asDouble();
 	}
@@ -704,7 +704,7 @@ else
     xtmp = p.findGroup("AxisMap");
 	ACE_ASSERT (xtmp.size() == nj+1);
 	printf("_axis_map = ");
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		params._axis_map[i-1] = xtmp.get(i).asInt();
 		printf("%d ",params._axis_map[i-1]);
@@ -713,7 +713,7 @@ else
 
 	xtmp = p.findGroup("FwdCouple");
 	ACE_ASSERT (xtmp.size() == nj+1);
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		params._fwdCouple[i-1] = xtmp.get(i).asDouble();
 	}
@@ -722,11 +722,11 @@ else
 
     xtmp = p.findGroup("Zeros");
 	ACE_ASSERT (xtmp.size() == nj+1);
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		params._zeros[i-1] = xtmp.get(i).asDouble();
 	}
-		
+
 	xtmp = p.findGroup("Signs");
 	ACE_ASSERT (xtmp.size() == nj+1);
 	for (i = 1; i < xtmp.size(); i++)
@@ -736,7 +736,7 @@ else
 
 	xtmp = p.findGroup("Stiff");
 	ACE_ASSERT (xtmp.size() == nj+1);
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		params._stiffPID[i-1] = xtmp.get(i).asInt();
 	}
@@ -744,7 +744,7 @@ else
     /////// LIMITS
     xtmp = p.findGroup("Max");
  	ACE_ASSERT (xtmp.size() == nj+1);
-    for(i=1;i<xtmp.size(); i++) 
+    for(i=1;i<xtmp.size(); i++)
 	{
 		params._limitsMax[i-1]=xtmp.get(i).asDouble();
 	}
@@ -763,7 +763,7 @@ else
     for(j=0;j<nj;j++)
         {
             char tmp[80];
-            sprintf(tmp, "LPid%d", j); 
+            sprintf(tmp, "LPid%d", j);
             xtmp = p.findGroup(tmp);
 
 			_filter_coeffs[j][r.DF_P]			= params._pids[j].kp = xtmp.get(1).asInt();
@@ -795,20 +795,20 @@ else
 
     xtmp = p.findGroup("EncWheel");
 	ACE_ASSERT (xtmp.size() == nj+1);
-    for (i = 1; i < xtmp.size(); i++) 
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		encWheels[i-1] = xtmp.get(i).asDouble();
 	}
 
-    xtmp = p.findGroup("Encoder");						
+    xtmp = p.findGroup("Encoder");
 	ACE_ASSERT (xtmp.size() == nj+1);
-	
-    for (i = 1; i < xtmp.size(); i++) 
+
+    for (i = 1; i < xtmp.size(); i++)
 	{
 		encoders[i-1] = xtmp.get(i).asDouble();
 		params._encoderToAngles[i-1] = encoders[i-1]*encWheels[i-1];
 	}
-		
+
 	params._fwdCouple[3] = params._fwdCouple[3]*encWheels[3];
 	params._fwdCouple[4] = params._fwdCouple[4]*encWheels[4];
 	params._fwdCouple[5] = params._fwdCouple[5]*encWheels[5];
@@ -829,13 +829,13 @@ else
 
 		return open(params);
 		}
-		
-		
+
+
 
 
 }
 
- 
+
 bool MEIMotionControl::close(void)
 {
 	MEIResources& r = RES(system_resources);
@@ -875,7 +875,7 @@ void MEIMotionControl::run ()
 }
 
 // return the number of controlled axes.
-bool MEIMotionControl::getAxes(int *ax)				
+bool MEIMotionControl::getAxes(int *ax)
 {
 	MEIResources& r = RES(system_resources);
     *ax = r.getJoints();
@@ -887,14 +887,14 @@ bool MEIMotionControl::getAxes(int *ax)
 bool MEIMotionControl::setPidRaw (int axis, const Pid &pid)
 {
 		MEIResources& r = RES(system_resources);
-	    
-			_filter_coeffs[axis][r.DF_P]			= int (pid.kp) ; 
+
+			_filter_coeffs[axis][r.DF_P]			= int (pid.kp) ;
 			_filter_coeffs[axis][r.DF_D]			= int (pid.kd) ;
 			_filter_coeffs[axis][r.DF_I]			= int (pid.ki) ;
 			_filter_coeffs[axis][r.DF_I_LIMIT]		= int (pid.max_int) ;
 			_filter_coeffs[axis][r.DF_OFFSET]		= int (pid.offset);
 			_filter_coeffs[axis][r.DF_DAC_LIMIT]	= int (pid.max_output);
-			
+
 			set_filter(axis, _filter_coeffs[axis]);
 
 	return true;
@@ -907,10 +907,10 @@ bool MEIMotionControl::getPidRaw (int axis, Pid *pids)
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
 
 	get_filter(axis, _filter_coeffs[axis]);
-	
+
 	int j = axis;
-	
-	
+
+
 	printf("\n filter_coeffs j:%d = %d ", j ,_filter_coeffs[j][0]);
 		printf(" %d",_filter_coeffs[j][1]);
 		printf(" %d",_filter_coeffs[j][2]);
@@ -921,7 +921,7 @@ bool MEIMotionControl::getPidRaw (int axis, Pid *pids)
 		printf(" %d",_filter_coeffs[j][7]);
 		printf(" %d",_filter_coeffs[j][8]);
 		printf(" %d",_filter_coeffs[j][9]);
-		
+
 		printf("\n");
 
 		pids[axis].kp = (double)_filter_coeffs[axis][r.DF_P];
@@ -951,7 +951,7 @@ bool MEIMotionControl::getPidsRaw (Pid *pids)
 	int i;
 	for (i = 0; i < r._Rnjoints; i++)
         {
-			
+
 		get_filter(i, _filter_coeffs[i]);
 
 		pids[i].kp			= (double)(_filter_coeffs[i][r.DF_P] );
@@ -971,7 +971,7 @@ bool MEIMotionControl::getPidsRaw (Pid *pids)
 		pids[i].max_int	,
 		pids[i].offset,
 		pids[i].max_output)	;
-		
+
 		printf("\n");
 		printf("\n filter_coeffs i:%d = %d ",
 		i,_filter_coeffs[i][0]);
@@ -994,9 +994,9 @@ bool MEIMotionControl::getPidsRaw (Pid *pids)
 bool MEIMotionControl::setPidsRaw(const Pid *pids)
 {
     MEIResources& r = RES(system_resources);
-    for (int i = 0; i < r.getJoints(); i++) 
+    for (int i = 0; i < r.getJoints(); i++)
 	{
-		_filter_coeffs[i][r.DF_P]			=	int(pids[i].kp) ; 
+		_filter_coeffs[i][r.DF_P]			=	int(pids[i].kp) ;
 		_filter_coeffs[i][r.DF_D]			=	int(pids[i].kd) ;
 		_filter_coeffs[i][r.DF_I]			=	int(pids[i].ki) ;
 		_filter_coeffs[i][r.DF_I_LIMIT]		=	int(pids[i].max_int);
@@ -1005,7 +1005,7 @@ bool MEIMotionControl::setPidsRaw(const Pid *pids)
 
 		set_filter(i, _filter_coeffs[i]);
     }
-	
+
 	return true;
 }
 
@@ -1092,7 +1092,7 @@ bool MEIMotionControl::getOutputsRaw(double *outs)
 
 
 //function to get the value of the positions setted as references
-bool MEIMotionControl::getReferenceRaw(int axis, double *ref)				
+bool MEIMotionControl::getReferenceRaw(int axis, double *ref)
 {
 	MEIResources& r = RES(system_resources);
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
@@ -1103,7 +1103,7 @@ bool MEIMotionControl::getReferenceRaw(int axis, double *ref)
 }
 
 
-bool MEIMotionControl::getReferencesRaw(double *ref)			
+bool MEIMotionControl::getReferencesRaw(double *ref)
 {
 	int i;
 	MEIResources& r = RES(system_resources);
@@ -1138,10 +1138,10 @@ bool MEIMotionControl::enablePidRaw(int axis)
 
 bool MEIMotionControl::setOffsetRaw(int axis, double v)
 {
-	
+
 	MEIResources& r = RES(system_resources);
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
-	
+
 	_filter_coeffs[axis][r.DF_OFFSET] = v;
 	set_filter(axis, _filter_coeffs[axis]);
 	return true;
@@ -1159,7 +1159,7 @@ bool MEIMotionControl::disablePidRaw(int axis)
 /*this function check the value of the flag _positionmode
 	it is just a way to safety manage the control
 	if _positionmode is true means you can control in position */
-bool MEIMotionControl::setPositionMode()		
+bool MEIMotionControl::setPositionMode()
 {
 	MEIResources& r = RES(system_resources);
 	if (_positionmode == false)
@@ -1195,7 +1195,7 @@ bool MEIMotionControl::setVelocityMode()
 
 
 /*it sets the reference postion and gives the command to move*/
-bool MEIMotionControl::positionMoveRaw(int axis, double ref)		
+bool MEIMotionControl::positionMoveRaw(int axis, double ref)
 {
 	MEIResources& r = RES(system_resources);
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
@@ -1226,7 +1226,7 @@ bool MEIMotionControl::positionMoveRaw(const double *refs)				//revisionata Matt
 	int i;
 	for (i = 0; i < r.getJoints (); i++)
 	{
-		int	check = axis_state(i);		
+		int	check = axis_state(i);
         if (ENABLED(i))
 			{
 				positionMoveRaw(i, refs[i]);
@@ -1239,7 +1239,7 @@ bool MEIMotionControl::positionMoveRaw(const double *refs)				//revisionata Matt
 				positionMoveRaw(i, refs[i]);
 			}
 		}
-	return true;   
+	return true;
 }
 
 bool MEIMotionControl::relativeMoveRaw(int j, double delta)
@@ -1254,7 +1254,7 @@ bool MEIMotionControl::relativeMoveRaw(const double *deltas)
 
 /// check motion done, single axis.
 //it returns true if the motion is terminated
-bool MEIMotionControl::checkMotionDoneRaw(int axis, bool *ret)			
+bool MEIMotionControl::checkMotionDoneRaw(int axis, bool *ret)
 {
 	MEIResources& r = RES(system_resources);
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
@@ -1265,7 +1265,7 @@ bool MEIMotionControl::checkMotionDoneRaw(int axis, bool *ret)
 			ret[axis] = false;
            return true;
         }
-	else 
+	else
 	{
 		printf("\nMotion on axis %d IS terminated!!", axis);
 		ret[axis] = true;
@@ -1288,9 +1288,9 @@ bool MEIMotionControl::checkMotionDoneRaw (bool *ret)
         }
 	return true;
 }
-	
 
-bool MEIMotionControl::setRefSpeedRaw(int axis, double sp)		
+
+bool MEIMotionControl::setRefSpeedRaw(int axis, double sp)
 {
 	MEIResources& r = RES(system_resources);
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
@@ -1311,7 +1311,7 @@ bool MEIMotionControl::setRefSpeedRaw(int axis, double sp)
 	return true;
 }
 
-bool MEIMotionControl::setRefSpeedsRaw(const double *spds)					
+bool MEIMotionControl::setRefSpeedsRaw(const double *spds)
 {
 	MEIResources& r = RES(system_resources);
       int i;
@@ -1333,7 +1333,7 @@ bool MEIMotionControl::setRefSpeedsRaw(const double *spds)
 	return true;
 }
 
-bool MEIMotionControl::setRefAccelerationRaw(int axis, double acc)			
+bool MEIMotionControl::setRefAccelerationRaw(int axis, double acc)
 {
 
 	MEIResources& r = RES(system_resources);
@@ -1341,18 +1341,18 @@ bool MEIMotionControl::setRefAccelerationRaw(int axis, double acc)
 	 return true;
 }
 
-bool MEIMotionControl::setRefAccelerationsRaw(const double *accs)	
+bool MEIMotionControl::setRefAccelerationsRaw(const double *accs)
 {
     MEIResources& r = RES(system_resources);
 	for (int i = 0; i < r.getJoints(); i++)
-		r._Rref_acc[i] = accs[i]; 
+		r._Rref_acc[i] = accs[i];
 
 	return true;
 }
 
 
 
-bool MEIMotionControl::getRefSpeedsRaw (double *spds)	
+bool MEIMotionControl::getRefSpeedsRaw (double *spds)
 {
 	MEIResources& r = RES(system_resources);
     for(int i = 0; i < r.getJoints(); i++)
@@ -1369,7 +1369,7 @@ bool MEIMotionControl::getRefSpeedRaw (int axis, double *spd)	//revisionata Matt
     ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
 
 	spd[axis] = r._Rref_speeds[axis];
-	
+
 	return true;
 }
 
@@ -1426,13 +1426,13 @@ bool MEIMotionControl::velocityMoveRaw (int axis, double sp) 				//revisionata M
 {
 	MEIResources& r = RES(system_resources);
     ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
-	
+
 	int check;
 	if(dsp_init(PCDSP_BASE))
 		return dsp_error;
 
 	//check if the axis is ready to worl or not
-	//	int check = axis_state(axis);		
+	//	int check = axis_state(axis);
 	if(_positionmode == false)
 		{
 		 if (!ENABLED(axis))
@@ -1464,7 +1464,7 @@ inline bool MEIMotionControl::velocityMoveRaw (const double *sp)
 
 	int i;
 	for(i = 0; i < r.getJoints(); i++)
-		{		
+		{
 			int check	= v_move(i, sp[i] , r._Rref_acc[i]);
 			if(check!=0)
 					printf("\n v_move exit with value %d, check the manual!!", check);
@@ -1502,7 +1502,7 @@ bool MEIMotionControl::setEncoderRaw(int axis, double val)
 bool MEIMotionControl::setEncodersRaw(const double *vals)
 {
 	MEIResources& r = RES(system_resources);
-		
+
 	int rc;
 
 	/// this is to (re)set the encoder ref value.
@@ -1528,24 +1528,24 @@ bool MEIMotionControl::resetEncoderRaw(int j)
 
 
 
-bool MEIMotionControl::resetEncodersRaw()		
+bool MEIMotionControl::resetEncodersRaw()
 {
 	MEIResources& r = RES(system_resources);
 
 	bool  ret;
     for(int i = 0; i < r.getJoints(); i++)
 		ret= resetEncoderRaw(i);
-	
+
     return ret;
 }
 
 bool MEIMotionControl::getEncodersRaw(double *v)		//revisionata Mattia
-{														
+{
 	MEIResources& r = RES(system_resources);
 	bool ret;
-	for (int i = 0; i < r.getJoints(); i++) 
+	for (int i = 0; i < r.getJoints(); i++)
 		ret = getEncoderRaw(i, v);
-	
+
 	return true;
 }
 
@@ -1619,18 +1619,18 @@ bool MEIMotionControl::getEncoderAccelerationRaw(int j, double *v)
     return NOT_IMPLEMENTED_YET("getEncoderAcc");
 }
 
-bool MEIMotionControl::disableAmpRaw(int axis)			
+bool MEIMotionControl::disableAmpRaw(int axis)
 {
 	MEIResources& r = RES(system_resources);
     ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
-	
+
 	int amp = disable_amplifier(axis);
 
 	_amplifiers = false;
 	return true;
 }
 
-bool MEIMotionControl::enableAmpRaw(int axis)				
+bool MEIMotionControl::enableAmpRaw(int axis)
 {
 	MEIResources& r = RES(system_resources);
 
@@ -1643,9 +1643,9 @@ bool MEIMotionControl::enableAmpRaw(int axis)
 	int rc = controller_run(axis);
 
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
-	
 
-	int amp = enable_amplifier(axis);						//set the state of the amp to the 
+
+	int amp = enable_amplifier(axis);						//set the state of the amp to the
 	short ampli;
 	int level = get_amp_enable_level(axis, &ampli);
 	printf("\nAmp%d enable  state : %d",axis,ampli);
@@ -1660,7 +1660,7 @@ bool MEIMotionControl::enableAmpRaw(int axis)
 }
 
 
-bool MEIMotionControl::getCurrentsRaw(double *cs)	
+bool MEIMotionControl::getCurrentsRaw(double *cs)
 {
 	return NOT_IMPLEMENTED_YET("getCurrentRaw");
 }
@@ -1681,7 +1681,7 @@ bool MEIMotionControl::getMaxCurrentRaw(int axis, double v)
 	    return NOT_IMPLEMENTED_YET("getMaxCurrentRaw");
 }
 
-//before starting the calibration you have to move each axis of the arm 
+//before starting the calibration you have to move each axis of the arm
 //they have to stay as much as possible far away from their limit..
 //this function looks for a median point between two special encoder-steps
 //the problem is that if the initial position is between home-index and the
@@ -1702,7 +1702,7 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
 	check = controller_run(axis);
 	check = enable_amplifier(axis);
 
-	
+
 	printf(("\nCalibration routine started.\n"));
 	if (! (_alreadyinint && _amplifiers) )
 		{
@@ -1728,7 +1728,7 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
         {
 			clear_status(i);
 			controller_run(i);
-			if(i != axis) 
+			if(i != axis)
 				{
 					speeds1[i]	= 0.0;
 					speeds2[i]	= 0.0;
@@ -1744,14 +1744,14 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
 		check = set_home_index_config(axis,INDEX_ONLY);
 		//the level of HOMe index is LOW
 		check = set_home_level(axis, FALSE);
-		
+
 		//this is needed just for velocity command
 		//remember to set is back to  NO_EVENT before using position command
 		//otherwise it is not going to work!
 		check = set_home(axis, STOP_EVENT);
 
 		//check if the axis is ready to work or not
-		check = axis_state(axis);		
+		check = axis_state(axis);
 		if(check!=0)
 		{
 			printf("\n some action did not exit in the right way for the %d axis \nI am going to reset the STOP",axis);
@@ -1789,7 +1789,7 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
 		// go back to HOME position
 		printf("\nGoing back home...\n");
 		check = axis_state(axis);
-		
+
 		if(check!=0)
 		{
 			printf("\n some action did not exit in the right way for the %d axis \nI am going to reset the STOP",axis);
@@ -1808,7 +1808,7 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
 		check = positionMoveRaw(axis,r._RposHome[axis]);
 		while (!motion_done(axis));
 		check = getEncoderRaw(axis,debug);
-		
+
 
 		printf(("\nGathering second index...\n"));
 		check = axis_state(axis);
@@ -1863,11 +1863,11 @@ bool MEIMotionControl::calibrateRaw(int axis, double zero)
 bool MEIMotionControl::doneRaw(int axis)
 {
 	MEIResources& r = RES(system_resources);
-	
+
 	bool ret[6] =		  {		0,		0,		0,		0,		0,		0};
 
 	checkMotionDoneRaw(axis, ret);
-	
+
 	if (ret[axis]==1)
 	return true;
 	else
@@ -1880,7 +1880,7 @@ bool MEIMotionControl::setPrintFunction(int (*f) (const char *fmt, ...))
 	return NOT_IMPLEMENTED_YET("setPrintFunction");
 }
 
-bool MEIMotionControl::getAmpStatusRaw(int *st)				
+bool MEIMotionControl::getAmpStatusRaw(int *st)
 {
 
 	MEIResources& r = RES(system_resources);
@@ -1894,10 +1894,10 @@ bool MEIMotionControl::getAmpStatusRaw(int *st)
         }
 
 	return true;
-	
+
 }
 
-bool MEIMotionControl::getAmpStatusRaw(int i, int *st)				
+bool MEIMotionControl::getAmpStatusRaw(int i, int *st)
 {
 
 	MEIResources& r = RES(system_resources);
@@ -1908,15 +1908,15 @@ bool MEIMotionControl::getAmpStatusRaw(int i, int *st)
 
     *st=value;
 
-	return true;	
+	return true;
 }
 
-bool MEIMotionControl::setLimitsRaw(int axis, double min, double max)	
+bool MEIMotionControl::setLimitsRaw(int axis, double min, double max)
 {
-		
+
 	MEIResources& r = RES(system_resources);
-	
-	//trick to re-initialize limits 
+
+	//trick to re-initialize limits
 	if(axis == 99)
 	{
 		for(int i=0; i<r.getJoints(); i++)
@@ -1929,7 +1929,7 @@ bool MEIMotionControl::setLimitsRaw(int axis, double min, double max)
 
 	}
 
-	//regular limit setting 
+	//regular limit setting
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
 
 	set_positive_sw_limit(axis,max,STOP_EVENT);
@@ -1939,7 +1939,7 @@ bool MEIMotionControl::setLimitsRaw(int axis, double min, double max)
 	return true;
 }
 
-bool MEIMotionControl::getLimitsRaw(int axis, double *min, double *max)	
+bool MEIMotionControl::getLimitsRaw(int axis, double *min, double *max)
 {
 	int iMin, iMax;
 
@@ -1947,7 +1947,7 @@ bool MEIMotionControl::getLimitsRaw(int axis, double *min, double *max)
 	ACE_ASSERT (axis >= 0 && axis <= r.getJoints());
 
 	double tmpmax,tmpmin;
-	
+
 	iMax =	get_positive_sw_limit(axis,&tmpmax,r._Revents);
 	iMin =	get_negative_sw_limit(axis,&tmpmin,r._Revents);
 
@@ -1961,7 +1961,7 @@ bool MEIMotionControl::loadBootMemory()
 {
 
     MEIResources& r = RES(system_resources);
-	
+
     int ret = 0;
     for(int j=0; j<r.getJoints(); j++)
         {
@@ -1978,7 +1978,7 @@ bool MEIMotionControl::loadBootMemory()
 bool MEIMotionControl::saveBootMemory ()
 {
     MEIResources& r = RES(system_resources);
-	
+
     int ret = 0;
     for(int j=0; j<r.getJoints(); j++)
         {
@@ -2021,7 +2021,7 @@ inline bool MEIMotionControl::ENABLED (int axis)
 		return false;
 	}
 	else return true;
-	
+
 }
 
 
@@ -2044,13 +2044,13 @@ bool MEIMotionControl::_readWord16Array (int msg, double *out)
 
 /// to send a Word16.
 bool MEIMotionControl::_writeWord16 (int msg, int axis, short s)
-{	
+{
 	return NOT_IMPLEMENTED_YET("_writeWord16");
 }
 
 /// write a DWord
 bool MEIMotionControl::_writeDWord (int msg, int axis, int value)
-{		
+{
 	return NOT_IMPLEMENTED_YET("_writeDWord");
 
 }
@@ -2063,9 +2063,9 @@ bool MEIMotionControl::_writeWord16Ex (int msg, int axis, short s1, short s2)
 
 ///
 /// sends a message and gets a dword back.
-/// 
+///
 bool MEIMotionControl::_readDWord (int msg, int axis, int& value)
-{    
+{
 	return NOT_IMPLEMENTED_YET("_readDWord");
 }
 

--- a/src/devices/microphone/LinuxMicrophoneDeviceDriver.cpp
+++ b/src/devices/microphone/LinuxMicrophoneDeviceDriver.cpp
@@ -7,11 +7,11 @@
 
 #include <MicrophoneDeviceDriver.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <fcntl.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #include <sys/ioctl.h>
 #include <sys/soundcard.h>
 
@@ -48,13 +48,13 @@ bool MicrophoneDeviceDriver::open(yarp::os::Searchable& config) {
     int chns = ( nChannels == 1 ) ? 1 : 2;
     int rate = samplesPerSec;
     dsp = ::open( devname, O_RDONLY );
-    if ( dsp < 0 ) { perror( devname ); exit(1); }
+    if ( dsp < 0 ) { perror( devname ); std::exit(1); }
     if ( ioctl( dsp, SNDCTL_DSP_RESET, NULL ) < 0 )
-        { perror( "ioctl" ); exit(1); }
+        { perror( "ioctl" ); std::exit(1); }
     if (      ( ioctl( dsp, SNDCTL_DSP_SETFMT,   &bits ) < 0 )
               ||( ioctl( dsp, SNDCTL_DSP_CHANNELS, &chns ) < 0 )
               ||( ioctl( dsp, SNDCTL_DSP_SPEED,    &rate ) < 0 )    )
-        { perror( "audio format not not supported\n" ); exit(1); }
+        { perror( "audio format not not supported\n" ); std::exit(1); }
 
     printf("Ok, opened microphone...\n");
 

--- a/src/devices/nvidia/FBO_Filter.h
+++ b/src/devices/nvidia/FBO_Filter.h
@@ -3,28 +3,28 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#ifdef WIN32
+#if defined(_WIN32)
 #include <GL/glew.h>
 #define GLEW_STATIC 1
 #else
 #include <GL/glew.h>
 #endif
 
-#include <assert.h>
+#include <cassert>
 
 #include <GL/gl.h>
 #include <GL/glext.h>
 #include <GL/glu.h>
 #include <GL/glut.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <Cg/cgGL.h>
 
 
 
 class FBO_Filter {
 protected:
-    void checkProfile(const char *name, CGprofile profile, 
+    void checkProfile(const char *name, CGprofile profile,
                       CGprofile highlight = CG_PROFILE_UNKNOWN) {
         CGbool supported = cgGLIsProfileSupported(profile);
         bool show = (highlight==CG_PROFILE_UNKNOWN)||(highlight==profile);
@@ -32,7 +32,7 @@ protected:
             printf("Cg profile %s is%s supported.\n", name,
                    supported?"":" not");
         }
-    } 
+    }
 
     void checkProfiles(CGprofile highlight = CG_PROFILE_UNKNOWN) {
 #ifdef DEBUG
@@ -50,13 +50,13 @@ protected:
     void checkCg(const char *act) {
         CGerror error;
         const char *str = cgGetLastErrorString(&error);
-        
+
         if (error!=CG_NO_ERROR) {
             printf("nvidia device - %s: %s\n", act, str);
             if (error == CG_COMPILER_ERROR) {
                 printf("  %s\n", cgGetLastListing(cgContext));
             }
-            exit(1);
+            std::exit(1);
         } else {
             printf("nvidia device - %s: OK\n", act);
         }
@@ -86,21 +86,21 @@ protected:
 public :
     CGprogram getProgram() { return cgProgram; }
 
-    FBO_Filter(CGprofile cgp,      ///< Desired profile.  Typically 
+    FBO_Filter(CGprofile cgp,      ///< Desired profile.  Typically
                                     ///  CG_PROFILE_FP30 or CG_PROFILE_FP40
                char *name,         ///< filename of the Cg program.  Note that
                                     /// the entry point function should be named
-                                    /// "FragmentProgram" in the Cg 
-               GLuint outputTex,   ///< the open GL texture object 
-                                    /// to which the results will go 
-               int W,             ///< width of the output texture, 
+                                    /// "FragmentProgram" in the Cg
+               GLuint outputTex,   ///< the open GL texture object
+                                    /// to which the results will go
+               int W,             ///< width of the output texture,
                int H);
 
     ///TODO figure out readback formats from target texture information.
     GLuint apply(GLuint iTex,    ///< OpenGL texture object to use as input
-                 bool FBOtex,     ///< set to true if the input texture is the result of a previous 
+                 bool FBOtex,     ///< set to true if the input texture is the result of a previous
                                   ///  FBO_filter.  False if not.
-                 GLenum rb_fmt = GL_RGBA, 
+                 GLenum rb_fmt = GL_RGBA,
                  GLenum rb_type = GL_FLOAT);
 };
 
@@ -111,9 +111,9 @@ CGprogram FBO_Filter::load_cgprogram(CGprofile prof, char *name) {
 }
 
 void FBO_Filter::renderBegin() {
-  //since we might be operating on downsampled images, we need 
+  //since we might be operating on downsampled images, we need
   //to reshape our current drawing area. Record the previous
-  // settings first though. 
+  // settings first though.
   glGetIntegerv(GL_VIEWPORT, previousViewportDims);
 
   glViewport(0, 0, (GLsizei) tWidth, (GLsizei) tHeight);
@@ -214,8 +214,8 @@ FBO_Filter::FBO_Filter(CGprofile cgp, char *name, GLuint outputTex, int W, int H
 
     if (glewGetExtension("GL_EXT_framebuffer_object") != GL_TRUE) {
         printf("GL_EXT_framebuffer_object extension needed but not supported\n");
-        exit(1);
-    } 
+        std::exit(1);
+    }
 
     //create the framebuffer object.
     oTex = outputTex ;

--- a/src/devices/nvidia/NVIDIADeviceDriver.cpp
+++ b/src/devices/nvidia/NVIDIADeviceDriver.cpp
@@ -3,8 +3,8 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <GL/glew.h>
 #include <GL/gl.h>

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -26,8 +26,8 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/sig/Image.h>
 
-#include <stdio.h>
-#include <string.h> // memcpy
+#include <cstdio>
+#include <cstring> // memcpy
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -83,9 +83,9 @@ bool OpenCVGrabber::open(Searchable & config) {
 
         m_loop = false;
 
-        int camera_idx = 
-            config.check("camera", 
-                         Value(CV_CAP_ANY), 
+        int camera_idx =
+            config.check("camera",
+                         Value(CV_CAP_ANY),
                          "if present, read from camera identified by this index").asInt();
 
         // Try to open a capture object for the first camera

--- a/src/devices/openni2/OpenNI2SkeletonTracker.h
+++ b/src/devices/openni2/OpenNI2SkeletonTracker.h
@@ -9,7 +9,7 @@
 #define OPENNI2_SKELETON_TRACKER_H
 
 #include <string>
-#include <time.h>
+#include <ctime>
 #include <iostream>
 
 #include <OpenNI.h>
@@ -58,7 +58,7 @@ public:
     }UserSkeleton;
 
     int getDeviceStatus();
-     
+
     /**
      * Struct with the data from the RGB camera, the depth camera, and a set of userSkeletons
      */

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -22,7 +22,7 @@
 #include <yarp/sig/Image.h>
 #include <yarp/os/LockGuard.h>
 
-#include <math.h>
+#include <cmath>
 
 #include <OVR_CAPI_Util.h>
 

--- a/src/devices/portaudio/PortAudioBuffer.cpp
+++ b/src/devices/portaudio/PortAudioBuffer.cpp
@@ -7,14 +7,14 @@
 
 #include "PortAudioBuffer.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <portaudio.h>
 
 
 circularBuffer::circularBuffer(int bufferSize)
 {
-    maxsize  = bufferSize + 1; 
+    maxsize  = bufferSize + 1;
     start = 0;
     end   = 0;
     elems = (SAMPLE *) calloc(maxsize, sizeof(SAMPLE));

--- a/src/devices/portaudio/PortAudioBuffer.h
+++ b/src/devices/portaudio/PortAudioBuffer.h
@@ -9,7 +9,7 @@
 #define PortAudioBufferh
 
 #include <portaudio.h>
-#include <stdio.h>
+#include <cstdio>
 
 /* Select sample format. */
 #if 0
@@ -44,7 +44,7 @@ class circularBuffer
     {
         return (end + 1) % maxsize == start;
     }
- 
+
     inline const SAMPLE* getRawData()
     {
         return elems;
@@ -62,10 +62,10 @@ class circularBuffer
         if (end == start)
         {
             printf ("ERROR: buffer ovverrun!\n");
-            start = (start + 1) % maxsize; // full, overwrite 
+            start = (start + 1) % maxsize; // full, overwrite
         }
     }
- 
+
     inline int size()
     {
         int i;
@@ -73,7 +73,7 @@ class circularBuffer
             i = end-start;
         else if (end==start)
             i = 0;
-        else          
+        else
             i = maxsize - start + end;
         return i;
     }
@@ -88,7 +88,7 @@ class circularBuffer
         start = (start + 1) % maxsize;
         return elem;
     }
- 
+
     inline unsigned int getMaxSize()
     {
         return maxsize;

--- a/src/devices/portaudio/PortAudioDeviceDriver.cpp
+++ b/src/devices/portaudio/PortAudioDeviceDriver.cpp
@@ -7,8 +7,8 @@
 
 #include <PortAudioDeviceDriver.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <portaudio.h>
 
 #include <yarp/os/Time.h>
@@ -94,13 +94,13 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             // final buffer
             for( i=0; i<framesLeft/num_channels; i++ )
             {
-                *wptr++ = playdata->read();  // left 
-                if( num_channels == 2 ) *wptr++ = playdata->read();  // right 
+                *wptr++ = playdata->read();  // left
+                if( num_channels == 2 ) *wptr++ = playdata->read();  // right
             }
             for( ; i<framesPerBuffer; i++ )
             {
-                *wptr++ = 0;  // left 
-                if( num_channels == 2 ) *wptr++ = 0;  // right 
+                *wptr++ = 0;  // left
+                if( num_channels == 2 ) *wptr++ = 0;  // right
             }
             finished = paComplete;
         }
@@ -108,8 +108,8 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
         {
             for( i=0; i<framesPerBuffer; i++ )
             {
-                *wptr++ = playdata->read();  // left 
-                if( num_channels == 2 ) *wptr++ = playdata->read();  // right 
+                *wptr++ = playdata->read();  // left
+                if( num_channels == 2 ) *wptr++ = playdata->read();  // right
             }
             finished = paContinue;
         }
@@ -149,7 +149,7 @@ bool PortAudioDeviceDriver::open(yarp::os::Searchable& config)
     driverConfig.wantRead = (bool)config.check("read","if present, just deal with reading audio (microphone)");
     driverConfig.wantWrite = (bool)config.check("write","if present, just deal with writing audio (speaker)");
     driverConfig.deviceNumber = config.check("id",Value(-1),"which portaudio index to use (-1=automatic)").asInt();
-    
+
     if (!(driverConfig.wantRead||driverConfig.wantWrite))
     {
         driverConfig.wantRead = driverConfig.wantWrite = true;
@@ -230,7 +230,7 @@ bool PortAudioDeviceDriver::open(PortAudioDeviceDriverSettings& config)
               wantWrite?(&outputParameters):NULL,
               frequency,
               DEFAULT_FRAMES_PER_BUFFER,
-              paClipOff,      
+              paClipOff,
               bufferIOCallback,
               &dataBuffers );
 
@@ -238,7 +238,7 @@ bool PortAudioDeviceDriver::open(PortAudioDeviceDriverSettings& config)
     {
         fprintf( stderr, "An error occurred while using the portaudio stream\n" );
         fprintf( stderr, "Error number: %d\n", err );
-        fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) ); 
+        fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     }
 
     //start the thread
@@ -322,7 +322,7 @@ bool PortAudioDeviceDriver::getSound(yarp::sig::Sound& sound)
     {
         this->startRecording();
     }
-    
+
     int buff_size = 0;
     static int buff_size_wdt = 0;
     while (buff_size<this->numSamples*this->numChannels)
@@ -385,7 +385,7 @@ void streamThread::run()
             something_to_play = false;
             err = Pa_StartStream( stream );
             if( err != paNoError ) {handleError(); return;}
-        
+
             while( ( err = Pa_IsStreamActive( stream ) ) == 1 )
                 {yarp::os::Time::delay(SLEEP_TIME);}
             if( err < 0 ) {handleError(); return;}
@@ -393,12 +393,12 @@ void streamThread::run()
             err = Pa_StopStream( stream );
             //err = Pa_AbortStream( stream );
             if( err < 0 ) {handleError(); return;}
-        
+
         }
-        
+
         if (something_to_record)
         {
-            while( ( err = Pa_IsStreamActive( stream ) ) == 1 ) 
+            while( ( err = Pa_IsStreamActive( stream ) ) == 1 )
                 {yarp::os::Time::delay(SLEEP_TIME);}
             if( err < 0 ) {handleError(); return;}
         }
@@ -411,13 +411,13 @@ void streamThread::run()
 bool PortAudioDeviceDriver::immediateSound(yarp::sig::Sound& sound)
 {
     dataBuffers.playData->clear();
-    
+
     //unsigned char* dataP= sound.getRawData();
     int num_bytes = sound.getBytesPerSample();
     int num_channels = sound.getChannels();
     int num_samples = sound.getRawDataSize()/num_channels/num_bytes;
     // memcpy(data.samplesBuffer,dataP,num_samples/**num_bytes*num_channels*/);
-    
+
     for (int i=0; i<num_samples; i++)
         for (int j=0; j<num_channels; j++)
             dataBuffers.playData->write (sound.get(i,j));
@@ -434,7 +434,7 @@ bool PortAudioDeviceDriver::renderSound(yarp::sig::Sound& sound)
         chans != this->numChannels)
     {
         //wait for current playback to finish
-        while (Pa_IsStreamStopped(stream )==0) 
+        while (Pa_IsStreamStopped(stream )==0)
         {
             yarp::os::Time::delay(SLEEP_TIME);
         }
@@ -467,7 +467,7 @@ bool PortAudioDeviceDriver::appendSound(yarp::sig::Sound& sound)
     int num_channels = sound.getChannels();
     int num_samples = sound.getRawDataSize()/num_channels/num_bytes;
     // memcpy(data.samplesBuffer,dataP,num_samples/**num_bytes*num_channels*/);
-    
+
     for (int i=0; i<num_samples; i++)
         for (int j=0; j<num_channels; j++)
             dataBuffers.playData->write (sound.get(i,j));

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -4,6 +4,8 @@
 * CopyPolicy: Released under the terms of the GPLv2 or later, see GPL.TXT
 */
 
+#define _USE_MATH_DEFINES
+
 #include <rpLidar.h>
 
 #include <yarp/os/Time.h>
@@ -12,12 +14,11 @@
 #include <yarp/os/LockGuard.h>
 #include <yarp/os/ResourceFinder.h>
 #include <iostream>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <limits>
 
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 //#define LASER_DEBUG
 //#define FORCE_SCAN

--- a/src/devices/serial/SerialDeviceDriver.cpp
+++ b/src/devices/serial/SerialDeviceDriver.cpp
@@ -6,8 +6,8 @@
 
 #include <SerialDeviceDriver.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 ///#include <yarp/os/Time.h>
 #include <yarp/os/Log.h>

--- a/src/devices/serial/SerialDeviceDriver.h
+++ b/src/devices/serial/SerialDeviceDriver.h
@@ -11,9 +11,10 @@
 #include <yarp/dev/SerialInterfaces.h>
 #include <yarp/os/Bottle.h>
 
+#include <stdio.h>
+
 #include <ace/DEV_Connector.h>
 #include <ace/TTY_IO.h>
-#include <ace/OS_NS_stdio.h>
 
 namespace yarp {
     namespace dev {
@@ -24,7 +25,7 @@ namespace yarp {
 
 using namespace yarp::os;
 
-class yarp::dev::SerialDeviceDriverSettings 
+class yarp::dev::SerialDeviceDriverSettings
 {
 public:
     char CommChannel[100]; // Contains the name of the com port "COM1", "COM2" (windows) or "/etc/stty0", "/dev/stty1" (linux), etc...
@@ -70,7 +71,7 @@ public:
  * @ingroup dev_impl_media
  *
  * A basic Serial Communications Link (RS232, USB).
- * 
+ *
  */
 class yarp::dev::SerialDeviceDriver : public DeviceDriver, public ISerialDevice
 {

--- a/src/devices/stage/StageControl.cpp
+++ b/src/devices/stage/StageControl.cpp
@@ -7,9 +7,9 @@
 
 #include "StageControl.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <yarp/os/Time.h>
 

--- a/src/devices/stage/StageControl.h
+++ b/src/devices/stage/StageControl.h
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/os/Thread.h>

--- a/src/devices/test_grabber/TestFrameGrabber.h
+++ b/src/devices/test_grabber/TestFrameGrabber.h
@@ -8,7 +8,7 @@
 #ifndef YARP_DEV_TESTFRAMEGRABBER_H
 #define YARP_DEV_TESTFRAMEGRABBER_H
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/sig/ImageFile.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>

--- a/src/devices/urbtc/kernel_module/urbtc.c
+++ b/src/devices/urbtc/kernel_module/urbtc.c
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * Author information summary for YARP:
  *
  * Copyright (C) 2001-2004 Greg Kroah-Hartman (greg@kroah.com)
@@ -7,7 +7,7 @@
  *
  */
 /*
- * USB H8 based motor controller driver 
+ * USB H8 based motor controller driver
  *
  * based on USB Skeleton driver.
  */
@@ -20,7 +20,7 @@
  *	modify it under the terms of the GNU General Public License as
  *	published by the Free Software Foundation, version 2.
  *
- * This driver is based on the 2.6.3 version of drivers/usb/usb-skeleton.c 
+ * This driver is based on the 2.6.3 version of drivers/usb/usb-skeleton.c
  * but has been rewritten to be easy to read and use, as no locks are now
  * needed anymore.
  *
@@ -30,7 +30,7 @@
 
 #include <linux/config.h>
 #include <linux/kernel.h>
-#include <linux/errno.h>
+#include <linux/cerrno>
 #include <linux/init.h>
 #include <linux/slab.h>
 #include <linux/module.h>
@@ -90,7 +90,7 @@ struct usb_urbtc {
 static struct usb_driver urbtc_driver;
 
 static void urbtc_delete(struct kref *kref)
-{	
+{
 	struct usb_urbtc *dev = to_urbtc_dev(kref);
 
 	usb_put_dev(dev->udev);
@@ -149,7 +149,7 @@ static int urbtc_release(struct inode *inode, struct file *file)
 		if (dev->readbuf_enabled)
 			usb_kill_urb(dev->readbuf_urb);
 	}
-		
+
 	/* decrement the count on our device */
 	kref_put(&dev->kref, urbtc_delete);
 	return 0;
@@ -161,8 +161,8 @@ static void urbtc_read_bulk_callback(struct urb *urb, struct pt_regs *regs)
 	int res;
 
 	/* sync/async unlink faults aren't errors */
-	if (urb->status && 
-	    !(urb->status == -ENOENT || 
+	if (urb->status &&
+	    !(urb->status == -ENOENT ||
 	      urb->status == -ECONNRESET ||
 	      urb->status == -ESHUTDOWN)) {
 		dbg("%s - nonzero read bulk status received: %d",
@@ -195,7 +195,7 @@ static ssize_t urbtc_read(struct file *file, char *buffer, size_t count, loff_t 
 	struct usb_urbtc *dev = (struct usb_urbtc *)file->private_data;
 	int retval = 0;
 	int bytes_read;
-	
+
 	if (count != sizeof(struct uin))
 		return -EINVAL;
 
@@ -268,8 +268,8 @@ static void urbtc_write_bulk_callback(struct urb *urb, struct pt_regs *regs)
 	struct usb_urbtc *dev = (struct usb_urbtc *)urb->context;
 
 	/* sync/async unlink faults aren't errors */
-	if (urb->status && 
-	    !(urb->status == -ENOENT || 
+	if (urb->status &&
+	    !(urb->status == -ENOENT ||
 	      urb->status == -ECONNRESET ||
 	      urb->status == -ESHUTDOWN)) {
 		dbg("%s - nonzero write bulk status received: %d",
@@ -277,7 +277,7 @@ static void urbtc_write_bulk_callback(struct urb *urb, struct pt_regs *regs)
 	}
 
 	/* free up our allocated buffer */
-	usb_buffer_free(urb->dev, urb->transfer_buffer_length, 
+	usb_buffer_free(urb->dev, urb->transfer_buffer_length,
 			urb->transfer_buffer, urb->transfer_dma);
 	up(&dev->limit_sem);
 }
@@ -455,7 +455,7 @@ static struct file_operations urbtc_fops = {
 	.release =	urbtc_release,
 };
 
-/* 
+/*
  * usb class driver info in order to get a minor number from the usb core,
  * and to have the device registered with the driver core
  */

--- a/src/devices/vfw/VfwGrabber.cpp
+++ b/src/devices/vfw/VfwGrabber.cpp
@@ -55,7 +55,7 @@
 #include <VfwGrabber.h>
 using namespace yarp::dev;
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <vfw.h>
 
@@ -85,8 +85,8 @@ typedef struct CvCaptureCAM_VFW
 }
 CvCaptureCAM_VFW;
 
-static LRESULT PASCAL FrameCallbackProc( HWND hWnd, VIDEOHDR* hdr ) 
-{ 
+static LRESULT PASCAL FrameCallbackProc( HWND hWnd, VIDEOHDR* hdr )
+{
     CvCaptureCAM_VFW* capture = 0;
 
     if (!hWnd) return FALSE;
@@ -99,8 +99,8 @@ static LRESULT PASCAL FrameCallbackProc( HWND hWnd, VIDEOHDR* hdr )
     //hdr->lpData;
     //hdr->dwBytesUsed;
 
-    return (LRESULT)TRUE; 
-} 
+    return (LRESULT)TRUE;
+}
 
 
 // Initialize camera input
@@ -109,18 +109,18 @@ static int icvOpenCAM_VFW( CvCaptureCAM_VFW* capture, int wIndex )
     char szDeviceName[80];
     char szDeviceVersion[80];
     HWND hWndC = 0;
-    
+
     if( (unsigned)wIndex >= 10 )
         wIndex = 0;
 
-    for( ; wIndex < 10; wIndex++ ) 
+    for( ; wIndex < 10; wIndex++ )
         {
-            if( capGetDriverDescription( wIndex, szDeviceName, 
-                                         sizeof (szDeviceName), szDeviceVersion, 
-                                         sizeof (szDeviceVersion))) 
+            if( capGetDriverDescription( wIndex, szDeviceName,
+                                         sizeof (szDeviceName), szDeviceVersion,
+                                         sizeof (szDeviceVersion)))
                 {
                     printf("Possible input: %s\n", szDeviceName);
-                    hWndC = capCreateCaptureWindow ( "My Own Capture Window", 
+                    hWndC = capCreateCaptureWindow ( "My Own Capture Window",
                                                      WS_POPUP | WS_CHILD, 0, 0, 320, 240, 0, 0);
                     if( capDriverConnect (hWndC, wIndex))
                         break;
@@ -128,7 +128,7 @@ static int icvOpenCAM_VFW( CvCaptureCAM_VFW* capture, int wIndex )
                     hWndC = 0;
                 }
         }
-    
+
     capture->capWnd = 0;
     if( hWndC )
         {
@@ -137,12 +137,12 @@ static int icvOpenCAM_VFW( CvCaptureCAM_VFW* capture, int wIndex )
             capture->hdr = 0;
             capture->hic = 0;
             capture->fourcc = (DWORD)-1;
-        
+
             memset( &capture->caps, 0, sizeof(capture->caps));
             capDriverGetCaps( hWndC, &capture->caps, sizeof(&capture->caps));
             ::MoveWindow( hWndC, 0, 0, 320, 240, TRUE );
             capSetUserData( hWndC, (size_t)capture );
-            capSetCallbackOnFrame( hWndC, FrameCallbackProc ); 
+            capSetCallbackOnFrame( hWndC, FrameCallbackProc );
             CAPTUREPARMS p;
             capCaptureGetSetup(hWndC,&p,sizeof(CAPTUREPARMS));
             p.dwRequestMicroSecPerFrame = 66667/2;
@@ -158,7 +158,7 @@ static  void icvCloseCAM_VFW( CvCaptureCAM_VFW* capture )
 {
     if( capture && capture->capWnd )
         {
-            capSetCallbackOnFrame( capture->capWnd, NULL ); 
+            capSetCallbackOnFrame( capture->capWnd, NULL );
             capDriverDisconnect( capture->capWnd );
             DestroyWindow( capture->capWnd );
             if( capture->hic )
@@ -251,7 +251,7 @@ static Image* icvRetrieveFrameCAM_VFW( CvCaptureCAM_VFW* capture )
                                         }
                                 }
                         }
-        
+
                     if( code == ICERR_OK )
                         {
                             if (!done) {

--- a/src/devices/wxsdl/WxsdlWriter.cpp
+++ b/src/devices/wxsdl/WxsdlWriter.cpp
@@ -335,7 +335,7 @@ void SDLPanel::putImage(ImageOf<PixelRgb>& image) {
         
         mutex.post();
 
-#ifdef WIN32
+#if defined(_WIN32)
         Refresh();
 #else
         wxMutexGuiEnter();

--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -8,9 +8,9 @@
 #include "RosType.h"
 #include "md5.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include <sys/stat.h>
 #include <string>
 #include <sstream>
@@ -30,7 +30,9 @@
 #  include <ace/OS_NS_sys_wait.h>
 #else
 #  include <unistd.h>
-#  include <sys/wait.h>
+#  if defined(YARP_HAS_SYS_WAIT_H)
+#    include <sys/wait.h>
+#  endif
 #  ifndef ACE_OS
 #    define ACE_OS
 #  endif
@@ -82,7 +84,7 @@ RosType::RosTypes::RosTypes() {
     system_resource = new std::vector<RosType>();
     if (!system_resource) {
         fprintf(stderr,"Failed to allocated storage for ros types\n");
-        exit(1);
+        std::exit(1);
     }
 }
 
@@ -95,7 +97,7 @@ RosType::RosTypes::RosTypes(const RosTypes& alt) {
     system_resource = new std::vector<RosType>();
     if (!system_resource) {
         fprintf(stderr,"Failed to allocated storage for ros types\n");
-        exit(1);
+        std::exit(1);
     }
     HELPER(system_resource) = HELPER(alt.system_resource);
 }
@@ -221,7 +223,7 @@ bool RosType::read(const char *tname, RosTypeSearch& env, RosTypeCodeGen& gen,
     }
     if (!fin) {
         fprintf(stderr, "[type] FAILED to open %s\n", path.c_str());
-        exit(1);
+        std::exit(1);
     }
 
     if (verbose) {
@@ -340,11 +342,11 @@ bool RosType::cache(const char *tname, RosTypeSearch& env,
     }
     if (!fin) {
         fprintf(stderr, "[type] FAILED to open %s\n", tname);
-        exit(1);
+        std::exit(1);
     }
     if (!fout) {
         fprintf(stderr, "[type] FAILED to open %s\n", rosType.c_str());
-        exit(1);
+        std::exit(1);
     }
 
     do {
@@ -531,7 +533,7 @@ bool RosTypeSearch::fetchFromRos(const std::string& target_file,
     if (verbose) {
         fprintf(stderr,"[ros]  %s\n", cmd.c_str());
     }
-    pid_t p = ACE_OS::fork();
+    pid_t p = yarp::os::fork();
     if (p==0) {
 #ifdef __linux__
         // This was ACE_OS::execlp, but that fails
@@ -539,7 +541,7 @@ bool RosTypeSearch::fetchFromRos(const std::string& target_file,
 #else
         ACE_OS::execlp("sh","sh","-c",cmd.c_str(),(char *)NULL);
 #endif
-        exit(0);
+        std::exit(0);
     } else {
         ACE_OS::wait(NULL);
     }
@@ -766,7 +768,7 @@ std::string RosTypeSearch::findFile(const char *tname) {
     // File not found. abort if needed
     if (abort_on_error) {
         fprintf(stderr, "[type] %s not found. Aborting\n", tname);
-        exit(1);
+        std::exit(1);
     } else {
         fprintf(stderr, "[type] %s not found. Continuing\n", tname);
     }

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -7,8 +7,8 @@
 
 #include <RosTypeCodeGenYarp.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/os/Os.h>
 #include <iostream>
@@ -118,7 +118,7 @@ bool RosTypeCodeGenYarp::beginType(const std::string& tname,
         if (!out) {
             fprintf(stderr,"Failed to open %s for writing\n",
                     alt_fname.c_str());
-            exit(1);
+            std::exit(1);
         }
         if (verbose) {
             printf("Generating %s\n", alt_fname.c_str());
@@ -137,7 +137,7 @@ bool RosTypeCodeGenYarp::beginType(const std::string& tname,
     out = fopen(fname.c_str(),"w");
     if (!out) {
         fprintf(stderr,"Failed to open %s for writing\n", fname.c_str());
-        exit(1);
+        std::exit(1);
     }
     fprintf(out,"// This is an automatically generated file.\n");
     fprintf(out,"// Generated from this %s.msg definition:\n", safe_tname.c_str());
@@ -450,7 +450,7 @@ bool RosTypeCodeGenYarp::writeField(bool bare, const RosField& field) {
                             field.rosName.c_str());
                 }
                 fprintf(out,"    if (%s.size()>0) {connection.appendExternalBlock((char*)&%s[0],sizeof(%s)*%s.size());}\n",
-                        field.rosName.c_str(), 
+                        field.rosName.c_str(),
                         field.rosName.c_str(),
                         t.yarpType.c_str(),
                         field.rosName.c_str());
@@ -676,7 +676,7 @@ RosYarpType RosTypeCodeGenYarp::mapPrimitive(const RosField& field) {
     } else {
         fprintf(stderr, "Please translate %s in RosTypeCodeGenYarp.cpp\n",
                 name.c_str());
-        exit(1);
+        std::exit(1);
     }
     if (flavor=="int") {
         ry.yarpWriter = "appendInt";

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
@@ -9,7 +9,7 @@
 #define YARP2_ROSTYPECODEGENYARP_INC
 
 #include <RosType.h>
-#include <stdio.h>
+#include <cstdio>
 
 class RosYarpType {
 public:

--- a/src/idls/rosmsg/src/main.cpp
+++ b/src/idls/rosmsg/src/main.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <string>
 
@@ -25,12 +25,14 @@
 #  include <ace/OS_NS_sys_wait.h>
 #else
 #  include <unistd.h>
-#  include <sys/wait.h>
+#  if defined(YARP_HAS_SYS_WAIT_H)
+#    include <sys/wait.h>
+#  endif
 #  ifndef ACE_OS
 #    define ACE_OS
 #  endif
 #endif
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace yarp::os;
 using namespace std;

--- a/src/idls/rosmsg/tests/demo/main.cpp
+++ b/src/idls/rosmsg/tests/demo/main.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <Demo.h>
 #include <Tennis.h>
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
     if (!test_signs()) return 1;
     if (!test_serialization()) return 1;
-    
+
     Demo demo1;
     if (!test_lists(test,demo1,"regular")) return 1;
     Demo::bottleStyle demo2;

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -24,7 +24,7 @@
 #include <map>
 #include <set>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <sys/stat.h>
 #include <sstream>
 #include "t_generator.h"
@@ -2000,7 +2000,7 @@ void t_yarp_generator::generate_service(t_service* tservice) {
         if (!returntype->is_void()) {
           indent(f_curr_) << declare_field(&returnfield) << endl;
         }
-        
+
         indent(f_curr_) << function_prototype(*fn_iter,false,NULL,"init") << ";" << endl;
         indent(f_curr_) << "virtual bool write(yarp::os::ConnectionWriter& connection);" << endl;
         indent(f_curr_) << "virtual bool read(yarp::os::ConnectionReader& connection);" << endl;
@@ -2019,7 +2019,7 @@ void t_yarp_generator::generate_service(t_service* tservice) {
         //        << " : public yarp::os::Portable {"
         //        << endl;
         //indent(f_curr_) << "public:" << endl;
-        
+
         vector<t_field*> args = (*fn_iter)->get_arglist()->get_members();
         vector<t_field*>::iterator arg_iter;
         t_type* returntype = (*fn_iter)->get_returntype();
@@ -2044,7 +2044,7 @@ void t_yarp_generator::generate_service(t_service* tservice) {
         indent_down();
         indent(f_curr_) << "}" << endl;
         f_curr_ << endl;
-        
+
         indent(f_curr_) << "bool " << service_name_ << "_" << fname << "::read(yarp::os::ConnectionReader& connection) {" << endl;
         indent_up();
         if (!(*fn_iter)->is_oneway()) {

--- a/src/idls/thrift/src_gen/lexer.cc
+++ b/src/idls/thrift/src_gen/lexer.cc
@@ -15,10 +15,10 @@
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <cstdlib>
 
 /* end standard C headers. */
 
@@ -32,7 +32,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -49,7 +49,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -170,7 +170,7 @@ extern FILE *yyin, *yyout;
 
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE yylex. 
+     *       existing scanners that call yyless() from OUTSIDE yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -182,7 +182,7 @@ extern FILE *yyin, *yyout;
                     if ( yytext[yyl] == '\n' )\
                         --yylineno;\
             }while(0)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -244,7 +244,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -1300,14 +1300,14 @@ static yyconst flex_int16_t yy_chk[1735] =
 /* Table of booleans, true if rule could match eol. */
 static yyconst flex_int32_t yy_rule_can_match_eol[170] =
     {   0,
-1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 1, 0, 0, 0,     };
 
 extern int yy_flex_debug;
@@ -1376,7 +1376,7 @@ char *yytext_ptr;
 #pragma GCC diagnostic ignored "-Wunused-label"
 
 #include <string>
-#include <errno.h>
+#include <cerrno>
 
 #include "main.h"
 #include "globals.h"
@@ -1598,7 +1598,7 @@ YY_DECL
 	register yy_state_type yy_current_state;
 	register char *yy_cp, *yy_bp;
 	register int yy_act;
-    
+
 
 
 
@@ -1693,7 +1693,7 @@ find_rule: /* we branch to this label when backing up */
 			int yyl;
 			for ( yyl = (yy_prev_more_offset); yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+
     yylineno++;
 ;
 			}
@@ -2718,7 +2718,7 @@ static int yy_get_next_buffer (void)
 {
 	register yy_state_type yy_current_state;
 	register char *yy_cp;
-    
+
 	yy_current_state = (yy_start);
 
 	(yy_state_ptr) = (yy_state_buf);
@@ -2748,7 +2748,7 @@ static int yy_get_next_buffer (void)
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
 	register int yy_is_jam;
-    
+
 	register YY_CHAR yy_c = 1;
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
@@ -2773,7 +2773,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-    
+
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -2835,7 +2835,7 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	if ( c == '\n' )
-		   
+
     yylineno++;
 ;
 
@@ -2845,12 +2845,12 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ *
  * @note This function does not reset the start condition to @c INITIAL .
  */
     void yyrestart  (FILE * input_file )
 {
-    
+
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -2863,11 +2863,11 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ *
  */
     void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-    
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
@@ -2907,13 +2907,13 @@ static void yy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ *
  * @return the allocated buffer state.
  */
     YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
@@ -2936,11 +2936,11 @@ static void yy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with yy_create_buffer()
- * 
+ *
  */
     void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
-    
+
 	if ( ! b )
 		return;
 
@@ -2956,7 +2956,7 @@ static void yy_load_buffer_state  (void)
 #ifndef __cplusplus
 extern int isatty (int );
 #endif /* __cplusplus */
-    
+
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -2965,7 +2965,7 @@ extern int isatty (int );
 
 {
 	int oerrno = errno;
-    
+
 	yy_flush_buffer(b );
 
 	b->yy_input_file = file;
@@ -2981,13 +2981,13 @@ extern int isatty (int );
     }
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-    
+
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ *
  */
     void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
@@ -3016,7 +3016,7 @@ extern int isatty (int );
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *
  */
 void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
@@ -3046,7 +3046,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *
  */
 void yypop_buffer_state (void)
 {
@@ -3070,7 +3070,7 @@ void yypop_buffer_state (void)
 static void yyensure_buffer_stack (void)
 {
 	int num_to_alloc;
-    
+
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -3083,9 +3083,9 @@ static void yyensure_buffer_stack (void)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -3113,13 +3113,13 @@ static void yyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
- * @return the newly allocated buffer state object. 
+ *
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -3148,14 +3148,14 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ *
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
 YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
 {
-    
+
 	return yy_scan_bytes(yystr,strlen(yystr) );
 }
 
@@ -3163,7 +3163,7 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ *
  * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
@@ -3172,7 +3172,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
 	char *buf;
 	yy_size_t n;
 	int i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) yyalloc(n  );
@@ -3226,16 +3226,16 @@ static void yy_fatal_error (yyconst char* msg )
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- * 
+ *
  */
 int yyget_lineno  (void)
 {
-        
+
     return yylineno;
 }
 
 /** Get the input stream.
- * 
+ *
  */
 FILE *yyget_in  (void)
 {
@@ -3243,7 +3243,7 @@ FILE *yyget_in  (void)
 }
 
 /** Get the output stream.
- * 
+ *
  */
 FILE *yyget_out  (void)
 {
@@ -3251,7 +3251,7 @@ FILE *yyget_out  (void)
 }
 
 /** Get the length of the current token.
- * 
+ *
  */
 int yyget_leng  (void)
 {
@@ -3259,7 +3259,7 @@ int yyget_leng  (void)
 }
 
 /** Get the current token.
- * 
+ *
  */
 
 char *yyget_text  (void)
@@ -3269,18 +3269,18 @@ char *yyget_text  (void)
 
 /** Set the current line number.
  * @param line_number
- * 
+ *
  */
 void yyset_lineno (int  line_number )
 {
-    
+
     yylineno = line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param in_str A readable stream.
- * 
+ *
  * @see yy_switch_to_buffer
  */
 void yyset_in (FILE *  in_str )
@@ -3311,7 +3311,7 @@ static int yy_init_globals (void)
 
     /* We do not touch yylineno unless the option is enabled. */
     yylineno =  1;
-    
+
     (yy_buffer_stack) = 0;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
@@ -3342,7 +3342,7 @@ static int yy_init_globals (void)
 /* yylex_destroy is for both reentrant and non-reentrant scanners. */
 int yylex_destroy  (void)
 {
-    
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		yy_delete_buffer(YY_CURRENT_BUFFER  );

--- a/src/idls/thrift/src_gen/parser.cc
+++ b/src/idls/thrift/src_gen/parser.cc
@@ -2,20 +2,20 @@
 /* A Bison parser, made by GNU Bison 2.4.1.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C
-   
+
       Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
    Free Software Foundation, Inc.
-   
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -28,7 +28,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -97,7 +97,7 @@
 
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
-#include <stdio.h>
+#include <cstdio>
 #ifndef _MSC_VER
 #include <inttypes.h>
 #else
@@ -350,7 +350,7 @@ YYID (yyi)
 #    define YYSTACK_ALLOC alloca
 #    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
-#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#     include <cstdlib> /* INFRINGES ON USER NAME SPACE */
 #     ifndef _STDLIB_H
 #      define _STDLIB_H 1
 #     endif
@@ -378,7 +378,7 @@ YYID (yyi)
 #  if (defined __cplusplus && ! defined _STDLIB_H \
        && ! ((defined YYMALLOC || defined malloc) \
 	     && (defined YYFREE || defined free)))
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   include <cstdlib> /* INFRINGES ON USER NAME SPACE */
 #   ifndef _STDLIB_H
 #    define _STDLIB_H 1
 #   endif
@@ -934,7 +934,7 @@ while (YYID (0))
 #if YYDEBUG
 
 # ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstdio> /* INFRINGES ON USER NAME SPACE */
 #  define YYFPRINTF fprintf
 # endif
 

--- a/src/idls/thrift/src_thrift/main.cc
+++ b/src/idls/thrift/src_thrift/main.cc
@@ -28,15 +28,15 @@
  */
 
 #include <cassert>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <stdarg.h>
 #include <time.h>
 #include <string>
 #include <algorithm>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <errno.h>
+#include <cerrno>
 #include <limits.h>
 
 #ifdef MINGW
@@ -746,8 +746,8 @@ void validate_const_rec(std::string name, t_type* type, t_const_value* value) {
       }
     }
     if (!found) {
-      throw "type error: const " + name + " was declared as type " 
-        + type->get_name() + " which is an enum, but " 
+      throw "type error: const " + name + " was declared as type "
+        + type->get_name() + " which is an enum, but "
         + value->get_identifier() + " is not a valid value for that enum";
     }
   } else if (type->is_struct() || type->is_xception()) {
@@ -1061,7 +1061,7 @@ int main(int argc, char** argv) {
         g_incl_searchpath.push_back(arg);
       } else if ((strcmp(arg, "-o") == 0) || (strcmp(arg, "-out") == 0)) {
         out_path_is_absolute = (strcmp(arg, "-out") == 0) ? true : false;
-		  
+
 		arg = argv[++i];
         if (arg == NULL) {
           fprintf(stderr, "-o: missing output directory\n");

--- a/src/idls/thrift/tests/demo/main.cpp
+++ b/src/idls/thrift/tests/demo/main.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/all.h>
 #include <yarp/os/impl/UnitTest.h>
@@ -72,7 +72,7 @@ public:
         return result;
     }
 
-    virtual int32_t test_partial(const int32_t x, 
+    virtual int32_t test_partial(const int32_t x,
                                  const std::vector<int32_t> & lst,
                                  const int32_t y) {
         printf("test_partial with %d and %d\n", x, y);
@@ -196,12 +196,12 @@ public:
         called_did_set_id = false;
     }
 
-    virtual bool will_set_id() { 
+    virtual bool will_set_id() {
         called_will_set_id = true;
         return false;
     }
 
-    virtual bool did_set_id() { 
+    virtual bool did_set_id() {
         called_did_set_id = true;
         return false;
     }
@@ -636,7 +636,7 @@ bool test_missing_method() {
 
 bool test_unwrap() {
     printf("\n*** test_unwrap()\n");
-    
+
     DemoStructList s;
     s.lst.push_back(DemoStruct(5,10));
     s.lst.push_back(DemoStruct(9,900));
@@ -656,7 +656,7 @@ bool test_unwrap() {
 
 bool test_tostring() {
     printf("\n*** test_tostring()\n");
-    
+
     DemoStructList s;
     s.lst.push_back(DemoStruct(5,10));
     s.lst.push_back(DemoStruct(9,900));
@@ -880,7 +880,7 @@ bool test_help() {
         e.edit(d,false);
         Bottle bot("help");
         DummyConnector con;
-        
+
         bot.write(con.getWriter());
         e.read(con.getReader());
         bot.read(con.getReader());
@@ -898,7 +898,7 @@ bool test_help() {
         e.edit(d,false);
         Bottle bot("help x");
         DummyConnector con;
-        
+
         bot.write(con.getWriter());
         e.read(con.getReader());
         bot.read(con.getReader());
@@ -959,7 +959,7 @@ bool test_settings(UnitTest& test) {
 
     if (!sender_port.open("/sender")) return 1;
     if (!receiver_port.open("/receiver")) return 1;
-    yarp.connect("/sender","/receiver");    
+    yarp.connect("/sender","/receiver");
 
     settings.set_id(5);
     test.checkEqual(receiver.state().id,5,"int assignment");

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -165,15 +165,20 @@ set(YARP_OS_IMPL_HDRS include/yarp/os/impl/ACELockImpl.h
                       include/yarp/os/impl/NameConfig.h
                       include/yarp/os/impl/NameserCarrier.h
                       include/yarp/os/impl/NameServer.h
+                      include/yarp/os/impl/PlatformDirent.h
+                      include/yarp/os/impl/PlatformLimits.h
                       include/yarp/os/impl/PlatformList.h
                       include/yarp/os/impl/PlatformMap.h
+                      include/yarp/os/impl/PlatformNetdb.h
                       include/yarp/os/impl/PlatformSet.h
                       include/yarp/os/impl/PlatformSignal.h
                       include/yarp/os/impl/PlatformSize.h
+                      include/yarp/os/impl/PlatformSysStat.h
                       include/yarp/os/impl/PlatformStdio.h
                       include/yarp/os/impl/PlatformStdlib.h
                       include/yarp/os/impl/PlatformThread.h
                       include/yarp/os/impl/PlatformTime.h
+                      include/yarp/os/impl/PlatformUnistd.h
                       include/yarp/os/impl/PlatformVector.h
                       include/yarp/os/impl/PortCommand.h
                       include/yarp/os/impl/PortCore.h
@@ -275,6 +280,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/NullConnectionWriter.cpp
                  src/Os.cpp
                  src/Ping.cpp
+                 src/PlatformTime.cpp
                  src/Portable.cpp
                  src/PortablePair.cpp
                  src/PortCommand.cpp

--- a/src/libYARP_OS/examples/receiver.cpp
+++ b/src/libYARP_OS/examples/receiver.cpp
@@ -8,7 +8,7 @@
 // source for receiver.cpp
 #include <yarp/os/Port.h>
 #include <yarp/os/Bottle.h>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 

--- a/src/libYARP_OS/examples/sender.cpp
+++ b/src/libYARP_OS/examples/sender.cpp
@@ -9,12 +9,12 @@
 #include <yarp/os/Port.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 
 int main() {
-    Bottle bot1; 
+    Bottle bot1;
     bot1.addString("testing"); // a simple message
     Port output;
     output.open("/out");

--- a/src/libYARP_OS/include/yarp/os/Bytes.h
+++ b/src/libYARP_OS/include/yarp/os/Bytes.h
@@ -8,7 +8,7 @@
 #define YARP_OS_BYTES_H
 
 #include <yarp/os/api.h>
-#include <stddef.h> //defines size_t
+#include <cstddef> //defines size_t
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/LogStream.h
+++ b/src/libYARP_OS/include/yarp/os/LogStream.h
@@ -17,6 +17,7 @@
 #include <yarp/os/Os.h>
 
 #include <cstdio>
+#include <cstdlib>
 
 namespace std {
 template <typename T>
@@ -61,7 +62,7 @@ public:
             if (stream->type == yarp::os::Log::FatalType) {
                 yarp_print_trace(stderr, stream->file, stream->line);
                 delete stream;
-                yarp::os::exit(-1);
+                std::exit(-1);
             }
             delete stream;
         }

--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -14,6 +14,7 @@
 
 namespace yarp {
     namespace os {
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
         enum
         {
             YARP_SIGTERM,
@@ -22,87 +23,172 @@ namespace yarp {
 
         typedef void(*YarpSignalHandler)(int);
         /**
-        * Wrapper for the ACE_OS::signal signal.
-        * Attach a function handler to a signal.
-        * @param signum signal number (e.g. SIGTERM/SIGINT) to handle
-        * @param sighandler handler function
-        */
+         * @brief Portable wrapper for the signal() function.
+         *
+         * Attach a function handler to a signal.
+         *
+         * @param signum signal number (e.g. SIGTERM/SIGINT) to handle
+         * @param sighandler handler function
+         * @deprecated Since YARP 2.3.70. Use std::signal().
+         */
+        YARP_DEPRECATED_MSG("Use std::signal")
         YARP_OS_API YarpSignalHandler signal(int signum, YarpSignalHandler sighandler);
+#endif // YARP_NO_DEPRECATED
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+        /**
+         * @brief Portable wrapper for the exit() function.
+         *
+         * @deprecated Since YARP 2.3.70. Use std::exit().
+         */
+        YARP_OS_DEPRECATED_API_MSG("Use std::exit()")
+        void exit(int exit_code); // FIXME noreturn
+#endif // YARP_NO_DEPRECATED
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+        /**
+         * @brief Portable wrapper for the abort() function.
+         *
+         * @deprecated Since YARP 2.3.70. Use std::abort().
+         */
+        YARP_OS_DEPRECATED_API_MSG("Use std::abort()")
+        void abort(bool verbose = false);
+#endif // YARP_NO_DEPRECATED
 
         /**
-        * Wrapper for ACE_OS::exit().
-        */
-        YARP_OS_API void exit(int v);
-
-        /**
-        * Wrapper for ACE_OS::abort().
-        */
-        YARP_OS_API void abort(bool verbose=false);
-
-        /**
-        * Wrapper for ACE_OS::getenv().
-        * @param var string that containt the environment variable name
-        * @return the value corresponding to the envarionment variable v
-        */
+         * @brief Portable wrapper for the getenv() function.
+         *
+         * Get an environment variable.
+         *
+         * @param[in] var string that containt the environment variable name
+         * @return the value corresponding to the envarionment variable v
+         */
         YARP_OS_API const char *getenv(const char *var);
 
         /**
-        * Wrapper for ACE_OS::getppid().
-        * @return the process id (pid)
-        */
+         * @brief Portable wrapper for the getppid() function.
+         *
+         * Get process identification.
+         *
+         * @return the process id (pid)
+         */
         YARP_OS_API int getpid();
 
         /**
-        * Wrapper for ACE_OS::setprogname().
-        * @param progname the program name
-        */
+         * @brief Portable wrapper for the setprogname() function.
+         *
+         * Set the program name.
+         *
+         * @param[in] progname the program name
+         */
         YARP_OS_API void setprogname(const char *progname);
 
         /**
-        * Wrapper for ACE_OS::getprogname().
-        * @return the program name
-        */
+         * @brief Portable wrapper for the getprogname() function.
+         *
+         * Get the program name.
+         *
+         * @param[out] progname the program name
+         * @param size The size of the @c progname array
+         */
         YARP_OS_API void getprogname(char* progname, size_t size);
 
         /**
-        * Wrapper for ACE_OS::hostname().
-        * @return the system hostname
-        */
+         * @brief Portable wrapper for the gethostname() function.
+         *
+         * Returns the null-terminated hostname in the character array
+         * @c hostname, which has a length of @c size bytes.
+         *
+         * @param[out] the system hostname
+         * @param size The size of the @c hostname array
+         */
         YARP_OS_API void gethostname(char* hostname, size_t size);
 
         /**
-        * Wrapper for ACE_OS::mkdir(). Create a directory.
-        * @param p name of the new directory.
-        */
+         * @brief Portable wrapper for the mkdir() function.
+         *
+         * Create a directory.
+         *
+         * @param[in] p name of the new directory
+         * @return 0 on success
+         *
+         * @sa mkdir_p
+         */
         YARP_OS_API int mkdir(const char *p);
 
         /**
-        * Create a directory and all parent directories needed
-        * @param p desired path
-        * @param ignoreLevels components of name to ignore. Set to 1 if 
-        * last element of path is a filename, for example.
+        * @brief Create a directory and all parent directories needed.
+        *
+        * @param[in] p desired path
+        * @param ignoreLevels components of name to ignore. Set to 1 if
+        * last element of path is a filename, for example
         * @return 0 on success
+        *
+        * @sa mkdir
         */
         YARP_OS_API int mkdir_p(const char *p, int ignoreLevels = 0);
 
         /**
-        * Wrapper for ACE_OS::rmdir(). Remove an empty directory.
-        * @param p name of the directory.
-        */
+         * @brief Portable wrapper for the rmdir() function.
+         *
+         * Remove an empty directory.
+         *
+         * @param[in] p name of the directory
+         * @return 0 on success
+         */
         YARP_OS_API int rmdir(const char *p);
 
         /**
-        * Wrapper for ACE_OS::rename(). Changes the name of the file or 
-        * directory specified by oldname to newname. 
-        * @param oldname old name of the file/directory. 
-        * @param newname new name of the file/directory. 
-        */
+         * @brief Portable wrapper for the rename() function.
+         *
+         * Changes the name of the file or directory specified by @c oldname to
+         * @c newname.
+         *
+         * @param[in] oldname old name of the file/directory
+         * @param[in] newname new name of the file/directory
+         * @return 0 on success
+         */
         YARP_OS_API int rename(const char *oldname, const char *newname);
 
         /**
-        * Wrapper for ACE_OS::stat() function.
-        */
+         * @brief Portable wrapper for the stat() function.
+         *
+         * Get file status.
+         *
+         * @param[in]
+         * @return 0 on success (i.e. the file exists)
+         */
         YARP_OS_API int stat(const char *path);
+
+        /**
+         * @brief Portable wrapper for the getcwd() function.
+         *
+         * Get current working directory.
+         * The getcwd() function copies an absolute pathname of the current
+         * working directory to the array pointed to by @c buf, which is of
+         * length @c size.
+         *
+         * @param[out] buf The buffer where the path is copied
+         * @param size The size of the buffer
+         * @return a pointer to @c buf or NULL on failure
+         *
+         * @since YARP 2.3.70
+         */
+        YARP_OS_API char* getcwd(char *buf, size_t size);
+
+        /**
+         * @brief Portable wrapper for the fork() function.
+         *
+         * Create a child process.
+         *
+         * @return On success, the PID of the child process is returned in the
+         * parent, and 0 is returned in the child. On failure, -1 is returned
+         * in the parent, no child process is created, and errno is set
+         * appropriately
+         *
+         * @since YARP 2.3.70
+         */
+        YARP_OS_API int fork(void);
     }
 }
 

--- a/src/libYARP_OS/include/yarp/os/Ping.h
+++ b/src/libYARP_OS/include/yarp/os/Ping.h
@@ -7,7 +7,7 @@
 #ifndef YARP_OS_PING_H
 #define YARP_OS_PING_H
 
-#include <math.h>
+#include <cmath>
 #include <yarp/os/ConstString.h>
 
 namespace yarp {
@@ -21,15 +21,15 @@ namespace yarp {
 
 class yarp::os::Stat {
 public:
-    Stat() { 
+    Stat() {
         clear();
     }
 
     void clear() {
-        tot = tot2 = 0; 
+        tot = tot2 = 0;
         ct = at = 0;
         mu = 0;
-        sigma = 1e10; 
+        sigma = 1e10;
         // infinity would be better, but methods of getting infinity
         // require awkward dependencies
     }

--- a/src/libYARP_OS/include/yarp/os/RosNameSpace.h
+++ b/src/libYARP_OS/include/yarp/os/RosNameSpace.h
@@ -13,7 +13,7 @@
 #include <yarp/os/Thread.h>
 #include <yarp/os/Semaphore.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/Run.h
+++ b/src/libYARP_OS/include/yarp/os/Run.h
@@ -7,7 +7,7 @@
 #ifndef YARP_OS_RUN_H
 #define YARP_OS_RUN_H
 
-#include <string.h>
+#include <cstring>
 #include <yarp/os/api.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/Property.h>
@@ -164,7 +164,7 @@ public:
     static bool mLogged;
     static yarp::os::ConstString mLoggerPort;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     static YarpRunInfoVector mProcessVector;
     static YarpRunInfoVector mStdioVector;
 #else
@@ -191,7 +191,7 @@ protected:
     static ConstString mPortName;
     static int mProcCNT;
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
     static void cleanBeforeExec();
     static void writeToPipe(int fd,yarp::os::ConstString str);
     static int readFromPipe(int fd,char* &data,int& buffsize);

--- a/src/libYARP_OS/include/yarp/os/SharedLibraryClassApi.h
+++ b/src/libYARP_OS/include/yarp/os/SharedLibraryClassApi.h
@@ -9,7 +9,7 @@
 
 #include <yarp/conf/system.h>
 #include <yarp/os/Vocab.h>
-#include <string.h>
+#include <cstring>
 
 namespace yarp {
     namespace os {
@@ -27,7 +27,7 @@ extern "C" {
     /**
      *
      * Collection of hooks for creating/destroying a plugin.
-     * Be careful to check carefully for compatibility before 
+     * Be careful to check carefully for compatibility before
      * using create() or destroy().
      *
      */

--- a/src/libYARP_OS/include/yarp/os/Value.h
+++ b/src/libYARP_OS/include/yarp/os/Value.h
@@ -11,7 +11,7 @@
 #include <yarp/os/Searchable.h>
 #include <yarp/os/Portable.h>
 #include <yarp/os/Bottle.h>
-#include <stddef.h> // defines size_t
+#include <cstddef> // defines size_t
 
 namespace yarp {
     namespace os {
@@ -104,14 +104,14 @@ public:
     virtual bool isBool() const;
 
     /**
-     * Checks if value is an integer (32 bit or smaller). If so, asInt() will 
+     * Checks if value is an integer (32 bit or smaller). If so, asInt() will
      * return that integer.
      * @return true iff value is an integer
      */
     virtual bool isInt() const;
 
     /**
-     * Checks if value is a 64-bit integer or smaller. If so, asInt64() will 
+     * Checks if value is a 64-bit integer or smaller. If so, asInt64() will
      * return that integer.
      * @return true iff value is a 64-bit integer or smaller
      */

--- a/src/libYARP_OS/include/yarp/os/YarpNameSpace.h
+++ b/src/libYARP_OS/include/yarp/os/YarpNameSpace.h
@@ -9,7 +9,7 @@
 
 #include <yarp/os/NameSpace.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace os {
@@ -27,7 +27,7 @@ public:
     virtual Contact getNameServerContact() const {
         return contact;
     }
-    
+
     virtual Contact queryName(const ConstString& name);
 
     virtual Contact registerName(const ConstString& name);
@@ -38,42 +38,42 @@ public:
 
     virtual Contact unregisterContact(const Contact& contact);
 
-    virtual bool setProperty(const ConstString& name, const ConstString& key, 
+    virtual bool setProperty(const ConstString& name, const ConstString& key,
                              const Value& value);
 
     virtual Value *getProperty(const ConstString& name, const ConstString& key);
 
-    virtual bool connectPortToTopic(const Contact& src, 
+    virtual bool connectPortToTopic(const Contact& src,
                                     const Contact& dest,
                                     ContactStyle style) {
         return connectTopic("subscribe",false,true,src,dest,style);
     }
 
-    virtual bool connectTopicToPort(const Contact& src, 
+    virtual bool connectTopicToPort(const Contact& src,
                                     const Contact& dest,
                                     ContactStyle style) {
         return connectTopic("subscribe",true,false,src,dest,style);
     }
 
-    virtual bool disconnectPortFromTopic(const Contact& src, 
+    virtual bool disconnectPortFromTopic(const Contact& src,
                                          const Contact& dest,
                                          ContactStyle style) {
         return connectTopic("unsubscribe",false,true,src,dest,style);
     }
 
-    virtual bool disconnectTopicFromPort(const Contact& src, 
+    virtual bool disconnectTopicFromPort(const Contact& src,
                                          const Contact& dest,
                                          ContactStyle style) {
         return connectTopic("unsubscribe",true,false,src,dest,style);
     }
 
-    virtual bool connectPortToPortPersistently(const Contact& src, 
+    virtual bool connectPortToPortPersistently(const Contact& src,
                                                const Contact& dest,
                                                ContactStyle style) {
         return connectTopic("subscribe",false,false,src,dest,style);
     }
 
-    virtual bool disconnectPortToPortPersistently(const Contact& src, 
+    virtual bool disconnectPortToPortPersistently(const Contact& src,
                                                   const Contact& dest,
                                                   ContactStyle style) {
         return connectTopic("unsubscribe",false,false,src,dest,style);
@@ -82,7 +82,7 @@ public:
     virtual bool connectTopic(const ConstString& dir,
                               bool srcIsTopic,
                               bool destIsTopic,
-                              const Contact& src, 
+                              const Contact& src,
                               const Contact& dest,
                               ContactStyle style) {
         Contact dynamicSrc = src;

--- a/src/libYARP_OS/include/yarp/os/idl/WireTypes.h
+++ b/src/libYARP_OS/include/yarp/os/idl/WireTypes.h
@@ -8,21 +8,23 @@
 #ifndef YARP_OS_IDL_WIRETYPES_H
 #define YARP_OS_IDL_WIRETYPES_H
 
-#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
+
+#if __cplusplus >= 201103L
+# include <cstdint>
+#elif defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
   typedef __int32 int32_t;
   typedef unsigned __int32 uint32_t;
   typedef __int64 int64_t;
   typedef unsigned __int64 uint64_t;
 #else
-#  include <stdint.h>
+# include <stdint.h>
 #endif
-
 
 #include <string>
 #include <vector>
 #include <map>
 #include <set>
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/idl/WireWriter.h>
 #include <yarp/os/idl/WireReader.h>

--- a/src/libYARP_OS/include/yarp/os/impl/ACESemaphoreImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ACESemaphoreImpl.h
@@ -11,7 +11,7 @@
 
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 #include <yarp/os/impl/PlatformTime.h>
 
 #ifdef ACE_WIN32

--- a/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
@@ -19,7 +19,7 @@
 #include <yarp/os/NetInt64.h>
 
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/Companion.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Companion.h
@@ -14,7 +14,7 @@
 
 #include <yarp/os/impl/PlatformMap.h>
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
 // ACE headers may fiddle with main
 #ifdef main

--- a/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
@@ -11,7 +11,7 @@
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/Semaphore.h>
 
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 
 #ifdef YARP_HAS_ACE
 #include <ace/SOCK_Dgram.h>

--- a/src/libYARP_OS/include/yarp/os/impl/Dispatcher.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Dispatcher.h
@@ -11,7 +11,7 @@
 
 #include <yarp/os/impl/PlatformMap.h>
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/Logger.h>
 
 

--- a/src/libYARP_OS/include/yarp/os/impl/Logger.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Logger.h
@@ -7,24 +7,29 @@
 #ifndef YARP_OS_IMPL_LOGGER_H
 #define YARP_OS_IMPL_LOGGER_H
 
-#include <stdio.h>
 #include <yarp/conf/api.h>
 #include <yarp/conf/system.h>
 #include <yarp/os/ConstString.h>
+#include <yarp/os/Log.h>
+
+#include <yarp/os/impl/PlatformStdio.h>
 
 #ifdef YARP_HAS_ACE
-#  include <ace/Log_Msg.h>
-#  include <ace/Log_Record.h>
-#  include <ace/Log_Msg_Callback.h>
+# include <ace/Log_Msg.h>
+# include <ace/Log_Record.h>
+# include <ace/Log_Msg_Callback.h>
+// In one of these files or their inclusions, there is a definition of "main"
+# ifdef main
+#  undef main
+# endif
 #else
 #  define LM_DEBUG      04
 #  define LM_INFO      010
 #  define LM_WARNING   040
 #  define LM_ERROR    0200
 #endif
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
-#include <yarp/os/Log.h>
 
 namespace yarp {
     namespace os {
@@ -198,12 +203,12 @@ private:
 #define YARP_FAIL(log,x)  ((Logger*)&(log))->internal_fail(x)
 
 #define YARP_LONGEST_MESSAGE 1000
-#define YARP_SPRINTF0(log,mode,msg)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg); (log).internal_ ## mode(&(_yarp_buf[0])); }
-#define YARP_SPRINTF1(log,mode,msg,a)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a); (log).internal_ ## mode(&(_yarp_buf[0])); }
-#define YARP_SPRINTF2(log,mode,msg,a,b)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b); (log).internal_ ## mode(&(_yarp_buf[0])); }
-#define YARP_SPRINTF3(log,mode,msg,a,b,c)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c); (log).internal_ ## mode(&(_yarp_buf[0])); }
-#define YARP_SPRINTF4(log,mode,msg,a,b,c,d)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c,d); (log).internal_ ## mode(&(_yarp_buf[0])); }
-#define YARP_SPRINTF5(log,mode,msg,a,b,c,d,e)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; ACE_OS::snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c,d,e); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF0(log,mode,msg)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF1(log,mode,msg,a)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF2(log,mode,msg,a,b)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF3(log,mode,msg,a,b,c)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF4(log,mode,msg,a,b,c,d)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c,d); (log).internal_ ## mode(&(_yarp_buf[0])); }
+#define YARP_SPRINTF5(log,mode,msg,a,b,c,d,e)  { char _yarp_buf[YARP_LONGEST_MESSAGE]; snprintf(&(_yarp_buf[0]),YARP_LONGEST_MESSAGE,msg,a,b,c,d,e); (log).internal_ ## mode(&(_yarp_buf[0])); }
 
 
 

--- a/src/libYARP_OS/include/yarp/os/impl/McastCarrier.h
+++ b/src/libYARP_OS/include/yarp/os/impl/McastCarrier.h
@@ -16,7 +16,7 @@
 #include <yarp/os/impl/SplitString.h>
 #include <yarp/os/impl/PlatformSize.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/MemoryOutputStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/MemoryOutputStream.h
@@ -9,6 +9,8 @@
 #include <yarp/os/OutputStream.h>
 #include <yarp/os/Bytes.h>
 
+#include <cstring>
+
 namespace yarp {
     namespace os {
         namespace impl {

--- a/src/libYARP_OS/include/yarp/os/impl/POSIXSemaphoreImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/POSIXSemaphoreImpl.h
@@ -8,7 +8,7 @@
 #define YARP_OS_IMPL_POSIXSEMAPHOREIMPL_H
 
 #include <semaphore.h>
-#include <time.h>
+#include <ctime>
 
 #include <yarp/os/api.h>
 

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformDirent.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformDirent.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_OS_IMPL_PLATFORMDIRENT_H
+#define YARP_OS_IMPL_PLATFORMDIRENT_H
+
+#include <yarp/conf/system.h>
+#ifdef YARP_HAS_ACE
+# include <ace/OS_NS_dirent.h>
+#else
+# include <dirent.h>
+#endif
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    typedef ACE_DIRENT dirent;
+    typedef ACE_DIR DIR;
+    using ACE_OS::opendir;
+    using ACE_OS::closedir;
+    using ACE_OS::scandir;
+    inline int alphasort(const ACE_DIRENT **f1, const ACE_DIRENT **f2) { return ACE_OS::alphasort(f1, f2); }
+#else
+    using ::dirent;
+    using ::DIR;
+    using ::opendir;
+    using ::closedir;
+    using ::scandir;
+    using ::alphasort;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
+#endif // YARP_OS_IMPL_PLATFORMDIRENT_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformLimits.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformLimits.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_OS_IMPL_PLATFORMLIMITS_H
+#define YARP_OS_IMPL_PLATFORMLIMITS_H
+
+#include <yarp/conf/system.h>
+#ifdef YARP_HAS_ACE
+# include <ace/os_include/os_limits.h>
+#else
+# include <limits.h>
+#endif
+
+#ifndef HOST_NAME_MAX
+  YARP_COMPILER_ERROR("HOST_NAME_MAX not defined on this platform")
+#endif
+
+#endif // YARP_OS_IMPL_PLATFORMLIMITS_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformNetdb.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformNetdb.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_OS_IMPL_PLATFORMNETDB_H
+#define YARP_OS_IMPL_PLATFORMNETDB_H
+
+#include <yarp/conf/system.h>
+#ifdef YARP_HAS_ACE
+# include <ace/OS_NS_netdb.h>
+#elif defined(YARP_HAS_NETDB_H)
+# include <netdb.h>
+#endif
+
+
+#ifndef NI_MAXHOST
+  YARP_COMPILER_ERROR("NI_MAXHOST not defined on this platform")
+#endif
+
+#ifndef NI_NUMERICHOST
+  YARP_COMPILER_ERROR("NI_NUMERICHOST not defined on this platform")
+#endif
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    using ACE_OS::gethostbyaddr;
+    using ACE_OS::gethostbyname;
+    // ACE_OS::getaddrinfo, etc are not implemented, anyway ACE implementation
+    // is different, therefore they are not neeeded.
+#else
+    using ::gethostbyaddr;
+    using ::gethostbyname;
+    using ::getaddrinfo;
+    using ::freeaddrinfo;
+    using ::gai_strerror;
+    using ::getnameinfo;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
+
+#endif // YARP_OS_IMPL_PLATFORMNETDB_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformSignal.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformSignal.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia, Anne van Rossum
- * Authors: Paul Fitzpatrick, Anne van Rossum
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -9,15 +8,44 @@
 
 #include <yarp/conf/system.h>
 #ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_unistd.h>
-#  include <ace/OS_NS_signal.h>
-#else
-#  include <signal.h>
-#  ifndef __APPLE__
-#    define ACE_SignalHandler sighandler_t
-#  else
-#    define ACE_SignalHandler sig_t
-#  endif
+# include <ace/OS_NS_signal.h>
+#elif defined(YARP_HAS_SIGNAL_H)
+# include <signal.h>
+#elif definef(YARP_HAS_SYS_SIGNAL_H)
+# include <sys/signal.h>
 #endif
+
+#include <csignal>
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    using ACE_OS::sigemptyset;
+    using ACE_OS::sigaction;
+    using ACE_OS::kill;
+#else
+    using ::sigemptyset;
+    using ::sigaction;
+    using ::kill;
+#endif
+
+// std::signal is broken for Visual Studio 12 2013
+// (Fixed in Visual studio 14 2015)
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+# ifdef YARP_HAS_ACE
+    using ACE_OS::signal;
+# else
+    YARP_COMPILER_ERROR("signal not defined on this platform")
+# endif
+#else
+    using std::signal;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
 
 #endif // YARP_OS_IMPL_PLATFORMSIGNAL_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformStdio.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformStdio.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia, Anne van Rossum
- * Authors: Paul Fitzpatrick, Anne van Rossum
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -9,12 +8,28 @@
 
 #include <yarp/conf/system.h>
 #ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_stdio.h>
+# include <ace/OS_NS_stdio.h>
 #else
-#  include <cstdio>
-#  ifndef ACE_OS
-#    define ACE_OS
-#  endif
+# include <stdio.h>
 #endif
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    using ACE_OS::fileno;
+# if defined(_MSC_VER) && _MSC_VER < 1900
+    using ACE_OS::snprintf;
+# endif
+#else
+    using ::fileno;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
+
 
 #endif // YARP_OS_IMPL_PLATFORMSTDIO_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformStdlib.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformStdlib.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia, Anne van Rossum
- * Authors: Paul Fitzpatrick, Anne van Rossum
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
@@ -9,52 +8,43 @@
 
 #include <yarp/conf/system.h>
 #ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_stdlib.h>
-#  include <ace/OS_NS_string.h>
-#  include <ace/OS_NS_sys_stat.h>
-#  include <ace/OS_NS_dirent.h>
-#  include <ace/OS_NS_unistd.h>
+# include <ace/OS_NS_stdlib.h>
 #else
-#  include <cstring>
-#  include <stdlib.h>
-#  include <string.h>
-#  include <unistd.h>
-#  include <dirent.h>
-#  include <sys/types.h>
-#  include <sys/stat.h>
-#  ifndef ACE_OS
-#    define ACE_OS
-#  endif
-#  ifndef ACE_stat
-#    define ACE_stat struct stat
-#  endif
-#  ifndef ACE_DIRENT
-#    define ACE_DIRENT dirent
-#  endif
-#  ifndef ACE_DIR
-#    define ACE_DIR DIR
-#  endif
+# include <stdlib.h>
 #endif
 
-// ACE wrappers are glitching on Debian 4; use workaround
-#if defined(__linux__) || !defined(YARP_HAS_ACE)
-#define YARP_DIRENT dirent
-#define YARP_readdir ::readdir
-#define YARP_scandir ::scandir
-#define YARP_closedir ::closedir
-#define YARP_alphasort ::alphasort
-#define YARP_unlink ::unlink
-#define YARP_opendir ::opendir
-#define YARP_stat ::stat
+namespace yarp {
+namespace os {
+namespace impl {
+
+
+#if defined(_WIN32)
+    // ACE bindings for setenv and unsetenv do not work
+    // on WIN32 (last tested ACE 6.4.2).
+    inline int setenv(const char *name, const char *value, int overwrite) {
+        YARP_UNUSED(overwrite);
+        return _putenv_s(name, value);
+    }
+    inline int unsetenv(const char *name) {
+        return _putenv_s(name, "");
+    }
+#elif defined(YARP_HAS_ACE)
+    using ACE_OS::setenv;
+    using ACE_OS::unsetenv;
 #else
-#define YARP_DIRENT ACE_DIRENT
-#define YARP_readdir ACE_OS::readdir
-#define YARP_closedir ACE_OS::closedir
-#define YARP_scandir ACE_OS::scandir
-#define YARP_alphasort (ACE_SCANDIR_COMPARATOR)ACE_OS::alphasort
-#define YARP_unlink ACE_OS::unlink
-#define YARP_opendir ACE_OS::opendir
-#define YARP_stat ACE_OS::stat
+    using ::setenv;
+    using ::unsetenv;
 #endif
+
+#ifdef YARP_HAS_ACE
+    using ACE_OS::getenv;
+#else
+    using ::getenv;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
 
 #endif // YARP_OS_IMPL_PLATFORMSTDLIB_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformSysStat.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformSysStat.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_OS_IMPL_PLATFORMSYSSTAT_H
+#define YARP_OS_IMPL_PLATFORMSYSSTAT_H
+
+#include <yarp/conf/system.h>
+#ifdef YARP_HAS_ACE
+# include <ace/OS_NS_sys_stat.h>
+#else
+# include <sys/stat.h>
+#endif
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    typedef ACE_stat YARP_stat;
+    using ACE_OS::stat;
+    using ACE_OS::mkdir;
+#else
+    typedef struct ::stat YARP_stat;
+    using ::stat;
+    using ::mkdir;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
+#endif // YARP_OS_IMPL_PLATFORMSYSSTAT_H

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformThread.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformThread.h
@@ -26,10 +26,10 @@
 #else
 #  include <pthread.h>
 #  define Platform_hthread_t pthread_t
-#  if !defined(__APPLE__)
-#    define Platform_thread_t long int
-#  else
+#  if defined(__APPLE__)
 #    define Platform_thread_t pthread_t
+#  else
+#    define Platform_thread_t long int
 #  endif
 #  define PLATFORM_THREAD_SELF() pthread_self()
 #  define PLATFORM_THREAD_RETURN void *

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformTime.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformTime.h
@@ -9,16 +9,14 @@
 #define YARP_OS_IMPL_PLATFORMTIME_H
 
 #include <yarp/conf/system.h>
-
+#include <yarp/os/impl/PlatformUnistd.h>
 #ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_unistd.h>
 #  include <ace/OS_NS_sys_time.h>
 #  include <ace/Time_Value.h>
 #  include <ace/High_Res_Timer.h>
 #  define PLATFORM_TIME_SET(x,y) x.set(y)
 #else
 #  include <sys/time.h>
-#  include <unistd.h>
 #  define ACE_Time_Value struct timeval
 #  define PLATFORM_TIME_SET(x,y) fromDouble(x,y)
 #endif
@@ -27,14 +25,19 @@ namespace yarp {
     namespace os {
         namespace impl {
 
-            // defined in src/RFModule.cpp for historical reasons
-            void getTime(ACE_Time_Value& now);
-            void sleepThread(ACE_Time_Value& sleep_period);
-            void addTime(ACE_Time_Value& val, const ACE_Time_Value & add);
-            void subtractTime(ACE_Time_Value & val,
-                              const ACE_Time_Value & subtract);
-            double toDouble(const ACE_Time_Value &v);
-            void fromDouble(ACE_Time_Value &v, double x,int unit=1);
+#ifdef YARP_HAS_ACE
+            typedef ACE_Time_Value YARP_timeval;
+#else
+            typedef struct timeval YARP_timeval;
+#endif
+
+            void getTime(YARP_timeval& now);
+            void sleepThread(YARP_timeval& sleep_period);
+            void addTime(YARP_timeval& val, const YARP_timeval & add);
+            void subtractTime(YARP_timeval & val,
+                              const YARP_timeval & subtract);
+            double toDouble(const YARP_timeval &v);
+            void fromDouble(YARP_timeval &v, double x,int unit=1);
         }
     }
 }

--- a/src/libYARP_OS/include/yarp/os/impl/PlatformUnistd.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PlatformUnistd.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_OS_IMPL_PLATFORMUNISTD_H
+#define YARP_OS_IMPL_PLATFORMUNISTD_H
+
+#include <yarp/conf/system.h>
+#ifdef YARP_HAS_ACE
+# include <ace/OS_NS_unistd.h>
+#else
+# include <unistd.h>
+#endif
+
+namespace yarp {
+namespace os {
+namespace impl {
+
+#ifdef YARP_HAS_ACE
+    using ACE_OS::rmdir;
+    inline int gethostname(char *name, size_t len) { return ACE_OS::hostname(name, len); }
+    using ACE_OS::getpid;
+    using ACE_OS::isatty;
+    using ACE_OS::getcwd;
+    using ACE_OS::fork;
+#else
+    using ::rmdir;
+    using ::gethostname;
+    using ::getpid;
+    using ::isatty;
+    using ::getcwd;
+    using ::fork;
+#endif
+
+} // namespace impl
+} // namespace os
+} // namespace yarp
+
+
+#endif // YARP_OS_IMPL_PLATFORMUNISTD_H

--- a/src/libYARP_OS/include/yarp/os/impl/PortCorePackets.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCorePackets.h
@@ -13,7 +13,7 @@
 #  include <ace/config.h>
 #  include <ace/String_Base.h>
 #endif
-#include <stdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/PortManager.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortManager.h
@@ -14,7 +14,7 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/Route.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/Protocol.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Protocol.h
@@ -17,8 +17,8 @@
 #include <yarp/os/ShiftStream.h>
 #include <yarp/os/Portable.h>
 #include <yarp/os/ConnectionState.h>
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/RunProcManager.h
+++ b/src/libYARP_OS/include/yarp/os/impl/RunProcManager.h
@@ -6,28 +6,30 @@
 #ifndef YARP_OS_IMPL_RUNPROCMANAGER_H
 #define YARP_OS_IMPL_RUNPROCMANAGER_H
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #  if !defined(WIN32_LEAN_AND_MEAN)
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <windows.h>
 #else
 #  include <sys/types.h>
-#  include <sys/wait.h>
-#  include <errno.h>
-#  include <stdlib.h>
+#  if defined(YARP_HAS_SYS_WAIT_H)
+#    include <sys/wait.h>
+#  endif
+#  include <cerrno>
+#  include <cstdlib>
 #  include <fcntl.h>
 #  include <unistd.h>
 #endif
 
-#include <stdio.h>
-#include <signal.h>
+#include <cstdio>
+#include <csignal>
 #include <yarp/os/Run.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ConstString.h>
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 typedef DWORD PID;
 typedef HANDLE FDESC;
 #else
@@ -116,7 +118,7 @@ public:
 
     }
     bool Match(yarp::os::ConstString& alias){ return mAlias==alias; }
-#ifndef WIN32
+#if !defined(_WIN32)
     virtual bool Clean(PID pid,YarpRunProcInfo* &pRef)
     {
         if (mPidCmd==pid)
@@ -168,7 +170,7 @@ public:
     int Signal(yarp::os::ConstString& alias,int signum);
     int Killall(int signum);
 
-#if defined(WIN32)
+#if defined(_WIN32)
     HANDLE hZombieHunter;
     void GetHandles(HANDLE* &lpHandles,DWORD &nCount);
 #else
@@ -228,7 +230,7 @@ public:
 
     void TerminateStdio();
 
-#ifndef WIN32
+#if !defined(_WIN32)
     virtual bool Clean(PID pid,YarpRunProcInfo* &pRef)
     {
         pRef = YARP_NULLPTR;

--- a/src/libYARP_OS/include/yarp/os/impl/RunReadWrite.h
+++ b/src/libYARP_OS/include/yarp/os/impl/RunReadWrite.h
@@ -15,10 +15,10 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/impl/RunCheckpoints.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <fcntl.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #include <process.h>
 #include <io.h>
@@ -73,7 +73,7 @@ protected:
 */
 
 class RunTerminator
-#if !defined(WIN32)
+#if !defined(_WIN32)
     : public yarp::os::Thread
 #endif
 {
@@ -81,7 +81,7 @@ public:
     RunTerminator(RunStdio* pStdio)
     {
         mStdio=pStdio;
-#if !defined(WIN32)
+#if !defined(_WIN32)
         int pipe_block[2];
         int warn_suppress = pipe(pipe_block);
         YARP_UNUSED(warn_suppress);
@@ -90,13 +90,13 @@ public:
 #endif
     }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     void start(){}
 #endif
 
     ~RunTerminator()
     {
-#if !defined(WIN32)
+#if !defined(_WIN32)
         fclose(fwait);
         fclose(fpost);
 #endif
@@ -104,7 +104,7 @@ public:
 
     void run()
     {
-#if !defined(WIN32)
+#if !defined(_WIN32)
         char dummy[24];
         char* warn_suppress = fgets(dummy,16,fwait);
         YARP_UNUSED(warn_suppress);
@@ -115,7 +115,7 @@ public:
 
     void exit()
     {
-#if defined(WIN32)
+#if defined(_WIN32)
         mStdio->exit();
 #else
         fprintf(fpost,"SHKIATTETE!\n");
@@ -172,7 +172,7 @@ public:
         mRunning=false;
         wPort.close();
 
-#if defined(WIN32)
+#if defined(_WIN32)
         RUNLOG(">>>exit()")
         ::exit(0);
 #else
@@ -272,7 +272,7 @@ public:
 
         rPort.interrupt();
 
-#if defined(WIN32)
+#if defined(_WIN32)
         for (int t=0; t<10; ++t) yarp::os::Time::delay(1.0);
 #endif
         RUNLOG(">>>exit()")

--- a/src/libYARP_OS/include/yarp/os/impl/TcpAcceptor.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TcpAcceptor.h
@@ -31,7 +31,7 @@
 
 #include <yarp/os/impl/TcpStream.h>
 
-//#include <sys/time.h>
+//#include <sys/ctime>
 //#include <iostream>
 //
 //#include <sys/types.h>

--- a/src/libYARP_OS/include/yarp/os/impl/TcpConnector.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TcpConnector.h
@@ -27,15 +27,7 @@
 
 #include <yarp/os/Contact.h>
 #include <yarp/os/impl/TcpStream.h>
-// General files
-//#include <sys/types.h>
-//#include <sys/socket.h>
-//#include <netinet/in.h>
-//#include <arpa/inet.h>
-//#include <sys/wait.h>
-//#include <signal.h>
-//#include <string.h>
-//#include <unistd.h>
+
 
 namespace yarp {
     namespace os {

--- a/src/libYARP_OS/include/yarp/os/impl/TcpStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TcpStream.h
@@ -30,9 +30,11 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <sys/wait.h>
-#include <signal.h>
-#include <string.h>
+#if defined(YARP_HAS_SYS_WAIT_H)
+# include <sys/wait.h>
+#endif
+#include <csignal>
+#include <cstring>
 #include <unistd.h>
 
 namespace yarp {

--- a/src/libYARP_OS/src/AuthHMAC.cpp
+++ b/src/libYARP_OS/src/AuthHMAC.cpp
@@ -7,8 +7,8 @@
 
 #include <cstdlib>
 #include <cstring> //needed by strcpy
-#include <stdio.h>
-#include <time.h>
+#include <cstdio>
+#include <ctime>
 #include <yarp/os/ConstString.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/Network.h>

--- a/src/libYARP_OS/src/BottleImpl.cpp
+++ b/src/libYARP_OS/src/BottleImpl.cpp
@@ -15,11 +15,12 @@
 
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/MemoryOutputStream.h>
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 
 #include <clocale>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 using yarp::os::impl::StoreInt;
 using yarp::os::impl::StoreVocab;
@@ -41,7 +42,7 @@ using yarp::os::Value;
 
 #define YARP_STRINIT(len) ((size_t)(len)), 0
 
-//#define YMSG(x) ACE_OS::printf x;
+//#define YMSG(x) printf x;
 //#define YTRACE(x) YMSG(("at %s\n",x))
 
 #define YMSG(x)
@@ -484,7 +485,7 @@ void BottleImpl::toBytes(const Bytes& data)
 {
     synch();
     yAssert(data.length() == byteCount());
-    ACE_OS::memcpy(data.get(), getBytes(), byteCount());
+    memcpy(data.get(), getBytes(), byteCount());
 }
 
 
@@ -684,14 +685,14 @@ void BottleImpl::setNested(bool nested)
 ConstString StoreInt::toString() const
 {
     char buf[256];
-    ACE_OS::sprintf(buf, "%d", x);
+    sprintf(buf, "%d", x);
     return ConstString(buf);
 }
 
 void StoreInt::fromString(const ConstString& src)
 {
-    // x = ACE_OS::atoi(src.c_str());
-    x = ACE_OS::strtol(src.c_str(), static_cast<char**>(YARP_NULLPTR), 0);
+    // x = atoi(src.c_str());
+    x = strtol(src.c_str(), static_cast<char**>(YARP_NULLPTR), 0);
 }
 
 bool StoreInt::readRaw(ConnectionReader& reader)
@@ -713,13 +714,13 @@ bool StoreInt::writeRaw(ConnectionWriter& writer)
 ConstString StoreInt64::toString() const
 {
     char buf[256];
-    ACE_OS::sprintf(buf, "%" YARP_INT64_FMT, x);
+    sprintf(buf, "%" YARP_INT64_FMT, x);
     return ConstString(buf);
 }
 
 void StoreInt64::fromString(const ConstString& src)
 {
-    x = ACE_OS::strtoll(src.c_str(), static_cast<char**>(YARP_NULLPTR), 0);
+    x = strtoll(src.c_str(), static_cast<char**>(YARP_NULLPTR), 0);
 }
 
 bool StoreInt64::readRaw(ConnectionReader& reader)
@@ -800,7 +801,7 @@ bool StoreVocab::writeRaw(ConnectionWriter& writer)
 ConstString StoreDouble::toString() const
 {
     char buf[512];
-    ACE_OS::sprintf(buf, "%f", x);
+    sprintf(buf, "%f", x);
     ConstString str(buf);
 
     // YARP Bug 2526259: Locale settings influence YARP behavior
@@ -840,7 +841,7 @@ void StoreDouble::fromString(const ConstString& src)
         struct lconv* lc = localeconv();
         tmp[offset] = lc->decimal_point[0];
     }
-    x = ACE_OS::strtod(tmp.c_str(), YARP_NULLPTR);
+    x = strtod(tmp.c_str(), YARP_NULLPTR);
 }
 
 bool StoreDouble::readRaw(ConnectionReader& reader)

--- a/src/libYARP_OS/src/BufferedConnectionWriter.cpp
+++ b/src/libYARP_OS/src/BufferedConnectionWriter.cpp
@@ -9,6 +9,8 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/DummyConnector.h>
 
+#include <cstring>
+
 using namespace yarp::os::impl;
 using namespace yarp::os;
 
@@ -101,7 +103,7 @@ bool BufferedConnectionWriter::addPool(const yarp::os::Bytes& data) {
         if (add) target->push_back(pool);
     }
     if (pool != YARP_NULLPTR) {
-        ACE_OS::memcpy(pool->get()+poolIndex,data.get(),data.length());
+        memcpy(pool->get()+poolIndex,data.get(),data.length());
         poolIndex += data.length();
         pool->setUsed(poolIndex);
         return true;

--- a/src/libYARP_OS/src/Contact.cpp
+++ b/src/libYARP_OS/src/Contact.cpp
@@ -9,21 +9,24 @@
 
 
 #include <yarp/os/Contact.h>
+
 #include <yarp/os/NetType.h>
 #include <yarp/os/Searchable.h>
 #include <yarp/os/Value.h>
-#include <yarp/os/impl/NameConfig.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 
+#include <yarp/os/impl/PlatformNetdb.h>
+#include <yarp/os/impl/NameConfig.h>
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 
 #ifdef YARP_HAS_ACE
-#  include <ace/INET_Addr.h>
+# include <ace/INET_Addr.h>
 #else
-#  include <sys/types.h>
-#  include <sys/socket.h>
-#  include <netdb.h>
-#  include <arpa/inet.h>
-#  include <cstdio>
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <arpa/inet.h>
 #endif
 
 
@@ -351,9 +354,9 @@ ConstString Contact::convertHostToIp(const char *name)
     hints.ai_socktype = SOCK_STREAM; // TCP stream sockets
     hints.ai_flags = AI_PASSIVE;     // fill in my IP for me
 
-    if ((status = getaddrinfo(name, "http", &hints, &res)) != 0) {
-        fprintf(stderr, "getaddrinfo error: %s\n", gai_strerror(status));
-        exit(1);
+    if ((status = yarp::os::impl::getaddrinfo(name, "http", &hints, &res)) != 0) {
+        fprintf(stderr, "getaddrinfo error: %s\n", yarp::os::impl::gai_strerror(status));
+        std::exit(1);
     }
 
     for(p = res; p != YARP_NULLPTR; p = p->ai_next) {
@@ -370,7 +373,7 @@ ConstString Contact::convertHostToIp(const char *name)
         // convert the IP to a string and print it:
         inet_ntop(p->ai_family, addr, ipstr, sizeof ipstr);
     }
-    freeaddrinfo(res);
+    yarp::os::impl::freeaddrinfo(res);
 #endif
 
     if (NameConfig::isLocalName(ipstr)) {

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -20,7 +20,6 @@
 #  include <ace/Log_Msg.h>
 #  include <ace/INET_Addr.h>
 #  include <ace/ACE.h>
-#  include <ace/OS_NS_string.h>
 #  include <ace/OS_Memory.h>
 #  include <ace/OS_NS_sys_select.h>
 #  include <ace/os_include/net/os_if.h>
@@ -32,7 +31,6 @@
 #  include <unistd.h>
 #endif
 
-#include <yarp/os/Time.h>
 #include <cerrno>
 #include <cstring>
 
@@ -113,7 +111,7 @@ bool DgramTwoWayStream::open(const Contact& local, const Contact& remote) {
 
     int s = -1;
     if ((s=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))==-1) {
-        exit(1);
+        std::exit(1);
     }
     struct sockaddr_in dgram_sin;
     memset((char *) &dgram_sin, 0, sizeof(dgram_sin));
@@ -121,18 +119,18 @@ bool DgramTwoWayStream::open(const Contact& local, const Contact& remote) {
     dgram_sin.sin_addr.s_addr = htonl(INADDR_ANY);
     dgram_sin.sin_port = htons(remote.getPort());
     if (local.isValid()) {
-        if (inet_aton(remote.getHost().c_str(), &dgram_sin.sin_addr)==0) {
+        if (inet_pton(AF_INET, remote.getHost().c_str(), &dgram_sin.sin_addr)==0) {
             YARP_ERROR(Logger::get(), "could not set up udp client\n");
-            exit(1);
+            std::exit(1);
         }
         if (connect(s, (struct sockaddr *)&dgram_sin, sizeof(dgram_sin))==-1) {
             YARP_ERROR(Logger::get(), "could not connect udp client\n");
-            exit(1);
+            std::exit(1);
         }
     } else {
         if (bind(s, (struct sockaddr *)&dgram_sin, sizeof(dgram_sin))==-1) {
             YARP_ERROR(Logger::get(), "could not create udp server\n");
-            exit(1);
+            std::exit(1);
         }
     }
     dgram_sockfd = s;
@@ -754,7 +752,7 @@ YARP_SSIZE_T DgramTwoWayStream::read(const Bytes& b) {
                 //printf("Monitored input of %d bytes\n", monitor.length());
                 if (monitor.length()>readBuffer.length()) {
                     printf("Too big!\n");
-                    exit(1);
+                    std::exit(1);
                 }
                 memcpy(readBuffer.get(),monitor.get(),monitor.length());
                 result = monitor.length();
@@ -827,7 +825,7 @@ YARP_SSIZE_T DgramTwoWayStream::read(const Bytes& b) {
             if (take>b.length()) {
                 take = b.length();
             }
-            ACE_OS::memcpy(b.get(),readBuffer.get()+readAt,take);
+            memcpy(b.get(),readBuffer.get()+readAt,take);
             readAt += take;
             readAvail -= take;
             return take;
@@ -839,7 +837,7 @@ YARP_SSIZE_T DgramTwoWayStream::read(const Bytes& b) {
 
 void DgramTwoWayStream::write(const Bytes& b) {
     //YARP_DEBUG(Logger::get(),"DGRAM prep writing");
-    //ACE_OS::printf("DGRAM write %d bytes\n",b.length());
+    //printf("DGRAM write %d bytes\n",b.length());
 
     if (reader) {
         return;

--- a/src/libYARP_OS/src/FallbackNameClient.cpp
+++ b/src/libYARP_OS/src/FallbackNameClient.cpp
@@ -83,19 +83,19 @@ Contact FallbackNameClient::seek() {
         }
         int len = 20;
         for (int i0=0; i0<len; i0++) {
-            ACE_OS::fprintf(stderr,"++");
+            fprintf(stderr,"++");
         }
-        ACE_OS::fprintf(stderr,"\n");
+        fprintf(stderr,"\n");
 
         for (int i=0; i<len; i++) {
             Time::delay(0.025);
-            ACE_OS::fprintf(stderr,"++");
+            fprintf(stderr,"++");
             if (seeker.getAddress().isValid()) {
-                ACE_OS::fprintf(stderr,"\n");
+                fprintf(stderr,"\n");
                 return seeker.getAddress();
             }
         }
-        ACE_OS::fprintf(stderr,"\n");
+        fprintf(stderr,"\n");
         YARP_INFO(Logger::get(),"No response to search for server");
         seeker.close();
         seeker.join();

--- a/src/libYARP_OS/src/LocalCarrier.cpp
+++ b/src/libYARP_OS/src/LocalCarrier.cpp
@@ -197,7 +197,7 @@ bool yarp::os::impl::LocalCarrier::becomeLocal(ConnectionState& proto, bool send
     }
     proto.takeStreams(stream);
     //YARP_ERROR(Logger::get(),"*** don't trust local carrier yet ****");
-    //ACE_OS::exit(1);
+    //exit(1);
     return true;
 }
 

--- a/src/libYARP_OS/src/Log.cpp
+++ b/src/libYARP_OS/src/Log.cpp
@@ -19,19 +19,19 @@
 
 #ifdef YARP_HAS_ACE
 # include <ace/Stack_Trace.h>
-#elif defined(YARP_HAS_EXECINFO)
+#elif defined(YARP_HAS_EXECINFO_H)
 # include <execinfo.h>
 #endif
 
 #include <yarp/conf/system.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
 
 #define YARP_MAX_LOG_MSG_SIZE 512
 
-#ifndef WIN32
+#if !defined(_WIN32)
 
  #define RED     (colored_output ? "\033[01;31m" : "")
  #define GREEN   (colored_output ? "\033[01;32m" : "")
@@ -43,7 +43,7 @@
  #define RED_BG  (colored_output ? "\033[01;41m" : "")
  #define CLEAR   (colored_output ? "\033[00m" : "")
 
-#else // WIN32
+#else
 
  // TODO colored and verbose_output for WIN32
  #define RED     ""
@@ -56,7 +56,7 @@
  #define RED_BG  ""
  #define CLEAR   ""
 
-#endif // WIN32
+#endif
 
 bool yarp::os::impl::LogImpl::colored_output(getenv("YARP_COLORED_OUTPUT")     &&  (strcmp(yarp::os::getenv("YARP_COLORED_OUTPUT"), "1") == 0));
 bool yarp::os::impl::LogImpl::verbose_output(getenv("YARP_VERBOSE_OUTPUT")     &&  (strcmp(yarp::os::getenv("YARP_VERBOSE_OUTPUT"), "1") == 0));
@@ -231,7 +231,7 @@ void yarp::os::Log::trace(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w =ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -257,7 +257,7 @@ void yarp::os::Log::debug(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w = ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -283,7 +283,7 @@ void yarp::os::Log::info(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w = ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -309,7 +309,7 @@ void yarp::os::Log::warning(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w = ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -335,7 +335,7 @@ void yarp::os::Log::error(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w = ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -362,7 +362,7 @@ void yarp::os::Log::fatal(const char *msg, ...) const
     va_start(args, msg);
     if (msg) {
         char buf[YARP_MAX_LOG_MSG_SIZE];
-        int w = ACE_OS::vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
+        int w = vsnprintf(buf, YARP_MAX_LOG_MSG_SIZE, msg, args);
         if (w>0 && buf[w-1]=='\n') {
             buf[w-1]=0;
         }
@@ -375,7 +375,7 @@ void yarp::os::Log::fatal(const char *msg, ...) const
     }
     va_end(args);
     yarp_print_trace(stderr, mPriv->file, mPriv->line);
-    yarp::os::exit(-1);
+    std::exit(-1);
 }
 
 yarp::os::LogStream yarp::os::Log::fatal() const
@@ -393,8 +393,8 @@ void yarp_print_trace(FILE *out, const char *file, int line) {
     ACE_Stack_Trace st(-1);
     // TODO demangle symbols using <cxxabi.h> and abi::__cxa_demangle
     //      when available.
-    ACE_OS::fprintf(out, "%s", st.c_str());
-#elif defined(YARP_HAS_EXECINFO)
+    fprintf(out, "%s", st.c_str());
+#elif defined(YARP_HAS_EXECINFO_H)
     const size_t max_depth = 100;
     size_t stack_depth;
     void *stack_addrs[max_depth];

--- a/src/libYARP_OS/src/Logger.cpp
+++ b/src/libYARP_OS/src/Logger.cpp
@@ -6,9 +6,8 @@
 
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/PlatformStdlib.h>
-#include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/PlatformThread.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/Network.h>
 #include <yarp/conf/system.h>
 
@@ -30,7 +29,7 @@ void Logger::fini() {
 
 void Logger::show(unsigned YARP_INT32 level, const ConstString& txt) {
     unsigned YARP_INT32 inLevel = level;
-    //ACE_OS::fprintf(stderr,"level %d txt %s\n", level, txt.c_str());
+    //fprintf(stderr,"level %d txt %s\n", level, txt.c_str());
     if (verbose>0) {
         level = 10000;
     }
@@ -46,14 +45,14 @@ void Logger::show(unsigned YARP_INT32 level, const ConstString& txt) {
     if (parent == YARP_NULLPTR) {
         if (level>=low) {
             if (inLevel<=LM_DEBUG) {
-                ACE_OS::fprintf(stream,"%s(%04x): %s\n",
+                fprintf(stream,"%s(%04x): %s\n",
                                 prefix.c_str(),
                                 (int)(long int)(PLATFORM_THREAD_SELF()),
                                 txt.c_str());
             } else {
-                ACE_OS::fprintf(stream,"%s: %s\n",prefix.c_str(),txt.c_str());
+                fprintf(stream,"%s: %s\n",prefix.c_str(),txt.c_str());
             }
-            ACE_OS::fflush(stream);
+            fflush(stream);
         }
     } else {
         ConstString more(prefix);
@@ -65,10 +64,10 @@ void Logger::show(unsigned YARP_INT32 level, const ConstString& txt) {
 
 
 void Logger::exit(int level) {
-    ACE_OS::exit(level);
+    exit(level);
 }
 
 
 void Logger::setPid() {
-    pid = ACE_OS::getpid();
+    pid = yarp::os::getpid();
 }

--- a/src/libYARP_OS/src/ManagedBytes.cpp
+++ b/src/libYARP_OS/src/ManagedBytes.cpp
@@ -4,10 +4,11 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <yarp/os/impl/PlatformStdlib.h>
-
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/Bottle.h>
+
+#include <cstdlib>
+#include <cstring>
 
 using namespace yarp::os;
 
@@ -78,7 +79,7 @@ bool ManagedBytes::allocateOnNeed(size_t neededLen, size_t allocateLen) {
     if (length()<neededLen && allocateLen>=neededLen) {
         char *buf = new char[allocateLen];
         yarp::os::NetworkBase::assertion(buf!=YARP_NULLPTR);
-        ACE_OS::memcpy(buf,get(),length());
+        memcpy(buf,get(),length());
         if (owned) {
             delete[] get();
             owned = false;
@@ -95,7 +96,7 @@ void ManagedBytes::copy() {
         YARP_SSIZE_T len = length();
         char *buf = new char[len];
         yarp::os::NetworkBase::assertion(buf!=YARP_NULLPTR);
-        ACE_OS::memcpy(buf,get(),len);
+        memcpy(buf,get(),len);
         b = Bytes(buf,len);
         owned = true;
     }

--- a/src/libYARP_OS/src/McastCarrier.cpp
+++ b/src/libYARP_OS/src/McastCarrier.cpp
@@ -6,7 +6,7 @@
 
 #include <yarp/conf/system.h>
 #include <yarp/os/impl/McastCarrier.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/Network.h>
 
@@ -22,7 +22,7 @@ ElectionOf<PeerRecord<McastCarrier> >& McastCarrier::getCaster() {
         NetworkBase::unlock();
         if (caster==YARP_NULLPTR) {
             YARP_ERROR(Logger::get(), "No memory for McastCarrier::caster");
-            exit(1);
+            std::exit(1);
         }
     } else {
         NetworkBase::unlock();
@@ -144,7 +144,7 @@ bool yarp::os::impl::McastCarrier::expectExtraHeader(ConnectionState& proto) {
         ip[i] = base[i];
         if (i!=0) { add += "."; }
         char buf[100];
-        ACE_OS::sprintf(buf,"%d",ip[i]);
+        sprintf(buf,"%d",ip[i]);
         add += buf;
     }
     port = 256*base[4]+base[5];

--- a/src/libYARP_OS/src/Module.cpp
+++ b/src/libYARP_OS/src/Module.cpp
@@ -6,9 +6,6 @@
 
 #ifndef YARP_NO_DEPRECATED
 
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/Logger.h>
 
 #include <yarp/os/Module.h>
@@ -19,6 +16,10 @@
 #include <yarp/os/Searchable.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Vocab.h>
+
+#include <cstdio>
+#include <csignal>
+#include <cstdlib>
 
 
 using namespace yarp::os::impl;
@@ -90,14 +91,14 @@ public:
                     //printf("ITEM 1: %s\n", reply.get(0).toString().c_str());
                     if (reply.get(0).toString()=="help") {
                         for (int i=0; i<reply.size(); i++) {
-                            ACE_OS::printf("%s\n",
+                            printf("%s\n",
                                            reply.get(i).toString().c_str());
                         }
                     } else {
-                        ACE_OS::printf("%s\n", reply.toString().c_str());
+                        printf("%s\n", reply.toString().c_str());
                     }
                 } else {
-                    ACE_OS::printf("Command not understood -- %s\n", str.c_str());
+                    printf("Command not understood -- %s\n", str.c_str());
                 }
             }
         }
@@ -315,10 +316,10 @@ static void handler (int) {
     static int ct = 0;
     ct++;
     if (ct>3) {
-        ACE_OS::printf("Aborting...\n");
-        ACE_OS::exit(1);
+        printf("Aborting...\n");
+        std::exit(1);
     }
-    ACE_OS::printf("[try %d of 3] Trying to shut down\n",
+    printf("[try %d of 3] Trying to shut down\n",
                    ct);
     terminated = true;
     if (module!=YARP_NULLPTR) {
@@ -336,10 +337,10 @@ bool Module::runModule() {
         module = this;
         //module = &HELPER(implementation);
     } else {
-        ACE_OS::printf("Module::runModule() signal handling currently only good for one module\n");
+        printf("Module::runModule() signal handling currently only good for one module\n");
     }
-    ACE_OS::signal(SIGINT, (ACE_SignalHandler) handler);
-    ACE_OS::signal(SIGTERM, (ACE_SignalHandler) handler);
+    signal(SIGINT, handler);
+    signal(SIGTERM, handler);
     while (updateModule()) {
         if (terminated) break;
         if (isStopping()) break;
@@ -347,13 +348,13 @@ bool Module::runModule() {
         if (isStopping()) break;
         if (terminated) break;
     }
-    ACE_OS::printf("Module closing\n");
+    printf("Module closing\n");
     close();
-    ACE_OS::printf("Module finished\n");
+    printf("Module finished\n");
     if (1) { //terminated) {
         // only portable way to bring down a thread reading from
         // the keyboard -- no good way to interrupt.
-        ACE_OS::exit(1);
+        std::exit(1);
     }
     return true;
 }
@@ -377,7 +378,7 @@ bool Module::attachTerminal() {
 
 int Module::runModule(int argc, char *argv[], bool skipFirst) {
     if (!openFromCommand(argc,argv,skipFirst)) {
-        ACE_OS::printf("Module failed to open\n");
+        printf("Module failed to open\n");
         return 1;
     }
     attachTerminal();
@@ -396,7 +397,7 @@ bool Module::openFromCommand(int argc, char *argv[], bool skipFirst) {
     if (options.check("file",val,"configuration file to use, if any")) {
         ConstString fname = val->toString();
         options.unput("file");
-        ACE_OS::printf("Working with config file %s\n", fname.c_str());
+        printf("Working with config file %s\n", fname.c_str());
         options.fromConfigFile(fname,false);
 
         // interpret command line options as a set of flags again

--- a/src/libYARP_OS/src/NameClient.cpp
+++ b/src/libYARP_OS/src/NameClient.cpp
@@ -5,16 +5,20 @@
  */
 
 #include <yarp/os/impl/NameClient.h>
+
+#include <yarp/os/NetType.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
+
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/TcpFace.h>
-#include <yarp/os/NetType.h>
 #include <yarp/os/impl/NameServer.h>
 #include <yarp/os/impl/NameConfig.h>
+#include <yarp/os/impl/PlatformUnistd.h>
 #ifdef YARP_HAS_ACE
 #  include <yarp/os/impl/FallbackNameClient.h>
 #endif
-#include <yarp/os/Network.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -355,7 +359,7 @@ Contact NameClient::registerName(const ConstString& name, const Contact& suggest
         cmd.addString("set");
         cmd.addString(reg.c_str());
         cmd.addString("process");
-        cmd.addInt(ACE_OS::getpid());
+        cmd.addInt(yarp::os::getpid());
         send(cmd,reply);
     }
     return address;

--- a/src/libYARP_OS/src/NameServer.cpp
+++ b/src/libYARP_OS/src/NameServer.cpp
@@ -30,7 +30,7 @@
 using namespace yarp::os::impl;
 using namespace yarp::os;
 
-//#define YMSG(x) ACE_OS::printf x;
+//#define YMSG(x) printf x;
 //#define YTRACE(x) YMSG(("at %s\n",x))
 
 #define YMSG(x)

--- a/src/libYARP_OS/src/NetType.cpp
+++ b/src/libYARP_OS/src/NetType.cpp
@@ -7,7 +7,9 @@
 #include <yarp/os/NetType.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/ManagedBytes.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+
+#include <cstdlib>
+#include <cstring>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -15,7 +17,7 @@ using namespace yarp::os;
 int NetType::netInt(const yarp::os::Bytes& code) {
     yAssert(code.length()==sizeof(NetInt32));
     NetInt32 tmp;
-    ACE_OS::memcpy((char*)(&tmp),code.get(),code.length());
+    memcpy((char*)(&tmp),code.get(),code.length());
     return tmp;
 }
 
@@ -26,37 +28,37 @@ bool NetType::netInt(int data, const yarp::os::Bytes& code) {
         YARP_ERROR(Logger::get(),"not enough room for integer");
         return false;
     }
-    ACE_OS::memcpy(code.get(),b.get(),code.length());
+    memcpy(code.get(),b.get(),code.length());
     return true;
 }
 
 ConstString NetType::toHexString(int x) {
     char buf[256];
-    ACE_OS::sprintf(buf,"%x",x);
+    sprintf(buf,"%x",x);
     return buf;
 }
 
 ConstString NetType::toString(int x) {
     char buf[256];
-    ACE_OS::sprintf(buf,"%d",x);
+    sprintf(buf,"%d",x);
     return buf;
 }
 
 ConstString NetType::toString(long x) {
     char buf[256];
-    ACE_OS::sprintf(buf,"%ld",x);
+    sprintf(buf,"%ld",x);
     return buf;
 }
 
 ConstString NetType::toString(unsigned int x) {
     char buf[256];
-    ACE_OS::sprintf(buf,"%u",x);
+    sprintf(buf,"%u",x);
     return buf;
 }
 
 
 int NetType::toInt(const ConstString& x) {
-    return ACE_OS::atoi(x.c_str());
+    return atoi(x.c_str());
 }
 
 

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -14,8 +14,9 @@
 #include <yarp/os/PortReport.h>
 #include <yarp/os/PortInfo.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/RosNameSpace.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 #include <yarp/os/impl/NameClient.h>
 
 #include <algorithm>
@@ -298,7 +299,7 @@ public:
 
     void getPid(NodeArgs& na)
     {
-        na.reply = Value(static_cast<int>(ACE_OS::getpid()));
+        na.reply = Value(static_cast<int>(yarp::os::getpid()));
         na.success();
     }
 

--- a/src/libYARP_OS/src/Os.cpp
+++ b/src/libYARP_OS/src/Os.cpp
@@ -4,67 +4,67 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <cstdio>
 
 #include <yarp/os/Os.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <yarp/os/impl/NameConfig.h>
+#include <yarp/os/impl/PlatformUnistd.h>
+#include <yarp/os/impl/PlatformSysStat.h>
 #include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/NameConfig.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
 #ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_stdio.h>
-#  include <ace/OS_NS_unistd.h>
-#  include <ace/OS_NS_signal.h>
-#  include <ace/OS_NS_stdlib.h>
-#  include <ace/OS_NS_sys_stat.h>
-#  include <ace/ACE.h>
+# include <ace/ACE.h>
 #endif
 
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
 yarp::os::YarpSignalHandler yarp::os::signal(int signum, yarp::os::YarpSignalHandler sighandler)
 {
-    switch (signum)
-    {
+    switch (signum) {
         case yarp::os::YARP_SIGINT:
-            return ACE_OS::signal(SIGINT, (ACE_SignalHandler) sighandler);
+            return yarp::os::impl::signal(SIGINT, sighandler);
         case yarp::os::YARP_SIGTERM:
-            return ACE_OS::signal(SIGTERM, (ACE_SignalHandler) sighandler);
+            return yarp::os::impl::signal(SIGTERM, sighandler);
         default:
             return YARP_NULLPTR; //signal not implemented yet
     }
 }
+#endif // YARP_NO_DEPRECATED
 
-void yarp::os::exit(int v)
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+void yarp::os::exit(int exit_code)
 {
-    ACE_OS::exit(v); //may cause crash... exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/
-    //::exit(v);     //...this seems to work(?)
+    std::exit(exit_code); //may cause crash... exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/
 }
+#endif // YARP_NO_DEPRECATED
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
 void yarp::os::abort(bool verbose)
 {
-#if defined(WIN32)
-    if (verbose==false)
-    {
+#if defined(_WIN32)
+    if (verbose==false) {
         //to suppress windows dialog message
         _set_abort_behavior(0, _WRITE_ABORT_MSG);
         _set_abort_behavior(0, _CALL_REPORTFAULT);
     }
 #endif
-    ACE_OS::abort();   // exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/ and http://www.cplusplus.com/reference/cstdlib/abort/
+    std::abort();   // exit is not recommended in processes with multi thread, see http://www.cplusplus.com/reference/cstdlib/exit/ and http://www.cplusplus.com/reference/cstdlib/abort/
 }
+#endif // YARP_NO_DEPRECATED
 
 const char *yarp::os::getenv(const char *var)
 {
-    return ACE_OS::getenv(var);
+    return std::getenv(var);
 }
 
 int yarp::os::mkdir(const char *p)
 {
-#ifdef YARP_HAS_ACE
-    return ACE_OS::mkdir(p);
-#else
-    return ::mkdir(p,0777);
-#endif
+    return yarp::os::impl::mkdir(p, 0755);
 }
 
 int yarp::os::mkdir_p(const char *p, int ignoreLevels) {
@@ -74,31 +74,23 @@ int yarp::os::mkdir_p(const char *p, int ignoreLevels) {
 
 int yarp::os::rmdir(const char *p)
 {
-#ifdef YARP_HAS_ACE
-    return ACE_OS::rmdir(p);
-#else
-    return ::rmdir(p);
-#endif
+    return yarp::os::impl::rmdir(p);
 }
 
 int yarp::os::rename(const char *oldname, const char *newname)
 {
-#ifdef YARP_HAS_ACE
-    return ACE_OS::rename(oldname,newname);
-#else
     return std::rename(oldname,newname);
-#endif
 }
 
 int yarp::os::stat(const char *path)
 {
-    ACE_stat dummy;
-    return ACE_OS::stat(path, &dummy);
+    yarp::os::impl::YARP_stat dummy;
+    return yarp::os::impl::stat(path, &dummy);
 }
 
 int yarp::os::getpid()
 {
-    pid_t pid = ACE_OS::getpid();
+    pid_t pid = yarp::os::impl::getpid();
     return pid;
 }
 
@@ -108,38 +100,43 @@ void yarp::os::setprogname(const char *progname)
     ACE_OS::setprogname(ACE::basename(progname));
 #else
     // not available
+    YARP_UNUSED(progname);
 #endif
 }
 
 
-void yarp::os::getprogname(char*progname, size_t size)
+void yarp::os::getprogname(char* progname, size_t size)
 {
 #ifdef YARP_HAS_ACE
-    const char* tmp = ACE_OS::getprogname ();
-    if (strlen(tmp)==0)
-    {
-        strncpy(progname,"no_progname",size);
-    }
-    else
-    {
-        strncpy(progname,tmp,size);
+    const char* tmp = ACE_OS::getprogname();
+    if (std::strlen(tmp)==0) {
+        std::strncpy(progname,"no_progname",size);
+    } else {
+        std::strncpy(progname,tmp,size);
     }
 #else
     // not available
     *progname = '\0';
+    YARP_UNUSED(size);
 #endif
 }
 
 
 void yarp::os::gethostname(char* hostname, size_t size)
 {
-#ifdef YARP_HAS_ACE
-    ACE_OS::hostname(hostname, size);
-#else
-    ::gethostname(hostname, size);
-#endif
-    if (strlen(hostname)==0)
-    {
-        strncpy(hostname,"no_hostname",size);
+    yarp::os::impl::gethostname(hostname, size);
+    if (std::strlen(hostname)==0) {
+        std::strncpy(hostname,"no_hostname",size);
     }
+}
+
+char* yarp::os::getcwd(char *buf, size_t size)
+{
+    return yarp::os::impl::getcwd(buf, size);
+}
+
+int yarp::os::fork(void)
+{
+    pid_t pid = yarp::os::impl::fork();
+    return pid;
 }

--- a/src/libYARP_OS/src/PlatformTime.cpp
+++ b/src/libYARP_OS/src/PlatformTime.cpp
@@ -1,0 +1,101 @@
+/*
+* Copyright (C) 2009 The RobotCub consortium
+* Author: Lorenzo Natale, Anne van Rossum, Paul Fitzpatrick
+* Based on code by Paul Fitzpatrick 2007.
+* CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+*/
+
+
+#include <yarp/os/impl/PlatformTime.h>
+
+#include <yarp/os/Time.h>
+
+//time helper functions
+void yarp::os::impl::getTime(YARP_timeval& now) {
+    if (Time::isSystemClock()) {
+#ifdef YARP_HAS_ACE
+        now = ACE_OS::gettimeofday();
+#else
+        struct timezone *tz = YARP_NULLPTR;
+        gettimeofday(&now, tz);
+#endif
+    } else {
+#ifdef YARP_HAS_ACE
+        now.set(Time::now());
+#else
+        double t = Time::now();
+        now.tv_sec = static_cast<int>(t);
+        now.tv_usec = static_cast<int>((t-now.tv_sec)*1e6);
+#endif
+    }
+}
+
+
+void yarp::os::impl::sleepThread(YARP_timeval& sleep_period) {
+    if (Time::isSystemClock()) {
+#ifdef YARP_HAS_ACE
+        if (sleep_period.usec() < 0 || sleep_period.sec() < 0)
+            sleep_period.set(0,0);
+        ACE_OS::sleep(sleep_period);
+#else
+        if (sleep_period.tv_usec < 0 || sleep_period.tv_sec < 0) {
+            sleep_period.tv_usec = 0;
+            sleep_period.tv_sec = 0;
+        }
+        usleep(sleep_period.tv_sec * 1000000 + sleep_period.tv_usec );
+#endif
+    } else {
+        Time::delay(toDouble(sleep_period));
+    }
+}
+
+
+void yarp::os::impl::addTime(YARP_timeval& val, const YARP_timeval & add) {
+#ifdef YARP_HAS_ACE
+    val += add;
+#else
+    val.tv_usec += add.tv_usec;
+    int over = val.tv_usec % 1000000;
+    if (over != val.tv_usec) {
+        val.tv_usec = over;
+        val.tv_sec++;
+    }
+    val.tv_sec += add.tv_sec;
+#endif
+}
+
+
+void yarp::os::impl::subtractTime(YARP_timeval & val, const YARP_timeval & subtract) {
+#ifdef YARP_HAS_ACE
+    val -= subtract;
+#else
+    if (val.tv_usec > subtract.tv_usec) {
+        val.tv_usec -= subtract.tv_usec;
+        val.tv_sec -= subtract.tv_sec;
+        return;
+    }
+    int over = 1000000 + val.tv_usec - subtract.tv_usec;
+    val.tv_usec = over;
+    val.tv_sec--;
+    val.tv_sec -= subtract.tv_sec;
+#endif
+}
+
+
+double yarp::os::impl::toDouble(const YARP_timeval &v) {
+#ifdef YARP_HAS_ACE
+    return double(v.sec()) + v.usec() * 1e-6;
+#else
+    return double(v.tv_sec) + v.tv_usec * 1e-6;
+#endif
+}
+
+
+void yarp::os::impl::fromDouble(YARP_timeval &v, double x,int unit) {
+#ifdef YARP_HAS_ACE
+        v.msec(static_cast<int>(x*1000/unit+0.5));
+#else
+        v.tv_usec = static_cast<int>(x*1000000/unit+0.5) % 1000000;
+        v.tv_sec = static_cast<int>(x/unit);
+#endif
+}

--- a/src/libYARP_OS/src/PortCommand.cpp
+++ b/src/libYARP_OS/src/PortCommand.cpp
@@ -44,7 +44,7 @@ bool PortCommand::read(ConnectionReader& reader) {
 
 bool PortCommand::write(ConnectionWriter& writer) {
     //ACE_DEBUG((LM_DEBUG,"PortCommand::writeBlock"));
-    //ACE_OS::printf("Writing port command, text mode %d\n", writer.isTextMode());
+    //printf("Writing port command, text mode %d\n", writer.isTextMode());
     if (!writer.isTextMode()) {
         int len = 0;
         if (ch=='\0') {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -22,7 +22,7 @@
 #include <yarp/os/SystemInfo.h>
 #include <yarp/os/DummyConnector.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #ifdef YARP_HAS_ACE
 #  include <ace/INET_Addr.h>
 #  include <ace/Sched_Params.h>
@@ -35,7 +35,7 @@
 #endif
 
 
-//#define YMSG(x) ACE_OS::printf x;
+//#define YMSG(x) printf x;
 //#define YTRACE(x) YMSG(("at %s\n",x))
 
 #define YMSG(x)
@@ -2080,7 +2080,7 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                 op = Carriers::connect(addr);
                                 if (op==YARP_NULLPTR) {
                                     fprintf(stderr,"NO CONNECTION\n");
-                                    exit(1);
+                                    std::exit(1);
                                 } else {
                                     op->attachPort(contactable);
                                     op->open(r);
@@ -2627,7 +2627,7 @@ int PortCore::getPid() {
     return ACE_OS::getpid();
 #elif defined(__linux__)
     return getpid();
-#elif defined(WIN32)
+#elif defined(_WIN32)
     return (int) GetCurrentProcessId();
 #endif
     return -1;

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -4,21 +4,22 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-
-#include <yarp/os/Time.h>
 #include <yarp/os/impl/PortCoreInputUnit.h>
-#include <yarp/os/impl/PortCommand.h>
-#include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/BufferedConnectionWriter.h>
+
 #include <yarp/os/Name.h>
-#include <yarp/os/Time.h>
 #include <yarp/os/PortReport.h>
 #include <yarp/os/PortInfo.h>
+#include <yarp/os/Time.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <yarp/os/impl/BufferedConnectionWriter.h>
+#include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/PortCommand.h>
 
-//#define YMSG(x) ACE_OS::printf x;
+#include <cstdio>
+#include <csignal>
+
+//#define YMSG(x) printf x;
 //#define YTRACE(x) YMSG(("at %s\n",x))
 
 
@@ -192,7 +193,7 @@ void PortCoreInputUnit::run() {
             break;
         }
         char key = cmd.getKey();
-        //ACE_OS::printf("Port command is [%c:%d/%s]\n",
+        //printf("Port command is [%c:%d/%s]\n",
         //         (key>=32)?key:'?', key, cmd.getText().c_str());
 
         PortManager& man = getOwner();
@@ -330,9 +331,9 @@ void PortCoreInputUnit::run() {
 #if !defined(NDEBUG)
         case 'i':
             printf("Interrupt requested\n");
-            //ACE_OS::kill(0,2); // SIGINT
-            //ACE_OS::kill(Logger::get().getPid(),2); // SIGINT
-            ACE_OS::kill(Logger::get().getPid(),15); // SIGTERM
+            //yarp::os::impl::kill(0,2); // SIGINT
+            //yarp::os::impl::kill(Logger::get().getPid(),2); // SIGINT
+            yarp::os::impl::kill(Logger::get().getPid(),15); // SIGTERM
             break;
 #endif
         case '?':

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -17,7 +17,7 @@
 #include <yarp/os/impl/Companion.h>
 
 
-#define YMSG(x) ACE_OS::printf x;
+#define YMSG(x) printf x;
 #define YTRACE(x) YMSG(("at %s\n",x))
 
 

--- a/src/libYARP_OS/src/PortReaderBuffer.cpp
+++ b/src/libYARP_OS/src/PortReaderBuffer.cpp
@@ -356,7 +356,7 @@ void PortReaderBufferBase::release(PortReader *completed) {
     //HELPER(implementation).configure(completed,true,false);
     //HELPER(implementation).stateSema.post();
     printf("release not implemented anymore; not needed\n");
-    yarp::os::exit(1);
+    std::exit(1);
 }
 
 int PortReaderBufferBase::check() {
@@ -536,7 +536,7 @@ void PortReaderBufferBase::setAutoRelease(bool flag) {
     //HELPER(implementation).setAutoRelease(flag);
     //HELPER(implementation).stateSema.post();
     printf("setAutoRelease not implemented anymore; not needed\n");
-    exit(1);
+    std::exit(1);
 }
 #endif // YARP_NO_DEPRECATED
 

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -14,16 +14,11 @@
 #include <yarp/os/impl/SplitString.h>
 
 #include <yarp/os/impl/PlatformMap.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <yarp/os/impl/PlatformDirent.h>
 
-#ifdef YARP_HAS_ACE
-#  include <ace/OS_NS_ctype.h>
-#else
-#  include <ctype.h>
-#  define ace_isalnum isalnum
-#endif
-
-#include <stdio.h>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
 #include <algorithm>
 
 using namespace yarp::os::impl;
@@ -316,15 +311,15 @@ public:
         }
     }
 
-    bool readDir(const ConstString& dirname, ACE_DIR *&dir, ConstString& result, const ConstString& section=ConstString()) {
+    bool readDir(const ConstString& dirname, yarp::os::impl::DIR *&dir, ConstString& result, const ConstString& section=ConstString()) {
         bool ok = true;
         YARP_DEBUG(Logger::get(),
                    ConstString("reading directory ") + dirname);
 
-        struct YARP_DIRENT **namelist;
-        YARP_closedir(dir);
+        yarp::os::impl::dirent **namelist;
+        yarp::os::impl::closedir(dir);
         dir = YARP_NULLPTR;
-        int n = YARP_scandir(dirname.c_str(),&namelist,YARP_NULLPTR,YARP_alphasort);
+        int n = yarp::os::impl::scandir(dirname.c_str(), &namelist, YARP_NULLPTR, yarp::os::impl::alphasort);
         if (n<0) {
             return false;
         }
@@ -349,7 +344,7 @@ public:
 
     bool readFile(const ConstString& fname, ConstString& result, bool allowDir) {
         if (allowDir) {
-            ACE_DIR *dir = ACE_OS::opendir(fname.c_str());
+            yarp::os::impl::DIR *dir = yarp::os::impl::opendir(fname.c_str());
             if (dir) return readDir(fname,dir,result);
         }
         YARP_DEBUG(Logger::get(),
@@ -439,7 +434,7 @@ public:
 
         YARP_DEBUG(Logger::get(), ConstString("looking for ") + dirname.c_str());
 
-        ACE_DIR *dir = ACE_OS::opendir(dirname.c_str());
+        yarp::os::impl::DIR *dir = yarp::os::impl::opendir(dirname.c_str());
         if (!dir) {
             YARP_ERROR(Logger::get(), ConstString("cannot read from ") + dirname);
             return false;
@@ -734,7 +729,7 @@ public:
             }
 
             if (inVar) {
-                if (ACE_OS::ace_isalnum(ch)||(ch=='_')) {
+                if (isalnum(ch)||(ch=='_')) {
                     var += ch;
                     continue;
                 } else {

--- a/src/libYARP_OS/src/QosStyle.cpp
+++ b/src/libYARP_OS/src/QosStyle.cpp
@@ -8,7 +8,7 @@
 #include <yarp/os/ConstString.h>
 #include <yarp/os/Vocab.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 
 yarp::os::QosStyle::QosStyle() :

--- a/src/libYARP_OS/src/Random.cpp
+++ b/src/libYARP_OS/src/Random.cpp
@@ -5,14 +5,14 @@
 
 #include <yarp/os/Random.h>
 
-#include <math.h>
-#include <yarp/os/impl/PlatformStdlib.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstdlib>
 
 using namespace yarp::os;
 
 double Random::uniform() {
-    return double (ACE_OS::rand ()) / double (RAND_MAX);
+    return double (rand()) / double (RAND_MAX);
 }
 
 double Random::normal() {
@@ -69,12 +69,12 @@ double Random::normal(double m, double s)
 }
 
 void Random::seed(int seed) {
-    ACE_OS::srand (seed);
+    srand (seed);
 }
 
 
 int Random::uniform(int min, int max) {
-    int ret = int ((double (ACE_OS::rand()) / double (RAND_MAX)) * (max - min + 1) + min);
+    int ret = int ((double (rand()) / double (RAND_MAX)) * (max - min + 1) + min);
 
     // there's a small chance the value is = max+1
     if (ret <= max)

--- a/src/libYARP_OS/src/RateThread.cpp
+++ b/src/libYARP_OS/src/RateThread.cpp
@@ -13,14 +13,14 @@
 
 #include <yarp/os/Time.h>
 
-#include <math.h> //sqrt
+#include <cmath> //sqrt
 
 //added threadRelease/threadInit methods and synchronization -nat
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
 
-//const ACE_Time_Value _timeout_value(20,0);    // (20 sec) timeout value for the release (20 sec)
+//const YARP_timeval _timeout_value(20,0);    // (20 sec) timeout value for the release (20 sec)
 
 class RateThreadCallbackAdapter: public ThreadImpl
 {
@@ -29,11 +29,11 @@ private:
     double adaptedPeriod;
     RateThread& owner;
     Semaphore mutex;
-    ACE_Time_Value now;
-    ACE_Time_Value currentRunTV;
-    ACE_Time_Value previousRunTV;
-    ACE_Time_Value sleep;
-    ACE_Time_Value sleepPeriodTV;
+    YARP_timeval now;
+    YARP_timeval currentRunTV;
+    YARP_timeval previousRunTV;
+    YARP_timeval sleep;
+    YARP_timeval sleepPeriodTV;
     //ACE_High_Res_Timer thread_timer; // timer to estimate thread time
 
     bool suspended;
@@ -163,7 +163,7 @@ public:
         count++;
         lock();
 
-        ACE_Time_Value elapsedTV;
+        YARP_timeval elapsedTV;
         getTime(elapsedTV);
         double elapsed=toDouble(elapsedTV)-currentRun;
 

--- a/src/libYARP_OS/src/RosNameSpace.cpp
+++ b/src/libYARP_OS/src/RosNameSpace.cpp
@@ -5,19 +5,17 @@
  */
 
 #include <yarp/os/RosNameSpace.h>
+
+#include <yarp/os/DummyConnector.h>
 #include <yarp/os/Os.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <yarp/os/Vocab.h>
+
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/NameClient.h>
 #include <yarp/os/impl/NameConfig.h>
-#include <yarp/os/DummyConnector.h>
-#include <yarp/os/Vocab.h>
+#include <yarp/os/impl/PlatformLimits.h>
 
-#ifdef YARP_HAS_ACE
-#  include <ace/os_include/os_netdb.h>
-#else
-#  include <netdb.h>
-#endif
+#include <cstdio>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -80,7 +78,7 @@ Contact RosNameSpace::queryName(const ConstString& name) {
 Contact RosNameSpace::registerName(const ConstString& name) {
     fprintf(stderr,"ROS name server does not do 'raw' registrations.\n");
     fprintf(stderr,"Use [Buffered]Port::open to get complete registrations.\n");
-    yarp::os::exit(1);
+    std::exit(1);
 
     return Contact();
 }
@@ -635,9 +633,8 @@ Contact RosNameSpace::rosify(const Contact& contact) {
     ConstString carrier = ((contact.getCarrier() == "rosrpc")  ? "rosrpc" : "http");
     ConstString hostname = contact.getHost();
     if (yarp::os::impl::NameConfig::isLocalName(hostname)) {
-        char hn[NI_MAXHOST];
-        hostname[NI_MAXHOST-1] = '\0';
-        yarp::os::gethostname(hn, sizeof(hostname));
+        char hn[HOST_NAME_MAX];
+        yarp::os::gethostname(hn, sizeof(hn));
         hostname = hn;
     }
     return Contact(carrier, hostname, contact.getPort());

--- a/src/libYARP_OS/src/RunCheckpoints.cpp
+++ b/src/libYARP_OS/src/RunCheckpoints.cpp
@@ -6,23 +6,22 @@
 
 #include <yarp/os/impl/RunCheckpoints.h>
 #include <yarp/conf/compiler.h>
-#include <ctime>
+#include <yarp/os/impl/PlatformUnistd.h>
+#include <yarp/os/impl/PlatformTime.h>
 
-#if defined(WIN32)
-#include <time.h>
+#include <ctime>
+#include <cstdio>
+
+#if defined(_WIN32)
 #include <windows.h>
-#else
-#include <unistd.h>
-#include <sys/time.h>
 #endif
-#include <stdio.h>
 
 
 YarprunCheckpoints::YarprunCheckpoints()
 {
     char path[256];
 
-#if defined(WIN32)
+#if defined(_WIN32)
     time_t now=time(YARP_NULLPTR);
     srand((unsigned)now);
     sprintf(path,"C:/Users/user/Documents/yarprun_log/yarprun_log_%d_%s_%u.txt",GetCurrentProcessId(),ctime(&now),(unsigned)rand());

--- a/src/libYARP_OS/src/RunProcManager.cpp
+++ b/src/libYARP_OS/src/RunProcManager.cpp
@@ -10,13 +10,13 @@
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/impl/RunProcManager.h>
 
-#include <string.h>
+#include <cstring>
 #include <yarp/os/impl/RunCheckpoints.h>
 
 #define WAIT() { RUNLOG("<<<mutex.wait()") mutex.wait(); RUNLOG(">>>mutex.wait()") }
 #define POST() { RUNLOG("<<<mutex.post()") mutex.post(); RUNLOG(">>>mutex.post()") }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include <process.h>
 
     #define SIGKILL 9
@@ -89,7 +89,7 @@ YarpRunProcInfo::YarpRunProcInfo(yarp::os::ConstString& alias,yarp::os::ConstStr
 
 bool YarpRunProcInfo::Signal(int signum)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     if (signum==SIGKILL)
     {
         if (mHandleCmd)
@@ -123,7 +123,7 @@ bool YarpRunProcInfo::IsActive()
     {
         return false;
     }
-#if defined(WIN32)
+#if defined(_WIN32)
     DWORD status;
     RUNLOG("<<<GetExitCodeProcess(mHandleCmd,&status)")
     bool ret=(::GetExitCodeProcess(mHandleCmd,&status) && status==STILL_ACTIVE);
@@ -137,7 +137,7 @@ bool YarpRunProcInfo::IsActive()
 
 bool YarpRunProcInfo::Clean()
 {
-#if !defined(WIN32)
+#if !defined(_WIN32)
     if (!mCleanCmd && waitpid(mPidCmd, YARP_NULLPTR, WNOHANG) == mPidCmd)
     {
         fprintf(stderr,"CLEANUP cmd %d\n",mPidCmd);
@@ -173,7 +173,7 @@ YarpRunInfoVector::~YarpRunInfoVector()
         }
     }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     if (hZombieHunter)
     {
         HANDLE hkill=hZombieHunter;
@@ -196,7 +196,7 @@ bool YarpRunInfoVector::Add(YarpRunProcInfo *process)
         return false;
     }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     if (hZombieHunter)
     {
         HANDLE hkill=hZombieHunter;
@@ -207,7 +207,7 @@ bool YarpRunInfoVector::Add(YarpRunProcInfo *process)
 
     m_apList[m_nProcesses++]=process;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     hZombieHunter=CreateThread(0,0,ZombieHunter,this,0,0);
 #endif
 
@@ -271,7 +271,7 @@ int YarpRunInfoVector::Killall(int signum)
     return nKill;
 }
 
-#if defined(WIN32)
+#if defined(_WIN32)
 void YarpRunInfoVector::GetHandles(HANDLE* &lpHandles,DWORD &nCount)
 {
     WAIT()
@@ -500,7 +500,7 @@ YarpRunProcInfo(alias,on,pidCmd,handleCmd,hold)
 
 bool YarpRunCmdWithStdioInfo::Clean()
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     if (mPidCmd)
     {
         mPidCmd=0;
@@ -611,7 +611,7 @@ void YarpRunCmdWithStdioInfo::TerminateStdio()
 ////////////////////////////////////
 ////////////////////////////////////
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #define TA_FAILED        0
 #define TA_SUCCESS_CLEAN 1

--- a/src/libYARP_OS/src/RunReadWrite.cpp
+++ b/src/libYARP_OS/src/RunReadWrite.cpp
@@ -4,21 +4,13 @@
 * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 */
 
-#include <stdio.h>
-#include <signal.h>
+#include <cstdio>
+#include <csignal>
 #include <yarp/os/Time.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/impl/RunReadWrite.h>
 
-#if !defined(WIN32)
-//#include <sys/wait.h>
-//#include <errno.h>
-//#include <string.h>
-//#include <stdlib.h>
-#endif
-
-/////////////////////////////////////
 
 int RunWrite::loop()
 {
@@ -138,7 +130,7 @@ int RunReadWrite::loop()
     }
     /////////////////////
 
-    #if !defined(WIN32)
+    #if !defined(_WIN32)
     if (getppid()!=1)
     #endif
     {
@@ -147,7 +139,7 @@ int RunReadWrite::loop()
 
         while (mRunning)
         {
-            #if !defined(WIN32)
+            #if !defined(_WIN32)
             if (getppid()==1) break;
             #endif
 
@@ -161,7 +153,7 @@ int RunReadWrite::loop()
 
             if (!mRunning) break;
 
-            #if !defined(WIN32)
+            #if !defined(_WIN32)
             if (getppid()==1) break;
             #endif
 
@@ -199,7 +191,7 @@ int RunReadWrite::loop()
 
         if (mForwarded) fPort.close();
 
-#if defined(WIN32)
+#if defined(_WIN32)
         ::exit(0);
 #else
         int term_pipe[2];
@@ -240,7 +232,7 @@ void RunReadWrite::run()
     {
         RUNLOG("mRunning")
 
-        #if !defined(WIN32)
+        #if !defined(_WIN32)
         if (getppid()==1) break;
         #endif
 
@@ -248,7 +240,7 @@ void RunReadWrite::run()
 
         RUNLOG(txt)
 
-        #if !defined(WIN32)
+        #if !defined(_WIN32)
         if (getppid()==1) break;
         #endif
 

--- a/src/libYARP_OS/src/ShmemCarrier.cpp
+++ b/src/libYARP_OS/src/ShmemCarrier.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 #include <yarp/os/impl/ShmemCarrier.h>
 #include <yarp/os/ConstString.h>
 // removing old shmem version
@@ -103,8 +103,8 @@ bool yarp::os::impl::ShmemCarrier::becomeShmem(ConnectionState& proto, bool send
         // "classic" shmem
         //becomeShmemVersion<ShmemTwoWayStream>(proto,sender);
         //becomeShmemVersionTwoWayStream(proto,sender);
-        ACE_OS::printf("Classic shmem no longer exists\n");
-        ACE_OS::exit(1);
+        printf("Classic shmem no longer exists\n");
+        std::exit(1);
         return false;
     } else {
         // experimental shmem

--- a/src/libYARP_OS/src/ShmemInputStream.cpp
+++ b/src/libYARP_OS/src/ShmemInputStream.cpp
@@ -189,10 +189,10 @@ YARP_SSIZE_T ShmemInputStreamImpl::read(const Bytes& b)
     while (!(ret=read(data,(int)len)))
     {
         #ifdef _ACE_USE_SV_SEM
-        ACE_Time_Value tv=ACE_OS::gettimeofday();
+        YARP_timeval tv=ACE_OS::gettimeofday();
         tv.sec(tv.sec()+1);
         #else
-        ACE_Time_Value tv(1);
+        YARP_timeval tv(1);
         #endif
 
         m_pWaitDataMutex->acquire(tv);

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -11,7 +11,6 @@
 #ifdef YARP_HAS_ACE
 #  include <ace/INET_Addr.h>
 #  include <ace/os_include/netinet/os_tcp.h>
-#  include <ace/os_include/os_netdb.h>
 #else
 #  include <yarp/os/impl/TcpAcceptor.h>
 #  include <yarp/os/impl/TcpStream.h>
@@ -35,8 +34,8 @@ int SocketTwoWayStream::open(const Contact& address) {
         host = config.getHostName(true);
     }
     ACE_INET_Addr addr(address.getPort(),host.c_str());
-    ACE_Time_Value openTimeout;
-    ACE_Time_Value *timeout = YARP_NULLPTR;
+    YARP_timeval openTimeout;
+    YARP_timeval *timeout = YARP_NULLPTR;
     if (address.hasTimeout()) {
         openTimeout.set(address.getTimeout());
         timeout = &openTimeout;
@@ -93,13 +92,36 @@ void SocketTwoWayStream::updateAddresses() {
     memset(&remote, 0, sizeof(remote));
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);
-    if (local.sa_family == AF_INET) {
-        struct sockaddr_in *ipv4local = (struct sockaddr_in *) &local;
-        struct sockaddr_in *ipv4remote = (struct sockaddr_in *) &remote;
-        localAddress = Contact(inet_ntoa(ipv4local->sin_addr),ntohs(ipv4local->sin_port));
-        remoteAddress = Contact(inet_ntoa(ipv4remote->sin_addr),ntohs(ipv4remote->sin_port));
+    if (local.sa_family == AF_INET || local.sa_family == AF_INET6) {
+        char* localHostAddress = new char[local.sa_family == AF_INET ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN];
+        char* remoteHostAddress = new char[remote.sa_family == AF_INET ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN];
+        const char* ret = YARP_NULLPTR;
+        ret = inet_ntop(local.sa_family,
+                        (local.sa_family == AF_INET ? reinterpret_cast<void*>(&reinterpret_cast<struct sockaddr_in*>(&local)->sin_addr):
+                                                      reinterpret_cast<void*>(&reinterpret_cast<struct sockaddr_in6*>(&local)->sin6_addr)),
+                        localHostAddress,
+                        (local.sa_family == AF_INET ? INET_ADDRSTRLEN:
+                                                      INET6_ADDRSTRLEN));
+        if(ret) {
+            localAddress = Contact(localHostAddress, ntohs(reinterpret_cast<struct sockaddr_in*>(&local)->sin_port));
+        } else {
+            YARP_ERROR(Logger::get(), "SocketTwoWayStream::updateAddresses failed getting local address");
+        }
+        ret = inet_ntop(remote.sa_family,
+                       (remote.sa_family == AF_INET ? reinterpret_cast<void*>(&reinterpret_cast<struct sockaddr_in*>(&remote)->sin_addr):
+                                                      reinterpret_cast<void*>(&reinterpret_cast<struct sockaddr_in6*>(&remote)->sin6_addr)),
+                       remoteHostAddress,
+                       (remote.sa_family == AF_INET ? INET_ADDRSTRLEN:
+                                                      INET6_ADDRSTRLEN));
+        if(ret) {
+            remoteAddress = Contact(remoteHostAddress, ntohs(reinterpret_cast<struct sockaddr_in*>(&remote)->sin_port));
+        } else {
+            YARP_ERROR(Logger::get(), "SocketTwoWayStream::updateAddresses failed getting local address");
+        }
+        delete[] localHostAddress;
+        delete[] remoteHostAddress;
     } else {
-        YARP_ERROR(Logger::get(),"ipv6 address type not propagated without ACE");
+        YARP_ERROR(Logger::get(),"Unknown address type");
     }
 #endif
 }

--- a/src/libYARP_OS/src/SplitString.cpp
+++ b/src/libYARP_OS/src/SplitString.cpp
@@ -6,7 +6,8 @@
 
 #include <yarp/os/impl/SplitString.h>
 
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
+#include <cstring>
 
 
 using yarp::os::impl::SplitString;
@@ -29,7 +30,7 @@ int SplitString::size()
 void SplitString::set(int index, const char *txt)
 {
     if (index>=0&&index<size()) {
-        ACE_OS::strncpy(buf[index],(char*)txt,MAX_ARG_LEN);
+        strncpy(buf[index],(char*)txt,MAX_ARG_LEN);
     }
 }
 
@@ -69,7 +70,7 @@ void SplitString::apply(const char *command, char splitter)
                     at++;
                 }
                 sub_at = 0;
-            } 
+            }
         }
     }
     for (i=0; i<MAX_ARG_CT; i++) {

--- a/src/libYARP_OS/src/SystemClock.cpp
+++ b/src/libYARP_OS/src/SystemClock.cpp
@@ -8,42 +8,19 @@
 #include <yarp/os/SystemClock.h>
 #include <yarp/conf/system.h>
 
-#if defined YARP_HAS_CXX11
-#  include <chrono>
-#  include <thread>
-#else
-#  include <yarp/os/impl/PlatformTime.h>
-#endif
+#include <chrono>
+#include <thread>
 
 void yarp::os::SystemClock::delaySystem(double seconds)
 {
-#if defined YARP_HAS_CXX11
 #if defined _MSC_VER && _MSC_VER <= 1800
     std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(seconds)));
 #else
     std::this_thread::sleep_for(std::chrono::duration<double>(seconds));
 #endif
-
-#elif defined YARP_HAS_ACE
-    ACE_Time_Value tv;
-    tv.sec (long(seconds));
-    tv.usec (long((seconds-long(seconds)) * 1.0e6));
-    ACE_OS::sleep(tv);
-#else
-    usleep(seconds*1000000);
-#endif
 }
 
 double yarp::os::SystemClock::nowSystem()
 {
-#if defined YARP_HAS_CXX11
     return std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-#elif defined YARP_HAS_ACE
-    ACE_Time_Value timev = ACE_OS::gettimeofday();
-    return double(timev.sec()) + timev.usec() * 1e-6;
-#else
-    struct timeval currentTime;
-    gettimeofday(&currentTime, YARP_NULLPTR);
-    return (double)(currentTime.tv_sec + currentTime.tv_usec * 1e-6);
-#endif
 }

--- a/src/libYARP_OS/src/SystemInfo.cpp
+++ b/src/libYARP_OS/src/SystemInfo.cpp
@@ -4,9 +4,9 @@
  *  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <yarp/os/SystemInfo.h>
 #include <yarp/os/SystemInfoSerializer.h>
 using namespace yarp::os;
@@ -37,7 +37,7 @@ extern char **environ;
 #include <sys/mount.h>
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #include <shlobj.h>
 #include <Lmcons.h>
@@ -109,7 +109,7 @@ bool getCpuEntry(const char* tag, const char *buff, yarp::os::ConstString& value
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 class CpuLoadCollector: public yarp::os::RateThread
 {
 public:
@@ -239,7 +239,7 @@ SystemInfo::MemoryInfo SystemInfo::getMemoryInfo()
     memory.totalSpace = 0;
     memory.freeSpace = 0;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     MEMORYSTATUSEX statex;
     statex.dwLength = sizeof (statex);
     if(GlobalMemoryStatusEx (&statex))
@@ -303,7 +303,7 @@ SystemInfo::StorageInfo SystemInfo::getStorageInfo()
     storage.totalSpace = 0;
     storage.freeSpace = 0;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
         DWORD dwSectorsPerCluster=0, dwBytesPerSector=0;
         DWORD dwFreeClusters=0, dwTotalClusters=0;
@@ -442,7 +442,7 @@ SystemInfo::ProcessorInfo SystemInfo::getProcessorInfo()
     processor.modelNumber = 0;
     processor.siblings = 0;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     SYSTEM_INFO sysinf;
     GetSystemInfo(&sysinf);
     switch (sysinf.wProcessorArchitecture) {
@@ -556,7 +556,7 @@ SystemInfo::PlatformInfo SystemInfo::getPlatformInfo()
 {
     PlatformInfo platform;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     platform.name = "Windows";
     OSVERSIONINFOEX osver;
     osver.dwOSVersionInfoSize = sizeof(osver);
@@ -678,7 +678,7 @@ SystemInfo::UserInfo SystemInfo::getUserInfo()
     UserInfo user;
     user.userID = 0;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     char path[MAX_PATH+1];
     if(SHGetFolderPathA(YARP_NULLPTR, CSIDL_PROFILE, YARP_NULLPTR, 0, path ) == S_OK)
         user.homeDir = path;
@@ -714,7 +714,7 @@ SystemInfo::LoadInfo SystemInfo::getLoadInfo()
     load.cpuLoad15 = 0.0;
     load.cpuLoadInstant = 0;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     if(globalLoadCollector)
     {
         load = globalLoadCollector->getCpuLoad();
@@ -806,7 +806,7 @@ SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid) {
         info.schedPriority = param.__sched_priority;
     info.schedPolicy = sched_getscheduler(pid);
 
-#elif defined(WIN32)
+#elif defined(_WIN32)
     HANDLE hnd = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if(hnd) {
         TCHAR filename[MAX_PATH];

--- a/src/libYARP_OS/src/TcpAcceptor.cpp
+++ b/src/libYARP_OS/src/TcpAcceptor.cpp
@@ -79,10 +79,8 @@ int TcpAcceptor::shared_open(const Contact& address) {
     servAddr.sin_addr.s_addr = INADDR_ANY;
     servAddr.sin_family = AF_INET;
     servAddr.sin_port = htons((address.getPort()>0)?address.getPort():0);
-    inet_aton(address.getHost().c_str(), &servAddr.sin_addr);
+    inet_pton(AF_INET, address.getHost().c_str(), &servAddr.sin_addr);
     memset(servAddr.sin_zero, '\0', sizeof servAddr.sin_zero);
-
-//    servAddress = Address(inet_ntoa(servAddr.sin_addr),servAddr.sin_port);
 
     if (bind(get_handle(), (struct sockaddr *)&servAddr,
             sizeof (struct sockaddr)) == -1) {
@@ -123,8 +121,6 @@ int TcpAcceptor::shared_open(const Contact& address) {
  * Accept connection and set field for clientAddress.
  */
 int TcpAcceptor::accept(TcpStream &new_stream) {
-//    printf("Waiting for client to accept...\n");
-
     sockaddr *addr = 0;
     int len = 0; int *len_ptr = &len;
 
@@ -134,13 +130,6 @@ int TcpAcceptor::accept(TcpStream &new_stream) {
         return -1;
     }
 
-//    clientAddress = Address(inet_ntoa(clientAddr.sin_addr),clientAddr.sin_port);
-
-//    char text[256];
-//    sprintf(text, "Connected to client %s", inet_ntoa(clientAddr.sin_addr));
-//    sprintf(text, " with server fd %i and client fd %i", sockets.get_serv_sockfd(), sockets.get_client_sockfd());
-//    printf("%s\n", text);
-//    happy = true;
     return 1;
 }
 

--- a/src/libYARP_OS/src/TcpConnector.cpp
+++ b/src/libYARP_OS/src/TcpConnector.cpp
@@ -26,12 +26,14 @@
 
 // General files
 #include <yarp/os/impl/TcpConnector.h>
-#include <yarp/os/Log.h>
 
-#include <sys/socket.h>
-#include <netdb.h>
+#include <yarp/os/Log.h>
+#include <yarp/os/impl/PlatformNetdb.h>
+
 #include <iostream>
 #include <cstdio>
+
+#include <sys/socket.h>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -70,25 +72,21 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address) {
     servAddr.sin_port = htons(address.getPort());
     memset(servAddr.sin_zero, '\0', sizeof servAddr.sin_zero);
 
-    struct hostent *hostInfo = gethostbyname(address.getHost().c_str());
+    struct hostent *hostInfo = yarp::os::impl::gethostbyname(address.getHost().c_str());
     if (hostInfo) {
         bcopy(hostInfo->h_addr,(char *)(&servAddr.sin_addr),hostInfo->h_length);
     } else {
-        inet_aton(address.getHost().c_str(), &servAddr.sin_addr);
+        inet_pton(AF_INET, address.getHost().c_str(), &servAddr.sin_addr);
     }
-
-//     Address servAddress,
-//     servAddress = Address(inet_ntoa(servAddr.sin_addr),servAddr.sin_port);
 
     yAssert(new_stream.get_handle() != -1);
 
     int result = ::connect(new_stream.get_handle(), (sockaddr*) &servAddr, sizeof(servAddr));
 
-//    std::cout << "Connect [handle=" << new_stream.get_handle() << "] at " << inet_ntoa(servAddr.sin_addr) << ":" << servAddr.sin_port << std::endl;
-
     if (result < 0) {
         perror("TcpConnector::connect fail");
-        std::cerr << "Connect [handle=" << new_stream.get_handle() << "] at " << inet_ntoa(servAddr.sin_addr) << ":" << servAddr.sin_port << std::endl;
+        char buf[INET_ADDRSTRLEN];
+        std::cerr << "Connect [handle=" << new_stream.get_handle() << "] at " << inet_ntop(AF_INET, &servAddr.sin_addr, buf, INET_ADDRSTRLEN) << ":" << servAddr.sin_port << std::endl;
     }
     return result;
 }

--- a/src/libYARP_OS/src/TcpFace.cpp
+++ b/src/libYARP_OS/src/TcpFace.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/impl/Protocol.h>
 #include <yarp/os/impl/NameConfig.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -85,7 +85,7 @@ InputProtocol *TcpFace::read() {
 
     int result = stream->open(peerAcceptor);
     if (result<0) {
-        //ACE_OS::printf("exception on tcp stream read: %s\n", e.toString().c_str());
+        //printf("exception on tcp stream read: %s\n", e.toString().c_str());
         stream->close();
         delete stream;
         stream = YARP_NULLPTR;

--- a/src/libYARP_OS/src/TcpStream.cpp
+++ b/src/libYARP_OS/src/TcpStream.cpp
@@ -27,7 +27,7 @@
 
 // General files
 #include <sys/socket.h>
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/impl/TcpStream.h>
 

--- a/src/libYARP_OS/src/Terminator.cpp
+++ b/src/libYARP_OS/src/Terminator.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/SocketTwoWayStream.h>
 #include <yarp/os/impl/Companion.h>
 #include <yarp/os/impl/PortCommand.h>
@@ -61,7 +61,7 @@ Terminee::Terminee(const char *name) {
     ok = false;
     if (name == YARP_NULLPTR) {
         quit = true;
-        ACE_OS::printf("Terminator: Please supply a proper port name\n");
+        printf("Terminator: Please supply a proper port name\n");
         return;
     }
 

--- a/src/libYARP_OS/src/Things.cpp
+++ b/src/libYARP_OS/src/Things.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <yarp/os/Things.h>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -5,14 +5,14 @@
  */
 
 #include <yarp/os/impl/ThreadImpl.h>
-#include <yarp/os/impl/SemaphoreImpl.h>
-#include <yarp/os/impl/Logger.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/impl/PlatformThread.h>
-#include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 
-#include <stdlib.h>
+#include <yarp/os/impl/Logger.h>
+#include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/PlatformThread.h>
+#include <yarp/os/impl/SemaphoreImpl.h>
+
+#include <cstdlib>
 
 #if defined(YARP_HAS_CXX11)
 #  if defined(YARP_HAS_ACE)
@@ -54,14 +54,11 @@ void ThreadImpl::fini()
     }
 }
 
-#ifdef __WIN32__
-static unsigned __stdcall theExecutiveBranch (void *args)
-#else
+
 PLATFORM_THREAD_RETURN theExecutiveBranch (void *args)
-#endif
 {
     // just for now -- rather deal with broken pipes through normal procedures
-    ACE_OS::signal(SIGPIPE, SIG_IGN);
+    yarp::os::impl::signal(SIGPIPE, SIG_IGN);
 
 
     /*

--- a/src/libYARP_OS/src/UnitTest.cpp
+++ b/src/libYARP_OS/src/UnitTest.cpp
@@ -8,9 +8,9 @@
 #include <yarp/os/impl/UnitTest.h>
 #include <yarp/os/impl/Logger.h>
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/Network.h>
-#include <math.h>
+#include <cmath>
 
 #ifdef YARP_TEST_HEAP
 #include <yarp/os/Mutex.h>
@@ -193,7 +193,7 @@ bool UnitTest::checkEqualImpl(int x, int y,
                               const char *fname,
                               int fline) {
     char buf[1000];
-    ACE_OS::sprintf(buf, "in file %s:%d [%s] %s (%d) == %s (%d)",
+    sprintf(buf, "in file %s:%d [%s] %s (%d) == %s (%d)",
                     fname, fline, desc, txt1, x, txt2, y);
     if (x==y) {
         report(0,ConstString("  [") + desc + "] passed ok");
@@ -210,7 +210,7 @@ bool UnitTest::checkEqualishImpl(double x, double y,
                                  const char *fname,
                                  int fline) {
     char buf[1000];
-    ACE_OS::sprintf(buf, "in file %s:%d [%s] %s (%g) == %s (%g)",
+    sprintf(buf, "in file %s:%d [%s] %s (%g) == %s (%g)",
                     fname, fline, desc, txt1, x, txt2, y);
     bool ok = (fabs(x-y)<0.0001);
     if (ok) {
@@ -229,7 +229,7 @@ bool UnitTest::checkEqualImpl(const ConstString& x, const ConstString& y,
                               const char *fname,
                               int fline) {
     char buf[1000];
-    ACE_OS::sprintf(buf, "in file %s:%d [%s] %s (%s) == %s (%s)",
+    sprintf(buf, "in file %s:%d [%s] %s (%s) == %s (%s)",
                     fname, fline, desc, txt1, humanize(x).c_str(), txt2, humanize(y).c_str());
     bool ok = (x==y);
     if (ok) {

--- a/src/libYARP_OS/src/YarpNameSpace.cpp
+++ b/src/libYARP_OS/src/YarpNameSpace.cpp
@@ -7,7 +7,7 @@
 #include <yarp/os/YarpNameSpace.h>
 #include <yarp/os/DummyConnector.h>
 #include <yarp/os/impl/NameClient.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/NameConfig.h>
 

--- a/src/libYARP_OS/src/YarpPlugin.cpp
+++ b/src/libYARP_OS/src/YarpPlugin.cpp
@@ -7,14 +7,14 @@
 #include <yarp/os/YarpPlugin.h>
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdlib>
 #include <yarp/os/impl/NameClient.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;

--- a/src/libYARP_OS/src/ydr.cpp
+++ b/src/libYARP_OS/src/ydr.cpp
@@ -14,9 +14,9 @@
 
 #include <yarp/os/impl/ydr.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <yarp/os/all.h>
 using namespace yarp::os;

--- a/src/libYARP_dev/include/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardHelper.h
@@ -7,9 +7,9 @@
 #ifndef YARP_DEV_CONTROLBOARDHELPER_H
 #define YARP_DEV_CONTROLBOARDHELPER_H
 
-#include <string.h> // for memset
-#include <stdio.h> // for printf
-#include <math.h> //fabs
+#include <cstring> // for memset
+#include <cstdio> // for printf
+#include <cmath> //fabs
 #include <yarp/os/Log.h>
 
 /*

--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfacesImpl.inl
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfacesImpl.inl
@@ -7,7 +7,7 @@
 #include <yarp/dev/ImplementControlBoardInterfaces.h>
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <math.h>
+#include <cmath>
 
 // Be careful: this file contains template implementations and is included by translation
 // units that use the template (e.g. .cpp files). Avoid putting here non-template functions to

--- a/src/libYARP_dev/include/yarp/dev/ServerFrameGrabber.h
+++ b/src/libYARP_dev/include/yarp/dev/ServerFrameGrabber.h
@@ -8,7 +8,7 @@
 #ifndef YARP_DEV_SERVERFRAMEGRABBER_H
 #define YARP_DEV_SERVERFRAMEGRABBER_H
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/DataSource.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>

--- a/src/libYARP_dev/include/yarp/dev/ServerSerial.h
+++ b/src/libYARP_dev/include/yarp/dev/ServerSerial.h
@@ -7,8 +7,8 @@
 #ifndef YARP_DEV_SERVERSERIAL_H
 #define YARP_DEV_SERVERSERIAL_H
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>

--- a/src/libYARP_dev/include/yarp/dev/ServerSoundGrabber.h
+++ b/src/libYARP_dev/include/yarp/dev/ServerSoundGrabber.h
@@ -6,7 +6,7 @@
 #ifndef YARP_DEV_SERVERSOUNDGRABBER_H
 #define YARP_DEV_SERVERSOUNDGRABBER_H
 
-#include <stdio.h>
+#include <cstdio>
 
 
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/include/yarp/dev/TestMotor.h
+++ b/src/libYARP_dev/include/yarp/dev/TestMotor.h
@@ -8,7 +8,7 @@
 #ifndef YARP_DEV_TESTMOTOR_H
 #define YARP_DEV_TESTMOTOR_H
 
-#include <stdio.h>
+#include <cstdio>
 
 
 #include <yarp/dev/ControlBoardInterfaces.h>

--- a/src/libYARP_dev/src/ClientControlBoard.cpp
+++ b/src/libYARP_dev/src/ClientControlBoard.cpp
@@ -13,7 +13,7 @@
  */
 
 
-#include <string.h>
+#include <cstring>
 
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/src/ControlBoardInterfacesImpl.cpp
+++ b/src/libYARP_dev/src/ControlBoardInterfacesImpl.cpp
@@ -8,7 +8,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.inl" //ControlBoardHelper
 #include <yarp/os/Log.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 
 bool StubImplPositionControlRaw::NOT_YET_IMPLEMENTED(const char *func)

--- a/src/libYARP_dev/src/ControlCalibrationImpl.cpp
+++ b/src/libYARP_dev/src/ControlCalibrationImpl.cpp
@@ -10,7 +10,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/os/Log.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::dev;
 

--- a/src/libYARP_dev/src/ControlMode2Impl.cpp
+++ b/src/libYARP_dev/src/ControlMode2Impl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/ControlModeImpl.cpp
+++ b/src/libYARP_dev/src/ControlModeImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/DeviceDriver.cpp
+++ b/src/libYARP_dev/src/DeviceDriver.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Value.h>

--- a/src/libYARP_dev/src/DeviceGroup.cpp
+++ b/src/libYARP_dev/src/DeviceGroup.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Semaphore.h>

--- a/src/libYARP_dev/src/DevicePipe.cpp
+++ b/src/libYARP_dev/src/DevicePipe.cpp
@@ -7,7 +7,7 @@
 
 #include <yarp/dev/DevicePipe.h>
 #include <yarp/os/Time.h>
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/AudioVisualInterfaces.h>
 

--- a/src/libYARP_dev/src/Drivers.cpp
+++ b/src/libYARP_dev/src/Drivers.cpp
@@ -19,7 +19,7 @@
 #include <yarp/dev/Drivers.h>
 
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformSignal.h>
+#include <csignal>
 #include <yarp/os/impl/Logger.h>
 
 #include <yarp/os/YarpPlugin.h>
@@ -353,7 +353,7 @@ static void handler (int) {
     ct++;
     if (ct>3) {
         yInfo("Aborting...");
-        yarp::os::exit(1);
+        std::exit(1);
     }
     if (terminatorKey!="") {
         yInfo("[try %d of 3] Trying to shut down %s", ct, terminatorKey.c_str());
@@ -361,15 +361,15 @@ static void handler (int) {
         Terminator::terminateByName(terminatorKey.c_str());
     } else {
         yInfo("Aborting...");
-        yarp::os::exit(1);
+        std::exit(1);
     }
 }
 
 
 int Drivers::yarpdev(int argc, char *argv[]) {
 
-    ACE_OS::signal(SIGINT, (ACE_SignalHandler) handler);
-    ACE_OS::signal(SIGTERM, (ACE_SignalHandler) handler);
+    ::signal(SIGINT, handler);
+    ::signal(SIGTERM, handler);
 
     // get command line options
     ResourceFinder rf;

--- a/src/libYARP_dev/src/IAxisInfoImpl.cpp
+++ b/src/libYARP_dev/src/IAxisInfoImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ImplementAxisInfo.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 
 ////////////////////////

--- a/src/libYARP_dev/src/IControlLimit2sImpl.cpp
+++ b/src/libYARP_dev/src/IControlLimit2sImpl.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/IEncodersTimedImpl.cpp
+++ b/src/libYARP_dev/src/IEncodersTimedImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/IInteractionModeImpl.cpp
+++ b/src/libYARP_dev/src/IInteractionModeImpl.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/IMotorEncodersImpl.cpp
+++ b/src/libYARP_dev/src/IMotorEncodersImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (m >= castToMapper(helper)->axes()){yError("motor id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/IMotorImpl.cpp
+++ b/src/libYARP_dev/src/IMotorImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (m >= castToMapper(helper)->axes()){yError("motor id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/IPositionControl2Impl.cpp
+++ b/src/libYARP_dev/src/IPositionControl2Impl.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/IPositionDirectImpl.cpp
+++ b/src/libYARP_dev/src/IPositionDirectImpl.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/IRemoteVariablesImpl.cpp
+++ b/src/libYARP_dev/src/IRemoteVariablesImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 
 ////////////////////////

--- a/src/libYARP_dev/src/IVelocityControl2Impl.cpp
+++ b/src/libYARP_dev/src/IVelocityControl2Impl.cpp
@@ -5,7 +5,7 @@
  */
 
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/ImpedanceControlImpl.cpp
+++ b/src/libYARP_dev/src/ImpedanceControlImpl.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/ImplementImpedanceControl.h>
 #include <yarp/dev/ControlBoardHelper.h>

--- a/src/libYARP_dev/src/LaserMeasurementData.cpp
+++ b/src/libYARP_dev/src/LaserMeasurementData.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <yarp/dev/LaserMeasurementData.h>
-#include <math.h>
+#include <cmath>
 
 using namespace yarp::dev;
 

--- a/src/libYARP_dev/src/PopulateDrivers.cpp
+++ b/src/libYARP_dev/src/PopulateDrivers.cpp
@@ -14,8 +14,8 @@
 #include <yarp/dev/Drivers.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/Bottle.h>
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <yarp/dev/RemoteFrameGrabber.h>
 #include <yarp/dev/ServerFrameGrabber.h>
 #include <yarp/dev/DevicePipe.h>

--- a/src/libYARP_dev/src/ServerControlBoard.cpp
+++ b/src/libYARP_dev/src/ServerControlBoard.cpp
@@ -4,7 +4,7 @@
 * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 */
 
-#include <string.h>
+#include <cstring>
 
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/src/ServerSerial.cpp
+++ b/src/libYARP_dev/src/ServerSerial.cpp
@@ -194,7 +194,7 @@ yarp::dev::ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ServerS
     //ACE_ASSERT (ser != 0);
     if (ser==0) {
         yError("Could not get serial device\n");
-        yarp::os::exit(1);
+        std::exit(1);
     }
 
 

--- a/src/libYARP_dev/src/TorqueControlImpl.cpp
+++ b/src/libYARP_dev/src/TorqueControlImpl.cpp
@@ -7,7 +7,7 @@
 #include "yarp/dev/ControlBoardInterfacesImpl.h"
 #include <yarp/dev/ControlBoardHelper.h>
 
-#include <stdio.h>
+#include <cstdio>
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -12,7 +12,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 
-#include <string.h>         // for memset function
+#include <cstring>         // for memset function
 
 using namespace yarp::os;
 using namespace yarp::dev;

--- a/src/libYARP_dev/src/devices/FrameTransformServer/FrameTransformServer.cpp
+++ b/src/libYARP_dev/src/devices/FrameTransformServer/FrameTransformServer.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/LockGuard.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace yarp::sig;
 using namespace yarp::math;
@@ -49,7 +49,7 @@ int Transforms_server_storage::set_transform(FrameTransform t)
     {
        //@@@ this linear search requires optimization!
        if (m_transforms[i].dst_frame_id == t.dst_frame_id && m_transforms[i].src_frame_id == t.src_frame_id)
-       {   
+       {
           //transform already exists, update it
           m_transforms[i]=t;
           return i;
@@ -611,7 +611,7 @@ void FrameTransformServer::run()
         size_t    tfVecSize_timed_ros = m_ros_timed_transform_storage->size();
 #if 0
         yDebug() << "yarp size" << tfVecSize_yarp << "ros_size" << tfVecSize_ros;
-#endif 
+#endif
         yarp::os::Bottle& b = m_streamingPort.prepare();
         b.clear();
 

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -7,8 +7,8 @@
 
 #include "RGBDSensorWrapper.h"
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarpRosHelper.h>
@@ -232,7 +232,7 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
         //    yWarning() << "RGBDSensorWrapper: ROS topic support is not yet implemented";
         Value* temp;
         string confUseRos;
-        
+
         rosGroup.check("use_ROS", temp);
         confUseRos = temp->asString();
 
@@ -257,14 +257,14 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
         unsigned int                    i;
         std::vector<param<string> >     rosStringParam;
         param<string>*                  prm;
-        
+
         rosStringParam.push_back(param<string>(nodeName,       nodeName_param          ));
         rosStringParam.push_back(param<string>(rosFrameId,     frameId_param           ));
         rosStringParam.push_back(param<string>(colorTopicName, colorTopicName_param    ));
         rosStringParam.push_back(param<string>(depthTopicName, depthTopicName_param    ));
         rosStringParam.push_back(param<string>(cInfoTopicName, depthInfoTopicName_param));
         rosStringParam.push_back(param<string>(dInfoTopicName, colorInfoTopicName_param));
-        
+
         for (i = 0; i < rosStringParam.size(); i++)
         {
             prm = &rosStringParam[i];
@@ -279,10 +279,10 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
             }
             *(prm->var) = rosGroup.find(prm->parname).asString().c_str();
         }
-        
+
         if (rosGroup.check("forceInfoSync"))
         {
-            forceInfoSync = rosGroup.find("forceInfoSync").asBool();    
+            forceInfoSync = rosGroup.find("forceInfoSync").asBool();
         }
     }
 
@@ -305,7 +305,7 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
             depthFrame_StreamingPort_Name = rootName + "/depthImage:o";
         }
     }
-    
+
     // check if we need to create subdevice or if they are
     // passed later on thorugh attachAll()
     if(config.check("subdevice"))
@@ -645,10 +645,10 @@ void RGBDSensorWrapper::shallowCopyImages(const ImageOf<PixelFloat>& src, ImageO
 
 
 
-void RGBDSensorWrapper::deepCopyImages(const yarp::sig::FlexImage& src, 
-                                       sensor_msgs_Image&          dest, 
-                                       const string&               frame_id, 
-                                       const TickTime&             timeStamp, 
+void RGBDSensorWrapper::deepCopyImages(const yarp::sig::FlexImage& src,
+                                       sensor_msgs_Image&          dest,
+                                       const string&               frame_id,
+                                       const TickTime&             timeStamp,
                                        const UInt&                 seq)
 {
     dest.data.resize(src.getRawImageSize());
@@ -670,12 +670,12 @@ void RGBDSensorWrapper::deepCopyImages(const DepthImage&  src,
                                        const UInt&        seq)
 {
     dest.data.resize(src.getRawImageSize());
-    
+
     dest.width           = src.width();
     dest.height          = src.height();
-    
+
     memcpy(dest.data.data(), src.getRawImage(), src.getRawImageSize());
-    
+
     dest.encoding        = yarp2RosPixelCode(src.getPixelCode());
     dest.step            = src.getRowSize();
     dest.header.frame_id = frame_id;
@@ -693,7 +693,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
     vector<param<double> >  parVector;
     param<double>*          par;
     bool                    ok;
-    
+
     currentSensor = sensorType == COLOR_SENSOR ? "Rgb" : "Depth";
     ok            = sensorType == COLOR_SENSOR ? sensor_p->getRgbIntrinsicParam(camData) : sensor_p->getDepthIntrinsicParam(camData);
 
@@ -708,7 +708,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
         yWarning() << "missing distortion model";
         return false;
     }
-    
+
     distModel = camData.find("distortionModel").asString();
     if (distModel != "plumb_bob")
     {
@@ -718,7 +718,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
 
     //std::vector<param<string> >     rosStringParam;
     //rosStringParam.push_back(param<string>(nodeName, "asd"));
-    
+
     parVector.push_back(param<double>(fx,"focalLengthX"));
     parVector.push_back(param<double>(fy,"focalLengthY"));
     parVector.push_back(param<double>(cx,"principalPointX"));
@@ -732,7 +732,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
     for(i = 0; i < parVector.size(); i++)
     {
         par = &parVector[i];
-        
+
         if(!camData.check(par->parname))
         {
             yWarning() << "RGBSensorWrapper: driver has not the param:" << par->parname;
@@ -740,21 +740,21 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
         }
         *par->var = camData.find(par->parname).asDouble();
     }
-    
+
     cameraInfo.header.frame_id    = frame_id;
     cameraInfo.header.seq         = seq;
     cameraInfo.header.stamp       = normalizeSecNSec(stamp);
     cameraInfo.width              = sensorType == COLOR_SENSOR ? sensor_p->getRgbWidth() : sensor_p->getDepthWidth();
     cameraInfo.height             = sensorType == COLOR_SENSOR ? sensor_p->getRgbHeight() : sensor_p->getDepthHeight();
     cameraInfo.distortion_model   = distModel;
-    
+
     cameraInfo.D.resize(5);
     cameraInfo.D[0] = k1;
     cameraInfo.D[1] = k2;
     cameraInfo.D[2] = t1;
     cameraInfo.D[3] = t2;
     cameraInfo.D[4] = k3;
-    
+
     cameraInfo.K.resize(9);
     cameraInfo.K[0]  = fx;       cameraInfo.K[1] = 0;        cameraInfo.K[2] = cx;
     cameraInfo.K[3]  = 0;        cameraInfo.K[4] = fy;       cameraInfo.K[5] = cy;
@@ -771,12 +771,12 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
 
     cameraInfo.R.assign(9, 0);
     cameraInfo.R.at(0) = cameraInfo.R.at(4) = cameraInfo.R.at(8) = 1;
-    
+
     cameraInfo.P.resize(12);
     cameraInfo.P[0]  = fx;      cameraInfo.P[1] = 0;    cameraInfo.P[2]  = cx;  cameraInfo.P[3]  = 0;
     cameraInfo.P[4]  = 0;       cameraInfo.P[5] = fy;   cameraInfo.P[6]  = cy;  cameraInfo.P[7]  = 0;
     cameraInfo.P[8]  = 0;       cameraInfo.P[9] = 0;    cameraInfo.P[10] = 1;   cameraInfo.P[11] = 0;
-    
+
     cameraInfo.binning_x  = cameraInfo.binning_y = 0;
     cameraInfo.roi.height = cameraInfo.roi.width = cameraInfo.roi.x_offset = cameraInfo.roi.y_offset = 0;
     cameraInfo.roi.do_rectify = false;
@@ -785,7 +785,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
 
 bool RGBDSensorWrapper::writeData()
 {
-    
+
     //colorImage.setPixelCode(VOCAB_PIXEL_RGB);
     //             depthImage.setPixelCode(VOCAB_PIXEL_MONO_FLOAT);
 
@@ -835,10 +835,10 @@ bool RGBDSensorWrapper::writeData()
         sensor_msgs_CameraInfo& camInfoC        = rosPublisherPort_colorCaminfo.prepare();
         sensor_msgs_CameraInfo& camInfoD        = rosPublisherPort_depthCaminfo.prepare();
         TickTime                cRosStamp, dRosStamp;
-        
+
         cRosStamp = normalizeSecNSec(colorStamp.getTime());
         dRosStamp = normalizeSecNSec(depthStamp.getTime());
-        
+
         deepCopyImages(colorImage, rColorImage, rosFrameId, cRosStamp, nodeSeq);
         deepCopyImages(depthImage, rDepthImage, rosFrameId, dRosStamp, nodeSeq);
         // TBD: We should check here somehow if the timestamp was correctly updated and, if not, update it ourselves.

--- a/src/libYARP_dev/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
+++ b/src/libYARP_dev/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
@@ -4,7 +4,10 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
+#define _USE_MATH_DEFINES
+
 #include "Rangefinder2DClient.h"
+
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/dev/IFrameTransform.h>
@@ -12,8 +15,7 @@
 #include <yarp/math/FrameTransform.h>
 
 #include <limits>
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 /*! \file Rangefinder2DClient.cpp */
 

--- a/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -4,13 +4,14 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include "Rangefinder2DWrapper.h"
-#include <sstream>
-#include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/os/Log.h>
-#include <yarp/os/LogStream.h>
 #define _USE_MATH_DEFINES
-#include <math.h>
+
+#include "Rangefinder2DWrapper.h"
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/os/LogStream.h>
+
+#include <cmath>
+#include <sstream>
 
 using namespace yarp::sig;
 using namespace yarp::dev;

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <string.h>
+#include <cstring>
 
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "stateExtendedReader.hpp"
-#include <string.h>
+#include <cstring>
 
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.hpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.hpp
@@ -8,7 +8,7 @@
 #define YARP_DEV_REMOTECONTROLBOARD_STATEEXTENDEDREADER_H
 
 
-#include <string.h>
+#include <cstring>
 
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
@@ -8,7 +8,7 @@
 #ifndef YARP_DEV_SERVERGRABBER_H
 #define YARP_DEV_SERVERGRABBER_H
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/dev/DataSource.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>

--- a/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.cpp
+++ b/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "ServerInertial.h"
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>

--- a/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.h
+++ b/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.h
@@ -8,7 +8,7 @@
 #ifndef YARP_DEV_SERVERINERTIAL_SERVERINERTIAL_H
 #define YARP_DEV_SERVERINERTIAL_SERVERINERTIAL_H
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>

--- a/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+++ b/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
@@ -29,8 +29,7 @@
 
 #include <string>
 #include <vector>
-
-#include <stdarg.h>
+#include <cstdarg>
 
 #ifdef MSVC
     #pragma warning(disable:4355)

--- a/src/libYARP_dev/src/devices/msgs/ros/include/yarpRosHelper.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/yarpRosHelper.h
@@ -12,7 +12,7 @@
 
 
 #include <iostream>
-#include <limits.h>
+#include <climits>
 #include <cmath>
 #include <yarp/os/LogStream.h>
 

--- a/src/libYARP_gsl/include/yarp/gsl/impl/gsl_structs.h
+++ b/src/libYARP_gsl/include/yarp/gsl/impl/gsl_structs.h
@@ -11,7 +11,7 @@
 #ifndef YARP_GSL_IMPL_GSL_COMPATIBILITY_H
 #define YARP_GSL_IMPL_GSL_COMPATIBILITY_H
 
-#include <stddef.h>
+#include <cstddef>
 
 
 #ifndef gsl_block

--- a/src/libYARP_init/src/CustomInit.cpp
+++ b/src/libYARP_init/src/CustomInit.cpp
@@ -4,7 +4,7 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/Network.h>
 
 static int __custom_yarp_is_initialized = 0;

--- a/src/libYARP_logger/src/YarpLogger.cpp
+++ b/src/libYARP_logger/src/YarpLogger.cpp
@@ -20,7 +20,7 @@
 #include <cstring>
 #include <string>
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 #include <iterator>
 #include <yarp/os/RpcClient.h>
@@ -277,7 +277,7 @@ void LoggerEngine::logger_thread::run()
                 unknown_format_received++;
                 continue;
             }
-            
+
             MessageEntry body;
             std::string s;
 

--- a/src/libYARP_manager/include/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/localbroker.h
@@ -26,7 +26,7 @@
 
 #include <yarp/manager/broker.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include<Windows.h>
 #endif
 
@@ -102,7 +102,7 @@ private:
     bool psCmd(int pid);
     bool killCmd(int pid);
     bool stopCmd(int pid);
-#if defined(WIN32)
+#if defined(_WIN32)
     HANDLE read_from_pipe_cmd_to_stdout;
     HANDLE write_to_pipe_cmd_to_stdout;
     string lastError2String();

--- a/src/libYARP_manager/include/yarp/manager/utility.h
+++ b/src/libYARP_manager/include/yarp/manager/utility.h
@@ -14,7 +14,7 @@
 #include <cctype>
 #include <string>
 #include <vector>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 

--- a/src/libYARP_manager/include/yarp/manager/ymm-dir.h
+++ b/src/libYARP_manager/include/yarp/manager/ymm-dir.h
@@ -13,17 +13,17 @@
 #define YARP_MANAGER_YMMDIR
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
     #define PATH_SEPERATOR      "\\"
 
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
-    #include <string.h>
-    #include <stdlib.h>
+    #include <cstring>
+    #include <cstdlib>
     #include <sys/types.h>
     #include <sys/stat.h>
-    #include <errno.h>
+    #include <cerrno>
 
     /* File type and permission flags for stat() */
     #if defined(_MSC_VER)  &&  !defined(S_IREAD)

--- a/src/libYARP_manager/include/yarp/manager/ymm-types.h
+++ b/src/libYARP_manager/include/yarp/manager/ymm-types.h
@@ -71,7 +71,7 @@ typedef enum __Carrier {
 */
 #ifdef YMM_DEBUG
      #include <iostream>
-     #include <assert.h>
+     #include <cassert>
      #define __ASSERT( _cond ) assert(_cond)
      #define __CHECK_NULLPTR(_ptr) \
              assert(_ptr); \

--- a/src/libYARP_manager/src/arbitrator.cpp
+++ b/src/libYARP_manager/src/arbitrator.cpp
@@ -17,7 +17,7 @@
 #include <cmath>
 #include <yarp/math/Math.h>
 //#include <gsl/gsl_version.h>
-//#include <gsl/gsl_math.h>
+//#include <gsl/gsl_cmath>
 //#include <gsl/gsl_eigen.h>
 #endif
 

--- a/src/libYARP_manager/src/localbroker.cpp
+++ b/src/libYARP_manager/src/localbroker.cpp
@@ -21,7 +21,7 @@
 #define WRITE_TO_PIPE           1
 #define READ_FROM_PIPE          0
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include<Windows.h>
     #define SIGKILL 9
 #else
@@ -31,7 +31,7 @@
     #include <fcntl.h>
     #include <cerrno>
     #include <unistd.h>
-    #include <string.h>
+    #include <cstring>
 
     #define PIPE_TIMEOUT        0
     #define PIPE_EVENT          1
@@ -43,7 +43,7 @@ using namespace yarp::os;
 using namespace yarp::manager;
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 class LocalTerminateParams
 {
 public:
@@ -226,7 +226,7 @@ bool LocalBroker::init(const char* szcmd, const char* szparam,
     }
     */
 
-#if defined(WIN32)
+#if defined(_WIN32)
     // do nothing
     bInitialized = true;
     return true;
@@ -270,7 +270,7 @@ bool LocalBroker::stop()
     if(bOnlyConnector) return false;
 
     strError.clear();
-#if defined(WIN32)
+#if defined(_WIN32)
     stopCmd(ID);
     stopStdout();
 #else
@@ -299,7 +299,7 @@ bool LocalBroker::kill()
 
     strError.clear();
 
-#if defined(WIN32)
+#if defined(_WIN32)
     killCmd(ID);
     stopStdout();
 #else
@@ -513,7 +513,7 @@ bool LocalBroker::threadInit()
 void LocalBroker::run()
 {
 
-#if defined(WIN32)
+#if defined(_WIN32)
     //windows implementaion
     DWORD dwRead;
     CHAR buff[1024];
@@ -560,7 +560,7 @@ void LocalBroker::setWindowMode(WindowMode m)
 }
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 string LocalBroker::lastError2String()
 {
@@ -599,8 +599,8 @@ int LocalBroker::ExecuteCmd(void)
     DWORD dwCreationFlags;
 
     //these come from xml
-    /* 
-    // These are not supported until we find a way to send break signals to 
+    /*
+    // These are not supported until we find a way to send break signals to
     // consoles that are not inherited
     if (strDisplay=="--visible_na")
         windowMode=WINDOW_VISIBLE;
@@ -610,7 +610,7 @@ int LocalBroker::ExecuteCmd(void)
 
     // this is for "attach to stoud only"
     if (windowMode==WINDOW_VISIBLE)
-    { 
+    {
         //this is common to all processes
         cmd_startup_info.dwFlags |= STARTF_USESHOWWINDOW;
         cmd_startup_info.wShowWindow = SW_SHOWNA;
@@ -634,7 +634,7 @@ int LocalBroker::ExecuteCmd(void)
 
         dwCreationFlags=CREATE_NEW_PROCESS_GROUP; //CREATE_NEW_CONSOLE|CREATE_NEW_PROCESS_GROUP,
     }
-  
+
 
 
     /*
@@ -682,7 +682,7 @@ int LocalBroker::ExecuteCmd(void)
                                 bWorkdir?strWorkdirOk.c_str():NULL, // working directory
                                 &cmd_startup_info,   // STARTUPINFO pointer
                                 &cmd_process_info);  // receives PROCESS_INFORMATION
-       
+
     if (!bSuccess && bWorkdir)
     {
             bSuccess=CreateProcess(NULL,    // command name
@@ -743,13 +743,13 @@ bool LocalBroker::stopCmd(int pid)
 
     LocalTerminateParams params(pid);
     EnumWindows((WNDENUMPROC)LocalTerminateAppEnum,(LPARAM)&params);
-    
-    // I believe we do not need this. It is ignored by console applications created with CREATE_NEW_PROCESS_GROUP 
-    GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid); 
+
+    // I believe we do not need this. It is ignored by console applications created with CREATE_NEW_PROCESS_GROUP
+    GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid);
 
     //send BREAK_EVENT becaue we created the process with CREATE_NEW_PROCESS_GROUP
-    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid); 
-    
+    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+
     CloseHandle(hProc);
     return true;
 }
@@ -896,7 +896,7 @@ int LocalBroker::ExecuteCmd(void)
         int nargs = 0;
         char **szarg = new char*[C_MAXARGS + 1];
         parseArguments(szcmd, &nargs, szarg);
-        szarg[nargs]=0;                
+        szarg[nargs]=0;
         if(strEnv.size())
         {
             yarp::os::impl::SplitString ss(strEnv.c_str(), ';');

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -6,7 +6,7 @@
  *  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-#include <string.h>
+#include <cstring>
 #include <yarp/manager/manager.h>
 #include <yarp/manager/yarpbroker.h>
 #include <yarp/manager/localbroker.h>
@@ -286,7 +286,7 @@ bool Manager::prepare(bool silent)
         exe->setParam((*itr)->getParam());
         exe->setHost((*itr)->getHost());
         exe->setStdio((*itr)->getStdio());
-        exe->setWorkDir((*itr)->getWorkDir());        
+        exe->setWorkDir((*itr)->getWorkDir());
         exe->setPostExecWait((*itr)->getPostExecWait());
         exe->setPostStopWait((*itr)->getPostStopWait());
         string env;
@@ -661,7 +661,7 @@ bool Manager::run(void)
             (*itr)->enableAutoConnect();
         else
             (*itr)->disableAutoConnect();
-        (*itr)->start();       
+        (*itr)->start();
         yarp::os::Time::delay(0.2);
         wait = (wait > (*itr)->getPostExecWait()) ? wait : (*itr)->getPostExecWait();
     }

--- a/src/libYARP_manager/src/scriptbroker.cpp
+++ b/src/libYARP_manager/src/scriptbroker.cpp
@@ -76,7 +76,7 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
             const char* guess=guessString.c_str();
             if (fileExists (guess))
             {
-#ifdef WIN32
+#if defined(_WIN32)
                 strCmd = "\"" + std::string(guess) + "\"";
 #else
                 strCmd = guess;

--- a/src/libYARP_manager/src/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarpbroker.cpp
@@ -25,7 +25,7 @@
 #define KILL_TIMEOUT            10.0
 #define EVENT_THREAD_PERIOD     500
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #define SIGKILL 9
 #endif
 

--- a/src/libYARP_math/include/yarp/math/Vec2D.h
+++ b/src/libYARP_math/include/yarp/math/Vec2D.h
@@ -16,7 +16,7 @@
 namespace yarp
 {
     namespace math
-    { 
+    {
         template <typename T>
         class Vec2D;
     }

--- a/src/libYARP_math/src/Quaternion.cpp
+++ b/src/libYARP_math/src/Quaternion.cpp
@@ -6,7 +6,7 @@
 
 #include <yarp/math/Quaternion.h>
 #include <yarp/math/Math.h>
-#include <math.h>
+#include <cmath>
 #include <cstdio>
 
 using namespace yarp::math;

--- a/src/libYARP_math/src/Rand.cpp
+++ b/src/libYARP_math/src/Rand.cpp
@@ -7,9 +7,9 @@
 
 #include <yarp/os/Semaphore.h>
 #include <yarp/math/Rand.h>
-#include <time.h>
-#include <stdio.h>
-#include <math.h>
+#include <ctime>
+#include <cstdio>
+#include <cmath>
 
 using namespace yarp::os;
 using namespace yarp::sig;
@@ -18,8 +18,8 @@ using namespace yarp::math::impl;
 
 /*
 * This class was used in the past to wrap random generation
-* routines that were not thread safe. Nowdays it could be no 
-* longer required because gsl routines are already declared to be 
+* routines that were not thread safe. Nowdays it could be no
+* longer required because gsl routines are already declared to be
 * thread safe.
 */
 class ThreadSafeRandScalar : public RandScalar
@@ -31,7 +31,7 @@ public:
 
     }
 
-    void init()        
+    void init()
     {
         mutex.wait();
         RandScalar::init();

--- a/src/libYARP_math/src/RandScalar.cpp
+++ b/src/libYARP_math/src/RandScalar.cpp
@@ -9,9 +9,9 @@
 
 #include <yarp/math/RandScalar.h>
 #include <yarp/sig/Vector.h>
-#include <time.h>
-#include <stdio.h>
-#include <math.h>
+#include <ctime>
+#include <cstdio>
+#include <cmath>
 
 // implementation of Marsenne Twister
 #include <yarp/math/impl/mt.h>

--- a/src/libYARP_math/src/RandnScalar.cpp
+++ b/src/libYARP_math/src/RandnScalar.cpp
@@ -8,9 +8,9 @@
 #include <yarp/math/RandnScalar.h>
 #include <yarp/math/RandScalar.h>
 #include <yarp/sig/Vector.h>
-#include <time.h>
-#include <stdio.h>
-#include <math.h>
+#include <ctime>
+#include <cstdio>
+#include <cmath>
 
 using namespace yarp::sig;
 using namespace yarp::math;

--- a/src/libYARP_math/src/Vec2D.cpp
+++ b/src/libYARP_math/src/Vec2D.cpp
@@ -26,7 +26,7 @@ YARP_END_PACK
 
 namespace yarp
 {
-    namespace math 
+    namespace math
     {
         template<>
         bool Vec2D<double>::read(yarp::os::ConnectionReader& connection)
@@ -198,11 +198,11 @@ yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator =(const yarp::math::Vec2D<T
     return *this;
 }
 
-template  yarp::math::Vec2D<double> YARP_math_API operator + (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
-template  yarp::math::Vec2D<int>    YARP_math_API operator + (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
-template  yarp::math::Vec2D<double> YARP_math_API operator - (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
-template  yarp::math::Vec2D<int>    YARP_math_API operator - (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
-template  yarp::math::Vec2D<double> YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<double> rhs);
-template  yarp::math::Vec2D<int>    YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<int> rhs);
-template  class YARP_math_API yarp::math::Vec2D<double>;
-template  class YARP_math_API yarp::math::Vec2D<int>;
+template yarp::math::Vec2D<double> YARP_math_API operator + (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
+template yarp::math::Vec2D<int>    YARP_math_API operator + (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
+template yarp::math::Vec2D<double> YARP_math_API operator - (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
+template yarp::math::Vec2D<int>    YARP_math_API operator - (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
+template yarp::math::Vec2D<double> YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<double> rhs);
+template yarp::math::Vec2D<int>    YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<int> rhs);
+template class yarp::math::Vec2D<double>;
+template class yarp::math::Vec2D<int>;

--- a/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
+++ b/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
@@ -20,7 +20,7 @@
 
 #include <yarp/name/NameService.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace yarp {
     namespace name {

--- a/src/libYARP_rtf/src/TestCase.cpp
+++ b/src/libYARP_rtf/src/TestCase.cpp
@@ -75,7 +75,7 @@ bool yarp::rtf::TestCase::setup(int argc, char** argv)
         // if the config file cannot be found from default context or
         // there is not any context, use the robotname environment as context
         if(!useSuitContext && !useTestContext && !cfgfile.size() && envprop.check("robotname")) {
-            rf.setContext(envprop.find("robotname").asString().c_str());
+            rf.setDefaultContext(envprop.find("robotname").asString().c_str());
             cfgfile = rf.findFileByName(cfgname.c_str());
         }
         RTF_ASSERT_ERROR_IF(cfgfile.size(),

--- a/src/libYARP_serversql/include/yarp/serversql/impl/SqliteTripleSource.h
+++ b/src/libYARP_serversql/include/yarp/serversql/impl/SqliteTripleSource.h
@@ -8,8 +8,8 @@
 #ifndef YARP_SERVERSQL_IMPL_SQLITETRIPLESOURCE_H
 #define YARP_SERVERSQL_IMPL_SQLITETRIPLESOURCE_H
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <sqlite3.h>
 
@@ -197,7 +197,7 @@ public:
                 fprintf(stderr,"(Query was): %s\n", query);
                 fprintf(stderr,"(Location): %s:%d\n", __FILE__, __LINE__);
                 if (verbose) {
-                    exit(1);
+                    std::exit(1);
                 }
                 sqlite3_free(msg);
             }

--- a/src/libYARP_serversql/src/AllocatorOnTriples.cpp
+++ b/src/libYARP_serversql/src/AllocatorOnTriples.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/serversql/impl/AllocatorOnTriples.h>
 
@@ -124,7 +124,7 @@ Contact AllocatorOnTriples::completePortNumber(const Contact& c) {
                 fprintf(stderr,"Ran out of port numbers\n");
                 fprintf(stderr,"* Make sure ports/programs get closed properly.\n");
                 fprintf(stderr,"* If programs terminate without closing ports, run \"yarp clean\" from time to time..\n");
-                exit(1);
+                std::exit(1);
             }
         } else {
             regid++;
@@ -196,7 +196,7 @@ Contact AllocatorOnTriples::completeHost(const yarp::os::Contact& c) {
         int v2 = mcastCursor/255;
         if (v2>=255) {
             fprintf(stderr,"Ran out of mcast addresses\n");
-            exit(1);
+            std::exit(1);
         }
         sprintf(buf,"224.1.%d.%d", v2+1,v1+1);
         name = buf;

--- a/src/libYARP_serversql/src/NameServiceOnTriples.cpp
+++ b/src/libYARP_serversql/src/NameServiceOnTriples.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/os/Vocab.h>
 #include <yarp/os/NestedContact.h>

--- a/src/libYARP_serversql/src/StyleNameService.cpp
+++ b/src/libYARP_serversql/src/StyleNameService.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/serversql/impl/StyleNameService.h>
 

--- a/src/libYARP_serversql/src/SubscriberOnSql.cpp
+++ b/src/libYARP_serversql/src/SubscriberOnSql.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <sqlite3.h>
 
@@ -14,7 +14,7 @@
 #include <yarp/serversql/impl/SubscriberOnSql.h>
 #include <yarp/serversql/impl/ParseName.h>
 
-#ifndef WIN32
+#if !defined(_WIN32)
 #include <unistd.h>
 #else
 #include <io.h>
@@ -69,7 +69,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     if (result!=SQLITE_OK) {
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up subscriptions table\n");
-        exit(1);
+        std::exit(1);
     }
 
     const char *check_subscriptions_size = "PRAGMA table_info(subscriptions)";
@@ -78,7 +78,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     result = sqlite3_prepare_v2(db, check_subscriptions_size, -1, &statement, YARP_NULLPTR);
     if (result!=SQLITE_OK) {
         fprintf(stderr,"Failed to set up subscriptions table\n");
-        exit(1);
+        std::exit(1);
     }
 
     int count = 0;
@@ -93,7 +93,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
         if (result!=SQLITE_OK) {
             sqlite3_close(db);
             fprintf(stderr,"Failed to set up subscriptions table\n");
-            exit(1);
+            std::exit(1);
         }
     }
 
@@ -106,7 +106,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     if (result!=SQLITE_OK) {
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up topics table\n");
-        exit(1);
+        std::exit(1);
     }
 
     const char *check_topic_size = "PRAGMA table_info(topics)";
@@ -115,7 +115,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     result = sqlite3_prepare_v2(db, check_topic_size, -1, &statement, YARP_NULLPTR);
     if (result!=SQLITE_OK) {
         fprintf(stderr,"Failed to set up topics table\n");
-        exit(1);
+        std::exit(1);
     }
 
     count = 0;
@@ -131,7 +131,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
         if (result!=SQLITE_OK) {
             sqlite3_close(db);
             fprintf(stderr,"Failed to set up topics table\n");
-            exit(1);
+            std::exit(1);
         }
     }
 
@@ -144,7 +144,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     if (result!=SQLITE_OK) {
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up live table\n");
-        exit(1);
+        std::exit(1);
     }
 
     const char *create_struct_table = "CREATE TABLE IF NOT EXISTS structures (\n\
@@ -155,7 +155,7 @@ bool SubscriberOnSql::open(const ConstString& filename, bool fresh) {
     if (result!=SQLITE_OK) {
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up structures table\n");
-        exit(1);
+        std::exit(1);
     }
 
     implementation = db;

--- a/src/libYARP_serversql/src/TripleSourceCreator.cpp
+++ b/src/libYARP_serversql/src/TripleSourceCreator.cpp
@@ -10,7 +10,7 @@
 #include <yarp/conf/compiler.h>
 #include <yarp/serversql/impl/SqliteTripleSource.h>
 
-#ifndef WIN32
+#if !defined(_WIN32)
 #include <unistd.h>
 #else
 #include <io.h>
@@ -36,7 +36,7 @@ static bool sql_enact(sqlite3 *db, const char *cmd) {
         }
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up database tables\n");
-        exit(1);
+        std::exit(1);
     }
     return true;
 }
@@ -83,7 +83,7 @@ TripleSource *TripleSourceCreator::open(const char *filename,
         }
         sqlite3_close(db);
         fprintf(stderr,"Failed to set up database tables\n");
-        exit(1);
+        std::exit(1);
     }
 
     string cmd_synch = string("PRAGMA synchronous=") + (cautious?"FULL":"OFF") + ";";

--- a/src/libYARP_serversql/src/yarpserver.cpp
+++ b/src/libYARP_serversql/src/yarpserver.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/conf/system.h>
 #include <yarp/os/all.h>

--- a/src/libYARP_sig/include/yarp/sig/ImageDraw.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageDraw.h
@@ -7,7 +7,7 @@
 #ifndef YARP_SIG_IMAGEDRAW_H
 #define YARP_SIG_IMAGEDRAW_H
 
-#include <math.h>
+#include <cmath>
 
 #include <yarp/sig/Image.h>
 

--- a/src/libYARP_sig/include/yarp/sig/IplImage.h
+++ b/src/libYARP_sig/include/yarp/sig/IplImage.h
@@ -73,8 +73,8 @@
 
 //#include <yarp/YARPConfig.h>
 
-#include <assert.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdlib>
 
 #if defined _MSC_VER || defined __BORLANDC__
 typedef __int64 int64;
@@ -229,9 +229,9 @@ int _iplCalcPadding (int lineSize, int align);
 #define IPLAPIIMPL(type,name,arg) extern type name arg
 
 
-IPLAPIIMPL(IplConvKernel*, 
+IPLAPIIMPL(IplConvKernel*,
            iplCreateConvKernel,(int nCols, int nRows,
-                                int anchorX, int anchorY, 
+                                int anchorX, int anchorY,
                                 int* values, int nShiftR));
 
 IPLAPIIMPL(IplConvKernelFP*,

--- a/src/libYARP_sig/include/yarp/sig/Matrix.h
+++ b/src/libYARP_sig/include/yarp/sig/Matrix.h
@@ -8,7 +8,7 @@
 #ifndef YARP_SIG_MATRIX_H
 #define YARP_SIG_MATRIX_H
 
-#include <stdlib.h> //defines size_t
+#include <cstdlib> //defines size_t
 #include <memory.h> //memset
 #include <yarp/os/Portable.h>
 #include <yarp/sig/Vector.h>

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -8,8 +8,8 @@
 #ifndef YARP_SIG_VECTOR_H
 #define YARP_SIG_VECTOR_H
 
-//#include <stdlib.h> //defines size_t
-#include <stddef.h> //defines size_t
+//#include <cstdlib> //defines size_t
+#include <cstddef> //defines size_t
 #include <yarp/os/Portable.h>
 #include <yarp/os/ConstString.h>
 #include <yarp/os/ManagedBytes.h>

--- a/src/libYARP_sig/src/Image.cpp
+++ b/src/libYARP_sig/src/Image.cpp
@@ -530,7 +530,7 @@ void ImageStorage::_set_ipl_header(int x, int y, int pixel_type, int quantum,
         case VOCAB_PIXEL_INVALID:
             // not a type!
             printf ("*** Trying to allocate an invalid pixel type image\n");
-            exit(1);
+            std::exit(1);
             break;
 
         case -2:
@@ -771,7 +771,7 @@ void Image::wrapIplImage(void *iplImage) {
                    str.c_str());
             printf("Try RGB, BGR, or \n");
             printf("Or fix code at %s line %d\n",__FILE__,__LINE__);
-            exit(1);
+            std::exit(1);
         }
     }
 
@@ -799,7 +799,7 @@ void Image::wrapIplImage(void *iplImage) {
         case VOCAB_PIXEL_RGB:
         case VOCAB_PIXEL_BGR:
             fprintf(stderr,"No translation currently available for this pixel type\n");
-            exit(1);
+            std::exit(1);
             break;
         }
     } else if (p->depth == IPL_DEPTH_32S) {

--- a/src/libYARP_sig/src/ImageCopy.cpp
+++ b/src/libYARP_sig/src/ImageCopy.cpp
@@ -722,7 +722,7 @@ void Image::copyPixels(const unsigned char *src, int id1,
 
         default:
             printf("*** Tried to copy type %d to %d\n", id1, id2);
-            exit(1);
+            std::exit(1);
             break;
         }
 

--- a/src/libYARP_sig/src/IplImage.cpp
+++ b/src/libYARP_sig/src/IplImage.cpp
@@ -5,8 +5,8 @@
  */
 
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include <yarp/os/Log.h>
 #include <yarp/sig/IplImage.h>

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -15,7 +15,7 @@
 #include <yarp/os/NetInt32.h>
 
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/Logger.h>
 
 using namespace yarp::sig;
@@ -166,7 +166,7 @@ ConstString Matrix::toString(int precision, int width, const char* endRowStr) co
     if(width>0) // if width is specified use a space as separator
     {
         for(r=0;r<nrows;r++)
-        {        
+        {
             for(c=0;c<ncols;c++)
             {
                 sprintf(tmp, "% *.*lf ", width, precision, (*this)[r][c]);
@@ -212,7 +212,7 @@ void Matrix::updatePointers()
 const Matrix &Matrix::operator=(const Matrix &r)
 {
     if (this == &r) return *this;
-    
+
     if(nrows!=r.nrows || ncols!=r.ncols)
     {
         if (storage)
@@ -315,7 +315,7 @@ void Matrix::zero()
     memset(storage, 0, sizeof(double)*ncols*nrows);
 }
 
-Matrix Matrix::removeCols(int first_col, int how_many) 
+Matrix Matrix::removeCols(int first_col, int how_many)
 {
     Matrix ret;
     ret.resize(nrows, ncols-how_many);
@@ -332,9 +332,9 @@ Matrix Matrix::removeCols(int first_col, int how_many)
             c_out++;
         }
 
-    if (storage) 
-      delete [] storage; 
-    
+    if (storage)
+      delete [] storage;
+
     nrows=ret.nrows;
     ncols=ret.ncols;
     storage=new double[ncols*nrows];
@@ -343,7 +343,7 @@ Matrix Matrix::removeCols(int first_col, int how_many)
     return ret;
 }
 
-Matrix Matrix::removeRows(int first_row, int how_many) 
+Matrix Matrix::removeRows(int first_row, int how_many)
 {
     Matrix ret;
     ret.resize(nrows-how_many, ncols);
@@ -360,9 +360,9 @@ Matrix Matrix::removeRows(int first_row, int how_many)
             r_out++;
         }
 
-    if (storage) 
-        delete [] storage; 
-    
+    if (storage)
+        delete [] storage;
+
     nrows=ret.nrows;
     ncols=ret.ncols;
     storage=new double[ncols*nrows];
@@ -492,7 +492,7 @@ bool Matrix::setRow(int row, const Vector &r)
 bool Matrix::setCol(int col, const Vector &c)
 {
     if((col<0) || (col>=ncols) || (c.length() != (size_t)nrows))
-        return false; 
+        return false;
 
     for(int r=0;r<nrows;r++)
         (*this)[r][col]=c[r];
@@ -551,7 +551,7 @@ Matrix::Matrix(const Matrix &m): yarp::os::Portable(),
     nrows=m.nrows;
     ncols=m.ncols;
 
-    if (m.storage!=0) 
+    if (m.storage!=0)
     {
         storage=new double [nrows*ncols];
         memcpy(storage, m.storage, nrows*ncols*sizeof(double));

--- a/src/libYARP_sig/src/SoundFile.cpp
+++ b/src/libYARP_sig/src/SoundFile.cpp
@@ -15,8 +15,8 @@
 
 #include <yarp/sig/Sound.h>
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/libYARP_sig/src/Vector.cpp
+++ b/src/libYARP_sig/src/Vector.cpp
@@ -13,8 +13,8 @@
 #include <yarp/os/NetFloat64.h>
 
 #include <yarp/os/impl/PlatformVector.h>
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <yarp/os/impl/Logger.h>
 
 #include <yarp/sig/Matrix.h>

--- a/src/libYARP_wire_rep_utils/WireBottle.cpp
+++ b/src/libYARP_wire_rep_utils/WireBottle.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "WireBottle.h"
 
 #include <yarp/os/NetInt32.h>

--- a/src/libYARP_wire_rep_utils/WireImage.h
+++ b/src/libYARP_wire_rep_utils/WireImage.h
@@ -14,8 +14,8 @@
 #include <yarp/os/ConnectionWriter.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/sig/Image.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include <wire_rep_utils_api.h>
 
@@ -62,17 +62,17 @@ public:
     RosWireImage() {
     }
 
-    void init(const yarp::sig::FlexImage& img, 
+    void init(const yarp::sig::FlexImage& img,
               const yarp::os::ConstString& frame) {
         image = &img;
-        yarp::os::ConnectionWriter *pbuf = 
+        yarp::os::ConnectionWriter *pbuf =
             yarp::os::ConnectionWriter::createBufferedConnectionWriter();
         if (!pbuf) ::exit(1);
         yarp::os::ConnectionWriter& buf = *pbuf;
         yarp::os::StringOutputStream ss;
         // probably need to translate encoding format better, but at
         // a guess "rgb" and "bgr" will work ok.
-        yarp::os::ConstString encoding = 
+        yarp::os::ConstString encoding =
             yarp::os::Vocab::decode(image->getPixelCode()).c_str();
         switch (image->getPixelCode()) {
         case VOCAB_PIXEL_BGR:
@@ -155,7 +155,7 @@ public:
     }
 
     virtual yarp::os::PortReader *getReplyHandler() { return NULL; }
-    
+
     virtual yarp::os::Portable *getReference() { return NULL; }
 
     virtual bool dropRequested() { return false; }

--- a/src/libYARP_wire_rep_utils/WireTwiddler.cpp
+++ b/src/libYARP_wire_rep_utils/WireTwiddler.cpp
@@ -9,9 +9,9 @@
 
 #include <vector>
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 #include <yarp/os/StringInputStream.h>
 #include <yarp/os/StringOutputStream.h>
@@ -152,7 +152,7 @@ int WireTwiddler::configure(Bottle& desc, int offset, bool& ignored,
         //pass
     } else {
         fprintf(stderr,"%s does not know about %s\n", __FILE__, kind.c_str());
-        yarp::os::exit(1);
+        std::exit(1);
     }
 
     dbg_printf("Type %s (%s) len %d unit %d %s\n",
@@ -419,7 +419,7 @@ void WireTwiddlerReader::compute(const WireTwiddlerGap& gap) {
         bool bigendian = prop.find("is_bigendian").asInt()==1;
         if (bigendian) {
             fprintf(stderr,"Sorry, cannot handle bigendian images yet.\n");
-            yarp::os::exit(1);
+            std::exit(1);
         }
         ConstString encoding = prop.find("encoding").asString();
         int bpp = 1;
@@ -467,7 +467,7 @@ void WireTwiddlerReader::compute(const WireTwiddlerGap& gap) {
         default:
             fprintf(stderr, "Sorry, cannot handle [%s] images yet.\n",
                 encoding.c_str());
-            yarp::os::exit(1);
+            std::exit(1);
             break;
         }
         int quantum = 1;

--- a/src/libyarpc/test1.cpp
+++ b/src/libyarpc/test1.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 

--- a/src/libyarpc/test2.cpp
+++ b/src/libyarpc/test2.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
     yarpPortable writer, reader;
     yarpPortableInit(&writer,&wcallbacks);
     yarpPortableInit(&reader,&rcallbacks);
-    
+
     printf("Writing (in background)...\n");
 
     result = yarpPortWrite(port1,&writer);

--- a/src/libyarpc/yarp.h
+++ b/src/libyarpc/yarp.h
@@ -10,7 +10,7 @@
 #ifndef YET_ANOTHER_ROBOT_PLATFORM_CVERSION_INC
 #define YET_ANOTHER_ROBOT_PLATFORM_CVERSION_INC
 
-#ifndef WIN32
+#if !defined(_WIN32)
 #define YARP_DECLARE(return_type) return_type
 #else
 #ifdef yarpc_EXPORTS

--- a/src/libyarpc/yarpcontact.cpp
+++ b/src/libyarpc/yarpcontact.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"

--- a/src/libyarpc/yarpnetwork.cpp
+++ b/src/libyarpc/yarpnetwork.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"
@@ -13,7 +13,7 @@
 static yarpNetworkPtr __yarp_network;
 
     /**
-     * Create a network.  There should typically be one of 
+     * Create a network.  There should typically be one of
      * these in a program using YARP.  You need one of these in order
      * to create ports.
      */
@@ -65,7 +65,7 @@ YARP_DEFINE(int) yarpNetworkSetLocalMode(yarpNetworkPtr network,
      * If the carrier is NULL, the connection will be of type tcp.
      *
      */
-YARP_DEFINE(int) yarpNetworkConnect(yarpNetworkPtr network, 
+YARP_DEFINE(int) yarpNetworkConnect(yarpNetworkPtr network,
                                     const char *src,
                                     const char *dest,
                                     const char *carrier) {
@@ -79,7 +79,7 @@ YARP_DEFINE(int) yarpNetworkConnect(yarpNetworkPtr network,
      * Disconnect two ports from each other.
      *
      */
-YARP_DEFINE(int) yarpNetworkDisconnect(yarpNetworkPtr network, 
+YARP_DEFINE(int) yarpNetworkDisconnect(yarpNetworkPtr network,
                                     const char *src,
                                     const char *dest) {
     YARP_NETWORK(network).disconnect(src,dest);

--- a/src/libyarpc/yarpport.cpp
+++ b/src/libyarpc/yarpport.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"
@@ -117,7 +117,7 @@ YARP_DEFINE(int) yarpPortEnableBackgroundWrite(yarpPortPtr port,
      * will be called.
      *
      */
-YARP_DEFINE(int) yarpPortWrite(yarpPortPtr port, 
+YARP_DEFINE(int) yarpPortWrite(yarpPortPtr port,
                                yarpPortablePtr msg) {
     YARP_OK(port);
     Portable *amsg = MAKE_PORTABLE(msg);
@@ -135,7 +135,7 @@ YARP_DEFINE(int) yarpPortWrite(yarpPortPtr port,
      * before any other port methods.
      *
      */
-YARP_DEFINE(int) yarpPortRead(yarpPortPtr port, 
+YARP_DEFINE(int) yarpPortRead(yarpPortPtr port,
                               yarpPortablePtr msg,
                               int willReply) {
     YARP_OK(port);
@@ -150,7 +150,7 @@ YARP_DEFINE(int) yarpPortRead(yarpPortPtr port,
      * Give a reply to a previously read message.
      *
      */
-YARP_DEFINE(int) yarpPortReply(yarpPortPtr port, 
+YARP_DEFINE(int) yarpPortReply(yarpPortPtr port,
                                yarpPortablePtr msg) {
     YARP_OK(port);
     Portable *amsg = MAKE_PORTABLE(msg);
@@ -164,7 +164,7 @@ YARP_DEFINE(int) yarpPortReply(yarpPortPtr port,
      * Write a message to a port, then wait for a reply.
      *
      */
-YARP_DEFINE(int) yarpPortWriteWithReply(yarpPortPtr port, 
+YARP_DEFINE(int) yarpPortWriteWithReply(yarpPortPtr port,
                                         yarpPortablePtr msg,
                                         yarpPortablePtr reply) {
     YARP_OK(port);

--- a/src/libyarpc/yarpportable.cpp
+++ b/src/libyarpc/yarpportable.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "yarp.h"
 #include "yarpimpl.h"
@@ -34,7 +34,7 @@ static int __default_onCompletion(void *client) {
 
 static int __installed_callbacks = 0;
 
-YARP_DEFINE(int) yarpPortableCallbacksInstall(yarpPortableCallbacksPtr 
+YARP_DEFINE(int) yarpPortableCallbacksInstall(yarpPortableCallbacksPtr
                                               callbacks) {
     if (!__installed_callbacks) {
         yarpPortableCallbacksComplete(callbacks);
@@ -44,7 +44,7 @@ YARP_DEFINE(int) yarpPortableCallbacksInstall(yarpPortableCallbacksPtr
     return 0;
 }
 
-YARP_DEFINE(int) yarpPortableCallbacksComplete(yarpPortableCallbacksPtr 
+YARP_DEFINE(int) yarpPortableCallbacksComplete(yarpPortableCallbacksPtr
                                                callbacks) {
     if (!callbacks->write) callbacks->write = __default_write;
     if (!callbacks->read) callbacks->read = __default_read;

--- a/src/libyarpc/yarpreader.cpp
+++ b/src/libyarpc/yarpreader.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"
@@ -44,7 +44,7 @@ YARP_DEFINE(int) yarpReaderExpectDouble(yarpReaderPtr reader, double *data) {
      * Read text from a connection.
      *
      */
-YARP_DEFINE(int) yarpReaderExpectText(yarpReaderPtr reader, 
+YARP_DEFINE(int) yarpReaderExpectText(yarpReaderPtr reader,
                                       yarpStringPtr str,
                                       char terminal) {
     YARP_OK(reader);
@@ -57,7 +57,7 @@ YARP_DEFINE(int) yarpReaderExpectText(yarpReaderPtr reader,
      * Read a block of data from a connection.
      *
      */
-YARP_DEFINE(int) yarpReaderExpectBlock(yarpReaderPtr reader, 
+YARP_DEFINE(int) yarpReaderExpectBlock(yarpReaderPtr reader,
                                        const char *data,
                                        int len) {
     YARP_OK(reader);

--- a/src/libyarpc/yarpthread.cpp
+++ b/src/libyarpc/yarpthread.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"
@@ -34,7 +34,7 @@ public:
     YarpcxxThread(yarpThreadCallbacksPtr callbacks,
                   void *client) : callbacks(callbacks), client(client) {
     }
-    
+
     virtual void run() {
         if (callbacks->run) callbacks->run(client);
     }
@@ -50,7 +50,7 @@ public:
             callbacks->afterStart(success,client);
         }
     }
-    
+
     virtual void onStop() {
         if (callbacks->onStop) callbacks->onStop(client);
     }
@@ -59,11 +59,11 @@ public:
         if (callbacks->threadInit) return !callbacks->threadInit(client);
         return true;
     }
-    
+
     virtual void threadRelease() {
         if (callbacks->threadRelease) callbacks->threadRelease(client);
     }
-    
+
 private:
     yarpThreadCallbacksPtr callbacks;
     void *client;

--- a/src/libyarpc/yarptime.cpp
+++ b/src/libyarpc/yarptime.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"

--- a/src/libyarpc/yarpwriter.cpp
+++ b/src/libyarpc/yarpwriter.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarp.h"
 #include "yarpimpl.h"

--- a/src/libyarpcxx/include/yarp/yarpcxx.h
+++ b/src/libyarpcxx/include/yarp/yarpcxx.h
@@ -9,9 +9,9 @@
 #define YARPCXX_yarpcxx_INC
 
 #include <yarp.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
-#define YARPCXX_VALID(x) if ((x)==NULL) { fprintf(stderr, "Memory allocation failure, %s:%d\n", __FILE__, __LINE__);  exit(1); }
+#define YARPCXX_VALID(x) if ((x)==NULL) { fprintf(stderr, "Memory allocation failure, %s:%d\n", __FILE__, __LINE__);  std::exit(1); }
 
 #endif

--- a/src/libyarpcxx/yarpcxx_test1.cpp
+++ b/src/libyarpcxx/yarpcxx_test1.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/all.h>
 using namespace yarp::os;

--- a/src/libyarpcxx/yarpcxx_test2.cpp
+++ b/src/libyarpcxx/yarpcxx_test2.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <yarp/os/all.h>
 
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
 
     Network yarp;
     yarp.setLocalMode(1);
-    
+
     Port p1, p2;
     bool ok = p1.open("/test1") && p2.open("/test2");
     if (!ok) {
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
 
     MyPortable i1, i2;
     i1.val = 15;
-    
+
     printf("Writing (in background)...\n");
     p1.write(i1);
 
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
 
     p1.close();
     p2.close();
-    
+
     return 0;
 }
 

--- a/src/yarp/yarpconfig.cpp
+++ b/src/yarp/yarpconfig.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/impl/NameConfig.h>
 #include "yarpcontext.h"
 #include "yarprobot.h"
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
 
 void show_help() {
@@ -32,8 +32,8 @@ int main(int argc, char *argv[]) {
 
     yarp::os::Property options;
     options.fromCommand(argc,argv);
-    if (options.check("help")) { 
-        show_help(); 
+    if (options.check("help")) {
+        show_help();
         return 0;
     }
     if (argc>=2) {

--- a/src/yarp/yarpcontext.cpp
+++ b/src/yarp/yarpcontext.cpp
@@ -10,7 +10,7 @@
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/ResourceFinderOptions.h>
 #include <yarp/os/Bottle.h>
-#include <stdio.h>
+#include <cstdio>
 
 
 #include "yarpcontextutils.h"

--- a/src/yarp/yarpcontextutils.h
+++ b/src/yarp/yarpcontextutils.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #define PATH_SEPARATOR      "\\"
 #else
     #define PATH_SEPARATOR      "/"

--- a/src/yarp/yarprobot.cpp
+++ b/src/yarp/yarprobot.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/ResourceFinderOptions.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Os.h>
-#include <stdio.h>
+#include <cstdio>
 
 #include "yarpcontextutils.h"
 #include "yarprobot.h"

--- a/src/yarpbatterygui/main.cpp
+++ b/src/yarpbatterygui/main.cpp
@@ -24,8 +24,8 @@
 #include <iostream>
 #include <iomanip>
 #include <string>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 
 #include "display.h"
 #include "ui_display.h"

--- a/src/yarpdataplayer/include/msvc/dirent.h
+++ b/src/yarpdataplayer/include/msvc/dirent.h
@@ -78,11 +78,11 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <errno.h>
+#include <cerrno>
 
 /* Entries missing from MSVC 6.0 */
 #if !defined(FILE_ATTRIBUTE_DEVICE)

--- a/src/yarpdataplayer/src/main.cpp
+++ b/src/yarpdataplayer/src/main.cpp
@@ -1,7 +1,7 @@
 #include "include/mainwindow.h"
 #include <QApplication>
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #pragma warning (disable : 4099)
     #pragma warning (disable : 4250)
     #pragma warning (disable : 4520)
@@ -11,12 +11,12 @@
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Network.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include <windows.h>
 #else
-    #include <errno.h>
+    #include <cerrno>
     #include <sys/types.h>
-    #include <signal.h>
+    #include <csignal>
 #endif
 
 using namespace std;

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -7,9 +7,9 @@
 #include <include/aboutdlg.h>
 #include <QMessageBox>
 #include "include/log.h"
-#include <signal.h>
+#include <csignal>
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #pragma warning (disable : 4099)
     #pragma warning (disable : 4250)
     #pragma warning (disable : 4520)
@@ -82,12 +82,12 @@ MainWindow::MainWindow(yarp::os::ResourceFinder &rf, QWidget *parent) :
 
     QString port = QString("/%1/rpc:i").arg(moduleName);
     rpcPort.open( port.toLatin1().data() );
-    
+
     ::signal(SIGINT, sighandler);
     ::signal(SIGTERM, sighandler);
-    
+
     attach(rpcPort);
-    
+
     quitFromCmd = false;
 
     connect(ui->mainWidget,SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)),this,SLOT(onItemDoubleClicked(QTreeWidgetItem*,int)));
@@ -99,13 +99,13 @@ MainWindow::MainWindow(yarp::os::ResourceFinder &rf, QWidget *parent) :
     connect(this,SIGNAL(internalSetFrame(std::string,int)),this,SLOT(onInternalSetFrame(std::string,int)),Qt::BlockingQueuedConnection);
     connect(this,SIGNAL(internalGetFrame(std::string, int*)),this,SLOT(onInternalGetFrame(std::string,int*)),Qt::BlockingQueuedConnection);
     connect(this,SIGNAL(internalQuit()),this,SLOT(onInternalQuit()),Qt::QueuedConnection);
-    
+
     QShortcut *openShortcut = new QShortcut(QKeySequence("Ctrl+O"), parent);
     QObject::connect(openShortcut, SIGNAL(activated()), this, SLOT(onInternalLoad(QString)));
-    
+
     QShortcut *closeShortcut = new QShortcut(QKeySequence("Ctrl+Q"), parent);
     QObject::connect(closeShortcut, SIGNAL(activated()), this, SLOT(onInternalQuit()));
-    
+
 }
 
 /**********************************************************/
@@ -330,12 +330,12 @@ bool MainWindow::cmdSafeExit(void)
         if (utilities->masterThread->isSuspended()){
             utilities->masterThread->resume();
         }
-        
+
         utilities->masterThread->stop();
         LOG( "done stopping!\n");
         for (int i=0; i < subDirCnt; i++)
             utilities->partDetails[i].currFrame = 1;
-        
+
         LOG( "Module closing...\nCleaning up...\n");
         for (int x=0; x < subDirCnt; x++){
             utilities->partDetails[x].worker->release();
@@ -362,12 +362,12 @@ bool MainWindow::safeExit(void)
         if (utilities->masterThread->isSuspended()){
             utilities->masterThread->resume();
         }
-        
+
         utilities->masterThread->stop();
         LOG( "done stopping!\n");
         for (int i=0; i < subDirCnt; i++)
             utilities->partDetails[i].currFrame = 1;
-        
+
         LOG( "Module closing...\nCleaning up...\n");
         for (int x=0; x < subDirCnt; x++){
             utilities->partDetails[x].worker->release();
@@ -428,7 +428,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
         QMessageBox::StandardButton resBtn = QMessageBox::question( this, APP_NAME,
                                                                "Quitting, Are you sure?\n",
                                                                QMessageBox::No | QMessageBox::Yes, QMessageBox::Yes);
-        
+
         if (resBtn != QMessageBox::Yes) {
             event->ignore();
 
@@ -586,7 +586,7 @@ void MainWindow::addPart(const char* szName, const char* type, int frames, const
         item->setText(PORT,QString("%1").arg(portName));
         ui->mainWidget->resizeColumnToContents(PORT);
     }
-    
+
     QProgressBar *progress = new QProgressBar();
     progress->setMaximum(100);
     progress->setValue(0);
@@ -650,7 +650,7 @@ void MainWindow::onMenuFileOpen()
         utilities->repeat = false;
         ui->actionRepeat->setChecked(false);
     }
-    
+
     if (ui->actionStrict->isChecked())
     {
         LOG("send strict mode is activated, setting it to false\n");
@@ -667,7 +667,7 @@ void MainWindow::onMenuFileOpen()
         ui->mainWidget->clear();
         for (int x=0; x < subDirCnt; x++)
             utilities->closePorts(utilities->partDetails[x]);
-        
+
         doGuiSetup(dir);
     }
 }
@@ -946,7 +946,7 @@ bool MainWindow::setTimeTaken(const char* szName, double time)
         row->setText(TIMETAKEN,QString("%1 s").arg(time, 0, 'f', 3));
         return true;
     }
-    
+
     return false;
 }
 
@@ -973,7 +973,7 @@ void MainWindow::onUpdateGuiRateThread()
                 if (utilities->partDetails[i].currFrame <= utilities->partDetails[i].maxFrame){
                     int rate = (int)utilities->partDetails[i].worker->getFrameRate();
                     setFrameRate(utilities->partDetails[i].name.c_str(),rate);
-                    
+
                     double time = utilities->partDetails[i].worker->getTimeTaken();
 
                     if (time > 700000){ //value of a time stamp...
@@ -1056,7 +1056,7 @@ void InitThread::run()
     if (subDirCnt > 0){
         utilities->getMaxTimeStamp();
     }
-    
+
     if (subDirCnt > 0){
         utilities->getMinTimeStamp();
     }
@@ -1064,18 +1064,18 @@ void InitThread::run()
     //set initial frames for all parts depending on first timestamps
     for (int x=0; x < subDirCnt; x++){
         utilities->initialFrame.push_back( utilities->partDetails[x].currFrame);
-        
+
         double totalTime = 0.0;
         double final = utilities->partDetails[x].timestamp[utilities->partDetails[x].timestamp.length()-1];
         double initial = utilities->partDetails[x].timestamp[utilities->partDetails[x].currFrame];
-        
+
         //LOG("initial timestamp is = %lf\n", initial);
         //LOG("final timestamp is  = %lf\n", final);
-        
+
         totalTime = final - initial;
-        
+
         LOG("The part %s, should last for: %lf with %d frames\n", utilities->partDetails[x].name.c_str(), totalTime, utilities->partDetails[x].maxFrame);
-        
+
     }
 
     utilities->masterThread = new MasterThread(utilities, subDirCnt, mainWindow);

--- a/src/yarpdataplayer/src/utils.cpp
+++ b/src/yarpdataplayer/src/utils.cpp
@@ -15,13 +15,13 @@
  * Public License for more details
 */
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #pragma warning (disable : 4099)
     #pragma warning (disable : 4250)
     #pragma warning (disable : 4520)
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include "include/msvc/dirent.h"
     #undef max                  /*conflict with pango lib coverage.h*/
     #include <direct.h>
@@ -35,7 +35,7 @@
 #endif
 
 #include <yarp/os/Time.h>
-#include <stdio.h>              /* defines FILENAME_MAX */
+#include <cstdio>              /* defines FILENAME_MAX */
 #include "include/utils.h"
 
 #include <iostream>
@@ -226,7 +226,7 @@ bool Utilities::checkLogValidity(const char *filename)
         int itr = 0;
         while( getline( str, line ) && itr < 3){
             Bottle b( line.c_str() );
-            if (itr >= 0){ 
+            if (itr >= 0){
                 if ( b.size() < 1){
                     check = false;
                 } else {
@@ -410,7 +410,7 @@ void Utilities::stopAtEnd()
     for (int i=0; i < totalThreads; i++){
         partDetails[i].currFrame = (int)initialFrame[i];
     }
-    
+
     //TODO SIGNAL
     //masterThread->wnd->resetButtonOnStop();
     pause();

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -15,7 +15,7 @@
  * Public License for more details
 */
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #pragma warning (disable : 4099)
     #pragma warning (disable : 4250)
     #pragma warning (disable : 4520)

--- a/src/yarpfs/link.cpp
+++ b/src/yarpfs/link.cpp
@@ -7,15 +7,15 @@
 
 #include <fuse/fuse.h>
 //#include <fuse/fuse_lowlevel.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
 
 #include <yarp/os/all.h>
 #include <yarp/os/impl/NameConfig.h>
 
 #include <string>
-#include <signal.h>
+#include <csignal>
 
 #include <ace/Containers_T.h>
 
@@ -26,7 +26,7 @@
 int yarp_readlink(const char *path, char *buf, size_t size) {
 
     YPath ypath(path);
-    if (!ypath.isSymLink()) { 
+    if (!ypath.isSymLink()) {
         return -ENOENT;
     }
 
@@ -65,7 +65,7 @@ int yarp_symlink(const char *to, const char *from) {
     // special symlink entry
     //Contact src = Network::queryName(to);
     Contact dest(from, "symlink", "none", 1);
-    printf("Planning to register %s / %d / %d\n", 
+    printf("Planning to register %s / %d / %d\n",
            dest.toString().c_str(),
            dest.isValid(),
            dest.getPort());
@@ -78,7 +78,7 @@ int yarp_symlink(const char *to, const char *from) {
 
 int yarp_link(const char *from, const char *to) {
     //TODO: will it ever be possible to hard link ports?
-    //  If possible, it might be an alias for yarp_simlink, as with YARP 
+    //  If possible, it might be an alias for yarp_simlink, as with YARP
     //  there isn't a sym/hard linking difference
 
     //Create the new Contact

--- a/src/yarpfs/yarpfs.cpp
+++ b/src/yarpfs/yarpfs.cpp
@@ -9,16 +9,16 @@
 
 #include <fuse/fuse.h>
 //#include <fuse/fuse_lowlevel.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
 //#include <fcntl.h>
 
 #include <yarp/os/all.h>
 #include <yarp/os/impl/NameConfig.h>
 
 #include <string>
-#include <signal.h>
+#include <csignal>
 
 #include <ace/Containers_T.h>
 
@@ -39,7 +39,7 @@ int yarp_getattr(const char *path, struct stat *stbuf)
     YPath ypath(path);
 
     memset(stbuf, 0, sizeof(struct stat));
-    printf("Checking attr // port %d, stem %d, act %d, sym %d\n", 
+    printf("Checking attr // port %d, stem %d, act %d, sym %d\n",
            ypath.isPort(),
            ypath.isStem(),
            ypath.isAct(),

--- a/src/yarpfs/yarputils.h
+++ b/src/yarpfs/yarputils.h
@@ -12,9 +12,9 @@
 
 #include <fuse/fuse.h>
 //#include <fuse/fuse_lowlevel.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
 //#include <fcntl.h>
 
 #include <yarp/os/all.h>
@@ -22,7 +22,7 @@
 #include <yarp/os/impl/NameConfig.h>
 
 #include <string>
-#include <signal.h>
+#include <csignal>
 
 #include <ace/Containers_T.h>
 
@@ -73,7 +73,7 @@ private:
             if (leafLike) {
                 if (reply.size()>1) {
                     _isAct = true;
-                } 
+                }
             } else {
                 if (reply.size()>1) {
                     _isStem = true;
@@ -237,7 +237,7 @@ public:
 
         const char *yarp_str = str.c_str();
         printf(">>> Got %s\n", str.c_str());
-        
+
         offset = 0;
         size_t len = strlen(yarp_str);
         if (offset < len) {
@@ -246,7 +246,7 @@ public:
             memcpy(buf, yarp_str + offset, size);
         } else
             size = 0;
-        
+
         return size;
     }
 };

--- a/src/yarphear/yarphear.cpp
+++ b/src/yarphear/yarphear.cpp
@@ -8,8 +8,8 @@
 
 #include <deque>
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 
 #include <yarp/os/all.h>
 #include <yarp/os/Log.h>

--- a/src/yarplaserscannergui/main.cpp
+++ b/src/yarplaserscannergui/main.cpp
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <fstream>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 #include <limits>
 #include <cmath>
 
@@ -221,7 +221,7 @@ void drawLaser(const Vector *comp, vector<yarp::dev::LaserMeasurementData> *las,
         //if (length<0)     length = 0;
         //else if (length>15)    length = 15; //15m maximum
 
-        //the following rotation is performed to have x axis aligned with screen vertical 
+        //the following rotation is performed to have x axis aligned with screen vertical
         CvPoint ray;
         ray.x = int(-y*scale);
         ray.y = int(-x*scale);

--- a/src/yarplogger-console/main.cpp
+++ b/src/yarplogger-console/main.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C)2014  iCub Facility - Istituto Italiano di Tecnologia
  * Author: Marco Randazzo
  * email:  marco.randazzo@iit.it
@@ -25,7 +25,7 @@
 #include <yarp/logger/YarpLogger.h>
 
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os;
 using namespace yarp::yarpLogger;
@@ -70,16 +70,16 @@ class logger_module : public yarp::os::RFModule
 
     virtual double getPeriod()
     {
-        return 10.0; 
+        return 10.0;
     }
-    
+
     virtual bool updateModule()
     {
         printf("logger running, listening to %d ports\n",the_logger->get_num_of_processes());
-        return true; 
+        return true;
     }
 
-    virtual bool respond(const yarp::os::Bottle& command,yarp::os::Bottle& reply) 
+    virtual bool respond(const yarp::os::Bottle& command,yarp::os::Bottle& reply)
     {
         reply.clear();
         if (command.get(0).asString()=="quit")
@@ -170,7 +170,7 @@ class logger_module : public yarp::os::RFModule
     }
 };
 
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
     yarp::os::Network yarp;
     if (!yarp.checkNetwork())

--- a/src/yarplogger/main.cpp
+++ b/src/yarplogger/main.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C)2014  iCub Facility - Istituto Italiano di Tecnologia
  * Author: Marco Randazzo
  * email:  marco.randazzo@iit.it
@@ -21,6 +21,7 @@
 #include <yarp/logger/YarpLogger.h>
 #include <yarp/os/Os.h>
 #include <cstdio>
+#include <csignal>
 
 static void sighandler (int signal)
 {
@@ -47,8 +48,8 @@ int main(int argc, char *argv[])
     bool cannot_close = rf.check("no_stop");
     if (cannot_close)
     {
-        yarp::os::signal(yarp::os::YARP_SIGINT, sighandler);
-        yarp::os::signal(yarp::os::YARP_SIGTERM, sighandler);
+        std::signal(SIGINT, sighandler);
+        std::signal(SIGTERM, sighandler);
     }
 
     MainWindow w(rf);

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -9,10 +9,10 @@
 
 #include "ymanager.h"
 
-#include <cstring>
 #include <yarp/manager/xmlapploader.h>
 #include <yarp/manager/application.h>
 #include <yarp/manager/ymm-dir.h>
+#include <yarp/os/ResourceFinder.h>
 
 /*
  * TODO: using stringstream should be avoided to keep
@@ -20,28 +20,32 @@
  */
 #include <sstream>
 
-#include <yarp/os/ResourceFinder.h>
+#include <cstring>
+#include <csignal>
 
 using namespace yarp::os;
 using namespace yarp::manager;
 
-#if defined(WIN32)
-    #include <yarp/os/impl/PlatformSignal.h>
-    #define HEADER      ""
-    #define OKBLUE      ""
-    #define OKGREEN     ""
-    #define WARNING     ""
-    #define FAIL        ""
-    #define INFO        ""
-    #define ENDC        ""
+#if defined(_WIN32)
+# define HEADER      ""
+# define OKBLUE      ""
+# define OKGREEN     ""
+# define WARNING     ""
+# define FAIL        ""
+# define INFO        ""
+# define ENDC        ""
 #else
-    #include <unistd.h>
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <errno.h>
-    #include <sys/types.h>
-    #include <signal.h>
-
+# include <unistd.h>
+# include <cerrno>
+# if defined(YARP_HAS_SYS_TYPES_H)
+#  include <sys/types.h>
+# endif
+# if defined(YARP_HAS_SYS_WAIT_H)
+#  include <sys/wait.h>
+# endif
+# if defined(YARP_HAS_SYS_PRCTL_H)
+#  include <sys/prctl.h>
+# endif
     string HEADER = "";
     string OKBLUE = "";
     string OKGREEN = "";
@@ -100,7 +104,7 @@ Options:\n\
   --help                  Show help\n"
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 static Manager* __pManager = NULL;
 #endif
 
@@ -124,7 +128,7 @@ static Manager* __pManager = NULL;
 YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
 {
 
-#if defined(WIN32)
+#if defined(_WIN32)
     __pManager = (Manager*) this;
 #endif
 
@@ -286,10 +290,10 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
 #endif
 
 
-#if defined(WIN32)
-    ACE_OS::signal(SIGINT, (ACE_SignalHandler) YConsoleManager::onSignal);
-    ACE_OS::signal(SIGBREAK, (ACE_SignalHandler) YConsoleManager::onSignal);
-    ACE_OS::signal(SIGTERM, (ACE_SignalHandler) YConsoleManager::onSignal);
+#if defined(_WIN32)
+    ::signal(SIGINT, YConsoleManager::onSignal);
+    ::signal(SIGBREAK, YConsoleManager::onSignal);
+    ::signal(SIGTERM, YConsoleManager::onSignal);
 #else
     struct sigaction new_action, old_action;
 
@@ -394,7 +398,7 @@ YConsoleManager::~YConsoleManager()
 
 void YConsoleManager::onSignal(int signum)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     cout<<INFO<<"[force exit] yarpmanager will terminate all of the running modules on exit.";
     if( __pManager)
         __pManager->kill();
@@ -461,7 +465,7 @@ void YConsoleManager::myMain(void)
         }
     }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     if(bShouldRun)
     {
         kill();
@@ -1192,7 +1196,7 @@ void YConsoleManager::updateAppNames(vector<string>* names)
 void YConsoleManager::setColorTheme(ColorTheme theme)
 {
 
-#if defined(WIN32)
+#if defined(_WIN32)
     // do nothing here
 #else
     switch(theme) {

--- a/src/yarpmanager/src-builder/arrow.cpp
+++ b/src/yarpmanager/src-builder/arrow.cpp
@@ -43,7 +43,7 @@
 #include "destinationportitem.h"
 #include "sourceportitem.h"
 
-#include <math.h>
+#include <cmath>
 
 #include <QPen>
 #include <QPainter>
@@ -637,12 +637,12 @@ QVariant LineHandle::itemChange(GraphicsItemChange change, const QVariant &value
 
                 dist =  current_point.y() -  base_point.y();
 
-                if(::abs(dist) <= AUTOSNIPE_MARGINE){
+                if (::fabs(dist) <= AUTOSNIPE_MARGINE) {
                     modified = true;
                     current_point = QPointF(current_point.x(), current_point.y() -dist);
                 }
                 dist =  current_point.x() -  base_point.x();
-                if(::abs(dist) <= AUTOSNIPE_MARGINE){
+                if (::fabs(dist) <= AUTOSNIPE_MARGINE) {
                     modified = true;
                     //moveBy(-dist, 0);
                     current_point = QPointF(current_point.x()-dist, current_point.y());
@@ -658,12 +658,12 @@ QVariant LineHandle::itemChange(GraphicsItemChange change, const QVariant &value
                     base_point = mapToItem(parent,parent->mapFromItem(parent->endItem(),parent->endItem()->connectionPoint()));
                 }
                 dist =  current_point.y() -  base_point.y();
-                if(::abs(dist) <= AUTOSNIPE_MARGINE){
+                if (::fabs(dist) <= AUTOSNIPE_MARGINE) {
                     modified = true;
                     current_point = QPointF(current_point.x(), current_point.y() -dist);
                 }
                 dist =  current_point.x() -  base_point.x();
-                if(::abs(dist) <= AUTOSNIPE_MARGINE){
+                if (::fabs(dist) <= AUTOSNIPE_MARGINE) {
                     modified = true;
                     //moveBy(-dist, 0);
                     current_point = QPointF(current_point.x()-dist, current_point.y());

--- a/src/yarpmanager/src-builder/builderitem.cpp
+++ b/src/yarpmanager/src-builder/builderitem.cpp
@@ -1,6 +1,7 @@
 #include "builderitem.h"
 #include "arrow.h"
-#include "math.h"
+#include <cmath>
+
 ItemSignalHandler *BuilderItem::signalHandler(){
     return sigHandler;
 }

--- a/src/yarpmanager/src-builder/moduleitem.cpp
+++ b/src/yarpmanager/src-builder/moduleitem.cpp
@@ -3,7 +3,7 @@
 #include <QDebug>
 #include <QCursor>
 #include <QGraphicsScene>
-#include "math.h"
+#include <cmath>
 
 #define TRIANGLEH   (double)((double)PORT_LINE_WIDTH * (double)sqrt(3.0) ) / 2.0
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -1592,7 +1592,7 @@ void ApplicationViewWidget::onYARPHear()
             QString from = it->text(3);
             QString to = QString("/inspect/hear%1").arg(from);
 
-#if defined(WIN32)
+#if defined(_WIN32)
             QString cmd = "cmd.exe";
             QString param;
             param = QString("/C yarphear --name %1").arg(to);
@@ -1661,7 +1661,7 @@ void ApplicationViewWidget::onYARPRead()
             QString from = it->text(3);
             QString to = QString("/inspect/read%1").arg(from);
 
-#if defined(WIN32)
+#if defined(_WIN32)
             QString cmd = "cmd.exe";
             QString param;
             param = QString("/C yarp read %1").arg(to);

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -75,7 +75,7 @@ EntitiesTreeWidget::EntitiesTreeWidget(QWidget *parent) : QTreeWidget(parent)
     connect(remove,SIGNAL(triggered()),this,SLOT(onRemove()));
     connect(reopen,SIGNAL(triggered()),this,SLOT(onReopen()));
 
-    #if defined(WIN32)
+    #if defined(_WIN32)
         ext_editor = "notepad.exe";
     #else
         ext_editor = "xdg-open";

--- a/src/yarpmanager/src-manager/main.cpp
+++ b/src/yarpmanager/src-manager/main.cpp
@@ -29,15 +29,15 @@ Options:\n\
 #define DEF_CONFIG_FILE     "ymanager.ini"
 
 
-#if defined(WIN32)
-//#include <yarp/os/impl/PlatformSignal.h>
+#if defined(_WIN32)
+//#include <csignal>
 #include <windows.h>
 
 #else
 
-#include <errno.h>
+#include <cerrno>
 #include <sys/types.h>
-#include <signal.h>
+#include <csignal>
 #endif
 
 void onSignal(int signum);
@@ -45,11 +45,11 @@ void onSignal(int signum);
 int main(int argc, char *argv[])
 {
 
-#if defined(WIN32)
-    // We create a console. This is inherited by console processes created by the localhost broker. 
+#if defined(_WIN32)
+    // We create a console. This is inherited by console processes created by the localhost broker.
     // It is useful because new processes can receive ctrl+brk signals and shutdown cleanly.
-    // This console is not actually needed for printing so we hide it.  In principle we could 
-    // redirect the output of all processes to this console, in practice this would be end up 
+    // This console is not actually needed for printing so we hide it.  In principle we could
+    // redirect the output of all processes to this console, in practice this would be end up
     // soon in a big mess.
    AllocConsole();
    HWND hwnd = GetConsoleWindow();
@@ -171,11 +171,11 @@ int main(int argc, char *argv[])
         config.put("auto_dependency", "no");
     }
 
-#if defined(WIN32)
+#if defined(_WIN32)
     //setup signal handler for windows
-//    ACE_OS::signal(SIGINT, (ACE_SignalHandler) onSignal);
-//    ACE_OS::signal(SIGBREAK, (ACE_SignalHandler) onSignal);
-//    ACE_OS::signal(SIGTERM, (ACE_SignalHandler) onSignal);
+//    signal(SIGINT, onSignal);
+//    signal(SIGBREAK, onSignal);
+//    signal(SIGTERM, onSignal);
 
 #else
     // Set up the structure to specify the new action.

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -36,16 +36,19 @@
 
 
 
-#if defined(WIN32)
-    #pragma warning (disable : 4250)
-    #pragma warning (disable : 4520)
+#if defined(_WIN32)
+# pragma warning (disable : 4250)
+# pragma warning (disable : 4520)
 #else
-    #include <unistd.h>
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <errno.h>
-    #include <sys/types.h>
-    #include <signal.h>
+# include <unistd.h>
+# include <cerrno>
+# include <csignal>
+# if defined(YARP_HAS_SYS_TYPES_H)
+#  include <sys/types.h>
+# endif
+# if defined(YARP_HAS_SYS_WAIT_H)
+#  include <sys/wait.h>
+# endif
 #endif
 
 #ifndef APP_NAME
@@ -262,7 +265,7 @@ void MainWindow::init(yarp::os::Property config)
         ext_editor = config.find("external_editor").asString();
         ((EntitiesTreeWidget*)ui->entitiesTree)->setExtEditor(ext_editor);
     }else{
-#if defined(WIN32)
+#if defined(_WIN32)
         ext_editor = "notepad.exe";
 #else
         ext_editor = "xdg-open";

--- a/src/yarpmotorgui/main.cpp
+++ b/src/yarpmotorgui/main.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+#include <csignal>
 
 using namespace yarp::dev;
 using namespace yarp::os;
@@ -178,7 +179,7 @@ int main(int argc, char *argv[])
             QMessageBox::critical(0, "Error", "You cannot use both --parts and --names options simultaneously");
             return 1;
         }
-        
+
         if (b_name != 0 && b_part == 0)
         {
             //check port names from config file
@@ -221,7 +222,7 @@ int main(int argc, char *argv[])
             pParts = Bottle("/icub/head /icub/torso /icub/left_arm /icub/right_arm /icub/left_leg /icub/right_leg");
         }
     }
-    
+
     //Check 1 in the panel
     for(int n = 0; n < pParts.size(); n++)
     {
@@ -259,8 +260,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    yarp::os::signal(yarp::os::YARP_SIGINT,  sighandler);
-    yarp::os::signal(yarp::os::YARP_SIGTERM, sighandler);
+    std::signal(SIGINT, sighandler);
+    std::signal(SIGTERM, sighandler);
 
     mainW  = &w;
     appRet = 0;

--- a/src/yarpmotorgui/sliderWithTarget.cpp
+++ b/src/yarpmotorgui/sliderWithTarget.cpp
@@ -9,9 +9,9 @@
 #include <QKeyEvent>
 #include <QPainter>
 #include <QStyle>
-#include <math.h>
+#include <cmath>
 
-//just because old VS2010 does not implement round() function in math.h
+//just because old VS2010 does not implement round() function in cmath
 double my_round(double number)
 {
     return number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5);

--- a/src/yarprobotinterface/XMLReader.cpp
+++ b/src/yarprobotinterface/XMLReader.cpp
@@ -13,6 +13,8 @@
 #include "Types.h"
 
 #include <yarp/os/LogStream.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
 
 #include <tinyxml.h>
 #include <string>
@@ -20,8 +22,6 @@
 #include <sstream>
 #include <iterator>
 #include <algorithm>
-
-#include <yarp/os/Property.h>
 
 #define SYNTAX_ERROR(line) yFatal() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
@@ -250,16 +250,11 @@ RobotInterface::XMLReader::Private::~Private()
 RobotInterface::Robot& RobotInterface::XMLReader::Private::readRobotFile(const std::string &fileName)
 {
     filename = fileName;
-#ifdef WIN32
+#if defined(_WIN32)
     std::replace(filename.begin(), filename.end(), '/', '\\');
 #endif
-
     curr_filename = fileName;
-#ifdef WIN32
-    path = filename.substr(0, filename.rfind("\\"));
-#else // WIN32
-    path = filename.substr(0, filename.rfind("/"));
-#endif //WIN32
+    path = filename.substr(0, filename.rfind(yarp::os::Network::getDirectorySeparator()));
 
     yDebug() << "Reading file" << filename.c_str();
     TiXmlDocument *doc = new TiXmlDocument(filename.c_str());
@@ -427,12 +422,10 @@ RobotInterface::DeviceList RobotInterface::XMLReader::Private::readDevicesTag(Ti
     std::string filename;
     if (devicesElem->QueryStringAttribute("file", &filename) == TIXML_SUCCESS) {
         // yDebug() << "Found devices file [" << filename << "]";
-#ifdef WIN32
+#if defined(_WIN32)
         std::replace(filename.begin(), filename.end(), '/', '\\');
-        filename = path + "\\" + filename;
-#else // WIN32
-        filename = path + "/" + filename;
-#endif //WIN32
+#endif
+        filename = path + yarp::os::Network::getDirectorySeparator() + filename;
         return readDevicesFile(filename);
     }
 
@@ -720,12 +713,10 @@ RobotInterface::ParamList RobotInterface::XMLReader::Private::readParamsTag(TiXm
     std::string filename;
     if (paramsElem->QueryStringAttribute("file", &filename) == TIXML_SUCCESS) {
         // yDebug() << "Found params file [" << filename << "]";
-#ifdef WIN32
+#if defined(_WIN32)
         std::replace(filename.begin(), filename.end(), '/', '\\');
-        filename = path + "\\" + filename;
-#else // WIN32
-        filename = path + "/" + filename;
-#endif //WIN32
+#endif
+        filename = path + yarp::os::Network::getDirectorySeparator() + filename;
         return readParamsFile(filename);
     }
 
@@ -888,12 +879,10 @@ RobotInterface::ActionList RobotInterface::XMLReader::Private::readActionsTag(Ti
     std::string filename;
     if (actionsElem->QueryStringAttribute("file", &filename) == TIXML_SUCCESS) {
         // yDebug() << "Found actions file [" << filename << "]";
-#ifdef WIN32
+#if defined(_WIN32)
         std::replace(filename.begin(), filename.end(), '/', '\\');
-        filename = path + "\\" + filename;
-#else // WIN32
-        filename = path + "/" + filename;
-#endif //WIN32
+#endif
+        filename = path + yarp::os::Network::getDirectorySeparator() + filename;
         return readActionsFile(filename);
     }
 

--- a/src/yarprobotinterface/main.cpp
+++ b/src/yarprobotinterface/main.cpp
@@ -14,7 +14,7 @@
 #include <yarp/dev/Drivers.h>
 
 #ifdef ICUB_USE_REALTIME_LINUX
-#include <signal.h>
+#include <csignal>
 #include <unistd.h>
 #include <sys/mman.h>
 #endif //ICUB_USE_REALTIME_LINUX

--- a/src/yarprun/yarprun.cpp
+++ b/src/yarprun/yarprun.cpp
@@ -11,7 +11,7 @@
 
 #include <yarp/os/Run.h>
 #include <yarp/os/Network.h>
-#include <stdio.h>
+#include <cstdio>
 
 
 int main(int argc, char *argv[])

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -14,7 +14,7 @@
 #include <QQuickItem>
 #include "videoproducer.h"
 
-//#include <yarp/os/impl/PlatformStdio.h>
+//#include <cstdio>
 #include <yarp/os/Property.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/BufferedPort.h>

--- a/tests/libYARP_OS/DgramTwoWayStreamTest.cpp
+++ b/tests/libYARP_OS/DgramTwoWayStreamTest.cpp
@@ -10,7 +10,7 @@
 #include <yarp/os/ConstString.h>
 #include <yarp/os/impl/UnitTest.h>
 #include <yarp/os/NetType.h>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;

--- a/tests/libYARP_OS/EventTest.cpp
+++ b/tests/libYARP_OS/EventTest.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <math.h>
+#include <cmath>
 
 #include <yarp/conf/system.h>
 #include <yarp/os/all.h>

--- a/tests/libYARP_OS/NetTypeTest.cpp
+++ b/tests/libYARP_OS/NetTypeTest.cpp
@@ -11,8 +11,9 @@
 #include <yarp/os/NetFloat64.h>
 
 #include <yarp/os/impl/UnitTest.h>
-#include <yarp/os/impl/PlatformStdlib.h>
-//#include "TestList.h"
+
+#include <cstdlib>
+#include <cstring>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;

--- a/tests/libYARP_OS/PropertyTest.cpp
+++ b/tests/libYARP_OS/PropertyTest.cpp
@@ -11,10 +11,10 @@
 
 #include <yarp/os/impl/UnitTest.h>
 #include <yarp/os/impl/Logger.h>
+#include <yarp/os/impl/PlatformSysStat.h>
 
-#include <yarp/os/impl/PlatformStdlib.h>
-
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -559,11 +559,10 @@ check $x $y\n\
         report(0,"checking directory scanning");
         // change directory name if test files removed
         ConstString dirname = "__test_dir_1";
-        ACE_stat sb;
-        if (ACE_OS::stat(dirname.c_str(),&sb)<0) {
+        if (yarp::os::stat(dirname.c_str())<0) {
             yarp::os::mkdir(dirname.c_str());
         }
-        checkTrue(ACE_OS::stat(dirname.c_str(),&sb)>=0,"test directory present");
+        checkTrue(yarp::os::stat(dirname.c_str())>=0,"test directory present");
         {
             FILE *fout = fopen((dirname + "/t1.ini").c_str(),"w");
             yAssert(fout!=NULL);

--- a/tests/libYARP_OS/ProtocolTest.cpp
+++ b/tests/libYARP_OS/ProtocolTest.cpp
@@ -8,7 +8,7 @@
 #include <yarp/os/impl/FakeTwoWayStream.h>
 #include <yarp/os/impl/Protocol.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/UnitTest.h>
 
 using namespace yarp::os;
@@ -23,10 +23,10 @@ public:
     }
 
     void show(FakeTwoWayStream *fake1, FakeTwoWayStream *fake2) {
-        ACE_OS::printf("fake1  //  in: [%s]  //  out: [%s]\n",
+        printf("fake1  //  in: [%s]  //  out: [%s]\n",
                        simplify(fake1->getInputText()).c_str(),
                        simplify(fake1->getOutputText()).c_str());
-        ACE_OS::printf("fake2  //  in: [%s]  //  out: [%s]\n\n",
+        printf("fake2  //  in: [%s]  //  out: [%s]\n\n",
                        simplify(fake2->getInputText()).c_str(),
                        simplify(fake2->getOutputText()).c_str());
     }

--- a/tests/libYARP_OS/RateThreadTest.cpp
+++ b/tests/libYARP_OS/RateThreadTest.cpp
@@ -63,7 +63,7 @@ private:
 
         virtual bool threadInit()
         {
-            ACE_OS::printf("-->Starting rate thread: %.2lf[ms]...", getRate());
+            printf("-->Starting rate thread: %.2lf[ms]...", getRate());
             n=0;
             t1=0;
             t2=0;
@@ -83,7 +83,7 @@ private:
             n++;
             t1=t2;
 
-            // ACE_OS::printf(".");
+            // printf(".");
         }
 
         virtual void threadRelease()
@@ -93,7 +93,7 @@ private:
             else
                 period=0;
 
-            ACE_OS::printf("thread quit\n");
+            printf("thread quit\n");
         }
 
     };
@@ -313,22 +313,22 @@ public:
 
         //try plausible rates
         double p;
-        ACE_OS::sprintf(message, "Thread1 requested period: %d[ms]", 15);
+        sprintf(message, "Thread1 requested period: %d[ms]", 15);
         report(0, message);
         p=test(15, 1);
-        ACE_OS::sprintf(message, "Thread1 estimated: %.2lf[ms]", p);
+        sprintf(message, "Thread1 estimated: %.2lf[ms]", p);
         report(0, message);
 
-        ACE_OS::sprintf(message, "Thread2 requested period: %d[ms]", 10);
+        sprintf(message, "Thread2 requested period: %d[ms]", 10);
         report(0, message);
         p=test(10, 1);
-        ACE_OS::sprintf(message, "Thread2 estimated period: %.2lf[ms]", p);
+        sprintf(message, "Thread2 estimated period: %.2lf[ms]", p);
         report(0, message);
 
-        ACE_OS::sprintf(message, "Thread3 requested period: %d[ms]", 1);
+        sprintf(message, "Thread3 requested period: %d[ms]", 1);
         report(0, message);
         p=test(1, 1);
-        ACE_OS::sprintf(message, "Thread3 estimated period: %.2lf[ms]", p);
+        sprintf(message, "Thread3 estimated period: %.2lf[ms]", p);
         report(0, message);
 
         report(0, "successful");

--- a/tests/libYARP_OS/ResourceFinderTest.cpp
+++ b/tests/libYARP_OS/ResourceFinderTest.cpp
@@ -7,16 +7,20 @@
 
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/impl/UnitTest.h>
-#include <yarp/os/impl/Logger.h>
 #include <yarp/os/Os.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/YarpPlugin.h>
+
+#include <yarp/os/impl/PlatformDirent.h>
+#include <yarp/os/impl/PlatformSysStat.h>
+#include <yarp/os/impl/PlatformUnistd.h>
+#include <yarp/os/impl/UnitTest.h>
+
+#include <cstdlib>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
 
-#include <stdio.h>
+#include <cstdio>
 
 class ResourceFinderTest : public UnitTest {
 public:
@@ -338,11 +342,10 @@ public:
 
 
     void mkdir(const ConstString& dirname) {
-        ACE_stat sb;
-        if (ACE_OS::stat(dirname.c_str(),&sb)<0) {
+        if (yarp::os::stat(dirname.c_str())<0) {
             yarp::os::mkdir(dirname.c_str());
         }
-        int r = ACE_OS::stat(dirname.c_str(),&sb);
+        int r = yarp::os::stat(dirname.c_str());
         if (r<0) {
             // show problem
             checkTrue(r>=0,"test directory present");
@@ -351,10 +354,10 @@ public:
 
     ConstString pathify(const Bottle& dirs) {
         char buf[1000];
-        char *result = getcwd(buf,sizeof(buf));
+        char *result = yarp::os::getcwd(buf,sizeof(buf));
         if (!result) {
             checkTrue(result!=NULL,"cwd/pwd not too long");
-            yarp::os::exit(1);
+            std::exit(1);
         }
         ConstString slash = Network::getDirectorySeparator();
         ConstString dir = buf;
@@ -733,7 +736,7 @@ public:
             rf.configure(0,NULL);
 
             char buf[1000];
-            char *result = getcwd(buf,sizeof(buf));
+            char *result = yarp::os::getcwd(buf,sizeof(buf));
             checkEqual(rf.getHomeContextPath(),result,"cwd found as context directory for writing");
             checkEqual(rf.getHomeRobotPath(),result,"cwd found as robot directory for writing");
         }

--- a/tests/libYARP_OS/RunTest.cpp
+++ b/tests/libYARP_OS/RunTest.cpp
@@ -11,8 +11,8 @@
 #include <yarp/os/Thread.h>
 
 #include <string>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 #include <yarp/os/impl/UnitTest.h>
 

--- a/tests/libYARP_OS/SemaphoreTest.cpp
+++ b/tests/libYARP_OS/SemaphoreTest.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <math.h>
+#include <cmath>
 
 #include <yarp/os/all.h>
 
@@ -48,7 +48,7 @@ public:
         report(0, "check blocking behavior...");
         SemaphoreTestHelper helper;
         helper.start();
-        Time::delay(0.5); 
+        Time::delay(0.5);
         checkEqual(helper.state,1,"helper blocked");
         helper.x.post();
         Time::delay(0.5);

--- a/tests/libYARP_OS/StampTest.cpp
+++ b/tests/libYARP_OS/StampTest.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <math.h>
+#include <cmath>
 
 #include <yarp/os/Stamp.h>
 #include <yarp/os/all.h>

--- a/tests/libYARP_OS/StringOutputStreamTest.cpp
+++ b/tests/libYARP_OS/StringOutputStreamTest.cpp
@@ -6,11 +6,12 @@
  */
 
 #include <yarp/os/StringOutputStream.h>
-#include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 
 #include <yarp/os/impl/UnitTest.h>
-//#include "TestList.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -23,7 +24,7 @@ public:
         report(0,"testing writing...");
         StringOutputStream sos;
         char txt[] = "Hello my friend";
-        Bytes b(txt,ACE_OS::strlen(txt));
+        Bytes b(txt,strlen(txt));
         sos.write(b);
         checkEqual(txt,sos.toString(),"single write");
         StringOutputStream sos2;

--- a/tests/libYARP_OS/TerminatorTest.cpp
+++ b/tests/libYARP_OS/TerminatorTest.cpp
@@ -23,30 +23,30 @@ public:
 
         Network::setLocalMode(true);
 
-        ACE_OS::printf("registering port name: ");
+        printf("registering port name: ");
         Terminee terminee("/tmp/quit");
         if (terminee.isOk())
-            ACE_OS::printf("ok\n");
+            printf("ok\n");
         else {
-            ACE_OS::printf("failed\n");
+            printf("failed\n");
             report(1,"failed to set terminator socket");
         }
 
-        ACE_OS::printf("sending quit message: ");
+        printf("sending quit message: ");
         if (Terminator::terminateByName("/tmp/quit"))
-            ACE_OS::printf("ok\n");
+            printf("ok\n");
         else {
-            ACE_OS::printf("failed\n");
+            printf("failed\n");
             report(1,"failed to set termination connection");
         }
 
-        ACE_OS::printf("quit flag was set properly: ");
+        printf("quit flag was set properly: ");
         if (!terminee.mustQuit()) {
-            ACE_OS::printf("failed\n");
+            printf("failed\n");
             report(1,"failed to receive the quit message");
         }
         else {
-            ACE_OS::printf("ok\n");
+            printf("ok\n");
         }
     }
 

--- a/tests/libYARP_OS/ThreadTest.cpp
+++ b/tests/libYARP_OS/ThreadTest.cpp
@@ -79,7 +79,7 @@ private:
 
         virtual void run() {
             for (int i=0; i<5; i++) {
-                //ACE_OS::printf("tick %d\n", i);
+                //printf("tick %d\n", i);
                 owner.state.wait();
                 owner.expectCount++;
                 owner.state.post();
@@ -104,7 +104,7 @@ private:
                 done = finished;
                 mutex.post();
                 owner.state.wait();
-                //ACE_OS::printf("burp\n");
+                //printf("burp\n");
                 owner.gotCount++;
                 owner.state.post();
             }
@@ -113,7 +113,7 @@ private:
                 owner.gotCount++;
                 owner.state.post();
             }
-            //ACE_OS::printf("done\n");
+            //printf("done\n");
         }
 
         virtual void close() {

--- a/tests/libYARP_OS/testModule/module.cpp
+++ b/tests/libYARP_OS/testModule/module.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Network.h>
 
@@ -36,17 +36,17 @@ public:
     /*
     * Message handler. Just echo all received messages.
     */
-    bool respond(const Bottle& command, Bottle& reply) 
+    bool respond(const Bottle& command, Bottle& reply)
     {
         printf("Got something, echo is on\n");
         if (command.get(0).asString()=="quit")
-            return false;     
+            return false;
         else
             reply=command;
         return true;
     }
 
-    /* 
+    /*
     * Configure function. Receive a previously initialized
     * resource finder object. Use it to configure your module.
     * Open port and attach it to message handler.
@@ -86,15 +86,15 @@ int main(int argc, char * argv[])
     MyModule module;
 
     yarp::os::ResourceFinder rf; //dummy resource finder, empty
-    
+
     //open a file
 
     printf("Configure module...\n");
     module.configure(rf);
     printf("Start module...\n");
     module.runModule();
-    
-    //remove file 
+
+    //remove file
     printf("Main returning...\n");
     return 0;
 }

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -19,7 +19,7 @@
 #include <yarp/math/FrameTransform.h>
 #include <yarp/os/LogStream.h>
 #define M_PI 3.14159265358979323846
-#include<math.h>
+#include<cmath>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;

--- a/tests/libYARP_dev/harness.cpp
+++ b/tests/libYARP_dev/harness.cpp
@@ -21,7 +21,7 @@
 
 #include "YarpBuildLocation.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
         FILE *fout = fopen(dest2.c_str(),"w");
         if (fout==NULL) {
             printf("Problem writing to %s\n", dest2.c_str());
-            yarp::os::exit(1);
+            std::exit(1);
         }
         fprintf(fout,"/**\n");
         fprintf(fout," * \\ingroup dev_examples\n");

--- a/tests/libYARP_math/MathTest.cpp
+++ b/tests/libYARP_math/MathTest.cpp
@@ -5,27 +5,19 @@
 */
 
 
-/**
- * \infile Tests for math.
- */
+#define _USE_MATH_DEFINES
 
-// Added tests for random generator.
-
-#include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/math/Math.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/math/Rand.h>
 #include <yarp/math/SVD.h>
-
 #include <yarp/os/Time.h>
 
-#if defined(_MSC_VER)
-# define _USE_MATH_DEFINES
-#endif
-#include <math.h>
+#include <cmath>
 #include <string>
+#include <cstdio>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -136,19 +128,19 @@ public:
     void vectorOps()
     {
         report(0,"checking vector operators...");
-    
+
         Vector a(3);
         Vector b(3);
         Vector c;
         a=1;
         b=1;
-    
-        //test 
+
+        //test
         c=a+b;
 
         double acc=c[0]+c[1]+c[2];
         checkTrue(acc==6, "operator+ on vectors");
-        
+
         c=a-b;
         acc=c[0]+c[1]+c[2];
         checkTrue(acc==0,  "operator- on vectors");
@@ -178,7 +170,7 @@ public:
 
     void vectMatrix()
     {
-        
+
         Matrix m(3,2);
         m=eye(3,2);
         Vector v1(3);
@@ -214,7 +206,7 @@ public:
 
         Matrix exp(3,2);
         exp=24; //expected result
-        
+
         bool ret=(exp==C);
         checkTrue(ret, "Matrix::operator*");
 
@@ -226,7 +218,7 @@ public:
         for(int r=0; r<res.rows(); r++)
             for(int c=0; c<res.cols(); c++)
                     acc+=res[r][c];
-        
+
         double expected=res.rows()*res.cols()*3.0;
 
         checkTrue((acc==expected), "Matrix element wise division");
@@ -269,7 +261,7 @@ public:
         printf("%s\n", M.toString().c_str());
         printf("%s\n", T.toString().c_str());
     }
-    
+
     void matrixInv() {
         Vector v(0);
 
@@ -291,13 +283,13 @@ public:
             {
                 if (fabs(I[r][c]-ref[r][c])>0.0001)
                     invGood=false;
-            
+
             }
-            
+
         checkTrue(invGood, "luinv");
 
         //printf("luinv: %s\n", I.toString().c_str());
-        
+
         /*  [ 2 1 0 0 ]^-1   [ 1 -1  1 -1 ]
          *  [ 1 2 1 0 ]      [-1  2 -2  2 ]
          *  [ 0 1 2 1 ]    = [ 1 -2  3 -3 ]
@@ -311,9 +303,9 @@ public:
         I = B * Binv;
         printf("chinv: %s\n", I.toString().c_str());
         */
-        
+
     }
-    
+
     void matrixDet() {
         report(0,"checking matrix determinant...");
         Matrix A(4,4);
@@ -336,7 +328,7 @@ public:
         A(3,1) = 1;
         A(3,2) = 4;
         A(3,3) = 7;
-        
+
         double val = det(A);
         bool ok = ((val - -163) < 1e-10 && (-163 - val) < 1e-10);
         checkTrue(ok, "Matrix determinant");
@@ -481,7 +473,7 @@ public:
         assertEqual(a1/s, a1[0]/s, testName);
         testName = "vector /= scalar";
         an=bn; an/=s; assertEqual(an, bn/s, testName);
-        testName = "vector / vector"; 
+        testName = "vector / vector";
         assertEqual(an/ones(n), an, testName);
         assertEqual(a1/b1, a1[0]/b1[0], testName);
         testName = "vector /= vector";
@@ -516,8 +508,8 @@ public:
         testName = "a x b = -b x a";
         assertEqual(cross(an, bn), -1.0*cross(bn, an), testName);
     }
-    
-    virtual void runTests() 
+
+    virtual void runTests()
     {
         checkMiscOperations();
         vectorOps();
@@ -683,7 +675,7 @@ public:
         m_check[2][0] = 0.2230062590462850;    m_check[2][1] = 0.9084427381107635;    m_check[2][2] = 0.3535533905932738;   m_check[2][3] = 0;
         m_check[3][0] = 0;                     m_check[3][1] = 0;                     m_check[3][2] = 0;                    m_check[3][3] = 1.0;
         assertEqual(m, m_check, "check m computation");
-        
+
         // q1
         //0.8201 -0.3369i -0.4579j -0.06527k
         v_check.resize(4, 0.0);

--- a/tests/libYARP_math/Vec2DTest.cpp
+++ b/tests/libYARP_math/Vec2DTest.cpp
@@ -8,7 +8,7 @@
  * \infile Tests for Vec2D.
  */
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/UnitTest.h>
 #include <yarp/os/Portable.h>
 
@@ -22,7 +22,7 @@
 #if defined(_MSC_VER)
 # define _USE_MATH_DEFINES
 #endif
-#include <math.h>
+#include <cmath>
 #include <string>
 
 using namespace yarp::os;

--- a/tests/libYARP_math/randTest.cpp
+++ b/tests/libYARP_math/randTest.cpp
@@ -9,7 +9,7 @@
  * \infile Tests for Rand.h/Rand.cpp
  */
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/math/Rand.h>
@@ -17,7 +17,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 
-#include <math.h>
+#include <cmath>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -129,7 +129,7 @@ public:
             average+=rv[k];
         }
         average/=N;
-        
+
         //computing std
         double std=0.0;
         for(k=0;k<N;k++)
@@ -179,7 +179,7 @@ public:
         checkTrue(!tmp, "default seed initialization for two sequences");
     }
 
-    virtual void runTests() 
+    virtual void runTests()
     {
         rand();
         randMatrix();

--- a/tests/libYARP_math/svdTest.cpp
+++ b/tests/libYARP_math/svdTest.cpp
@@ -9,14 +9,14 @@
  * \infile Tests for SVD.
  */
 
-#include <yarp/os/impl/PlatformStdio.h>
+#include <cstdio>
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/math/Math.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/math/SVD.h>
 #include <yarp/math/Rand.h>
-#include <math.h>
+#include <cmath>
 #include <string>
 
 using namespace yarp::os;
@@ -198,7 +198,7 @@ public:
 
         m=5;
         n=6;
-        U.resize(m,m); 
+        U.resize(m,m);
         V.resize(m,n);
         s.resize(m);
         for(int i=0; i<nTest; i++)
@@ -274,7 +274,7 @@ public:
         }
     }
 
-    virtual void runTests() 
+    virtual void runTests()
     {
         svd();
         svdCheckResizeOfOutputMatrices();

--- a/tests/libYARP_serversql/ServerTest.cpp
+++ b/tests/libYARP_serversql/ServerTest.cpp
@@ -5,8 +5,8 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <yarp/os/all.h>
 #include <yarp/os/impl/NameClient.h>

--- a/tests/libYARP_sig/MatrixTest.cpp
+++ b/tests/libYARP_sig/MatrixTest.cpp
@@ -16,7 +16,7 @@
 #include <yarp/gsl/Gsl.h>
 #include <yarp/gsl/impl/gsl_structs.h>
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 
 #include "TestList.h"


### PR DESCRIPTION
* Some refactoring to simplify porting to other platforms without ACE

* Prefer c++11 headers and methods

* Use `inet_ntop`/`inet_pton` instead of `inet_ntoa`/`inet_ntop`

* New methods:
  - `yarp::os::getcwd()`
  - `yarp::os::fork()`

* Deprecated methods:
  - `yarp::os::exit()`
  - `yarp::os::abort()`
  - `yarp::os::signal()`

* Cleanup