### PR TITLE
Fix mcast issue if you close the first connection

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -15,6 +15,8 @@ Bug Fixes
 * Fixed `Route::swapNames()` segfault in Windows and MacOS.
 * Fixed mcast without ACE on macOS
 * Fixed memory leak for inactive carriers
+* Fixed mcast, the connection now continue working also if you disconnect 
+  the *first* mcast connection. 
 
 Contributors
 ------------

--- a/src/libYARP_OS/include/yarp/os/impl/McastCarrier.h
+++ b/src/libYARP_OS/include/yarp/os/impl/McastCarrier.h
@@ -34,6 +34,8 @@ protected:
     Contact mcastAddress;
     ConstString mcastName;
     ConstString key;
+    DgramTwoWayStream *stream;
+    Contact local;
 
     static ElectionOf<PeerRecord<McastCarrier> > *caster;
 
@@ -58,6 +60,12 @@ public:
     void addSender(const ConstString& key);
     void removeSender(const ConstString& key);
     bool isElect();
+    /**
+     * @brief takeElection, this function is called when the elect mcast
+     * carrier dies and pass the write buffers to another one.
+     * @return true if the join of mcast is successful false otherwise.
+     */
+    bool takeElection();
 
     virtual bool isActive() override;
     virtual bool isBroadcast() override;


### PR DESCRIPTION
This PR fixes `MCastCarrier`, if you connected multiple ports through mcast to the same sender and if you disconnected the first receiver, the other carriers didn't have the buffers where actually write.

TESTED also on macOS.

please review code.

Thanks for the assist @barbalberto :+1: 