### PR TITLE
Fix Mutex behavior in yarp::dev::BoschIMU

### DIFF
--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -435,12 +435,9 @@ void BoschIMU::run()
 
     // TODO: how to optimally protect only code filling the data vector?
 
-    yarp::sig::Vector data_tmp;
-    data_tmp.resize(nChannels);
-    data_tmp.zero();
-
-    // Save the last errors count required later
-    errCounter errs_old = errs;
+    // In order to avoid zeros when a single read from a sensor is missing,
+    // initialize the new measure to be equal to the previous one
+    yarp::sig::Vector data_tmp = data;
 
     ///////////////////////////////////////////
     //
@@ -556,35 +553,8 @@ void BoschIMU::run()
     // Protect only this section in order to avoid slow race conditions when gathering this data
     mutex.lock();
 
-    data.zero();
-
-    if (errs_old.acceError != errs.acceError) {
-        data[3] = data_tmp[3];
-        data[4] = data_tmp[4];
-        data[5] = data_tmp[5];
-    }
-
-    if (errs_old.gyroError != errs.gyroError) {
-        data[6] = data_tmp[6];
-        data[7] = data_tmp[7];
-        data[8] = data_tmp[8];
-    }
-
-    if (errs_old.magnError != errs.magnError) {
-        data[9]  = data_tmp[9];
-        data[10] = data_tmp[10];
-        data[11] = data_tmp[11];
-    }
-
-    if (errs_old.quatError != errs.quatError) {
-        data[0]        = data_tmp[0];
-        data[1]        = data_tmp[1];
-        data[2]        = data_tmp[2];
-        quaternion.w() = quaternion_tmp.w();
-        quaternion.x() = quaternion_tmp.x();
-        quaternion.y() = quaternion_tmp.y();
-        quaternion.z() = quaternion_tmp.z();
-    }
+    data       = data_tmp;
+    quaternion = quaternion_tmp;
 
     mutex.unlock();
 

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -28,6 +28,8 @@ BoschIMU::BoschIMU() : RateThread(20), checkError(false)
 {
     data.resize(12);
     data.zero();
+    data_tmp.resize(12);
+    data_tmp.zero();
     errorCounter.resize(11);
     errorCounter.zero();
     totMessagesRead = 0;
@@ -437,7 +439,7 @@ void BoschIMU::run()
 
     // In order to avoid zeros when a single read from a sensor is missing,
     // initialize the new measure to be equal to the previous one
-    yarp::sig::Vector data_tmp = data;
+    data_tmp = data;
 
     ///////////////////////////////////////////
     //
@@ -521,7 +523,7 @@ void BoschIMU::run()
     //
     ///////////////////////////////////////////
 
-    yarp::math::Quaternion quaternion_tmp;
+    quaternion_tmp = quaternion;
     if (sendReadCommand(REG_QUATERN_DATA, 8, response, "Read quaternion")) {
         // Manually compose the data to safely handling endianess
         raw_data[0] = response[3] << 8 | response[2];

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -24,8 +24,7 @@ using namespace std;
 using namespace yarp::os;
 using namespace yarp::dev;
 
-BoschIMU::BoschIMU():   RateThread(20), mutex(1),
-                        checkError(false)
+BoschIMU::BoschIMU() : RateThread(20), checkError(false)
 {
     data.resize(12);
     data.zero();
@@ -555,7 +554,7 @@ void BoschIMU::run()
     }
 
     // Protect only this section in order to avoid slow race conditions when gathering this data
-    mutex.wait();
+    mutex.lock();
 
     data.zero();
 
@@ -587,7 +586,7 @@ void BoschIMU::run()
         quaternion.z() = quaternion_tmp.z();
     }
 
-    mutex.post();
+    mutex.unlock();
 
     if(timeStamp > timeLastReport + TIME_REPORT_INTERVAL)
     {
@@ -611,7 +610,7 @@ void BoschIMU::run()
 
 bool BoschIMU::read(yarp::sig::Vector &out)
 {
-    mutex.wait();
+    mutex.lock();
     out.resize(nChannels);
     out.zero();
 
@@ -624,7 +623,7 @@ bool BoschIMU::read(yarp::sig::Vector &out)
         out[15] = quaternion.z();
     }
 
-    mutex.post();
+    mutex.unlock();
     return true;
 };
 

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -136,7 +136,9 @@ protected:
     short                       status;
     int                         nChannels;
     yarp::sig::Vector           data;
+    yarp::sig::Vector           data_tmp;
     yarp::math::Quaternion      quaternion;
+    yarp::math::Quaternion      quaternion_tmp;
     yarp::sig::Vector           RPY_angle;
     double                      timeStamp;
     double                      timeLastReport;

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -6,13 +6,13 @@
 #define BOSCH_IMU_DEVICE
 
 #include <yarp/sig/Vector.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/RateThread.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/dev/SerialInterfaces.h>
 #include <yarp/dev/GenericSensorInterfaces.h>
 #include <yarp/math/Quaternion.h>
+#include <yarp/os/Mutex.h>
 
 namespace yarp {
     namespace dev {
@@ -132,7 +132,6 @@ class yarp::dev::BoschIMU:   public yarp::dev::DeviceDriver,
 {
 protected:
 
-    yarp::os::Semaphore         mutex;
     bool                        verbose;
     short                       status;
     int                         nChannels;
@@ -141,6 +140,7 @@ protected:
     yarp::sig::Vector           RPY_angle;
     double                      timeStamp;
     double                      timeLastReport;
+    yarp::os::Mutex             mutex;
 
     bool                        checkError;
 


### PR DESCRIPTION
Referring to https://github.com/robotology/yarp/issues/1229, these commits should fix the sharing of  data between the `run()` and `read()` methods.

I still have to test this branch on the robot, in the meantime please let me know if you have any feedback.

Particularly, I changed the behavior when a sensor fails to read a measure. Before the missing measure was set to zero, I think it has more sense setting its value to the previous measurement.

cc @barbalberto @traversaro @francesco-romano 