### PR TITLE
Implement IPWMControl and ICurrentControl in ControlBoardRemapper

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -25,6 +25,9 @@ Bug Fixes
 * Removed the inheritance from `SocketTwoWayStream` in `LocalCarrierStream`.
 * Fixed setConnectionQos() for local carrier.
 
+### YARP_dev 
+* IPWMControl and ICurrentControl interfaces are now correctly wrapped by the the `ControlBoardRemapper`.
+
 #### YARP_manager
 
 * Removed `using namespace` directive from headers.
@@ -41,6 +44,7 @@ Bug Fixes
 #### yarpview
 
 * Fixed coordinates of clicked point when yarpview window is resized.
+
 
 Contributors
 ------------

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -948,7 +948,7 @@ bool ControlBoardRemapper::disablePid(const PidControlTypeEnum& pidtype, int j)
         return false;
     }
 
-    return p->pid->disablePid(pidtype, j);
+    return p->pid->disablePid(pidtype, off);
 }
 
 bool ControlBoardRemapper::enablePid(const PidControlTypeEnum& pidtype, int j)
@@ -2610,55 +2610,6 @@ bool ControlBoardRemapper::getAmpStatus(int j, int *v)
     return false;
 }
 
-bool ControlBoardRemapper::getCurrents(double *vals)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
-        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
-
-        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
-
-        if (!p)
-        {
-            return false;
-        }
-
-        if (p->amp)
-        {
-            bool ok = p->amp->getCurrent(off, vals+l);
-            ret = ret && ok;
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    return ret;
-}
-
-bool ControlBoardRemapper::getCurrent(int j, double *val)
-{
-    int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
-    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
-
-    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
-
-    if (!p)
-    {
-        return false;
-    }
-
-    if (p->amp)
-    {
-        return p->amp->getCurrent(off,val);
-    }
-
-    return false;
-}
-
 bool ControlBoardRemapper::setMaxCurrent(int j, double v)
 {
     int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
@@ -4215,3 +4166,350 @@ bool ControlBoardRemapper::setInteractionModes(yarp::dev::InteractionModeEnum* m
 
     return ret;
 }
+
+bool ControlBoardRemapper::setRefDutyCycle(int m, double ref)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iPwm)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iPwm->setRefDutyCycle(off, ref);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefDutyCycles(const double* refs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iPwm)
+        {
+            bool ok = p->iPwm->setRefDutyCycle(off, refs[l]);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefDutyCycle(int m, double* ref)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iPwm)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iPwm->getRefDutyCycle(off, ref);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefDutyCycles(double* refs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iPwm)
+        {
+            bool ok = p->iPwm->getRefDutyCycle(off, refs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getDutyCycle(int m, double* val)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iPwm)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iPwm->getDutyCycle(off, val);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getDutyCycles(double* vals)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iPwm)
+        {
+            bool ok = p->iPwm->getDutyCycle(off, vals+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getCurrent(int j, double *val)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iCurr)
+    {
+        int off=(int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+        ret = p->iCurr->getCurrent(off, val);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getCurrents(double *vals)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iCurr)
+        {
+            bool ok = p->iCurr->getCurrent(off, vals+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getCurrentRange(int m, double* min, double* max)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iCurr)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iCurr->getCurrentRange(off, min, max);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getCurrentRanges(double* min, double* max)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iCurr)
+        {
+            bool ok = p->iCurr->getCurrentRange(off, min+l, max+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefCurrent(int m, double curr)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iCurr)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iCurr->setRefCurrent(off, curr);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefCurrents(const int n_motor, const int* motors, const double* currs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(selectedJointsBuffers.mutex);
+
+    selectedJointsBuffers.fillSubControlBoardBuffersFromArbitraryJointVector(currs,n_motor,motors,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        if (!(p && p->iCurr))
+        {
+            ret = false;
+            break;
+        }
+
+        bool ok = p->iCurr->setRefCurrents(selectedJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                          selectedJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                          selectedJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::setRefCurrents(const double* currs)
+{
+    bool ret=true;
+    yarp::os::LockGuard(allJointsBuffers.mutex);
+
+    allJointsBuffers.fillSubControlBoardBuffersFromCompleteJointVector(currs,remappedControlBoards);
+
+    for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
+    {
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(ctrlBrd);
+
+        bool ok = p->iCurr->setRefCurrents(allJointsBuffers.m_nJointsInSubControlBoard[ctrlBrd],
+                                           allJointsBuffers.m_jointsInSubControlBoard[ctrlBrd].data(),
+                                           allJointsBuffers.m_bufferForSubControlBoard[ctrlBrd].data());
+        ret = ret && ok;
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefCurrent(int m, double* curr)
+{
+    bool ret = false;
+
+    size_t subIndex=remappedControlBoards.lut[m].subControlBoardIndex;
+
+    yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (p && p->iCurr)
+    {
+        int off=(int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
+        ret = p->iCurr->getRefCurrent(off, curr);
+    }
+
+    return ret;
+}
+
+bool ControlBoardRemapper::getRefCurrents(double* currs)
+{
+    bool ret=true;
+
+    for(int l=0;l<controlledJoints;l++)
+    {
+        int off=(int)remappedControlBoards.lut[l].axisIndexInSubControlBoard;
+        size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
+
+        yarp::dev::RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
+
+        if (!p)
+        {
+            return false;
+        }
+
+        if (p->iCurr)
+        {
+            bool ok = p->iCurr->getRefCurrent(off, currs+l);
+            ret = ret && ok;
+        }
+        else
+        {
+            ret=false;
+        }
+    }
+
+    return ret;
+}
+
+

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
@@ -74,6 +74,8 @@ class ControlBoardRemapper : public yarp::dev::DeviceDriver,
                              public yarp::dev::IPositionControl2,
                              public yarp::dev::IPositionDirect,
                              public yarp::dev::IVelocityControl2,
+                             public yarp::dev::IPWMControl,
+                             public yarp::dev::ICurrentControl,
                              public yarp::dev::IEncodersTimed,
                              public yarp::dev::IMotor,
                              public yarp::dev::IMotorEncoders,
@@ -379,10 +381,6 @@ public:
 
     virtual bool getAmpStatus(int j, int *v) override;
 
-    virtual bool getCurrents(double *vals) override;
-
-    virtual bool getCurrent(int j, double *val) override;
-
     virtual bool setMaxCurrent(int j, double v) override;
 
     virtual bool getMaxCurrent(int j, double *v) override;
@@ -563,6 +561,37 @@ public:
 
     virtual bool setInteractionModes(yarp::dev::InteractionModeEnum *modes) override;
 
+    // IPWMControl
+    virtual bool setRefDutyCycle(int m, double ref) override;
+
+    virtual bool setRefDutyCycles(const double *refs) override;
+
+    virtual bool getRefDutyCycle(int m, double *ref) override;
+
+    virtual bool getRefDutyCycles(double *refs) override;
+
+    virtual bool getDutyCycle(int m, double *val) override;
+
+    virtual bool getDutyCycles(double *vals) override;
+
+    // ICurrentControl
+    virtual bool getCurrent(int m, double *curr) override;
+
+    virtual bool getCurrents(double *currs) override;
+
+    virtual bool getCurrentRange(int m, double *min, double *max) override;
+
+    virtual bool getCurrentRanges(double *min, double *max) override;
+
+    virtual bool setRefCurrents(const double *currs) override;
+
+    virtual bool setRefCurrent(int m, double curr) override;
+
+    virtual bool setRefCurrents(const int n_motor, const int *motors, const double *currs) override;
+
+    virtual bool getRefCurrents(double *currs) override;
+
+    virtual bool getRefCurrent(int m, double *curr) override;
 };
 
 }

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -37,8 +37,13 @@ RemappedSubControlBoard::RemappedSubControlBoard()
     iImpedance=0;
     iMode2=0;
     iInteract=0;
+    imotor=0;
+    iVar = 0;
+    iPwm = 0;
+    iCurr = 0;
 
     subdevice=0;
+
 
     attachedF=false;
     _subDevVerbose = false;
@@ -65,7 +70,11 @@ void RemappedSubControlBoard::detach()
     iMode2=0;
     iTimed=0;
     iInteract=0;
+    imotor=0;
     iVar = 0;
+    iPwm = 0;
+    iCurr = 0;
+
     attachedF=false;
 }
 
@@ -106,6 +115,8 @@ bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string
         subdevice->view(iInteract);
         subdevice->view(imotor);
         subdevice->view(iVar);
+        subdevice->view(iPwm);
+        subdevice->view(iCurr);
     }
     else
     {
@@ -146,6 +157,16 @@ bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string
     if ((info == 0) && (_subDevVerbose))
     {
         yWarning() << "ControlBoardRemapper:  Warning IAxisInfo not valid interface";
+    }
+
+    if ((iPwm == 0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning IPWMControl not valid interface";
+    }
+
+    if ((iCurr == 0) && (_subDevVerbose))
+    {
+        yWarning() << "ControlBoardRemapper:  Warning ICurrentControl not valid interface";
     }
 
 

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.h
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.h
@@ -71,6 +71,8 @@ public:
     yarp::dev::IInteractionMode      *iInteract;
     yarp::dev::IMotor                *imotor;
     yarp::dev::IRemoteVariables      *iVar;
+    yarp::dev::IPWMControl           *iPwm;
+    yarp::dev::ICurrentControl       *iCurr;
 
     RemappedSubControlBoard();
 


### PR DESCRIPTION
This change was triggered by the issue https://github.com/robotology/yarp/issues/1309. It implements the `IPWMControl` class methods in the control board re-mapper as follows:
- inheritance and implementation of `IPWMControl` methods in `ControlBoardRemapper` class. For now, only `setRefDutyCycle` has been implentented **\*** (sets the PWM for a single joint), the others only return a `false` status.
- handle the sub-device driver pointer `iPwm` in the `ControlBoardRemapperHelpers` class: initialisation, setting in the `attach` and `detach` methods, warning if sub-device driver is not attached.

(**\***)We track here the implemented methods:
- [x] setRefDutyCycle(int m, double ref)
- [x] setRefDutyCycles(const double *refs)
- [x] getRefDutyCycle(int m, double *ref)
- [x] getRefDutyCycles(double *refs)
- [x] getDutyCycle(int m, double *val)
- [x] getDutyCycles(double *vals)