### PR TITLE
yarpmanager: temporary undo for the automatic refresh

### DIFF
--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -1024,13 +1024,13 @@ bool ApplicationViewWidget::onRun()
     }
 
     std::vector<int> CIDs;
-    for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
+    /*for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
     {
         updateConnection(i, CIDs);
-    }
+    }*/
 
     std::vector<int> RIDs;
-    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+    /*for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
         QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
         if (it->isSelected()) {
             RIDs.push_back(it->text(1).toInt());
@@ -1038,7 +1038,7 @@ bool ApplicationViewWidget::onRun()
             it->setIcon(0,QIcon(":/refresh22.svg"));
             it->setTextColor(3,QColor("#000000"));
         }
-    }
+    }*/
 
 
     safeManager.safeRun(MIDs,CIDs,RIDs);
@@ -1113,13 +1113,13 @@ bool ApplicationViewWidget::onStop()
     }
 
     std::vector<int> CIDs;
-    for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
+    /*for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
     {
         updateConnection(i, CIDs);
-    }
+    }*/
 
     std::vector<int> RIDs;
-    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+    /*for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
         QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
         if (it->isSelected()) {
             RIDs.push_back(it->text(1).toInt());
@@ -1127,7 +1127,7 @@ bool ApplicationViewWidget::onStop()
             it->setIcon(0,QIcon(":/refresh22.svg"));
             it->setTextColor(3,QColor("#000000"));
         }
-    }
+    }*/
 
 
     safeManager.safeStop(MIDs,CIDs,RIDs);
@@ -1204,14 +1204,14 @@ bool ApplicationViewWidget::onKill()
     }
 
     std::vector<int> CIDs;
-    for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
+    /*for(int i=0;i<ui->connectionList->topLevelItemCount();i++)
     {
         updateConnection(i, CIDs);
 
-    }
+    }*/
 
     std::vector<int> RIDs;
-    for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
+    /*for(int i=0;i<ui->resourcesList->topLevelItemCount();i++) {
         QTreeWidgetItem *it = ui->resourcesList->topLevelItem(i);
         if (it->isSelected()) {
             RIDs.push_back(it->text(1).toInt());
@@ -1219,7 +1219,7 @@ bool ApplicationViewWidget::onKill()
             it->setIcon(0,QIcon(":/refresh22.svg"));
             it->setTextColor(3,QColor("#000000"));
         }
-    }
+    }*/
 
 
     safeManager.safeKill(MIDs, CIDs, RIDs);

--- a/src/yarpmanager/src-manager/safe_manager.cpp
+++ b/src/yarpmanager/src-manager/safe_manager.cpp
@@ -101,6 +101,7 @@ void SafeManager::run()
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::run(local_modIds[i], true);
 
+            /*
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::waitingModuleRun(local_modIds[i]);
 
@@ -126,13 +127,13 @@ void SafeManager::run()
                 {
                     if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
                 }
-            }
+            }*/
             break;
         }
     case MSTOP:{
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::stop(local_modIds[i], true);
-            for(unsigned int i=0; i<local_modIds.size(); i++)
+            /*for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::waitingModuleStop(local_modIds[i]);
 
             for(unsigned int i=0; i<local_conIds.size(); i++)
@@ -157,13 +158,13 @@ void SafeManager::run()
                 {
                     if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
                 }
-            }
+            }*/
             break;
         }
     case MKILL:{
             for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::kill(local_modIds[i], true);
-            for(unsigned int i=0; i<local_modIds.size(); i++)
+            /*for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::waitingModuleKill(local_modIds[i]);
 
             for(unsigned int i=0; i<local_conIds.size(); i++)
@@ -188,7 +189,7 @@ void SafeManager::run()
                 {
                     if(eventReceiver) eventReceiver->onResUnAvailable(local_resIds[i]);
                 }
-            }
+            }*/
             break;
         }
     case MCONNECT:{


### PR DESCRIPTION
This PR *undo* the changes about the automatic refresh of the connections after `start`, `stop`, `kill`.

It will be introduced using a dedicated thread.

sorry for the inconvenience.

This is the patch used on `iCubGenova01` setup.

please review code