### PR TITLE
BufferedPort: add check if the port is closed before calling write()

### DIFF
--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -40,8 +40,6 @@ using namespace yarp::os::impl;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#ifdef BROKEN_TEST
-
 namespace yarp {
     namespace dev {
         class BrokenDevice;
@@ -51,7 +49,7 @@ namespace yarp {
 /**
  * @ingroup dev_impl_media
  *
- * A fake camera for testing.
+ * A fake device for testing closure after a prepare of a closed port.
  */
 class yarp::dev::BrokenDevice : public DeviceDriver,
                                 public yarp::os::RateThread
@@ -92,8 +90,6 @@ private:
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb>> pImg;
 
 };
-
-#endif
 
 class TcpTestServer : public RateThread
 {
@@ -1599,12 +1595,10 @@ public:
 
         testCallbackLock();
 
-#ifdef BROKEN_TEST
         yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::BrokenDevice>("brokenDevice",
                                                       "brokenDevice",
                                                       "yarp::dev::BrokenDevice"));
         testPrepareDeadlock();
-#endif
 
 
 

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -1530,8 +1530,8 @@ public:
         yarp::dev::PolyDriver p;
         Property prop;
         prop.put("device","brokenDevice");
-        p.open(prop);
-        p.close();
+        checkTrue(p.open(prop),"Opening the broken_device");
+        checkTrue(p.close(),"Closing the broken_device");
     }
 
     virtual void runTests() {


### PR DESCRIPTION
This PR fix #1236.

Please review code.