### PR TITLE
Port changes to yarp.i from https://github.com/robotology-playground/yarp-matlab-bindings

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -20,9 +20,13 @@
 %}
 
 %import "yarp/conf/api.h"
+
+#if !defined (SWIGMATLAB)
 %feature("director") yarp::os::PortReader;
 %feature("director") yarp::os::RFModule;
 %feature("director") yarp::os::Thread;
+#endif
+
 %feature("autodoc", "1");
 
 #if defined (SWIGPYTHON) || defined (SWIGRUBY)
@@ -411,8 +415,12 @@ namespace yarp {
 %define MAKE_COMMS(name)
 %feature("notabstract") yarp::os::BufferedPort<name>;
 %feature("notabstract") BufferedPort ## name;
+
+#if !defined (SWIGMATLAB)
 %feature("director") yarp::os::TypedReaderCallback<name>;
 %feature("director") yarp::os::TypedReaderCallback<yarp::os::name>;
+#endif
+
 %template(TypedReader ## name) yarp::os::TypedReader<name>;
 %template(name ## Callback) yarp::os::TypedReaderCallback<name>;
 %template(BufferedPort ## name) yarp::os::BufferedPort<name>;
@@ -535,6 +543,12 @@ typedef yarp::os::TypedReaderCallback<Sound> TypedReaderCallbackSound;
 typedef yarp::os::BufferedPort<Sound> BufferedPortSound;
 %}
 
+%{
+typedef yarp::os::TypedReader<yarp::sig::Vector> TypedReaderVector;
+typedef yarp::os::TypedReaderCallback<yarp::sig::Vector> TypedReaderCallbackVector;
+typedef yarp::os::BufferedPort<yarp::sig::Vector> BufferedPortVector;
+%}
+
 %feature("notabstract") ImageRgb;
 %feature("notabstract") yarp::os::BufferedPort<ImageRgb>;
 %feature("notabstract") BufferedPortImageRgb;
@@ -558,6 +572,10 @@ typedef yarp::os::BufferedPort<Sound> BufferedPortSound;
 %feature("notabstract") Sound;
 %feature("notabstract") yarp::os::BufferedPort<Sound>;
 %feature("notabstract") BufferedPortSound;
+
+%feature("notabstract") Vector;
+%feature("notabstract") yarp::os::BufferedPort<Vector>;
+%feature("notabstract") BufferedPortVector;
 
 %template(ImageRgb) yarp::sig::ImageOf<yarp::sig::PixelRgb>;
 %template(TypedReaderImageRgb) yarp::os::TypedReader<yarp::sig::ImageOf<yarp::sig::PixelRgb> >;
@@ -587,6 +605,10 @@ typedef yarp::os::BufferedPort<Sound> BufferedPortSound;
 %template(TypedReaderSound) yarp::os::TypedReader<yarp::sig::Sound >;
 %template(TypedReaderCallbackSound) yarp::os::TypedReaderCallback<yarp::sig::Sound>;
 %template(BufferedPortSound) yarp::os::BufferedPort<yarp::sig::Sound >;
+
+%template(TypedReaderVector) yarp::os::TypedReader<yarp::sig::Vector >;
+%template(TypedReaderCallbackVector) yarp::os::TypedReaderCallback<yarp::sig::Vector>;
+%template(BufferedPortVector) yarp::os::BufferedPort<yarp::sig::Vector >;
 
 // Add getPixel and setPixel methods to access float values
 %extend yarp::sig::ImageOf<yarp::sig::PixelFloat> {
@@ -1117,6 +1139,21 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
         bool data = true;
         self->checkMotionDone(&data);
         return data;
+    }
+
+    int storeContext() {
+        // bad id to return if the real
+        // storeContext returns false
+        int badContextId = -1000;
+        int ret = badContextId;
+        // call the real storeContext
+        bool ok = self->storeContext(&ret);
+        // if not ok, return the badContextId
+        if( !ok ) {
+            ret = badContextId;
+        }
+
+        return ret;
     }
 }
 


### PR DESCRIPTION
Currently the MATLAB-specific part are ignored by the yarp cmake
build, but they are useful for yarp-matlab-bindings to use
the upstream yarp.i instead of having a separate copy