### PR TITLE
RateThread: add diagnostic message when timing may be an issue.

### DIFF
--- a/src/libYARP_OS/include/yarp/os/RateThread.h
+++ b/src/libYARP_OS/include/yarp/os/RateThread.h
@@ -206,6 +206,8 @@ private:
 
     void initWithSystemClock();
 
+    bool checkRequiredPeriod(int &period);
+
 friend class SystemRateThread;
 };
 


### PR DESCRIPTION
Check if RateThread period is negative and in that case an Assert is called.

Add 2 diagnostic messages:

- RateThread period set to 0ms: 0 is not an achievable period and shall not be used. If no specific period is required, a simple `yarp::os::Thread` shall be used instead. This is enclosed as `YARP_NO_DEPRECATED // since YARP 2.3.72` and in future version an Assert will be called as suggested by @drdanz.
- When the `run()` function takes more time to be executed than required period, a warning message will inform the user.