### PR TITLE
yarp::os::ThreadStats

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -106,6 +106,11 @@ Important Changes
 New Features
 ------------
 
+#### `YARP OS`
+
+* New `ThreadStats` and `MultipleThreadStats` classes for calculating statistic informations
+  on periodic functions.
+
 ### Libraries
 
 * New auto-generated interface libraries for ros messages:

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -112,6 +112,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Terminator.h
                  include/yarp/os/Things.h
                  include/yarp/os/Thread.h
+                 include/yarp/os/ThreadStats.h
                  include/yarp/os/Time.h
                  include/yarp/os/Timer.h
                  include/yarp/os/TwoWayStream.h
@@ -312,6 +313,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/Things.cpp
                  src/Thread.cpp
                  src/ThreadImpl.cpp
+                 src/ThreadStats.cpp
                  src/Time.cpp
                  src/Timer.cpp
                  src/TwoWayStream.cpp

--- a/src/libYARP_OS/include/yarp/os/ThreadStats.h
+++ b/src/libYARP_OS/include/yarp/os/ThreadStats.h
@@ -186,3 +186,130 @@ public:
      */
     void getEstUsed(double& av, double& std);
 };
+
+class YARP_OS_API yarp::os::MultipleThreadStats {
+private:
+    std::map<ThreadStats::ThreadId, yarp::os::ThreadStats> m_threads_stats;
+
+    // Constant values
+    // ===============
+    double m_period;
+    double m_window_length;
+    unsigned m_bins_pitch_ms;
+
+    // Private methods
+    // ===============
+    yarp::os::ConstString _messagePrefix() const;
+
+public:
+    /**
+     * Constructor of MultipleThreadStats object
+     * @param period Default value of ThreadStats objects created with
+     *                insertThreadStats(const ThreadStats&)
+     * @param window_length Default value of ThreadStats objects created with
+     *                       insertThreadStats(const ThreadStats&)
+     * @param bins_pitch_ms Default value of ThreadStats objects created with
+     *                               insertThreadStats(const ThreadStats&)
+     */
+    MultipleThreadStats(const double& period,
+                        const double& window_length   = WINDOW_LENGTH_DEFAULT,
+                        const unsigned& bins_pitch_ms = BINS_PITCH_MS_DEFAULT);
+
+    ~MultipleThreadStats() = default;
+
+    // Public API
+    // ==========
+
+    /**
+     * Insert a new ThreadStats object. Its `thread_id` must be unique.
+     *
+     * @param ts The ThreadStats object
+     * @return True if the insertion succeeded
+     */
+    bool insertThreadStats(const yarp::os::ThreadStats& ts);
+
+    /**
+     * Remove the ThreadStats object indexed by `t_id`
+     *
+     * @param t_id The id of the ThreadStats object to remove
+     * @return true if the removal succeeded
+     */
+    bool removeThreadStats(const ThreadStats::ThreadId& id);
+
+    /**
+     * Create a new handled ThreadStats object.
+     *
+     * @see insertThreadStats() for inserting an already existing ThreadStats object
+     * @see ThreadStats::ThreadStats(const double&, const double&, const unsigned&, const ThreadId&)
+     *
+     * @param t_id The thread id of the new ThreadStats object
+     * @param period The period of the new ThreadStats object
+     * @param window_length The windows length of the new ThreadStats object
+     * @param bins_pitch_ms The pitch between histogram binsid of the new ThreadStats object
+     * @return true if the insertion succeeded
+     */
+    bool newThreadStats(const ThreadStats::ThreadId& id = 0,
+                        const double& period            = 0,
+                        const double& window_length     = 0,
+                        const unsigned& bins_pitch_ms   = 0);
+
+    // ThreadStats transparent usage
+    // =============================
+
+    /**
+     * Refer to ThreadStats::tick()
+     */
+    void tick(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::tock()
+     */
+    void tock(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::resetStat()
+     */
+    void resetStat(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::sleepRemainingTime()
+     */
+    void sleepRemainingTime(const ThreadStats::ThreadId& id = 0) const;
+
+    /**
+     * Refer to ThreadStats::enableAdvancedStatistics()
+     */
+    void enableAdvancedStatistics(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::disableAdvancedStatistics()
+     */
+    void disableAdvancedStatistics(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::getEstPeriod()
+     */
+    double getEstPeriod(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::getEstPeriod()
+     */
+    void getEstPeriod(double& av, double& std, const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::getIterations()
+     */
+    unsigned getIterations(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::getEstUsed()
+     */
+    double getEstUsed(const ThreadStats::ThreadId& id = 0);
+
+    /**
+     * Refer to ThreadStats::getEstUsed()
+     */
+    void getEstUsed(double& av, double& std, const ThreadStats::ThreadId& id = 0);
+};
+
+#endif // YARP_THREAD_STATS_H

--- a/src/libYARP_OS/include/yarp/os/ThreadStats.h
+++ b/src/libYARP_OS/include/yarp/os/ThreadStats.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_THREAD_STATS_H
+#define YARP_THREAD_STATS_H
+
+#include <cassert>
+#include <cmath>
+#include <map>
+#include <yarp/os/ConstString.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Mutex.h>
+#include <yarp/os/Time.h>
+
+/*
+    Consider:
+    * |---------| Period of the Thread or the Device Under Test
+    * x           Time unit taken by the real computation
+    * -           Time unit not taken by the real computation
+
+    tick  tock
+    v     v
+    |xxxxxx---|xxxx-----|xxxxx----|xxxxxx---|
+     <--------><--------><--------><-------->   dT
+     <---->    <-->      <--->     <---->       elapsed
+*/
+
+namespace yarp {
+namespace os {
+class ThreadStats;
+class MultipleThreadStats;
+const unsigned WINDOW_LENGTH_DEFAULT = 60;
+const unsigned BINS_PITCH_MS_DEFAULT = 5;
+const unsigned MAX_JITTER_MS_DEFAULT = 100;
+} // namespace os
+} // namespace yarp
+
+class YARP_OS_API yarp::os::ThreadStats {
+public:
+    typedef int ThreadId;
+
+private:
+    // All times are in seconds and must be positive and non-zero
+
+    // Constant values
+    // ===============
+    double m_window_length;       // Length of the window for calculating statistic features
+    double m_period;              // Ideal period
+    unsigned m_cycles_per_window; // Number of cycles that fit in a selected window
+    unsigned m_maxJitter_ms;      // Maximum jitter allowed
+
+    // Instantaneous values
+    // ====================
+    double m_dT;        // Real period
+    double m_tick_time; // Time acquired during the tick phase
+    double m_tock_time; // Time acquired during the tock phase
+    double m_elapsed;   // Effective computational time taken by the thread
+
+    // Variables that keep data among cycles into the window_length
+    // ============================================================
+    unsigned m_cycle_count; // Counter of elapsed cycles
+    double m_time_total;    // Time passed from the last reset (sum of dT until window_length)
+    double m_elapsed_total; // Effective time passed from the last reset (sum of elapsed)
+    double m_elapsed_mu;    // Mean of the elapsed time over cycles inside the window_length
+    double m_elapsed_M2; // Variable used for the online calculation of the STD of the elapsed time
+    double m_dT_mu;      // Mean of the real period
+    double m_dT_M2;      // Variable used for the online calculation of the STD of the real period
+
+    // Advanced statistics: histogram
+    // ==============================
+    unsigned m_bins_pitch_ms;
+    typedef unsigned Bin;
+    typedef unsigned BinOccurrence;
+    std::map<Bin, BinOccurrence> m_jitter_pdf;
+
+    // Other variables
+    // ===============
+    ThreadId m_id;
+    bool m_advanced_statistics_enabled;
+    bool m_reset_stats;
+    yarp::os::Mutex m_mutex;
+
+    // Private methods
+    // ===============
+    void _resetStat();
+    void _insertJitter(double jitter);
+    void _initializeJitterPDF();
+    yarp::os::ConstString _messagePrefix() const;
+    void _reportAdvancedStatistics();
+    // Welford algorithm
+    double _calculateM2(const double sample, double& mean, double& M2, const double n);
+
+public:
+    ThreadStats(const double& period          = 0,
+                const double& window_length   = WINDOW_LENGTH_DEFAULT,
+                const unsigned& bins_pitch_ms = BINS_PITCH_MS_DEFAULT,
+                const ThreadId& id            = -1);
+    ThreadStats(const ThreadStats& ts);
+    ~ThreadStats() = default;
+
+    // Overloaded operators
+    // ====================
+    ThreadStats& operator=(const ThreadStats& ts);
+
+    // Public API
+    // ==========
+
+    /**
+     * Marks the beginning of the period where the statistic is calculated
+     * @see tock()
+     */
+    void tick();
+
+    /**
+     * Marks the end of the period where the statistic is calculated
+     * @see tick()
+     */
+    void tock();
+
+    /**
+     * Cleans the interal status of the class
+     */
+    void resetStat();
+
+    /**
+     * If the period is set in the object constructor, it gives the possibility of sleeping
+     * for the time `period - elapsed`
+     */
+    void sleepRemainingTime() const;
+
+    /**
+     * Enables the calculation of the advanced stastistic. For the time being it publishes
+     * to yDebug() the histogram of the jitter in the configured `windows_length`
+     */
+    void enableAdvancedStatistics();
+
+    /**
+     * Disables the calculation of the advanced statistic
+     *
+     * @see enableAdvancedStatistics()
+     */
+    void disableAdvancedStatistics();
+
+    // Set methods
+    // ===========
+
+    // Get methods
+    // ===========
+
+    /**
+     * Returns the object id
+     * @return The ThreadId value
+     */
+    ThreadId getThreadId() const;
+
+    // Backward compatibility
+    // ======================
+
+    /**
+     * Documented in RateThread::getEstPeriod()
+     */
+    double getEstPeriod();
+
+    /**
+     * Documented in RateThread::getEstPeriod(double&, double&)
+     */
+    void getEstPeriod(double& av, double& std);
+
+    /**
+     * Documented in RateThread::getIterations()
+     */
+    unsigned getIterations();
+
+    /**
+     * Documented in RateThread::getEstUsed()
+     */
+    double getEstUsed();
+
+    /**
+     * Documented in RateThread::getEstUsed(double&, double&)
+     */
+    void getEstUsed(double& av, double& std);
+};

--- a/src/libYARP_OS/src/ThreadStats.cpp
+++ b/src/libYARP_OS/src/ThreadStats.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/LockGuard.h>
+#include <yarp/os/ThreadStats.h>
+
+using namespace yarp::os;
+
+// ===========
+// ThreadStats
+// ===========
+
+ThreadStats::ThreadStats(const double& period,
+                         const double& window_length,
+                         const unsigned& bins_pitch_ms,
+                         const ThreadId& id)
+    : m_window_length(window_length)
+    , m_period(period)
+    , m_cycles_per_window(static_cast<unsigned>(m_window_length / m_period))
+    , m_maxJitter_ms(MAX_JITTER_MS_DEFAULT)
+    , m_tick_time(0)
+    , m_tock_time(0)
+    , m_bins_pitch_ms(bins_pitch_ms)
+    , m_id(id)
+    , m_advanced_statistics_enabled(false)
+    , m_reset_stats(false)
+{
+    assert(yarp::os::Time::isValid());
+    if (not Time::isValid()) {
+        yFatal() << _messagePrefix() << "The clock is not valid!";
+    }
+    _resetStat();
+}
+
+ThreadStats::ThreadStats(const ThreadStats& ts)
+    : m_window_length(ts.m_window_length)
+    , m_period(ts.m_period)
+    , m_cycles_per_window(static_cast<unsigned>(ts.m_window_length / ts.m_period))
+    , m_maxJitter_ms(MAX_JITTER_MS_DEFAULT)
+    , m_tick_time(0)
+    , m_tock_time(0)
+    , m_bins_pitch_ms(ts.m_bins_pitch_ms)
+    , m_id(ts.m_id)
+    , m_advanced_statistics_enabled(false)
+    , m_reset_stats(false)
+{
+    assert(yarp::os::Time::isValid());
+    if (not Time::isValid()) {
+        yFatal() << _messagePrefix() << "The clock is not valid!";
+    }
+    _resetStat();
+}
+
+// Overloaded operators
+// ====================
+
+ThreadStats& ThreadStats::operator=(const ThreadStats& ts)
+{
+    if (&ts == this) {
+        return *this;
+    }
+
+    this->m_window_length     = ts.m_window_length;
+    this->m_period            = ts.m_period;
+    this->m_cycles_per_window = static_cast<unsigned>(this->m_window_length / this->m_period);
+    this->m_tick_time         = 0;
+    this->m_tock_time         = 0;
+    this->m_bins_pitch_ms     = ts.m_bins_pitch_ms;
+    this->m_id                = ts.m_id;
+    this->m_advanced_statistics_enabled = false;
+    this->m_reset_stats                 = 0;
+    return *this;
+}
+
+// Private methods
+// ===============
+
+void ThreadStats::_resetStat()
+{
+    m_cycle_count   = 0;
+    m_time_total    = 0;
+    m_elapsed_total = 0;
+    m_elapsed_mu    = 0;
+    m_elapsed_M2    = 0;
+    m_dT_mu         = 0;
+    m_dT_M2         = 0;
+    _initializeJitterPDF();
+    m_reset_stats = false;
+}
+
+double ThreadStats::_calculateM2(const double sample, double& mean, double& M2, const double n)
+{
+    double delta = sample - mean;
+    mean += delta / n;
+    double delta2 = sample - mean;
+    return M2 += delta * delta2;
+}
+
+void ThreadStats::_initializeJitterPDF()
+{
+    for (unsigned i = 0; i < m_maxJitter_ms; i += m_bins_pitch_ms) {
+        m_jitter_pdf[i] = 0;
+    }
+}
+
+void ThreadStats::_insertJitter(double jitter)
+{
+    unsigned jitter_ms     = static_cast<unsigned>(jitter * 1000);
+    unsigned quantized_bin = jitter_ms - (jitter_ms % m_bins_pitch_ms);
+    // Get the current value. If no key is defined, it gets initialized to 0
+    // This workaroud allows avoiding to use exceptions
+    unsigned value              = m_jitter_pdf[quantized_bin];
+    m_jitter_pdf[quantized_bin] = value + 1;
+}
+
+ConstString ThreadStats::_messagePrefix() const
+{
+    ConstString s("yarp::os::ThreadStats");
+    if (m_id != -1) {
+        s += " (id=" + std::to_string(m_id) + ")";
+    }
+    s += ": ";
+    return s;
+}
+
+void ThreadStats::_reportAdvancedStatistics()
+{
+    {
+        // Report the pdf of cycle time
+        LockGuard lock(m_mutex);
+        unsigned samples_num = 0;
+        for (const auto& bin : m_jitter_pdf) {
+            samples_num += bin.second;
+        }
+        if (samples_num != 0) {
+            ConstString string_pdf;
+            for (const auto& bin : m_jitter_pdf) {
+                if (bin.first == 0) {
+                    string_pdf += "p(d<" + std::to_string(m_bins_pitch_ms) + ")=";
+                    string_pdf += std::to_string(static_cast<float>(bin.second)
+                                                 / static_cast<float>(samples_num));
+                }
+                else if (bin.first < m_maxJitter_ms) {
+                    string_pdf += " p(" + std::to_string(bin.first) + "<=d<";
+                    string_pdf += std::to_string(bin.first + m_bins_pitch_ms) + ")=";
+                    string_pdf += std::to_string(static_cast<float>(bin.second)
+                                                 / static_cast<float>(samples_num));
+                }
+                else {
+                    string_pdf += " p(d>=" + std::to_string(bin.first) + ")=";
+                    string_pdf += std::to_string(static_cast<float>(bin.second)
+                                                 / static_cast<float>(samples_num));
+                }
+            }
+            yDebug() << _messagePrefix() << string_pdf;
+        }
+        else {
+            yWarning() << _messagePrefix()
+                       << "The statistic has been asked but no data is available";
+        }
+    }
+
+    // Report the estimated period
+    double muP = 0, avP = 0;
+    getEstPeriod(muP, avP);
+    yDebug() << _messagePrefix() << "Estimated period: " << muP << "+-" << avP;
+
+    // Report the estimated used time
+    double muU = 0, avU = 0;
+    getEstUsed(muU, avU);
+    yDebug() << _messagePrefix() << "Estimated used time: " << muU << "+-" << avU;
+}
+
+// Public API
+// ==========
+
+void ThreadStats::tick()
+{
+    double tick_time_old;
+    {
+        LockGuard lock(m_mutex);
+        tick_time_old = m_tick_time;
+        m_tick_time   = Time::now();
+    }
+
+    if ((m_cycle_count >= m_cycles_per_window) || m_reset_stats) {
+        if (m_advanced_statistics_enabled) {
+            _reportAdvancedStatistics();
+        }
+        _resetStat();
+    }
+
+    {
+        LockGuard lock(m_mutex);
+        m_cycle_count++;
+
+        // Skip first period for dT calculation
+        if (m_cycle_count > 1) {
+            m_dT = m_tick_time - tick_time_old;
+            _insertJitter(m_dT); // TODO change name? is is not a Jitter
+            _calculateM2(m_dT, m_dT_mu, m_dT_M2, m_cycle_count - 1);
+            m_time_total += m_dT;
+        }
+    }
+}
+
+void ThreadStats::tock()
+{
+    LockGuard lock(m_mutex);
+    m_tock_time = Time::now();
+
+    m_elapsed = m_tock_time - m_tick_time;
+    _calculateM2(m_elapsed, m_elapsed_mu, m_elapsed_M2, m_cycle_count);
+    m_elapsed_total += m_elapsed;
+}
+
+void ThreadStats::sleepRemainingTime() const
+{
+    assert(m_period != 0.0);
+    assert((m_period - m_elapsed) >= 0);
+    if ((m_period - m_elapsed) < 0) {
+        yError() << _messagePrefix() << "Computational time was greater than the thread's period!";
+        return;
+    }
+    Time::delay(m_period - m_elapsed);
+}
+
+void ThreadStats::resetStat()
+{
+    LockGuard lock(m_mutex);
+    m_reset_stats = true;
+}
+
+void ThreadStats::enableAdvancedStatistics()
+{
+    LockGuard lock(m_mutex);
+    m_advanced_statistics_enabled = true;
+    _initializeJitterPDF();
+}
+
+void ThreadStats::disableAdvancedStatistics()
+{
+    LockGuard lock(m_mutex);
+    m_advanced_statistics_enabled = false;
+}
+
+// Get methods
+// ===========
+
+int ThreadStats::getThreadId() const
+{
+    return m_id;
+}
+
+// Backward compatibility
+// ======================
+
+double ThreadStats::getEstPeriod()
+{
+    double ret;
+    LockGuard lock(m_mutex);
+
+    if (m_cycle_count <= 1) {
+        ret = 0;
+    }
+    else {
+        ret = m_time_total / (m_cycle_count - 1);
+    }
+    return ret;
+}
+
+void ThreadStats::getEstPeriod(double& av, double& std)
+{
+    LockGuard lock(m_mutex);
+    if (m_cycle_count <= 1) {
+        av  = 0;
+        std = 0;
+    }
+    else {
+        unsigned samples_number = m_cycle_count - 1;
+        av                      = m_time_total / samples_number;
+        std                     = sqrt(1.0 / (samples_number - 1) * m_dT_M2);
+    }
+}
+
+unsigned ThreadStats::getIterations()
+{
+    LockGuard lock(m_mutex);
+    unsigned ret = m_cycle_count;
+    return ret;
+}
+
+double ThreadStats::getEstUsed()
+{
+    LockGuard lock(m_mutex);
+    double ret;
+
+    if (m_cycle_count < 1) {
+        ret = 0;
+    }
+    else {
+        ret = m_elapsed_total / m_cycle_count;
+    }
+
+    return ret;
+}
+
+void ThreadStats::getEstUsed(double& av, double& std)
+{
+    LockGuard lock(m_mutex);
+
+    if (m_cycle_count < 1) {
+        av  = 0;
+        std = 0;
+    }
+    else {
+        av  = m_elapsed_total / m_cycle_count;
+        std = sqrt(1.0 / (m_cycle_count - 1) * m_elapsed_M2);
+    }
+}


### PR DESCRIPTION
Referring to https://github.com/robotology/yarp/issues/1207, these `ThreadStats` and `MultipleThreadStats` classes allow the computation of statistics on threads / periodic functions.

`ThreadStats` is API compatible with the current `yarp::os::RateThreadCallbackAdapter` class. I successfully validated and compared the methods. The main difference is the function I use to calculate the variance, but no significative differences emerged.

Beyond the possible usage inside `RateThread`, these classes might be very useful to debug issues like https://github.com/robotology/yarp/issues/1229, especially the `MultipleThreadStats`. I developed this class having in mind a clean and easy setup of many profiling points in a whole class codebase.

[WIP] I still have minor edits I'd like the last version will implements. For the time being, please let me know if you have any feedback about the current status.

(I'd prefer keeping this out of the next yarp master freeze for the time being)