### PR TITLE
Add name server property

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -13,6 +13,7 @@ New Features
 #### `YARP_OS`
 
 * Added the property *yarprun* to ports opened through `yarprun --server`.
+* Added the property *nameserver* for the port opened through `yarpserver`.
 
 #### `YARP_dev`
 

--- a/src/libYARP_serversql/src/yarpserver.cpp
+++ b/src/libYARP_serversql/src/yarpserver.cpp
@@ -26,6 +26,8 @@
 #include <yarp/serversql/impl/ComposedNameService.h>
 #include <yarp/serversql/impl/ParseName.h>
 
+#include <yarp/os/impl/NameClient.h>
+
 using namespace yarp::os;
 using namespace yarp::name;
 using namespace yarp::serversql::impl;
@@ -274,6 +276,16 @@ yarpserversql_API int yarpserver_main(int argc, char *argv[]) {
         nc.preregister(alt);
     }
     nc.goPublic();
+
+    //Setting nameserver property
+    yarp::os::Bottle cmd, reply;
+    cmd.addString("set");
+    cmd.addString(server.getName());
+    cmd.addString("nameserver");
+    cmd.addString("true");
+
+    yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
+
     printf("Name server can be browsed at http://%s:%d/\n",
            nc.where().getHost().c_str(), nc.where().getPort());
     printf("\nOk.  Ready!\n");


### PR DESCRIPTION
This PR add the property *nameserver* to the port of the nameserver. 
It will be useful to check if exist a `yarpserver` launched with a certain namespace.

Please review code