### PR TITLE
Return empty list as getBusInfo's reply if no connections available

### DIFF
--- a/doc/release/v2_3_68_1.md
+++ b/doc/release/v2_3_68_1.md
@@ -84,6 +84,8 @@ Bug Fixes
   characters.
 * Fixed commands `yarp name get /port accepts` and `yarp name get /port offers`.
 * Fixed deadlock during a device closure after calling a prepare of a closed port.
+* Fixed reply to `yarp::os::Node::Helper::getBusInfo` if no connections available,
+  now it returns an empty list.
 
 #### YARP_sig
 

--- a/src/libYARP_OS/src/Node.cpp
+++ b/src/libYARP_OS/src/Node.cpp
@@ -281,6 +281,10 @@ public:
             opaque_id++;
         }
 
+        if (connections->size() == 0) {
+            connections->addList(); // add empty list
+        }
+
         na.reply = v;
         na.success();
     }


### PR DESCRIPTION
Apparently, `rosnode info` (ROS Python utility) always expects a `XMLRPCLegalValue` (see Slave API, output parameter `busInfo`) even if it's empty. Not doing so results in a `ValueError` caused by attempting to unpack three variables from a tuple of two values.

* http://wiki.ros.org/ROS/Slave_API#line-33
* https://github.com/ros/ros_comm/blob/ac9f45f/tools/rosnode/src/rosnode/__init__.py#L528
* https://github.com/ros/ros_comm/blob/ac9f45f/tools/rosnode/src/rosnode/__init__.py#L79

This bug was encountered when a CBW2 configured with `useROS true` (or `only`) was queried by `rosnode info /nameOfNode`. Moreover, `rostopic echo /nameOfTopic` hung the terminal (no output). Tested on ROS Kinetic, Ubuntu 16.04. Please review, should this entail any further implications.