### PR TITLE
Fix Network::connect()

### DIFF
--- a/doc/release/v2_3_70_1.md
+++ b/doc/release/v2_3_70_1.md
@@ -28,6 +28,7 @@ Bug Fixes
   the write. 
 * Fixed memory leak in port authentication.
 * Fixed Buffer not null terminated in impl/SplitString.
+* Added the check for spaces in the port names in `Network:metaConnect()`.
 
 ### YARP_dev 
 * IPWMControl and ICurrentControl interfaces are now correctly wrapped by the the `ControlBoardRemapper`.

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -285,7 +285,12 @@ static int metaConnect(const ConstString& src,
                   dest.c_str(),
                   (mode==YARP_ENACT_CONNECT)?"connect":((mode==YARP_ENACT_DISCONNECT)?"disconnect":"check")
                   );
-
+    // check if source name and destination name contain spaces
+    if(dest.find(" ") != std::string::npos || src.find(" ") != std::string::npos)
+    {
+        fprintf(stderr, "Failure: no way to make connection %s->%s,\n", src.c_str(), dest.c_str());
+        return 1;
+    }
     // get the expressed contacts, without name server input
     Contact dynamicSrc = Contact::fromString(src);
     Contact dynamicDest = Contact::fromString(dest);

--- a/tests/libYARP_OS/NetworkTest.cpp
+++ b/tests/libYARP_OS/NetworkTest.cpp
@@ -102,7 +102,9 @@ public:
         Network::sync("/p1");
         Network::sync("/p2");
         checkTrue(Network::connect("/p1","/p2"),"good connect");
-        checkFalse(Network::connect("/p1","/p3"),"bad connect");
+        checkFalse(Network::connect("/p1","/p3"),"bad connect, not existing destination");
+        checkFalse(Network::connect("/p1","/p2 /p3"),"bad connect, invalid destination");
+        checkFalse(Network::connect("/p1 /p2","/p2"),"bad connect, invalid source");
         p2.close();
         p1.close();
     }


### PR DESCRIPTION
The changes introduced by this PR add the check of the presence of spaces in dst and src port name in Network::metaConnect().
It fixes #1211.
Please review code.