### PR TITLE
Unification of DGramTwoWayStream

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -5,6 +5,16 @@ YARP 2.3.70.2 (UNRELEASED) Release Notes                            {#v2_3_70_2}
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+v2.3.70.2%22).
 
+Important Changes
+-----------------
+
+### Libraries
+
+#### `YARP_OS`
+
+* Unification of code in `DGramTwoWayStream` for the allocation of write
+  and read buffers (https://github.com/robotology/yarp/issues/899).
+
 Bug Fixes
 ---------
 

--- a/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
@@ -34,26 +34,18 @@ class YARP_OS_impl_API yarp::os::impl::DgramTwoWayStream : public TwoWayStream, 
 {
 
 public:
-    DgramTwoWayStream() : mutex(1)
-    {
+    DgramTwoWayStream() :
+                          closed(false), interrupting(false), reader(false),
 #ifndef YARP_HAS_ACE
-        dgram_sockfd = -1;
+                          dgram_sockfd(-1),
 #endif
-        interrupting = false;
-        closed = false;
-        reader = false;
-        writer = false;
-        dgram = YARP_NULLPTR;
-        mgram = YARP_NULLPTR;
-        happy = true;
-        bufferAlerted = bufferAlertNeeded = false;
-        multiMode = false;
-        errCount = 0;
-        lastReportTime = 0;
-        readAt = 0;
-        readAvail = 0;
-        writeAvail = 0;
-        pct = 0;
+                          dgram(YARP_NULLPTR), mgram(YARP_NULLPTR),
+                          mutex(1), readAt(0), readAvail(0),
+                          writeAvail(0), pct(0), happy(true),
+                          bufferAlertNeeded(false), bufferAlerted(false),
+                          multiMode(false), errCount(0), lastReportTime(0)
+    {
+
     }
 
     virtual bool openMonitor(int readSize=0, int writeSize=0)
@@ -151,7 +143,7 @@ public:
 
 private:
     yarp::os::ManagedBytes monitor;
-    bool closed, interrupting, reader, writer;
+    bool closed, interrupting, reader;
 #ifdef YARP_HAS_ACE
     ACE_SOCK_Dgram *dgram;
     ACE_SOCK_Dgram_Mcast *mgram;

--- a/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
+++ b/src/libYARP_OS/include/yarp/os/impl/DgramTwoWayStream.h
@@ -36,6 +36,9 @@ class YARP_OS_impl_API yarp::os::impl::DgramTwoWayStream : public TwoWayStream, 
 public:
     DgramTwoWayStream() : mutex(1)
     {
+#ifndef YARP_HAS_ACE
+        dgram_sockfd = -1;
+#endif
         interrupting = false;
         closed = false;
         reader = false;

--- a/src/libYARP_OS/src/DgramTwoWayStream.cpp
+++ b/src/libYARP_OS/src/DgramTwoWayStream.cpp
@@ -38,8 +38,7 @@ using namespace yarp::os::impl;
 using namespace yarp::os;
 
 #define CRC_SIZE 8
-#define READ_SIZE (120000-CRC_SIZE)
-#define WRITE_SIZE (60000-CRC_SIZE)
+#define UDP_MAX_DATAGRAM_SIZE 64000
 
 
 static bool checkCrc(char *buf, YARP_SSIZE_T length, YARP_SSIZE_T crcLength, int pct,
@@ -173,12 +172,11 @@ bool DgramTwoWayStream::open(const Contact& local, const Contact& remote) {
 }
 
 void DgramTwoWayStream::allocate(int readSize, int writeSize) {
-#if defined(__APPLE__)
     //These are only as another default. We should modify the method to return bool
     //and fail if we cannot read the socket size.
 
-    int _read_size = READ_SIZE+CRC_SIZE;
-    int _write_size = WRITE_SIZE+CRC_SIZE;
+    int _read_size = -1;
+    int _write_size = -1;
 
     int socketSendBufferSize = -1;
     int socketRecvBufferSize = -1;
@@ -246,6 +244,13 @@ void DgramTwoWayStream::allocate(int readSize, int writeSize) {
         YARP_INFO(Logger::get(), ConstString("Datagram write size reset to ") +
                   NetType::toString(_write_size));
     }
+
+    // force the size of the write buffer to be under the max size of a udp datagram.
+    if (_write_size > UDP_MAX_DATAGRAM_SIZE)
+    {
+        _write_size = UDP_MAX_DATAGRAM_SIZE;
+    }
+
     readBuffer.allocate(_read_size);
     writeBuffer.allocate(_write_size);
     readAt = 0;
@@ -260,52 +265,10 @@ void DgramTwoWayStream::allocate(int readSize, int writeSize) {
     if (_write_size > socketSendBufferSize && socketSendBufferSize != -1) {
         YARP_WARN(Logger::get(), "SND buffer size bigger than socket SND size. Errors can occur during writing");
     }
-
-#else
-    int _read_size = READ_SIZE+CRC_SIZE;
-    int _write_size = WRITE_SIZE+CRC_SIZE;
-
-    ConstString _env_dgram = NetworkBase::getEnvironment("YARP_DGRAM_SIZE");
-    ConstString _env_mode = "";
-    if (multiMode) {
-        _env_mode = NetworkBase::getEnvironment("YARP_MCAST_SIZE");
-    } else {
-        _env_mode = NetworkBase::getEnvironment("YARP_UDP_SIZE");
-    }
-    if ( _env_mode!="") {
-        _env_dgram = _env_mode;
-    }
-    if (_env_dgram!="") {
-        int sz = NetType::toInt(_env_dgram);
-        if (sz!=0) {
-            _read_size = _write_size = sz;
-        }
-        YARP_INFO(Logger::get(), ConstString("Datagram packet size set to ") +
-                  NetType::toString(_read_size));
-    }
-    if (readSize!=0) {
-        _read_size = readSize;
-        YARP_INFO(Logger::get(), ConstString("Datagram read size reset to ") +
-                  NetType::toString(_read_size));
-    }
-    if (writeSize!=0) {
-        _write_size = writeSize;
-        YARP_INFO(Logger::get(), ConstString("Datagram write size reset to ") +
-                  NetType::toString(_write_size));
-    }
-    readBuffer.allocate(_read_size);
-    writeBuffer.allocate(_write_size);
-    readAt = 0;
-    readAvail = 0;
-    writeAvail = CRC_SIZE;
-    //happy = true;
-    pct = 0;
-#endif
 }
 
 
 void DgramTwoWayStream::configureSystemBuffers() {
-#if defined(__APPLE__)
     //By default use system buffer size.
     //These can be overwritten by environment variables
     //Generic variable
@@ -373,48 +336,6 @@ void DgramTwoWayStream::configureSystemBuffers() {
             YARP_WARN(Logger::get(), "Failed to set SND socket buffer to desired size. Actual: " + NetType::toString(actualWriteSize) + ", Desired: " + NetType::toString(writeBufferSize));
         }
     }
-
-
-
-#else
-    // ask for more buffer space for udp/mcast
-
-    ConstString _dgram_buffer_size = NetworkBase::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
-
-     int window_size_desired = 600000;
-
-    if (_dgram_buffer_size!="")
-        window_size_desired = NetType::toInt(_dgram_buffer_size);
-
-    int window_size = window_size_desired;
-#if defined(YARP_HAS_ACE)
-    int result = dgram->set_option(SOL_SOCKET, SO_RCVBUF,
-                                   (char *) &window_size, sizeof(window_size));
-    dgram->set_option(SOL_SOCKET, SO_SNDBUF,
-                                   (char *) &window_size, sizeof(window_size));
-#else
-    int result = setsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF,
-                            (void*) &window_size, sizeof(window_size));
-#endif
-
-    window_size = 0;
-#if defined(YARP_HAS_ACE)
-    int len = 4;
-    int result2 = dgram->get_option(SOL_SOCKET, SO_RCVBUF,
-                                    (char *) &window_size, &len);
-#else
-    socklen_t len = 4;
-    int result2 = getsockopt(dgram_sockfd, SOL_SOCKET, SO_RCVBUF,
-                             (void *) &window_size, &len);
-#endif
-    if (result!=0||result2!=0||window_size<window_size_desired) {
-        // give a warning if we get CRC problems
-        bufferAlertNeeded = true;
-        bufferAlerted = false;
-    }
-    YARP_DEBUG(Logger::get(),
-               ConstString("Warning: buffer size set to ")+ NetType::toString(window_size) + ConstString(", you requested ") + NetType::toString(window_size_desired));
-#endif
 }
 
 
@@ -986,14 +907,13 @@ void DgramTwoWayStream::flush() {
     addCrc(writeBuffer.get(), writeAvail, CRC_SIZE, pct);
     pct++;
 
-    while (writeAvail>0) {
-        YARP_SSIZE_T writeAt = 0;
+    if (writeAvail>0) {
         //yAssert(dgram != YARP_NULLPTR);
         YARP_SSIZE_T len = 0;
 
 #if defined(YARP_HAS_ACE)
         if (mgram != YARP_NULLPTR) {
-            len = mgram->send(writeBuffer.get()+writeAt, writeAvail-writeAt);
+            len = mgram->send(writeBuffer.get(), writeAvail);
             YARP_DEBUG(Logger::get(),
                        ConstString("MCAST - wrote ") +
                        NetType::toString((int)len) + " bytes"
@@ -1002,11 +922,11 @@ void DgramTwoWayStream::flush() {
 #endif
             if (dgram != YARP_NULLPTR) {
 #if defined(YARP_HAS_ACE)
-            len = dgram->send(writeBuffer.get()+writeAt, writeAvail-writeAt,
+            len = dgram->send(writeBuffer.get(), writeAvail,
                               remoteHandle);
 #else
-            len = send(dgram_sockfd, writeBuffer.get()+writeAt,
-                       writeAvail-writeAt, 0);
+            len = send(dgram_sockfd, writeBuffer.get(),
+                       writeAvail, 0);
 #endif
             YARP_DEBUG(Logger::get(),
                        ConstString("DGRAM - wrote ") +
@@ -1014,7 +934,7 @@ void DgramTwoWayStream::flush() {
                        remoteAddress.toString()
                        );
         } else {
-            Bytes b(writeBuffer.get()+writeAt, writeAvail-writeAt);
+            Bytes b(writeBuffer.get(), writeAvail);
             monitor = ManagedBytes(b, false);
             monitor.copy();
             //printf("Monitored output of %d bytes\n", monitor.length());
@@ -1049,7 +969,6 @@ void DgramTwoWayStream::flush() {
             YARP_DEBUG(Logger::get(), "DGRAM failed to send message with error: " + ConstString(strerror(errno)));
             return;
         }
-        writeAt += len;
         writeAvail -= len;
 
         if (writeAvail!=0) {


### PR DESCRIPTION
This PR unifies the code in `DGramTwoWayStream` and deletes a useless `while()` in `flush()`, the packet is already divided in packets in the `write()` function in order to be sent through datagrams.
It fixes #899.

TODO:
- [x] Tests on Linux (with/without ACE) 
- [x] Tests on macOs (with/without ACE) 
- [x] Tests on Windows (with ACE) 

All tests passed, ready to be merged.