### PR TITLE
YarpManager: Fix "Computer" resource check

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -5,6 +5,25 @@ YARP 2.3.72 (UNRELEASED) Release Notes
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+v2.3.72%22).
 
+New Features
+------------
+
+#### `YARP_OS`
+
+* Added the property *yarprun* to ports opened through `yarprun --server`.
+
+Bug Fixes
+---------
+
+### GUIs
+
+#### yarpmanager
+
+* Fixed the check of the status of the Computers, now it verifies that the
+  corresponding port has been opened through `yarp run`. Be aware that after
+  these changes `yarpmanager` will not detect machines with `yarp 2.3.70` 
+  and earlier.
+
 
 Contributors
 ------------

--- a/src/libYARP_OS/src/Run.cpp
+++ b/src/libYARP_OS/src/Run.cpp
@@ -14,6 +14,7 @@
 #include <yarp/os/SystemInfoSerializer.h>
 #include <yarp/os/Time.h>
 
+#include <yarp/os/impl/NameClient.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/SplitString.h>
 #include <yarp/os/impl/PlatformSysPrctl.h>
@@ -878,6 +879,14 @@ int yarp::os::Run::server()
             if (mPortName[0]!='/') yError("Invalid port name '%s', it should start with '/'\n", mPortName.c_str());
             return YARPRUN_ERROR;
         }
+        yarp::os::Bottle cmd, reply;
+        cmd.addString("set");
+        cmd.addString(port.getName());
+        cmd.addString("yarprun");
+        cmd.addString("true");
+
+        yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
+
         yInfo() << "Yarprun succesfully started on port: " << mPortName.c_str();
 
         pServerPort=&port;


### PR DESCRIPTION
This PR introduces:

- add the property "yarprun" to the ports opened throgh `yarp run` or `yarprun`
- add the check for "Computers" if the corresponding port has been opened through `yarprun`

TODO:

- [x] Test on `iCubGenova01` setup

Please review code.