### PR TITLE
README.md: macOS: tap and install in a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ See full instructions at http://www.yarp.it/install.html
 
 On macOS:
 
-    brew tap robotology/cask
-    brew install yarp
+    brew install robotology/cask/yarp
 
 On Linux:
 


### PR DESCRIPTION
No need to tap and install separately. This command will do both.

Related, that repo has a confusing name. Opened https://github.com/robotology/homebrew-cask/issues/7 to discuss that.