### PR TITLE
Fix yarp::os::Route

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -5,6 +5,14 @@ YARP 2.3.70.1 (UNRELEASED) Release Notes
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+v2.3.70.1%22).
 
+Bug Fixes
+---------
+
+### Libraries
+
+#### YARP_OS
+
+* Fixed `Route::swapNames()` segfault in Windows and MacOS.
 
 Contributors
 ------------

--- a/src/libYARP_OS/src/Route.cpp
+++ b/src/libYARP_OS/src/Route.cpp
@@ -138,7 +138,7 @@ void Route::setCarrierName(const ConstString& carrierName)
 
 void Route::swapNames()
 {
-    std::swap(mPriv->fromName, mPriv->toName);
+    mPriv->fromName.swap(mPriv->toName);
 }
 
 ConstString Route::toString() const


### PR DESCRIPTION
This PR fixes the `yarp::os::Route::swapNames()` segfault in Windows, and MacOS (@francesco-romano ?).

Please review code.