### PR TITLE
[doc] Remove link to Urbi

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -122,7 +122,6 @@ The best way to learn how to use YARP is to read the tutorials and documentation
 \li <a href="http://playerstage.sourceforge.net/">Player/Stage</a>
 \li <a href="http://www.orocos.org/">Orocos</a>
 \li <a href="http://www.ros.org">ROS</a>
-\li <a href="http://gostai.com/products/urbi/">Urbi</a>
 
 \section yarp_papers Publications
 


### PR DESCRIPTION
This link is broken, and anyhow it seems that Urbi is not maintained anymore (see https://github.com/aldebaran/urbi)