### PR TITLE
H264 encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ addons:
       - libopencv-dev
       - libeigen3-dev
       - libgraphviz-dev
+      - libgstreamer1.0-dev
+      - libgstreamer-plugins-base1.0-dev
       # Bindings
       - swig3.0
       # C# bindings
@@ -329,6 +331,7 @@ before_script:
   - export YARP_CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=${YARP_INSTALL_PREFIX} -DYARP_EXPERIMENTAL_CXX11=ON"
   - if ! $TRAVIS_WITH_ACE; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DSKIP_ACE=ON -DYARP_TEST_HEAP=ON"; fi
   - if ! $TRAVIS_WITH_MATH; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DCREATE_LIB_MATH:BOOL=OFF -DENABLE_yarpmod_fakeIMU:BOOL=OFF -DENABLE_yarpmod_fakeLaser:BOOL=OFF"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DENABLE_yarpcar_h264:BOOL=ON"; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DYARP_COMPILE_BINDINGS=ON -DCREATE_LUA=ON -DCREATE_PYTHON=ON -DCREATE_TCL=ON -DCREATE_JAVA=ON -DCREATE_CSHARP=ON"; fi
   - if $TRAVIS_STATIC; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DCREATE_SHARED_LIBRARY=OFF"; fi
   - if $TRAVIS_CLEAN_API; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DYARP_CLEAN_API=ON -DYARP_COMPILE_TESTS=OFF"; fi

--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -454,6 +454,16 @@ checkandset_dependency(OpenNI2)
 find_package(Doxygen)
 checkandset_dependency(Doxygen)
 
+find_package(GLIB2 QUIET)
+checkandset_dependency(GLIB2)
+
+set(GStreamer_REQUIRED_VERSION 1.4)
+find_package(GStreamer ${GStreamer_REQUIRED_VERSION} QUIET)
+checkandset_dependency(GStreamer)
+
+set(GStreamerPluginsBase_REQUIRED_VERSION 1.4)
+find_package(GStreamerPluginsBase ${GStreamerPluginsBase_REQUIRED_VERSION} COMPONENTS app QUIET)
+checkandset_dependency(GStreamerPluginsBase)
 
 # PRINT DEPENDENCIES STATUS:
 
@@ -490,6 +500,9 @@ print_dependency(Libusb1)
 print_dependency(Stage)
 print_dependency(ZFP)
 print_dependency(OpenNI2)
+print_dependency(GLIB2)
+print_dependency(GStreamer)
+print_dependency(GStreamerPluginsBase)
 
 
 # CHECK DEPENDENCIES:

--- a/cmake/ycm-0.5.1/3rdparty/COPYING.qt-gstreamer
+++ b/cmake/ycm-0.5.1/3rdparty/COPYING.qt-gstreamer
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/ycm-0.5.1/3rdparty/FindGLIB2.cmake
+++ b/cmake/ycm-0.5.1/3rdparty/FindGLIB2.cmake
@@ -1,0 +1,66 @@
+# - Try to find the GLIB2 libraries
+# Once done this will define
+#
+#  GLIB2_FOUND - system has glib2
+#  GLIB2_INCLUDE_DIR - the glib2 include directory
+#  GLIB2_LIBRARIES - glib2 library
+
+# Copyright (c) 2008 Laurent Montel, <montel@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+
+if(GLIB2_INCLUDE_DIR AND GLIB2_LIBRARIES)
+    # Already in cache, be silent
+    set(GLIB2_FIND_QUIETLY TRUE)
+endif(GLIB2_INCLUDE_DIR AND GLIB2_LIBRARIES)
+
+if (NOT WIN32)
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PKG_GLIB QUIET glib-2.0)
+  endif()
+endif(NOT WIN32)
+
+find_path(GLIB2_MAIN_INCLUDE_DIR glib.h
+          PATH_SUFFIXES glib-2.0
+          HINTS ${PKG_GLIB_INCLUDE_DIRS} ${PKG_GLIB_INCLUDEDIR})
+
+# search the glibconfig.h include dir under the same root where the library is found
+find_library(GLIB2_LIBRARIES
+             NAMES glib-2.0
+             HINTS ${PKG_GLIB_LIBRARY_DIRS} ${PKG_GLIB_LIBDIR})
+
+find_path(GLIB2_INTERNAL_INCLUDE_DIR glibconfig.h
+          PATH_SUFFIXES glib-2.0/include ../lib/glib-2.0/include
+          HINTS ${PKG_GLIB_INCLUDE_DIRS} ${PKG_GLIB_LIBRARIES} ${CMAKE_SYSTEM_LIBRARY_PATH})
+
+set(GLIB2_INCLUDE_DIR ${GLIB2_MAIN_INCLUDE_DIR})
+
+# not sure if this include dir is optional or required
+# for now it is optional
+if(GLIB2_INTERNAL_INCLUDE_DIR)
+  set(GLIB2_INCLUDE_DIR ${GLIB2_INCLUDE_DIR} ${GLIB2_INTERNAL_INCLUDE_DIR})
+endif(GLIB2_INTERNAL_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLIB2  DEFAULT_MSG  GLIB2_LIBRARIES GLIB2_MAIN_INCLUDE_DIR)
+
+mark_as_advanced(GLIB2_INCLUDE_DIR GLIB2_LIBRARIES)
+
+
+find_program(GLIB2_GENMARSHAL_UTIL glib-genmarshal)
+
+macro(glib2_genmarshal output_name)
+    file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/genmarshal_tmp)
+    foreach(_declaration ${ARGN})
+        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/genmarshal_tmp "${_declaration}\n")
+    endforeach()
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${output_name}.h ${CMAKE_CURRENT_BINARY_DIR}/${output_name}.c
+        COMMAND ${GLIB2_GENMARSHAL_UTIL} --header genmarshal_tmp > ${output_name}.h
+        COMMAND ${GLIB2_GENMARSHAL_UTIL} --body genmarshal_tmp > ${output_name}.c
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+endmacro()

--- a/cmake/ycm-0.5.1/3rdparty/FindGStreamer.cmake
+++ b/cmake/ycm-0.5.1/3rdparty/FindGStreamer.cmake
@@ -1,0 +1,149 @@
+# - Try to find GStreamer
+# Once done this will define
+#
+#  GSTREAMER_FOUND - system has GStreamer
+#  GSTREAMER_INCLUDE_DIR - the GStreamer main include directory
+#  GSTREAMER_INCLUDE_DIRS - the GStreamer include directories
+#  GSTREAMER_LIBRARY - the main GStreamer library
+#  GSTREAMER_PLUGIN_DIR - the GStreamer plugin directory
+#
+#  And for all the plugin libraries specified in the COMPONENTS
+#  of find_package, this module will define:
+#
+#  GSTREAMER_<plugin_lib>_LIBRARY_FOUND - system has <plugin_lib>
+#  GSTREAMER_<plugin_lib>_LIBRARY - the <plugin_lib> library
+#  GSTREAMER_<plugin_lib>_INCLUDE_DIR - the <plugin_lib> include directory
+#
+# Copyright (c) 2010, Collabora Ltd.
+#   @author George Kiagiadakis <george.kiagiadakis@collabora.co.uk>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+if (GSTREAMER_INCLUDE_DIR AND GSTREAMER_LIBRARY)
+    set(GStreamer_FIND_QUIETLY TRUE)
+else()
+    set(GStreamer_FIND_QUIETLY FALSE)
+endif()
+
+set(GSTREAMER_ABI_VERSION "1.0")
+
+
+# Find the main library
+find_package(PkgConfig)
+
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PKG_GSTREAMER QUIET gstreamer-${GSTREAMER_ABI_VERSION})
+    if(PKG_GSTREAMER_FOUND)
+        exec_program(${PKG_CONFIG_EXECUTABLE}
+                     ARGS --variable pluginsdir gstreamer-${GSTREAMER_ABI_VERSION}
+                     OUTPUT_VARIABLE PKG_GSTREAMER_PLUGIN_DIR)
+    endif()
+    set(GSTREAMER_DEFINITIONS ${PKG_GSTREAMER_CFLAGS})
+endif()
+
+find_library(GSTREAMER_LIBRARY
+             NAMES gstreamer-${GSTREAMER_ABI_VERSION}
+             HINTS ${PKG_GSTREAMER_LIBRARY_DIRS} ${PKG_GSTREAMER_LIBDIR})
+
+find_path(GSTREAMER_INCLUDE_DIR
+          gst/gst.h
+          HINTS ${PKG_GSTREAMER_INCLUDE_DIRS} ${PKG_GSTREAMER_INCLUDEDIR}
+          PATH_SUFFIXES gstreamer-${GSTREAMER_ABI_VERSION})
+
+find_path(GSTREAMER_gstconfig_INCLUDE_DIR
+          gst/gstconfig.h
+          HINTS ${PKG_GSTREAMER_INCLUDE_DIRS} ${PKG_GSTREAMER_INCLUDEDIR}
+          PATH_SUFFIXES gstreamer-${GSTREAMER_ABI_VERSION})
+
+set(GSTREAMER_INCLUDE_DIRS ${GSTREAMER_INCLUDE_DIR} ${GSTREAMER_gstconfig_INCLUDE_DIR})
+list(REMOVE_DUPLICATES GSTREAMER_INCLUDE_DIRS)
+
+if (PKG_GSTREAMER_PLUGIN_DIR)
+    set(_GSTREAMER_PLUGIN_DIR ${PKG_GSTREAMER_PLUGIN_DIR})
+else()
+    get_filename_component(_GSTREAMER_LIB_DIR ${GSTREAMER_LIBRARY} PATH)
+    set(_GSTREAMER_PLUGIN_DIR ${_GSTREAMER_LIB_DIR}/gstreamer-${GSTREAMER_ABI_VERSION})
+endif()
+
+set(GSTREAMER_PLUGIN_DIR ${_GSTREAMER_PLUGIN_DIR}
+    CACHE PATH "The path to the gstreamer plugins installation directory")
+
+mark_as_advanced(GSTREAMER_LIBRARY
+                 GSTREAMER_INCLUDE_DIR
+                 GSTREAMER_gstconfig_INCLUDE_DIR
+                 GSTREAMER_PLUGIN_DIR)
+
+
+# Find additional libraries
+include(MacroFindGStreamerLibrary)
+
+macro(_find_gst_component _name _header)
+    find_gstreamer_library(${_name} ${_header} ${GSTREAMER_ABI_VERSION} ${GStreamer_FIND_QUIETLY})
+    set(_GSTREAMER_EXTRA_VARIABLES ${_GSTREAMER_EXTRA_VARIABLES}
+                                    GSTREAMER_${_name}_LIBRARY GSTREAMER_${_name}_INCLUDE_DIR)
+endmacro()
+
+foreach(_component ${GStreamer_FIND_COMPONENTS})
+    if (${_component} STREQUAL "base")
+        _find_gst_component(BASE gstbasesink.h)
+    elseif (${_component} STREQUAL "check")
+        _find_gst_component(CHECK gstcheck.h)
+    elseif (${_component} STREQUAL "controller")
+        _find_gst_component(CONTROLLER gstargbcontrolbinding.h)
+    elseif (${_component} STREQUAL "net")
+        _find_gst_component(NET gstnet.h)
+    else()
+        message (AUTHOR_WARNING "FindGStreamerPluginsBase.cmake: Invalid component \"${_component}\" was specified")
+    endif()
+endforeach()
+
+
+# Version check
+if (GStreamer_FIND_VERSION)
+    if (PKG_GSTREAMER_FOUND)
+        if("${PKG_GSTREAMER_VERSION}" VERSION_LESS "${GStreamer_FIND_VERSION}")
+            if(NOT GStreamer_FIND_QUIETLY)
+                message(STATUS "Found GStreamer version ${PKG_GSTREAMER_VERSION}, but at least version ${GStreamer_FIND_VERSION} is required")
+            endif()
+            set(GSTREAMER_VERSION_COMPATIBLE FALSE)
+        else()
+            set(GSTREAMER_VERSION_COMPATIBLE TRUE)
+        endif()
+    elseif(GSTREAMER_INCLUDE_DIR)
+        include(CheckCXXSourceCompiles)
+
+        set(CMAKE_REQUIRED_INCLUDES ${GSTREAMER_INCLUDE_DIR})
+        string(REPLACE "." "," _comma_version ${GStreamer_FIND_VERSION})
+        # Hack to invalidate the cached value
+        set(GSTREAMER_VERSION_COMPATIBLE GSTREAMER_VERSION_COMPATIBLE)
+
+        check_cxx_source_compiles("
+#define G_BEGIN_DECLS
+#define G_END_DECLS
+#include <gst/gstversion.h>
+
+#if GST_CHECK_VERSION(${_comma_version})
+int main() { return 0; }
+#else
+# error \"GStreamer version incompatible\"
+#endif
+" GSTREAMER_VERSION_COMPATIBLE)
+
+        if (NOT GSTREAMER_VERSION_COMPATIBLE AND NOT NOT GStreamer_FIND_QUIETLY)
+            message(STATUS "GStreamer ${GStreamer_FIND_VERSION} is required, but the version found is older")
+        endif()
+    else()
+        # We didn't find gstreamer at all
+        set(GSTREAMER_VERSION_COMPATIBLE FALSE)
+    endif()
+else()
+    # No version constrain was specified, thus we consider the version compatible
+    set(GSTREAMER_VERSION_COMPATIBLE TRUE)
+endif()
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GStreamer DEFAULT_MSG
+                                  GSTREAMER_LIBRARY GSTREAMER_INCLUDE_DIRS
+                                  GSTREAMER_VERSION_COMPATIBLE ${_GSTREAMER_EXTRA_VARIABLES})

--- a/cmake/ycm-0.5.1/3rdparty/FindGStreamerPluginsBase.cmake
+++ b/cmake/ycm-0.5.1/3rdparty/FindGStreamerPluginsBase.cmake
@@ -1,0 +1,90 @@
+# - Try to find gst-plugins-base
+# Once done this will define
+#
+#  GSTREAMER_PLUGINS_BASE_FOUND - system has gst-plugins-base
+#
+#  And for all the plugin libraries specified in the COMPONENTS
+#  of find_package, this module will define:
+#
+#  GSTREAMER_<plugin_lib>_LIBRARY_FOUND - system has <plugin_lib>
+#  GSTREAMER_<plugin_lib>_LIBRARY - the <plugin_lib> library
+#  GSTREAMER_<plugin_lib>_INCLUDE_DIR - the <plugin_lib> include directory
+#
+# Copyright (c) 2010, Collabora Ltd.
+#   @author George Kiagiadakis <george.kiagiadakis@collabora.co.uk>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+set(GSTREAMER_ABI_VERSION "1.0")
+
+
+# Find the pkg-config file for doing the version check
+find_package(PkgConfig)
+
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PKG_GSTREAMER_PLUGINS_BASE QUIET gstreamer-plugins-base-${GSTREAMER_ABI_VERSION})
+endif()
+
+
+# Find the plugin libraries
+include(MacroFindGStreamerLibrary)
+
+macro(_find_gst_plugins_base_component _name _header)
+    find_gstreamer_library(${_name} ${_header} ${GSTREAMER_ABI_VERSION} ${GStreamerPluginsBase_FIND_QUIETLY})
+    set(_GSTREAMER_PLUGINS_BASE_EXTRA_VARIABLES ${_GSTREAMER_PLUGINS_BASE_EXTRA_VARIABLES}
+                                        GSTREAMER_${_name}_LIBRARY GSTREAMER_${_name}_INCLUDE_DIR)
+endmacro()
+
+foreach(_component ${GStreamerPluginsBase_FIND_COMPONENTS})
+    if (${_component} STREQUAL "app")
+        _find_gst_plugins_base_component(APP gstappsrc.h)
+    elseif (${_component} STREQUAL "audio")
+        _find_gst_plugins_base_component(AUDIO audio.h)
+    elseif (${_component} STREQUAL "fft")
+        _find_gst_plugins_base_component(FFT gstfft.h)
+    elseif (${_component} STREQUAL "riff")
+        _find_gst_plugins_base_component(RIFF riff-ids.h)
+    elseif (${_component} STREQUAL "rtp")
+        _find_gst_plugins_base_component(RTP gstrtpbuffer.h)
+    elseif (${_component} STREQUAL "rtsp")
+        _find_gst_plugins_base_component(RTSP gstrtspdefs.h)
+    elseif (${_component} STREQUAL "sdp")
+        _find_gst_plugins_base_component(SDP gstsdp.h)
+    elseif (${_component} STREQUAL "tag")
+        _find_gst_plugins_base_component(TAG tag.h)
+    elseif (${_component} STREQUAL "pbutils")
+        _find_gst_plugins_base_component(PBUTILS pbutils.h)
+    elseif (${_component} STREQUAL "video")
+        _find_gst_plugins_base_component(VIDEO video.h)
+    else()
+        message (AUTHOR_WARNING "FindGStreamer.cmake: Invalid component \"${_component}\" was specified")
+    endif()
+endforeach()
+
+
+# Version check
+if (GStreamerPluginsBase_FIND_VERSION)
+    if (PKG_GSTREAMER_PLUGINS_BASE_FOUND)
+        if("${PKG_GSTREAMER_PLUGINS_BASE_VERSION}" VERSION_LESS "${GStreamerPluginsBase_FIND_VERSION}")
+            if (NOT GStreamerPluginsBase_FIND_QUIETLY)
+                message(STATUS "Found gst-plugins-base version ${PKG_GSTREAMER_PLUGINS_BASE_VERSION}, but at least version ${GStreamerPluginsBase_FIND_VERSION} is required")
+            endif()
+            set(GSTREAMER_PLUGINS_BASE_VERSION_COMPATIBLE FALSE)
+        else()
+            set(GSTREAMER_PLUGINS_BASE_VERSION_COMPATIBLE TRUE)
+        endif()
+    else()
+        # We can't make any version checks without pkg-config, just assume version is compatible and hope...
+        set(GSTREAMER_PLUGINS_BASE_VERSION_COMPATIBLE TRUE)
+    endif()
+else()
+    # No version constrain was specified, thus we consider the version compatible
+    set(GSTREAMER_PLUGINS_BASE_VERSION_COMPATIBLE TRUE)
+endif()
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GStreamerPluginsBase DEFAULT_MSG
+                                  GSTREAMER_PLUGINS_BASE_VERSION_COMPATIBLE
+                                  ${_GSTREAMER_PLUGINS_BASE_EXTRA_VARIABLES})

--- a/cmake/ycm-0.5.1/3rdparty/MacroFindGStreamerLibrary.cmake
+++ b/cmake/ycm-0.5.1/3rdparty/MacroFindGStreamerLibrary.cmake
@@ -1,0 +1,57 @@
+# - macro find_gstreamer_library
+#
+# Copyright (c) 2010, Collabora Ltd.
+#   @author George Kiagiadakis <george.kiagiadakis@collabora.co.uk>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+macro(find_gstreamer_library _name _header _abi_version _quiet)
+    string(TOLOWER ${_name} _lower_name)
+    string(TOUPPER ${_name} _upper_name)
+
+    if (GSTREAMER_${_upper_name}_LIBRARY AND GSTREAMER_${_upper_name}_INCLUDE_DIR)
+        set(_GSTREAMER_${_upper_name}_QUIET TRUE)
+    else()
+        set(_GSTREAMER_${_upper_name}_QUIET FALSE)
+    endif()
+
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(PKG_GSTREAMER_${_upper_name} QUIET gstreamer-${_lower_name}-${_abi_version})
+    endif()
+
+    find_library(GSTREAMER_${_upper_name}_LIBRARY
+                 NAMES gst${_lower_name}-${_abi_version}
+                 HINTS ${PKG_GSTREAMER_${_upper_name}_LIBRARY_DIRS}
+                       ${PKG_GSTREAMER_${_upper_name}_LIBDIR}
+    )
+
+    find_path(GSTREAMER_${_upper_name}_INCLUDE_DIR
+              gst/${_lower_name}/${_header}
+              HINTS ${PKG_GSTREAMER_${_upper_name}_INCLUDE_DIRS}
+                    ${PKG_GSTREAMER_${_upper_name}_INCLUDEDIR}
+              PATH_SUFFIXES gstreamer-${_abi_version}
+    )
+
+    if (GSTREAMER_${_upper_name}_LIBRARY AND GSTREAMER_${_upper_name}_INCLUDE_DIR)
+        set(GSTREAMER_${_upper_name}_LIBRARY_FOUND TRUE)
+    else()
+        set(GSTREAMER_${_upper_name}_LIBRARY_FOUND FALSE)
+    endif()
+
+    if (NOT _GSTREAMER_${_upper_name}_QUIET AND NOT _quiet)
+        if (GSTREAMER_${_upper_name}_LIBRARY)
+            message(STATUS "Found GSTREAMER_${_upper_name}_LIBRARY: ${GSTREAMER_${_upper_name}_LIBRARY}")
+        else()
+            message(STATUS "Could NOT find GSTREAMER_${_upper_name}_LIBRARY")
+        endif()
+
+        if (GSTREAMER_${_upper_name}_INCLUDE_DIR)
+            message(STATUS "Found GSTREAMER_${_upper_name}_INCLUDE_DIR: ${GSTREAMER_${_upper_name}_INCLUDE_DIR}")
+        else()
+            message(STATUS "Could NOT find GSTREAMER_${_upper_name}_INCLUDE_DIR")
+        endif()
+    endif()
+
+    mark_as_advanced(GSTREAMER_${_upper_name}_LIBRARY GSTREAMER_${_upper_name}_INCLUDE_DIR)
+endmacro()

--- a/cmake/ycm-0.5.1/3rdparty/README.qt-gstreamer
+++ b/cmake/ycm-0.5.1/3rdparty/README.qt-gstreamer
@@ -1,0 +1,7 @@
+Some of the files in this folder and its subfolder come from the qt-gstreamer
+git repository (ref ea0d273008316e875a2f6496c0f5f3fa1fcfb6b8):
+
+  https://github.com/GStreamer/qt-gstreamer
+
+Redistribution and use is allowed according to the terms of the 3-clause
+BSD license. See accompanying file COPYING.qt-gstreamer for details.

--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -42,6 +42,9 @@ New Features
 * The method `yarp::os::Network::runNameServer()` was removed.
 * Added possibility to enable and disable macOS AppNap (Os.h).
 * Added a few missing ConstString::assign overloads.
+* Added method 'yarp::os::carrier::createFace()', that returns the needed face
+  of the carrier. This method is used in carriers::listen and carriers::connect
+  in order to open new connection using the correct face.
 
 #### `YARP_dev`
 
@@ -55,6 +58,9 @@ New Features
 * Added hud element setted by the configuration file and connected diretly to
   image ports
 
+### Carriers
+* New H264 carrier. It let you to read and decoding a h264 stream
+  published by Gstreamer server.
 
 ### GUIs
 

--- a/src/carriers/CMakeLists.txt
+++ b/src/carriers/CMakeLists.txt
@@ -16,6 +16,7 @@ yarp_begin_plugin_library(yarpcar)
   add_subdirectory(portmonitor_carrier)
   add_subdirectory(depth_image_portmonitor)
   add_subdirectory(zfp_portmonitor)
+  add_subdirectory(h264_carrier)
 yarp_end_plugin_library(yarpcar)
 add_library(YARP::yarpcar ALIAS yarpcar)
 

--- a/src/carriers/h264_carrier/CMakeLists.txt
+++ b/src/carriers/h264_carrier/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (C) 2010 RobotCub Consortium
+# Authors: Valentina Gaggero
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+yarp_prepare_plugin(h264
+                    CATEGORY carrier
+                    TYPE yarp::os::H264Carrier
+                    INCLUDE H264Carrier.h
+                    EXTRA_CONFIG CODE=""
+                    DEPENDS "CREATE_OPTIONAL_CARRIERS;GLIB2_FOUND;GSTREAMER_FOUND;GSTREAMER_APP_LIBRARY_FOUND")
+
+if(NOT SKIP_h264)
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+  # GLIB2 is required by GStreamer
+  include_directories(SYSTEM ${GLIB2_INCLUDE_DIR})
+  include_directories(SYSTEM ${GSTREAMER_INCLUDE_DIRS})
+  include_directories(SYSTEM ${GSTREAMER_app_INCLUDE_DIR})
+
+  yarp_add_plugin(yarp_h264
+                  H264Carrier.h
+                  H264Carrier.cpp
+                  H264Stream.h
+                  H264Stream.cpp
+                  H264Decoder.cpp
+                  H264Decoder.h)
+
+  target_link_libraries(yarp_h264 YARP::YARP_OS
+                                  YARP::YARP_sig
+                                  YARP::YARP_wire_rep_utils
+                                  ${GLIB2_LIBRARIES}
+                                  ${GSTREAMER_LIBRARY}
+                                  ${GSTREAMER_APP_LIBRARY})
+
+  yarp_install(TARGETS yarp_h264
+               EXPORT YARP
+               COMPONENT runtime
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+  yarp_install(FILES h264.ini
+               COMPONENT runtime
+               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set_property(TARGET yarp_h264 PROPERTY FOLDER "Plugins/Carrier")
+endif()

--- a/src/carriers/h264_carrier/H264Carrier.cpp
+++ b/src/carriers/h264_carrier/H264Carrier.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <cstdio>
+
+
+#include "H264Carrier.h"
+#include "H264Stream.h"
+#include "yarp/os/Contact.h"
+#include "yarp/os/impl/FakeFace.h"
+
+
+using namespace yarp::os;
+using namespace yarp::sig;
+
+
+
+ConstString H264Carrier::getName()
+{
+    return "h264";
+}
+
+bool H264Carrier::isConnectionless()
+{
+    return true;
+}
+
+bool H264Carrier::canAccept()
+{
+    return true;
+}
+
+bool H264Carrier::canOffer()
+{
+    return true;
+}
+
+bool H264Carrier::isTextMode()
+{
+    return false;
+}
+
+bool H264Carrier::canEscape()
+{
+    return false;
+}
+
+void H264Carrier::handleEnvelope(const yarp::os::ConstString& envelope)
+{
+    this->envelope = envelope;
+}
+
+bool H264Carrier::requireAck()
+{
+    return false;
+}
+
+bool H264Carrier::supportReply()
+{
+    return false;
+}
+
+bool H264Carrier::isLocal()
+{
+    return false;
+}
+
+// this is important - flips expected flow of messages
+bool H264Carrier::isPush()
+{
+    return false;
+}
+
+ConstString H264Carrier::toString()
+{
+    return "h264_carrier";
+}
+
+void H264Carrier::getHeader(const Bytes& header)
+{
+}
+
+bool H264Carrier::checkHeader(const Bytes& header)
+{
+    return true;
+}
+
+void H264Carrier::setParameters(const Bytes& header)
+{
+    // no parameters - no carrier variants
+}
+
+
+// Now, the initial hand-shaking
+
+bool H264Carrier::prepareSend(ConnectionState& proto)
+{
+    // nothing special to do
+    return true;
+}
+
+bool H264Carrier::sendHeader(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::expectSenderSpecifier(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::expectExtraHeader(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::respondToHeader(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::expectReplyToHeader(ConnectionState& proto)
+{
+    // I'm the receiver...
+
+    H264Stream *stream = new H264Stream(proto.getRoute().getToContact().getPort());
+    if (stream==nullptr) { return false; }
+
+    yarp::os::Contact remote = proto.getStreams().getRemoteAddress();
+    bool ok = stream->open(remote);
+
+    //std::cout << "Remote contact info: host=" << proto.getRoute().getToContact().getHost() << " port= " << proto.getRoute().getToContact().getPort() <<std::endl;
+    if (!ok)
+    {
+        delete stream;
+        return false;
+    }
+    stream->start();
+
+    proto.takeStreams(stream);
+    return true;
+}
+
+bool H264Carrier::isActive()
+{
+    return true;
+}
+
+bool H264Carrier::write(ConnectionState& proto, SizedWriter& writer)
+{
+    //I should not be here: the carried doesn't perform writing
+    return false;
+}
+
+bool H264Carrier::reply(ConnectionState& proto, SizedWriter& writer)
+{
+    return false;
+}
+
+bool H264Carrier::sendIndex(ConnectionState& proto, SizedWriter& writer)
+{
+    return true;
+}
+
+bool H264Carrier::expectIndex(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::sendAck(ConnectionState& proto)
+{
+    return true;
+}
+
+bool H264Carrier::expectAck(ConnectionState& proto)
+{
+    return true;
+}
+
+ConstString H264Carrier::getBootstrapCarrierName()
+{
+    return "";
+}
+
+yarp::os::Face* H264Carrier::createFace(void)
+{
+    return new yarp::os::impl::FakeFace();
+}
+

--- a/src/carriers/h264_carrier/H264Carrier.h
+++ b/src/carriers/h264_carrier/H264Carrier.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef H264CARRIER_INC
+#define H264CARRIER_INC
+
+#include <yarp/os/Carrier.h>
+#include <yarp/os/Face.h>
+
+
+namespace yarp {
+    namespace os {
+        class H264Carrier;
+    }
+}
+
+/**
+ *
+ * A carrier for receiving frames compressed in h264 over rtp.
+ * This carrier uses gstreamer libraries to read rtp packets and to decode the h264 stream.
+ *
+ * Use this carrier in the following way:
+ * - suppose there is a server that streams video frames to IP x.x.x.x and to port p:
+ *   register this port to yarp by yarp command "yarp register" in this way: yarp register /serverH264Stream h264 x.x.x.x p
+ * - you need to connect your client port (for example /yarpview/img:i ) to /serverH264Stream port by h264 carrier to get the video stream:
+ *   yarp connect /serverH264Stream /yarpview/img:i h264
+ */
+
+class yarp::os::H264Carrier : public Carrier
+{
+private:
+    bool decoderIsRunning;
+    yarp::os::ConstString envelope;
+public:
+    H264Carrier()
+    {;}
+
+    virtual Carrier *create() override
+    {
+        return new H264Carrier();
+    }
+
+    virtual ConstString getName() override;
+
+    virtual bool isConnectionless() override;
+
+    virtual bool canAccept() override;
+
+    virtual bool canOffer() override;
+
+    virtual bool isTextMode() override;
+
+    virtual bool canEscape() override;
+
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) override;
+
+    virtual bool requireAck() override;
+
+    virtual bool supportReply() override;
+
+    virtual bool isLocal() override;
+
+    // this is important - flips expected flow of messages
+    virtual bool isPush() override;
+
+    virtual ConstString toString() override;
+
+    virtual void getHeader(const Bytes& header) override;
+
+    virtual bool checkHeader(const Bytes& header) override;
+
+    virtual void setParameters(const Bytes& header) override;
+
+
+    // Now, the initial hand-shaking
+
+    virtual bool prepareSend(ConnectionState& proto) override;
+
+    virtual bool sendHeader(ConnectionState& proto) override;
+
+    virtual bool expectSenderSpecifier(ConnectionState& proto) override;
+
+    virtual bool expectExtraHeader(ConnectionState& proto) override;
+
+    bool respondToHeader(ConnectionState& proto) override;
+
+    virtual bool expectReplyToHeader(ConnectionState& proto) override;
+
+    virtual bool isActive() override;
+
+
+    // Payload time!
+
+    virtual bool write(ConnectionState& proto, SizedWriter& writer) override;
+
+    virtual bool reply(ConnectionState& proto, SizedWriter& writer) override;
+
+    virtual bool sendIndex(ConnectionState& proto, SizedWriter& writer);
+
+    virtual bool expectIndex(ConnectionState& proto) override;
+
+    virtual bool sendAck(ConnectionState& proto) override;
+
+    virtual bool expectAck(ConnectionState& proto) override;
+
+    virtual ConstString getBootstrapCarrierName() override;
+
+    virtual yarp::os::Face* createFace(void) override;
+};
+
+#endif

--- a/src/carriers/h264_carrier/H264Decoder.cpp
+++ b/src/carriers/h264_carrier/H264Decoder.cpp
@@ -1,0 +1,464 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "H264Decoder.h"
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+
+
+#include <gst/gst.h>
+#include <glib.h>
+
+#include <gst/app/gstappsink.h>
+#include <stdio.h>
+#include <string.h>
+
+//#define debug_time 1
+
+#ifdef debug_time
+    #include <yarp/os/Time.h>
+    #define DBG_TIME_PERIOD_PRINTS 10 //10 sec
+#endif
+
+using namespace yarp::sig;
+using namespace yarp::os;
+
+
+typedef struct
+{
+    Mutex *m;
+    ImageOf<PixelRgb> *img;
+    bool isNew;
+    Semaphore *s;
+    bool isReq;
+
+} data_for_gst_callback;
+//-------------------------------------------------------------------
+//---------------  CALLBACK FUNCTIONS -------------------------------
+//-------------------------------------------------------------------
+
+/*
+static GstBusSyncReply bus_call (GstBus *bus, GstMessage *msg, gpointer data)
+{
+    GstElement *pipeline = (GstElement *) data;
+
+    switch (GST_MESSAGE_TYPE (msg))
+    {
+
+        case GST_MESSAGE_EOS:
+        {
+            g_print ("End of stream\n");
+            gst_element_set_state (pipeline, GST_STATE_NULL);
+            // g_main_loop_quit (loop);
+            break;
+        }
+
+        case GST_MESSAGE_ERROR:
+        {
+            gchar  *debug;
+            GError *error;
+
+            gst_message_parse_error (msg, &error, &debug);
+            g_free (debug);
+
+            g_printerr ("GSTREAMER: Error: %s\n", error->message);
+            g_error_free (error);
+
+            gst_element_set_state (pipeline, GST_STATE_NULL);
+            break;
+        }
+        default:
+        {
+            g_print("GSTREAMER: I received message of type %d\n", GST_MESSAGE_TYPE (msg));
+            break;
+        }
+    }
+
+  return GST_BUS_PASS;
+}
+*/
+
+static gboolean link_videosrc2rtpdepay(GstElement *e1, GstElement *e2)
+{
+    gboolean link_ok;
+    GstCaps *caps;
+
+
+// "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264, payload=(int)96, a-framerate=(string)30"
+    caps = gst_caps_new_simple("application/x-rtp",
+                               "media", G_TYPE_STRING, "video",
+                               "clock-rate", G_TYPE_INT, 90000,
+                               "encoding-name", G_TYPE_STRING, "H264",
+                               "payload", G_TYPE_INT, 96,
+                               "a-framerate", G_TYPE_STRING, "30",
+                               NULL);
+
+
+    link_ok = gst_element_link_filtered(e1, e2, caps);
+    if(!link_ok)
+    {
+        g_print("GSTREAMER: failed link videosrc2convert with caps!!\n");
+    }
+    else
+    {
+        g_print("GSTREAMER: link videosrc2convert with caps OK!!!!!!\n");
+    }
+
+    return (link_ok);
+}
+
+
+
+static gboolean link_convert2next(GstElement *e1, GstElement *e2)
+{
+    gboolean link_ok;
+    GstCaps *caps;
+
+    caps = gst_caps_new_simple("video/x-raw",
+                               "format", G_TYPE_STRING, "RGB",
+                              NULL);
+
+
+    link_ok = gst_element_link_filtered(e1, e2, caps);
+    if(!link_ok)
+    {
+        g_print("GSTREAMER: failed link_convert2next with caps\n");
+    }
+    else
+    {
+        g_print("GSTREAMER: link_convert2next with caps OK\n");
+    }
+
+    return (link_ok);
+}
+
+
+GstFlowReturn new_sample(GstAppSink *appsink, gpointer user_data)
+{
+#ifdef debug_time
+    static bool isFirst = true;
+    double start_time = Time::now();
+    double end_time=0;
+
+    static double last_call;
+    static double sumOf_timeBetweenCalls = 0;
+    static double sumOf_timeOfNewSampleFunc = 0;
+    static uint32_t count=0;
+    #define MAX_COUNT  100
+
+
+    if(!isFirst)
+        sumOf_timeBetweenCalls+=(start_time -last_call);
+
+    last_call = start_time;
+
+
+#endif
+
+    data_for_gst_callback *dec_data = (data_for_gst_callback*)user_data;
+
+    GstSample *sample = NULL;
+    g_signal_emit_by_name (appsink, "pull-sample", &sample, NULL);
+    if(!sample)
+    {
+        g_print("GSTREAMER: could not take a sample!\n");
+        return GST_FLOW_OK;
+    }
+
+    GstCaps *caps = gst_sample_get_caps (sample);
+    if(!caps)
+    {
+        g_print("GSTREAMER: could not get caps of sample!\n");
+        return GST_FLOW_ERROR;
+    }
+    GstStructure *struc = gst_caps_get_structure(caps, 0);
+    if(!struc)
+    {
+        g_print("GSTREAMER: could not get struct of caps!\n");
+        return GST_FLOW_ERROR;
+    }
+    gint width, height;
+    gboolean res;
+    res = gst_structure_get_int(struc, "width", &width);
+    if(!res)
+    {
+        g_print("GSTREAMER: could not get width!\n");
+        return GST_FLOW_ERROR;
+    }
+
+    res = gst_structure_get_int(struc, "height", &height);
+    if(!res)
+    {
+        g_print("GSTREAMER: could not get height!\n");
+        return GST_FLOW_ERROR;
+    }
+    //g_print("Image has size %d x %d", width, height);
+
+    GstBuffer *buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+    if(!gst_buffer_map(buffer, &map, GST_MAP_READ))
+    {
+        g_print("GSTREAMER: could not get map!\n");
+        return GST_FLOW_ERROR;
+    }
+    //HERE I GET MY IMAGE!!!!
+    //DO SOMETHING...
+    //ImageOf<PixelRgb> &yframebuff = yarp_stuff_ptr->yport_ptr->prepare();
+    dec_data->m->lock();
+    dec_data->isNew = true;
+    dec_data->img->resize(width, height);
+
+    unsigned char *ydata_ptr = dec_data->img->getRawImage();
+    memcpy(ydata_ptr, map.data, width*height*3);
+
+    dec_data->m->unlock();
+    gst_buffer_unmap(buffer, &map);
+
+    gst_sample_unref(sample);
+    if(dec_data->isReq)
+        dec_data->s->post();
+
+
+#ifdef debug_time
+    end_time = Time::now();
+    sumOf_timeOfNewSampleFunc += (end_time-start_time);
+    count++;
+    isFirst=false;
+
+    if(count>=MAX_COUNT)
+    {
+        g_print("On %d times: NewSampleFunc is long %.6f sec and sleeps %.6f sec\n",
+                MAX_COUNT, (sumOf_timeOfNewSampleFunc/MAX_COUNT), (sumOf_timeBetweenCalls/MAX_COUNT) );
+        count = 0;
+        isFirst = true;
+        sumOf_timeBetweenCalls = 0;
+        sumOf_timeOfNewSampleFunc = 0;
+    }
+
+
+#endif
+
+
+    return GST_FLOW_OK;
+
+}
+
+
+
+
+
+
+
+//----------------------------------------------------------------------
+
+
+
+
+
+
+
+
+class H264DecoderHelper
+{
+public:
+    //GMainLoop *loop;
+
+    GstElement *pipeline;
+    GstElement *source;
+    GstElement *sink;
+    GstElement *rtpDepay;
+    GstElement *parser;
+    GstElement *convert;
+    GstElement *decoder;
+
+    data_for_gst_callback gst_cbk_data;
+
+    GstBus *bus; //maybe can be moved in function where i use it
+    guint bus_watch_id;
+
+    ImageOf<PixelRgb> myframe;
+
+    H264DecoderHelper( Mutex * m_ptr, Semaphore *s_ptr)
+    {
+        gst_cbk_data.m = m_ptr;
+        gst_cbk_data.img = &myframe;
+        gst_cbk_data.s = s_ptr;
+    }
+    ~H264DecoderHelper(){;}
+
+    bool istantiateElements(void)
+    {
+        gst_init(NULL, NULL);
+        pipeline = gst_pipeline_new ("video-player");
+        source   = gst_element_factory_make ("udpsrc",       "video-source");
+        rtpDepay = gst_element_factory_make ("rtph264depay", "rtp-depay");
+        parser   = gst_element_factory_make ("h264parse",    "parser");
+        decoder  = gst_element_factory_make ("avdec_h264",   "decoder");
+        convert  = gst_element_factory_make ("videoconvert", "convert"); //because use RGB space
+        sink     = gst_element_factory_make ("appsink",      "video-output");
+
+        if (!pipeline || !source || !rtpDepay || !parser || !decoder || !convert || !sink)
+        {
+            g_printerr ("GSTREAMER: one element could not be created. Exiting.\n");
+            return false;
+        }
+        return true;
+    }
+
+    bool configureElements(gint portnumber) //maybe i can make callbak configurable in the future.....
+    {
+        // 1) configure source port
+        g_print("GSTREAMER: try to configure source port with %d.... \n", portnumber);
+        g_object_set(source, "port", portnumber/*3111*/, NULL);
+
+        // 2) configure callback on new frame
+        g_print("GSTREAMER: try to configure appsink.... \n");
+        //I decided to use callbaxk mechanism because it should have less overhead
+        g_object_set( sink, "emit-signals", false, NULL );
+
+        GstAppSinkCallbacks cbs; // Does this need to be kept alive?
+
+        // Set Video Sink callback methods
+        cbs.eos = NULL;
+        cbs.new_preroll = NULL;
+        cbs.new_sample = &new_sample;
+        gst_app_sink_set_callbacks( GST_APP_SINK( sink ), &cbs, &gst_cbk_data, NULL );
+
+  /*      //3) add watch ( a message handler)
+        bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
+        //bus_watch_id = gst_bus_add_watch (bus, bus_call, loop);
+        gst_object_unref (bus);
+
+        gst_bus_set_sync_handler(bus, bus_call, pipeline, NULL);
+        gst_object_unref (bus);
+    */
+        return true;
+
+    }
+
+    bool linkElements(void)
+    {
+
+        g_print("GSTREAMER: try to add elements to pipeline..... \n");
+        /* we add all elements into the pipeline */
+        gst_bin_add_many (GST_BIN (pipeline),
+                        source, rtpDepay, parser, decoder, convert, sink, NULL);
+
+        g_print("GSTREAMER: elements have been added in pipeline!\n");
+
+
+        /* autovideosrc ! "video/x-raw, width=640, height=480, format=(string)I420" ! videoconvert ! 'video/x-raw, format=(string)RGB'  ! yarpdevice ! glimagesink */
+        g_print("GSTREAMER: try to link_videosrc2convert..... \n");
+        gboolean result = link_videosrc2rtpdepay(source, rtpDepay);
+        if(!result)
+        {
+            return false;
+        }
+
+        g_print("GSTREAMER: try to link_convert2next..... \n");
+        result = link_convert2next(convert, sink);
+        if(!result)
+            {
+                return false;
+            }
+        g_print("GSTREAMER: try to link all other elements..... \n");
+        gst_element_link_many(rtpDepay, parser, decoder, convert, NULL);
+
+        return true;
+    }
+
+
+};
+
+
+
+#define GET_HELPER(x) (*((H264DecoderHelper*)(x)))
+
+H264Decoder::H264Decoder(int remotePortNum) : remotePort(remotePortNum), sysResource(nullptr)
+{
+    sysResource = new H264DecoderHelper(&mutex, &semaphore);
+    yAssert(sysResource != nullptr);
+}
+
+bool H264Decoder::init(void)
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    if(!helper.istantiateElements())
+    {
+        yError() << "H264Decoder: Error in istantiateElements";
+        return false;
+    }
+
+    if(!helper.configureElements(remotePort))
+    {
+        yError() << "Error in configureElements";
+        return false;
+    }
+
+    if(!helper.linkElements())
+    {
+        yError() << "Error in linkElements";
+        return false;
+    }
+
+    yDebug() << "gstreamer init ok";
+    return true;
+
+}
+
+
+bool H264Decoder::start()
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    gst_element_set_state (helper.pipeline, GST_STATE_PLAYING);
+    return true;
+
+}
+
+bool H264Decoder::stop()
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    gst_element_set_state (helper.pipeline, GST_STATE_NULL);
+    gst_bus_set_sync_handler(gst_pipeline_get_bus (GST_PIPELINE (helper.pipeline)), nullptr, nullptr, nullptr);
+     yDebug() << "Deleting pipeline";
+    gst_object_unref (GST_OBJECT (helper.pipeline));
+    return true;
+}
+
+H264Decoder::~H264Decoder()
+{
+    stop();
+    delete &GET_HELPER(sysResource);
+
+
+}
+
+ImageOf<PixelRgb> & H264Decoder::getLastFrame(void)
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    helper.gst_cbk_data.isNew = false;
+    helper.gst_cbk_data.isReq = false;
+    return helper.myframe;
+}
+
+bool H264Decoder::newFrameIsAvailable(void)
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    return helper.gst_cbk_data.isNew;
+}
+
+int H264Decoder::getLastFrameSize(void)
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    return (helper.myframe.width() * helper.myframe.height() * 3);
+}
+
+void H264Decoder::setReq(void)
+{
+    H264DecoderHelper &helper = GET_HELPER(sysResource);
+    helper.gst_cbk_data.isReq = true;
+
+}

--- a/src/carriers/h264_carrier/H264Decoder.h
+++ b/src/carriers/h264_carrier/H264Decoder.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef H264DECODER_INC
+#define H264DECODER_INC
+
+#include <yarp/os/Mutex.h>
+#include <yarp/sig/Image.h>
+#include <yarp/os/Semaphore.h>
+
+namespace yarp {
+    namespace os {
+        class H264Decoder;
+    }
+}
+
+class yarp::os::H264Decoder
+{
+private:
+    int remotePort;
+    void *sysResource;
+
+public:
+    yarp::os::Mutex mutex ; //==>create functions to work with it
+    yarp::os::Semaphore semaphore;
+
+    H264Decoder(int remotePort);
+    ~H264Decoder();
+    bool init(void);
+    bool start();
+    bool stop();
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> & getLastFrame(void);
+    int getLastFrameSize(void);
+    bool newFrameIsAvailable(void);
+    void setReq(void);
+};
+
+#endif

--- a/src/carriers/h264_carrier/H264Stream.cpp
+++ b/src/carriers/h264_carrier/H264Stream.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+
+#include <yarp/os/Log.h>
+#include <yarp/sig/Image.h>
+#include <yarp/sig/ImageNetworkHeader.h>
+
+#include <cstdio>
+#include <cstring>
+
+#include "H264Stream.h"
+
+//#define debug_time 1
+
+#ifdef debug_time
+    #include <yarp/os/Time.h>
+    #define DBG_TIME_PERIOD_PRINTS 10 //10 sec
+#endif
+
+
+using namespace yarp::os;
+using namespace yarp::sig;
+using namespace std;
+
+
+bool H264Stream::setStream(yarp::os::impl::DgramTwoWayStream *stream)
+{
+    delegate = stream;
+    if(nullptr == delegate)
+    {
+        return false;
+    }
+    return true;
+}
+
+void H264Stream::start (void)
+{
+    decoder = new H264Decoder(this->remotePort);
+    decoder->init();
+    decoder->start();
+}
+
+InputStream& H264Stream::getInputStream()
+{
+    return *this;
+}
+
+OutputStream& H264Stream::getOutputStream()
+{
+    return *this;
+}
+
+//using yarp::os::OutputStream::write;
+
+
+//using yarp::os::InputStream::read;
+
+bool H264Stream::setReadEnvelopeCallback(InputStream::readEnvelopeCallbackType callback, void* data)
+{
+    return true;
+}
+
+YARP_SSIZE_T H264Stream::read(const Bytes& b)
+{
+
+#ifdef debug_time
+    static bool isFirst = true;
+    double start_time = Time::now();
+    double start_timeCopy;
+    double end_time=0;
+    static double last_call;
+    static double sumOf_timeBetweenCalls=0;
+
+    static double sumOf_timeOnMutex = 0;
+    static double sumOf_timeOfCopyPerPahse[5] ={0};
+    static uint32_t count=0;
+    static uint32_t countPerPhase[5]={0};
+    #define MAX_COUNT  100
+
+
+    if(isFirst)
+    {
+        last_call = start_time;
+        isFirst = false;
+    }
+    else
+    {
+        sumOf_timeBetweenCalls+=(start_time -last_call);
+        last_call = start_time;
+    }
+
+
+#endif
+
+    bool debug = false;
+    if (remaining==0)
+    {
+        if (phase==1)
+        {
+            phase = 2;
+            cursor = (char*)(img.getRawImage());
+            remaining = img.getRawImageSize();
+        } else if (phase==3)
+        {
+            phase = 4;
+            cursor = nullptr;
+            remaining = blobHeader.blobLen;
+        } else
+        {
+            phase = 0;
+        }
+    }
+    while (phase==0)
+    {
+        decoder->mutex.lock();
+        int len = 0;
+        if(decoder->newFrameIsAvailable())
+        {
+            ImageOf<PixelRgb> & img_dec = decoder->getLastFrame();
+            img.copy(img_dec);
+            len = decoder->getLastFrameSize();
+            decoder->mutex.unlock();
+            #ifdef debug_time
+            end_time = Time::now();
+            sumOf_timeOnMutex +=(end_time - start_time);
+            count++;
+            if(count>=MAX_COUNT)
+            {
+                printf("STREAM On %d times: timeOnMutex is long %.6f sec\n",
+                        MAX_COUNT, (sumOf_timeOnMutex/MAX_COUNT) );
+                for(int x=0; x<5; x++)
+                {
+                    printf("STREAM: phase:%d, count=%lu, time=%.6f sec\n", x, countPerPhase[x], ((countPerPhase[x]==0) ? 0: sumOf_timeOfCopyPerPahse[x]/countPerPhase[x]) );
+                    countPerPhase[x] = 0;
+                    sumOf_timeOfCopyPerPahse[x] = 0;
+                }
+                printf("H264: sleep=%.6f\n\n", sumOf_timeBetweenCalls/count);
+                count = 0;
+                isFirst = true;
+                sumOf_timeOnMutex = 0;
+                sumOf_timeBetweenCalls = 0;
+            }
+            #endif
+
+        }
+        else
+        {
+            //printf("h264Stream::read has been called but no frame is available!!\n");
+            phase = 0;
+            remaining = 0;
+            cursor = nullptr;
+            decoder->setReq();
+            decoder->mutex.unlock();
+            decoder->semaphore.waitWithTimeout(1);
+            return 0;
+        }
+
+
+        if (debug)
+        {
+            printf("Length is \"%d\"\n", len);
+        }
+        imgHeader.setFromImage(img);
+        phase = 1;
+        cursor = (char*)(&imgHeader);
+        remaining = sizeof(imgHeader);
+    }
+
+    if (remaining>0)
+    {
+        int allow = remaining;
+        if ((int)b.length()<allow)
+        {
+            allow = b.length();
+        }
+        if (cursor!=nullptr)
+        {
+            #ifdef debug_time
+            start_timeCopy = Time::now();
+            #endif
+            memcpy(b.get(),cursor,allow);
+            cursor+=allow;
+            remaining-=allow;
+            if (debug) printf("returning %d bytes\n", allow);
+            #ifdef debug_time
+                end_time = Time::now();
+                sumOf_timeOfCopyPerPahse[phase] +=(end_time - start_timeCopy);
+                countPerPhase[phase]++;
+            #endif
+            return allow;
+        } else
+        {
+            int result = delegate->getInputStream().read(b);
+            if (debug) printf("Read %d bytes\n", result);
+            if (result>0)
+            {
+                remaining-=result;
+                if (debug) printf("%d bytes of meat\n", result);
+                return result;
+            }
+        }
+    }
+    return -1;
+}
+
+
+void H264Stream::write(const Bytes& b)
+{
+    delegate->getOutputStream().write(b);
+}
+

--- a/src/carriers/h264_carrier/H264Stream.h
+++ b/src/carriers/h264_carrier/H264Stream.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+
+#ifndef H264STREAM_INC
+#define H264STREAM_INC
+
+#include <yarp/os/impl/DgramTwoWayStream.h>
+#include <yarp/sig/Image.h>
+#include <yarp/sig/ImageNetworkHeader.h>
+#include "BlobNetworkHeader.h"
+#include "H264Decoder.h"
+#include <yarp/os/InputStream.h>
+
+
+namespace yarp {
+    namespace os {
+        class H264Stream;
+    }
+}
+
+class yarp::os::H264Stream : public yarp::os::impl::DgramTwoWayStream
+{
+private:
+
+    DgramTwoWayStream *delegate;
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> img;
+    yarp::sig::ImageNetworkHeader imgHeader;
+    BlobNetworkHeader blobHeader;
+    int phase;
+    char *cursor;
+    int remaining;
+    H264Decoder *decoder;
+    int remotePort;
+public:
+    H264Stream( int remotePort) :
+            phase(0),
+            cursor(NULL),
+            remaining(0),
+            remotePort(remotePort)
+    {;}
+
+    virtual ~H264Stream()
+    {
+        if (decoder!=NULL)
+        {
+            delete decoder;
+            decoder = NULL;
+        }
+
+        if (delegate!=NULL)
+        {
+            delete delegate;
+            delegate = NULL;
+        }
+    }
+
+    bool setStream(yarp::os::impl::DgramTwoWayStream *stream);
+
+    void start (void);
+
+    virtual InputStream& getInputStream() override;
+    virtual OutputStream& getOutputStream() override;
+
+    using yarp::os::OutputStream::write;
+    virtual void write(const Bytes& b) override;
+
+    using yarp::os::InputStream::read;
+    virtual YARP_SSIZE_T read(const Bytes& b) override;
+
+    virtual bool setReadEnvelopeCallback(InputStream::readEnvelopeCallbackType callback, void* data) override;
+
+};
+
+#endif

--- a/src/carriers/h264_carrier/h264.ini
+++ b/src/carriers/h264_carrier/h264.ini
@@ -1,0 +1,4 @@
+[plugin h264]
+type carrier
+name h264
+library yarp_h264

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -231,6 +231,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/BottleImpl.cpp
                  src/BufferedConnectionWriter.cpp
                  src/Bytes.cpp
+                 src/Carrier.cpp
                  src/Carriers.cpp
                  src/Companion.cpp
                  src/ConnectionReader.cpp

--- a/src/libYARP_OS/include/yarp/os/Carrier.h
+++ b/src/libYARP_OS/include/yarp/os/Carrier.h
@@ -15,6 +15,8 @@
 #include <yarp/os/ConnectionReader.h>
 #include <yarp/os/Connection.h>
 #include <yarp/os/ConnectionState.h>
+#include <yarp/os/Face.h>
+
 
 #define YARP_ENACT_CONNECT 1
 #define YARP_ENACT_DISCONNECT 2
@@ -112,10 +114,7 @@ public:
      *
      * @return true if carrier uses a broadcast mechanism.
      */
-    virtual bool isBroadcast() override
-    {
-        return false;
-    }
+    virtual bool isBroadcast() override;
 
     /**
      * Check if reading is implemented for this carrier.
@@ -157,10 +156,7 @@ public:
      *
      * @param envelope the envelope to transmit bundled with data.
      */
-    virtual void handleEnvelope(const yarp::os::ConstString& envelope) override
-    {
-        YARP_UNUSED(envelope);
-    }
+    virtual void handleEnvelope(const yarp::os::ConstString& envelope) override;
 
     /**
      * Check if carrier has flow control, requiring sent messages
@@ -200,10 +196,7 @@ public:
      *
      * @return true if carrier is "push" style, false if "pull" style
      */
-    virtual bool isPush() override
-    {
-        return true;
-    }
+    virtual bool isPush() override;
 
     /**
      * Perform any initialization needed before writing on a connection.
@@ -303,9 +296,7 @@ public:
      * Do cleanup and preparation for the coming disconnect, if
      * necessary.
      */
-    virtual void prepareDisconnect() override
-    {
-    }
+    virtual void prepareDisconnect() override;
 
 
     /**
@@ -318,16 +309,12 @@ public:
     /**
      * Close the carrier.
      */
-    virtual void close()
-    {
-    }
+    virtual void close();
 
     /**
      * Destructor.
      */
-    virtual ~Carrier()
-    {
-    }
+    virtual ~Carrier();
 
     /**
      * Get the name of the carrier that should be used prior to
@@ -343,10 +330,7 @@ public:
      *
      * @return the name of the bootstrap carrier.
      */
-    virtual ConstString getBootstrapCarrierName()
-    {
-        return "tcp";
-    }
+    virtual ConstString getBootstrapCarrierName();
 
     /**
      * Some carrier types may require special connection logic.
@@ -366,15 +350,7 @@ public:
                         const Contact& dest,
                         const ContactStyle& style,
                         int mode,
-                        bool reversed)
-    {
-        YARP_UNUSED(src);
-        YARP_UNUSED(dest);
-        YARP_UNUSED(style);
-        YARP_UNUSED(mode);
-        YARP_UNUSED(reversed);
-        return -1;
-    }
+                        bool reversed);
 
 
     /**
@@ -383,10 +359,7 @@ public:
      *
      * @return true if carrier wants Carrier::modifyIncomingData called.
      */
-    virtual bool modifiesIncomingData() override
-    {
-        return false;
-    }
+    virtual bool modifiesIncomingData() override;
 
     /**
      * Modify incoming payload data, if appropriate.
@@ -402,10 +375,7 @@ public:
      *       input, the setParentConnectionReader(&reader) should be called for
      *       the new one, or the envelope will not be handled correctly.
      */
-    virtual ConnectionReader& modifyIncomingData(ConnectionReader& reader) override
-    {
-        return reader;
-    }
+    virtual ConnectionReader& modifyIncomingData(ConnectionReader& reader) override;
 
     /**
      * Determine whether incoming data should be accepted.
@@ -414,11 +384,7 @@ public:
      * @return true if data should be accepted, false if it should be
      *         discarded.
      */
-    virtual bool acceptIncomingData(ConnectionReader& reader) override
-    {
-        YARP_UNUSED(reader);
-        return true;
-    }
+    virtual bool acceptIncomingData(ConnectionReader& reader) override;
 
     /**
      * Check if this carrier modifies outgoing data through the
@@ -426,10 +392,7 @@ public:
      *
      * @return true if carrier wants Carrier::modifyOutgoingData called.
      */
-    virtual bool modifiesOutgoingData() override
-    {
-        return false;
-    }
+    virtual bool modifiesOutgoingData() override;
 
     /**
      * Modify outgoing payload data, if appropriate.
@@ -441,10 +404,7 @@ public:
      * @param writer for outgoing data.
      * @return writer for modified version of outgoing data.
      */
-    virtual PortWriter& modifyOutgoingData(PortWriter& writer) override
-    {
-        return writer;
-    }
+    virtual PortWriter& modifyOutgoingData(PortWriter& writer) override;
 
     /**
      * Check if this carrier modifies outgoing data through the
@@ -452,10 +412,7 @@ public:
      *
      * @return true if carrier wants Carrier::modifyReply called.
      */
-    virtual bool modifiesReply() override
-    {
-        return false;
-    }
+    virtual bool modifiesReply() override;
 
     /**
      * Modify reply payload data, if appropriate.
@@ -463,10 +420,7 @@ public:
      * @param reader for the replied message.
      * @return reader for modified version of the replied message.
      */
-    virtual PortReader& modifyReply(PortReader& reader) override
-    {
-        return reader;
-    }
+    virtual PortReader& modifyReply(PortReader& reader) override;
 
     /**
      * Determine whether outgoing data should be accepted.
@@ -475,51 +429,36 @@ public:
      * @return true if data should be accepted, false if it should be
      *         discarded.
      */
-    virtual bool acceptOutgoingData(PortWriter& writer) override
-    {
-        YARP_UNUSED(writer);
-        return true;
-    }
-
+    virtual bool acceptOutgoingData(PortWriter& writer) override;
 
     /**
      * Give carrier a shot at looking at how the connection is set up.
      *
      * @return true if the carrier was correctly configured.
      */
-    virtual bool configure(ConnectionState& proto)
-    {
-        YARP_UNUSED(proto);
-        return true;
-    }
+    virtual bool configure(ConnectionState& proto);
 
-    virtual bool configureFromProperty(yarp::os::Property& options)
-    {
-        YARP_UNUSED(options);
-        return true;
-    }
+    virtual bool configureFromProperty(yarp::os::Property& options);
 
     /**
      * Configure carrier from port administrative commands.
      *
      * @param params properties
      */
-    virtual void setCarrierParams(const Property& params) override
-    {
-        YARP_UNUSED(params);
-    }
-
+    virtual void setCarrierParams(const Property& params) override;
     /**
      * Get carrier configuration and deliver it by port administrative
      * commands.
      *
      * @param params properties
      */
-    virtual void getCarrierParams(Property& params) override
-    {
-        YARP_UNUSED(params);
-    }
+    virtual void getCarrierParams(Property& params) override;
 
+    /**
+     * Create new Face object that the carrier needs.
+     *
+     */
+    virtual yarp::os::Face* createFace(void);
 };
 
 #endif // YARP_OS_CARRIER_H

--- a/src/libYARP_OS/include/yarp/os/impl/FakeFace.h
+++ b/src/libYARP_OS/include/yarp/os/impl/FakeFace.h
@@ -20,7 +20,7 @@ namespace yarp {
 /**
  * A dummy Face for testing purposes.
  */
-class yarp::os::impl::FakeFace : public yarp::os::Face
+class YARP_OS_impl_API yarp::os::impl::FakeFace : public yarp::os::Face
 {
 public:
     virtual bool open(const Contact& address) override;

--- a/src/libYARP_OS/src/Carrier.cpp
+++ b/src/libYARP_OS/src/Carrier.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright: (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * Author: Valentina Gaggero <valentina.gaggero@iit.it>
+ * Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+#include <yarp/os/Carrier.h>
+#include <yarp/os/impl/TcpFace.h>
+
+using namespace yarp::os;
+
+bool Carrier::isBroadcast()
+{
+    return false;
+}
+
+void Carrier::handleEnvelope(const yarp::os::ConstString& envelope)
+{
+    YARP_UNUSED(envelope);
+}
+
+bool Carrier::isPush()
+{
+    return true;
+}
+
+ConstString Carrier::getBootstrapCarrierName()
+{
+    return "tcp";
+}
+
+int  Carrier::connect(const Contact& src,
+                              const Contact& dest,
+                              const ContactStyle& style,
+                              int mode,
+                             bool reversed)
+{
+    YARP_UNUSED(src);
+    YARP_UNUSED(dest);
+    YARP_UNUSED(style);
+    YARP_UNUSED(mode);
+    YARP_UNUSED(reversed);
+    return -1;
+}
+
+bool Carrier::modifiesIncomingData()
+{
+    return false;
+}
+
+
+ConnectionReader& Carrier::modifyIncomingData(ConnectionReader& reader)
+{
+    return reader;
+}
+
+bool Carrier::acceptIncomingData(ConnectionReader& reader)
+{
+    YARP_UNUSED(reader);
+    return true;
+}
+
+
+bool Carrier::modifiesOutgoingData()
+{
+    return false;
+}
+
+
+PortWriter& Carrier::modifyOutgoingData(PortWriter& writer)
+{
+    return writer;
+}
+
+bool Carrier::modifiesReply()
+{
+    return false;
+}
+
+void Carrier::prepareDisconnect()
+{;}
+
+void Carrier::close()
+{;}
+
+Carrier::~Carrier()
+{;}
+
+PortReader& Carrier::modifyReply(PortReader& reader)
+{
+    return reader;
+}
+
+bool Carrier::acceptOutgoingData(PortWriter& writer)
+{
+    YARP_UNUSED(writer);
+    return true;
+}
+
+
+bool Carrier::configure(ConnectionState& proto)
+{
+    YARP_UNUSED(proto);
+    return true;
+}
+
+bool Carrier::configureFromProperty(yarp::os::Property& options)
+{
+    YARP_UNUSED(options);
+    return true;
+}
+
+
+void Carrier::setCarrierParams(const Property& params)
+{
+    YARP_UNUSED(params);
+}
+
+void Carrier::getCarrierParams(Property& params)
+{
+    YARP_UNUSED(params);
+}
+
+yarp::os::Face* Carrier::createFace(void)
+{
+    return new yarp::os::impl::TcpFace();
+}

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -20,6 +20,7 @@
 #include <yarp/os/Thread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/YarpPlugin.h>
+#include <yarp/os/Face.h>
 
 #include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
@@ -1376,6 +1377,10 @@ public:
     }
     virtual bool configureFromProperty(yarp::os::Property& options) override {
         return getContent().configureFromProperty(options);
+    }
+
+    virtual yarp::os::Face* createFace(void) override {
+        return getContent().createFace();
     }
 };
 


### PR DESCRIPTION
Here is implemented the H264 carrier. 
It can be used to read and decode a h264 stream published by Gstreamer.

In order to accomplished it, I needed to add method `yarp::os::carrier::createFace()`,  that returns the needed face of the carrier. This method is used in `yarp::os::carriers::listen` and in `yarp::os::carriers::connect `  in order to open new connection using the correct face.
