### PR TITLE
OS/impl/BottleImpl: There is no need for the Bottle implementation to be a Portable itself

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/BottleImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BottleImpl.h
@@ -433,7 +433,7 @@ public:
  * Handy to use until you work out how to make your own more
  * efficient formats for transmission.
  */
-class YARP_OS_impl_API yarp::os::impl::BottleImpl : public yarp::os::Portable
+class YARP_OS_impl_API yarp::os::impl::BottleImpl
 {
 public:
     BottleImpl();
@@ -476,10 +476,10 @@ public:
     ConstString toString();
     size_t size() const;
 
-    virtual bool read(ConnectionReader& reader) override;
-    virtual bool write(ConnectionWriter& writer) override;
+    bool read(ConnectionReader& reader);
+    bool write(ConnectionWriter& writer);
 
-    virtual void onCommencement() override;
+    void onCommencement();
 
     const char* getBytes();
     size_t byteCount();

--- a/tests/libYARP_OS/PortCoreTest.cpp
+++ b/tests/libYARP_OS/PortCoreTest.cpp
@@ -101,7 +101,7 @@ public:
         sender.start();
         receiver.start();
         //Time::delay(1);
-        BottleImpl bot;
+        Bottle bot;
         bot.addInt(0);
         bot.addString("Hello world");
         report(0,"sending bottle, should received nothing");
@@ -149,7 +149,7 @@ public:
         sender.start();
         receiver.start();
         //Time::delay(1);
-        BottleImpl bot;
+        Bottle bot;
         bot.addInt(0);
         bot.addString("Hello world");
         report(0,"sending bottle, should received nothing");


### PR DESCRIPTION
`BottleImpl` is the private implementation for the `Bottle` class.
There is no need to be a `Portable`, it's never written on a port (it was used in the `PortCoreTest`, but it makes no sense, and it is changed here to use `Bottle` instead).