### PR TITLE
Bug fix for FrameTransformClient::waitForTransform

### DIFF
--- a/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
+++ b/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
@@ -605,7 +605,7 @@ bool yarp::dev::FrameTransformClient::waitForTransform(const std::string &target
 {
     //loop fintanto che ccantTRransform e' true o ppure scade timeout
     double start = yarp::os::Time::now();
-    while (canTransform(target_frame_id, source_frame_id))
+    while (!canTransform(target_frame_id, source_frame_id))
     {
         if (yarp::os::Time::now() - start > timeout)
         {


### PR DESCRIPTION
The method was blocking until a transform was **not** possible, rather then the contrary.