### PR TITLE
ServerGrabber enhancement

### DIFF
--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -386,7 +386,8 @@ bool ServerGrabber::open(yarp::os::Searchable& config) {
 
 bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
 {
-    if(config.find("period").isInt())
+    if(config.check("period","refresh period(in ms) of the broadcasted values through yarp ports")
+            && config.find("period").isInt())
         period = config.find("period").asInt();
     else
         yWarning()<<"ServerGrabber: period parameter not found, using default of"<< DEFAULT_THREAD_PERIOD << "ms";
@@ -395,16 +396,20 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
         yError()<<"ServerGrabber: found both 'subdevice' and 'left_config/right_config' parameters...";
         return false;
     }
-    if(!config.check("subdevice") && config.check("left_config") && config.check("right_config"))
+    if(!config.check("subdevice", "name of the subdevice to use as a data source")
+            && config.check("left_config","name of the ini file containing the configuration of one of two subdevices to use as a data source")
+            && config.check("right_config" , "name of the ini file containing the configuration of one of two subdevices to use as a data source"))
         param.twoCameras=true;
-    if(config.check("twoCameras"))//extra conf parameter for the yarprobotinterface
+    if(config.check("twoCameras", "if true ServerGrabber will open and handle two devices, if false only one"))//extra conf parameter for the yarprobotinterface
         param.twoCameras=config.find("twoCameras").asBool();
-    if(config.check("split"))
+    if(config.check("split", "set 'true' to split the streaming on two different ports"))
         param.split=config.find("split").asBool();
-    if(config.find("capabilities").asString()=="COLOR")
-        param.cap=COLOR;
-    else if(config.find("capabilities").asString()=="RAW")
-        param.cap=RAW;
+    if(config.check("capabilities","two capabilities supported, COLOR and RAW respectively for rgb and raw streaming")){
+        if(config.find("capabilities").asString()=="COLOR")
+            param.cap=COLOR;
+        else if(config.find("capabilities").asString()=="RAW")
+            param.cap=RAW;
+    }
     else
         yWarning()<<"ServerGrabber: 'capabilities' parameter not found or mispelled, the option available are COLOR(default) and RAW, using default";
     param.canDrop = !config.check("no_drop","if present, use strict policy for sending data");

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -332,6 +332,12 @@ bool ServerGrabber::open(yarp::os::Searchable& config) {
         return false;
     }
 
+    if(!initialize_YARP(config))
+    {
+        yError() <<"ServerGrabber: Error initializing YARP ports";
+        return false;
+    }
+
     if(isSubdeviceOwned){
         if(! openAndAttachSubDevice(config))
         {
@@ -346,12 +352,6 @@ bool ServerGrabber::open(yarp::os::Searchable& config) {
         return false;
     }
 
-
-    if(!initialize_YARP(config) )
-    {
-        yError() <<"ServerGrabber: Error initializing YARP ports";
-        return false;
-    }
 
     param.active = true;
 //    //ASK/TODO update usage and see if we need to add DeviceResponder as dependency

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
@@ -77,6 +77,7 @@ typedef struct
     bool singleThreaded;
     bool twoCameras;
     bool split;
+    bool splitterMode;
     bool hasAudio;
     Capabilities cap;
 
@@ -269,6 +270,7 @@ public:
 
     void run();
 protected:
+
     bool fromConfig(yarp::os::Searchable &config);
 
     bool initialize_YARP(yarp::os::Searchable &params);

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
@@ -277,6 +277,12 @@ protected:
 
     void stopThread();
 
+    void split(const yarp::sig::Image& inputImage, yarp::sig::Image& _img, yarp::sig::Image& _img2);
+
+    void setupFlexImage(const yarp::sig::Image& img, yarp::sig::FlexImage& flex_i);
+
+    void stitch(yarp::sig::FlexImage& flex_i,const yarp::sig::Image& _img,const yarp::sig::Image& _img2);
+
     void shallowCopyImages(const yarp::sig::FlexImage& src, yarp::sig::FlexImage& dest);
 
     void cleanUp();


### PR DESCRIPTION
This PR introduces:

- The possibility to set `--split true` also if the server open one device(e.g leopard_python), the image will be splitted and sent on two separate ports. This feature has been introduced for `iCub Purple` users (cc @vvasco @arrenglover @Iaxama) 
- Description of the parameter for `yarpdev --verbose`
- Code refactoring

TODO before merging:

- [x] Tests on the robot(mainly robotinterface)
- [x] Update tests

Please review code.

PR ready to be merged :+1: 