### PR TITLE
libYARP_manager: add check for avoiding double free

### DIFF
--- a/src/libYARP_manager/src/kbase.cpp
+++ b/src/libYARP_manager/src/kbase.cpp
@@ -97,7 +97,8 @@ bool KnowledgeBase::addApplication(Application* app, char* szAppName_, bool modi
     }
 
     if(modifyName){
-        delete szAppName_;
+        if (szAppName_)
+            delete szAppName_;
         szAppName_ = new char(app->getNameLenght());
         strcpy(szAppName_, app->getName());
     }


### PR DESCRIPTION
This PR fixes the possible double free (issue robotology/gazebo-yarp-plugins#299)

please review code.