### PR TITLE
Remove using namespace directive from headers 

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -16,7 +16,11 @@ Bug Fixes
 * Fixed mcast without ACE on macOS
 * Fixed memory leak for inactive carriers
 * Fixed mcast, the connection now continue working also if you disconnect 
-  the *first* mcast connection. 
+  the *first* mcast connection.
+
+#### YARP_manager
+
+* Removed `using namespace` directive from headers.
 
 Contributors
 ------------

--- a/src/libYARP_manager/include/yarp/manager/application.h
+++ b/src/libYARP_manager/include/yarp/manager/application.h
@@ -20,7 +20,6 @@
 #include <yarp/manager/primresource.h>
 #include <yarp/manager/arbitrator.h>
 
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -46,12 +45,12 @@ public:
 protected:
 
 private:
-    string strOld;
-    string strNew;
+    std::string strOld;
+    std::string strNew;
 };
 
-typedef vector<Portmap> PortmapContainer;
-typedef vector<Portmap>::iterator PortmapIterator;
+typedef std::vector<Portmap> PortmapContainer;
+typedef std::vector<Portmap>::iterator PortmapIterator;
 
 
 
@@ -125,14 +124,14 @@ public:
 protected:
 
 private:
-    string strFrom;
-    string strTo;
-    string strId;
+    std::string strFrom;
+    std::string strTo;
+    std::string strId;
     bool bExternalTo;
     bool bExternalFrom;
-    string strCarrier;
-    string strQosFrom;
-    string strQosTo;
+    std::string strCarrier;
+    std::string strQosFrom;
+    std::string strQosTo;
     bool bPersist;
     Node* appOwner;
     bool bWithPriority;
@@ -144,11 +143,11 @@ private:
 };
 
 
-typedef vector<Connection> CnnContainer;
-typedef vector<Connection>::iterator CnnIterator;
+typedef std::vector<Connection> CnnContainer;
+typedef std::vector<Connection>::iterator CnnIterator;
 
-typedef vector<ResYarpPort> ResourceContainer;
-typedef vector<ResYarpPort>::iterator ResourceIterator;
+typedef std::vector<ResYarpPort> ResourceContainer;
+typedef std::vector<ResYarpPort>::iterator ResourceIterator;
 
 
 
@@ -220,28 +219,28 @@ public:
 protected:
 
 private:
-    string strName;
-    string strHost;
-    string strParam;
-    string strWorkDir;
-    string strStdio;
-    string strBroker;
-    string strPrefix;
-    string strEnvironment;
-    string strDisplay;
+    std::string strName;
+    std::string strHost;
+    std::string strParam;
+    std::string strWorkDir;
+    std::string strStdio;
+    std::string strBroker;
+    std::string strPrefix;
+    std::string strEnvironment;
+    std::string strDisplay;
     int iRank;
     ResourceContainer resources;
     double waitStart;
     double waitStop;
     PortmapContainer portmaps;
     PortmapIterator findPortmap(Portmap& portmap);
-    string strTag;
+    std::string strTag;
     GraphicModel modelBase;
 };
 
 
-typedef vector<ModuleInterface> IModuleContainer;
-typedef vector<ModuleInterface>::iterator IModuleIterator;
+typedef std::vector<ModuleInterface> IModuleContainer;
+typedef std::vector<ModuleInterface>::iterator IModuleIterator;
 
 
 /**
@@ -271,14 +270,14 @@ public:
 protected:
 
 private:
-    string strName;
-    string strPrefix;
+    std::string strName;
+    std::string strPrefix;
     GraphicModel modelBase;
 };
 
 
-typedef vector<ApplicationInterface> IApplicationContainer;
-typedef vector<ApplicationInterface>::iterator IApplicationIterator;
+typedef std::vector<ApplicationInterface> IApplicationContainer;
+typedef std::vector<ApplicationInterface>::iterator IApplicationIterator;
 
 /**
  * Class Application
@@ -370,23 +369,23 @@ public:
     GraphicModel& getModelBase(void) { return modelBase;}
     void setModelBase(GraphicModel& mdl) { modelBase = mdl; };
 
-    map<string, int> modList;
+    std::map<std::string, int> modList;
 
 protected:
 
 private:
-    string strName;
-    string strVersion;
-    string strDescription;
+    std::string strName;
+    std::string strVersion;
+    std::string strDescription;
     AuthorContainer authors;
     IModuleContainer Imodules;
     IApplicationContainer Iapplications;
     ResourceContainer resources;
     CnnContainer connections;
     ArbContainer arbitrators;
-    string strPrefix;
-    string strBasePrefix;
-    string strXmlFile;
+    std::string strPrefix;
+    std::string strBasePrefix;
+    std::string strXmlFile;
     Node* appOwner;
 
     GraphicModel modelBase;
@@ -399,8 +398,8 @@ private:
 
 };
 
-typedef vector<Application*> ApplicaitonPContainer;
-typedef vector<Application*>::iterator ApplicationPIterator;
+typedef std::vector<Application*> ApplicaitonPContainer;
+typedef std::vector<Application*>::iterator ApplicationPIterator;
 
 } // namespace yarp
 } // namespace manager

--- a/src/libYARP_manager/include/yarp/manager/arbitrator.h
+++ b/src/libYARP_manager/include/yarp/manager/arbitrator.h
@@ -51,7 +51,7 @@ public:
         return NULL;
     }
 
-    map<std::string, std::string>& getRuleMap(void) { return rules; }
+    std::map<std::string, std::string>& getRuleMap(void) { return rules; }
     int ruleCount(void) { return rules.size(); }
 
     GraphicModel* getModel(void) { return model;}

--- a/src/libYARP_manager/include/yarp/manager/broker.h
+++ b/src/libYARP_manager/include/yarp/manager/broker.h
@@ -15,7 +15,6 @@
 
 #include <yarp/manager/ymm-types.h>
 
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -73,7 +72,7 @@ protected:
     unsigned int UNIQUEID;
     BrokerEventSink* eventSink;
     bool bWithWatchDog;
-    string strDisplay;
+    std::string strDisplay;
     
 private:
 

--- a/src/libYARP_manager/include/yarp/manager/data.h
+++ b/src/libYARP_manager/include/yarp/manager/data.h
@@ -15,7 +15,6 @@
 #include <yarp/manager/utility.h>
 #include <yarp/conf/api.h>
 
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -60,10 +59,10 @@ public:
 protected:
 
 private:
-    string strName;
-    string strPort;
-    string carrier;
-    string strDescription;
+    std::string strName;
+    std::string strPort;
+    std::string carrier;
+    std::string strDescription;
     bool bWithPriority;
     bool bRequired;
     Node*  modOwner;
@@ -105,10 +104,10 @@ public:
 protected:
 
 private:
-    string strName;
-    string strPort;
-    string carrier;
-    string strDescription;
+    std::string strName;
+    std::string strPort;
+    std::string carrier;
+    std::string strDescription;
     Node*  modOwner;
     NodeType portType;
 };

--- a/src/libYARP_manager/include/yarp/manager/executable.h
+++ b/src/libYARP_manager/include/yarp/manager/executable.h
@@ -23,8 +23,6 @@
 #include <yarp/manager/application.h>
 #include <yarp/manager/execstate.h>
 
-//using namespace yarp::os;
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -119,12 +117,12 @@ public: // from BrokerEventSink
 
 private:
     bool bAutoConnect;
-    string strCommand;
-    string strParam;
-    string strHost;
-    string strStdio;
-    string strWorkdir;
-    string strEnv;
+    std::string strCommand;
+    std::string strParam;
+    std::string strHost;
+    std::string strStdio;
+    std::string strWorkdir;
+    std::string strEnv;
     int theID;
     double waitStart;
     double waitStop;
@@ -151,8 +149,8 @@ private:
 };
 
 
-typedef vector<Executable*> ExecutablePContainer;
-typedef vector<Executable*>::iterator ExecutablePIterator;
+typedef std::vector<Executable*> ExecutablePContainer;
+typedef std::vector<Executable*>::iterator ExecutablePIterator;
 typedef void (Executable::*ExecutableFuncPtr)(void);
 
 class ConcurentWrapper : public yarp::os::Thread

--- a/src/libYARP_manager/include/yarp/manager/graph.h
+++ b/src/libYARP_manager/include/yarp/manager/graph.h
@@ -17,13 +17,12 @@
 #include <yarp/manager/ymm-types.h>
 #include <yarp/manager/node.h>
 
-using namespace std;
 
 namespace yarp {
 namespace manager {
 
-typedef map<string, Node*> NodePContainer;
-typedef map<string, Node*>::iterator NodePIterator;
+typedef std::map<std::string, Node*> NodePContainer;
+typedef std::map<std::string, Node*>::iterator NodePIterator;
 
 class GraphIterator;
 
@@ -68,7 +67,7 @@ private:
 /**
  *  Class GraphIterator
  */
-class GraphIterator: public iterator<input_iterator_tag, Node*>
+class GraphIterator: public std::iterator<std::input_iterator_tag, Node*>
 {
 public:
     GraphIterator(void){}

--- a/src/libYARP_manager/include/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/include/yarp/manager/impl/textparser.h
@@ -35,10 +35,8 @@ public:
 
     std::string    parseText(const char *element)
     {
-        using namespace yarp::os;
-        using namespace std;
 
-        string ret, startKeyword, endKeyword;
+        std::string ret, startKeyword, endKeyword;
         size_t s, e;
         bool   badSymbol;
 
@@ -49,16 +47,16 @@ public:
             ret          = element;
             startKeyword = "$ENV{";
             endKeyword   = "}";
-            badSymbol    = ret.find("$") != string::npos;
+            badSymbol    = ret.find("$") != std::string::npos;
             s            = ret.find(startKeyword);
             e            = ret.find(endKeyword, s);
 
-            if(s != string::npos && e != string::npos)
+            if(s != std::string::npos && e != std::string::npos)
             {
-                string envName, envValue;
+                std::string envName, envValue;
 
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
-                envValue  = NetworkBase::getEnvironment(envName.c_str());
+                envValue  = yarp::os::NetworkBase::getEnvironment(envName.c_str());
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
                 badSymbol = false;
                 return parseText(ret.c_str());
@@ -70,9 +68,9 @@ public:
             s            = ret.find(startKeyword);
             e            = ret.find(endKeyword, s);
 
-            if(s != string::npos && e != string::npos)
+            if(s != std::string::npos && e != std::string::npos)
             {
-                string envName, envValue;
+                std::string envName, envValue;
 
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
                 envValue  = variables[envName];

--- a/src/libYARP_manager/include/yarp/manager/kbase.h
+++ b/src/libYARP_manager/include/yarp/manager/kbase.h
@@ -20,9 +20,6 @@
 #include <yarp/manager/logicresource.h>
 #include <yarp/manager/primresource.h>
 
-
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -30,8 +27,8 @@ namespace manager {
 #define NODELINK_SUPERFICIAL    1
 #define NODELINK_DEEP           2
 
-typedef vector<Node*> NodePVector;
-typedef vector<Node*>::iterator NodePVIterator;
+typedef std::vector<Node*> NodePVector;
+typedef std::vector<Node*>::iterator NodePVIterator;
 
 
 /**
@@ -64,7 +61,7 @@ public:
                             bool bAutoDependancy=false, bool bSilent=false);
     bool checkConsistency(void);
 
-    Node* getNode(string appName);
+    Node* getNode(std::string appName);
 
     const ModulePContainer& getSelModules(void) { return selmodules; }
     const CnnContainer& getSelConnection(void) { return selconnections; }
@@ -110,7 +107,7 @@ public:
     bool setApplicationPrefix(Application* app, const char* szPrefix, bool updateBasePref=true);
     bool saveApplication(AppSaver* appSaver, Application* application);
 
-    const string getUniqueAppID(Application* parent, const char* szAppName);
+    const std::string getUniqueAppID(Application* parent, const char* szAppName);
 
     bool exportAppGraph(const char* szFileName) {
             return exportDotGraph(tmpGraph, szFileName); }
@@ -141,7 +138,7 @@ private:
     CnnContainer selconnections;
     ResourcePContainer selresources;
 
-    map<string, int> appList;
+    std::map<std::string, int> appList;
 
     bool moduleCompleteness(Module* module);
     void updateNodesLink(Graph& graph, int level);
@@ -194,8 +191,8 @@ class sortApplication
 public:
      bool operator()(Application *f, Application *s)
      {
-        string strFirst((*f).getName());
-        string strSecond((*s).getName());
+        std::string strFirst((*f).getName());
+        std::string strSecond((*s).getName());
         transform(strFirst.begin(), strFirst.end(), strFirst.begin(),
                   (int(*)(int))toupper);
         transform(strSecond.begin(), strSecond.end(), strSecond.begin(),
@@ -210,8 +207,8 @@ class sortModules
 public:
      bool operator()(Module *f, Module *s)
      {
-        string strFirst((*f).getName());
-        string strSecond((*s).getName());
+        std::string strFirst((*f).getName());
+        std::string strSecond((*s).getName());
         transform(strFirst.begin(), strFirst.end(), strFirst.begin(),
                   (int(*)(int))toupper);
         transform(strSecond.begin(), strSecond.end(), strSecond.begin(),
@@ -226,8 +223,8 @@ class sortResources
 public:
      bool operator()(GenericResource *f, GenericResource *s)
      {
-        string strFirst(f->getName());
-        string strSecond(s->getName());
+        std::string strFirst(f->getName());
+        std::string strSecond(s->getName());
         transform(strFirst.begin(), strFirst.end(), strFirst.begin(),
                   (int(*)(int))toupper);
         transform(strSecond.begin(), strSecond.end(), strSecond.begin(),

--- a/src/libYARP_manager/include/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/localbroker.h
@@ -81,15 +81,15 @@ public: // for rate thread
 protected:
 
 private:
-    string strCmd;
-    string strParam;
-    string strHost;
-    string strStdio;
-    string strWorkdir;
-    string strTag;
-    string strEnv;
+    std::string strCmd;
+    std::string strParam;
+    std::string strHost;
+    std::string strStdio;
+    std::string strWorkdir;
+    std::string strTag;
+    std::string strEnv;
     int ID;
-    string strError;
+    std::string strError;
     bool bOnlyConnector;
     bool bInitialized;
     int  pipe_to_stdout[2];
@@ -105,7 +105,7 @@ private:
 #if defined(_WIN32)
     HANDLE read_from_pipe_cmd_to_stdout;
     HANDLE write_to_pipe_cmd_to_stdout;
-    string lastError2String();
+    std::string lastError2String();
 #else
     int waitPipe(int pipe_fd);
     int waitPipeSignal(int pipe_fd);

--- a/src/libYARP_manager/include/yarp/manager/logicresource.h
+++ b/src/libYARP_manager/include/yarp/manager/logicresource.h
@@ -14,7 +14,6 @@
 #include <yarp/manager/utility.h>
 #include <yarp/manager/resource.h>
 #include <yarp/conf/api.h>
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -38,8 +37,8 @@ public:
 protected:
 
 private:
-    string strDistrib;
-    string strRelease;
+    std::string strDistrib;
+    std::string strRelease;
     bool satisfy_platform(Platform* os);
 
 };
@@ -66,9 +65,9 @@ public:
 protected:
 
 private:
-    string strPort;
-    string strRequest;
-    string strReply;
+    std::string strPort;
+    std::string strRequest;
+    std::string strReply;
     double timeout;
 };
 

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -16,8 +16,6 @@
 #include <yarp/manager/executable.h>
 #include <yarp/manager/yarpbroker.h>
 
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -52,7 +50,7 @@ public:
     bool updateConnection(unsigned int id, const char* from,
                 const char* to, const char* carrier);
 
-    Node* getNode(string appName);
+    Node* getNode(std::string appName);
 
     bool run(void);
     bool run(unsigned int id, bool async=false);
@@ -123,10 +121,10 @@ private:
     bool bAutoConnect;
     bool bRestricted;
     ErrorLogger* logger;
-    string strAppName;
-    string strDefBroker;
+    std::string strAppName;
+    std::string strDefBroker;
     YarpBroker connector;
-    vector<string> listOfXml;
+    std::vector<std::string> listOfXml;
 
     KnowledgeBase knowledge;
     ExecutablePContainer runnables;

--- a/src/libYARP_manager/include/yarp/manager/manifestloader.h
+++ b/src/libYARP_manager/include/yarp/manager/manifestloader.h
@@ -97,8 +97,8 @@ private:
  */
 
 struct AppTemplate {
-    string name;
-    string tmpFileName;
+    std::string name;
+    std::string tmpFileName;
 };
 
 

--- a/src/libYARP_manager/include/yarp/manager/module.h
+++ b/src/libYARP_manager/include/yarp/manager/module.h
@@ -18,8 +18,6 @@
 #include <yarp/manager/resource.h>
 #include <yarp/conf/api.h>
 
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -43,8 +41,8 @@ public:
     }
 
 private:
-    string strName;
-    string strEmail;
+    std::string strName;
+    std::string strEmail;
 };
 
 /**
@@ -80,23 +78,23 @@ public:
 protected:
 
 private:
-    string strParam;
-    string strDesc;
-    string strDefault;
-    string strValue;
+    std::string strParam;
+    std::string strDesc;
+    std::string strDefault;
+    std::string strValue;
     bool bRequired;
     bool bSwitch;
 };
 
 
-typedef vector<InputData> InputContainer;
-typedef vector<OutputData> OutputContainer;
-typedef vector<InputData>::iterator InputIterator;
-typedef vector<OutputData>::iterator OutputIterator;
-typedef vector<Author> AuthorContainer;
-typedef vector<Author>::iterator AuthorIterator;
-typedef vector<Argument> ArgumentContainer;
-typedef vector<Argument>::iterator ArgumentIterator;
+typedef std::vector<InputData> InputContainer;
+typedef std::vector<OutputData> OutputContainer;
+typedef std::vector<InputData>::iterator InputIterator;
+typedef std::vector<OutputData>::iterator OutputIterator;
+typedef std::vector<Author> AuthorContainer;
+typedef std::vector<Author>::iterator AuthorIterator;
+typedef std::vector<Argument> ArgumentContainer;
+typedef std::vector<Argument>::iterator ArgumentIterator;
 
 
 
@@ -200,10 +198,10 @@ protected:
 
 private:
     Node* modOwner;
-    string strName;
-    string strVersion;
-    string strDescription;
-    string strHost;
+    std::string strName;
+    std::string strVersion;
+    std::string strDescription;
+    std::string strHost;
     bool bForced;
     int iRank;
     ArgumentContainer arguments;
@@ -212,18 +210,18 @@ private:
     InputContainer inputs;
     ResourcePContainer resources;
 
-    string strParam;
-    string strXmlFile;
-    string strWorkDir;
-    string strStdio;
-    string strBroker;
+    std::string strParam;
+    std::string strXmlFile;
+    std::string strWorkDir;
+    std::string strStdio;
+    std::string strBroker;
     bool bNeedDeployer;
-    string strPrefix;
-    string strEnvironment;
-    string strBasePrefix;
+    std::string strPrefix;
+    std::string strEnvironment;
+    std::string strBasePrefix;
     double waitStart;
     double waitStop;
-    string strDisplay;
+    std::string strDisplay;
     GraphicModel modelBase;
 
     ArgumentIterator findArgument(Argument& argument);
@@ -234,8 +232,8 @@ private:
     bool getParamValue(const char* key, bool bSwitch, std::string &param);
 };
 
-typedef vector<Module*> ModulePContainer;
-typedef vector<Module*>::iterator ModulePIterator;
+typedef std::vector<Module*> ModulePContainer;
+typedef std::vector<Module*>::iterator ModulePIterator;
 
 
 #define PRINT_MODULE(m)\

--- a/src/libYARP_manager/include/yarp/manager/node.h
+++ b/src/libYARP_manager/include/yarp/manager/node.h
@@ -16,7 +16,6 @@
 
 #include <yarp/manager/ymm-types.h>
 
-using namespace std;
 
 namespace yarp {
 namespace manager {
@@ -24,15 +23,15 @@ namespace manager {
 class Node;
 class Link;
 
-typedef vector<Link> LinkContainer;
-typedef vector<Link>::iterator LinkIterator;
+typedef std::vector<Link> LinkContainer;
+typedef std::vector<Link>::iterator LinkIterator;
 
 class GraphicModel {
 
 public:
     GraphicModel(void) {}
     virtual ~GraphicModel() {}
-    vector<GyPoint> points;
+    std::vector<GyPoint> points;
 };
 
 
@@ -119,12 +118,12 @@ private:
     bool bSatisfied;
     bool bVisited;
     NodeType type;
-    string label;
+    std::string label;
     GraphicModel* model;
 };
 
-typedef vector<Node*> NodePVector;
-typedef vector<Node*>::iterator NodePVIterator;
+typedef std::vector<Node*> NodePVector;
+typedef std::vector<Node*>::iterator NodePVIterator;
 
 } // namespace yarp
 } // namespace manager

--- a/src/libYARP_manager/include/yarp/manager/physicresource.h
+++ b/src/libYARP_manager/include/yarp/manager/physicresource.h
@@ -15,8 +15,6 @@
 #include <yarp/manager/primresource.h>
 #include <yarp/manager/resource.h>
 
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -56,7 +54,7 @@ protected:
 private:
     size_t cores;
     double frequency;
-    string compCompatibility;
+    std::string compCompatibility;
     Capacity globalMemory;
     Capacity sharedMemory;
     Capacity constantMemory;

--- a/src/libYARP_manager/include/yarp/manager/primresource.h
+++ b/src/libYARP_manager/include/yarp/manager/primresource.h
@@ -16,8 +16,6 @@
 #include <yarp/manager/logicresource.h>
 #include <yarp/conf/api.h>
 
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -96,9 +94,9 @@ public:
 protected:
 
 private:
-    string strIP4;
-    string strIP6;
-    string strMAC;
+    std::string strIP4;
+    std::string strIP6;
+    std::string strMAC;
 };
 
 
@@ -138,8 +136,8 @@ public:
 protected:
 
 private:
-    string strArchitecure;
-    string strModel;
+    std::string strArchitecure;
+    std::string strModel;
     size_t cores;
     size_t siblings;
     double frequency;
@@ -151,12 +149,12 @@ private:
  * Class Computer
  */
 typedef struct _Process {
-    string command;
+    std::string command;
     int pid;
 } Process;
 
-typedef vector<Process> ProcessContainer;
-typedef vector<Process>::iterator ProcessIterator;
+typedef std::vector<Process> ProcessContainer;
+typedef std::vector<Process>::iterator ProcessIterator;
 
 class Computer : public GenericResource {
 public:
@@ -209,8 +207,8 @@ private:
 
 };
 
-typedef vector<Computer> ComputerContainer;
-typedef vector<Computer>::iterator ComputerIterator;
+typedef std::vector<Computer> ComputerContainer;
+typedef std::vector<Computer>::iterator ComputerIterator;
 
 } // namespace yarp
 } // namespace manager

--- a/src/libYARP_manager/include/yarp/manager/resource.h
+++ b/src/libYARP_manager/include/yarp/manager/resource.h
@@ -14,8 +14,6 @@
 #include <yarp/manager/utility.h>
 #include <yarp/conf/api.h>
 
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -54,16 +52,16 @@ protected:
 private:
     bool bAvailable;
     bool bDisabled;
-    string strName;
-    string strTypeName;
-    string strDescription;
+    std::string strName;
+    std::string strTypeName;
+    std::string strDescription;
     Node*  modOwner;
-    string strXmlFile;
+    std::string strXmlFile;
 
 };
 
-typedef vector<GenericResource*> ResourcePContainer;
-typedef vector<GenericResource*>::iterator ResourcePIterator;
+typedef std::vector<GenericResource*> ResourcePContainer;
+typedef std::vector<GenericResource*>::iterator ResourcePIterator;
 
 
 

--- a/src/libYARP_manager/include/yarp/manager/singleapploader.h
+++ b/src/libYARP_manager/include/yarp/manager/singleapploader.h
@@ -32,8 +32,8 @@ protected:
 
 private:
     Application app;
-    string strModule;
-    string strHost;
+    std::string strModule;
+    std::string strHost;
 };
 
 } // namespace yarp

--- a/src/libYARP_manager/include/yarp/manager/utility.h
+++ b/src/libYARP_manager/include/yarp/manager/utility.h
@@ -20,9 +20,6 @@
 
 #include <yarp/manager/ymm-types.h>
 
-
-using namespace std;
-
 namespace yarp {
 namespace manager {
 
@@ -66,10 +63,10 @@ public:
     static ErrorLogger* Instance(void);
 
     void addWarning(const char* szWarning);
-    void addWarning(const string &str);
+    void addWarning(const std::string &str);
     void addWarning(OSTRINGSTREAM &stream);
     void addError(const char* szError);
-    void addError(const string &str);
+    void addError(const std::string &str);
     void addError(OSTRINGSTREAM &stream);
     const char* getLastError(void);
     const char* getLastWarning(void);
@@ -83,13 +80,13 @@ private:
     ErrorLogger(){};
     ErrorLogger(ErrorLogger const&){};
     static ErrorLogger* pInstance;
-    vector<string> errors;
-    vector<string> warnings;
+    std::vector<std::string> errors;
+    std::vector<std::string> warnings;
 };
 
 
 bool compareString(const char* szFirst, const char* szSecond);
-void trimString(string& str);
+void trimString(std::string& str);
 OS strToOS(const char* szOS);
 
 class Graph;

--- a/src/libYARP_manager/include/yarp/manager/xmlapploader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlapploader.h
@@ -37,10 +37,10 @@ public:
 protected:
 
 private:
-    string         strAppName;
-    string         strPath;
-    string         strFileName;
-    vector<string> fileNames;
+    std::string         strAppName;
+    std::string         strPath;
+    std::string         strFileName;
+    std::vector<std::string> fileNames;
     Application    app;
     TextParser*    parser;
     Application*   parsXml(const char* szFile);

--- a/src/libYARP_manager/include/yarp/manager/xmlmodloader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlmodloader.h
@@ -36,10 +36,10 @@ public:
 protected:
 
 private:
-    string strName;
-    string strPath;
-    string strFileName;
-    vector<string> fileNames;
+    std::string strName;
+    std::string strPath;
+    std::string strFileName;
+    std::vector<std::string> fileNames;
     TextParser*    parser;
     Module module;
     Module* parsXml(const char* szFile);

--- a/src/libYARP_manager/include/yarp/manager/xmlresloader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlresloader.h
@@ -36,10 +36,10 @@ public:
 protected:
 
 private:
-    string strName;
-    string strPath;
-    string strFileName;
-    vector<string> fileNames;
+    std::string strName;
+    std::string strPath;
+    std::string strFileName;
+    std::vector<std::string> fileNames;
     TextParser*    parser;
     ComputerContainer computers;
     Computer dummyComputer;

--- a/src/libYARP_manager/include/yarp/manager/xmltemploader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmltemploader.h
@@ -35,10 +35,10 @@ public:
 protected:
 
 private:
-    string strAppName;
-    string strPath;
-    string strFileName;
-    vector<string> fileNames;
+    std::string strAppName;
+    std::string strPath;
+    std::string strFileName;
+    std::vector<std::string> fileNames;
     TextParser     parser;
     AppTemplate app;
     AppTemplate* parsXml(const char* szFile);

--- a/src/libYARP_manager/include/yarp/manager/yarpbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/yarpbroker.h
@@ -28,9 +28,6 @@
 #include <yarp/manager/broker.h>
 #include <yarp/manager/primresource.h>
 
-using namespace std;
-//using namespace yarp::os;
-
 namespace yarp {
 namespace manager {
 
@@ -68,7 +65,7 @@ public:
                         yarp::os::SystemInfoSerializer& info);
      bool getAllProcesses(const char* server,
                         ProcessContainer &processes);
-     bool getAllPorts(vector<std::string> &stingList);
+     bool getAllPorts(std::vector<std::string> &stingList);
 
      bool setQos(const char* from, const char* to,
                  const char* qosFrom, const char* qosTo);
@@ -81,21 +78,21 @@ public: // for rate thread
 protected:
 
 private:
-    string strCmd;
-    string strParam;
-    string strHost;
-    string strStdio;
-    string strWorkdir;
-    string strTag;
-    string strEnv;
+    std::string strCmd;
+    std::string strParam;
+    std::string strHost;
+    std::string strStdio;
+    std::string strWorkdir;
+    std::string strTag;
+    std::string strEnv;
     unsigned int ID;
     yarp::os::Property command;
-    string strError;
+    std::string strError;
     bool bOnlyConnector;
     bool bInitialized;
     yarp::os::Semaphore semParam;
-    string strStdioUUID;
-    string __trace_message;
+    std::string strStdioUUID;
+    std::string __trace_message;
 
     yarp::os::BufferedPort<yarp::os::Bottle> stdioPort;
     //yarp::os::Port port;

--- a/src/libYARP_manager/src/executable.cpp
+++ b/src/libYARP_manager/src/executable.cpp
@@ -160,7 +160,7 @@ RSTATE Executable::state(void)
     if(compareString(strState, "DYING"))
         return DYING;
 
-    std::cerr<<"Unknown state!"<<endl;
+    std::cerr<<"Unknown state!"<<std::endl;
     return STUNKNOWN;
 }
 

--- a/src/libYARP_manager/src/localbroker.cpp
+++ b/src/libYARP_manager/src/localbroker.cpp
@@ -41,6 +41,7 @@
 
 using namespace yarp::os;
 using namespace yarp::manager;
+using namespace std;
 
 
 #if defined(_WIN32)

--- a/src/libYARP_manager/src/logicresource.cpp
+++ b/src/libYARP_manager/src/logicresource.cpp
@@ -13,6 +13,7 @@
 
 
 using namespace yarp::manager;
+using namespace std;
 
 
 /**

--- a/src/libYARP_manager/src/manager.cpp
+++ b/src/libYARP_manager/src/manager.cpp
@@ -30,6 +30,7 @@
 
 
 using namespace yarp::manager;
+using namespace std;
 
 
 /**

--- a/src/libYARP_manager/src/physicresource.cpp
+++ b/src/libYARP_manager/src/physicresource.cpp
@@ -13,6 +13,7 @@
 
 
 using namespace yarp::manager;
+using namespace std;
 
 
 /**

--- a/src/libYARP_manager/src/primresource.cpp
+++ b/src/libYARP_manager/src/primresource.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 
 using namespace yarp::manager;
+using namespace std;
 
 
 /**

--- a/src/libYARP_manager/src/scriptbroker.cpp
+++ b/src/libYARP_manager/src/scriptbroker.cpp
@@ -18,6 +18,7 @@
 
 using namespace yarp::os;
 using namespace yarp::manager;
+using namespace std;
 
 static char slash = NetworkBase::getDirectorySeparator()[0];
 

--- a/src/libYARP_manager/src/utility.cpp
+++ b/src/libYARP_manager/src/utility.cpp
@@ -18,6 +18,7 @@
 
 
 using namespace yarp::manager;
+using namespace std;
 
 
 //#if defined(_MSC_VER) && (_MSC_VER == 1600)

--- a/src/yarpdataplayer/include/mainwindow.h
+++ b/src/yarpdataplayer/include/mainwindow.h
@@ -22,9 +22,6 @@
 #include "yarpdataplayer_IDL.h"
 #include "include/loadingwidget.h"
 
-using namespace std;
-using namespace yarp::os;
-
 class InitThread;
 
 namespace Ui {
@@ -207,7 +204,7 @@ signals:
     void internalPlay();
     void internalPause();
     void internalStop();
-    void internalStep(Bottle *reply);
+    void internalStep(yarp::os::Bottle *reply);
     void internalSetFrame(const std::string &name, const int frameNum);
     void internalGetFrame(const std::string &name, int *frame);
 
@@ -240,7 +237,7 @@ private slots:
     void onInternalPlay();
     void onInternalPause();
     void onInternalStop();
-    void onInternalStep(Bottle *reply);
+    void onInternalStep(yarp::os::Bottle *reply);
     void onInternalSetFrame(const std::string &name, const int frameNum);
     void onInternalGetFrame(const std::string &name, int *frame);
 

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -37,6 +37,8 @@
 #endif
 
 using namespace std;
+using namespace yarp::os;
+
 void sighandler(int sig)
 {
     LOG("\n\nCaught ctrl-c, please quit within gui for clean exit\n\n");

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -29,6 +29,7 @@
 using namespace yarp::sig;
 using namespace yarp::sig::file;
 using namespace yarp::os;
+using namespace std;
 
 #ifdef HAS_OPENCV
   using namespace cv;

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -25,6 +25,7 @@
 
 using namespace yarp::os;
 using namespace yarp::manager;
+using namespace std;
 
 #if defined(_WIN32)
 # define HEADER      ""
@@ -46,13 +47,13 @@ using namespace yarp::manager;
 # if defined(YARP_HAS_SYS_PRCTL_H)
 #  include <sys/prctl.h>
 # endif
-    string HEADER = "";
-    string OKBLUE = "";
-    string OKGREEN = "";
-    string WARNING = "";
-    string FAIL = "";
-    string INFO = "";
-    string ENDC = "";
+    std::string HEADER = "";
+    std::string OKBLUE = "";
+    std::string OKGREEN = "";
+    std::string WARNING = "";
+    std::string FAIL = "";
+    std::string INFO = "";
+    std::string ENDC = "";
 #endif
 
 
@@ -67,7 +68,7 @@ using namespace yarp::manager;
     char* command_generator (const char* text, int state);
     char* appname_generator (const char* text, int state);
     char ** my_completion (const char* text, int start, int end);
-    vector<string> appnames;
+    std::vector<std::string> appnames;
 #endif
 
 #define DEF_CONFIG_FILE     "ymanager.ini"

--- a/src/yarpmanager-console/ymanager.h
+++ b/src/yarpmanager-console/ymanager.h
@@ -18,8 +18,6 @@
 #include <yarp/os/Property.h>
 #include <yarp/os/ConstString.h>
 
-using namespace std;
-
 //namespace ymm {
 
 typedef enum _ColorTheme {
@@ -54,14 +52,14 @@ private:
 
     void help(void);
     void myMain(void);
-    bool process(const vector<string> &cmdList);
+    bool process(const std::vector<std::string> &cmdList);
     bool exit(void);
     void reportErrors(void);
     void which(void);
     void checkStates(void);
     void checkConnections(void);
     bool loadRecursiveApplications(const char* szPath);
-    void updateAppNames(vector<string>* apps);
+    void updateAppNames(std::vector<std::string>* apps);
     void setColorTheme(ColorTheme theme);
     static void onSignal(int signum);
 };

--- a/src/yarpmanager/src-builder/applicationitem.cpp
+++ b/src/yarpmanager/src-builder/applicationitem.cpp
@@ -7,6 +7,8 @@
 #include <QGraphicsDropShadowEffect>
 #include <QDebug>
 
+using namespace std;
+
 ApplicationItem::ApplicationItem(Application* application, Manager *manager,  QList <int> *usedIds,bool isInApp,
                                  bool editingMode,
                                  int *connectionsId,

--- a/src/yarpmanager/src-builder/builderitem.h
+++ b/src/yarpmanager/src-builder/builderitem.h
@@ -12,8 +12,6 @@
 
 #include "commons.h"
 
-
-using namespace std;
 using namespace yarp::manager;
 
 class PortItem;

--- a/src/yarpmanager/src-builder/builderwindow.cpp
+++ b/src/yarpmanager/src-builder/builderwindow.cpp
@@ -3,7 +3,7 @@
 #include <QHBoxLayout>
 #include <QSplitter>
 
-
+using namespace std;
 
 BuilderWindow::BuilderWindow(Application *app, Manager *lazyManager, SafeManager *safeManager, bool editingMode, QWidget *parent) :
     QWidget(parent)/*,

--- a/src/yarpmanager/src-builder/propertiestable.cpp
+++ b/src/yarpmanager/src-builder/propertiestable.cpp
@@ -1,6 +1,8 @@
 #include "propertiestable.h"
 #include <QDebug>
 
+using namespace std;
+
 PropertiesTable::PropertiesTable(Manager *manager,QWidget *parent) : QWidget(parent)
 {
     QHBoxLayout *lay = new QHBoxLayout(this);

--- a/src/yarpmanager/src-builder/propertiestable.h
+++ b/src/yarpmanager/src-builder/propertiestable.h
@@ -11,8 +11,6 @@
 #include <yarp/manager/manager.h>
 #include "moduleitem.h"
 
-
-using namespace std;
 using namespace yarp::manager;
 
 #include <QComboBox>

--- a/src/yarpmanager/src-builder/yarpbuilderlib.h
+++ b/src/yarpmanager/src-builder/yarpbuilderlib.h
@@ -6,7 +6,6 @@
 #include <yarp/manager/manager.h>
 #include "safe_manager.h"
 
-using namespace std;
 using namespace yarp::manager;
 
 class YARPBUILDERLIBSHARED_EXPORT YarpBuilderLib

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -20,6 +20,8 @@
 #include <QDragEnterEvent>
 #include <QPainter>
 
+using namespace std;
+
 EntitiesTreeWidget::EntitiesTreeWidget(QWidget *parent) : QTreeWidget(parent)
 {
 

--- a/src/yarpmanager/src-manager/entitiestreewidget.h
+++ b/src/yarpmanager/src-manager/entitiestreewidget.h
@@ -37,7 +37,7 @@ public:
 
     QTreeWidgetItem * getWidgetItemByFilename(const QString xmlFile);
 
-    void setExtEditor(string editor);
+    void setExtEditor(std::string editor);
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -45,7 +45,7 @@ private:
     void syncApplicationList(QString selectNodeForEditing = "", bool open = false);
     bool loadRecursiveTemplates(const char* szPath);
     bool loadRecursiveApplications(const char* szPath);
-    bool initializeFile(string _class);
+    bool initializeFile(std::string _class);
 
 private:
     Ui::MainWindow *ui;
@@ -60,7 +60,7 @@ private:
     QToolBar *builderToolBar;
     GenericViewWidget *prevWidget;
 
-    string ext_editor;
+    std::string ext_editor;
 
 protected:
     void closeEvent(QCloseEvent *) override;


### PR DESCRIPTION
This PR remove `using namespace` directive from several headers.
Fixes #1285
Please review code. 