### PR TITLE
OS/NameConfig: Disable YARP_CONF environment variable

### DIFF
--- a/doc/cmd_yarp.dox
+++ b/doc/cmd_yarp.dox
@@ -141,8 +141,7 @@ For the author's machine, the result is:
 \verbatim
 /home/paulfitz/.config/yarp/conf/yarp.conf
 \endverbatim
-If the YARP_CONF directory is set, this will be where the conf/yarp.conf
-file is created/read.  The first line of that file looks like this:
+The first line of that file looks like this:
 \verbatim
  15.255.112.22 10000
 \endverbatim

--- a/doc/name_server.dox
+++ b/doc/name_server.dox
@@ -346,7 +346,6 @@ important key is "name", whose value is the name of the port.
 For yarp utilities to correctly discover how
 to contact the name server,
 there should be a file yarp.conf in the directory $HOME/.yarp/conf/
-(or in the directory specified by an environment variable $YARP_CONF)
 that looks like this:
 \verbatim
 192.168.0.3 10000

--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -8,6 +8,16 @@ A (partial) list of bug fixed and issues resolved in this release can be found
 Important Changes
 -----------------
 
+### System Configuration
+
+* The `YARP_CONF` environment variable has been deprecated for a long time
+  (since April 2013) and it is no longer used. Since there was not a proper
+  warning, the warning is printed now at runtime when the variable is set. See
+  [`ResourceFinder::getConfigHome()` documentation](http://yarp.it/classyarp_1_1os_1_1ResourceFinder.html)
+  for informations about paths used by YARP to detect the configuration files.
+  If you still need to use the `YARP_CONF` for some reason, you can use the
+  `YARP_CONFIG_HOME` environment variable instead.
+
 ### Build System
 
 * A compiler supporting C++11 is now required.

--- a/example/external/c/yarpmin.c
+++ b/example/external/c/yarpmin.c
@@ -62,6 +62,10 @@ int find_name_server(int verbose) {
 #else
     const char *sep = "/";
 #endif
+    // =================================================================
+    // WARNING: This code is deprecated and will no longer work,
+    //          see ResourceFinder documentation for paths searched
+    //          by YARP
     if (getenv("YARP_CONF")!=NULL) {
         safe_printf(path,sizeof(path),"%s",getenv("YARP_CONF"));
     } else if (getenv("HOMEDIR")!=NULL) {
@@ -77,6 +81,8 @@ int find_name_server(int verbose) {
         }
         return -1;
     }
+    // =================================================================
+
     if (verbose) {
         fprintf(stderr,"YARP config file should be present in %s\n", path);
     }

--- a/example/external/python/find_name_server.py
+++ b/example/external/python/find_name_server.py
@@ -7,6 +7,10 @@
 import os
 
 def find_name_server():
+    # ==================================================================
+    # WARNING: This code is deprecated and will no longer work,
+    #          see ResourceFinder documentation for paths searched
+    #          by YARP
     if "YARP_CONF" in os.environ.keys():
         base = os.environ["YARP_CONF"]
     elif "HOMEDIR" in os.environ.keys():
@@ -17,6 +21,7 @@ def find_name_server():
         print "Please set YARP_CONF to the location reported by this command:"
         print "  yarp conf"
         return None
+    # ==================================================================
 
     print "Config files should be in", base
 

--- a/example/profiling/local.sh
+++ b/example/profiling/local.sh
@@ -8,7 +8,7 @@
 export ACE_ROOT=/home/icub/Code/ACE_wrappers
 export YARP_DIR=/home/icub/Code/yarp2
 export YARP_ROOT=$YARP_DIR
-export YARP_CONF=$YARP_DIR/conf
+export YARP_CONFIG_DIR=$YARP_DIR/conf
 export ICUB_DIR=/home/icub/Code/iCub
 export ICUB_ROOT=$ICUB_DIR
 export ICUB_CONF=$ICUB_DIR/conf

--- a/example/profiling/remote.sh
+++ b/example/profiling/remote.sh
@@ -7,7 +7,7 @@
 export ACE_ROOT=/home/icub/Code/ACE_wrappers
 export YARP_DIR=/home/icub/Code/yarp2
 export YARP_ROOT=$YARP_DIR
-export YARP_CONF=$YARP_DIR/conf
+export YARP_CONFIG_DIR=$YARP_DIR/conf
 export ICUB_DIR=/home/icub/Code/iCub
 export ICUB_ROOT=$ICUB_DIR
 export ICUB_CONF=$ICUB_DIR/conf

--- a/src/libYARP_OS/src/NameConfig.cpp
+++ b/src/libYARP_OS/src/NameConfig.cpp
@@ -77,33 +77,22 @@ bool NameConfig::fromString(const ConstString& txt) {
 }
 
 ConstString NameConfig::expandFilename(const char *fname) {
-    ConstString root = NetworkBase::getEnvironment("YARP_CONF");
-
-    // yarp 2.4 modifications begin
-    // We should now be using YARP_CONFIG_HOME.
-    // We still respect the YARP_CONF variable if defined, but it
-    // is deprecated.
-    if (root=="") {
-        root = ResourceFinder::getConfigHome();
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+    ConstString yarp_conf = NetworkBase::getEnvironment("YARP_CONF");
+    if (!yarp_conf.empty()) {
+        YARP_WARN(Logger::get(), "The YARP_CONF variable is deprecated and it is no longer used. "
+                                 "Please check the documentation for yarp::os::ResourceFinder::getConfigHome()");
     }
-    // yarp 2.4 modifications end
+#endif
 
-    ConstString home = NetworkBase::getEnvironment("HOME");
-    ConstString homepath = NetworkBase::getEnvironment("HOMEPATH");
-    ConstString conf = "";
-    if (root!="") {
-        //conf = new File(new File(root,"conf"),"namer.conf");
-        //conf = root + "/conf/" + fname;
-        // users of YARP_CONF want /conf postfix removed
+    ConstString root = ResourceFinder::getConfigHome();
+    ConstString conf;
+    if (!root.empty()) {
         conf = root + NetworkBase::getDirectorySeparator() + fname;
-    } else if (homepath!="") {
-        conf = NetworkBase::getEnvironment("HOMEDRIVE") + homepath + "\\yarp\\conf\\" + fname;
-    } else if (home!="") {
-        conf = home + "/.yarp/conf/" + fname;
     } else {
-        YARP_ERROR(Logger::get(),"Cannot read configuration - please set YARP_CONF or HOME or HOMEPATH");
-        std::exit(1);
+        conf = fname;
     }
+
     YARP_DEBUG(Logger::get(),ConstString("Configuration file: ") + conf.c_str());
     return conf.c_str();
 }

--- a/src/yarp/yarp.1
+++ b/src/yarp/yarp.1
@@ -73,7 +73,6 @@ This will report where the name server location is configured. For the author's 
 
 .fi
 .PP
- If the YARP_CONF directory is set, this will be where the conf/yarp.conf file is created/read.
 .SH "yarp check"
 .PP
 Does some sanity tests of your setup. If you run 'yarp server' in one terminal, and then run this command ('yarp check') in another, you should see something like:

--- a/src/yarp/yarpconfig.cpp
+++ b/src/yarp/yarpconfig.cpp
@@ -22,8 +22,6 @@ void show_help() {
     printf("  --namespace  report file that caches the current YARP namespace\n");
     printf("  --nameserver report file that caches nameserver contact information\n");
     printf("\n");
-    printf("Setting YARP_CONF overrides the path used for namespace/nameserver cache files.\n");
-    printf("\n");
     yarp_context_help();
     yarp_robot_help();
 }

--- a/tests/integration/check-runtime.sh
+++ b/tests/integration/check-runtime.sh
@@ -43,7 +43,7 @@ make
 make install
 
 cd $base
-export YARP_CONF=$PWD
+export YARP_CONFIG_DIR=$PWD
 echo "0 0 local" > yarp.conf
 export YARP_DATA_DIRS=$PWD/fakebot/share/yarp
 


### PR DESCRIPTION
The `YARP_CONF` environment variable has been deprecated for a long time (since April 2013) and it is no longer used. Since there was not a proper warning, the warning is printed now at runtime when the variable
is set. See [`ResourceFinder::getConfigHome()` documentation](http://yarp.it/classyarp_1_1os_1_1ResourceFinder.html) for informations about paths used by YARP to detect the	configuration files.

If you still need to use the `YARP_CONF` for some reason, you can use the `YARP_CONFIG_HOME` environment variable instead.
