### PR TITLE
Fix Clang warnings - libYARP_math

### DIFF
--- a/src/libYARP_math/src/Quaternion.cpp
+++ b/src/libYARP_math/src/Quaternion.cpp
@@ -17,6 +17,7 @@ class QuaternionPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    QuaternionPortContentHeader() : listTag(0), listLen(0) {}
 };
 YARP_END_PACK
 

--- a/src/libYARP_math/src/RandnScalar.cpp
+++ b/src/libYARP_math/src/RandnScalar.cpp
@@ -71,7 +71,8 @@ double RandnScalar::get(double u, double sigma)
 
 inline void RandnScalar::boxMuller()
 {
-    double x1, x2;
+    double x1 = 0.0;
+    double x2 = 0.0;
     double w = 2.0;
 
     while (w >= 1.0)

--- a/src/libYARP_math/src/Vec2D.cpp
+++ b/src/libYARP_math/src/Vec2D.cpp
@@ -21,6 +21,7 @@ class Vec2DPortContentHeader
 public:
     yarp::os::NetInt32 listTag;
     yarp::os::NetInt32 listLen;
+    Vec2DPortContentHeader() : listTag(0), listLen(0) {}
 };
 YARP_END_PACK
 


### PR DESCRIPTION
libYARP_math - fix file by file

- missing initialization, the content content could be garbage