### PR TITLE
Frametransform fix

### DIFF
--- a/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
+++ b/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
@@ -386,7 +386,6 @@ bool yarp::dev::FrameTransformClient::open(yarp::os::Searchable &config)
         yError("FrameTransformClient::open() error could not open rpc port %s, check network", local_rpcUser.c_str());
         return false;
     }
-    m_rpc_InterfaceToUser.setReader(*this);
 
     if (!m_rpc_InterfaceToServer.open(local_rpcServer.c_str()))
     {
@@ -395,7 +394,7 @@ bool yarp::dev::FrameTransformClient::open(yarp::os::Searchable &config)
     }
 
     m_transform_storage = new Transforms_client_storage(local_streaming_name);
-    bool ok=Network::connect(remote_streaming_name.c_str(), local_streaming_name.c_str(), "udp");
+    bool ok = Network::connect(remote_streaming_name.c_str(), local_streaming_name.c_str(), "udp");
     if (!ok)
     {
         yError("FrameTransformClient::open() error could not connect to %s", remote_streaming_name.c_str());
@@ -409,6 +408,8 @@ bool yarp::dev::FrameTransformClient::open(yarp::os::Searchable &config)
         return false;
     }
 
+
+    m_rpc_InterfaceToUser.setReader(*this);
     return true;
 }
 

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -113,6 +113,10 @@ public:
 
         bool ok_view = ddtransformclient.view(itf);
         checkTrue(ok_view && itf!=0, "iTransform interface open reported successful");
+        if(!ok_view)
+        {
+            return;
+        }
         yarp::sig::Matrix m1(4, 4);
         m1[0][0] = cos(M_PI / 4); m1[0][1] = -sin(M_PI / 4); m1[0][2] = 0; m1[0][3] = 3;
         m1[1][0] = sin(M_PI / 4); m1[1][1] = cos(M_PI /4);   m1[1][2] = 0; m1[1][3] = 1;


### PR DESCRIPTION
- fixed an on-closure segfault in transformClient (if without the transformServer)
- added a check in the correlated test to prevent a segfaul in the opening failure case of the trasformClient