### PR TITLE
yarpmanager: add the scan of available carriers before performing connect and disconnect

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -23,6 +23,13 @@ Bug Fixes
   corresponding port has been opened through `yarp run`. Be aware that after
   these changes `yarpmanager` will not detect machines with `yarp 2.3.70` 
   and earlier.
+* Added scan among the available carriers when you click connect and disconnect,
+  if the specified carrier is not available a proper error message will be
+  written on log.
+* the column carrier in the connection list has been substituted with a combobox
+  with the available carriers.
+* Added modifiers column in the connection list for portmonitors.
+* Added automatic ports/resources refresh after `run/stop/kill`.
 
 
 Contributors

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -80,6 +80,9 @@ public:
     bool detachStdout(unsigned int id);
     bool updateResources(void);
     bool updateResource(const char* szName);
+    bool waitingModuleRun(unsigned int id);
+    bool waitingModuleStop(unsigned int id);
+    bool waitingModuleKill(unsigned int id);
     bool loadBalance(void);
 
     void setDefaultBroker(const char* szBroker) { if(szBroker) strDefBroker = szBroker; }

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -981,6 +981,8 @@ void ApplicationViewWidget::attachStdOutNestedApplication(QTreeWidgetItem *it,st
 /*! \brief Called when the Run button has been pressed */
 bool ApplicationViewWidget::onRun()
 {
+    selectAllConnections(true);
+    selectAllResources(true);
     if (safeManager.busy() ) {
         return false;
     }
@@ -1013,9 +1015,41 @@ bool ApplicationViewWidget::onRun()
         }
     }
 
-    safeManager.safeRun(MIDs);
+    std::vector<int> CIDs;
+    for(int i=0;i<ui->connectionList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);
+
+        if (it->isSelected()) {
+            CIDs.push_back(it->text(1).toInt());
+            safeManager.updateConnection(it->text(1).toInt(),
+                                     it->text(3).toLatin1().data(),
+                                     it->text(4).toLatin1().data(),
+                                     it->text(5).toLatin1().data());
+
+            it->setText(2,"waiting");
+            it->setIcon(0,QIcon(":/refresh.svg"));
+            it->setTextColor(2,QColor("#000000"));
+        }
+
+    }
+
+    std::vector<int> RIDs;
+    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
+        if (it->isSelected()) {
+            RIDs.push_back(it->text(1).toInt());
+            it->setText(3,"waiting");
+            it->setIcon(0,QIcon(":/refresh22.svg"));
+            it->setTextColor(3,QColor("#000000"));
+        }
+    }
+
+
+    safeManager.safeRun(MIDs,CIDs,RIDs);
     yarp::os::Time::delay(0.1);
     selectAllModule(false);
+    selectAllConnections(false);
+    selectAllResources(false);
     return true;
 }
 
@@ -1050,6 +1084,8 @@ void ApplicationViewWidget::runNestedApplication(QTreeWidgetItem *it,std::vector
 /*! \brief Called when the Stop button has been pressed */
 bool ApplicationViewWidget::onStop()
 {
+    selectAllConnections(true);
+    selectAllResources(true);
     if (safeManager.busy()) {
         return false;
     }
@@ -1080,10 +1116,41 @@ bool ApplicationViewWidget::onStop()
 
     }
 
+    std::vector<int> CIDs;
+    for(int i=0;i<ui->connectionList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);
 
-    safeManager.safeStop(MIDs);
+        if (it->isSelected()) {
+            CIDs.push_back(it->text(1).toInt());
+            safeManager.updateConnection(it->text(1).toInt(),
+                                     it->text(3).toLatin1().data(),
+                                     it->text(4).toLatin1().data(),
+                                     it->text(5).toLatin1().data());
+
+            it->setText(2,"waiting");
+            it->setIcon(0,QIcon(":/refresh.svg"));
+            it->setTextColor(2,QColor("#000000"));
+        }
+
+    }
+
+    std::vector<int> RIDs;
+    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
+        if (it->isSelected()) {
+            RIDs.push_back(it->text(1).toInt());
+            it->setText(3,"waiting");
+            it->setIcon(0,QIcon(":/refresh22.svg"));
+            it->setTextColor(3,QColor("#000000"));
+        }
+    }
+
+
+    safeManager.safeStop(MIDs,CIDs,RIDs);
     yarp::os::Time::delay(0.1);
     selectAllModule(false);
+    selectAllConnections(false);
+    selectAllResources(false);
     return true;
 }
 
@@ -1117,6 +1184,8 @@ void ApplicationViewWidget::stopNestedApplication(QTreeWidgetItem *it,std::vecto
 /*! \brief Called when the Kill button has been pressed */
 bool ApplicationViewWidget::onKill()
 {
+    selectAllConnections(true);
+    selectAllResources(true);
     if (safeManager.busy()) {
         return false;
     }
@@ -1150,10 +1219,41 @@ bool ApplicationViewWidget::onKill()
 
     }
 
+    std::vector<int> CIDs;
+    for(int i=0;i<ui->connectionList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->connectionList->topLevelItem(i);
 
-    safeManager.safeKill(MIDs);
+        if (it->isSelected()) {
+            CIDs.push_back(it->text(1).toInt());
+            safeManager.updateConnection(it->text(1).toInt(),
+                                     it->text(3).toLatin1().data(),
+                                     it->text(4).toLatin1().data(),
+                                     it->text(5).toLatin1().data());
+
+            it->setText(2,"waiting");
+            it->setIcon(0,QIcon(":/refresh.svg"));
+            it->setTextColor(2,QColor("#000000"));
+        }
+
+    }
+
+    std::vector<int> RIDs;
+    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+        QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
+        if (it->isSelected()) {
+            RIDs.push_back(it->text(1).toInt());
+            it->setText(3,"waiting");
+            it->setIcon(0,QIcon(":/refresh22.svg"));
+            it->setTextColor(3,QColor("#000000"));
+        }
+    }
+
+
+    safeManager.safeKill(MIDs, CIDs, RIDs);
     yarp::os::Time::delay(0.1);
     selectAllModule(false);
+    selectAllConnections(false);
+    selectAllResources(false);
     return true;
 }
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -654,10 +654,18 @@ void ApplicationViewWidget::updateApplicationWindow()
         QString to = QString("%1").arg((*cnnitr).to());
         QString carrier = QString("%1").arg((*cnnitr).carrier());
         QString status = "disconnected";
+        QString modifier="";
+        size_t pos = carrier.toStdString().find("+");
+        if(pos != std::string::npos)
+        {
+            modifier = carrier.mid(pos);
+            QStringList myStringList = carrier.split('+');
+            carrier = myStringList.first();
+        }
 
 
         QStringList l;
-        l << type << sId << status << from << to << carrier;
+        l << type << sId << status << from << to << carrier << modifier;
         CustomTreeWidgetItem *it = new CustomTreeWidgetItem(ui->connectionList,l);
         ui->moduleList->addTopLevelItem(it);
 
@@ -753,7 +761,7 @@ bool ApplicationViewWidget::isEditable(QTreeWidgetItem *it,int col)
         break;
     }
     case yarp::manager::INOUTD:{
-           if (col == 3 || col == 4 || col == 5 ) {
+           if (col == 3 || col == 4 || col == 5 || col == 6) {
                if (it->text(2) == "disconnected") {
                     return true;
                }
@@ -1307,12 +1315,14 @@ bool ApplicationViewWidget::onConnect()
             {
                 carrier=it->text(5);
             }
-            scanAvailableCarriers(carrier);
+            if(!scanAvailableCarriers(carrier))
+                continue;
+            carrier = carrier + it->text(6); //adding modifier.
             MIDs.push_back(it->text(1).toInt());
             safeManager.updateConnection(it->text(1).toInt(),
                                      it->text(3).toLatin1().data(),
                                      it->text(4).toLatin1().data(),
-                                     it->text(5).toLatin1().data());
+                                     carrier.toLatin1().data());
 
             it->setText(2,"waiting");
             it->setIcon(0,QIcon(":/refresh22.svg"));

--- a/src/yarpmanager/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager/src-manager/applicationviewwidget.h
@@ -110,6 +110,7 @@ private:
     void attachStdOutNestedApplication(QTreeWidgetItem *it,std::vector<int> *MIDs);
     void modStdOutNestedApplication(QTreeWidgetItem *it, int id,QString s);
     void selectAllNestedApplicationModule(QTreeWidgetItem *it, bool check);
+    bool scanAvailableCarriers(QString carrier, bool isConnection = true);
 
 
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager/src-manager/applicationviewwidget.h
@@ -119,6 +119,7 @@ private:
     QDockWidget *builderWidget;
     BuilderWindow *builder;
     QToolBar *builderToolBar;
+    QStringList stringLst;
 
     Ui::ApplicationViewWidget *ui;
     SafeManager safeManager;

--- a/src/yarpmanager/src-manager/applicationviewwidget.ui
+++ b/src/yarpmanager/src-manager/applicationviewwidget.ui
@@ -178,6 +178,11 @@ background-color: rgb(255, 255, 255);*/
             <string>Carrier</string>
            </property>
           </column>
+          <column>
+           <property name="text">
+            <string>Modifiers</string>
+           </property>
+          </column>
          </widget>
          <widget class="CustomTreeWidget" name="resourcesList">
           <property name="sizePolicy">

--- a/src/yarpmanager/src-manager/safe_manager.cpp
+++ b/src/yarpmanager/src-manager/safe_manager.cpp
@@ -100,16 +100,95 @@ void SafeManager::run()
     case MRUN:{
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::run(local_modIds[i], true);
+
+            for(unsigned int i=0; i<local_modIds.size(); i++)
+                Manager::waitingModuleRun(local_modIds[i]);
+
+            for(unsigned int i=0; i<local_conIds.size(); i++)
+            {
+                if(Manager::connected(local_conIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onConConnect(local_conIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onConDisconnect(local_conIds[i]);
+                }
+                refreshPortStatus(local_conIds[i]);
+            }
+            for(unsigned int i=0; i<local_resIds.size(); i++)
+            {
+                if(Manager::exist(local_resIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onResAvailable(local_resIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
+                }
+            }
             break;
         }
     case MSTOP:{
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::stop(local_modIds[i], true);
+            for(unsigned int i=0; i<local_modIds.size(); i++)
+                Manager::waitingModuleStop(local_modIds[i]);
+
+            for(unsigned int i=0; i<local_conIds.size(); i++)
+            {
+                if(Manager::connected(local_conIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onConConnect(local_conIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onConDisconnect(local_conIds[i]);
+                }
+                refreshPortStatus(local_conIds[i]);
+            }
+            for(unsigned int i=0; i<local_resIds.size(); i++)
+            {
+                if(Manager::exist(local_resIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onResAvailable(local_resIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
+                }
+            }
             break;
         }
     case MKILL:{
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::kill(local_modIds[i], true);
+            for(unsigned int i=0; i<local_modIds.size(); i++)
+                Manager::waitingModuleKill(local_modIds[i]);
+
+            for(unsigned int i=0; i<local_conIds.size(); i++)
+            {
+                if(Manager::connected(local_conIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onConConnect(local_conIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onConDisconnect(local_conIds[i]);
+                }
+                refreshPortStatus(local_conIds[i]);
+            }
+            for(unsigned int i=0; i<local_resIds.size(); i++)
+            {
+                if(Manager::exist(local_resIds[i]))
+                {
+                    if(eventReceiver) eventReceiver->onResAvailable(local_resIds[i]);
+                }
+                else
+                {
+                    if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
+                }
+            }
             break;
         }
     case MCONNECT:{
@@ -230,36 +309,42 @@ void SafeManager::run()
         eventReceiver->onError();
 }
 
-void SafeManager::safeRun(std::vector<int>& MIDs)
+void SafeManager::safeRun(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int> &RIDs)
 {
     if(busy()) return;
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
+    conIds = CIDs;
+    resIds = RIDs;
     action = MRUN;
     POST_SEMAPHOR();
     if(!yarp::os::Thread::isRunning())
         yarp::os::Thread::start();
 }
 
-void SafeManager::safeStop(std::vector<int>& MIDs)
+void SafeManager::safeStop(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int> &RIDs)
 {
     if(busy()) return;
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
+    conIds = CIDs;
+    resIds = RIDs;
     action = MSTOP;
     POST_SEMAPHOR();
     if(!yarp::os::Thread::isRunning())
         yarp::os::Thread::start();
 }
 
-void SafeManager::safeKill(std::vector<int>& MIDs)
+void SafeManager::safeKill(std::vector<int>& MIDs, std::vector<int> &CIDs, std::vector<int> &RIDs)
 {
     if(busy()) return;
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
+    conIds = CIDs;
+    resIds = RIDs;
     action = MKILL;
     POST_SEMAPHOR();
     if(!yarp::os::Thread::isRunning())

--- a/src/yarpmanager/src-manager/safe_manager.h
+++ b/src/yarpmanager/src-manager/safe_manager.h
@@ -67,9 +67,9 @@ public:
     void run() override;
     void threadRelease() override;
 
-    void safeRun(std::vector<int>& MIDs);
-    void safeStop(std::vector<int>& MIDs);
-    void safeKill(std::vector<int>& MIDs);
+    void safeRun(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int>& RIDs);
+    void safeStop(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int>& RIDs);
+    void safeKill(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int>& RIDs);
     void safeConnect(std::vector<int>& CIDs);
     void safeDisconnect(std::vector<int>& CDs);
     void safeRefresh(std::vector<int>& MIDs,


### PR DESCRIPTION
This PR introduces:
- [x]  scan among the available carriers when you click connect and disconnect, if the specified carrier is not available a proper error message will be written on log.
- [x] the column *carrier* in the connection list has been substituted with a combobox with the available carriers
- [x] add modifiers column in the connection list
- [x] Fix #1197 
- [x] add automatic ports/resources refresh after `run/stop/kill`
- [x] test on `iCubGenova01` setup

Please review code.