### PR TITLE
Fix local carrier

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -22,6 +22,8 @@ Bug Fixes
 * Fixed memory leak for inactive carriers
 * Fixed mcast, the connection now continue working also if you disconnect 
   the *first* mcast connection.
+* Removed the inheritance from `SocketTwoWayStream` in `LocalCarrierStream`.
+* Fixed setConnectionQos() for local carrier.
 
 #### YARP_manager
 

--- a/src/libYARP_OS/include/yarp/os/impl/LocalCarrier.h
+++ b/src/libYARP_OS/include/yarp/os/impl/LocalCarrier.h
@@ -8,7 +8,6 @@
 #define YARP_OS_IMPL_LOCALCARRIER_H
 
 #include <yarp/os/AbstractCarrier.h>
-#include <yarp/os/impl/SocketTwoWayStream.h>
 #include <yarp/os/Semaphore.h>
 
 
@@ -44,16 +43,34 @@ private:
 /**
  * A stream for communicating locally within a process.
  */
-class yarp::os::impl::LocalCarrierStream : public SocketTwoWayStream
+class yarp::os::impl::LocalCarrierStream : public TwoWayStream,
+                                           public InputStream,
+                                           public OutputStream
 {
 public:
     void attach(LocalCarrier *owner, bool sender);
 
+    virtual InputStream& getInputStream() override;
+    virtual OutputStream& getOutputStream() override;
+    virtual const Contact& getLocalAddress() override;
+    virtual const Contact& getRemoteAddress() override;
+    virtual bool setTypeOfService(int tos) override;
+
+    using yarp::os::InputStream::read;
+    virtual YARP_SSIZE_T read(const yarp::os::Bytes& b) override;
+
+    using yarp::os::OutputStream::write;
+    virtual void write(const yarp::os::Bytes& b) override;
+
+    virtual void reset() override;
+    virtual void beginPacket() override;
+    virtual void endPacket() override;
     virtual void interrupt() override;
     virtual void close() override;
     virtual bool isOk() override;
 
 private:
+    Contact localAddress, remoteAddress;
     LocalCarrier *owner;
     bool sender;
     bool done;

--- a/src/libYARP_OS/src/LocalCarrier.cpp
+++ b/src/libYARP_OS/src/LocalCarrier.cpp
@@ -7,6 +7,7 @@
 
 #include <yarp/os/impl/LocalCarrier.h>
 #include <yarp/os/Portable.h>
+#include <yarp/os/impl/Logger.h>
 
 using namespace yarp::os;
 
@@ -56,12 +57,61 @@ void yarp::os::impl::LocalCarrierStream::attach(LocalCarrier *owner, bool sender
     done = false;
 }
 
+InputStream& yarp::os::impl::LocalCarrierStream::getInputStream()
+{
+    return *this;
+}
+
+OutputStream& yarp::os::impl::LocalCarrierStream::getOutputStream()
+{
+    return *this;
+}
+
+const Contact& yarp::os::impl::LocalCarrierStream::getLocalAddress()
+{
+    return localAddress;
+}
+
+const Contact& yarp::os::impl::LocalCarrierStream::getRemoteAddress()
+{
+    return remoteAddress;
+}
+
+bool yarp::os::impl::LocalCarrierStream::setTypeOfService(int tos)
+{
+    YARP_UNUSED(tos);
+    return true;
+}
+
+YARP_SSIZE_T yarp::os::impl::LocalCarrierStream::read(const yarp::os::Bytes& b)
+{
+    yAssert(false);
+    return b.length();
+}
+
+void yarp::os::impl::LocalCarrierStream::write(const yarp::os::Bytes& b)
+{
+    YARP_UNUSED(b);
+    yAssert(false);
+}
+
+void yarp::os::impl::LocalCarrierStream::reset()
+{
+}
+
+void yarp::os::impl::LocalCarrierStream::beginPacket()
+{
+}
+
+void yarp::os::impl::LocalCarrierStream::endPacket()
+{
+}
+
 void yarp::os::impl::LocalCarrierStream::interrupt() {
     done = true;
 }
 
 void yarp::os::impl::LocalCarrierStream::close() {
-    SocketTwoWayStream::close();
     if (owner != YARP_NULLPTR) {
         LocalCarrier *owned = owner;
         owner = YARP_NULLPTR;


### PR DESCRIPTION
This PR removes the inheritance from `SocketTwoWayStream` in `LocalCarrierStream` and fixes `setConnectionQos()` for `local` carrier. 