### PR TITLE
Fix Clang warnings - libYARP_sig

### DIFF
--- a/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageNetworkHeader.h
@@ -46,6 +46,12 @@ public:
     yarp::os::NetInt32 paramBlobTag;
     yarp::os::NetInt32 paramBlobLen;
 
+    ImageNetworkHeader() : listTag(0), listLen(0), paramNameTag(0), 
+                           paramName(0), paramIdTag(0), id(0), 
+                           paramListTag(0), paramListLen(0), depth(0),
+                           imgSize(0), quantum(0), width(0),
+                           height(0), paramBlobTag(0), paramBlobLen(0) {}
+
     void setFromImage(const Image& image) {
         listTag = BOTTLE_TAG_LIST;
         listLen = 4;

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -93,6 +93,9 @@ bool yarp::sig::submatrix(const Matrix &in, Matrix &out, int r1, int r2, int c1,
     const double *i=in.data()+in.cols()*r1+c1;
     const int offset=in.cols()-(c2-c1+1);
 
+    if(i == YARP_NULLPTR || t == YARP_NULLPTR)
+        return false;
+
     for(int r=0;r<=(r2-r1);r++)
     {
         for(int c=0;c<=(c2-c1);c++)
@@ -472,6 +475,9 @@ bool Matrix::operator==(const yarp::sig::Matrix &r) const
 
     const double *tmp1=data();
     const double *tmp2=r.data();
+
+    if(tmp1 == YARP_NULLPTR || tmp2 == YARP_NULLPTR)
+        return false;
 
     int c=rows()*cols();
     while(c--)

--- a/src/libYARP_sig/src/Matrix.cpp
+++ b/src/libYARP_sig/src/Matrix.cpp
@@ -36,6 +36,11 @@ public:
     yarp::os::NetInt32 cols;
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+
+    MatrixPortContentHeader() : outerListTag(0), outerListLen(0), 
+                                rowsTag(0), rows(0), 
+                                colsTag(0), cols(0),
+                                listTag(0), listLen(0) {}
 };
 YARP_END_PACK
 

--- a/src/libYARP_sig/src/SoundFile.cpp
+++ b/src/libYARP_sig/src/SoundFile.cpp
@@ -55,20 +55,19 @@ YARP_END_PACK
 
 bool PcmWavHeader::parse_from_file(FILE *fp)
 {
-    size_t result;
-    result = fread(&wavHeader,sizeof(wavHeader),1,fp);
-    result = fread(&wavLength,sizeof(wavLength),1,fp);
-    result = fread(&formatHeader1,sizeof(formatHeader1),1,fp);
+    fread(&wavHeader,sizeof(wavHeader),1,fp);
+    fread(&wavLength,sizeof(wavLength),1,fp);
+    fread(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fread(&formatHeader2,sizeof(formatHeader2),1,fp);
-    result = fread(&formatLength,sizeof(formatLength),1,fp);
+    fread(&formatHeader2,sizeof(formatHeader2),1,fp);
+    fread(&formatLength,sizeof(formatLength),1,fp);
 
-    result = fread(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
-    result = fread(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
-    result = fread(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
-    result = fread(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
-    result = fread(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
-    result = fread(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
+    fread(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
+    fread(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
+    fread(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
+    fread(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
+    fread(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
+    fread(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
     if (pcm.pcmBitsPerSample!=16)
     {
         printf("sorry, lousy wav read code only does 16-bit ints\n");
@@ -78,24 +77,23 @@ bool PcmWavHeader::parse_from_file(FILE *fp)
     //extra bytes in pcm chuck
     int extra_size = formatLength-sizeof(pcm);
     pcmExtraData.allocate(extra_size);
-    result = fread(&pcmExtraData,extra_size,1,fp);
+    fread(&pcmExtraData,extra_size,1,fp);
 
     //extra chuncks
-    result = fread(&dummyHeader,sizeof(dummyHeader),1,fp);
+    fread(&dummyHeader,sizeof(dummyHeader),1,fp);
 
     while (dummyHeader!=VOCAB4('d','a','t','a'))
     {
-        result = fread(&dummyLength,sizeof(dummyLength),1,fp);
+        fread(&dummyLength,sizeof(dummyLength),1,fp);
         dummyData.clear();
         dummyData.allocate(dummyLength);
-        result = fread(&dummyData,dummyLength,1,fp);
-        result = fread(&dummyHeader,sizeof(dummyHeader),1,fp);
+        fread(&dummyData,dummyLength,1,fp);
+        fread(&dummyHeader,sizeof(dummyHeader),1,fp);
     }
 
     dataHeader=dummyHeader;
-    result = fread(&dataLength,sizeof(dataLength),1,fp);
+    fread(&dataLength,sizeof(dataLength),1,fp);
 
-    YARP_UNUSED(result);
     return true;
 }
 
@@ -122,25 +120,24 @@ void PcmWavHeader::setup_to_write(const Sound& src, FILE *fp)
     dataHeader = VOCAB4('d','a','t','a');
     dataLength = bytes;
 
-    size_t result;
-    result = fwrite(&wavHeader,sizeof(wavHeader),1,fp);
-    result = fwrite(&wavLength,sizeof(wavLength),1,fp);
-    result = fwrite(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fwrite(&formatHeader2,sizeof(formatHeader2),1,fp);
-    result = fwrite(&formatLength,sizeof(formatLength),1,fp);
+    fwrite(&wavHeader,sizeof(wavHeader),1,fp);
+    fwrite(&wavLength,sizeof(wavLength),1,fp);
+    fwrite(&formatHeader1,sizeof(formatHeader1),1,fp);
 
-    result = fwrite(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
-    result = fwrite(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
-    result = fwrite(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
-    result = fwrite(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
-    result = fwrite(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
-    result = fwrite(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
+    fwrite(&formatHeader2,sizeof(formatHeader2),1,fp);
+    fwrite(&formatLength,sizeof(formatLength),1,fp);
 
-    result = fwrite(&dataHeader,sizeof(dataHeader),1,fp);
-    result = fwrite(&dataLength,sizeof(dataLength),1,fp);
+    fwrite(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
+    fwrite(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
+    fwrite(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
+    fwrite(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
+    fwrite(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
+    fwrite(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
 
-    YARP_UNUSED(result);
+    fwrite(&dataHeader,sizeof(dataHeader),1,fp);
+    fwrite(&dataLength,sizeof(dataLength),1,fp);
+
 }
 
 bool yarp::sig::file::read(Sound& dest, const char *src)

--- a/src/libYARP_sig/src/Vector.cpp
+++ b/src/libYARP_sig/src/Vector.cpp
@@ -36,6 +36,7 @@ class VectorPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    VectorPortContentHeader() : listTag(0), listLen(0) {}
 };
 YARP_END_PACK
 

--- a/tests/libYARP_sig/MatrixTest.cpp
+++ b/tests/libYARP_sig/MatrixTest.cpp
@@ -460,7 +460,7 @@ public:
         Bottle *bot1 = bot.get(0).asList();
         Bottle *bot2 = bot.get(1).asList();
         checkTrue(bot1!=NULL&&bot2!=NULL,"got head/body");
-        if (bot1==NULL&&bot2==NULL) return;
+        if (bot1==NULL || bot2==NULL) return;
         checkEqual(bot1->get(0).asInt(),rr,"row count matches");
         checkEqual(bot1->get(1).asInt(),cc,"column count matches");
         Bottle *lst = bot1->get(2).asList();


### PR DESCRIPTION
libYARP_sig - fix file by file

- after the assignment the var is never read
- possible access to null pointer
- missing initialization, the content content could be garbage