### PR TITLE
Event driven joypad

### DIFF
--- a/src/devices/SDLJoypad/SDLJoypad.cpp
+++ b/src/devices/SDLJoypad/SDLJoypad.cpp
@@ -361,7 +361,7 @@ yarp::sig::Vector Vector3(const double& x, const double& y)
 
 bool SDLJoypad::getRawStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
 {
-    if(stick_id > m_stickCount - 1){yError() << "SDLJoypad: stick id out of bound!"; return false;}
+    if (stick_id > m_stickCount - 1){yError() << "SDLJoypad: stick id out of bound!"; return false;}
     value.clear();
     updateJoypad();
     stick& stk = m_sticks[stick_id];
@@ -373,9 +373,9 @@ bool SDLJoypad::getRawStick(unsigned int stick_id, yarp::sig::Vector& value, Joy
         value.push_back(val * stk.direction[i] * (fabs(val) > stk.deadZone));
     }
 
-    if(coordinate_mode == JypCtrlcoord_POLAR)
+    if (coordinate_mode == JypCtrlcoord_POLAR)
     {
-        if(stk.axes_ids.size() > 2)
+        if (stk.axes_ids.size() > 2)
         {
             yError() << "polar coordinate system is supported only for bidimensional stick at the moment";
             return false;

--- a/src/devices/SDLJoypad/SDLJoypad.cpp
+++ b/src/devices/SDLJoypad/SDLJoypad.cpp
@@ -242,54 +242,59 @@ bool SDLJoypad::parseStickInfo(const yarp::os::Searchable& cfg)
     return true;
 }
 
-
 bool SDLJoypad::close()
 {
     return false;
 }
 
-bool SDLJoypad::getAxisCount(unsigned int& axes_count)
+bool SDLJoypad::getRawAxisCount(unsigned int& axes_count)
 {
     axes_count = m_axisCount;
     return true;
 }
 
-bool SDLJoypad::getButtonCount(unsigned int& button_count)
+bool SDLJoypad::getRawButtonCount(unsigned int& button_count)
 {
     button_count = m_buttonCount;
     return true;
 }
 
-bool SDLJoypad::getTrackballCount(unsigned int& trackball_count)
+bool SDLJoypad::getRawTrackballCount(unsigned int& trackball_count)
 {
     trackball_count = m_ballCount;
     return true;
 }
 
-bool SDLJoypad::getHatCount(unsigned int& hat_count)
+bool SDLJoypad::getRawHatCount(unsigned int& hat_count)
 {
     hat_count = m_hatCount;
     return true;
 }
 
-bool SDLJoypad::getTouchSurfaceCount(unsigned int& touch_count)
+bool SDLJoypad::getRawTouchSurfaceCount(unsigned int& touch_count)
 {
     touch_count = m_touchCount;
     return true;
 }
 
-bool SDLJoypad::getStickCount(unsigned int& stick_count)
+bool SDLJoypad::getRawStickCount(unsigned int& stick_count)
 {
     stick_count = m_stickCount;
     return true;
 }
 
-bool SDLJoypad::getStickDoF(unsigned int stick_id, unsigned int& DoF)
+bool SDLJoypad::getRawStickDoF(unsigned int stick_id, unsigned int& DoF)
 {
-    return false;
+    if(stick_id > m_sticks.size()-1)
+    {
+        yError() << "SDL_Joypad: stick_id out of bounds when calling 'getStickDoF'' method";
+        return false;
+    }
+    DoF = 2;
+    return true;
 }
 
-bool SDLJoypad::getButton(unsigned int button_id, float& value)
+bool SDLJoypad::getRawButton(unsigned int button_id, float& value)
 {
     if(button_id > m_buttonCount - 1){yError() << "SDLJoypad: button id out of bound!"; return false;}
     updateJoypad();
@@ -315,7 +320,7 @@ bool SDLJoypad::getButton(unsigned int button_id, float& value)
     return true;
 }
 
-bool SDLJoypad::getRawAxis(unsigned int axis_id, double& value)
+bool SDLJoypad::getPureAxis(unsigned int axis_id, double& value)
 {
     if(axis_id > m_axisCount - 1){yError() << "SDLJoypad: axis id out of bound!"; return false;}
     size_t i;
@@ -338,12 +343,12 @@ bool SDLJoypad::getRawAxis(unsigned int axis_id, double& value)
     return true;
 }
 
-bool SDLJoypad::getAxis(unsigned int axis_id, double& value)
+bool SDLJoypad::getRawAxis(unsigned int axis_id, double& value)
 {
     if(axis_id > m_axisCount - 1){yError() << "SDLJoypad: axis id out of bound!"; return false;}
     //if(!m_axes.at(axis_id)) {yWarning() << "SDLJoypad: requested axis is part of a stick!";}
     updateJoypad();
-    return getRawAxis(axis_id, value);
+    return getPureAxis(axis_id, value);
 }
 
 yarp::sig::Vector Vector3(const double& x, const double& y)
@@ -354,7 +359,7 @@ yarp::sig::Vector Vector3(const double& x, const double& y)
     return ret;
 }
 
-bool SDLJoypad::getStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
+bool SDLJoypad::getRawStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
 {
     if(stick_id > m_stickCount - 1){yError() << "SDLJoypad: stick id out of bound!"; return false;}
     value.clear();
@@ -380,12 +385,12 @@ bool SDLJoypad::getStick(unsigned int stick_id, yarp::sig::Vector& value, Joypad
     return true;
 }
 
-bool SDLJoypad::getTouch(unsigned int touch_id, yarp::sig::Vector& value)
+bool SDLJoypad::getRawTouch(unsigned int touch_id, yarp::sig::Vector& value)
 {
     return false;
 }
 
-bool SDLJoypad::getHat(unsigned int hat_id, unsigned char& value)
+bool SDLJoypad::getRawHat(unsigned int hat_id, unsigned char& value)
 {
     if(hat_id > m_hatCount - 1){yError() << "SDLJoypad: axis id out of bound!"; return false;}
     updateJoypad();
@@ -407,7 +412,7 @@ bool SDLJoypad::getHat(unsigned int hat_id, unsigned char& value)
     return true;
 }
 
-bool SDLJoypad::getTrackball(unsigned int trackball_id, yarp::sig::Vector& value)
+bool SDLJoypad::getRawTrackball(unsigned int trackball_id, yarp::sig::Vector& value)
 {
     if(trackball_id > m_ballCount - 1){yError() << "SDLJoypad: trackball id out of bound!"; return false;}
     updateJoypad();

--- a/src/devices/SDLJoypad/SDLJoypad.h
+++ b/src/devices/SDLJoypad/SDLJoypad.h
@@ -31,7 +31,7 @@ struct yarp::dev::SDLJoypadImpl::stick
     std::vector<int>           direction;
 };
 
-class yarp::dev::SDLJoypad : public yarp::dev::IJoypadController,
+class yarp::dev::SDLJoypad : public yarp::dev::IJoypadEventDriven,//public yarp::dev::IJoypadController,
                              public yarp::dev::DeviceDriver
 {
     typedef std::vector<yarp::dev::SDLJoypadImpl::stick> stickVector;
@@ -52,41 +52,41 @@ class yarp::dev::SDLJoypad : public yarp::dev::IJoypadController,
     void updateJoypad();
     void pollActions();
     bool parseStickInfo(const yarp::os::Searchable& cfg);
-    bool getRawAxis(unsigned int axis_id, double& value);
+    bool getPureAxis(unsigned int axis_id, double& value);
 public:
 
     SDLJoypad();
     virtual ~SDLJoypad();
     //DeviceDriver
-    virtual bool open(yarp::os::Searchable& config);
-    virtual bool close();
+    virtual bool open(yarp::os::Searchable& config) YARP_OVERRIDE;
+    virtual bool close() YARP_OVERRIDE;
 
     //IJoypadController
-    virtual bool getAxisCount(unsigned int& axis_count) override;
+    virtual bool getRawAxisCount(unsigned int& axis_count) YARP_OVERRIDE;
 
-    virtual bool getButtonCount(unsigned int& button_count) override;
+    virtual bool getRawButtonCount(unsigned int& button_count) YARP_OVERRIDE;
 
-    virtual bool getHatCount(unsigned int& hat_count) override;
+    virtual bool getRawHatCount(unsigned int& hat_count) YARP_OVERRIDE;
 
-    virtual bool getTrackballCount(unsigned int& trackball_count) override;
+    virtual bool getRawTrackballCount(unsigned int& trackball_count) YARP_OVERRIDE;
 
-    virtual bool getTouchSurfaceCount(unsigned int& touch_count) override;
+    virtual bool getRawTouchSurfaceCount(unsigned int& touch_count) YARP_OVERRIDE;
 
-    virtual bool getStickCount(unsigned int& stick_count) override;
+    virtual bool getRawStickCount(unsigned int& stick_count) YARP_OVERRIDE;
 
-    virtual bool getStickDoF(unsigned int  stick_id, unsigned int& DoF) override;
+    virtual bool getRawStickDoF(unsigned int  stick_id, unsigned int& DoF) YARP_OVERRIDE;
 
-    virtual bool getButton(unsigned int  button_id, float& value) override;
+    virtual bool getRawButton(unsigned int  button_id, float& value) YARP_OVERRIDE;
 
-    virtual bool getTrackball(unsigned int  trackball_id, yarp::sig::Vector& value) override;
+    virtual bool getRawTrackball(unsigned int  trackball_id, yarp::sig::Vector& value) YARP_OVERRIDE;
 
-    virtual bool getHat(unsigned int  hat_id, unsigned char& value) override;
+    virtual bool getRawHat(unsigned int  hat_id, unsigned char& value) YARP_OVERRIDE;
 
-    virtual bool getAxis(unsigned int  axis_id, double& value) override;
+    virtual bool getRawAxis(unsigned int  axis_id, double& value) YARP_OVERRIDE;
 
-    virtual bool getStick(unsigned int  stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) override;
+    virtual bool getRawStick(unsigned int  stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) YARP_OVERRIDE;
 
-    virtual bool getTouch(unsigned int  touch_id, yarp::sig::Vector& value) override;
+    virtual bool getRawTouch(unsigned int  touch_id, yarp::sig::Vector& value) YARP_OVERRIDE;
 };
 
 

--- a/src/libYARP_dev/include/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/include/yarp/dev/IJoypadController.h
@@ -46,6 +46,13 @@ public:
     */
     virtual ~IJoypadController(){}
 
+    /**
+      Activate event Driven mode
+     * @brief eventDriven
+     * @param enable a bool to turn on or off the eventDriven mode
+     * * @param event a pointer to a valid yarp::dev::IJoypadEvent object whom action() method will be called on event detection
+     * @return true if succeded. false otherwise
+     */
     virtual bool eventDriven(bool enable, yarp::dev::IJoypadEvent* event = YARP_NULLPTR){return false;}
     virtual bool isEventDriven(){return false;}
 
@@ -251,6 +258,7 @@ public:
     virtual void run() YARP_OVERRIDE;
 
     virtual bool eventDriven(bool enable, yarp::dev::IJoypadEvent* event = YARP_NULLPTR) YARP_OVERRIDE;
+    virtual bool isEventDriven() YARP_OVERRIDE { return EventDrivenEnabled;}
 };
 
 

--- a/src/libYARP_dev/include/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/include/yarp/dev/IJoypadController.h
@@ -10,7 +10,9 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
+#include <yarp/os/RateThread.h>
 #include <map>
+#include <vector>
 
 #define HAT_ACTIONS_ID_SHIFT 100
 
@@ -19,19 +21,23 @@ namespace yarp
     namespace dev
     {
         class IJoypadController;
+        class IJoypadEvent;
+        class IJoypadEventDriven;
     }
 }
 
-class  YARP_dev_API yarp::dev::IJoypadController
+class YARP_dev_API yarp::dev::IJoypadController
 {
+public:
+    enum JoypadCtrl_coordinateMode {JypCtrlcoord_POLAR  =  0, JypCtrlcoord_CARTESIAN = 1};
+
 protected:
     std::map<int, std::string> m_actions;
 
     virtual bool parseActions(const yarp::os::Searchable& cfg, int *count = YARP_NULLPTR);
     virtual bool executeAction(int action_id);
-public:
 
-    enum JoypadCtrl_coordinateMode {JypCtrlcoord_POLAR  =  0, JypCtrlcoord_CARTESIAN = 1};
+public:
 
     /**
     Destructor
@@ -39,6 +45,9 @@ public:
     * @return
     */
     virtual ~IJoypadController(){}
+
+    virtual bool eventDriven(bool enable, yarp::dev::IJoypadEvent* event = YARP_NULLPTR){return false;}
+    virtual bool isEventDriven(){return false;}
 
     /**
       Get number of Axes
@@ -155,6 +164,96 @@ public:
     */
     virtual bool getTouch(unsigned int touch_id, yarp::sig::Vector& value) = 0;
 };
+
+class YARP_dev_API yarp::dev::IJoypadEvent
+{
+public:
+    virtual ~IJoypadEvent();
+
+    template <typename T> struct joyData
+    {
+        unsigned int m_id;
+        T            m_datum;
+
+        joyData(unsigned int id, const T& datum)
+        {
+            m_id    = id;
+            m_datum = datum;
+        }
+    };
+
+    virtual void action(std::vector<joyData<float> >             buttons,
+                        std::vector<joyData<double> >            axes,
+                        std::vector<joyData<unsigned char> >     hats,
+                        std::vector<joyData<yarp::sig::Vector> > trackBalls,
+                        std::vector<joyData<yarp::sig::Vector> > sticks,
+                        std::vector<joyData<yarp::sig::Vector> > Touch) = 0;
+};
+
+
+
+class YARP_dev_API yarp::dev::IJoypadEventDriven : yarp::os::RateThread,
+                                                   public yarp::dev::IJoypadController
+{
+private:
+    yarp::dev::IJoypadEvent*       m_event;
+    bool                           EventDrivenEnabled;
+    std::vector<float>             old_buttons;
+    std::vector<double>            old_axes;
+    std::vector<unsigned char>     old_hats;
+    std::vector<yarp::sig::Vector> old_trackballs;
+    std::vector<yarp::sig::Vector> old_sticks;
+    std::vector<yarp::sig::Vector> old_touches;
+protected:
+    virtual bool getRawAxisCount(unsigned int& axis_count) = 0;
+    virtual bool getRawButtonCount(unsigned int& button_count) = 0;
+    virtual bool getRawTrackballCount(unsigned int& Trackball_count) = 0;
+    virtual bool getRawHatCount(unsigned int& Hat_count) = 0;
+    virtual bool getRawTouchSurfaceCount(unsigned int& touch_count) = 0;
+    virtual bool getRawStickCount(unsigned int& stick_count) = 0;
+    virtual bool getRawStickDoF(unsigned int stick_id, unsigned int& DoF) = 0;
+    virtual bool getRawButton(unsigned int button_id, float& value) = 0;
+    virtual bool getRawTrackball(unsigned int trackball_id, yarp::sig::Vector& value) = 0;
+    virtual bool getRawHat(unsigned int hat_id, unsigned char& value) = 0;
+    virtual bool getRawAxis(unsigned int axis_id, double& value) = 0;
+    virtual bool getRawStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) = 0;
+    virtual bool getRawTouch(unsigned int touch_id, yarp::sig::Vector& value) = 0;
+    using IJoypadController::m_actions;
+    using IJoypadController::executeAction;
+    using IJoypadController::parseActions;
+
+public:
+
+    virtual bool getAxisCount(unsigned int& axis_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getButtonCount(unsigned int& button_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getTrackballCount(unsigned int& Trackball_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getHatCount(unsigned int& Hat_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getTouchSurfaceCount(unsigned int& touch_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getStickCount(unsigned int& stick_count) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getStickDoF(unsigned int stick_id, unsigned int& DoF) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getButton(unsigned int button_id, float& value) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getTrackball(unsigned int trackball_id, yarp::sig::Vector& value) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getHat(unsigned int hat_id, unsigned char& value) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getAxis(unsigned int axis_id, double& value) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) YARP_OVERRIDE YARP_FINAL;
+    virtual bool getTouch(unsigned int touch_id, yarp::sig::Vector& value) YARP_OVERRIDE YARP_FINAL;
+    using IJoypadController::JoypadCtrl_coordinateMode;
+    using IJoypadController::JypCtrlcoord_CARTESIAN;
+    using IJoypadController::JypCtrlcoord_POLAR;
+
+
+
+    IJoypadEventDriven();
+
+    IJoypadEventDriven(int rate);
+
+    virtual bool threadInit() YARP_OVERRIDE;
+    virtual void run() YARP_OVERRIDE;
+
+    virtual bool eventDriven(bool enable, yarp::dev::IJoypadEvent* event = YARP_NULLPTR) YARP_OVERRIDE;
+};
+
+
 #define YRPJOY_HAT_CENTERED	 0x00
 #define YRPJOY_HAT_UP		 0x01
 #define YRPJOY_HAT_RIGHT	 0x02

--- a/src/libYARP_dev/src/IJoypadController.cpp
+++ b/src/libYARP_dev/src/IJoypadController.cpp
@@ -1,5 +1,6 @@
 #include <yarp/dev/IJoypadController.h>
 #include <yarp/os/LogStream.h>
+#include <cmath>
 using namespace std;
 using namespace yarp::dev;
 using namespace yarp::os;
@@ -9,6 +10,371 @@ using namespace yarp::os;
 #define myDebug() yDebug() << MESSAGE_PREFIX
 #define myWarning() yWarning() << MESSAGE_PREFIX
 #define buttActionGroupName "BUTTON_EXECUTE"
+
+#define JoyData yarp::dev::IJoypadEvent::joyData
+
+yarp::dev::IJoypadEventDriven::IJoypadEventDriven() : IJoypadEventDriven(10){}
+
+yarp::dev::IJoypadEventDriven::IJoypadEventDriven(int rate) : RateThread(rate)
+{
+    EventDrivenEnabled = false;
+    m_event = YARP_NULLPTR;
+}
+
+bool isEqual(const float& a, const float& b, const float& tollerance)
+{
+    return fabs(a - b) < tollerance;
+}
+
+bool isEqual(const double& a, const double& b, const double& tollerance)
+{
+    return fabs(a - b) < tollerance;
+}
+
+bool isEqual(const yarp::sig::Vector& a, const yarp::sig::Vector& b, const double& tollerance)
+{
+    if (a.size() != b.size()) return false;
+
+    bool ret = true;
+
+    for (size_t i = 0; i < a.size(); i++)
+    {
+        if (ret &= fabs(a[i] - b[i]) < tollerance);
+    }
+    return ret;
+}
+
+bool yarp::dev::IJoypadEventDriven::threadInit()
+{
+    unsigned int count;
+    if(getRawButtonCount(count) && count)
+    {
+        float value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawButton(i, value);
+            old_buttons.push_back(value);
+        }
+    }
+
+    if(getRawAxisCount(count) && count)
+    {
+        double value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawAxis(i, value);
+            old_axes.push_back(value);
+        }
+    }
+
+    if(getRawHatCount(count) && count)
+    {
+        unsigned char value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawHat(i, value);
+            old_hats.push_back(value);
+        }
+    }
+
+    if(getRawTrackballCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawTrackball(i, value);
+            old_trackballs.push_back(value);
+        }
+    }
+
+    if(getRawStickCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawStick(i, value, IJoypadController::JypCtrlcoord_CARTESIAN);
+            old_sticks.push_back(value);
+
+        }
+    }
+
+    if(getRawTouchSurfaceCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawTouch(i, value);
+            old_touches.push_back(value);
+        }
+    }
+    return true;
+}
+
+void yarp::dev::IJoypadEventDriven::run()
+{
+    bool perform = false;
+    if(!m_event)
+    {
+        return;
+    }
+
+    unsigned int                             count;
+    std::vector<JoyData<float> >             buttons;
+    std::vector<JoyData<double> >            axes;
+    std::vector<JoyData<unsigned char> >     hats;
+    std::vector<JoyData<yarp::sig::Vector> > trackBalls;
+    std::vector<JoyData<yarp::sig::Vector> > sticks;
+    std::vector<JoyData<yarp::sig::Vector> > Touch;
+
+    if(getRawButtonCount(count) && count)
+    {
+        float value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawButton(i, value);
+            if(!isEqual(value, old_buttons[i], 0.00001f))
+            {
+                perform = true;
+                buttons.push_back(JoyData<float>(i, value));
+                old_buttons[i] = value;
+            }
+        }
+    }
+
+    if(getRawAxisCount(count) && count)
+    {
+        double value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawAxis(i, value);
+            if(!isEqual(value, old_axes[i], 0.00001))
+            {
+                perform = true;
+                axes.push_back(JoyData<double>(i, value));
+                old_axes[i] = value;
+            }
+        }
+    }
+
+    if(getRawHatCount(count) && count)
+    {
+        unsigned char value = 0;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawHat(i, value);
+            if(value != old_hats[i])
+            {
+                perform = true;
+                hats.push_back(JoyData<unsigned char>(i, value));
+                old_hats[i] = value;
+            }
+        }
+    }
+
+    if(getRawTrackballCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawTrackball(i, value);
+            if(!isEqual(value, old_trackballs[i], 0.00001))
+            {
+                perform = true;
+                trackBalls.push_back(JoyData<yarp::sig::Vector>(i, value));
+                old_trackballs[i] = value;
+            }
+        }
+    }
+
+    if(getRawStickCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawStick(i, value, IJoypadController::JypCtrlcoord_CARTESIAN);
+            if(!isEqual(value, old_sticks[i], 0.00001))
+            {
+                perform = true;
+                sticks.push_back(JoyData<yarp::sig::Vector>(i, value));
+                old_sticks[i] = value;
+            }
+        }
+    }
+
+    if(getRawTouchSurfaceCount(count) && count)
+    {
+        yarp::sig::Vector value;
+        for(unsigned int i = 0; i < count; i++)
+        {
+            getRawTouch(i, value);
+            if(!isEqual(value, old_touches[i], 0.00001))
+            {
+                perform = true;
+                Touch.push_back(JoyData<yarp::sig::Vector>(i, value));
+                old_touches[i] = value;
+            }
+        }
+    }
+
+    if(perform)
+    {
+        m_event->action(buttons, axes, hats, trackBalls, sticks, Touch);
+    }
+}
+
+bool yarp::dev::IJoypadEventDriven::eventDriven(bool enable, IJoypadEvent *event)
+{
+    if (enable)
+    {
+        if (event)
+        {
+            if(isRunning())
+            {
+                stop();
+            }
+
+            m_event = event;
+            EventDrivenEnabled = true;
+            start();
+
+            return true;
+        }
+        else
+        {
+            if(isRunning())
+            {
+                yError() << "IJoypadController: event thread is already running";
+                return false;
+            }
+
+            if (m_event)
+            {
+                EventDrivenEnabled = true;
+                start();
+                return true;
+            }
+            else
+            {
+                yError() << "IJoypadController: you must provide a valid event to start the event thread";
+                return false;
+            }
+        }
+    }
+
+    if(isRunning())
+    {
+        stop();
+        EventDrivenEnabled = false;
+        return true;
+    }
+
+    return false;
+}
+
+bool yarp::dev::IJoypadEventDriven::getAxisCount(unsigned int& axis_count)
+{
+    return getRawAxisCount(axis_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getButtonCount(unsigned int& button_count)
+{
+    return getRawButtonCount(button_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getTrackballCount(unsigned int& Trackball_count)
+{
+    return getRawTrackballCount(Trackball_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getHatCount(unsigned int& Hat_count)
+{
+    return getRawHatCount(Hat_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getTouchSurfaceCount(unsigned int& touch_count)
+{
+    return getRawTouchSurfaceCount(touch_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getStickCount(unsigned int& stick_count)
+{
+    return getRawStickCount(stick_count);
+}
+
+bool yarp::dev::IJoypadEventDriven::getStickDoF(unsigned int stick_id, unsigned int& DoF)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+    return getStickDoF(stick_id, DoF);
+}
+
+bool yarp::dev::IJoypadEventDriven::getButton(unsigned int button_id, float& value)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+    return getRawButton(button_id, value);
+}
+
+bool yarp::dev::IJoypadEventDriven::getTrackball(unsigned int trackball_id, yarp::sig::Vector& value)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+
+    return getRawTrackball(trackball_id, value);
+}
+
+bool yarp::dev::IJoypadEventDriven::getHat(unsigned int hat_id, unsigned char& value)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+
+    return getRawHat(hat_id, value);
+}
+
+bool yarp::dev::IJoypadEventDriven::getAxis(unsigned int axis_id, double& value)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+
+    return getRawAxis(axis_id, value);
+}
+
+bool yarp::dev::IJoypadEventDriven::getStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+
+    return getRawStick(stick_id, value, coordinate_mode);
+}
+
+bool yarp::dev::IJoypadEventDriven::getTouch(unsigned int touch_id, yarp::sig::Vector& value)
+{
+    if (EventDrivenEnabled)
+    {
+        yError() << "EventDriven is enable.. you can't poll the joypad state";
+        return false;
+    }
+
+    return getRawTouch(touch_id, value);
+}
 
 bool yarp::dev::IJoypadController::executeAction(int action_id)
 {
@@ -79,3 +445,5 @@ bool yarp::dev::IJoypadController::parseActions(const yarp::os::Searchable& cfg,
     myInfo() << actCount << "action parsed succesfully";
     return true;
 }
+
+yarp::dev::IJoypadEvent::~IJoypadEvent(){};

--- a/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.cpp
+++ b/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.cpp
@@ -209,36 +209,37 @@ bool JoypadControlClient::getCount(const int& vocab_toget, unsigned int& value)
     }
 }
 
-bool JoypadControlClient::getButtonCount(unsigned int& button_count)
+bool JoypadControlClient::getRawButtonCount(unsigned int& button_count)
 {
     return getCount(VOCAB_BUTTON, button_count);
 }
 
-bool JoypadControlClient::getAxisCount(unsigned int& axis_count)
+bool JoypadControlClient::getRawAxisCount(unsigned int& axis_count)
 {
     return getCount(VOCAB_AXIS, axis_count);
 }
 
-bool JoypadControlClient::getTrackballCount(unsigned int& Trackball_count)
+bool JoypadControlClient::getRawTrackballCount(unsigned int& Trackball_count)
 {
     return getCount(VOCAB_TRACKBALL, Trackball_count);
 }
 
-bool JoypadControlClient::getHatCount(unsigned int& Hat_count)
+bool JoypadControlClient::getRawHatCount(unsigned int& Hat_count)
 {
     return getCount(VOCAB_HAT, Hat_count);
 }
 
-bool JoypadControlClient::getTouchSurfaceCount(unsigned int& touch_count)
+bool JoypadControlClient::getRawTouchSurfaceCount(unsigned int& touch_count)
 {
     return getCount(VOCAB_TOUCH, touch_count);
 }
 
-bool JoypadControlClient::getStickCount(unsigned int& stick_count)
+bool JoypadControlClient::getRawStickCount(unsigned int& stick_count)
 {
     return getCount(VOCAB_STICK, stick_count);
 }
-bool JoypadControlClient::getStickDoF(unsigned int stick_id, unsigned int& DoF)
+
+bool JoypadControlClient::getRawStickDoF(unsigned int stick_id, unsigned int& DoF)
 {
     Bottle cmd, response;
     cmd.addVocab(VOCAB_IJOYPADCTRL);
@@ -258,7 +259,7 @@ bool JoypadControlClient::getStickDoF(unsigned int stick_id, unsigned int& DoF)
     }
 }
 
-bool JoypadControlClient::getButton(unsigned int button_id, float& value)
+bool JoypadControlClient::getRawButton(unsigned int button_id, float& value)
 {
     if(m_rpc_only)
     {
@@ -297,7 +298,7 @@ bool JoypadControlClient::getButton(unsigned int button_id, float& value)
     }
 }
 
-bool JoypadControlClient::getTrackball(unsigned int trackball_id, yarp::sig::Vector& value)
+bool JoypadControlClient::getRawTrackball(unsigned int trackball_id, yarp::sig::Vector& value)
 {
     value.clear();
     if(m_rpc_only)
@@ -337,7 +338,7 @@ bool JoypadControlClient::getTrackball(unsigned int trackball_id, yarp::sig::Vec
     }
 }
 
-bool JoypadControlClient::getHat(unsigned int hat_id, unsigned char& value)
+bool JoypadControlClient::getRawHat(unsigned int hat_id, unsigned char& value)
 {
     if(m_rpc_only)
     {
@@ -374,7 +375,7 @@ bool JoypadControlClient::getHat(unsigned int hat_id, unsigned char& value)
     }
 }
 
-bool JoypadControlClient::getAxis(unsigned int axis_id, double& value)
+bool JoypadControlClient::getRawAxis(unsigned int axis_id, double& value)
 {
     if(m_rpc_only)
     {
@@ -413,7 +414,7 @@ bool JoypadControlClient::getAxis(unsigned int axis_id, double& value)
     }
 }
 
-bool JoypadControlClient::getStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
+bool JoypadControlClient::getRawStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode)
 {
     value.clear();
     if(m_rpc_only || coordinate_mode == IJoypadController::JypCtrlcoord_POLAR)
@@ -483,7 +484,7 @@ bool JoypadControlClient::getStick(unsigned int stick_id, yarp::sig::Vector& val
     }
 }
 
-bool JoypadControlClient::getTouch(unsigned int touch_id, yarp::sig::Vector& value)
+bool JoypadControlClient::getRawTouch(unsigned int touch_id, yarp::sig::Vector& value)
 {
     value.clear();
     if(m_rpc_only)

--- a/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.h
+++ b/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.h
@@ -19,7 +19,7 @@ namespace yarp
     }
 }
 
-class yarp::dev::JoypadControlClient : public yarp::dev::IJoypadController,
+class yarp::dev::JoypadControlClient : public yarp::dev::IJoypadEventDriven,
                                        public yarp::dev::DeviceDriver
 {
 private:
@@ -55,19 +55,19 @@ public:
     virtual bool close() YARP_OVERRIDE;
 
     //IJoypadController;
-    virtual bool getAxisCount(unsigned int& axis_count) YARP_OVERRIDE;
-    virtual bool getButtonCount(unsigned int& button_count) YARP_OVERRIDE;
-    virtual bool getTrackballCount(unsigned int& Trackball_count) YARP_OVERRIDE;
-    virtual bool getHatCount(unsigned int& Hat_count) YARP_OVERRIDE;
-    virtual bool getTouchSurfaceCount(unsigned int& touch_count) YARP_OVERRIDE;
-    virtual bool getStickCount(unsigned int& stick_count) YARP_OVERRIDE;
-    virtual bool getStickDoF(unsigned int stick_id, unsigned int& DoF) YARP_OVERRIDE;
-    virtual bool getButton(unsigned int button_id, float& value) YARP_OVERRIDE;
-    virtual bool getTrackball(unsigned int trackball_id, yarp::sig::Vector& value) YARP_OVERRIDE;
-    virtual bool getHat(unsigned int hat_id, unsigned char& value) YARP_OVERRIDE;
-    virtual bool getAxis(unsigned int axis_id, double& value) YARP_OVERRIDE;
-    virtual bool getStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) YARP_OVERRIDE;
-    virtual bool getTouch(unsigned int touch_id, yarp::sig::Vector& value) YARP_OVERRIDE;
+    virtual bool getRawAxisCount(unsigned int& axis_count) YARP_OVERRIDE;
+    virtual bool getRawButtonCount(unsigned int& button_count) YARP_OVERRIDE;
+    virtual bool getRawTrackballCount(unsigned int& Trackball_count) YARP_OVERRIDE;
+    virtual bool getRawHatCount(unsigned int& Hat_count) YARP_OVERRIDE;
+    virtual bool getRawTouchSurfaceCount(unsigned int& touch_count) YARP_OVERRIDE;
+    virtual bool getRawStickCount(unsigned int& stick_count) YARP_OVERRIDE;
+    virtual bool getRawStickDoF(unsigned int stick_id, unsigned int& DoF) YARP_OVERRIDE;
+    virtual bool getRawButton(unsigned int button_id, float& value) YARP_OVERRIDE;
+    virtual bool getRawTrackball(unsigned int trackball_id, yarp::sig::Vector& value) YARP_OVERRIDE;
+    virtual bool getRawHat(unsigned int hat_id, unsigned char& value) YARP_OVERRIDE;
+    virtual bool getRawAxis(unsigned int axis_id, double& value) YARP_OVERRIDE;
+    virtual bool getRawStick(unsigned int stick_id, yarp::sig::Vector& value, JoypadCtrl_coordinateMode coordinate_mode) YARP_OVERRIDE;
+    virtual bool getRawTouch(unsigned int touch_id, yarp::sig::Vector& value) YARP_OVERRIDE;
 
     #undef JoyPort
 

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
@@ -18,6 +18,53 @@ namespace yarp
         }
     }
 }
+
+//TODO: finish the single port mode.. the struct below is for this purpose
+struct JoyData : public yarp::os::Portable
+{
+    yarp::sig::Vector Buttons;
+    yarp::sig::Vector Sticks;
+    yarp::sig::Vector Axes;
+    yarp::sig::Vector Balls;
+    yarp::sig::Vector Touch;
+    yarp::sig::VectorOf<unsigned char> Hats;
+
+    bool read(yarp::os::ConnectionReader& connection) override
+    {
+        Buttons.resize(connection.expectInt());
+        Sticks.resize(connection.expectInt());
+        Axes.resize(connection.expectInt());
+        Balls.resize(connection.expectInt());
+        Touch.resize(connection.expectInt());
+        Hats.resize(connection.expectInt());
+        connection.expectBlock((char*)Buttons.data(), Buttons.length() * sizeof(double));
+        connection.expectBlock((char*)Sticks.data(),  Sticks.length()  * sizeof(double));
+        connection.expectBlock((char*)Axes.data(),    Axes.length()    * sizeof(double));
+        connection.expectBlock((char*)Balls.data(),   Balls.length()   * sizeof(double));
+        connection.expectBlock((char*)Touch.data(),   Touch.length()   * sizeof(double));
+        connection.expectBlock((char*)&Hats[0],       Hats.size()      * sizeof(char));
+        return !connection.isError();
+    }
+
+    bool write(yarp::os::ConnectionWriter& connection) override
+    {
+        connection.appendInt(Buttons.length());
+        connection.appendInt(Sticks.length());
+        connection.appendInt(Axes.length()  );
+        connection.appendInt(Balls.length() );
+        connection.appendInt(Touch.length() );
+        connection.appendInt(Hats.size()  );
+        connection.appendBlock((char*)Buttons.data(), Buttons.length() * sizeof(double));
+        connection.appendBlock((char*)Sticks.data(),  Sticks.length()  * sizeof(double));
+        connection.appendBlock((char*)Axes.data(),    Axes.length()    * sizeof(double));
+        connection.appendBlock((char*)Balls.data(),   Balls.length()   * sizeof(double));
+        connection.appendBlock((char*)Touch.data(),   Touch.length()   * sizeof(double));
+        connection.appendBlock((char*)&Hats[0],       Hats.size()      * sizeof(char));
+        connection.convertTextMode();
+        return !connection.isError();
+    }
+};
+
 struct yarp::dev::JoypadControl::LoopablePort
 {
     bool                  valid;

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.h
@@ -43,52 +43,6 @@ public:
     virtual bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
 };
 
-//TODO: finish the single port mode.. the struct below is for this purpose
-struct JoyData : public yarp::os::Portable
-{
-    yarp::sig::Vector Buttons;
-    yarp::sig::Vector Sticks;
-    yarp::sig::Vector Axes;
-    yarp::sig::Vector Balls;
-    yarp::sig::Vector Touch;
-    yarp::sig::VectorOf<unsigned char> Hats;
-
-    bool read(yarp::os::ConnectionReader& connection) override
-    {
-        Buttons.resize(connection.expectInt());
-        Sticks.resize(connection.expectInt());
-        Axes.resize(connection.expectInt());
-        Balls.resize(connection.expectInt());
-        Touch.resize(connection.expectInt());
-        Hats.resize(connection.expectInt());
-        connection.expectBlock((char*)Buttons.data(), Buttons.length() * sizeof(double));
-        connection.expectBlock((char*)Sticks.data(),  Sticks.length()  * sizeof(double));
-        connection.expectBlock((char*)Axes.data(),    Axes.length()    * sizeof(double));
-        connection.expectBlock((char*)Balls.data(),   Balls.length()   * sizeof(double));
-        connection.expectBlock((char*)Touch.data(),   Touch.length()   * sizeof(double));
-        connection.expectBlock((char*)&Hats[0],       Hats.size()      * sizeof(char));
-        return !connection.isError();
-    }
-
-    bool write(yarp::os::ConnectionWriter& connection) override
-    {
-        connection.appendInt(Buttons.length());
-        connection.appendInt(Sticks.length());
-        connection.appendInt(Axes.length()  );
-        connection.appendInt(Balls.length() );
-        connection.appendInt(Touch.length() );
-        connection.appendInt(Hats.size()  );
-        connection.appendBlock((char*)Buttons.data(), Buttons.length() * sizeof(double));
-        connection.appendBlock((char*)Sticks.data(),  Sticks.length()  * sizeof(double));
-        connection.appendBlock((char*)Axes.data(),    Axes.length()    * sizeof(double));
-        connection.appendBlock((char*)Balls.data(),   Balls.length()   * sizeof(double));
-        connection.appendBlock((char*)Touch.data(),   Touch.length()   * sizeof(double));
-        connection.appendBlock((char*)&Hats[0],       Hats.size()      * sizeof(char));
-        connection.convertTextMode();
-        return !connection.isError();
-    }
-};
-
 class yarp::dev::JoypadControlServer: public yarp::dev::DeviceDriver,
                                       public yarp::dev::IWrapper,
                                       public yarp::dev::IMultipleWrapper,


### PR DESCRIPTION
The Joypad EventDriven mode can be activated when using the `IJoypadController` interface by providing a valid pointer to a `IJoypadEvent` object. A thread will start and will call the `IJoypadEvent::action` method containing the detected events at every `RateThread::run`.