### PR TITLE
OS: Refactor yarp::os::Route

### DIFF
--- a/doc/release/v2_3_70.md
+++ b/doc/release/v2_3_70.md
@@ -1,6 +1,7 @@
 YARP 2.3.70 (UNRELEASED) Release Notes
 ======================================
 
+
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+v2.3.70%22).
 
@@ -177,8 +178,20 @@ New Features
 * The following overload method is added to the `yarp::os::ResourceFinder`
   class:
   * `bool setDefaultContext(const yarp::os::ConstString& contextName)`
-* Added clear() method to PID class.
-  
+* Added `clear()` method to PID class.
+* The class `yarp::os::Route` was refactored:
+  * The following methods were deprecated:
+    - `addFromName()`
+    - `addToName()`
+    - `addCarrierName()`
+    - `addToContact()`
+  * The following methods were added:
+    - `setFromName()`
+    - `setToName()`
+    - `setCarrierName()`
+    - `setToContact()`
+    - `swapNames()`
+
 #### YARP_dev
 
 * Added `getRgbResolution` and `getRgbSupportedConfigurations` to the

--- a/src/carriers/human_carrier/HumanCarrier.h
+++ b/src/carriers/human_carrier/HumanCarrier.h
@@ -93,7 +93,9 @@ public:
 
     virtual bool expectSenderSpecifier(ConnectionState& proto) {
         // interpret everything that sendHeader wrote
-        proto.setRoute(proto.getRoute().addFromName(proto.is().readLine()));
+        Route route = proto.getRoute();
+        route.setFromName(proto.is().readLine());
+        proto.setRoute(route);
         return proto.is().isOk();
     }
 

--- a/src/carriers/mpi_carrier/src/MpiCarrier.cpp
+++ b/src/carriers/mpi_carrier/src/MpiCarrier.cpp
@@ -109,7 +109,10 @@ bool MpiCarrier::expectSenderSpecifier(ConnectionState& proto) {
     #endif
 
     other = proto.is().readLine();
-    proto.setRoute(proto.getRoute().addFromName(other));
+    Route r = proto.getRoute();
+    r.setFromName(other);
+    proto.setRoute(r);
+
     // Receiver
     route = name + "<-" + other;
 

--- a/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
+++ b/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
@@ -187,7 +187,9 @@ bool TcpRosCarrier::expectReplyToHeader(ConnectionState& proto) {
         string name = header.data["callerid"];
         dbg_printf("<incoming> callerid is %s\n", name.c_str());
         dbg_printf("Route was %s\n", proto.getRoute().toString().c_str());
-        proto.setRoute(proto.getRoute().addToName(name.c_str()));
+        Route route = proto.getRoute();
+        route.setToName(name.c_str());
+        proto.setRoute(route);
         dbg_printf("Route is now %s\n", proto.getRoute().toString().c_str());
     }
 
@@ -222,8 +224,9 @@ bool TcpRosCarrier::expectReplyToHeader(ConnectionState& proto) {
 }
 
 bool TcpRosCarrier::expectSenderSpecifier(ConnectionState& proto) {
-    proto.setRoute(proto.getRoute().addFromName("tcpros"));
-
+    Route route = proto.getRoute();
+    route.setFromName("tcpros");
+    proto.setRoute(route);
     dbg_printf("Trying for tcpros header\n");
     ManagedBytes m(headerLen1);
     Bytes mrem(m.get()+4,m.length()-4);
@@ -260,11 +263,13 @@ bool TcpRosCarrier::expectSenderSpecifier(ConnectionState& proto) {
     }
     dbg_printf("<outgoing> Type of data is %s\n", rosname.c_str());
 
+    route = proto.getRoute();
     if (header.data.find("callerid")!=header.data.end()) {
-        proto.setRoute(proto.getRoute().addFromName(header.data["callerid"].c_str()));
+        route.setFromName(header.data["callerid"].c_str());
     } else {
-        proto.setRoute(proto.getRoute().addFromName("tcpros"));
+        route.setFromName("tcpros");
     }
+    proto.setRoute(route);
 
     // Let's just ignore everything that is sane and holy, and
     // send the same header right back.

--- a/src/carriers/xmlrpc_carrier/XmlRpcCarrier.cpp
+++ b/src/carriers/xmlrpc_carrier/XmlRpcCarrier.cpp
@@ -75,7 +75,9 @@ void toXmlRpcValue(Value& vin, XmlRpcValue& vout)
 
 bool XmlRpcCarrier::expectSenderSpecifier(ConnectionState& proto)
 {
-    proto.setRoute(proto.getRoute().addFromName("rpc"));
+    Route route = proto.getRoute();
+    route.setFromName("rpc");
+    proto.setRoute(route);
     return true;
 }
 

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -309,6 +309,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/ResourceFinderOptions.cpp
                  src/RFModule.cpp
                  src/RosNameSpace.cpp
+                 src/Route.cpp
                  src/RpcClient.cpp
                  src/RpcServer.cpp
                  src/RunCheckpoints.cpp

--- a/src/libYARP_OS/include/yarp/os/Route.h
+++ b/src/libYARP_OS/include/yarp/os/Route.h
@@ -7,166 +7,235 @@
 #ifndef YARP_OS_ROUTE_H
 #define YARP_OS_ROUTE_H
 
+#include <yarp/conf/compiler.h>
+#include <yarp/conf/system.h>
 #include <yarp/os/api.h>
-#include <yarp/os/ConstString.h>
-#include <yarp/os/Contact.h>
+
+// Defined in this file:
+namespace yarp { namespace os { class ConstString; }}
+
+// Other forward declarations:
+namespace yarp { namespace os { class ConstString; }}
+namespace yarp { namespace os { class Contact; }}
+
 
 namespace yarp {
-    namespace os {
-        class Route;
-    }
-}
+namespace os {
 
 /**
- * Information about a connection between two ports.
+ * @ingroup comm_class
+ * @brief Information about a connection between two ports.
+ *
  * Contains the names of the endpoints, and the name of
  * the carrier in use between them.
  */
-class YARP_OS_API yarp::os::Route {
+class YARP_OS_API Route {
 public:
-    /**
-     *
-     * Constructor.
-     *
-     */
-    Route() {}
+
+/** @{ */
 
     /**
-     * Create a route.
+     * @brief Default constructor.
+     */
+    Route();
+
+    /**
+     * @brief Create a route.
      *
-     * @param fromKey Source of route.
-     * @param toKey Destination of route.
+     * @param fromName Source of route.
+     * @param toName Destination of route.
      * @param carrier Type of carrier.
      */
-    Route(const ConstString& fromKey,
-          const ConstString& toKey,
-          const ConstString& carrier) :
-            fromKey(fromKey),
-            toKey(toKey),
-            carrier(carrier) {
-    }
+    Route(const ConstString& fromName,
+          const ConstString& toName,
+          const ConstString& carrierName);
 
     /**
-     * Copy constructor
+     * @brief Copy constructor
      *
-     * @param alt Route to copy.
+     * @param rhs Route to copy.
      */
-    Route(const Route& alt) :
-            fromKey(alt.fromKey),
-            toKey(alt.toKey),
-            fromContact(alt.fromContact),
-            toContact(alt.toContact),
-            carrier(alt.carrier) {
-    }
+    Route(const Route& rhs);
+
+#if defined(YARP_HAS_CXX11) && YARP_COMPILER_CXX_RVALUE_REFERENCES
+    /**
+     * @brief Move constructor.
+     *
+     * @param rhs the Route to be moved
+     */
+    Route(Route&& rhs);
+#endif
 
     /**
-     * Get the source of the route.
+     * @brief Destructor.
+     */
+    virtual ~Route();
+
+    /**
+     * Copy assignment operator.
+     *
+     * @param rhs the Route to copy
+     * @return this object
+     */
+    Route& operator=(const Route& rhs);
+
+#if defined(YARP_HAS_CXX11) && YARP_COMPILER_CXX_RVALUE_REFERENCES
+    /**
+     * @brief Move assignment operator.
+     *
+     * @param rhs the Route to be moved
+     * @return this object
+     */
+    Route& operator=(Route&& rhs);
+#endif
+
+/** @} */
+/** @{ */
+
+    /**
+     * @brief Get the source of the route.
      *
      * @return the source of the route (a port name)
      */
-    const ConstString& getFromName() const {
-        return fromKey;
-    }
+    const ConstString& getFromName() const;
 
     /**
-     * Get the destination of the route.
+     * @brief Set the source of the route.
      *
+     * @param fromName the source of the route (a port name)
+     */
+    void setFromName(const ConstString& fromName);
+
+/** @} */
+/** @{ */
+
+    /**
+     * @brief Get the destination of the route.
      *
      * @return the destination of the route (a port name)
      */
-    const ConstString& getToName() const {
-        return toKey;
-    }
-
+    const ConstString& getToName() const;
 
     /**
-     * Get the destination contact of the route, if avaiable
+     * @brief Set the destination of the route.
      *
+     * @param toName the destination of the route (a port name)
+     */
+    void setToName(const ConstString& toName);
+
+/** @} */
+/** @{ */
+
+    /**
+     * @brief Get the destination contact of the route, if avaiable
      *
      * @return the destination of the route as a contact
      */
-    const Contact& getToContact() const {
-        return toContact;
-    }
+    const Contact& getToContact() const;
 
     /**
-     * Get the carrier type of the route.
+     * @brief Set the destination contact of the route
      *
+     * @param toContact the destination of the route as a contact
+     */
+    void setToContact(const Contact& toContact);
+
+/** @} */
+/** @{ */
+
+    /**
+     * @brief Get the carrier type of the route.
      *
      * @return the carrier type of the route.
      */
-    const ConstString& getCarrierName() const {
-        return carrier;
-    }
+    const ConstString& getCarrierName() const;
 
     /**
-     * Copy this route with a different source.
+     * @brief Set the carrier type of the route.
      *
-     * @param fromName The new source of the route.
-     *
-     * @return the created route.
+     * @param carrierName the carrier type of the route.
      */
-    Route addFromName(const ConstString& fromName) const {
-        Route result(*this);
-        result.fromKey = fromName;
-        return result;
-    }
+    void setCarrierName(const ConstString& carrierName);
+
+/** @} */
+/** @{ */
 
     /**
-     * Copy this route with a different destination.
-     *
-     * @param toName The new destination of the route.
-     *
-     * @return the created route.
+     * @brief Swap from and to names
      */
-    Route addToName(const ConstString& toName) const {
-        Route result(*this);
-        result.toKey = toName;
-        return result;
-    }
+    void swapNames();
+
+/** @} */
+/** @{ */
 
     /**
-     * Copy this route with a different contact.
-     *
-     * @param toContact new destination contact of the route.
-     *
-     * @return the created route.
-     */
-    Route addToContact(const Contact& toContact) const {
-        Route result(*this);
-        result.toContact = toContact;
-        return result;
-    }
-
-    /**
-     * Copy this route with a different carrier.
-     *
-     * @param carrierName The new carrier of the route.
-     *
-     * @return the created route.
-     */
-    Route addCarrierName(const ConstString& carrierName) const {
-        Route result(*this);
-        result.carrier = carrierName;
-        return result;
-    }
-
-    /**
-     * Render a text form of the route, "source->carrier->dest"
+     * @brief Render a text form of the route, "source->carrier->dest"
      *
      * @return the route in text form.
      */
-    ConstString toString() const {
-        return getFromName() + "->" + getCarrierName() + "->" +
-            getToName();
-    }
+    ConstString toString() const;
+
+/** @} */
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+
+/** @{ */
+
+    /**
+     * @brief Copy this route with a different source.
+     *
+     * @param fromName The new source of the route.
+     * @return the created route.
+     *
+     * @deprecated since YARP 2.3.70
+     */
+    YARP_DEPRECATED_MSG("Use setFromName instead")
+    Route addFromName(const ConstString& fromName) const;
+
+    /**
+     * @brief Copy this route with a different destination.
+     *
+     * @param toName The new destination of the route.
+     * @return the created route.
+     *
+     * @deprecated since YARP 2.3.70
+     */
+    YARP_DEPRECATED_MSG("Use setToName instead")
+    Route addToName(const ConstString& toName) const;
+
+    /**
+     * @brief Copy this route with a different contact.
+     *
+     * @param toContact new destination contact of the route.
+     * @return the created route.
+     *
+     * @deprecated since YARP 2.3.70
+     */
+    YARP_DEPRECATED_MSG("Use setToConstact instead")
+    Route addToContact(const Contact& toContact) const;
+
+    /**
+     * @brief Copy this route with a different carrier.
+     *
+     * @param carrierName The new carrier of the route.
+     * @return the created route.
+     *
+     * @deprecated since YARP 2.3.70
+     */
+    YARP_DEPRECATED_MSG("Use setCarrierName instead")
+    Route addCarrierName(const ConstString& carrierName) const;
+#endif // YARP_NO_DEPRECATED
+
 
 private:
-    ConstString fromKey;
-    ConstString toKey;
-    Contact fromContact;
-    Contact toContact;
-    ConstString carrier;
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+private:
+    class Private;
+    Private * mPriv;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 };
+
+} // namespace os
+} // namespace yarp
 
 #endif // YARP_OS_ROUTE_H

--- a/src/libYARP_OS/src/AbstractCarrier.cpp
+++ b/src/libYARP_OS/src/AbstractCarrier.cpp
@@ -124,7 +124,9 @@ bool AbstractCarrier::expectSenderSpecifier(ConnectionState& proto)
     // add null termination for YARP1
     b.get()[len] = '\0';
     ConstString s = b.get();
-    proto.setRoute(proto.getRoute().addFromName(s));
+    Route route = proto.getRoute();
+    route.setFromName(s);
+    proto.setRoute(route);
     return true;
 }
 

--- a/src/libYARP_OS/src/HttpCarrier.cpp
+++ b/src/libYARP_OS/src/HttpCarrier.cpp
@@ -618,7 +618,9 @@ bool yarp::os::impl::HttpCarrier::sendHeader(ConnectionState& proto) {
 }
 
 bool yarp::os::impl::HttpCarrier::expectSenderSpecifier(ConnectionState& proto) {
-    proto.setRoute(proto.getRoute().addFromName("web"));
+    Route route = proto.getRoute();
+    route.setFromName("web");
+    proto.setRoute(route);
     ConstString remainder = proto.is().readLine();
     if (!urlDone) {
         for (unsigned int i=0; i<remainder.length(); i++) {

--- a/src/libYARP_OS/src/LocalCarrier.cpp
+++ b/src/libYARP_OS/src/LocalCarrier.cpp
@@ -184,7 +184,9 @@ bool yarp::os::impl::LocalCarrier::expectExtraHeader(ConnectionState& proto) {
     //printf("receiver %ld (%s) sees sender %ld (%s)\n",
     //       (long int) this, portName.c_str(),
     //       (long int) peer, peer->portName.c_str());
-    proto.setRoute(proto.getRoute().addFromName(peer->portName));
+    Route route = proto.getRoute();
+    route.setFromName(peer->portName);
+    proto.setRoute(route);
     peerMutex.post();
 
     return true;

--- a/src/libYARP_OS/src/NameserCarrier.cpp
+++ b/src/libYARP_OS/src/NameserCarrier.cpp
@@ -155,7 +155,9 @@ bool yarp::os::impl::NameserCarrier::sendHeader(ConnectionState& proto) {
 }
 
 bool yarp::os::impl::NameserCarrier::expectSenderSpecifier(ConnectionState& proto) {
-    proto.setRoute(proto.getRoute().addFromName("anon"));
+    Route route = proto.getRoute();
+    route.setFromName("anon");
+    proto.setRoute(route);
     return true;
 }
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -875,10 +875,10 @@ bool PortCore::addOutput(const ConstString& dest, void *id, OutputStream *os,
     if (aname=="") {
         aname = address.toURI(false);
     }
-    Route r = Route(getName(), aname,
-                    (parts.getCarrier()!="")?parts.getCarrier():
-                    address.getCarrier());
-    r = r.addToContact(contact);
+    Route r(getName(),
+            aname,
+            ((parts.getCarrier()!="") ? parts.getCarrier() : address.getCarrier()));
+    r.setToContact(contact);
 
     // Check for any restrictions on the port.  Perhaps it can only
     // read, or write.
@@ -963,7 +963,8 @@ bool PortCore::addOutput(const ConstString& dest, void *id, OutputStream *os,
         // sender.  HTTP and ROS have pull connections, initiated
         // by the receiver.
         // We invert the route, flip the protocol direction, and add.
-        op->rename(Route().addFromName(r.getToName()).addToName(r.getFromName()).addCarrierName(r.getCarrierName()));
+        r.swapNames();
+        op->rename(r);
         InputProtocol *ip =  &(op->getInput());
         stateMutex.wait();
         if (!finished) {
@@ -2085,7 +2086,9 @@ bool PortCore::adminBlock(ConnectionReader& reader, void *id,
                                     op->attachPort(contactable);
                                     op->open(r);
                                 }
-                                op->rename(Route().addFromName(op->getRoute().getToName()).addToName(op->getRoute().getFromName()).addCarrierName(op->getRoute().getCarrierName()));
+                                Route route = op->getRoute();
+                                route.swapNames();
+                                op->rename(route);
                                 InputProtocol *ip =  &(op->getInput());
                                 stateMutex.wait();
                                 PortCoreUnit *unit = new PortCoreInputUnit(*this,

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -137,7 +137,8 @@ void PortCoreInputUnit::run() {
             OutputProtocol *op = &(ip->getOutput());
             Route r = op->getRoute();
             // reverse route
-            op->rename(Route().addFromName(r.getToName()).addToName(r.getFromName()).addCarrierName(r.getCarrierName()));
+            r.swapNames();
+            op->rename(r);
 
             getOwner().addOutput(op);
             ip = YARP_NULLPTR;
@@ -317,7 +318,8 @@ void PortCoreInputUnit::run() {
                 ip->endRead();
                 Route r = op->getRoute();
                 // reverse route
-                op->rename(Route().addFromName(r.getToName()).addToName(r.getFromName()).addCarrierName(r.getCarrierName()));
+                r.swapNames();
+                op->rename(r);
 
                 getOwner().addOutput(op);
                 ip = YARP_NULLPTR;

--- a/src/libYARP_OS/src/Protocol.cpp
+++ b/src/libYARP_OS/src/Protocol.cpp
@@ -39,8 +39,12 @@ Protocol::Protocol(TwoWayStream* stream) :
 }
 
 bool Protocol::open(const ConstString& name) {
-    if (name=="") return false;
-    setRoute(getRoute().addToName(name));
+    if (name=="") {
+        return false;
+    }
+    Route r = getRoute();
+    r.setToName(name);
+    setRoute(r);
     // We are not the initiator of the connection, so we
     // expect to receive a header (carrier-dependent).
     bool ok = expectHeader();
@@ -72,7 +76,7 @@ void Protocol::setRoute(const Route& route) {
     if (from.find(' ')!=ConstString::npos) {
         Bottle b(from.c_str());
         if (b.size()>1) {
-            r = r.addFromName(b.get(0).toString().c_str());
+            r.setFromName(b.get(0).toString().c_str());
             for (int i=1; i<b.size(); i++) {
                 Value& v = b.get(i);
                 Bottle *lst = v.asList();
@@ -83,7 +87,7 @@ void Protocol::setRoute(const Route& route) {
                     carrier = carrier + "+" + v.toString().c_str();
                 }
             }
-            r = r.addCarrierName(carrier);
+            r.setCarrierName(carrier);
         }
     }
 
@@ -303,7 +307,9 @@ void Protocol::setCarrier(const ConstString& carrierNameBase) {
     // has all the protocol-specific behavior.
     ConstString carrierName = carrierNameBase;
     if (carrierNameBase=="") carrierName = "tcp";
-    setRoute(getRoute().addCarrierName(carrierName));
+    Route route = getRoute();
+    route.setCarrierName(carrierName);
+    setRoute(route);
     if (delegate==YARP_NULLPTR) {
         delegate = Carriers::chooseCarrier(carrierName);
         if (delegate!=YARP_NULLPTR) {
@@ -379,7 +385,9 @@ bool Protocol::expectProtocolSpecifier() {
         YARP_DEBUG(log, "unrecognized protocol");
         return false;
     }
-    setRoute(getRoute().addCarrierName(delegate->getName()));
+    Route r = getRoute();
+    r.setCarrierName(delegate->getName());
+    setRoute(r);
     delegate->setParameters(header);
     return true;
 }

--- a/src/libYARP_OS/src/Route.cpp
+++ b/src/libYARP_OS/src/Route.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2006 RobotCub Consortium
+ * Authors: Paul Fitzpatrick
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <yarp/os/Route.h>
+#include <yarp/os/ConstString.h>
+#include <yarp/os/Contact.h>
+
+
+using yarp::os::Route;
+using yarp::os::ConstString;
+using yarp::os::Contact;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+class Route::Private
+{
+public:
+    Private(const ConstString& fromName,
+            const ConstString& toName,
+            const ConstString& fromContact,
+            const ConstString& toContact,
+            const ConstString& carrierName) :
+        fromName(fromName),
+        toName(toName),
+        fromContact(fromContact),
+        toContact(toContact),
+        carrierName(carrierName)
+    {
+    }
+
+    ConstString fromName;
+    ConstString toName;
+    Contact fromContact;
+    Contact toContact;
+    ConstString carrierName;
+
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+
+
+
+
+
+Route::Route() :
+        mPriv(new Private(ConstString(),
+                          ConstString(),
+                          ConstString(),
+                          ConstString(),
+                          ConstString()))
+{
+}
+
+Route::Route(const ConstString& fromName,
+             const ConstString& toName,
+             const ConstString& carrierName) :
+        mPriv(new Private(fromName,
+                          toName,
+                          ConstString(),
+                          ConstString(),
+                          carrierName))
+{
+}
+
+Route::Route(const Route& rhs) :
+        mPriv(new Private(*(rhs.mPriv)))
+{
+}
+
+#if defined(YARP_HAS_CXX11) && YARP_COMPILER_CXX_RVALUE_REFERENCES
+Route::Route(Route&& rhs) :
+        mPriv(new Private(std::move(*(rhs.mPriv))))
+{
+}
+#endif
+
+Route::~Route()
+{
+    delete mPriv;
+}
+
+Route& Route::operator=(const Route& rhs)
+{
+    if (&rhs != this) {
+        *mPriv = *(rhs.mPriv);
+    }
+    return *this;
+}
+
+#if defined(YARP_HAS_CXX11) && YARP_COMPILER_CXX_RVALUE_REFERENCES
+Route& Route::operator=(Route&& rhs)
+{
+    if (&rhs != this) {
+        std::swap(mPriv, rhs.mPriv);
+    }
+    return *this;
+}
+#endif
+
+const ConstString& Route::getFromName() const
+{
+    return mPriv->fromName;
+}
+
+void Route::setFromName(const ConstString& fromName)
+{
+    mPriv->fromName = fromName;
+}
+
+const ConstString& Route::getToName() const
+{
+    return mPriv->toName;
+}
+
+void Route::setToName(const ConstString& toName)
+{
+    mPriv->toName = toName;
+}
+
+const Contact& Route::getToContact() const
+{
+    return mPriv->toContact;
+}
+
+void Route::setToContact(const Contact& toContact)
+{
+    mPriv->toContact = toContact;
+}
+
+const ConstString& Route::getCarrierName() const
+{
+    return mPriv->carrierName;
+}
+
+void Route::setCarrierName(const ConstString& carrierName)
+{
+    mPriv->carrierName = carrierName;
+}
+
+void Route::swapNames()
+{
+    std::swap(mPriv->fromName, mPriv->toName);
+}
+
+ConstString Route::toString() const
+{
+    return getFromName() + "->" + getCarrierName() + "->" + getToName();
+}
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
+
+Route Route::addFromName(const ConstString& fromName) const
+{
+    Route result(*this);
+    result.mPriv->fromName = fromName;
+    return result;
+}
+
+Route Route::addToName(const ConstString& toName) const
+{
+    Route result(*this);
+    result.mPriv->toName = toName;
+    return result;
+}
+
+
+Route Route::addToContact(const Contact& toContact) const
+{
+    Route result(*this);
+    result.mPriv->toContact = toContact;
+    return result;
+}
+
+Route Route::addCarrierName(const ConstString& carrierName) const
+{
+    Route result(*this);
+    result.mPriv->carrierName = carrierName;
+    return result;
+}
+
+#endif // YARP_NO_DEPRECATED

--- a/src/libYARP_OS/src/TextCarrier.cpp
+++ b/src/libYARP_OS/src/TextCarrier.cpp
@@ -90,7 +90,9 @@ bool yarp::os::impl::TextCarrier::expectReplyToHeader(ConnectionState& proto) {
 
 bool yarp::os::impl::TextCarrier::expectSenderSpecifier(ConnectionState& proto) {
     YARP_SPRINTF0(Logger::get(), debug, "TextCarrier::expectSenderSpecifier");
-    proto.setRoute(proto.getRoute().addFromName(proto.is().readLine()));
+    Route route = proto.getRoute();
+    route.setFromName(proto.is().readLine());
+    proto.setRoute(route);
     return true;
 }
 


### PR DESCRIPTION
* The following methods were deprecated:
    - `addFromName()`
    - `addToName()`
    - `addCarrierName()`
    - `addToContact()`
* The following methods were added:
    - `setFromName()`
    - `setToName()`
    - `setCarrierName()`
    - `setToContact()`
    - `swapNames()`
* Added move constructors and copy and move assignment operators
* Use PIMPL idiom
* Update everything to the new API.

Even though it takes more lines to do the same thing, this saves several copies of the `Route` object.

I don't think this is used anywhere outside YARP.