### PR TITLE
YarpFixManager: fix yarp fixture for compatibility with recent changes in libYARP_manager

### DIFF
--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -61,8 +61,8 @@ bool YarpFixManager::setup(int argc, char** argv) {
         enableRestrictedMode();
 
         // load the fixture (application xml)
-        char szAppName[255];
-        ret = addApplication(appfile.c_str(), szAppName, true);
+        char* szAppName = YARP_NULLPTR;
+        ret = addApplication(appfile.c_str(), &szAppName, true);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (addApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
@@ -72,6 +72,11 @@ bool YarpFixManager::setup(int argc, char** argv) {
                             "yarpmanager (loadApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
         initialized = true;
+        if (szAppName)
+        {
+            delete [] szAppName;
+            szAppName = YARP_NULLPTR;
+        }
     }
 
     //run the modules and connect


### PR DESCRIPTION
This PR introduces changes in `YarpFixManager` to make it compatible with recent changes in `libYARP_manager`, fixes robotology/gazebo-yarp-plugins#299 (TESTED) 

MERGE AFTER robotology/yarp#1244