### PR TITLE
yarpmanager: fix SaveAs button, before it doesn't do anything

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -123,6 +123,13 @@ Bug Fixes
 #### yarpmanager
 
 * Remove extra ';' from enviornment variables and port prefix (#980, #982).
+* Fix `saveAs` action(#755).
+* Add warning in case of creation of a new file(application) that already exists.
+* Fix double tab open of the same application.
+* Add key shortcuts for the actions.
+* Remove automatically applications, modules and resources that no longer exist on disk.
+  when double click on them or click `edit` .
+* Fix the addition to the tree of multiple applications pointing to the same xml file.
 
 #### yarplaserscannergui
 

--- a/src/libYARP_manager/include/yarp/manager/application.h
+++ b/src/libYARP_manager/include/yarp/manager/application.h
@@ -294,6 +294,7 @@ public:
     void setVersion(const char* szVersion) { if(szVersion) strVersion = szVersion; }
     void setDescription(const char* szDesc) { if(szDesc) strDescription = szDesc; }
     const char* getName(void) { return strName.c_str(); }
+    size_t getNameLenght() {return strName.length(); }
     const char* getVersion(void) { return strVersion.c_str(); }
     const char* getDescription(void) { return strDescription.c_str(); }
     virtual Node* clone(void);

--- a/src/libYARP_manager/include/yarp/manager/kbase.h
+++ b/src/libYARP_manager/include/yarp/manager/kbase.h
@@ -51,7 +51,7 @@ public:
                     ResourceLoader* _resloader);
     bool addApplication(Application* application,
                         char* szAppName_=NULL,
-                        int len=0);
+                        bool modifyName=false);
     bool addModule(Module* module);
     bool addResource(GenericResource* resource);
     bool removeApplication(Application* application);

--- a/src/libYARP_manager/include/yarp/manager/kbase.h
+++ b/src/libYARP_manager/include/yarp/manager/kbase.h
@@ -64,6 +64,8 @@ public:
                             bool bAutoDependancy=false, bool bSilent=false);
     bool checkConsistency(void);
 
+    Node* getNode(string appName);
+
     const ModulePContainer& getSelModules(void) { return selmodules; }
     const CnnContainer& getSelConnection(void) { return selconnections; }
     const ResourcePContainer& getSelResources(void) { return selresources; }

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -52,6 +52,8 @@ public:
     bool updateConnection(unsigned int id, const char* from,
                 const char* to, const char* carrier);
 
+    Node* getNode(string appName);
+
     bool run(void);
     bool run(unsigned int id, bool async=false);
     bool stop(void);

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -40,7 +40,7 @@ public:
     bool addResource(const char* szFileName);
     bool addResources(const char* szPath);
 
-    bool removeApplication(const char* szAppName);
+    bool removeApplication(const char* szFileName, const char* szAppName);
     bool removeModule(const char* szModName);
     bool removeResource(const char* szResName);
 

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -124,6 +124,7 @@ private:
     string strAppName;
     string strDefBroker;
     YarpBroker connector;
+    vector<string> listOfXml;
 
     KnowledgeBase knowledge;
     ExecutablePContainer runnables;

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -33,7 +33,7 @@ public:
             const char* szResPath, bool withWatchDog=false);
     virtual ~Manager();
 
-    bool addApplication(const char* szFileName, char* szAppName_=NULL, int len=0);
+    bool addApplication(const char* szFileName, char* szAppName_=NULL, bool modifyName=false);
     bool addApplications(const char* szPath);
     bool addModule(const char* szFileName);
     bool addModules(const char* szPath);

--- a/src/libYARP_manager/src/kbase.cpp
+++ b/src/libYARP_manager/src/kbase.cpp
@@ -1598,6 +1598,11 @@ bool KnowledgeBase::checkConsistency(void)
     return true;
 }
 
+Node* KnowledgeBase::getNode(string appName)
+{
+    return kbGraph.getNode(appName.c_str());
+}
+
 bool KnowledgeBase::constrainSatisfied(Node* node,
                                        bool bAutoDependancy,
                                        bool bSilent)

--- a/src/libYARP_manager/src/kbase.cpp
+++ b/src/libYARP_manager/src/kbase.cpp
@@ -75,7 +75,7 @@ bool KnowledgeBase::createFrom(ModuleLoader* _mloader,
 }
 
 
-bool KnowledgeBase::addApplication(Application* app, char* szAppName_, int len)
+bool KnowledgeBase::addApplication(Application* app, char* szAppName_, bool modifyName)
 {
     __CHECK_NULLPTR(app);
     ErrorLogger* logger  = ErrorLogger::Instance();
@@ -96,8 +96,11 @@ bool KnowledgeBase::addApplication(Application* app, char* szAppName_, int len)
         app->setLabel(newlable.str().c_str());
     }
 
-    if(szAppName_)
-        strncpy(szAppName_, app->getName(), len);
+    if(modifyName){
+        delete szAppName_;
+        szAppName_ = new char(app->getNameLenght());
+        strcpy(szAppName_, app->getName());
+    }
     if(!kbGraph.addNode(app))
     {
         OSTRINGSTREAM msg;

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -86,6 +86,10 @@ Manager::~Manager()
 
 bool Manager::addApplication(const char* szFileName, char* szAppName_, int len)
 {
+    if(find(listOfXml.begin(), listOfXml.end(),szFileName) == listOfXml.end())
+        listOfXml.push_back(szFileName);
+    else
+        return false;
     XmlAppLoader appload(szFileName);
     if(!appload.init())
         return false;

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -84,7 +84,7 @@ Manager::~Manager()
 }
 
 
-bool Manager::addApplication(const char* szFileName, char* szAppName_, int len)
+bool Manager::addApplication(const char* szFileName, char* szAppName_, bool modifyName)
 {
     if(find(listOfXml.begin(), listOfXml.end(),szFileName) == listOfXml.end())
         listOfXml.push_back(szFileName);
@@ -96,7 +96,8 @@ bool Manager::addApplication(const char* szFileName, char* szAppName_, int len)
     Application* application = appload.getNextApplication();
     if(!application)
         return false;
-    return knowledge.addApplication(application, szAppName_, len);
+
+    return knowledge.addApplication(application, szAppName_, modifyName);
 }
 
 

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -89,7 +89,7 @@ bool Manager::addApplication(const char* szFileName, char* szAppName_, int len)
     if(find(listOfXml.begin(), listOfXml.end(),szFileName) == listOfXml.end())
         listOfXml.push_back(szFileName);
     else
-        return false;
+        return true;//it means that the app exist already so it is safe to return true
     XmlAppLoader appload(szFileName);
     if(!appload.init())
         return false;
@@ -107,7 +107,11 @@ bool Manager::addApplications(const char* szPath)
         return false;
     Application* application;
     while((application = appload.getNextApplication()))
+    {
+        const char* currentFile = application->getXmlFile();
         knowledge.addApplication(application);
+        listOfXml.push_back(currentFile);
+    }
     return true;
 }
 
@@ -161,7 +165,7 @@ bool Manager::addResources(const char* szPath)
 }
 
 
-bool Manager::removeApplication(const char* szAppName)
+bool Manager::removeApplication(const char *szFileName, const char* szAppName)
 {
     //Note: use it with care. it is better we first check that no application
     //is loaded.
@@ -170,11 +174,10 @@ bool Manager::removeApplication(const char* szAppName)
         logger->addError("Application cannot be removed if there is a loaded application");
         return false;
     }
-
+    listOfXml.erase(std::remove(listOfXml.begin(), listOfXml.end(), szFileName), listOfXml.end());
     Application* app = knowledge.getApplication(szAppName);
     if(!app)
         return false;
-
     return knowledge.removeApplication(app);
 }
 

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -404,6 +404,11 @@ bool Manager::updateConnection(unsigned int id, const char* from,
     return true;
 }
 
+Node* Manager::getNode(string appName)
+{
+    Node* node = knowledge.getNode(appName);
+    return node;
+}
 
 bool Manager::exist(unsigned int id)
 {

--- a/src/yarpmanager/src-builder/builderwindow.cpp
+++ b/src/yarpmanager/src-builder/builderwindow.cpp
@@ -125,13 +125,26 @@ QString BuilderWindow::getFileName()
         return "";
     return QString(application->getXmlFile());
 }
-
+void BuilderWindow::setFileName(QString filename)
+{
+    Application* application = manager.getKnowledgeBase()->getApplication();
+    if(application)
+        application->setXmlFile(filename.toStdString().c_str());
+    return;
+}
 QString BuilderWindow::getAppName()
 {
     Application* application = manager.getKnowledgeBase()->getApplication();
     if(!application)
         return "";
     return QString(application->getName());
+}
+void BuilderWindow::setAppName(QString appName)
+{
+    Application* application = manager.getKnowledgeBase()->getApplication();
+    if(application)
+        application->setName(appName.toStdString().c_str());
+    return;
 }
 
 void BuilderWindow::prepareManagerFrom(Manager* lazy,

--- a/src/yarpmanager/src-builder/builderwindow.h
+++ b/src/yarpmanager/src-builder/builderwindow.h
@@ -57,7 +57,9 @@ public:
     void setOutputPortAvailable(QString, bool);
     void setInputPortAvailable(QString, bool);
     QString getFileName();
+    void setFileName(QString filename);
     QString getAppName();
+    void setAppName(QString appName);
 
     QToolBar *getToolBar();
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -184,12 +184,26 @@ QString ApplicationViewWidget::getFileName()
     return "";
 }
 
+void ApplicationViewWidget::setFileName(QString filename)
+{
+    if(builder)
+        builder->setFileName(filename);
+    return;
+}
+
 QString ApplicationViewWidget::getAppName()
 {
     if (builder) {
         return builder->getAppName();
     }
     return "";
+}
+
+void ApplicationViewWidget::setAppName(QString appName)
+{
+    if(builder)
+        builder->setAppName(appName);
+    return;
 }
 
 ApplicationViewWidget::~ApplicationViewWidget()

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -178,31 +178,41 @@ bool ApplicationViewWidget::save()
 
 QString ApplicationViewWidget::getFileName()
 {
-    return app->getXmlFile();
+
+    if (app)
+        return app->getXmlFile();
+    else if (builder)
+        return builder->getFileName();
+    else
+        return "";
 }
 
 void ApplicationViewWidget::setFileName(QString filename)
 {
-    app->setXmlFile(filename.toStdString().c_str());
-    if(builder)
+    if (app)
+        app->setXmlFile(filename.toStdString().c_str());
+    if (builder)
         builder->setFileName(filename);
     return;
 }
 
 QString ApplicationViewWidget::getAppName()
 {
-    if (builder) {
+    if (app)
+        return app->getName();
+    else if (builder) {
         return builder->getAppName();
     }
     else
-        return app->getName();
+        return "";
 }
 
 void ApplicationViewWidget::setAppName(QString appName)
 {
-    app->setName(appName.toStdString().c_str());
-    if(builder)
+    if (builder)
         builder->setAppName(appName);
+    if (app)
+        app->setName(appName.toStdString().c_str());
     return;
 }
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -180,8 +180,12 @@ QString ApplicationViewWidget::getFileName()
 {
 
     if (app)
-        return app->getXmlFile();
-    else if (builder)
+    {
+        const char* ret = app->getXmlFile();
+        if (ret)
+            return ret;
+    }
+    if (builder)
         return builder->getFileName();
     else
         return "";
@@ -199,8 +203,12 @@ void ApplicationViewWidget::setFileName(QString filename)
 QString ApplicationViewWidget::getAppName()
 {
     if (app)
-        return app->getName();
-    else if (builder) {
+    {
+        const char* ret = app->getName();
+        if (ret)
+            return ret;
+    }
+    if (builder) {
         return builder->getAppName();
     }
     else

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -178,14 +178,12 @@ bool ApplicationViewWidget::save()
 
 QString ApplicationViewWidget::getFileName()
 {
-    if (builder) {
-        return builder->getFileName();
-    }
-    return "";
+    return app->getXmlFile();
 }
 
 void ApplicationViewWidget::setFileName(QString filename)
 {
+    app->setXmlFile(filename.toStdString().c_str());
     if(builder)
         builder->setFileName(filename);
     return;
@@ -196,11 +194,13 @@ QString ApplicationViewWidget::getAppName()
     if (builder) {
         return builder->getAppName();
     }
-    return "";
+    else
+        return app->getName();
 }
 
 void ApplicationViewWidget::setAppName(QString appName)
 {
+    app->setName(appName.toStdString().c_str());
     if(builder)
         builder->setAppName(appName);
     return;

--- a/src/yarpmanager/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager/src-manager/applicationviewwidget.h
@@ -70,7 +70,9 @@ public:
 
     bool save();
     QString getFileName();
+    void setFileName(QString filename);
     QString getAppName();
+    void setAppName(QString appName);
 
     bool isEditingMode();
 

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -219,18 +219,45 @@ void EntitiesTreeWidget::onItemDoubleClicked(QTreeWidgetItem *item,int column)
 
     if (item->data(0,Qt::UserRole).toInt()  == (int)yarp::manager::APPLICATION) {
         yarp::manager::Application *app = (yarp::manager::Application*)item->data(0,Qt::UserRole + 1).toLongLong();
-        viewApplication(app);
+        if(app)
+        {
+            QString fileName = QString("%1").arg(app->getXmlFile());
+
+            QFile file(fileName);
+            if(!file.exists()){
+                missingFile=true;
+                onRemove();
+                return;
+            }
+            viewApplication(app);
+        }
     }
 
     if (item->data(0,Qt::UserRole).toInt()  == (int)yarp::manager::MODULE) {
         yarp::manager::Module *mod = (yarp::manager::Module*)item->data(0,Qt::UserRole + 1).toLongLong();
         if (mod) {
+            QString fileName = QString("%1").arg(mod->getXmlFile());
+
+            QFile file(fileName);
+            if(!file.exists()){
+                missingFile=true;
+                onRemove();
+                return;
+            }
             viewModule(mod);
         }
     }
 
     if (item->data(0,Qt::UserRole).toInt()  == (int)yarp::manager::RESOURCE) {
         yarp::manager::Computer *res = (yarp::manager::Computer*)item->data(0,Qt::UserRole + 1).toLongLong();
+        QString fileName = QString("%1").arg(res->getXmlFile());
+
+        QFile file(fileName);
+        if(!file.exists()){
+            missingFile=true;
+            onRemove();
+            return;
+        }
         viewResource(res);
     }
 
@@ -452,7 +479,17 @@ void EntitiesTreeWidget::onEditApplication()
     if (it->parent() == applicationNode) {
         if (it->data(0,Qt::UserRole)  == yarp::manager::APPLICATION) {
             yarp::manager::Application *app = (yarp::manager::Application*)it->data(0,Qt::UserRole + 1).toLongLong();
-            viewApplication(app,true);
+            if(app){
+                QString fileName = QString("%1").arg(app->getXmlFile());
+
+                QFile file(fileName);
+                if(!file.exists()){
+                    missingFile=true;
+                    onRemove();
+                    return;
+                }
+                viewApplication(app,true);
+            }
         }
     }
 }
@@ -541,6 +578,7 @@ void EntitiesTreeWidget::onReopen()
                 if(!file.exists()){
                     missingFile=true;
                     onRemove();
+                    return;
                 }
 
                 reopenApplication(appName,fileName);

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -23,6 +23,7 @@
 EntitiesTreeWidget::EntitiesTreeWidget(QWidget *parent) : QTreeWidget(parent)
 {
 
+    missingFile = false;
     applicationNode = new QTreeWidgetItem(this,QStringList() << "Application");
     modulesNode = new QTreeWidgetItem(this,QStringList() << "Modules");
     resourcesNode = new QTreeWidgetItem(this,QStringList() << "Resources");
@@ -536,6 +537,12 @@ void EntitiesTreeWidget::onReopen()
                 QString fileName = QString("%1").arg(app->getXmlFile());
                 QString appName = it->text(0);
 
+                QFile file(fileName);
+                if(!file.exists()){
+                    missingFile=true;
+                    onRemove();
+                }
+
                 reopenApplication(appName,fileName);
             }
 
@@ -546,6 +553,11 @@ void EntitiesTreeWidget::onReopen()
             if (res) {
                 QString fileName = QString("%1").arg(res->getXmlFile());
                 QString resName = it->text(0);
+                QFile file(fileName);
+                if(!file.exists()){
+                    missingFile=true;
+                    onRemove();
+                }
 
                 reopenResource(resName,fileName);
             }
@@ -556,6 +568,11 @@ void EntitiesTreeWidget::onReopen()
             if (mod) {
                 QString fileName = QString("%1").arg(mod->getXmlFile());
                 QString modName = it->text(0);
+                QFile file(fileName);
+                if(!file.exists()){
+                    missingFile=true;
+                    onRemove();
+                }
 
                 reopenModule(modName,fileName);
             }
@@ -579,7 +596,7 @@ void EntitiesTreeWidget::onRemove()
 
 
 
-    if (QMessageBox::question(this,"Removing","Are you sure to remove this item?") == QMessageBox::Yes) {
+    if (missingFile || QMessageBox::question(this,"Removing","Are you sure to remove this item?") == QMessageBox::Yes) {
 
         if (item->parent() == applicationNode) {
             if (item->data(0,Qt::UserRole)  == yarp::manager::APPLICATION) {
@@ -610,7 +627,6 @@ void EntitiesTreeWidget::onRemove()
         }
 
         while(item->childCount()>0) {
-            cout<<"removing "<<item->child(0)->text(0).toStdString()<<" the father is "<<item->text(0).toStdString();
             delete item->takeChild(0);
         }
 
@@ -618,5 +634,6 @@ void EntitiesTreeWidget::onRemove()
             int index = item->parent()->indexOfChild(item);
             delete item->parent()->takeChild(index);
         }
+        missingFile = false;
     }
 }

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -358,7 +358,7 @@ void EntitiesTreeWidget::mousePressEvent(QMouseEvent *event)
 
 /*! \brief Clear the application node
 */
-void EntitiesTreeWidget::clearApplication()
+void EntitiesTreeWidget::clearApplications()
 {
     if (!applicationNode) {
         return;

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -403,6 +403,13 @@ void EntitiesTreeWidget::clearTemplates()
     }
 }
 
+QTreeWidgetItem * EntitiesTreeWidget::getWidgetItemByFilename(const QString xmlFile){
+    QList<QTreeWidgetItem*> clist = this->findItems(xmlFile, Qt::MatchContains|Qt::MatchRecursive, 0);
+    if (clist.size())
+        return clist.at(0)->parent();
+    return YARP_NULLPTR;
+}
+
 /*! \brief Called when a context menu has been requested
     \param p the point where the context menu should appear
 */
@@ -579,7 +586,8 @@ void EntitiesTreeWidget::onRemove()
                 yarp::manager::Application *app = (yarp::manager::Application*)item->data(0,Qt::UserRole + 1).toLongLong();
                 if (app) {
                     QString appName = item->text(0);
-                    removeApplication(appName);
+                    QString xmlFile = app->getXmlFile();
+                    removeApplication(xmlFile,appName);
                 }
 
             }
@@ -602,6 +610,7 @@ void EntitiesTreeWidget::onRemove()
         }
 
         while(item->childCount()>0) {
+            cout<<"removing "<<item->child(0)->text(0).toStdString()<<" the father is "<<item->text(0).toStdString();
             delete item->takeChild(0);
         }
 

--- a/src/yarpmanager/src-manager/entitiestreewidget.h
+++ b/src/yarpmanager/src-manager/entitiestreewidget.h
@@ -63,6 +63,8 @@ private:
 
     QString ext_editor;
 
+    bool missingFile;
+
 
 signals:
     void viewResource(yarp::manager::Computer*);

--- a/src/yarpmanager/src-manager/entitiestreewidget.h
+++ b/src/yarpmanager/src-manager/entitiestreewidget.h
@@ -35,6 +35,8 @@ public:
     void clearResources();
     void clearTemplates();
 
+    QTreeWidgetItem * getWidgetItemByFilename(const QString xmlFile);
+
     void setExtEditor(string editor);
 
 protected:
@@ -68,7 +70,7 @@ signals:
     void viewApplication(yarp::manager::Application*, bool editing = false);
     void importFiles();
     void openFiles();
-    void removeApplication(QString);
+    void removeApplication(QString,QString);
     void removeModule(QString);
     void removeResource(QString);
     void reopenApplication(QString, QString);

--- a/src/yarpmanager/src-manager/entitiestreewidget.h
+++ b/src/yarpmanager/src-manager/entitiestreewidget.h
@@ -30,7 +30,7 @@ public:
     void addModule(yarp::manager::Module* mod);
     void addAppTemplate(yarp::manager::AppTemplate* tmp);
 
-    void clearApplication();
+    void clearApplications();
     void clearModules();
     void clearResources();
     void clearTemplates();

--- a/src/yarpmanager/src-manager/genericviewwidget.cpp
+++ b/src/yarpmanager/src-manager/genericviewwidget.cpp
@@ -27,6 +27,11 @@ bool GenericViewWidget::isModified()
     return m_modified;
 }
 
+void GenericViewWidget::setModified(bool mod)
+{
+    m_modified=mod;
+}
+
 void GenericViewWidget::onModified(bool mod)
 {
     this->m_modified = mod;

--- a/src/yarpmanager/src-manager/genericviewwidget.h
+++ b/src/yarpmanager/src-manager/genericviewwidget.h
@@ -28,6 +28,7 @@ public:
     explicit GenericViewWidget(QWidget *parent = 0);
     yarp::manager::NodeType getType();
     bool isModified();
+    void setModified(bool mod);
 
 protected:
     yarp::manager::NodeType type;

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -751,6 +751,7 @@ bool MainWindow::onTabClose(int index)
             }
 
         }
+        QString prova = aw->getFileName();
         listOfApplicationsOpen.erase(std::remove(listOfApplicationsOpen.begin(), listOfApplicationsOpen.end(), aw->getFileName()), listOfApplicationsOpen.end());
         aw->closeManager();
     }
@@ -1103,8 +1104,6 @@ void MainWindow::onSaveAs()
         return;
     }
 
-    //onTabClose() //useful for checking I'm overwriting a xml if I have to stop the applications or not..
-
     GenericViewWidget *w = (GenericViewWidget *)ui->mainTabs->currentWidget();
     if(!w){
         return;
@@ -1112,6 +1111,8 @@ void MainWindow::onSaveAs()
     yarp::manager::NodeType type = ((GenericViewWidget*)w)->getType();
     if(type == yarp::manager::APPLICATION){
         ApplicationViewWidget *ww = (ApplicationViewWidget*)w;
+        QString oldAppName = ww->getAppName();
+        QString oldFileName = ww->getFileName();
         ww->setFileName(fileName);
         size_t it1 = fileName.toStdString().find(".xml");
         if(it1 == string::npos)
@@ -1120,36 +1121,31 @@ void MainWindow::onSaveAs()
             return;
         }
         QString appName = fileName.toStdString().substr(0,it1).c_str();
-        QString shortAppName; // without the path
         size_t it2 =appName.toStdString().find_last_of("/");
-        cout<<it2<<endl;
         if(it2 != string::npos)
         {
-            shortAppName = appName.toStdString().substr(it2+1).c_str();
+            currentAppName = appName.toStdString().substr(it2+1).c_str();
         }
         else
         {
-            shortAppName = appName;
+            currentAppName = appName;
         }
-        ww->setAppName(shortAppName);
-    }
-    if(fileName.isEmpty()){
-        return;
-    }
-
-    if(lazyManager.addApplication(fileName.toLatin1().data())){
+        ww->setAppName(currentAppName);
+        if(fileName.isEmpty()){
+            return;
+        }
+        reportErrors();
+        onSave();
+        ww->setAppName(oldAppName);
+        ww->setFileName(oldFileName);
+        onTabClose(ui->mainTabs->currentIndex());
         syncApplicationList();
+        Application* newApp = (Application*) lazyManager.getNode(currentAppName.toStdString());
+        if (newApp)
+        {
+            viewApplication(newApp,true);
+        }
     }
-
-    if(lazyManager.addResource(fileName.toLatin1().data())){
-        syncApplicationList();
-    }
-    if(lazyManager.addModule(fileName.toLatin1().data())){
-        syncApplicationList();
-    }
-    reportErrors();
-    onSave();
-
 }
 
 /*! \brief Open File (Modules, Applications, Resources) */

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -123,6 +123,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(this,SIGNAL(selectItem(QString)),ui->entitiesTree,SLOT(onSelectItem(QString)));
 
+    //Adding actions for making the window listen key events(shortcuts)
+    this->addAction(ui->actionQuit);
+    this->addAction(ui->actionSave);
+    this->addAction(ui->actionSave_As);
+    this->addAction(ui->actionClose);
     onTabChangeItem(-1);
 
     ui->action_Manager_Window->setChecked(true);
@@ -312,7 +317,7 @@ void MainWindow::reportErrors()
  */
 void MainWindow::syncApplicationList(QString selectNodeForEditing)
 {
-    ui->entitiesTree->clearApplication();
+    ui->entitiesTree->clearApplications();
     ui->entitiesTree->clearModules();
     ui->entitiesTree->clearResources();
     //ui->entitiesTree->clearTemplates();
@@ -916,12 +921,15 @@ void MainWindow::onNewApplication()
         currentAppVersion = newApplicationWizard->version;
         fileName = newApplicationWizard->fileName;
         initializeFile("Application");
+        char* appName;
+        appName = new char (newApplicationWizard->name.toLatin1().size());
+        strcpy(appName, newApplicationWizard->name.toLatin1().data());
 
         if (lazyManager.addApplication(newApplicationWizard->fileName.toLatin1().data(),
-                                      newApplicationWizard->name.toLatin1().data()))
+                                      appName,true))
         {
-
-            syncApplicationList(newApplicationWizard->name);
+            QString newApp(appName);
+            syncApplicationList(newApp);
 
         }
         else
@@ -929,6 +937,7 @@ void MainWindow::onNewApplication()
             reportErrors();
         }
 
+        delete appName;
         delete newApplicationWizard;
         QFile f(fileName);
         f.remove();

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -705,7 +705,8 @@ bool MainWindow::onTabClose(int index)
 
         if (!aw)
         {
-            yWarning("ApplicationViewWidget is NULL!");
+            yError("ApplicationViewWidget is NULL!");
+            return false;
         }
 
         if(aw && aw->isRunning()){

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -56,6 +56,8 @@ private:
     QString currentAppDescription;
     QString currentAppVersion;
 
+    vector<QString> listOfApplicationsOpen;
+
     EntitiesTreeWidget *entitiesTree;
     QToolBar *builderToolBar;
     GenericViewWidget *prevWidget;

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -101,7 +101,7 @@ public slots:
     void viewResource(yarp::manager::Computer *res);
     void viewApplication(yarp::manager::Application *app, bool editingMode);
 
-    void onRemoveApplication(QString);
+    void onRemoveApplication(QString , QString);
     void onRemoveModule(QString);
     void onRemoveResource(QString);
     void onReopenApplication(QString,QString);

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -50,6 +50,7 @@ private:
     Ui::MainWindow *ui;
     yarp::manager::Manager lazyManager;
     yarp::os::Property config;
+    QString fileName;
 
     EntitiesTreeWidget *entitiesTree;
     QToolBar *builderToolBar;
@@ -63,6 +64,7 @@ protected:
 
 private slots:
     void onSave();
+    void onSaveAs();
     void onOpen();
     void onClose();
     void onImportFiles();

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -45,12 +45,16 @@ private:
     void syncApplicationList(QString selectNodeForEditing = "");
     bool loadRecursiveTemplates(const char* szPath);
     bool loadRecursiveApplications(const char* szPath);
+    bool initializeFile(string _class);
 
 private:
     Ui::MainWindow *ui;
     yarp::manager::Manager lazyManager;
     yarp::os::Property config;
     QString fileName;
+    QString currentAppName;
+    QString currentAppDescription;
+    QString currentAppVersion;
 
     EntitiesTreeWidget *entitiesTree;
     QToolBar *builderToolBar;

--- a/src/yarpmanager/src-manager/mainwindow.ui
+++ b/src/yarpmanager/src-manager/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>YARP module manager</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../res.qrc">
+   <iconset resource="../../yarplogger/res.qrc">
     <normaloff>:/logo.svg</normaloff>:/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -221,7 +221,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>19</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="nativeMenuBar">
@@ -350,14 +350,20 @@
    <property name="text">
     <string>Open File</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
   </action>
   <action name="actionClose">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/close.svg</normaloff>:/close.svg</iconset>
    </property>
    <property name="text">
     <string>Close</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
    </property>
   </action>
   <action name="actionSave">
@@ -371,6 +377,9 @@
    <property name="text">
     <string>Save</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
   </action>
   <action name="actionSave_As">
    <property name="enabled">
@@ -383,10 +392,13 @@
    <property name="text">
     <string>Save As</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
+   </property>
   </action>
   <action name="actionImport_Files">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/folder-new.svg</normaloff>:/folder-new.svg</iconset>
    </property>
    <property name="text">
@@ -395,11 +407,14 @@
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/close.svg</normaloff>:/close.svg</iconset>
    </property>
    <property name="text">
     <string>Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
   </action>
   <action name="actionSelect_All">
@@ -422,16 +437,19 @@
   </action>
   <action name="actionRun">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/play.svg</normaloff>:/play.svg</iconset>
    </property>
    <property name="text">
     <string>Run</string>
    </property>
+   <property name="shortcut">
+    <string>F5</string>
+   </property>
   </action>
   <action name="actionStop">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpdataplayer/src/RC/res.qrc">
      <normaloff>:/stop.svg</normaloff>:/stop.svg</iconset>
    </property>
    <property name="text">
@@ -523,6 +541,8 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../yarpdataplayer/src/RC/res.qrc"/>
+  <include location="../../yarplogger/res.qrc"/>
   <include location="../res.qrc"/>
  </resources>
  <connections/>

--- a/src/yarpmanager/src-manager/newapplicationwizard.cpp
+++ b/src/yarpmanager/src-manager/newapplicationwizard.cpp
@@ -142,6 +142,23 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
 
     connect(browseBtn,SIGNAL(clicked()),this,SLOT(onBrowse()));
     connect(nameEdit,SIGNAL(textChanged(QString)),this,SLOT(onNameChanged(QString)));
+    connect(folderCombo,SIGNAL(activated(int)),
+            this,SLOT(onSwitchCall()));
+
+}
+
+void NewApplicationWizard::checkFileAlreadyExists(){
+    buildFileName();
+    if(fileExists(this->fileName))
+    {
+        fileEdit->setStyleSheet("color: #FF0000");
+        alreadyExists = true;
+    }
+    else
+    {
+        fileEdit->setStyleSheet("color: #000000");
+        alreadyExists = false;
+    }
 
 }
 
@@ -151,22 +168,17 @@ void NewApplicationWizard::onNameChanged(QString name)
     if(!name.isEmpty())
     {
         fileEdit->setText(QString("%1.xml").arg(name.toLatin1().data()));
-        buildFileName();
-        if(fileExists(this->fileName))
-        {
-            fileEdit->setStyleSheet("color: #FF0000");
-            alreadyExists = true;
-        }
-        else
-        {
-            fileEdit->setStyleSheet("color: #000000");
-            alreadyExists = false;
-        }
+        checkFileAlreadyExists();
     }
     else
     {
         fileEdit->setText("");
     }
+}
+
+void NewApplicationWizard::onSwitchCall()
+{
+    checkFileAlreadyExists();
 }
 
 bool NewApplicationWizard::fileExists(QString path) {
@@ -205,6 +217,7 @@ void NewApplicationWizard::onBrowse( )
     if(!dir.isEmpty()){
         folderCombo->addItem(dir);
         folderCombo->setCurrentText(dir);
+        folderCombo->activated(folderCombo->count());
     }
 
 }

--- a/src/yarpmanager/src-manager/newapplicationwizard.cpp
+++ b/src/yarpmanager/src-manager/newapplicationwizard.cpp
@@ -142,14 +142,13 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
 
     connect(browseBtn,SIGNAL(clicked()),this,SLOT(onBrowse()));
     connect(nameEdit,SIGNAL(textChanged(QString)),this,SLOT(onNameChanged(QString)));
-    connect(folderCombo,SIGNAL(activated(int)),
-            this,SLOT(onSwitchCall()));
+    connect(folderCombo, SIGNAL(activated(int)), this, SLOT(onSwitchCall()));
 
 }
 
 void NewApplicationWizard::checkFileAlreadyExists(){
     buildFileName();
-    if(fileExists(this->fileName))
+    if (fileExists(this->fileName))
     {
         fileEdit->setStyleSheet("color: #FF0000");
         alreadyExists = true;
@@ -165,7 +164,7 @@ void NewApplicationWizard::checkFileAlreadyExists(){
 
 void NewApplicationWizard::onNameChanged(QString name)
 {
-    if(!name.isEmpty())
+    if (!name.isEmpty())
     {
         fileEdit->setText(QString("%1.xml").arg(name.toLatin1().data()));
         checkFileAlreadyExists();
@@ -196,11 +195,11 @@ bool NewApplicationWizard::fileExists(QString path) {
 
 void NewApplicationWizard::buildFileName(){
     QString sep="";
-    if(folderCombo->currentText().at(folderCombo->currentText().size()-1) != '/') //checking if the path terminate with / or not
+    if (folderCombo->currentText().at(folderCombo->currentText().size()-1) != '/') //checking if the path terminate with / or not
         #ifdef WIN32
-            sep="\\";
+            {sep="\\";}
         #else
-            sep="/";
+            {sep="/";}
         #endif
     this->fileName = QString("%1"+sep+"%2").arg(folderCombo->currentText().toLatin1().data()).arg(fileEdit->text().toLatin1().data());
 }
@@ -225,27 +224,26 @@ void NewApplicationWizard::onBrowse( )
 
 void NewApplicationWizard::accept()
 {
-    if(nameEdit->text().isEmpty()){
+    if (nameEdit->text().isEmpty()){
         name = nameEdit->placeholderText();
     }else{
         name = nameEdit->text();
     }
-    if(descrEdit->text().isEmpty()){
+    if (descrEdit->text().isEmpty()){
         description = descrEdit->placeholderText();
     }else{
         description = descrEdit->text();
     }
-    if(versionEdit->text().isEmpty()){
+    if (versionEdit->text().isEmpty()){
         version = versionEdit->placeholderText();
     }else{
         version = versionEdit->text();
     }
     buildFileName();
-    if(alreadyExists)
+    if (alreadyExists)
     {
         QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(this, "Quit","The file choosen already exists, do you want to overwrite it?",
-                                      QMessageBox::Yes|QMessageBox::No);
+        reply = QMessageBox::question(this, "Quit", "The file choosen already exists, do you want to overwrite it?", QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
         {
             QDialog::reject();

--- a/src/yarpmanager/src-manager/newapplicationwizard.cpp
+++ b/src/yarpmanager/src-manager/newapplicationwizard.cpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 
 #include <yarp/manager/ymm-dir.h>
+#include <yarp/os/Network.h>
 
 using namespace std;
 using namespace yarp::manager;
@@ -70,6 +71,7 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
 
 
     browseBtn = new QPushButton("...");
+    browseBtn->setDisabled(saveAs);
 
 
 
@@ -195,12 +197,11 @@ bool NewApplicationWizard::fileExists(QString path) {
 
 void NewApplicationWizard::buildFileName(){
     QString sep="";
-    if (folderCombo->currentText().at(folderCombo->currentText().size()-1) != '/') //checking if the path terminate with / or not
-        #ifdef WIN32
-            {sep="\\";}
-        #else
-            {sep="/";}
-        #endif
+    //checking if the path terminate with / or not
+    if (folderCombo->currentText().at(folderCombo->currentText().size()-1) != '/')
+    {
+        sep = yarp::os::Network::getDirectorySeparator().c_str();
+    }
     this->fileName = QString("%1"+sep+"%2").arg(folderCombo->currentText().toLatin1().data()).arg(fileEdit->text().toLatin1().data());
 }
 

--- a/src/yarpmanager/src-manager/newapplicationwizard.h
+++ b/src/yarpmanager/src-manager/newapplicationwizard.h
@@ -24,6 +24,7 @@ public:
     QString version;
     QString authors;
     QString fileName;
+    bool alreadyExists;
 
 private:
     QLabel *nameLbl;
@@ -41,7 +42,6 @@ private:
     QLineEdit *fileEdit;
 
     yarp::os::Property *m_config;
-    bool alreadyExists;
     bool saveAs;
 
 

--- a/src/yarpmanager/src-manager/newapplicationwizard.h
+++ b/src/yarpmanager/src-manager/newapplicationwizard.h
@@ -16,7 +16,7 @@ class NewApplicationWizard : public QWizard
 {
     Q_OBJECT
 public:
-    NewApplicationWizard(yarp::os::Property *);
+    NewApplicationWizard(yarp::os::Property * config, bool _saveAs=false);
 
 public:
     QString name;
@@ -41,6 +41,8 @@ private:
     QLineEdit *fileEdit;
 
     yarp::os::Property *m_config;
+    bool alreadyExists;
+    bool saveAs;
 
 
 
@@ -50,6 +52,8 @@ signals:
 private slots:
     void onBrowse();
     void onNameChanged(QString name);
+    bool fileExists(QString path);
+    void buildFileName();
 
 public slots:
     void accept();

--- a/src/yarpmanager/src-manager/newapplicationwizard.h
+++ b/src/yarpmanager/src-manager/newapplicationwizard.h
@@ -51,7 +51,9 @@ signals:
 
 private slots:
     void onBrowse();
+    void checkFileAlreadyExists();
     void onNameChanged(QString name);
+    void onSwitchCall();
     bool fileExists(QString path);
     void buildFileName();
 


### PR DESCRIPTION
The changes introduced by this PR fix #755:

TODO before merging
- [x] fix `actionSave_As` 
- [x] Add warning in case of a new file created with the same name
- [x] Fix of addition to the tree of multiple application pointing to the same xml file
- [x] Fix double tab open of the same application
- [x] add shortcuts for the actions
- [x] tests
- [x] update yarp changelog

Ready to be merged :+1: 