### PR TITLE
Clean up rtf fixtures

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -331,7 +331,7 @@ else()
   endif()
 endif()
 
-set(RTF_REQUIRED_VERSION 1.3.0)
+set(RTF_REQUIRED_VERSION 1.3.3)
 find_package(RTF ${RTF_REQUIRED_VERSION} QUIET)
 checkandset_dependency(RTF)
 

--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -12,7 +12,7 @@ Important Changes
   removed.
 * C++11 is required also for using YARP, not just for compiling.
 * Optional dependency on YCM now requires version 0.5.1 or later.
-* Optional dependency on RTF now requires version 1.3.0 or later.
+* Optional dependency on RTF now requires version 1.3.3 or later.
 * Dropped `YARP1` support.
 
 ### Libraries

--- a/src/libYARP_rtf/src/JointsPosMotion.cpp
+++ b/src/libYARP_rtf/src/JointsPosMotion.cpp
@@ -53,12 +53,12 @@ void yarp::rtf::jointsPosMotion::Private::init(yarp::dev::PolyDriver *polydriver
     timeout = 5.0;
 
     dd = polydriver;
-    RTF_ASSERT_ERROR_IF(dd->isValid(), "Unable to open device driver");
-    RTF_ASSERT_ERROR_IF(dd->view(ienc), "Unable to open encoders interface");
-    RTF_ASSERT_ERROR_IF(dd->view(ipos), "Unable to open position interface");
-    RTF_ASSERT_ERROR_IF(dd->view(icmd), "Unable to open control mode interface");
-    RTF_ASSERT_ERROR_IF(dd->view(iimd), "Unable to open interaction mode interface");
-    RTF_ASSERT_ERROR_IF(dd->view(ilim), "Unable to open limits interface");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->isValid(), "Unable to open device driver");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->view(ienc), "Unable to open encoders interface");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->view(ipos), "Unable to open position interface");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->view(icmd), "Unable to open control mode interface");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->view(iimd), "Unable to open interaction mode interface");
+    RTF_ASSERT_ERROR_IF_FALSE(dd->view(ilim), "Unable to open limits interface");
 }
 
 
@@ -163,7 +163,7 @@ void yarp::rtf::jointsPosMotion::setTimeout(double timeout)
 
 void yarp::rtf::jointsPosMotion::setSpeed(yarp::sig::Vector &speedlist)
 {
-    RTF_ASSERT_ERROR_IF((speedlist.size() != mPriv->jointsList.size()), "Speed list has a different size of joint list");
+    RTF_ASSERT_ERROR_IF_FALSE((speedlist.size() != mPriv->jointsList.size()), "Speed list has a different size of joint list");
     mPriv->speed = speedlist;
     for (size_t i = 0; i < mPriv->n_joints; i++) {
         mPriv->ipos->setRefSpeed((int)mPriv->jointsList[i], mPriv->speed[i]);
@@ -174,7 +174,7 @@ void yarp::rtf::jointsPosMotion::setSpeed(yarp::sig::Vector &speedlist)
 bool yarp::rtf::jointsPosMotion::goToSingle(int j, double pos, double *reached_pos)
 {
     size_t i = mPriv->getIndexOfJoint(j);
-    RTF_ASSERT_ERROR_IF(i < mPriv->n_joints, "Cannot move a joint not in list.");
+    RTF_ASSERT_ERROR_IF_FALSE(i < mPriv->n_joints, "Cannot move a joint not in list.");
 
     mPriv->ipos->positionMove((int)mPriv->jointsList[i], pos);
     double tmp = 0;
@@ -242,7 +242,7 @@ bool yarp::rtf::jointsPosMotion::checkJointLimitsReached(int j)
 {
     size_t i = mPriv->getIndexOfJoint(j);
 
-    RTF_ASSERT_ERROR_IF(i < mPriv->n_joints, "Cannot move a joint not in list.");
+    RTF_ASSERT_ERROR_IF_FALSE(i < mPriv->n_joints, "Cannot move a joint not in list.");
 
     double enc=0;
     mPriv->ienc->getEncoder((int)mPriv->jointsList[i], &enc);

--- a/src/libYARP_rtf/src/TestCase.cpp
+++ b/src/libYARP_rtf/src/TestCase.cpp
@@ -39,7 +39,7 @@ bool yarp::rtf::TestCase::setup(int argc, char** argv)
 {
     // check yarp network
     mPriv->yarp.setVerbosity(-1);
-    RTF_ASSERT_ERROR_IF(mPriv->yarp.checkNetwork(),
+    RTF_ASSERT_ERROR_IF_FALSE(mPriv->yarp.checkNetwork(),
                         "YARP network does not seem to be available, is the yarp server accessible?");
 
     // loading environment properties by parsing the string value
@@ -64,7 +64,7 @@ bool yarp::rtf::TestCase::setup(int argc, char** argv)
     if(rf.check("from")) {
 
         std::string cfgname = rf.find("from").asString();
-        RTF_ASSERT_ERROR_IF(cfgname.size(),
+        RTF_ASSERT_ERROR_IF_FALSE(cfgname.size(),
                             "Empty value was set for the '--from' property");
 
         // loading configuration file indicated by --from
@@ -78,7 +78,7 @@ bool yarp::rtf::TestCase::setup(int argc, char** argv)
             rf.setDefaultContext(envprop.find("robotname").asString().c_str());
             cfgfile = rf.findFileByName(cfgname.c_str());
         }
-        RTF_ASSERT_ERROR_IF(cfgfile.size(),
+        RTF_ASSERT_ERROR_IF_FALSE(cfgfile.size(),
                             RTF::Asserter::format("Cannot find configuration file %s", cfgfile.c_str()));
         RTF_TEST_REPORT(RTF::Asserter::format("Loading configuration from %s", cfgfile.c_str()));
         // update the properties with environment

--- a/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/CMakeLists.txt
@@ -9,12 +9,12 @@ include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
 
 add_definitions(-DSHLIBPP_FILTER_API)
 
-add_library(rtf_fixturemanager_yarpmanager MODULE YarpFixManager.h
-                                                  YarpFixManager.cpp)
-set_property(TARGET rtf_fixturemanager_yarpmanager PROPERTY PREFIX "")
-set_property(TARGET rtf_fixturemanager_yarpmanager PROPERTY OUTPUT_NAME yarpmanager)
+rtf_add_plugin(rtf_fixturemanager_yarpmanager OUTPUT_NAME yarpmanager
+                                              SOURCES     YarpFixManager.cpp
+                                              HEADERS     YarpFixManager.h)
 
 target_link_libraries(rtf_fixturemanager_yarpmanager PRIVATE RTF::RTF
+                                                             RTF::RTF_dll
                                                              YARP::YARP_OS
                                                              YARP::YARP_init
                                                              YARP::YARP_manager)

--- a/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/rtf-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -36,7 +36,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
     if(!initialized) {
         // check yarp network
         yarp.setVerbosity(-1);
-        RTF_ASSERT_ERROR_IF(yarp.checkNetwork(),
+        RTF_ASSERT_ERROR_IF_FALSE(yarp.checkNetwork(),
                             "YARP network does not seem to be available, is the yarp server accessible?");
 
         // load the config file and update the environment if available
@@ -46,7 +46,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
         rf.setDefaultContext("RobotTesting");
         rf.configure(argc, argv, false);
 
-        RTF_ASSERT_ERROR_IF(rf.check("fixture"),
+        RTF_ASSERT_ERROR_IF_FALSE(rf.check("fixture"),
                             "No application xml file is set (add --fixture yourfixture.xml)");
 
         fixtureName = rf.find("fixture").asString();
@@ -57,7 +57,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
             appfile = rf.findFileByName(std::string(fixtureName).c_str());
         }
 
-        RTF_ASSERT_ERROR_IF(!appfile.empty(),
+        RTF_ASSERT_ERROR_IF_FALSE(!appfile.empty(),
                             RTF::Asserter::format("yarpmanager cannot find application file %s. Is it in the 'fixtures' folder?",
                                                   fixtureName.c_str()));
 
@@ -70,12 +70,12 @@ bool YarpFixManager::setup(int argc, char** argv) {
         // load the fixture (application xml)
         char* szAppName = nullptr;
         ret = addApplication(appfile.c_str(), &szAppName, true);
-        RTF_ASSERT_ERROR_IF(ret,
+        RTF_ASSERT_ERROR_IF_FALSE(ret,
                             "yarpmanager (addApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
 
         ret = loadApplication(szAppName);
-        RTF_ASSERT_ERROR_IF(ret,
+        RTF_ASSERT_ERROR_IF_FALSE(ret,
                             "yarpmanager (loadApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
         initialized = true;
@@ -88,7 +88,7 @@ bool YarpFixManager::setup(int argc, char** argv) {
 
     //run the modules and connect
     ret = run();
-    RTF_ASSERT_ERROR_IF(ret,
+    RTF_ASSERT_ERROR_IF_FALSE(ret,
                         "yarpmanager (run) cannot setup the fixture because " +
                         std::string(getLogger()->getFormatedErrorString()));
     return true;
@@ -100,7 +100,7 @@ void YarpFixManager::tearDown() {
     if(!ret)
         ret = kill();
     const char* szerror = getLogger()->getLastError();
-    RTF_ASSERT_ERROR_IF(ret,
+    RTF_ASSERT_ERROR_IF_FALSE(ret,
                         "yarpmanager cannot teardown the fixture because " +
                         std::string((szerror) ? szerror : ""));
 }
@@ -108,7 +108,7 @@ void YarpFixManager::tearDown() {
 
 void YarpFixManager::onExecutableFailed(void* which) {
     Executable* exe = (Executable*) which;
-    RTF_ASSERT_ERROR_IF(exe!=nullptr, "Executable is null!");
+    RTF_ASSERT_ERROR_IF_FALSE(exe!=nullptr, "Executable is null!");
     TestMessage msg(Asserter::format("Fixture %s collapsed", fixtureName.c_str()),
                     Asserter::format("Module %s is failed!", exe->getCommand()),
                     RTF_SOURCEFILE(), RTF_SOURCELINE());
@@ -117,7 +117,7 @@ void YarpFixManager::onExecutableFailed(void* which) {
 
 void YarpFixManager::onCnnFailed(void* which) {
     Connection* cnn = (Connection*) which;
-    RTF_ASSERT_ERROR_IF(cnn!=nullptr, "Connection is null!");
+    RTF_ASSERT_ERROR_IF_FALSE(cnn!=nullptr, "Connection is null!");
     TestMessage msg(Asserter::format("Fixture %s collapsed", fixtureName.c_str()),
                     Asserter::format("Connection %s - %s is failed!",
                                      cnn->from(), cnn->to()),

--- a/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpplugin/CMakeLists.txt
@@ -9,15 +9,15 @@ include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
 
 add_definitions(-DSHLIBPP_FILTER_API)
 
-add_library(rtf_fixturemanager_yarpplugin MODULE YarpPluginFixture.h
-                                                 YarpPluginFixture.cpp)
-set_property(TARGET rtf_fixturemanager_yarpplugin PROPERTY PREFIX "")
-set_property(TARGET rtf_fixturemanager_yarpplugin PROPERTY OUTPUT_NAME yarpplugin)
+rtf_add_plugin(rtf_fixturemanager_yarpplugin OUTPUT_NAME yarpplugin
+                                             SOURCES     YarpPluginFixture.cpp
+                                             HEADERS     YarpPluginFixture.h)
 
-target_link_libraries(rtf_fixturemanager_yarpplugin RTF::RTF
-                                                    YARP::YARP_OS
-                                                    YARP::YARP_init
-                                                    YARP::YARP_dev)
+target_link_libraries(rtf_fixturemanager_yarpplugin PRIVATE RTF::RTF
+                                                            RTF::RTF_dll
+                                                            YARP::YARP_OS
+                                                            YARP::YARP_init
+                                                            YARP::YARP_dev)
 
 yarp_install(TARGETS rtf_fixturemanager_yarpplugin
              EXPORT YARP

--- a/src/rtf-plugins/fixture-managers/yarpserver/CMakeLists.txt
+++ b/src/rtf-plugins/fixture-managers/yarpserver/CMakeLists.txt
@@ -9,11 +9,11 @@ include_directories(SYSTEM ${RTF_INCLUDE_DIRS})
 
 add_definitions(-DSHLIBPP_FILTER_API)
 
-add_library(rtf_fixturemanager_yarpserver MODULE yarpserverfixture.cpp)
-set_property(TARGET rtf_fixturemanager_yarpserver PROPERTY PREFIX "")
-set_property(TARGET rtf_fixturemanager_yarpserver PROPERTY OUTPUT_NAME yarpserver)
+rtf_add_plugin(rtf_fixturemanager_yarpserver OUTPUT_NAME yarpserver
+                                             SOURCES     yarpserverfixture.cpp)
 
 target_link_libraries(rtf_fixturemanager_yarpserver PRIVATE RTF::RTF
+                                                            RTF::RTF_dll
                                                             YARP::YARP_OS
                                                             YARP::YARP_init
                                                             YARP::YARP_serversql)


### PR DESCRIPTION
This PR increases the `RTF` required version to 1.3.2 and cleans up the rtf plugins after recent changes on devel branch of `RTF`.

Plugins tested, it can be merged.