### PR TITLE
Clock refactoring update

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -658,19 +658,22 @@ public:
 
     /**
      * This function specifically initialize the clock
-     * In case clockType is one of the valid cases, the corersponding clock
-     * will be initialized.
+     * In case clockType is one of the valid cases:
+     *      YARP_CLOCK_SYSTEM,
+     *      YARP_CLOCK_NETWORK,
+     *      YARP_CLOCK_CUSTOM
+     * (see yarp::os::Time for more), the corresponding clock will be initialized.
      *
-     * In case the clockType is UNINITIALIZED_CLOCK, the environment variable
+     * In case the clockType is YARP_CLOCK_DEFAULT, the environment variable
      * YARP_CLOCK will be used to choose between system or network clock.
      *
-     * See description of useNetworkClock() for more details about the
+     * See description of yarp::os::Time::useNetworkClock() for more details about the
      * network clock.
      *
      * This function is called by Network constructor and by Network::init(),
      * and Network::initMinimum().
      *
-     * In case of failure throws YARP_FAIL assert.
+     * In case of failure calls YARP_FAIL assert.
      **/
     static void yarpClockInit(yarp::os::yarpClockType clockType, Clock *custom=YARP_NULLPTR);
 };

--- a/src/libYARP_OS/include/yarp/os/Time.h
+++ b/src/libYARP_OS/include/yarp/os/Time.h
@@ -141,10 +141,6 @@ public:
      *
      */
     static bool isValid();
-
-private:
-    static yarpClockType yarp_clock_type;
-
 };
 
 #endif // YARP_OS_TIME_H

--- a/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 iCub Facility - Istituto Italiano di Tecnologia
+ * Author:  Alberto Cardellino
+ * email:   alberto.cardellino@iit.it
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+
+
+#ifndef YARP_OS_IMPL_TIMEIMPL_H
+#define YARP_OS_IMPL_TIMEIMPL_H
+
+#include <yarp/os/Time.h>
+
+namespace yarp {
+    namespace os {
+        static Clock *pclock = YARP_NULLPTR;
+        static yarpClockType yarp_clock_type  = YARP_CLOCK_UNINITIALIZED;
+
+        namespace impl {
+
+            static void removeClock()
+            {
+                if(yarp::os::pclock != YARP_NULLPTR)
+                    delete yarp::os::pclock;
+                yarp_clock_type = YARP_CLOCK_UNINITIALIZED;
+            }
+        }
+    }
+}
+
+#endif // YARP_OS_IMPL_TIMEIMPL_H

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -33,6 +33,7 @@
 #include <yarp/os/impl/PortCommand.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 #include <yarp/os/impl/ThreadImpl.h>
+#include <yarp/os/impl/TimeImpl.h>
 
 #ifdef YARP_HAS_ACE
 # include <ace/config.h>
@@ -671,6 +672,7 @@ void NetworkBase::finiMinimum() {
         Bottle::fini();
         BottleImpl::fini();
         ThreadImpl::fini();
+        yarp::os::impl::removeClock();
 #ifdef YARP_HAS_ACE
         ACE::fini();
 #endif

--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -13,6 +13,8 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/impl/ThreadImpl.h>
+#include <yarp/os/impl/TimeImpl.h>
+
 
 #ifdef ACE_WIN32
 // for WIN32 MM functions
@@ -22,10 +24,8 @@
 using namespace yarp::os;
 using namespace yarp::os::impl;
 
-static Clock *pclock = YARP_NULLPTR;
 static bool clock_owned = false;
 static bool network_clock_ok = false;
-yarpClockType yarp::os::Time::yarp_clock_type  = YARP_CLOCK_UNINITIALIZED;
 
 
 static void lock() {


### PR DESCRIPTION
In case yarp::os::Time()/delay() are used without prior Network initialization a warning message is printed to warn the user.

If YARP_NO_DEPRECATED is set, the program terminates with error instead.