### PR TITLE
Fix clang static analyzer warning

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -8,6 +8,8 @@ A (partial) list of bug fixed and issues resolved in this release can be found
 Bug Fixes
 ---------
 
+* Fixed several warnings reported by clang static analyzer.
+
 ### Libraries
 
 #### YARP_OS

--- a/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
@@ -98,7 +98,6 @@ void jpeg_net_src (j_decompress_ptr cinfo, char *buf, int buflen) {
         cinfo->src = (struct jpeg_source_mgr *)
             (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT,
                                         sizeof(jpeg_source_mgr));
-        src = (net_src_ptr) cinfo->src;
     }
 
     src = (net_src_ptr) cinfo->src;

--- a/src/carriers/portmonitor_carrier/PortMonitor.cpp
+++ b/src/carriers/portmonitor_carrier/PortMonitor.cpp
@@ -137,7 +137,7 @@ bool PortMonitor::acceptIncomingData(yarp::os::ConnectionReader& reader)
 {
     if(!bReady) return false;
 
-    bool result;
+    bool result = false;
     localReader = &reader;
     // If no accept callback avoid calling the binder
     if(binder->hasAccept())

--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -58,7 +58,6 @@ std::vector<std::string> normalizedMessage(const std::string& line) {
     if (pending&&result!="") {
         if (result[0]=='#'&&can_quote) return all;
         all.push_back(result);
-        pending = false;
     }
     return all;
 }

--- a/src/libYARP_OS/include/yarp/os/Log.h
+++ b/src/libYARP_OS/include/yarp/os/Log.h
@@ -70,7 +70,7 @@ public:
     void info(const char *msg, ...) const YARP_ATTRIBUTE_FORMAT(printf, 2, 3);
     void warning(const char *msg, ...) const YARP_ATTRIBUTE_FORMAT(printf, 2, 3);
     void error(const char *msg, ...) const YARP_ATTRIBUTE_FORMAT(printf, 2, 3);
-    void fatal(const char *msg, ...) const YARP_ATTRIBUTE_FORMAT(printf, 2, 3);
+    void fatal YARP_NORETURN (const char *msg, ...) const YARP_ATTRIBUTE_FORMAT(printf, 2, 3);
 
     LogStream trace() const;
     LogStream debug() const;

--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -42,7 +42,8 @@ namespace yarp {
          * @deprecated Since YARP 2.3.70. Use std::exit().
          */
         YARP_OS_DEPRECATED_API_MSG("Use std::exit()")
-        void exit(int exit_code); // FIXME noreturn
+
+        void exit YARP_NORETURN (int exit_code);
 #endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 2.3.70
@@ -52,7 +53,8 @@ namespace yarp {
          * @deprecated Since YARP 2.3.70. Use std::abort().
          */
         YARP_OS_DEPRECATED_API_MSG("Use std::abort()")
-        void abort(bool verbose = false);
+
+        void abort YARP_NORETURN (bool verbose = false);
 #endif // YARP_NO_DEPRECATED
 
         /**

--- a/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
@@ -364,7 +364,6 @@ public:
             appendStringBase(str);
         } else {
             ConstString s = str;
-            str += terminate;
             appendBlockCopy(yarp::os::Bytes((char*)(s.c_str()), s.length()));
         }
     }

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -823,7 +823,7 @@ YARP_SSIZE_T DgramTwoWayStream::read(const Bytes& b) {
             //YARP_DEBUG(Logger::get(), "DGRAM Waiting for something!");
             YARP_SSIZE_T result = -1;
 #if defined(YARP_HAS_ACE)
-            if (mgram && restrictInterfaceIp.isValid()) {
+            if (dgram && restrictInterfaceIp.isValid()) {
                 /*
                 printf("Consider remote mcast\n");
                 printf("What we know:\n");

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -610,7 +610,6 @@ bool DgramTwoWayStream::join(const Contact& group, bool sender,
 
     int result = -1;
     if (ipLocal.isValid()) {
-        result = 0;
         result = dmcast->join(addr, 1);
 
         if (result==0) {
@@ -1035,7 +1034,7 @@ void DgramTwoWayStream::flush() {
             // better solution was to increase recv buffer size
 
             double first = yarp::os::Time::now();
-            double now = first;
+            double now;
             int ct = 0;
             do {
                 //printf("Busy wait... %d\n", ct);
@@ -1050,7 +1049,6 @@ void DgramTwoWayStream::flush() {
             YARP_DEBUG(Logger::get(), "DGRAM failed to send message with error: " + ConstString(strerror(errno)));
             return;
         }
-        writeAt += len;
         writeAvail -= len;
 
         if (writeAvail!=0) {

--- a/src/libYARP_OS/src/NameClient.cpp
+++ b/src/libYARP_OS/src/NameClient.cpp
@@ -220,7 +220,6 @@ ConstString NameClient::send(const ConstString& cmd, bool multi) {
             ConstString line = "";
             line = ip->getInputStream().readLine();
             if (!(ip->isOk())) {
-                more = false;
                 //YARP_DEBUG(Logger::get(), e.toString() + " <<< exception from name server");
                 retry = true;
                 break;

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -232,7 +232,6 @@ static int enactConnection(const Contact& src,
         noteDud(src);
         return 1;
     }
-    ok = false;
     ConstString msg = "";
     if (reply.get(0).isInt()) {
         ok = (reply.get(0).asInt()==0);

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -164,12 +164,12 @@ void PortCoreInputUnit::run() {
             //printf("HAVE A REFERENCE\n");
             if (localReader!=YARP_NULLPTR) {
                 bool ok = localReader->read(br);
-                if (!br.isActive()) { done = true; break; }
+                if (!br.isActive()) { break; }
                 if (!ok) continue;
             } else {
                 PortManager& man = getOwner();
                 bool ok = man.readBlock(br, id, YARP_NULLPTR);
-                if (!br.isActive()) { done = true; break; }
+                if (!br.isActive()) { break; }
                 if (!ok) continue;
             }
             //printf("DONE WITH A REFERENCE\n");
@@ -181,15 +181,14 @@ void PortCoreInputUnit::run() {
 
         if (ip->getConnection().canEscape()) {
             bool ok = cmd.read(br);
-            if (!br.isActive()) { done = true; break; }
+            if (!br.isActive()) { break; }
             if (!ok) continue;
         } else {
             cmd = PortCommand('d', "");
-            if (!ip->isOk()) { done = true; break; }
+            if (!ip->isOk()) { break; }
         }
 
         if (closing||isDoomed()) {
-            done = true;
             break;
         }
         char key = cmd.getKey();
@@ -372,11 +371,9 @@ void PortCoreInputUnit::run() {
             ip->endRead();
         }
         if (ip==YARP_NULLPTR) {
-            done = true;
             break;
         }
         if (closing||isDoomed()||(!ip->isOk())) {
-            done = true;
             break;
         }
     }

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -290,7 +290,7 @@ bool PortCoreOutputUnit::sendHelper() {
         if (!done) {
             if (op->getConnection().isActive()) {
                 replied = op->write(buf);
-                if (replied && op->getSender().modifiesReply()) {
+                if (replied && op->getSender().modifiesReply() && cachedReader != YARP_NULLPTR) {
                     cachedReader = &op->getSender().modifyReply(*cachedReader);
                 }
             }

--- a/src/libYARP_OS/src/Run.cpp
+++ b/src/libYARP_OS/src/Run.cpp
@@ -772,9 +772,8 @@ void yarp::os::Run::writeToPipe(int fd, yarp::os::ConstString str)
 {
     int len=str.length()+1;
 
-    ssize_t warn_suppress = write(fd, &len, 4);
-    warn_suppress = write(fd, str.c_str(), len);
-    YARP_UNUSED(warn_suppress);
+    write(fd, &len, 4);
+    write(fd, str.c_str(), len);
 }
 
 int yarp::os::Run::readFromPipe(int fd, char* &data, int& buffsize)

--- a/src/libYARP_OS/src/SharedLibrary.cpp
+++ b/src/libYARP_OS/src/SharedLibrary.cpp
@@ -32,7 +32,10 @@ public:
     inline char* getError()
     {
 #ifdef YARP_HAS_ACE
-        return dll->error();
+        if(dll != YARP_NULLPTR)
+            return dll->error();
+        else
+            return const_cast<char*>("Unknown error");
 #else
         return yarp::os::impl::dlerror();
 #endif

--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -51,7 +51,6 @@ static void removeClock()
     if (old_pclock) {
         if (old_clock_owned) {
             delete old_pclock;          // This will wake up all sleeping threads
-            old_clock_owned = false;
         }
         old_pclock = YARP_NULLPTR;
     }

--- a/src/libYARP_OS/src/WireReader.cpp
+++ b/src/libYARP_OS/src/WireReader.cpp
@@ -300,12 +300,11 @@ bool WireReader::readBinary(ConstString& str)
     if (state->len<=0) {
         return false;
     }
-    int tag = state->code;
     if (state->code<0) {
         if (noMore()) {
             return false;
         }
-        tag = reader.expectInt();
+        int tag = reader.expectInt();
         if (tag!=BOTTLE_TAG_BLOB) {
             return false;
         }

--- a/src/libYARP_conf/include/yarp/conf/api.h.in
+++ b/src/libYARP_conf/include/yarp/conf/api.h.in
@@ -107,6 +107,12 @@ recommended usage of this header within YARP is:
 #  define YARP_NODISCARD
 #endif
 
+// YARP_NORETURN inform the compiler that the function will not return
+#if (YARP_COMPILER_CXX_ATTRIBUTES)
+#  define YARP_NORETURN [[noreturn]]
+#else
+#  define YARP_NORETURN
+#endif
 
 // YARP_UNUSED: Suppress unused variable warnings
 #define YARP_UNUSED(var) (void)var

--- a/src/libYARP_dev/src/MapGrid2D.cpp
+++ b/src/libYARP_dev/src/MapGrid2D.cpp
@@ -284,7 +284,7 @@ bool MapGrid2D::loadROSParams(string ros_yaml_filename, string& pgm_occ_filename
         orig_y = b->get(1).asDouble();
         orig_t = b->get(2).asDouble();
     }
-    return true;
+    return ret;
 }
 
 bool MapGrid2D::loadMapYarpAndRos(string yarp_filename, string ros_yaml_filename)

--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -134,7 +134,7 @@ bool PolyDriver::closeMain() {
             delete &HELPER(system_resource);
             system_resource = NULL;
             if (dd!=NULL) {
-                result = dd->close();
+                dd->close();
                 delete dd;
                 dd = NULL;
             }

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -938,7 +938,7 @@ bool ControlBoardRemapper::resetPid(const PidControlTypeEnum& pidtype, int j)
 
 bool ControlBoardRemapper::disablePid(const PidControlTypeEnum& pidtype, int j)
 {
-    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    (int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
     size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
 
     yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -301,7 +301,8 @@ YARP_WARNING_POP
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
-                            *ok = rpc_iCtrlMode->setImpedancePositionMode(axis);
+                            if(rpc_iCtrlMode)
+                                *ok = rpc_iCtrlMode->setImpedancePositionMode(axis);
 YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
                         break;
@@ -313,7 +314,8 @@ YARP_WARNING_POP
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
-                            *ok = rpc_iCtrlMode->setImpedanceVelocityMode(axis);
+                            if(rpc_iCtrlMode)
+                                *ok = rpc_iCtrlMode->setImpedanceVelocityMode(axis);
 YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
                         break;
@@ -365,7 +367,8 @@ YARP_WARNING_POP
                     if (ControlBoardWrapper_p->verbose())
                         yDebug("getControlModes\n");
                     int *p = new int[controlledJoints];
-                    *ok = rpc_iCtrlMode->getControlModes(p);
+                    if(rpc_iCtrlMode)
+                        *ok = rpc_iCtrlMode->getControlModes(p);
 
                     response.addVocab(VOCAB_IS);
                     response.addVocab(VOCAB_CM_CONTROL_MODES);
@@ -387,7 +390,8 @@ YARP_WARNING_POP
 
                     int p=-1;
                     int axis = cmd.get(3).asInt();
-                    *ok = rpc_iCtrlMode->getControlMode(axis, &p);
+                    if(rpc_iCtrlMode)
+                        *ok = rpc_iCtrlMode->getControlMode(axis, &p);
 
                     response.addVocab(VOCAB_IS);
                     response.addInt(axis);

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.cpp
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.cpp
@@ -28,7 +28,6 @@ inline void cat(Vector& a, const Vector& b)
 bool JoypadCtrlParser::configure(yarp::dev::IJoypadController* interface)
 {
     bool ret;
-    ret = false;
     if(interface)
     {
         device = interface;

--- a/src/libYARP_dev/src/devices/Map2DServer/Map2DServer.cpp
+++ b/src/libYARP_dev/src/devices/Map2DServer/Map2DServer.cpp
@@ -270,7 +270,7 @@ bool Map2DServer::loadMaps(std::string mapsfile)
         }
     }
     file.close();
-    return true;
+    return ret;
 }
 
 bool Map2DServer::open(yarp::os::Searchable &config)

--- a/src/libYARP_manager/include/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/include/yarp/manager/impl/textparser.h
@@ -58,7 +58,6 @@ public:
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
                 envValue  = yarp::os::NetworkBase::getEnvironment(envName.c_str());
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
-                badSymbol = false;
                 return parseText(ret.c_str());
             }
 
@@ -75,7 +74,6 @@ public:
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
                 envValue  = variables[envName];
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
-                badSymbol = false;
                 return parseText(ret.c_str());
             }
 

--- a/src/libYARP_manager/include/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/include/yarp/manager/impl/textparser.h
@@ -38,7 +38,7 @@ public:
 
         std::string ret, startKeyword, endKeyword;
         size_t s, e;
-        bool   badSymbol;
+        bool   badSymbol = false;
 
         ret = "";
 

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -8,7 +8,7 @@
 
 
 #include <yarp/manager/binexparser.h>
-
+#include <yarp/os/Log.h>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -16,12 +16,17 @@
 #include <string>
 #include <algorithm>
 #include <cmath>
+#include <inttypes.h>
+#include <limits.h>
+#include <stddef.h>
 
 
 #define EXPNOT     '~'
 #define EXPAND     '&'
 #define EXPOR      '|'
 #define IMPLY      ':'
+
+#define PRECISION(max_value) sizeof(max_value) * 8
 
 
 using namespace std;
@@ -345,12 +350,15 @@ std::string BinaryExpParser::popNextOperand(std::string &strexp) {
 
 void BinaryExpParser::createTruthTable(const int n)
 {
+    yAssert((n-1) > 0);
+    yAssert((n-1) < PRECISION(INT_MAX));
+    yAssert(1 <= (INT_MAX >> (n-1)));
+
     truthTable.clear();
     // n input + one output
     truthTable.resize(n+1);
     for(int i=0; i<n+1; i++)
         truthTable[i].resize(1 << n);
-
     int num_to_fill = 1 << (n - 1);
     for(int col = 0; col < n; ++col, num_to_fill >>= 1)
     {
@@ -364,6 +372,11 @@ void BinaryExpParser::createTruthTable(const int n)
 void BinaryExpParser::printTruthTable(std::string lopr)
 {
     int n = truthTable.size();
+
+    yAssert((n-1) > 0);
+    yAssert((n-1) < PRECISION(INT_MAX));
+    yAssert(1 <= (INT_MAX >> (n-1)));
+
     map<string, bool>::iterator itr;
     for(itr=operands.begin(); itr!=operands.end(); itr++)
        cout<<(*itr).first<<"\t";

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -262,7 +262,7 @@ bool BinaryExpParser::checkExpression(std::string& strexp)
 void BinaryExpParser::parseExpression(std::string &strexp, BinaryNodePtr& node)
 {
     string op;
-    BinaryNodePtr rightNode;
+    BinaryNodePtr rightNode = YARP_NULLPTR;
     parseNot(strexp, node);
     while(!strexp.empty() &&
           ((*strexp.begin() == EXPAND) ||

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -41,8 +41,15 @@ bool BinaryExpParser::parse(string _exp)
 
     binTree.clear();
     operands.clear();
-    BinaryNodePtr root;
+    BinaryNodePtr root = YARP_NULLPTR;
     parseExpression(strexp, root);
+    if(root == YARP_NULLPTR)
+    {
+        ErrorLogger* logger = ErrorLogger::Instance();
+        string msg = "BinaryExpParser: failed to parse the expression";
+        logger->addError(msg);
+        return false;
+    }
     if(invalidOperands.size())
     {
         ErrorLogger* logger = ErrorLogger::Instance();

--- a/src/libYARP_math/src/Quaternion.cpp
+++ b/src/libYARP_math/src/Quaternion.cpp
@@ -17,6 +17,11 @@ class QuaternionPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    QuaternionPortContentHeader()
+    {
+        listTag = 0;
+        listLen = 0;
+    }
 };
 YARP_END_PACK
 

--- a/src/libYARP_math/src/RandnScalar.cpp
+++ b/src/libYARP_math/src/RandnScalar.cpp
@@ -71,7 +71,8 @@ double RandnScalar::get(double u, double sigma)
 
 inline void RandnScalar::boxMuller()
 {
-    double x1, x2;
+    double x1 = 0.0;
+    double x2 = 0.0;
     double w = 2.0;
 
     while (w >= 1.0)

--- a/src/libYARP_math/src/Vec2D.cpp
+++ b/src/libYARP_math/src/Vec2D.cpp
@@ -21,6 +21,11 @@ class Vec2DPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    Vec2DPortContentHeader()
+    {
+        listTag = 0;
+        listLen = 0;
+    }
 };
 YARP_END_PACK
 

--- a/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
+++ b/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
@@ -55,7 +55,7 @@ public:
         yarp::os::Contact remote;
         remote = reader.getRemoteContact();
         if (lock) service->lock();
-        ok = service->apply(cmd,reply,event,remote);
+        service->apply(cmd,reply,event,remote);
         for (int i=0; i<event.size(); i++) {
             yarp::os::Bottle *e = event.get(i).asList();
             if (e!=0/*NULL*/) {

--- a/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
@@ -46,6 +46,25 @@ public:
     yarp::os::NetInt32 paramBlobTag;
     yarp::os::NetInt32 paramBlobLen;
 
+    ImageNetworkHeader()
+    {
+        listTag      = 0;
+        listLen      = 0;
+        paramNameTag = 0;
+        paramName    = 0;
+        paramIdTag   = 0;
+        id           = 0;
+        paramListTag = 0;
+        paramListLen = 0;
+        depth        = 0;
+        imgSize      = 0;
+        quantum      = 0;
+        width        = 0;
+        height       = 0;
+        paramBlobTag = 0;
+        paramBlobLen = 0;
+    }
+
     void setFromImage(const Image& image) {
         listTag = BOTTLE_TAG_LIST;
         listLen = 4;

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -36,6 +36,19 @@ public:
     yarp::os::NetInt32 cols;
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+
+    MatrixPortContentHeader()
+    {
+        outerListTag = 0;
+        outerListLen = 0;
+        rowsTag      = 0;
+        rows         = 0;
+        colsTag      = 0;
+        cols         = 0;
+        listTag      = 0;
+        listLen      = 0;
+
+    }
 };
 YARP_END_PACK
 

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -88,6 +88,9 @@ bool yarp::sig::submatrix(const Matrix &in, Matrix &out, int r1, int r2, int c1,
     const double *i=in.data()+in.cols()*r1+c1;
     const int offset=in.cols()-(c2-c1+1);
 
+    if(i == YARP_NULLPTR || t == YARP_NULLPTR)
+        return false;
+
     for(int r=0;r<=(r2-r1);r++)
     {
         for(int c=0;c<=(c2-c1);c++)
@@ -467,6 +470,9 @@ bool Matrix::operator==(const yarp::sig::Matrix &r) const
 
     const double *tmp1=data();
     const double *tmp2=r.data();
+
+    if(tmp1 == YARP_NULLPTR || tmp2 == YARP_NULLPTR)
+        return false;
 
     int c=rows()*cols();
     while(c--)

--- a/src/libYARP_sig/src/SoundFile.cpp
+++ b/src/libYARP_sig/src/SoundFile.cpp
@@ -55,20 +55,19 @@ YARP_END_PACK
 
 bool PcmWavHeader::parse_from_file(FILE *fp)
 {
-    size_t result;
-    result = fread(&wavHeader,sizeof(wavHeader),1,fp);
-    result = fread(&wavLength,sizeof(wavLength),1,fp);
-    result = fread(&formatHeader1,sizeof(formatHeader1),1,fp);
+    fread(&wavHeader,sizeof(wavHeader),1,fp);
+    fread(&wavLength,sizeof(wavLength),1,fp);
+    fread(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fread(&formatHeader2,sizeof(formatHeader2),1,fp);
-    result = fread(&formatLength,sizeof(formatLength),1,fp);
+    fread(&formatHeader2,sizeof(formatHeader2),1,fp);
+    fread(&formatLength,sizeof(formatLength),1,fp);
 
-    result = fread(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
-    result = fread(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
-    result = fread(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
-    result = fread(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
-    result = fread(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
-    result = fread(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
+    fread(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
+    fread(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
+    fread(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
+    fread(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
+    fread(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
+    fread(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
     if (pcm.pcmBitsPerSample!=16)
     {
         printf("sorry, lousy wav read code only does 16-bit ints\n");
@@ -78,24 +77,23 @@ bool PcmWavHeader::parse_from_file(FILE *fp)
     //extra bytes in pcm chuck
     int extra_size = formatLength-sizeof(pcm);
     pcmExtraData.allocate(extra_size);
-    result = fread(&pcmExtraData,extra_size,1,fp);
+    fread(&pcmExtraData,extra_size,1,fp);
 
     //extra chuncks
-    result = fread(&dummyHeader,sizeof(dummyHeader),1,fp);
+    fread(&dummyHeader,sizeof(dummyHeader),1,fp);
 
     while (dummyHeader!=VOCAB4('d','a','t','a'))
     {
-        result = fread(&dummyLength,sizeof(dummyLength),1,fp);
+        fread(&dummyLength,sizeof(dummyLength),1,fp);
         dummyData.clear();
         dummyData.allocate(dummyLength);
-        result = fread(&dummyData,dummyLength,1,fp);
-        result = fread(&dummyHeader,sizeof(dummyHeader),1,fp);
+        fread(&dummyData,dummyLength,1,fp);
+        fread(&dummyHeader,sizeof(dummyHeader),1,fp);
     }
 
     dataHeader=dummyHeader;
-    result = fread(&dataLength,sizeof(dataLength),1,fp);
+    fread(&dataLength,sizeof(dataLength),1,fp);
 
-    YARP_UNUSED(result);
     return true;
 }
 
@@ -122,25 +120,24 @@ void PcmWavHeader::setup_to_write(const Sound& src, FILE *fp)
     dataHeader = VOCAB4('d','a','t','a');
     dataLength = bytes;
 
-    size_t result;
-    result = fwrite(&wavHeader,sizeof(wavHeader),1,fp);
-    result = fwrite(&wavLength,sizeof(wavLength),1,fp);
-    result = fwrite(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fwrite(&formatHeader2,sizeof(formatHeader2),1,fp);
-    result = fwrite(&formatLength,sizeof(formatLength),1,fp);
+    fwrite(&wavHeader,sizeof(wavHeader),1,fp);
+    fwrite(&wavLength,sizeof(wavLength),1,fp);
+    fwrite(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fwrite(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
-    result = fwrite(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
-    result = fwrite(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
-    result = fwrite(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
-    result = fwrite(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
-    result = fwrite(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
+    fwrite(&formatHeader2,sizeof(formatHeader2),1,fp);
+    fwrite(&formatLength,sizeof(formatLength),1,fp);
 
-    result = fwrite(&dataHeader,sizeof(dataHeader),1,fp);
-    result = fwrite(&dataLength,sizeof(dataLength),1,fp);
+    fwrite(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
+    fwrite(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
+    fwrite(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
+    fwrite(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
+    fwrite(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
+    fwrite(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
 
-    YARP_UNUSED(result);
+    fwrite(&dataHeader,sizeof(dataHeader),1,fp);
+    fwrite(&dataLength,sizeof(dataLength),1,fp);
+
 }
 
 bool yarp::sig::file::read(Sound& dest, const char *src)

--- a/src/libYARP_sig/src/Vector.cpp
+++ b/src/libYARP_sig/src/Vector.cpp
@@ -36,6 +36,10 @@ class VectorPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    VectorPortContentHeader(){
+        listTag = 0;
+        listLen = 0;
+    }
 };
 YARP_END_PACK
 

--- a/src/libYARP_wire_rep_utils/WireBottle.cpp
+++ b/src/libYARP_wire_rep_utils/WireBottle.cpp
@@ -100,7 +100,6 @@ bool WireBottle::extractBlobFromBottle(yarp::os::SizedWriter& src,
     bool has_header = false;
     int payload_index = 0;
     int payload_offset = 0;
-    int remaining = total_len;
     if (src.length(0)>=12) {
         // could this be a Bottle compatible blob?
         char *base = (char*)src.data(0);
@@ -119,7 +118,6 @@ bool WireBottle::extractBlobFromBottle(yarp::os::SizedWriter& src,
                     has_header = true;
                     payload_index = 0;
                     payload_offset = 12;
-                    remaining -= payload_offset;
                 }
             }
         }

--- a/src/yarpmanager/src-builder/propertiestable.cpp
+++ b/src/yarpmanager/src-builder/propertiestable.cpp
@@ -203,6 +203,7 @@ void PropertiesTable::showModuleTab(ModuleItem *mod)
     for(int i=0;i<mod->getInnerModule()->argumentCount();i++){
         Argument a = mod->getInnerModule()->getArgumentAt(i);
         QTreeWidgetItem *it = new QTreeWidgetItem(parametersItem,QStringList() << a.getParam() << a.getDescription());
+        Q_UNUSED(it);
 
     }
 
@@ -210,6 +211,7 @@ void PropertiesTable::showModuleTab(ModuleItem *mod)
     for(int i=0;i<mod->getInnerModule()->authorCount();i++){
         Author a = mod->getInnerModule()->getAuthorAt(i);
         QTreeWidgetItem *it = new QTreeWidgetItem(authorsItem,QStringList() << a.getName() << a.getEmail());
+        Q_UNUSED(it);
     }
 
     QTreeWidgetItem *inputsItem = new QTreeWidgetItem(moduleDescription,QStringList() << "Inputs" );
@@ -358,13 +360,12 @@ void PropertiesTable::onModItemChanged(QTreeWidgetItem *it,int col)
             manager->getKnowledgeBase()->setModulePrefix(currentModule->getInnerModule(), strPrefix.c_str(), false);
         }
 
-    }
-
-    for(int i=0;i<modules.count();i++){
-        Module *module = modules.at(i)->getInnerModule();
-        if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
-             module->setStdio(currentModule->getInnerModule()->getStdio());
-             module->setWorkDir(currentModule->getInnerModule()->getWorkDir());
+        for(int i=0;i<modules.count();i++){
+            Module *module = modules.at(i)->getInnerModule();
+            if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
+                 module->setStdio(currentModule->getInnerModule()->getStdio());
+                 module->setWorkDir(currentModule->getInnerModule()->getWorkDir());
+            }
         }
     }
     modified();
@@ -412,14 +413,13 @@ void PropertiesTable::onComboChanged(QWidget *combo)
     modParams->setText(1,params);
     if(currentModule){
         currentModule->getInnerModule()->setParam(params.toLatin1().data());
-    }
-
-    for(int i=0;i<modules.count();i++){
-        Module *module = modules.at(i)->getInnerModule();
-        if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
-             module->setParam(currentModule->getInnerModule()->getParam());
-             module->setHost(currentModule->getInnerModule()->getHost());
-             module->setBroker(currentModule->getInnerModule()->getBroker());
+        for(int i=0;i<modules.count();i++){
+            Module *module = modules.at(i)->getInnerModule();
+            if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
+                 module->setParam(currentModule->getInnerModule()->getParam());
+                 module->setHost(currentModule->getInnerModule()->getHost());
+                 module->setBroker(currentModule->getInnerModule()->getBroker());
+            }
         }
     }
     modified();

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -343,6 +343,10 @@ bool JointItem::eventFilter(QObject *obj, QEvent *event)
                     onSliderVelocityReleased();
                 }
             }
+
+            if(slider == YARP_NULLPTR)
+                return false;
+
             
             if(keyEvent->type() == QEvent::KeyPress){
                 if(key == Qt::Key_Left || key == Qt::Key_Down){

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -800,7 +800,7 @@ void MainWindow::onHomeAllParts()
             continue;
         }
 
-        bool done = part->homePart();
+        part->homePart();
     }
 }
 

--- a/tests/libYARP_OS/BinPortableTest.cpp
+++ b/tests/libYARP_OS/BinPortableTest.cpp
@@ -79,6 +79,9 @@ public:
         BinPortable<BinPortableTarget> t1, t2;
         t1.content().x = 10;
         t1.content().y = 20;
+
+        t2.content().x = 0;
+        t2.content().y = 0;
         
         t1.write(con.getWriter());
         t2.read(con.getReader());

--- a/tests/libYARP_OS/DgramTwoWayStreamTest.cpp
+++ b/tests/libYARP_OS/DgramTwoWayStreamTest.cpp
@@ -216,7 +216,6 @@ public:
                 break;
             };
 
-            mismatch = false;
             bool goodRead[4];
             int length[4];
             for (int k=0; k<4; k++) {

--- a/tests/libYARP_OS/PortReaderBufferTest.cpp
+++ b/tests/libYARP_OS/PortReaderBufferTest.cpp
@@ -130,6 +130,11 @@ public:
         out.write(true);
         Bottle *datum = in.read();
         checkTrue(datum!=NULL, "got message #2");
+        if(datum == NULL)
+        {
+            report(1, "Message #2 is null..");
+            return;
+        }
         checkEqual(datum->size(),4,"message is ok");
         in.useCallback();
         in.count = 0;

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -553,6 +553,11 @@ public:
         PortablePair<Bottle,Bottle> *result = buf.read();
 
         checkTrue(result!=NULL,"got something check");
+        if(result == NULL)
+        {
+            report(1, "PortReadBuffer gave nothing..");
+            return;
+        }
         checkEqual(bot1.head.size(),result->head.size(),"head size check");
         checkEqual(bot1.body.size(),result->body.size(),"body size check");
 

--- a/tests/libYARP_dev/TestFrameGrabberTest.cpp
+++ b/tests/libYARP_dev/TestFrameGrabberTest.cpp
@@ -281,6 +281,7 @@ public:
             }
             checkTrue(result,"checking the retificationMatrix");
             result = dd.close();
+            checkTrue(result, "checking closure");
             p.unput("remote");
             p.put("remote","/grabber/right/rpc");
             result = dd.open(p);

--- a/tests/libYARP_sig/MatrixTest.cpp
+++ b/tests/libYARP_sig/MatrixTest.cpp
@@ -460,7 +460,7 @@ public:
         Bottle *bot1 = bot.get(0).asList();
         Bottle *bot2 = bot.get(1).asList();
         checkTrue(bot1!=NULL&&bot2!=NULL,"got head/body");
-        if (bot1==NULL&&bot2==NULL) return;
+        if (bot1==NULL || bot2==NULL) return;
         checkEqual(bot1->get(0).asInt(),rr,"row count matches");
         checkEqual(bot1->get(1).asInt(),cc,"column count matches");
         Bottle *lst = bot1->get(2).asList();


### PR DESCRIPTION
For the *strange* `YARP_NORETURN` placement : 
Via Stackoverflow: https://stackoverflow.com/questions/26888805/how-to-declare-a-lambdas-operator-as-noreturn
Clang is correct. An attribute can appertain to a function being declared, or to its type; the two are different. [[noreturn]] must appertain to the function itself. The difference can be seen in
```
// [[noreturn]] appertains to the entity that's being declared
void f [[noreturn]] ();    // §8.3 [dcl.meaning]/p1:
                           // The optional attribute-specifier-seq following a
                           // declarator-id appertains to the entity that is declared."
[[noreturn]] void h ();    // §7 [dcl.dcl]/p2:
                           // "The attribute-specifier-seq in a simple-declaration 
                           // appertains to each of the entities declared by
                           // the declarators of the init-declarator-list."

// ill-formed - [[noreturn]] appertains to the type (§8.3.5 [dcl.fct]/p1: 
// "The optional attribute-specifier-seq appertains to the function type.")
void g () [[noreturn]] {}
```

Indeed if you compile this in g++ it tells you that
```
warning: attribute ignored [-Wattributes]
 void g () [[noreturn]] {}
                      ^
```
note: an attribute that appertains to a type-specifier is ignored
Note that it doesn't emit a warning that g() actually does return. 