### PR TITLE
Updated RPATH macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+# RPATH cmake policy set to NEW
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.9)
+  cmake_policy(SET CMP0068 NEW)
+endif()
+
 # Pick up our CMake scripts - they are all in the cmake subdirectory.
 set(YARP_MODULE_DIR "${CMAKE_SOURCE_DIR}/cmake")
 set(YARP_MODULE_PATH "${YARP_MODULE_DIR}")

--- a/cmake/YarpOptions.cmake
+++ b/cmake/YarpOptions.cmake
@@ -359,8 +359,8 @@ yarp_deprecated_option(INSTALL_WITH_RPATH)
 add_install_rpath_support(LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"       # Libraries
                           BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"       # Binaries
                                    "${CMAKE_INSTALL_FULL_LIBDIR}/yarp"  # Plugins
+                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
                           USE_LINK_PATH)
-
 
 #########################################################################
 # Specify yarp version and copyright into macOS bundles


### PR DESCRIPTION
Added a new variable INSTALL_NAME_DIR to specify the absolute installation path of the libraries.
This variable will be used if RPATH is disabled either for the full project or for the installation