### PR TITLE
Install missing rtf/api.h header

### DIFF
--- a/src/libYARP_rtf/CMakeLists.txt
+++ b/src/libYARP_rtf/CMakeLists.txt
@@ -8,7 +8,8 @@ project(YARP_rtf)
 
 set(YARP_rtf_HDRS include/yarp/rtf/JointsPosMotion.h
                   include/yarp/rtf/TestAsserter.h
-                  include/yarp/rtf/TestCase.h)
+                  include/yarp/rtf/TestCase.h
+                  include/yarp/rtf/api.h)
 
 set(YARP_rtf_SRCS src/JointsPosMotion.cpp
                   src/TestAsserter.cpp


### PR DESCRIPTION
Installing `rtf/api.h` fixes https://github.com/robotology/icub-tests/issues/34