### PR TITLE
Fix mcast yarpserver

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -14,6 +14,11 @@ Bug Fixes
 
 * Fixed truncation of double in `Property::fromString()`.
 
+### Tools
+
+* Added the fallback port in `yarpserver` also if `yarp`
+  is compiled without ACE, since we support mcast without
+  ACE since `v2.3.70`.
 
 Contributors
 ------------

--- a/src/libYARP_OS/src/FallbackNameServer.cpp
+++ b/src/libYARP_OS/src/FallbackNameServer.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <yarp/conf/system.h>
-#ifdef YARP_HAS_ACE
 
 #include <yarp/os/impl/FallbackNameServer.h>
 #include <yarp/os/impl/DgramTwoWayStream.h>
@@ -56,13 +55,5 @@ void FallbackNameServer::close() {
     closed = true;
     listen.interrupt();
 }
-
-
-
-#else
-
-int FallbackNameServerDummySymbol = 42;
-
-#endif // YARP_HAS_ACE
 
 

--- a/src/libYARP_name/src/BootstrapServer.cpp
+++ b/src/libYARP_name/src/BootstrapServer.cpp
@@ -7,9 +7,8 @@
 
 #include <yarp/conf/system.h>
 
-#ifdef YARP_HAS_ACE
 #include <yarp/os/impl/FallbackNameServer.h>
-#endif
+
 
 #include <yarp/os/impl/NameServer.h>
 #include <yarp/os/impl/NameConfig.h>
@@ -28,7 +27,7 @@ using namespace yarp::os::impl;
  * Adapt YARP multicast server to use a different NameService.
  *
  */
-#ifdef YARP_HAS_ACE
+
 class BootstrapServerAdapter : public NameServerStub {
 private:
     FallbackNameServer *fallback;
@@ -70,45 +69,38 @@ public:
         return true;
     }
 };
-#endif
 
 BootstrapServer::BootstrapServer(NameService& owner) {
-#ifdef YARP_HAS_ACE
+
     implementation = new BootstrapServerAdapter(owner);
     if (implementation==NULL) {
         fprintf(stderr,"Cannot allocate ServerAdapter\n");
         ::exit(1);
     }
-#else
-    fprintf(stderr,"No BootstrapServer available without ACE multicast\n");
-    ::exit(1);
-#endif
 }
 
 BootstrapServer::~BootstrapServer() {
-#ifdef YARP_HAS_ACE
+
     if (implementation!=NULL) {
         delete ((BootstrapServerAdapter*)implementation);
         implementation = NULL;
     }
-#endif
+
 }
 
 bool BootstrapServer::start() {
-#ifdef YARP_HAS_ACE
+
     if (implementation!=NULL) {
         return ((BootstrapServerAdapter*)implementation)->start();
     }
-#endif
     return false;
 }
 
 bool BootstrapServer::stop() {
-#ifdef YARP_HAS_ACE
+
     if (implementation!=NULL) {
         return ((BootstrapServerAdapter*)implementation)->stop();
     }
-#endif
     return false;
 }
 
@@ -206,13 +198,9 @@ bool BootstrapServer::configFileBootstrap(yarp::os::Contact& contact,
 
 
 Contact BootstrapServer::where() {
-#ifdef YARP_HAS_ACE
     Contact addr = FallbackNameServer::getAddress();
     addr.setName("fallback");
     return addr;
-#else
-    return Contact();
-#endif
 }
 
 //#endif

--- a/src/libYARP_serversql/src/yarpserver.cpp
+++ b/src/libYARP_serversql/src/yarpserver.cpp
@@ -245,9 +245,8 @@ yarpserversql_API int yarpserver_main(int argc, char *argv[]) {
     }
 
     NameServerManager name(nc);
-#ifdef YARP_HAS_ACE
     BootstrapServer fallback(name);
-#endif
+
 
     Port server;
     name.setPort(server);
@@ -258,18 +257,15 @@ yarpserversql_API int yarpserver_main(int argc, char *argv[]) {
         return 1;
     }
     printf("\n");
-
-#ifdef YARP_HAS_ACE
     fallback.start();
-#endif
+
 
     // Repeat registrations for the server and fallback server -
     // these registrations are more complete.
     printf("Registering name server with itself:\n");
     nc.preregister(nc.where());
-#ifdef YARP_HAS_ACE
     nc.preregister(fallback.where());
-#endif
+
     Contact alt = nc.whereDelegate();
     if (alt.isValid()) {
         nc.preregister(alt);


### PR DESCRIPTION
Since `v2_3_70` we support mcast also without ACE.
This PR add the open of the `fallback` port also if `yarp` is compiled with `SKIP_ACE`.

Please review code.