### PR TITLE
Fix double truncation in Property::fromString()

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -8,6 +8,12 @@ A (partial) list of bug fixed and issues resolved in this release can be found
 Bug Fixes
 ---------
 
+### Libraries
+
+#### YARP_OS
+
+* Fixed truncation of double in `Property::fromString()`.
+
 
 Contributors
 ------------

--- a/src/libYARP_OS/src/BottleImpl.cpp
+++ b/src/libYARP_OS/src/BottleImpl.cpp
@@ -801,7 +801,7 @@ bool StoreVocab::writeRaw(ConnectionWriter& writer)
 ConstString StoreDouble::toString() const
 {
     char buf[512];
-    sprintf(buf, "%f", x);
+    sprintf(buf, "%g", x);
     ConstString str(buf);
 
     // YARP Bug 2526259: Locale settings influence YARP behavior

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -192,8 +192,7 @@ public:
         PropertyItem *p = getProp(key, true);
         p->singleton = false;
         p->clear();
-        // inefficient! copy not implemented yet...
-        p->bot.fromString(val.toString().c_str());
+        p->bot = val;
         return p->bot;
     }
 

--- a/tests/libYARP_OS/PropertyTest.cpp
+++ b/tests/libYARP_OS/PropertyTest.cpp
@@ -54,6 +54,31 @@ public:
         p.unput("ten");
         checkTrue(p.find("ten").isNull(),"unput");
     }
+    void checkAsDoublePrec()
+    {
+        Property p;
+        report(0,"checking that issue https://github.com/robotology/yarp/issues/1057 is properly solved");
+        double val = 1e-5;
+        p.fromString("(dbl 0.00001)");
+        checkTrue(fabs(p.find("dbl").asDouble() - val) < 1e-12, "checking 1e-5");
+        p.unput("dbl");
+        val = 1e-6;
+        p.fromString("(dbl 0.000001)");
+        checkTrue(fabs(p.find("dbl").asDouble() - val) < 1e-12, "checking 1e-6");
+        p.unput("dbl");
+        val = 1e-7;
+        p.fromString("(dbl 0.0000001)");
+        checkTrue(fabs(p.find("dbl").asDouble() - val) < 1e-12, "checking 1e-7");
+        p.unput("dbl");
+        val = 1e-8;
+        p.fromString("(dbl 0.00000001)");
+        checkTrue(fabs(p.find("dbl").asDouble() - val) < 1e-12, "checking 1e-8");
+        p.unput("dbl");
+        val = 1e-9;
+        p.fromString("(dbl 0.000000001)");
+        checkTrue(fabs(p.find("dbl").asDouble() - val) < 1e-12, "checking 1e-9");
+
+    }
 
 
     void checkNegative() {
@@ -617,6 +642,7 @@ check $x $y\n\
         checkPutGet();
         checkExternal();
         checkTypes();
+        checkAsDoublePrec();
         checkNegative();
         checkCopy();
         checkExpansion();


### PR DESCRIPTION
This PR fixes double truncation in `Property::fromString()`, and it substitutes in `Property::putBottle()` the inefficient  `a.fromString(b.toString())` with `a = b`.
Fixes #1057 . 
Please review code.