### PR TITLE
Add iCubCluster functionality to yarpmanager

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -22,7 +22,8 @@ New Features
 ### GUIs
 
 * New `yarpviz` gui imported from https://github.com/robotology/yarpviz
-
+* Imported the `iCubCluster`(https://github.com/robotology/icub-main/tree/master/app/iCubCluster)
+  in `yarpmanager`(available only for unix-like os). 
 
 Bug Fixes
 ---------

--- a/src/libYARP_manager/CMakeLists.txt
+++ b/src/libYARP_manager/CMakeLists.txt
@@ -34,6 +34,7 @@ if(CREATE_LIB_MANAGER)
                         include/yarp/manager/singleapploader.h
                         include/yarp/manager/utility.h
                         include/yarp/manager/xmlapploader.h
+                        include/yarp/manager/xmlclusterloader.h
                         include/yarp/manager/xmlappsaver.h
                         include/yarp/manager/xmlmodloader.h
                         include/yarp/manager/xmlresloader.h
@@ -66,6 +67,7 @@ if(CREATE_LIB_MANAGER)
                         src/singleapploader.cpp
                         src/utility.cpp
                         src/xmlapploader.cpp
+                        src/xmlclusterloader.cpp
                         src/xmlappsaver.cpp
                         src/xmlmodloader.cpp
                         src/xmlresloader.cpp

--- a/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
@@ -5,8 +5,8 @@
  */
 
 
-#ifndef YARP_MANAGER_XMLCLUSTERLOADER
-#define YARP_MANAGER_XMLCLUSTERLOADER
+#ifndef YARP_MANAGER_XMLCLUSTERLOADER_H
+#define YARP_MANAGER_XMLCLUSTERLOADER_H
 
 #include <yarp/manager/ymm-types.h>
 #include <yarp/manager/manifestloader.h>
@@ -16,7 +16,7 @@
 namespace yarp {
 namespace manager {
 
-struct ClusNode
+struct ClusterNode
 {
     std::string name = "";
     bool display = false;
@@ -34,7 +34,7 @@ struct Cluster
     std::string nameSpace = "";
     std::string nsNode = "";
     std::string ssh_options = "";
-    std::vector<ClusNode> nodes;
+    std::vector<ClusterNode> nodes;
 };
 
 /**
@@ -43,7 +43,7 @@ struct Cluster
 class XmlClusterLoader {
 
 public:
-    XmlClusterLoader(std::string szFileName);
+    XmlClusterLoader(const std::string& szFileName);
     virtual ~XmlClusterLoader();
     bool parseXmlFile(Cluster& _cluster);
 
@@ -54,8 +54,8 @@ private:
     Cluster     cluster;
 };
 
-} // namespace yarp
 } // namespace manager
+} // namespace yarp
 
 
-#endif // __YARP_MANAGER_XMLCLUSTERLOADER_
+#endif // YARP_MANAGER_XMLCLUSTERLOADER_H

--- a/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 iCub Facility
+ * Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+
+#ifndef YARP_MANAGER_XMLCLUSTERLOADER
+#define YARP_MANAGER_XMLCLUSTERLOADER
+
+#include <yarp/manager/ymm-types.h>
+#include <yarp/manager/manifestloader.h>
+
+
+
+namespace yarp {
+namespace manager {
+
+struct ClusNode
+{
+    std::string name = "";
+    bool display = false;
+    std::string displayValue = "none";
+    std::string user = "";
+    std::string ssh_options = "";
+    bool onOff = false;
+    bool log = true;
+};
+
+struct Cluster
+{
+    std::string name = "";
+    std::string user = "";
+    std::string nameSpace = "";
+    std::string nsNode = "";
+    std::string ssh_options = "";
+    std::vector<ClusNode> nodes;
+};
+
+/**
+ * Class XmlClusterLoader
+ */
+class XmlClusterLoader {
+
+public:
+    XmlClusterLoader(std::string szFileName);
+    virtual ~XmlClusterLoader();
+    bool parseXmlFile(Cluster& _cluster);
+
+protected:
+
+private:
+    std::string confFile;
+    Cluster     cluster;
+};
+
+} // namespace yarp
+} // namespace manager
+
+
+#endif // __YARP_MANAGER_XMLCLUSTERLOADER_

--- a/src/libYARP_manager/src/xmlclusterloader.cpp
+++ b/src/libYARP_manager/src/xmlclusterloader.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2017 iCub Facility
+ * Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+
+#include <yarp/manager/xmlclusterloader.h>
+#include <yarp/manager/utility.h>
+#include <yarp/manager/ymm-dir.h>
+#include <tinyxml.h>
+#include <yarp/os/Value.h>
+#ifdef WITH_GEOMETRY
+#include <yarp/os/Property.h> // for parsing geometry information
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <fstream>
+#include <yarp/os/Network.h>
+#include <yarp/manager/impl/textparser.h>
+
+
+
+using namespace std;
+using namespace yarp::manager;
+
+/**
+ * load only one application indicated by its xml file name
+ */
+XmlClusterLoader::XmlClusterLoader(std::string szFileName):confFile(szFileName)
+{
+}
+
+
+XmlClusterLoader::~XmlClusterLoader()
+{
+}
+
+bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
+{
+    cluster.nodes.clear();
+    ErrorLogger* logger  = ErrorLogger::Instance();
+    TiXmlDocument doc(confFile);
+    if (!doc.LoadFile())
+    {
+        OSTRINGSTREAM err;
+        err<<"XmlClusterLoader: unable to load "<<confFile;
+        logger->addError(err);
+        return false;
+    }
+
+    /* retrieving root element */
+    TiXmlElement *root = doc.RootElement();
+    if (!root)
+    {
+        logger->addError("XmlClusterLoader: unable to find root element");
+        return false;
+    }
+
+    if (root->ValueStr() != "cluster")
+    {
+        OSTRINGSTREAM err;
+        err<<"XmlClusterLoader:No tag cluster found in"<<confFile;
+        logger->addError(err);
+        return false;
+    }
+
+    if (root->Attribute("name"))
+    {
+        cluster.name = root->Attribute("name");
+    }
+
+    if (root->Attribute("user"))
+    {
+        cluster.user = root->Attribute("user");
+    }
+
+    TiXmlElement *nameserver = root->FirstChildElement("nameserver");
+    if (!nameserver)
+    {
+        OSTRINGSTREAM err;
+        err<<"XmlClusterLoader:No tag nameserver found in"<<confFile;
+        logger->addError(err);
+        return false;
+    }
+
+    if (nameserver->Attribute("namespace"))
+    {
+        cluster.nameSpace = nameserver->Attribute("namespace");
+
+    }
+
+    if (nameserver->Attribute("node"))
+    {
+        cluster.nsNode = nameserver->Attribute("node");
+
+    }
+
+    if (nameserver->Attribute("ssh-options"))
+    {
+        cluster.ssh_options = nameserver->Attribute("ssh-options");
+
+    }
+
+
+
+    for(TiXmlElement* node = root->FirstChildElement("node");
+        node != NULL; node = node->NextSiblingElement("node"))
+    {
+        ClusNode c_node;
+        if (node->GetText())
+        {
+           c_node.name = node->GetText();
+        }
+
+        if (node->Attribute("display"))
+        {
+            c_node.display = true;
+            c_node.displayValue = node->Attribute("display");
+        }
+
+        if (node->Attribute("user"))
+        {
+            c_node.user = node->Attribute("user");
+        }
+        else
+        {
+            c_node.user = cluster.user;
+        }
+
+        if (node->Attribute("ssh-options"))
+        {
+            c_node.ssh_options = node->Attribute("ssh-options");
+        }
+        cluster.nodes.push_back(c_node);
+
+
+    }
+    _cluster = cluster;
+    return true;
+
+}

--- a/src/libYARP_manager/src/xmlclusterloader.cpp
+++ b/src/libYARP_manager/src/xmlclusterloader.cpp
@@ -10,16 +10,12 @@
 #include <yarp/manager/ymm-dir.h>
 #include <tinyxml.h>
 #include <yarp/os/Value.h>
-#ifdef WITH_GEOMETRY
-#include <yarp/os/Property.h> // for parsing geometry information
-#endif
 
 #include <algorithm>
 #include <cctype>
 #include <string>
 #include <fstream>
 #include <yarp/os/Network.h>
-#include <yarp/manager/impl/textparser.h>
 
 
 
@@ -29,7 +25,7 @@ using namespace yarp::manager;
 /**
  * load only one application indicated by its xml file name
  */
-XmlClusterLoader::XmlClusterLoader(std::string szFileName):confFile(szFileName)
+XmlClusterLoader::XmlClusterLoader(const string &szFileName):confFile(szFileName)
 {
 }
 
@@ -109,7 +105,7 @@ bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
     for (TiXmlElement* node = root->FirstChildElement("node");
         node != NULL; node = node->NextSiblingElement("node"))
     {
-        ClusNode c_node;
+        ClusterNode c_node;
         if (node->GetText())
         {
            c_node.name = node->GetText();

--- a/src/libYARP_manager/src/xmlclusterloader.cpp
+++ b/src/libYARP_manager/src/xmlclusterloader.cpp
@@ -106,7 +106,7 @@ bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
 
 
 
-    for(TiXmlElement* node = root->FirstChildElement("node");
+    for (TiXmlElement* node = root->FirstChildElement("node");
         node != NULL; node = node->NextSiblingElement("node"))
     {
         ClusNode c_node;

--- a/src/yarpmanager/CMakeLists.txt
+++ b/src/yarpmanager/CMakeLists.txt
@@ -20,6 +20,7 @@ if(CREATE_YARPMANAGER)
   # Manager files
   set(yarpmanager_manager_SRCS src-manager/aboutdlg.cpp
                                src-manager/applicationviewwidget.cpp
+                               src-manager/clusterWidget.cpp
                                src-manager/customtreewidget.cpp
                                src-manager/entitiestreewidget.cpp
                                src-manager/genericinfodlg.cpp
@@ -36,6 +37,7 @@ if(CREATE_YARPMANAGER)
 
   set(yarpmanager_manager_HDRS src-manager/aboutdlg.h
                                src-manager/applicationviewwidget.h
+                               src-manager/clusterWidget.h
                                src-manager/customtreewidget.h
                                src-manager/entitiestreewidget.h
                                src-manager/genericinfodlg.h
@@ -52,6 +54,7 @@ if(CREATE_YARPMANAGER)
 
   set(yarpmanager_manager_UI_FILES src-manager/aboutdlg.ui
                                    src-manager/applicationviewwidget.ui
+                                   src-manager/clusterWidget.ui
                                    src-manager/genericinfodlg.ui
                                    src-manager/mainwindow.ui
                                    src-manager/moduleviewwidget.ui

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -12,12 +12,22 @@
 #include <QLabel>
 #include <QRadioButton>
 
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/os/LogStream.h>
+
 using namespace std;
+using namespace yarp::os;
 
 ClusterWidget::ClusterWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ClusterWidget)
 {
+
+#ifdef WIN32
+    this->setDisabled(true);
+    return;
+#endif
+    confFile = "";
     ui->setupUi(this);
 
     ui->gridLayout->addWidget(new QLabel("Name"), 0, 0);
@@ -27,9 +37,44 @@ ClusterWidget::ClusterWidget(QWidget *parent) :
     ui->gridLayout->addWidget(new QLabel("Log"), 0, 4);
     ui->gridLayout->addWidget(new QLabel("Select"), 0, 5);
 
-    //TODO just for debug
-    for(int i=0; i<1; i++)
-        addRow("ciccio","none","giovanni",true);
+    //checking for the cluster-config.xml
+
+    ResourceFinder rf;
+    rf.setDefaultContext("iCubCluster");
+
+    confFile = rf.findFileByName("cluster-config.xml");
+
+    if(confFile.empty())
+    {
+        yError()<<"Unable to find cluster-config.xml in context iCubCluster";
+        this->setDisabled(true);
+        return;
+    }
+
+    //Parsing config file
+    if(!parseConfigFile())
+    {
+        yError()<<"Unable parse cluster-config.xml in context iCubCluster";
+        this->setDisabled(true);
+        return;
+    }
+
+    ui->lineEditUser->setText(cluster.user.c_str());
+    ui->lineEditNs->setText(cluster.nameSpace.c_str());
+    ui->lineEditNsNode->setText(cluster.nsNode.c_str());
+
+    //check if yarpserver is running
+
+    //check if yarprun is running
+
+    //Adding nodes
+
+    for(size_t i = 0; i<cluster.nodes.size(); i++)
+    {
+        ClusNode node = cluster.nodes[i];
+        addRow(node.name, node.displayValue, node.user, node.onOff, node.log);
+    }
+
 }
 
 void ClusterWidget::addRow(string name, string display, string user,
@@ -60,6 +105,98 @@ void ClusterWidget::addRow(string name, string display, string user,
 std::string ClusterWidget::getSSHCmd(std::string user, std::string host, std::string ssh_options)
 {
     return "";
+}
+
+bool ClusterWidget::parseConfigFile()
+{
+    TiXmlDocument doc(confFile);
+    if(!doc.LoadFile())
+    {
+        yError()<<"XmlParser: unable to load"<<confFile;
+        return false;
+    }
+
+    /* retrieving root element */
+    TiXmlElement *root = doc.RootElement();
+    if(!root)
+    {
+        yError()<<"XmlParser: unable to find root element";
+        return false;
+    }
+
+    if(root->ValueStr() != "cluster")
+    {
+        yError()<<"No tag cluster found in"<<confFile;
+        return false;
+    }
+
+    if(root->Attribute("name"))
+    {
+        cluster.name = root->Attribute("name");
+    }
+
+    if(root->Attribute("user"))
+    {
+        cluster.user = root->Attribute("user");
+    }
+
+    TiXmlElement *nameserver = root->FirstChildElement("nameserver");
+    if(!nameserver)
+    {
+        yError()<<"No tag nameserver found in"<<confFile;
+        return false;
+    }
+
+    if(nameserver->Attribute("namespace"))
+    {
+        cluster.nameSpace = nameserver->Attribute("namespace");
+
+    }
+
+    if(nameserver->Attribute("node"))
+    {
+        cluster.nsNode = nameserver->Attribute("node");
+
+    }
+
+    if(nameserver->Attribute("ssh-options"))
+    {
+        cluster.ssh_options = nameserver->Attribute("ssh-options");
+
+    }
+
+
+
+    for(TiXmlElement* node = root->FirstChildElement("node");
+        node != NULL; node = node->NextSiblingElement("node"))
+    {
+        ClusNode c_node;
+        if(node->GetText())
+        {
+           c_node.name = node->GetText();
+        }
+
+        if(node->Attribute("display"))
+        {
+            c_node.display = true;
+            c_node.displayValue = node->Attribute("display");
+        }
+
+        if(node->Attribute("user"))
+            c_node.user = node->Attribute("user");
+        else
+            c_node.user = cluster.user;
+
+        if(node->Attribute("ssh-options"))
+            c_node.ssh_options = node->Attribute("ssh-options");
+        cluster.nodes.push_back(c_node);
+
+    }
+
+
+
+    return true;
+
 }
 
 ClusterWidget::~ClusterWidget()

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 iCub Facility
+ * Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "clusterWidget.h"
+#include "ui_clusterWidget.h"
+#include "iostream"
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QLabel>
+#include <QRadioButton>
+
+using namespace std;
+
+ClusterWidget::ClusterWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ClusterWidget)
+{
+    ui->setupUi(this);
+
+    ui->gridLayout->addWidget(new QLabel("Name"), 0, 0);
+    ui->gridLayout->addWidget(new QLabel("Display"), 0, 1);
+    ui->gridLayout->addWidget(new QLabel("User"), 0, 2);
+    ui->gridLayout->addWidget(new QLabel("On/off"), 0, 3);
+    ui->gridLayout->addWidget(new QLabel("Log"), 0, 4);
+    ui->gridLayout->addWidget(new QLabel("Select"), 0, 5);
+
+    //TODO just for debug
+    for(int i=0; i<1; i++)
+        addRow("ciccio","none","giovanni",true);
+}
+
+void ClusterWidget::addRow(string name, string display, string user,
+                           bool onOff, bool log, bool select)
+{
+    int rowCount = ui->gridLayout->rowCount();
+    ui->gridLayout->addWidget(new QLineEdit(name.c_str()), rowCount, 0);
+    ui->gridLayout->addWidget(new QLineEdit(display.c_str()), rowCount, 1);
+    ui->gridLayout->addWidget(new QLineEdit(user.c_str()), rowCount, 2);
+    ui->gridLayout->addWidget(new QCheckBox(), rowCount, 3);
+    ui->gridLayout->addWidget(new QCheckBox(), rowCount, 4);
+    ui->gridLayout->addWidget(new QCheckBox(), rowCount, 5);
+
+    //initialize checkboxes
+    qobject_cast<QCheckBox*>(ui->gridLayout->itemAtPosition(rowCount,3)->widget())->setChecked(onOff);
+    qobject_cast<QCheckBox*>(ui->gridLayout->itemAtPosition(rowCount,4)->widget())->setChecked(log);
+    qobject_cast<QCheckBox*>(ui->gridLayout->itemAtPosition(rowCount,5)->widget())->setChecked(select);
+
+    //read only
+    qobject_cast<QLineEdit*>(ui->gridLayout->itemAtPosition(rowCount,0)->widget())->setReadOnly(true);
+    qobject_cast<QLineEdit*>(ui->gridLayout->itemAtPosition(rowCount,1)->widget())->setReadOnly(true);
+    qobject_cast<QLineEdit*>(ui->gridLayout->itemAtPosition(rowCount,2)->widget())->setReadOnly(true);
+    qobject_cast<QCheckBox*>(ui->gridLayout->itemAtPosition(rowCount,3)->widget())->setAttribute(Qt::WA_TransparentForMouseEvents);
+    qobject_cast<QCheckBox*>(ui->gridLayout->itemAtPosition(rowCount,3)->widget())->setFocusPolicy(Qt::NoFocus);
+
+}
+
+std::string ClusterWidget::getSSHCmd(std::string user, std::string host, std::string ssh_options)
+{
+    return "";
+}
+
+ClusterWidget::~ClusterWidget()
+{
+    delete ui;
+}

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -49,6 +49,8 @@ ClusterWidget::ClusterWidget(QWidget *parent) :
     connect(ui->runSelBtn, SIGNAL(clicked(bool)), this, SLOT(onRunSelected()));
     connect(ui->stopSelBtn, SIGNAL(clicked(bool)), this, SLOT(onStopSelected()));
     connect(ui->killSelBtn, SIGNAL(clicked(bool)), this, SLOT(onKillSelected()));
+    //execute
+    connect(ui->executeBtn, SIGNAL(clicked(bool)), this, SLOT(onExecute()));
 
 }
 
@@ -291,6 +293,31 @@ void ClusterWidget::onKillSelected()
     }
     yarp::os::Time::delay(2.0);
     onCheckAll();
+}
+
+void ClusterWidget::onExecute()
+{
+    if (ui->lineEditExecute->text().trimmed().size() == 0)
+    {
+        return;
+    }
+
+    QList<QTreeWidgetItem*> selectedItems = ui->nodestreeWidget->selectedItems();
+    foreach (QTreeWidgetItem *it, selectedItems)
+    {
+        int itr = it->text(5).toInt();
+        ClusNode node = cluster.nodes[itr];
+
+        string cmdExecute = getSSHCmd(node.user, node.name, node.ssh_options);
+
+        cmdExecute = cmdExecute + " "+ ui->lineEditExecute->text().toStdString();
+
+        if (system(cmdExecute.c_str()) != 0)
+        {
+            yError()<<"ClusterWidget: faild to run"<<ui->lineEditExecute->text().toStdString()<<"on"<<node.name;
+        }
+        yDebug()<<cmdExecute;
+    }
 }
 
 

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -8,10 +8,33 @@
 #define CLUSTERWIDGET_H
 
 #include <QWidget>
+#include <tinyxml.h>
+#include <vector>
 
 namespace Ui {
 class ClusterWidget;
 }
+
+struct ClusNode
+{
+    std::string name = "";
+    bool display = false;
+    std::string displayValue = "none";
+    std::string user = "";
+    std::string ssh_options = "";
+    bool onOff = false;
+    bool log = true;
+};
+
+struct Cluster
+{
+    std::string name = "";
+    std::string user = "";
+    std::string nameSpace = "";
+    std::string nsNode = "";
+    std::string ssh_options = "";
+    std::vector<ClusNode> nodes;
+};
 
 class ClusterWidget : public QWidget
 {
@@ -27,7 +50,11 @@ private:
     void addRow(std::string name="", std::string display="none", std::string user="",
                                bool onOff=false, bool log=true, bool select=true);
     std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
+    bool parseConfigFile();
+private:
     Ui::ClusterWidget *ui;
+    std::string confFile;
+    Cluster cluster;
 };
 
 #endif // CLUSTERWIDGET_H

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -28,6 +28,7 @@ private slots:
     void onRunSelected();
     void onStopSelected();
     void onKillSelected();
+    void onExecute();
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -8,7 +8,6 @@
 #define CLUSTERWIDGET_H
 
 #include <QWidget>
-#include <tinyxml.h>
 #include <vector>
 
 namespace Ui {
@@ -51,6 +50,8 @@ private slots:
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();
+    void setConfigFile(std::string _confFile);
+    void init();
 
 private:
     void addRow(std::string name="", std::string display="none", std::string user="",

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -40,8 +40,7 @@ class ClusterWidget : public QWidget
 {
     Q_OBJECT
 private slots:
-//    void onBrowseFile();
-//    void onFileNameEditChanged(QString text);
+    void onCheckAll();
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();
@@ -51,6 +50,8 @@ private:
                                bool onOff=false, bool log=true, bool select=true);
     std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
     bool parseConfigFile();
+    void checkNameserver();
+    bool checkNode(std::string name);
 private:
     Ui::ClusterWidget *ui;
     std::string confFile;

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -9,8 +9,8 @@
 
 #include <QWidget>
 #include <vector>
-#include <customtreewidget.h>
 #include <yarp/manager/xmlclusterloader.h>
+#include <customtreewidget.h>
 
 namespace Ui {
 class ClusterWidget;
@@ -36,7 +36,7 @@ public:
 
 private:
     void addRow(std::string name="", std::string display="none", std::string user="",
-                               bool onOff=false, bool log=true, bool select=true);
+                               bool onOff=false, bool log=true, int id=0);
     std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
     bool checkNameserver();
     bool checkNode(std::string name);

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -41,6 +41,10 @@ class ClusterWidget : public QWidget
     Q_OBJECT
 private slots:
     void onCheckAll();
+    void onCheckServer();
+    void onRunServer();
+    void onStopServer();
+    void onKillServer();
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();
@@ -50,7 +54,7 @@ private:
                                bool onOff=false, bool log=true, bool select=true);
     std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
     bool parseConfigFile();
-    void checkNameserver();
+    bool checkNameserver();
     bool checkNode(std::string name);
 private:
     Ui::ClusterWidget *ui;

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -10,31 +10,11 @@
 #include <QWidget>
 #include <vector>
 #include <customtreewidget.h>
+#include <yarp/manager/xmlclusterloader.h>
 
 namespace Ui {
 class ClusterWidget;
 }
-
-struct ClusNode
-{
-    std::string name = "";
-    bool display = false;
-    std::string displayValue = "none";
-    std::string user = "";
-    std::string ssh_options = "";
-    bool onOff = false;
-    bool log = true;
-};
-
-struct Cluster
-{
-    std::string name = "";
-    std::string user = "";
-    std::string nameSpace = "";
-    std::string nsNode = "";
-    std::string ssh_options = "";
-    std::vector<ClusNode> nodes;
-};
 
 class ClusterWidget : public QWidget
 {
@@ -58,13 +38,13 @@ private:
     void addRow(std::string name="", std::string display="none", std::string user="",
                                bool onOff=false, bool log=true, bool select=true);
     std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
-    bool parseConfigFile();
     bool checkNameserver();
     bool checkNode(std::string name);
 private:
     Ui::ClusterWidget *ui;
     std::string confFile;
-    Cluster cluster;
+    yarp::manager::Cluster cluster;
+    yarp::manager::XmlClusterLoader* clusLoader;
 };
 
 #endif // CLUSTERWIDGET_H

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 iCub Facility
+ * Authors: Nicolo' Genesio <nicolo.genesio@iit.it>
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef CLUSTERWIDGET_H
+#define CLUSTERWIDGET_H
+
+#include <QWidget>
+
+namespace Ui {
+class ClusterWidget;
+}
+
+class ClusterWidget : public QWidget
+{
+    Q_OBJECT
+private slots:
+//    void onBrowseFile();
+//    void onFileNameEditChanged(QString text);
+public:
+    explicit ClusterWidget(QWidget *parent = 0);
+    ~ClusterWidget();
+
+private:
+    void addRow(std::string name="", std::string display="none", std::string user="",
+                               bool onOff=false, bool log=true, bool select=true);
+    std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
+    Ui::ClusterWidget *ui;
+};
+
+#endif // CLUSTERWIDGET_H

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -29,18 +29,21 @@ private slots:
     void onStopSelected();
     void onKillSelected();
     void onExecute();
+    void onNodeSelectionChanged();
+signals:
+    void logError(QString);
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();
-    void setConfigFile(std::string _confFile);
+    void setConfigFile(const std::string& _confFile);
     void init();
 
 private:
-    void addRow(std::string name="", std::string display="none", std::string user="",
-                               bool onOff=false, bool log=true, int id=0);
-    std::string getSSHCmd(std::string user, std::string host, std::string ssh_options);
+    void addRow(const std::string& name="", const std::string& display="none",
+                const std::string& user="", bool onOff=false, bool log=true, int id=0);
+    std::string getSSHCmd(const std::string& user, const std::string& host, const std::string& ssh_options);
     bool checkNameserver();
-    bool checkNode(std::string name);
+    bool checkNode(const std::string& name);
 private:
     Ui::ClusterWidget *ui;
     std::string confFile;

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -9,6 +9,7 @@
 
 #include <QWidget>
 #include <vector>
+#include <customtreewidget.h>
 
 namespace Ui {
 class ClusterWidget;

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -45,6 +45,9 @@ private slots:
     void onRunServer();
     void onStopServer();
     void onKillServer();
+    void onRunSelected();
+    void onStopSelected();
+    void onKillSelected();
 public:
     explicit ClusterWidget(QWidget *parent = 0);
     ~ClusterWidget();

--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -336,7 +336,12 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_12">
            <item>
-            <widget class="QTreeWidget" name="nodestreeWidget">
+            <widget class="CustomTreeWidget" name="nodestreeWidget">
+             <column>
+              <property name="text">
+               <string>Status</string>
+              </property>
+             </column>
              <column>
               <property name="text">
                <string>Name</string>
@@ -355,11 +360,6 @@
              <column>
               <property name="text">
                <string>Log</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Select</string>
               </property>
              </column>
             </widget>
@@ -464,6 +464,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>customtreewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>635</width>
-    <height>547</height>
+    <width>598</width>
+    <height>555</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -28,13 +28,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_13">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_7"/>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_11"/>
-   </item>
+  <layout class="QVBoxLayout" name="verticalLayout_6">
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
@@ -45,419 +39,408 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>599</width>
-        <height>527</height>
+        <width>578</width>
+        <height>535</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <spacer name="horizontalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="minimumSize">
-              <size>
-               <width>211</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Cluster Managerment Window</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_10">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="Line" name="line_5">
+          <spacer name="horizontalSpacer_9">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
-           <item>
-            <spacer name="horizontalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout">
-               <item>
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>User:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lineEditUser">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="label_2">
-                 <property name="text">
-                  <string>Namespace</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lineEditNs">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="Line" name="line_4">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="Line" name="line_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <spacer name="horizontalSpacer_7">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <item>
-                <widget class="QLabel" name="label_4">
-                 <property name="minimumSize">
-                  <size>
-                   <width>131</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="sizeIncrement">
-                  <size>
-                   <width>132</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="text">
-                  <string>Nameserver node:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_5">
-                 <property name="text">
-                  <string>--ros</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <item>
-                <widget class="QLineEdit" name="lineEditNsNode">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkNs">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkRos">
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QPushButton" name="checkServerBtn">
-                 <property name="text">
-                  <string>Check</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="runServerBtn">
-                 <property name="text">
-                  <string>Run</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="stopServerBtn">
-                 <property name="text">
-                  <string>Stop</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_8">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="Line" name="line">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Nodes</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_12">
-           <item>
-            <widget class="CustomTreeWidget" name="nodestreeWidget">
-             <column>
-              <property name="text">
-               <string>Status</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Name</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Display</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>User</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Log</string>
-              </property>
-             </column>
-            </widget>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_4">
-             <item>
-              <widget class="QPushButton" name="checkAllBtn">
-               <property name="text">
-                <string>Check All</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="stopSelBtn">
-               <property name="text">
-                <string>Stop Selected</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="runSelBtn">
-               <property name="text">
-                <string>Run Selected</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="killSelBtn">
-               <property name="text">
-                <string>Kill Selected</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="Line" name="line_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>20</width>
-             <height>29</height>
+             <width>40</width>
+             <height>20</height>
             </size>
            </property>
           </spacer>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_10">
+          <widget class="QLabel" name="label_3">
+           <property name="minimumSize">
+            <size>
+             <width>211</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Cluster Managerment Window</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <spacer name="horizontalSpacer_11">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>User:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineEditUser">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
-            <widget class="QPushButton" name="runServerBtn_2">
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Namespace</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineEditNs">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="Line" name="line_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="label_4">
+               <property name="minimumSize">
+                <size>
+                 <width>131</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="sizeIncrement">
+                <size>
+                 <width>132</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Nameserver node:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>--ros</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <item>
+              <widget class="QLineEdit" name="lineEditNsNode">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="checkNs">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="checkRos">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <item>
+              <widget class="QPushButton" name="checkServerBtn">
+               <property name="text">
+                <string>Check</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="runServerBtn">
+               <property name="text">
+                <string>Run</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="stopServerBtn">
+               <property name="text">
+                <string>Stop</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Nodes</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
+         <item>
+          <widget class="CustomTreeWidget" name="nodestreeWidget">
+           <column>
+            <property name="text">
+             <string>Status</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Display</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>User</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Log</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QPushButton" name="checkAllBtn">
              <property name="text">
-              <string>More...</string>
+              <string>Check All</string>
              </property>
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer_12">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+            <widget class="QPushButton" name="stopSelBtn">
+             <property name="text">
+              <string>Stop Selected</string>
              </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="runSelBtn">
+             <property name="text">
+              <string>Run Selected</string>
              </property>
-            </spacer>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="killSelBtn">
+             <property name="text">
+              <string>Kill Selected</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
         </layout>
        </item>
+       <item>
+        <widget class="Line" name="line_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Type the command you wish to execute:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QLineEdit" name="lineEditExecute"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="executeBtn">
+             <property name="text">
+              <string>Execute</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>7</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
+      <zorder>line_5</zorder>
+      <zorder>line_2</zorder>
+      <zorder>line</zorder>
+      <zorder>label_6</zorder>
+      <zorder>line_3</zorder>
       <zorder></zorder>
      </widget>
     </widget>

--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>504</height>
+    <width>635</width>
+    <height>547</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -28,7 +28,13 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5">
+  <layout class="QHBoxLayout" name="horizontalLayout_13">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_7"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_11"/>
+   </item>
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
@@ -39,109 +45,352 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>442</width>
-        <height>484</height>
+        <width>599</width>
+        <height>527</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <spacer name="horizontalSpacer_9">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <spacer name="horizontalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="minimumSize">
+              <size>
+               <width>211</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Cluster Managerment Window</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="Line" name="line_5">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_3">
-           <property name="minimumSize">
-            <size>
-             <width>211</width>
-             <height>0</height>
-            </size>
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item>
+                <widget class="QLabel" name="label">
+                 <property name="text">
+                  <string>User:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lineEditUser">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="label_2">
+                 <property name="text">
+                  <string>Namespace</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lineEditNs">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="Line" name="line_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QLabel" name="label_4">
+                 <property name="minimumSize">
+                  <size>
+                   <width>131</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="sizeIncrement">
+                  <size>
+                   <width>132</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Nameserver node:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_5">
+                 <property name="text">
+                  <string>--ros</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                <widget class="QLineEdit" name="lineEditNsNode">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkNs">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkRos">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <item>
+                <widget class="QPushButton" name="checkServerBtn">
+                 <property name="text">
+                  <string>Check</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="runServerBtn">
+                 <property name="text">
+                  <string>Run</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="stopServerBtn">
+                 <property name="text">
+                  <string>Stop</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_6">
            <property name="text">
-            <string>Cluster Managerment Window</string>
+            <string>Nodes</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_10">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="Line" name="line_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout">
+          <layout class="QHBoxLayout" name="horizontalLayout_12">
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>User:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="lineEditUser">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="QTreeWidget" name="nodestreeWidget">
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Display</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>User</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Log</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Select</string>
+              </property>
+             </column>
+            </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <layout class="QVBoxLayout" name="verticalLayout_4">
              <item>
-              <widget class="QLabel" name="label_2">
+              <widget class="QPushButton" name="checkAllBtn">
                <property name="text">
-                <string>Namespace</string>
+                <string>Check All</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineEditNs">
-               <property name="enabled">
-                <bool>false</bool>
+              <widget class="QPushButton" name="stopSelBtn">
+               <property name="text">
+                <string>Stop Selected</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="runSelBtn">
+               <property name="text">
+                <string>Run Selected</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="killSelBtn">
+               <property name="text">
+                <string>Kill Selected</string>
                </property>
               </widget>
              </item>
@@ -150,285 +399,66 @@
           </layout>
          </item>
          <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="Line" name="line_4">
+          <widget class="Line" name="line_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="Line" name="line_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
-          <spacer name="horizontalSpacer_7">
+          <spacer name="verticalSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
-             <height>20</height>
+             <width>20</width>
+             <height>29</height>
             </size>
            </property>
           </spacer>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
+          <layout class="QHBoxLayout" name="horizontalLayout_10">
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <item>
-              <widget class="QLabel" name="label_4">
-               <property name="minimumSize">
-                <size>
-                 <width>131</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="sizeIncrement">
-                <size>
-                 <width>132</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Nameserver node:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>--ros</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <spacer name="horizontalSpacer_11">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <item>
-              <widget class="QLineEdit" name="lineEditNsNode">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkNs">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkRos">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="QPushButton" name="runServerBtn_2">
+             <property name="text">
+              <string>More...</string>
+             </property>
+            </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
-             <item>
-              <widget class="QPushButton" name="checkServerBtn">
-               <property name="text">
-                <string>Check</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="runServerBtn">
-               <property name="text">
-                <string>Run</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="stopServerBtn">
-               <property name="text">
-                <string>Stop</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <spacer name="horizontalSpacer_12">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_8">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Nodes</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <item>
-          <layout class="QGridLayout" name="gridLayout"/>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <item>
-            <widget class="QPushButton" name="checkAllBtn">
-             <property name="text">
-              <string>Check All</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="stopSelBtn">
-             <property name="text">
-              <string>Stop Selected</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="runSelBtn">
-             <property name="text">
-              <string>Run Selected</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="killSelBtn">
-             <property name="text">
-              <string>Kill Selected</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="Line" name="line_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>29</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <item>
-          <spacer name="horizontalSpacer_11">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="runServerBtn_2">
-           <property name="text">
-            <string>More...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_12">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>
       </layout>
-      <zorder>line_2</zorder>
-      <zorder>line</zorder>
-      <zorder>line_3</zorder>
       <zorder></zorder>
-      <zorder>verticalSpacer</zorder>
-      <zorder>line_5</zorder>
-      <zorder>label_6</zorder>
      </widget>
     </widget>
    </item>

--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClusterWidget</class>
+ <widget class="QWidget" name="ClusterWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>462</width>
+    <height>504</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>286</width>
+    <height>155</height>
+   </size>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="cursor">
+   <cursorShape>ArrowCursor</cursorShape>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_5">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>442</width>
+        <height>484</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="minimumSize">
+            <size>
+             <width>211</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Cluster Managerment Window</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>User:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineEditUser">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Namespace</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineEditNs">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="Line" name="line_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="label_4">
+               <property name="minimumSize">
+                <size>
+                 <width>131</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="sizeIncrement">
+                <size>
+                 <width>132</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Nameserver node:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>--ros</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <item>
+              <widget class="QLineEdit" name="lineEditNsNode">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="checkNs">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="checkRos">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <item>
+              <widget class="QPushButton" name="checkServerBtn">
+               <property name="text">
+                <string>Check</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="runServerBtn">
+               <property name="text">
+                <string>Run</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="stopServerBtn">
+               <property name="text">
+                <string>Stop</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Nodes</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <layout class="QGridLayout" name="gridLayout"/>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QPushButton" name="checkAllBtn">
+             <property name="text">
+              <string>Check All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="stopSelBtn">
+             <property name="text">
+              <string>Stop Selected</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="runSelBtn">
+             <property name="text">
+              <string>Run Selected</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="killSelBtn">
+             <property name="text">
+              <string>Kill Selected</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>29</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_10">
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="runServerBtn_2">
+           <property name="text">
+            <string>More...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+      <zorder>line_2</zorder>
+      <zorder>line</zorder>
+      <zorder>line_3</zorder>
+      <zorder></zorder>
+      <zorder>verticalSpacer</zorder>
+      <zorder>line_5</zorder>
+      <zorder>label_6</zorder>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yarpmanager/src-manager/main.cpp
+++ b/src/yarpmanager/src-manager/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 
     // Setup resource finder
 
-    yarp::os::ResourceFinder rf;
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
     rf.setVerbose(false);
     rf.setDefaultContext("yarpmanager");
     rf.setDefaultConfigFile(DEF_CONFIG_FILE);

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -160,6 +160,7 @@ MainWindow::MainWindow(QWidget *parent) :
     {
         ui->clusterWidget->setConfigFile(confFile);
         ui->clusterWidget->init();
+        connect(ui->clusterWidget, SIGNAL(logError(QString)), this, SLOT(onLogError(QString)));
     }
     else
     {

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include "ui_mainwindow.h"
 
 #include <yarp/os/Log.h>
+#include <yarp/os/ResourceFinder.h>
 #include <yarp/manager/ymm-dir.h>
 #include <yarp/manager/xmlapploader.h>
 #include <yarp/manager/xmltemploader.h>
@@ -149,6 +150,23 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->actionKill->setEnabled(false);
 
     ui->action_Manager_Window->setChecked(true);
+#ifdef WIN32
+    ui->tabWidgetLeft->tabBar()->hide();
+#else
+    yarp::os::ResourceFinder rf;
+    rf.setDefaultContext("iCubCluster");
+
+    std::string confFile = rf.findFileByName("cluster-config.xml");
+    if (!confFile.empty())
+    {
+        ui->clusterWidget->setConfigFile(confFile);
+        ui->clusterWidget->init();
+    }
+    else
+    {
+        ui->tabWidgetLeft->tabBar()->hide();
+    }
+#endif
 
 }
 

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -153,8 +153,7 @@ MainWindow::MainWindow(QWidget *parent) :
 #ifdef WIN32
     ui->tabWidgetLeft->tabBar()->hide();
 #else
-    yarp::os::ResourceFinder rf;
-    rf.setDefaultContext("iCubCluster");
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
 
     std::string confFile = rf.findFileByName("cluster-config.xml");
     if (!confFile.empty())

--- a/src/yarpmanager/src-manager/mainwindow.h
+++ b/src/yarpmanager/src-manager/mainwindow.h
@@ -19,6 +19,7 @@
 #include "entitiestreewidget.h"
 #include "genericviewwidget.h"
 #include "newapplicationwizard.h"
+#include "clusterWidget.h"
 //#include "message_list.h"
 //#include "application_list.h"
 

--- a/src/yarpmanager/src-manager/mainwindow.ui
+++ b/src/yarpmanager/src-manager/mainwindow.ui
@@ -37,7 +37,7 @@
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
-          <widget class="QTabWidget" name="tabWidget_2">
+          <widget class="QTabWidget" name="tabWidgetLeft">
            <property name="tabPosition">
             <enum>QTabWidget::West</enum>
            </property>
@@ -392,7 +392,7 @@
   </action>
   <action name="actionOpen_File">
    <property name="icon">
-    <iconset resource="../../yarpmotorgui/res.qrc">
+    <iconset resource="../res.qrc">
      <normaloff>:/file-new.svg</normaloff>:/file-new.svg</iconset>
    </property>
    <property name="text">
@@ -419,7 +419,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../../yarpmotorgui/res.qrc">
+    <iconset resource="../res.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -434,7 +434,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../../yarpmotorgui/res.qrc">
+    <iconset resource="../res.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -672,7 +672,6 @@
  <resources>
   <include location="../../yarpdataplayer/src/RC/res.qrc"/>
   <include location="../../yarplogger/res.qrc"/>
-  <include location="../../yarpmotorgui/res.qrc"/>
   <include location="../res.qrc"/>
  </resources>
  <connections/>

--- a/src/yarpmanager/src-manager/mainwindow.ui
+++ b/src/yarpmanager/src-manager/mainwindow.ui
@@ -18,20 +18,8 @@
     <normaloff>:/logo.svg</normaloff>:/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <layout class="QGridLayout" name="gridLayout_4">
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
-     <number>0</number>
-    </property>
-    <item row="0" column="0">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
@@ -44,38 +32,53 @@
         </sizepolicy>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QSplitter" name="splitter_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
-          <widget class="EntitiesTreeWidget" name="entitiesTree">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QTabWidget" name="tabWidget_2">
+           <property name="tabPosition">
+            <enum>QTabWidget::West</enum>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+           <property name="currentIndex">
+            <number>1</number>
            </property>
-           <column>
-            <property name="text">
+           <widget class="QWidget" name="tab_2">
+            <attribute name="title">
+             <string>Cluster</string>
+            </attribute>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <item>
+              <widget class="ClusterWidget" name="clusterWidget" native="true"/>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="tab">
+            <attribute name="title">
              <string>Entities</string>
-            </property>
-           </column>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <item>
+              <widget class="EntitiesTreeWidget" name="entitiesTree">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <column>
+                <property name="text">
+                 <string>Entities</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </widget>
           <widget class="QTabWidget" name="mainTabs">
            <property name="sizePolicy">
@@ -389,7 +392,7 @@
   </action>
   <action name="actionOpen_File">
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpmotorgui/res.qrc">
      <normaloff>:/file-new.svg</normaloff>:/file-new.svg</iconset>
    </property>
    <property name="text">
@@ -416,7 +419,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpmotorgui/res.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -431,7 +434,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res.qrc">
+    <iconset resource="../../yarpmotorgui/res.qrc">
      <normaloff>:/file-save.svg</normaloff>:/file-save.svg</iconset>
    </property>
    <property name="text">
@@ -659,10 +662,17 @@
    <extends>QListWidget</extends>
    <header>logwidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>ClusterWidget</class>
+   <extends>QWidget</extends>
+   <header>clusterWidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../../yarpdataplayer/src/RC/res.qrc"/>
   <include location="../../yarplogger/res.qrc"/>
+  <include location="../../yarpmotorgui/res.qrc"/>
   <include location="../res.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
This PR import iCubCluster inside yarpmanager that looks like: 
![image](https://user-images.githubusercontent.com/19152494/28821594-51b59174-76b6-11e7-8581-e3d2770326de.png)


It has been successfully tested on `iCubGenova01` setup and it has (for now) the same functionalities of `icub-cluster.py`.

on `WIN32` the iCubCluster panel is for now disabled (sorry @randaz81 , @pattacini  and @lornat75 :sweat_smile: ).

@traversaro you owe me a beer :stuck_out_tongue:.

We should discuss about the cross dependency with icub-main( it needs only the `cluster-config.xml`) and about the deployer for windows.
We could keep it as it is for now and try to figure out later how to launch commands from and to windows machines.

@claudiofantacci @barbalberto @vtikha 

Fixes #730.

TODO before merging:

- [x] Implement the `More...` button, maybe in a smarter way...
- [x] Make ui nicer  
- [x] Fix the cross dipendence with iCub..
- [x] Fix codacy
