### PR TITLE
Deprecate IControlMode::setXXXMode(int) methods

### DIFF
--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -89,6 +89,14 @@ Important Changes
   e.g. `setTorquePid(int j, const Pid &pid) -> setPid(VOCAB_PIDTYPE_TORQUE,int j,const PID &pid)`  
 * Added iMap2D interface
 * Added yarp::dev::MapGrid2D data type
+* The following methods have been deprecated, use
+  `IControlMode2::setControlMode(int, VOCAB_CM_XXX)` instead:
+  - `IControlMode::setPositionMode(int)`
+  - `IControlMode::setVelocityMode(int)`
+  - `IControlMode::setTorqueMode(int)`
+  - `IControlMode::setImpedancePositionMode(int)`
+  - `IControlMode::setImpedanceVelocityMode(int)`
+  - ...plus their IControlModeRaw counterparts
 
 
 #### YARP_math

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -2143,30 +2143,6 @@ bool FakeMotionControl::stopRaw(const int n_joint, const int *joints)
 ///////////// END Position Control INTERFACE  //////////////////
 
 // ControlMode
-bool FakeMotionControl::setPositionModeRaw(int j)
-{
-    return DEPRECATED("setPositionModeRaw");
-}
-
-bool FakeMotionControl::setVelocityModeRaw(int j)
-{
-    return DEPRECATED("setVelocityModeRaw");
-}
-
-bool FakeMotionControl::setTorqueModeRaw(int j)
-{
-    return DEPRECATED("setTorqueModeRaw");
-}
-
-bool FakeMotionControl::setImpedancePositionModeRaw(int j)
-{
-    return DEPRECATED("setImpedancePositionModeRaw");
-}
-
-bool FakeMotionControl::setImpedanceVelocityModeRaw(int j)
-{
-    return DEPRECATED("setImpedanceVelocityModeRaw");
-}
 
 // puo' essere richiesto con get
 bool FakeMotionControl::getControlModeRaw(int j, int *v)

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -335,11 +335,6 @@ public:
     /////////////////////////////// END Position Control INTERFACE
 
     // ControlMode
-    virtual bool setPositionModeRaw(int j);
-    virtual bool setVelocityModeRaw(int j);
-    virtual bool setTorqueModeRaw(int j);
-    virtual bool setImpedancePositionModeRaw(int j);
-    virtual bool setImpedanceVelocityModeRaw(int j);
     virtual bool getControlModeRaw(int j, int *v);
     virtual bool getControlModesRaw(int *v);
 

--- a/src/libYARP_dev/include/yarp/dev/IControlMode.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlMode.h
@@ -26,40 +26,60 @@ class YARP_dev_API yarp::dev::IControlMode
 public:
     virtual ~IControlMode(){}
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
     * Set position mode, single axis.
     * @param j joint number
     * @return: true/false success failure.
+    * @deprecated since YARP 2.3.70
     */
-    virtual bool setPositionMode(int j)=0;
+    YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_POSITION) instead")
+    YARP_DEPRECATED virtual bool setPositionMode(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
     * Set velocity mode, single axis.
     * @param j joint number
     * @return: true/false success failure.
+    * @deprecated since YARP 2.3.70
     */
-    virtual bool setVelocityMode(int j)=0;
+    YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_VELOCITY) instead")
+    YARP_DEPRECATED virtual bool setVelocityMode(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
     * Set torque mode, single axis.
     * @param j joint number
     * @return: true/false success failure.
+    * @deprecated since YARP 2.3.70
     */
-    virtual bool setTorqueMode(int j)=0;
+    YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_TORQUE) instead")
+    YARP_DEPRECATED virtual bool setTorqueMode(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
     * Set impedance position mode, single axis.
     * @param j joint number
     * @return: true/false success failure.
+    * @deprecated since YARP 2.3.70
     */
-    virtual bool setImpedancePositionMode(int j)=0;
+    YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_IMPEDANCE_POS) instead")
+    YARP_DEPRECATED virtual bool setImpedancePositionMode(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     /**
     * Set impedance velocity mode, single axis.
     * @param j joint number
     * @return: true/false success failure.
+    * @deprecated since YARP 2.3.70
     */
-    virtual bool setImpedanceVelocityMode(int j)=0;
+    YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_IMPEDANCE_VEL) instead")
+    YARP_DEPRECATED virtual bool setImpedanceVelocityMode(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
 
     /**
     * Get the current control mode.
@@ -89,11 +109,13 @@ class yarp::dev::IControlModeRaw
 public:
     virtual ~IControlModeRaw(){}
 
-    virtual bool setPositionModeRaw(int j)=0;
-    virtual bool setVelocityModeRaw(int j)=0;
-    virtual bool setTorqueModeRaw(int j)=0;
-    virtual bool setImpedancePositionModeRaw(int j)=0;
-    virtual bool setImpedanceVelocityModeRaw(int j)=0;
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+    YARP_DEPRECATED virtual bool setPositionModeRaw(int j) { return false; }
+    YARP_DEPRECATED virtual bool setVelocityModeRaw(int j) { return false; }
+    YARP_DEPRECATED virtual bool setTorqueModeRaw(int j) { return false; }
+    YARP_DEPRECATED virtual bool setImpedancePositionModeRaw(int j) { return false; }
+    YARP_DEPRECATED virtual bool setImpedanceVelocityModeRaw(int j) { return false; }
+#endif // YARP_NO_DEPRECATED
     virtual bool getControlModeRaw(int j, int *mode)=0;
     virtual bool getControlModesRaw(int* modes)=0;
 };

--- a/src/libYARP_dev/include/yarp/dev/IControlMode.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlMode.h
@@ -34,7 +34,7 @@ public:
     * @deprecated since YARP 2.3.70
     */
     YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_POSITION) instead")
-    YARP_DEPRECATED virtual bool setPositionMode(int j) { return false; }
+    virtual bool setPositionMode(int j) { return false; }
 #endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
@@ -45,7 +45,7 @@ public:
     * @deprecated since YARP 2.3.70
     */
     YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_VELOCITY) instead")
-    YARP_DEPRECATED virtual bool setVelocityMode(int j) { return false; }
+    virtual bool setVelocityMode(int j) { return false; }
 #endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
@@ -56,7 +56,7 @@ public:
     * @deprecated since YARP 2.3.70
     */
     YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_TORQUE) instead")
-    YARP_DEPRECATED virtual bool setTorqueMode(int j) { return false; }
+    virtual bool setTorqueMode(int j) { return false; }
 #endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
@@ -67,7 +67,7 @@ public:
     * @deprecated since YARP 2.3.70
     */
     YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_IMPEDANCE_POS) instead")
-    YARP_DEPRECATED virtual bool setImpedancePositionMode(int j) { return false; }
+    virtual bool setImpedancePositionMode(int j) { return false; }
 #endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
@@ -78,7 +78,7 @@ public:
     * @deprecated since YARP 2.3.70
     */
     YARP_DEPRECATED_MSG("Use IControlMode2::setControlMode(j, VOCAB_CM_IMPEDANCE_VEL) instead")
-    YARP_DEPRECATED virtual bool setImpedanceVelocityMode(int j) { return false; }
+    virtual bool setImpedanceVelocityMode(int j) { return false; }
 #endif // YARP_NO_DEPRECATED
 
     /**

--- a/src/libYARP_dev/include/yarp/dev/IControlMode2.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlMode2.h
@@ -27,11 +27,13 @@ class YARP_dev_API yarp::dev::IControlMode2 : public yarp::dev::IControlMode
 public:
     virtual ~IControlMode2(){}
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     using IControlMode::setPositionMode;
     using IControlMode::setVelocityMode;
     using IControlMode::setTorqueMode;
     using IControlMode::setImpedancePositionMode;
     using IControlMode::setImpedanceVelocityMode;
+#endif // YARP_NO_DEPRECATED
     using IControlMode::getControlMode;
     using IControlMode::getControlModes;
 
@@ -96,11 +98,13 @@ class yarp::dev::IControlMode2Raw: public IControlModeRaw
 public:
     virtual ~IControlMode2Raw(){}
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
     using IControlModeRaw::setPositionModeRaw;
     using IControlModeRaw::setVelocityModeRaw;
     using IControlModeRaw::setTorqueModeRaw;
     using IControlModeRaw::setImpedancePositionModeRaw;
     using IControlModeRaw::setImpedanceVelocityModeRaw;
+#endif // YARP_NO_DEPRECATED
     using IControlModeRaw::getControlModeRaw;
     using IControlModeRaw::getControlModesRaw;
 

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlMode.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlMode.h
@@ -16,6 +16,12 @@ namespace yarp {
     }
 }
 
+#if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.70
+// A class implementing setXxxxxMode(int) causes a warning on MSVC
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#endif
+
 class YARP_dev_API yarp::dev::ImplementControlMode: public IControlMode
 {
     void *helper;
@@ -25,13 +31,19 @@ public:
     bool uninitialize();
     ImplementControlMode(IControlModeRaw *v);
     ~ImplementControlMode();
-    bool setTorqueMode(int j);
-    bool setImpedancePositionMode(int j);
-    bool setImpedanceVelocityMode(int j);
-    bool setPositionMode(int j);
-    bool setVelocityMode(int j);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+    YARP_DEPRECATED bool setTorqueMode(int j);
+    YARP_DEPRECATED bool setImpedancePositionMode(int j);
+    YARP_DEPRECATED bool setImpedanceVelocityMode(int j);
+    YARP_DEPRECATED bool setPositionMode(int j);
+    YARP_DEPRECATED bool setVelocityMode(int j);
+#endif // YARP_NO_DEPRECATED
     bool getControlMode(int j, int *f);
     bool getControlModes(int *modes);
 };
+
+#if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.70
+YARP_WARNING_POP
+#endif
 
 #endif // YARP_DEV_IMPLEMENTCONTROLMODE_H

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
@@ -17,6 +17,12 @@ namespace yarp {
     }
 }
 
+#if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.70
+// A class implementing setXxxxxMode(int) causes a warning on MSVC
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#endif
+
 class YARP_dev_API yarp::dev::ImplementControlMode2: public IControlMode2
 {
     void *helper;
@@ -35,11 +41,13 @@ public:
     virtual  ~ImplementControlMode2();
 
     // Control mode
-    bool setTorqueMode(int j);
-    bool setImpedancePositionMode(int j);
-    bool setImpedanceVelocityMode(int j);
-    bool setPositionMode(int j);
-    bool setVelocityMode(int j);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+    YARP_DEPRECATED bool setTorqueMode(int j);
+    YARP_DEPRECATED bool setImpedancePositionMode(int j);
+    YARP_DEPRECATED bool setImpedanceVelocityMode(int j);
+    YARP_DEPRECATED bool setPositionMode(int j);
+    YARP_DEPRECATED bool setVelocityMode(int j);
+#endif // YARP_NO_DEPRECATED
     bool getControlMode(int j, int *f);
     bool getControlModes(int *modes);
     // Control Mode 2
@@ -49,5 +57,8 @@ public:
     bool setControlModes(int *modes);
 };
 
+#if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.70
+YARP_WARNING_POP
+#endif
 
 #endif // YARP_DEV_IMPLEMENTCONTROLMODE2_H

--- a/src/libYARP_dev/src/ControlMode2Impl.cpp
+++ b/src/libYARP_dev/src/ControlMode2Impl.cpp
@@ -60,41 +60,57 @@ bool ImplementControlMode2::uninitialize ()
     return true;
 }
 
-
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 bool ImplementControlMode2::setPositionMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setPositionModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode2::setVelocityMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setVelocityModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode2::setTorqueMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setTorqueModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode2::setImpedancePositionMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setImpedancePositionModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode2::setImpedanceVelocityMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setImpedanceVelocityModeRaw(k);
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED
 
 bool ImplementControlMode2::getControlMode(int j, int *f)
 {

--- a/src/libYARP_dev/src/ControlModeImpl.cpp
+++ b/src/libYARP_dev/src/ControlModeImpl.cpp
@@ -50,40 +50,57 @@ bool ImplementControlMode::uninitialize ()
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 bool ImplementControlMode::setPositionMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setPositionModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode::setVelocityMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setVelocityModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode::setTorqueMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setTorqueModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode::setImpedancePositionMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setImpedancePositionModeRaw(k);
+YARP_WARNING_POP
 }
 
 bool ImplementControlMode::setImpedanceVelocityMode(int j)
 {
     JOINTIDCHECK
     int k=castToMapper(helper)->toHw(j);
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     return raw->setImpedanceVelocityModeRaw(k);
+YARP_WARNING_POP
 }
+#endif // YARP_NO_DEPRECATED
 
 bool ImplementControlMode::getControlMode(int j, int *f)
 {

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -4043,107 +4043,6 @@ bool ControlBoardWrapper::getCurrentImpedanceLimit(int j, double *min_stiff, dou
     return false;
 }
 
-bool ControlBoardWrapper::setPositionMode(int j)
-{
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMode2)
-    {
-        return p->iMode2->setControlMode(off+p->base, VOCAB_CM_POSITION);
-    }
-    else
-        if (p->iMode)
-        {
-            return p->iMode->setPositionMode(off+p->base);
-        }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setTorqueMode(int j)
-{
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMode2)
-    {
-        return p->iMode2->setControlMode(off+p->base, VOCAB_CM_TORQUE);
-    }
-    else
-        if (p->iMode)
-        {
-            return p->iMode->setTorqueMode(off+p->base);
-        }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setImpedancePositionMode(int j)
-{
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-//        Let´s propagate the legacy version as is until it will be removed
-    if (p->iMode)
-    {
-        return p->iMode->setImpedancePositionMode(off+p->base);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setImpedanceVelocityMode(int j)
-{
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-//        Let´s propagate the legacy version as is until it will be removed
-    if (p->iMode)
-    {
-        return p->iMode->setImpedanceVelocityMode(off+p->base);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setVelocityMode(int j)
-{
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMode2)
-    {
-        return p->iMode2->setControlMode(off+p->base, VOCAB_CM_VELOCITY);
-    }
-    else
-        if (p->iMode)
-        {
-            return p->iMode->setVelocityMode(off+p->base);
-        }
-
-    return false;
-}
-
 bool ControlBoardWrapper::getControlMode(int j, int *mode)
 {
     int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
@@ -4207,72 +4106,6 @@ bool ControlBoardWrapper::getControlModes(const int n_joint, const int *joints, 
      return ret;
 }
 
-bool ControlBoardWrapper::legacySetControlMode(const int j, const int mode)
-{
-    bool ret = true;
-    int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    switch(mode)
-    {
-        case VOCAB_CM_IDLE:
-        {
-
-            if(p->amp)
-            {
-                ret = ret && p->amp->disableAmp(off+p->base);
-            }
-            if(p->pid)
-            {
-                ret = ret && p->pid->disablePid(VOCAB_PIDTYPE_POSITION, off+p->base);
-            }
-        }
-        break;
-
-        case VOCAB_CM_TORQUE:
-        {
-            ret = p->iMode->setTorqueMode(off+p->base);
-        }
-        break;
-
-        case VOCAB_CM_POSITION:
-        {
-            ret = p->iMode->setPositionMode(off+p->base);
-        }
-        break;
-
-        case VOCAB_CM_VELOCITY:
-        {
-            ret = p->iMode->setVelocityMode(off+p->base);
-        }
-        break;
-
-        case VOCAB_CM_IMPEDANCE_POS:
-        {
-            ret = p->iMode->setImpedancePositionMode(off+p->base);
-        }
-        break;
-
-        case VOCAB_CM_IMPEDANCE_VEL:
-        {
-            ret = p->iMode->setImpedanceVelocityMode(off+p->base);
-        }
-        break;
-
-        default:
-        {
-            yError("ControlBoardWrapper received an invalid  setControlMode %s for joint %d\n", yarp::os::Vocab::decode(mode).c_str(), j);
-            ret = false;
-        }
-        break;
-    }
-    return ret;
-}
-
 bool ControlBoardWrapper::setControlMode(const int j, const int mode)
 {
     bool ret = true;
@@ -4286,13 +4119,6 @@ bool ControlBoardWrapper::setControlMode(const int j, const int mode)
     if (p->iMode2)
     {
         ret = p->iMode2->setControlMode(off+p->base, mode);
-    }
-    else
-    {
-        if (p->iMode)
-        {
-            legacySetControlMode(j, mode);
-        }
     }
     return ret;
 }
@@ -4359,13 +4185,6 @@ bool ControlBoardWrapper::setControlModes(int *modes)
 
             ret = ret && p->iMode2->setControlModes(wrapped_joints, joints, &modes[j_wrap]);
             j_wrap+=wrapped_joints;
-        }
-        else
-        {
-            for(int j_wrap = 0; j_wrap < wrapped_joints; j_wrap++)
-            {
-                ret = ret && legacySetControlMode(j_wrap, modes[j_wrap]);
-            }
         }
 
         if(joints!=0)

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -153,7 +153,7 @@ public:
 
 
 #if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.65
-// A class implementing setXxxxxMode() causes a warning on MSVC
+// A class implementing setXxxxxMode(int) causes a warning on MSVC
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
 #endif
@@ -1157,24 +1157,12 @@ public:
 
     virtual bool getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp);
 
-    virtual bool setPositionMode(int j);
-
-    virtual bool setTorqueMode(int j);
-
-    virtual bool setImpedancePositionMode(int j);
-
-    virtual bool setImpedanceVelocityMode(int j);
-
-    virtual bool setVelocityMode(int j);
-
     virtual bool getControlMode(int j, int *mode);
 
     virtual bool getControlModes(int *modes);
 
     // iControlMode2
     virtual bool getControlModes(const int n_joint, const int *joints, int *modes);
-
-    bool legacySetControlMode(const int j, const int mode);
 
     virtual bool setControlMode(const int j, const int mode);
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -255,8 +255,13 @@ void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
                         case VOCAB_CM_POSITION:
                             if(rpc_iCtrlMode2)
                                 *ok = rpc_iCtrlMode2->setControlMode(axis, VOCAB_CM_POSITION);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
                             else
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 *ok = rpc_iCtrlMode->setPositionMode(axis);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
                         break;
 
                         case VOCAB_CM_POSITION_DIRECT:
@@ -268,29 +273,49 @@ void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
                         case VOCAB_CM_VELOCITY:
                             if(rpc_iCtrlMode2)
                                 *ok = rpc_iCtrlMode2->setControlMode(axis, VOCAB_CM_VELOCITY);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
                             else
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 *ok = rpc_iCtrlMode->setVelocityMode(axis);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
                         break;
 
                         case VOCAB_CM_TORQUE:
                             if(rpc_iCtrlMode2)
                                 *ok = rpc_iCtrlMode2->setControlMode(axis, VOCAB_CM_TORQUE);
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
                             else
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                                 *ok = rpc_iCtrlMode->setTorqueMode(axis);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
                         break;
 
                         case VOCAB_CM_IMPEDANCE_POS:
                             yError() << "The 'impedancePosition' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_POSITION) instead";
 
                             //                      Let´s propagate the legacy version as is until it will be removed
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                             *ok = rpc_iCtrlMode->setImpedancePositionMode(axis);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
                         break;
 
                         case VOCAB_CM_IMPEDANCE_VEL:
                             yError() << "The 'impedanceVelocity' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_VELOCITY) instead";
 
                             //                      Let´s propagate the legacy version as is until it will be removed
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
                             *ok = rpc_iCtrlMode->setImpedanceVelocityMode(axis);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
                         break;
 
                         case VOCAB_CM_PWM:

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2739,31 +2739,6 @@ public:
     }
 
     // IControlMode
-    bool setPositionMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_POSITION);
-    }
-
-    bool setVelocityMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_VELOCITY);
-    }
-
-    bool setTorqueMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_TORQUE);
-    }
-
-    bool setImpedancePositionMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_IMPEDANCE_POS);
-    }
-
-    bool setImpedanceVelocityMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_IMPEDANCE_VEL);
-    }
-
     bool getControlMode(int j, int *mode)
     {
         double localArrivalTime=0.0;
@@ -3377,6 +3352,21 @@ public:
         extendedPortMutex.post();
         return ret;
     }
+
+#ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
+#if !defined(_MSC_VER)
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#endif
+    YARP_DEPRECATED bool setPositionMode(int j) { return setControlMode(j,VOCAB_CM_POSITION); }
+    YARP_DEPRECATED bool setVelocityMode(int j) { return setControlMode(j,VOCAB_CM_VELOCITY); }
+    YARP_DEPRECATED bool setTorqueMode(int j) { return setControlMode(j,VOCAB_CM_TORQUE); }
+    YARP_DEPRECATED bool setImpedancePositionMode(int j) { return setControlMode(j,VOCAB_CM_IMPEDANCE_POS); }
+    YARP_DEPRECATED bool setImpedanceVelocityMode(int j) { return setControlMode(j,VOCAB_CM_IMPEDANCE_VEL); }
+#if !defined(_MSC_VER)
+YARP_WARNING_POP
+#endif
+#endif // YARP_NO_DEPRECATED
 };
 
 #if defined(_MSC_VER) && !defined(YARP_NO_DEPRECATED) // since YARP 2.3.65

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2744,11 +2744,6 @@ public:
         return setControlMode(j,VOCAB_CM_POSITION);
     }
 
-    bool setPositionDirectMode(int j)
-    {
-        return setControlMode(j,VOCAB_CM_POSITION_DIRECT);
-    }
-
     bool setVelocityMode(int j)
     {
         return setControlMode(j,VOCAB_CM_VELOCITY);


### PR DESCRIPTION
Unused, doesn't belong to any controlboard interface, leads to confusion due to the recent deletion of `IPositionDirect::setPositionDirectMode`.