### PR TITLE
rosmsgs autogeneration fix

### DIFF
--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -450,6 +450,14 @@ bool RosType::emitType(RosTypeCodeGen& gen,
 
     if (!gen.beginConstruct()) return false;
     for (int i=0; i<(int)subRosType.size(); i++) {
+        if (!gen.initField(subRosType[i])) return false;
+        if (i != (int)subRosType.size() -1) {
+            if (!gen.nextInitConstruct(subRosType[i])) return false;
+        } else {
+            if (!gen.endInitConstruct()) return false;
+        }
+    }
+    for (int i=0; i<(int)subRosType.size(); i++) {
         if (!gen.constructField(subRosType[i])) return false;
     }
     if (!gen.endConstruct()) return false;

--- a/src/idls/rosmsg/src/RosType.h
+++ b/src/idls/rosmsg/src/RosType.h
@@ -219,6 +219,9 @@ public:
     virtual bool endDeclare() { return true; }
 
     virtual bool beginConstruct() { return true; }
+    virtual bool initField(const RosField& field) { return true; }
+    virtual bool nextInitConstruct(const RosField& field) { return true; }
+    virtual bool endInitConstruct() { return true; }
     virtual bool constructField(const RosField& field) { return true; }
     virtual bool endConstruct() { return true; }
 

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -185,8 +185,33 @@ bool RosTypeCodeGenYarp::endDeclare() {
 }
 
 bool RosTypeCodeGenYarp::beginConstruct() {
-    fprintf(out,"  %s() {\n", className.c_str());
+    fprintf(out,"  %s() :\n", className.c_str());
     return true;
+}
+
+bool RosTypeCodeGenYarp::initField(const RosField& field) {
+
+    if (!field.isConst()) {
+        if (field.isArray || !field.isPrimitive) {
+            fprintf(out, "    %s()", field.rosName.c_str());
+        } else {
+            RosYarpType t = mapPrimitive(field);
+            fprintf(out, "    %s(%s)", field.rosName.c_str(), t.yarpDefaultValue.c_str());
+        }
+    }
+    return true;
+}
+
+bool RosTypeCodeGenYarp::nextInitConstruct(const RosField& field) {
+    if (!field.isConst()) {
+        fprintf(out,",\n");
+    }
+    return true;
+}
+
+bool RosTypeCodeGenYarp::endInitConstruct() {
+   fprintf(out,"\n  {\n");
+   return true;
 }
 
 bool RosTypeCodeGenYarp::constructField(const RosField& field) {

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
@@ -54,6 +54,9 @@ public:
     virtual bool endDeclare() override;
 
     virtual bool beginConstruct() override;
+    virtual bool initField(const RosField& field) override;
+    virtual bool nextInitConstruct(const RosField& field) override;
+    virtual bool endInitConstruct() override;
     virtual bool constructField(const RosField& field) override;
     virtual bool endConstruct() override;
 

--- a/src/libYARP_dev/src/devices/msgs/ros/include/TickDuration.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/TickDuration.h
@@ -23,7 +23,10 @@ public:
   yarp::os::NetUint32 sec;
   yarp::os::NetUint32 nsec;
 
-  TickDuration() {
+  TickDuration() :
+    sec(0),
+    nsec(0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/TickTime.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/TickTime.h
@@ -16,7 +16,10 @@ public:
   yarp::os::NetUint32 sec;
   yarp::os::NetUint32 nsec;
 
-  TickTime() {
+  TickTime() :
+    sec(0),
+    nsec(0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Point.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Point.h
@@ -22,7 +22,11 @@ public:
   yarp::os::NetFloat64 y;
   yarp::os::NetFloat64 z;
 
-  geometry_msgs_Point() {
+  geometry_msgs_Point() :
+    x(0.0),
+    y(0.0),
+    z(0.0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Pose.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Pose.h
@@ -22,7 +22,10 @@ public:
   geometry_msgs_Point position;
   geometry_msgs_Quaternion orientation;
 
-  geometry_msgs_Pose() {
+  geometry_msgs_Pose() :
+    position(),
+    orientation()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Quaternion.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Quaternion.h
@@ -27,7 +27,12 @@ public:
   yarp::os::NetFloat64 z;
   yarp::os::NetFloat64 w;
 
-  geometry_msgs_Quaternion() {
+  geometry_msgs_Quaternion() :
+    x(0.0),
+    y(0.0),
+    z(0.0),
+    w(0.0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Transform.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Transform.h
@@ -24,7 +24,10 @@ public:
   geometry_msgs_Vector3 translation;
   geometry_msgs_Quaternion rotation;
 
-  geometry_msgs_Transform() {
+  geometry_msgs_Transform() :
+    translation(),
+    rotation()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_TransformStamped.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_TransformStamped.h
@@ -32,7 +32,11 @@ public:
   std::string child_frame_id;
   geometry_msgs_Transform transform;
 
-  geometry_msgs_TransformStamped() {
+  geometry_msgs_TransformStamped() :
+    header(),
+    child_frame_id(""),
+    transform()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Vector3.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Vector3.h
@@ -27,7 +27,11 @@ public:
   yarp::os::NetFloat64 y;
   yarp::os::NetFloat64 z;
 
-  geometry_msgs_Vector3() {
+  geometry_msgs_Vector3() :
+    x(0.0),
+    y(0.0),
+    z(0.0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Wrench.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Wrench.h
@@ -23,7 +23,10 @@ public:
   geometry_msgs_Vector3 force;
   geometry_msgs_Vector3 torque;
 
-  geometry_msgs_Wrench() {
+  geometry_msgs_Wrench() :
+    force(),
+    torque()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_WrenchStamped.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_WrenchStamped.h
@@ -23,7 +23,10 @@ public:
   std_msgs_Header header;
   geometry_msgs_Wrench wrench;
 
-  geometry_msgs_WrenchStamped() {
+  geometry_msgs_WrenchStamped() :
+    header(),
+    wrench()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_MapMetaData.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_MapMetaData.h
@@ -36,7 +36,13 @@ public:
   yarp::os::NetUint32 height;
   geometry_msgs_Pose origin;
 
-  nav_msgs_MapMetaData() {
+  nav_msgs_MapMetaData() :
+    map_load_time(),
+    resolution(0.0),
+    width(0),
+    height(0),
+    origin()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_OccupancyGrid.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_OccupancyGrid.h
@@ -34,7 +34,11 @@ public:
   nav_msgs_MapMetaData info;
   std::vector<char> data;
 
-  nav_msgs_OccupancyGrid() {
+  nav_msgs_OccupancyGrid() :
+    header(),
+    info(),
+    data()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_CameraInfo.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_CameraInfo.h
@@ -159,7 +159,19 @@ public:
   yarp::os::NetUint32 binning_y;
   sensor_msgs_RegionOfInterest roi;
 
-  sensor_msgs_CameraInfo() {
+  sensor_msgs_CameraInfo() :
+    header(),
+    height(0),
+    width(0),
+    distortion_model(""),
+    D(),
+    K(),
+    R(),
+    P(),
+    binning_x(0),
+    binning_y(0),
+    roi()
+  {
     K.resize(9,0.0);
     R.resize(9,0.0);
     P.resize(12,0.0);

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Image.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Image.h
@@ -50,7 +50,15 @@ public:
   yarp::os::NetUint32 step;
   std::vector<unsigned char> data;
 
-  sensor_msgs_Image() {
+  sensor_msgs_Image() :
+    header(),
+    height(0),
+    width(0),
+    encoding(""),
+    is_bigendian(0),
+    step(0),
+    data()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Imu.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Imu.h
@@ -49,7 +49,15 @@ public:
   geometry_msgs_Vector3 linear_acceleration;
   std::vector<yarp::os::NetFloat64> linear_acceleration_covariance;
 
-  sensor_msgs_Imu() {
+  sensor_msgs_Imu() :
+    header(),
+    orientation(),
+    orientation_covariance(),
+    angular_velocity(),
+    angular_velocity_covariance(),
+    linear_acceleration(),
+    linear_acceleration_covariance()
+  {
     orientation_covariance.resize(9,0.0);
     angular_velocity_covariance.resize(9,0.0);
     linear_acceleration_covariance.resize(9,0.0);

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_JointState.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_JointState.h
@@ -47,7 +47,13 @@ public:
   std::vector<yarp::os::NetFloat64> velocity;
   std::vector<yarp::os::NetFloat64> effort;
 
-  sensor_msgs_JointState() {
+  sensor_msgs_JointState() :
+    header(),
+    name(),
+    position(),
+    velocity(),
+    effort()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_LaserScan.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_LaserScan.h
@@ -54,7 +54,18 @@ public:
   std::vector<yarp::os::NetFloat32> ranges;
   std::vector<yarp::os::NetFloat32> intensities;
 
-  sensor_msgs_LaserScan() {
+  sensor_msgs_LaserScan() :
+    header(),
+    angle_min(0.0),
+    angle_max(0.0),
+    angle_increment(0.0),
+    time_increment(0.0),
+    scan_time(0.0),
+    range_min(0.0),
+    range_max(0.0),
+    ranges(),
+    intensities()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_RegionOfInterest.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_RegionOfInterest.h
@@ -40,7 +40,13 @@ public:
   yarp::os::NetUint32 width;
   bool do_rectify;
 
-  sensor_msgs_RegionOfInterest() {
+  sensor_msgs_RegionOfInterest() :
+    x_offset(0),
+    y_offset(0),
+    height(0),
+    width(0),
+    do_rectify(false)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_ColorRGBA.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_ColorRGBA.h
@@ -27,7 +27,12 @@ public:
   yarp::os::NetFloat32 b;
   yarp::os::NetFloat32 a;
 
-  std_msgs_ColorRGBA() {
+  std_msgs_ColorRGBA() :
+    r(0.0),
+    g(0.0),
+    b(0.0),
+    a(0.0)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_Header.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_Header.h
@@ -34,7 +34,11 @@ public:
   TickTime stamp;
   std::string frame_id;
 
-  std_msgs_Header() {
+  std_msgs_Header() :
+    seq(0),
+    stamp(),
+    frame_id("")
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/tf2_msgs_TFMessage.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/tf2_msgs_TFMessage.h
@@ -21,7 +21,9 @@ class tf2_msgs_TFMessage : public yarp::os::idl::WirePortable {
 public:
   std::vector<geometry_msgs_TransformStamped> transforms;
 
-  tf2_msgs_TFMessage() {
+  tf2_msgs_TFMessage() :
+    transforms()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/tf_tfMessage.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/tf_tfMessage.h
@@ -22,7 +22,9 @@ class tf_tfMessage : public yarp::os::idl::WirePortable {
 public:
   std::vector<geometry_msgs_TransformStamped> transforms;
 
-  tf_tfMessage() {
+  tf_tfMessage() :
+    transforms()
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_Marker.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_Marker.h
@@ -97,7 +97,23 @@ public:
   std::string mesh_resource;
   bool mesh_use_embedded_materials;
 
-  visualization_msgs_Marker() {
+  visualization_msgs_Marker() :
+    header(),
+    ns(""),
+    id(0),
+    type(0),
+    action(0),
+    pose(),
+    scale(),
+    color(),
+    lifetime(),
+    frame_locked(false),
+    points(),
+    colors(),
+    text(""),
+    mesh_resource(""),
+    mesh_use_embedded_materials(false)
+  {
   }
 
   void clear() {

--- a/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_MarkerArray.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_MarkerArray.h
@@ -24,7 +24,9 @@ class visualization_msgs_MarkerArray : public yarp::os::idl::WirePortable {
 public:
   std::vector<visualization_msgs_Marker> markers;
 
-  visualization_msgs_MarkerArray() {
+  visualization_msgs_MarkerArray() :
+    markers()
+  {
   }
 
   void clear() {


### PR DESCRIPTION
Change the code to complete autogenerated ROS msgs types with initialization lists, in order to fix the 'uninitialized scalar | pointer field' issues raised by Coverity static analyzer.
The pull also includes ROS types filled with initialization lists.