### PR TITLE
Added missing include in IControlMode.h

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -92,6 +92,7 @@ Bug Fixes
 * Fixed ControlBoardRemapper not returning an error on malformed axesNames.
 * `IControlLimits2Raw` now inherits publicly from IControlLimitsRaw.
 * Fixed missing include of `yarp/dev/api.h` in `IEncoders.h` (#1127)
+* Fixed missing include of `yarp/os/Vocab.h` in `IControlMode.h` (#1199)
 
 #### YARP_math
 

--- a/src/libYARP_dev/include/yarp/dev/IControlMode.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlMode.h
@@ -7,6 +7,8 @@
 #ifndef YARP_DEV_ICONTROLMODE_H
 #define YARP_DEV_ICONTROLMODE_H
 
+#include <yarp/os/Vocab.h>
+
 namespace yarp {
     namespace dev {
     class IControlModeRaw;


### PR DESCRIPTION
VOCAB3 and VOCAB4 are defined in yarp/os/Vocab.h