### PR TITLE
Fix Clang warnings - other libraries

### DIFF
--- a/src/libYARP_manager/include/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/include/yarp/manager/impl/textparser.h
@@ -38,7 +38,6 @@ public:
 
         std::string ret, startKeyword, endKeyword;
         size_t s, e;
-        bool   badSymbol;
 
         ret = "";
 
@@ -47,7 +46,7 @@ public:
             ret          = element;
             startKeyword = "$ENV{";
             endKeyword   = "}";
-            badSymbol    = ret.find("$") != std::string::npos;
+            bool badSymbol    = ret.find("$") != std::string::npos;
             s            = ret.find(startKeyword);
             e            = ret.find(endKeyword, s);
 

--- a/src/libYARP_manager/include/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/include/yarp/manager/impl/textparser.h
@@ -57,7 +57,6 @@ public:
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
                 envValue  = yarp::os::NetworkBase::getEnvironment(envName.c_str());
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
-                badSymbol = false;
                 return parseText(ret.c_str());
             }
 
@@ -74,7 +73,6 @@ public:
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
                 envValue  = variables[envName];
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
-                badSymbol = false;
                 return parseText(ret.c_str());
             }
 

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -267,7 +267,7 @@ bool BinaryExpParser::checkExpression(std::string& strexp)
 void BinaryExpParser::parseExpression(std::string &strexp, BinaryNodePtr& node)
 {
     string op;
-    BinaryNodePtr rightNode;
+    BinaryNodePtr rightNode = YARP_NULLPTR;
     parseNot(strexp, node);
     while(!strexp.empty() &&
           ((*strexp.begin() == EXPAND) ||

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -46,8 +46,15 @@ bool BinaryExpParser::parse(string _exp)
 
     binTree.clear();
     operands.clear();
-    BinaryNodePtr root;
+    BinaryNodePtr root = YARP_NULLPTR;
     parseExpression(strexp, root);
+    if(root == YARP_NULLPTR)
+    {
+        ErrorLogger* logger = ErrorLogger::Instance();
+        string msg = "BinaryExpParser: failed to parse the expression";
+        logger->addError(msg);
+        return false;
+    }
     if(invalidOperands.size())
     {
         ErrorLogger* logger = ErrorLogger::Instance();

--- a/src/libYARP_manager/src/binexparser.cpp
+++ b/src/libYARP_manager/src/binexparser.cpp
@@ -8,7 +8,7 @@
 
 
 #include <yarp/manager/binexparser.h>
-
+#include <yarp/os/Log.h>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -16,12 +16,17 @@
 #include <string>
 #include <algorithm>
 #include <cmath>
+#include <cinttypes>
+#include <climits>
+#include <cstddef>
 
 
 #define EXPNOT     '~'
 #define EXPAND     '&'
 #define EXPOR      '|'
 #define IMPLY      ':'
+
+#define PRECISION(max_value) sizeof(max_value) * 8
 
 
 using namespace std;
@@ -338,12 +343,15 @@ std::string BinaryExpParser::popNextOperand(std::string &strexp) {
 
 void BinaryExpParser::createTruthTable(const int n)
 {
+    yAssert((n-1) > 0);
+    yAssert((n-1) < PRECISION(INT_MAX));
+    yAssert(1 <= (INT_MAX >> (n-1)));
+
     truthTable.clear();
     // n input + one output
     truthTable.resize(n+1);
     for(int i=0; i<n+1; i++)
         truthTable[i].resize(1 << n);
-
     int num_to_fill = 1 << (n - 1);
     for(int col = 0; col < n; ++col, num_to_fill >>= 1)
     {
@@ -357,6 +365,11 @@ void BinaryExpParser::createTruthTable(const int n)
 void BinaryExpParser::printTruthTable(std::string lopr)
 {
     int n = truthTable.size();
+
+    yAssert((n-1) > 0);
+    yAssert((n-1) < PRECISION(INT_MAX));
+    yAssert(1 <= (INT_MAX >> (n-1)));
+
     map<string, bool>::iterator itr;
     for(itr=operands.begin(); itr!=operands.end(); itr++)
        cout<<(*itr).first<<"\t";

--- a/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
+++ b/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
@@ -55,7 +55,7 @@ public:
         yarp::os::Contact remote;
         remote = reader.getRemoteContact();
         if (lock) service->lock();
-        ok = service->apply(cmd,reply,event,remote);
+        service->apply(cmd,reply,event,remote);
         for (int i=0; i<event.size(); i++) {
             yarp::os::Bottle *e = event.get(i).asList();
             if (e!=0/*NULL*/) {

--- a/src/yarpmanager/src-builder/propertiestable.cpp
+++ b/src/yarpmanager/src-builder/propertiestable.cpp
@@ -203,6 +203,7 @@ void PropertiesTable::showModuleTab(ModuleItem *mod)
     for(int i=0;i<mod->getInnerModule()->argumentCount();i++){
         Argument a = mod->getInnerModule()->getArgumentAt(i);
         QTreeWidgetItem *it = new QTreeWidgetItem(parametersItem,QStringList() << a.getParam() << a.getDescription());
+        Q_UNUSED(it);
 
     }
 
@@ -210,6 +211,7 @@ void PropertiesTable::showModuleTab(ModuleItem *mod)
     for(int i=0;i<mod->getInnerModule()->authorCount();i++){
         Author a = mod->getInnerModule()->getAuthorAt(i);
         QTreeWidgetItem *it = new QTreeWidgetItem(authorsItem,QStringList() << a.getName() << a.getEmail());
+        Q_UNUSED(it);
     }
 
     QTreeWidgetItem *inputsItem = new QTreeWidgetItem(moduleDescription,QStringList() << "Inputs" );
@@ -358,13 +360,12 @@ void PropertiesTable::onModItemChanged(QTreeWidgetItem *it,int col)
             manager->getKnowledgeBase()->setModulePrefix(currentModule->getInnerModule(), strPrefix.c_str(), false);
         }
 
-    }
-
-    for(int i=0;i<modules.count();i++){
-        Module *module = modules.at(i)->getInnerModule();
-        if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
-             module->setStdio(currentModule->getInnerModule()->getStdio());
-             module->setWorkDir(currentModule->getInnerModule()->getWorkDir());
+        for(int i=0;i<modules.count();i++){
+            Module *module = modules.at(i)->getInnerModule();
+            if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
+                 module->setStdio(currentModule->getInnerModule()->getStdio());
+                 module->setWorkDir(currentModule->getInnerModule()->getWorkDir());
+            }
         }
     }
     modified();
@@ -412,14 +413,13 @@ void PropertiesTable::onComboChanged(QWidget *combo)
     modParams->setText(1,params);
     if(currentModule){
         currentModule->getInnerModule()->setParam(params.toLatin1().data());
-    }
-
-    for(int i=0;i<modules.count();i++){
-        Module *module = modules.at(i)->getInnerModule();
-        if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
-             module->setParam(currentModule->getInnerModule()->getParam());
-             module->setHost(currentModule->getInnerModule()->getHost());
-             module->setBroker(currentModule->getInnerModule()->getBroker());
+        for(int i=0;i<modules.count();i++){
+            Module *module = modules.at(i)->getInnerModule();
+            if(!strcmp(module->getName(),currentModule->getInnerModule()->getName())){
+                 module->setParam(currentModule->getInnerModule()->getParam());
+                 module->setHost(currentModule->getInnerModule()->getHost());
+                 module->setBroker(currentModule->getInnerModule()->getBroker());
+            }
         }
     }
     modified();

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -343,6 +343,10 @@ bool JointItem::eventFilter(QObject *obj, QEvent *event)
                     onSliderVelocityReleased();
                 }
             }
+
+            if(slider == YARP_NULLPTR)
+                return false;
+
             
             if(keyEvent->type() == QEvent::KeyPress){
                 if(key == Qt::Key_Left || key == Qt::Key_Down){

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -800,7 +800,7 @@ void MainWindow::onHomeAllParts()
             continue;
         }
 
-        bool done = part->homePart();
+        part->homePart();
     }
 }
 


### PR DESCRIPTION
libYARP_name, libYARP_manager, yarpmanager, yarpmotorgui - fix file by file

- after the assignment the var is never read
- possible access to null pointer
- missing initialization, the content content could be garbage
- shift operator with undefined behaviour 