### PR TITLE
[bindings] Fix included headers

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -388,6 +388,9 @@ namespace yarp {
 %include <yarp/os/PortReaderCreator.h>
 %include <yarp/os/Property.h>
 %include <yarp/os/Bottle.h>
+%include <yarp/os/TypedReader.h>
+%include <yarp/os/TypedReaderCallback.h>
+%include <yarp/os/TypedReaderThread.h>
 %include <yarp/os/PortReaderBuffer.h>
 %include <yarp/os/PortWriterBuffer.h>
 %include <yarp/os/Random.h>


### PR DESCRIPTION
Fix bug introduced by https://github.com/robotology/yarp/pull/1317 .
Fix https://github.com/robotology/yarp/issues/1325 . 

@drdanz I remember that we used to have Travis checking at least the bindings compilation, something happened and we don't have it anymore? 