### PR TITLE
Fix abstract carrier

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -24,6 +24,8 @@ Bug Fixes
   the *first* mcast connection.
 * Removed the inheritance from `SocketTwoWayStream` in `LocalCarrierStream`.
 * Fixed setConnectionQos() for local carrier.
+* Added `flush()` at the end of `AbstractCarrier::writeYarpInt()` to finalize
+  the write. 
 
 ### YARP_dev 
 * IPWMControl and ICurrentControl interfaces are now correctly wrapped by the the `ControlBoardRemapper`.

--- a/src/libYARP_OS/src/AbstractCarrier.cpp
+++ b/src/libYARP_OS/src/AbstractCarrier.cpp
@@ -356,4 +356,5 @@ void AbstractCarrier::writeYarpInt(int n, ConnectionState& proto)
     Bytes header(&(buf[0]), sizeof(buf));
     createYarpNumber(n, header);
     proto.os().write(header);
+    proto.os().flush();
 }


### PR DESCRIPTION
This pr add `proto.os().flush()` at the end of `writeYarpInt()` to finalize the write, that for some carriers is necessary.

Please review code.