### PR TITLE
Coverity fix - other libraries

### DIFF
--- a/src/libYARP_logger/include/yarp/logger/YarpLogger.h
+++ b/src/libYARP_logger/include/yarp/logger/YarpLogger.h
@@ -174,7 +174,14 @@ class yarp::yarpLogger::LogEntry
     bool                          append_logEntry(MessageEntry entry);
 
     public:
-    LogEntry                       (int _entry_list_max_size=10000) {logging_enabled=true;entry_list_max_size=_entry_list_max_size; last_read_message=-1;entry_list.reserve(entry_list_max_size);};
+    LogEntry(int _entry_list_max_size=10000) :
+        logging_enabled(true),
+        entry_list_max_size(_entry_list_max_size),
+        last_read_message(-1),
+        entry_list_max_size_enabled(true)
+    {
+        entry_list.reserve(entry_list_max_size);
+    }
 
     int  getLogEntryMaxSize        ()          {return entry_list_max_size;}
     bool getLogEntryMaxSizeEnabled ()          {return entry_list_max_size_enabled;}

--- a/src/libYARP_logger/src/YarpLogger.cpp
+++ b/src/libYARP_logger/src/YarpLogger.cpp
@@ -690,7 +690,6 @@ void LoggerEngine::set_listen_option               (std::string   option, bool e
 
 bool LoggerEngine::get_listen_option               (std::string   option)
 {
-    if (log_updater == NULL) return false;
     return false;
 }
 

--- a/src/libYARP_logger/src/YarpLogger.cpp
+++ b/src/libYARP_logger/src/YarpLogger.cpp
@@ -214,6 +214,7 @@ LoggerEngine::logger_thread::logger_thread (std::string _portname, int _rate,  i
 {
         logger_portName              = _portname;
         log_list_max_size            = _log_list_max_size;
+        log_list_max_size_enabled    = true;
         listen_to_LOGLEVEL_UNDEFINED = true;
         listen_to_LOGLEVEL_TRACE     = true;
         listen_to_LOGLEVEL_DEBUG     = true;

--- a/src/libYARP_math/src/RandScalar.cpp
+++ b/src/libYARP_math/src/RandScalar.cpp
@@ -31,7 +31,8 @@ RandScalar::RandScalar()
     init();
 }
 
-RandScalar::RandScalar(int seed)
+RandScalar::RandScalar(int s) :
+    seed(s)
 {
     impl = new MersenneTwister;
     implementation(impl)->init_genrand(seed);

--- a/src/libYARP_math/src/math.cpp
+++ b/src/libYARP_math/src/math.cpp
@@ -788,6 +788,7 @@ Vector yarp::math::dcm2rpy(const Matrix &R)
         else
         {
             // Not a unique solution: psi-phi=atan2(-R12,R11)
+            singularity = true;
             v[0]=0.0;
             v[1]=M_PI/2.0;
             v[2]=-atan2(-R(1,2),R(1,1));
@@ -796,6 +797,7 @@ Vector yarp::math::dcm2rpy(const Matrix &R)
     else
     {
         // Not a unique solution: psi+phi=atan2(-R12,R11)
+        singularity = true;
         v[0]=0.0;
         v[1]=-M_PI/2.0;
         v[2]=atan2(-R(1,2),R(1,1));

--- a/src/libYARP_wire_rep_utils/WireImage.h
+++ b/src/libYARP_wire_rep_utils/WireImage.h
@@ -59,8 +59,10 @@ private:
     yarp::os::ManagedBytes ros_const_header;
     const yarp::sig::FlexImage *image;
 public:
-    RosWireImage() {
-    }
+    RosWireImage() :
+        ros_seq_stamp({0,0,0}),
+        image(YARP_NULLPTR)
+    {}
 
     void init(const yarp::sig::FlexImage& img,
               const yarp::os::ConstString& frame) {

--- a/src/libYARP_wire_rep_utils/WireTwiddler.h
+++ b/src/libYARP_wire_rep_utils/WireTwiddler.h
@@ -167,6 +167,7 @@ public:
         pending_string_length = 0;
         pending_string_data = 0;
         override_length = -1;
+        lengthBuffer = 0;
     }
 
     virtual ~WireTwiddlerReader() {}
@@ -229,15 +230,57 @@ private:
                                int evidence);
 public:
     WireTwiddlerWriter(yarp::os::SizedWriter& parent,
-                       WireTwiddler& twiddler) : parent(&parent),
-                                                 twiddler(&twiddler) {
+                       WireTwiddler& twiddler) : 
+        parent(&parent),
+        twiddler(&twiddler),
+        srcs(),
+        block(0),
+        lastBlock(0),
+        offset(0),
+        blockPtr(YARP_NULLPTR),
+        blockLen(0),
+        lengthBuffer(0),
+        lengthBytes(),
+        zeros(0),
+        scratch(0),
+        accumOffset(0),
+        activeEmit(YARP_NULLPTR),
+        activeGap(YARP_NULLPTR),
+        activeEmitLength(0),
+        activeEmitOffset(0),
+        activeCheck(YARP_NULLPTR),
+        errorState(false),
+        scratchOffset(0),
+        codeExpected(),
+        codeReceived()
+    {
         update();
     }
 
     WireTwiddlerWriter() :
         parent(YARP_NULLPTR),
-        twiddler(YARP_NULLPTR) {
-    }
+        twiddler(YARP_NULLPTR),
+        srcs(),
+        block(0),
+        lastBlock(0),
+        offset(0),
+        blockPtr(YARP_NULLPTR),
+        blockLen(0),
+        lengthBuffer(0),
+        lengthBytes(),
+        zeros(0),
+        scratch(0),
+        accumOffset(0),
+        activeEmit(YARP_NULLPTR),
+        activeGap(YARP_NULLPTR),
+        activeEmitLength(0),
+        activeEmitOffset(0),
+        activeCheck(YARP_NULLPTR),
+        errorState(false),
+        scratchOffset(0),
+        codeExpected(),
+        codeReceived() 
+    {}
 
     virtual ~WireTwiddlerWriter();
 


### PR DESCRIPTION
fix submitted for issues raised by Coverity static analyzer in these YARP components
libYARP_math 
YARP_wire_rep_utils
YARP_serversql
YARP_logger