### PR TITLE
Coverity fix - Random.cpp

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -19,6 +19,10 @@ Bug Fixes
 ---------
 
 * Fixed several warnings reported by clang static analyzer.
+* Fixed warnings reported by coverity static analyzer migrating 
+  `yarp::os::Random` from `cstdlib`'s functions `rand` and `srand` 
+  to C++11 `std::default_random_engine`. `yarp::os::Random` methods are not 
+  influencing anymore the global state of `rand` and `srand`.
 
 ### Libraries
 

--- a/src/libYARP_OS/src/Random.cpp
+++ b/src/libYARP_OS/src/Random.cpp
@@ -8,77 +8,32 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdlib>
+#include <random>
 
 using namespace yarp::os;
+std::default_random_engine randengine;
 
 double Random::uniform() {
-    return double (rand()) / double (RAND_MAX);
+    std::uniform_real_distribution<double> udist(0.0, 1.0);
+    return udist(randengine);
 }
 
 double Random::normal() {
     return normal(0.0, 1.0);
 }
 
-
-//
-// normal distribution random number generator.
-// - it might be slow, the standard rand() is used as source.
-// - beware of initializing the seed of rand.
-
-// original code copyright reported below.
-// summary --
-//   CopyPolicy: Preserve copyright notice
-//   Copyright: 1994, Everett F. Carter Jr.
-
-/* boxmuller.c
-   Implements the Polar form of the Box-Muller
-   Transformation
-
-   (c) Copyright 1994, Everett F. Carter Jr.
-   Permission is granted by the author to use
-   this software for any application provided this
-   copyright notice is preserved.
-
-*/
-
-
-
 double Random::normal(double m, double s)
 {
-    double x1, x2, w, y1;
-    static double y2;
-    static int use_last = 0;
-
-    if (use_last) { /* use value from previous call */
-        y1 = y2;
-        use_last = 0;
-    } else {
-        do {
-            x1 = 2.0 * uniform() - 1.0;
-            x2 = 2.0 * uniform() - 1.0;
-            w = x1 * x1 + x2 * x2;
-        } while ( w >= 1.0 );
-
-        w = sqrt( (-2.0 * log( w ) ) / w );
-        y1 = x1 * w;
-        y2 = x2 * w;
-        use_last = 1;
-    }
-
-    return( m + y1 * s );
+    std::normal_distribution<double> ndist(m, s);
+    return ndist(randengine);
 }
 
 void Random::seed(int seed) {
-    srand (seed);
+    randengine.seed(seed);
 }
 
 
 int Random::uniform(int min, int max) {
-    int ret = int ((double (rand()) / double (RAND_MAX)) * (max - min + 1) + min);
-
-    // there's a small chance the value is = max+1
-    if (ret <= max)
-        return ret;
-    else
-        return max;
+    std::uniform_int_distribution<int> udist(min, max);
+    return udist(randengine);
 }

--- a/src/libYARP_OS/src/Random.cpp
+++ b/src/libYARP_OS/src/Random.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright: (C) 1994 Everett F. Carter Jr.
- * CopyPolicy: Preserve copyright notice
+ * Copyright (C) 2017 Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
 #include <yarp/os/Random.h>


### PR DESCRIPTION
libYARP_OS:
Random.cpp and Random.h files modified to fix coverity issue: calling risky function rand()