### PR TITLE
ZFP carrier: update find package and code to the latest library version

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -435,7 +435,8 @@ checkandset_dependency(Libusb1)
 find_package(Stage QUIET)
 checkandset_dependency(Stage)
 
-find_package(ZFP QUIET)
+set(ZFP_REQUIRED_VERSION 0.5.1)
+find_package(ZFP ${ZFP_REQUIRED_VERSION} QUIET)
 checkandset_dependency(ZFP)
 
 find_package(OpenNI2 QUIET)

--- a/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
+++ b/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
@@ -29,31 +29,41 @@ include(SelectLibraryConfigurations)
 
 find_path(ZFP_INCLUDE_DIR
           NAMES zfp.h
-          PATHS $ENV{ZFP_DIR}/include
+          PATHS $ENV{ZFP_ROOT}/inc
+                $ENV{ZFP_ROOT}/include
           DOC "ZFP include directory")
-
 find_library(ZFP_LIBRARY_RELEASE
              NAMES ZFP zfp
-             PATHS $ENV{ZFP_DIR}/lib
+             PATHS $ENV{ZFP_ROOT}/lib
              DOC "ZFP library file (release version)")
-
 find_library(ZFP_LIBRARY_DEBUG
              NAMES ZFPd zfpd
-             PATHS $ENV{ZFP_DIR}/lib
+             PATHS $ENV{ZFP_ROOT}/lib
              DOC "ZFP library file (debug version)")
 
-mark_as_advanced(ZFP_INCLUDE_DIRS
+mark_as_advanced(ZFP_INCLUDE_DIR
                  ZFP_LIBRARY_RELEASE
                  ZFP_LIBRARY_DEBUG)
 
 select_library_configurations(ZFP)
 
-set(ZFP_INCLUDE_DIRS ${ZFP_INCLUDE_DIR})
+if(EXISTS "${ZFP_INCLUDE_DIR}/zfp.h")
+  file(STRINGS "${ZFP_INCLUDE_DIR}/zfp.h" _contents REGEX "#define ZFP_VERSION_+")
+  if(_contents)
+    string(REGEX REPLACE ".*#define ZFP_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" ZFP_MAJOR_VERSION "${_contents}")
+    string(REGEX REPLACE ".*#define ZFP_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" ZFP_MINOR_VERSION "${_contents}")
+    string(REGEX REPLACE ".*#define ZFP_VERSION_RELEASE[ \t]+([0-9]+).*" "\\1" ZFP_PATCH_VERSION "${_contents}")
+    set(ZFP_VERSION "${ZFP_MAJOR_VERSION}.${ZFP_MINOR_VERSION}.${ZFP_PATCH_VERSION}")
+  endif()
+endif()
+
 set(ZFP_LIBRARIES ${ZFP_LIBRARY})
+set(ZFP_INCLUDE_DIRS ${ZFP_INCLUDE_DIR})
 
 find_package_handle_standard_args(ZFP
                                   FOUND_VAR ZFP_FOUND
-                                  REQUIRED_VARS ZFP_LIBRARIES ZFP_INCLUDE_DIRS)
+                                  REQUIRED_VARS ZFP_LIBRARIES ZFP_INCLUDE_DIRS
+                                  VERSION_VAR ZFP_VERSION)
 
 # Set package properties if FeatureSummary was included
 if(COMMAND set_package_properties)

--- a/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
+++ b/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
@@ -9,6 +9,10 @@
 #   ZFP_INCLUDE_DIRS    - ZFP include directory
 #   ZFP_LIBRARIES       - ZFP libraries
 #   ZFP_FOUND           - if false, you cannot build anything that requires ZFP
+#   ZFP_VERSION         - ZFP version
+#   ZFP_MAJOR_VERSION   - ZFP major version
+#   ZFP_MINOR_VERSION   - ZFP minor version
+#   ZFP_PATCH_VERSION   - ZFP release version
 
 #=============================================================================
 # Copyright 2016 iCub Facility, Istituto Italiano di Tecnologia

--- a/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
+++ b/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
@@ -27,7 +27,7 @@
 include(FindPackageHandleStandardArgs)
 include(SelectLibraryConfigurations)
 
-find_path(ZFP_INCLUDE_DIRS
+find_path(ZFP_INCLUDE_DIR
           NAMES zfp.h
           PATHS $ENV{ZFP_DIR}/include
           DOC "ZFP include directory")
@@ -48,6 +48,7 @@ mark_as_advanced(ZFP_INCLUDE_DIRS
 
 select_library_configurations(ZFP)
 
+set(ZFP_INCLUDE_DIRS ${ZFP_INCLUDE_DIR})
 set(ZFP_LIBRARIES ${ZFP_LIBRARY})
 
 find_package_handle_standard_args(ZFP

--- a/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
+++ b/cmake/ycm-0.3.1/find-modules/FindZFP.cmake
@@ -27,27 +27,28 @@
 include(FindPackageHandleStandardArgs)
 include(SelectLibraryConfigurations)
 
-find_path(ZFP_INCLUDE_DIR
+find_path(ZFP_INCLUDE_DIRS
           NAMES zfp.h
-          PATHS $ENV{ZFP_ROOT}/inc
+          PATHS $ENV{ZFP_DIR}/include
           DOC "ZFP include directory")
+
 find_library(ZFP_LIBRARY_RELEASE
              NAMES ZFP zfp
-             PATHS $ENV{ZFP_ROOT}/lib
+             PATHS $ENV{ZFP_DIR}/lib
              DOC "ZFP library file (release version)")
+
 find_library(ZFP_LIBRARY_DEBUG
              NAMES ZFPd zfpd
-             PATHS $ENV{ZFP_ROOT}/lib
+             PATHS $ENV{ZFP_DIR}/lib
              DOC "ZFP library file (debug version)")
 
-mark_as_advanced(ZFP_INCLUDE_DIR
+mark_as_advanced(ZFP_INCLUDE_DIRS
                  ZFP_LIBRARY_RELEASE
                  ZFP_LIBRARY_DEBUG)
 
 select_library_configurations(ZFP)
 
 set(ZFP_LIBRARIES ${ZFP_LIBRARY})
-set(ZFP_INCLUDE_DIRS ${ZFP_INCLUDE_DIR})
 
 find_package_handle_standard_args(ZFP
                                   FOUND_VAR ZFP_FOUND

--- a/src/carriers/zfp_portmonitor/CMakeLists.txt
+++ b/src/carriers/zfp_portmonitor/CMakeLists.txt
@@ -8,26 +8,24 @@ yarp_prepare_plugin(zfp TYPE ZfpMonitorObject
                         DEPENDS "CREATE_OPTIONAL_CARRIERS;ENABLE_yarpcar_portmonitor;ZFP")
 
 if(NOT SKIP_zfp)
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+  get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
+  get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
+  include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
+  include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
 
-    set(CMAKE_INCLUDE_CURRENT_DIR ON)
-    get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
-    get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
-    include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
-    include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
+  yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
+                              zfpPortmonitor.h)
+  target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
 
-    yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
-                                zfpPortmonitor.h)
-    target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
+  yarp_install(TARGETS yarp_pm_zfp
+               EXPORT YARP
+               COMPONENT runtime
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+  yarp_install(FILES zfp.ini
+               COMPONENT runtime
+               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-    yarp_install(TARGETS yarp_pm_zfp
-                EXPORT YARP
-                COMPONENT runtime
-                LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-                ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
-    yarp_install(FILES zfp.ini
-                COMPONENT runtime
-                DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
-
-    set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
-
+  set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
 endif()

--- a/src/carriers/zfp_portmonitor/CMakeLists.txt
+++ b/src/carriers/zfp_portmonitor/CMakeLists.txt
@@ -5,37 +5,29 @@
 yarp_prepare_plugin(zfp TYPE ZfpMonitorObject
                         INCLUDE zfpPortmonitor.h
                         CATEGORY portmonitor
-                        DEPENDS "CREATE_OPTIONAL_CARRIERS;ENABLE_yarpcar_portmonitor")
+                        DEPENDS "CREATE_OPTIONAL_CARRIERS;ENABLE_yarpcar_portmonitor;ZFP")
 
 if(NOT SKIP_zfp)
 
-    if(ZFP_FOUND)
-        set(CMAKE_INCLUDE_CURRENT_DIR ON)
-        get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
-        get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
-        include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
-        include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
+    set(CMAKE_INCLUDE_CURRENT_DIR ON)
+    get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
+    get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
+    include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
+    include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
 
-        yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
-                                    zfpPortmonitor.h)
-        target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
+    yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
+                                zfpPortmonitor.h)
+    target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
 
-        yarp_install(TARGETS yarp_pm_zfp
-                    EXPORT YARP
-                    COMPONENT runtime
-                    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-                    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
-        yarp_install(FILES zfp.ini
-                    COMPONENT runtime
-                    DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+    yarp_install(TARGETS yarp_pm_zfp
+                EXPORT YARP
+                COMPONENT runtime
+                LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+    yarp_install(FILES zfp.ini
+                COMPONENT runtime
+                DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-        set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
-
-    else()
-        message("ZFP carrier: ZFP library not found. " \n
-                " Please download the 'ZFP' library from 'http://computation.llnl.gov/projects/floating-point-compression'," \n
-                " build it using cmake and install it. Set the environment variable 'ZFP_DIR' to the installation folder. " \n
-                " The ZFP_DIR has to point to the install directory, not the build directory.")
-    endif()
+    set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
 
 endif()

--- a/src/carriers/zfp_portmonitor/CMakeLists.txt
+++ b/src/carriers/zfp_portmonitor/CMakeLists.txt
@@ -8,24 +8,34 @@ yarp_prepare_plugin(zfp TYPE ZfpMonitorObject
                         DEPENDS "CREATE_OPTIONAL_CARRIERS;ENABLE_yarpcar_portmonitor")
 
 if(NOT SKIP_zfp)
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-  get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
-  get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
-  include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
-  include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
 
-  yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
-                              zfpPortmonitor.h)
-  target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
+    if(ZFP_FOUND)
+        set(CMAKE_INCLUDE_CURRENT_DIR ON)
+        get_property(YARP_OS_INCLUDE_DIRS TARGET YARP_OS PROPERTY INCLUDE_DIRS)
+        get_property(YARP_sig_INCLUDE_DIRS TARGET YARP_sig PROPERTY INCLUDE_DIRS)
+        include_directories(${YARP_OS_INCLUDE_DIRS} ${YARP_sig_INCLUDE_DIRS})
+        include_directories(SYSTEM ${ZFP_INCLUDE_DIRS})
 
-  yarp_install(TARGETS yarp_pm_zfp
-               EXPORT YARP
-               COMPONENT runtime
-               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
-  yarp_install(FILES zfp.ini
-               COMPONENT runtime
-               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+        yarp_add_plugin(yarp_pm_zfp zfpPortmonitor.cpp
+                                    zfpPortmonitor.h)
+        target_link_libraries(yarp_pm_zfp YARP_OS YARP_sig ${ZFP_LIBRARIES})
 
-  set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
+        yarp_install(TARGETS yarp_pm_zfp
+                    EXPORT YARP
+                    COMPONENT runtime
+                    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+        yarp_install(FILES zfp.ini
+                    COMPONENT runtime
+                    DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+        set_property(TARGET yarp_pm_zfp PROPERTY FOLDER "Plugins/Port Monitor")
+
+    else()
+        message("ZFP carrier: ZFP library not found. " \n
+                " Please download the 'ZFP' library from 'http://computation.llnl.gov/projects/floating-point-compression'," \n
+                " build it using cmake and install it. Set the environment variable 'ZFP_DIR' to the installation folder. " \n
+                " The ZFP_DIR has to point to the install directory, not the build directory.")
+    endif()
+
 endif()

--- a/src/carriers/zfp_portmonitor/README.md
+++ b/src/carriers/zfp_portmonitor/README.md
@@ -3,6 +3,12 @@ zfp_portmonitor plugin
 ======================================================================
 Portmonitor plugin for compression and decompression of depth images using zfp library.
 
+Compilation and installation:
+Please download the 'ZFP' library version 0.5.1 or greater from 'http://computation.llnl.gov/projects/floating-point-compression'.
+Use the CMake build system to build the library and install it.
+Set the environment variable 'ZFP_DIR' to the installation folder.
+Note: the ZFP_DIR has to point to the install directory, not to the build directory.
+
 Usage:
 -----
 

--- a/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
+++ b/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
@@ -159,8 +159,8 @@ int ZfpMonitorObject::compress(float* array, float* &compressed, int &zfpsize, i
 
     /* set compression mode and parameters via one of three functions */
     /*  zfp_stream_set_rate(zfp, rate, type, 3, 0); */
-    /*  zfp_stream_set_precision(zfp, precision, type); */
-    zfp_stream_set_accuracy(zfp, tolerance, type);
+    /*  zfp_stream_set_precision(zfp, precision); */
+    zfp_stream_set_accuracy(zfp, tolerance);
 
     /* allocate buffer for compressed data */
     bufsize = zfp_stream_maximum_size(zfp, field);
@@ -209,7 +209,7 @@ int ZfpMonitorObject::decompress(float* array, float* &decompressed, int zfpsize
     /* set compression mode and parameters via one of three functions */
     /*  zfp_stream_set_rate(zfp, rate, type, 3, 0); */
     /*  zfp_stream_set_precision(zfp, precision, type); */
-    zfp_stream_set_accuracy(zfp, tolerance, type);
+    zfp_stream_set_accuracy(zfp, tolerance);
 
     /* allocate buffer for compressed data */
     bufsize = zfp_stream_maximum_size(zfp, field);


### PR DESCRIPTION
From zfp library version 0.5.1 the library providers start using CMake as a build system.
Some function API changed, so our find package and code has been updated.
