### PR TITLE
ros msgs autogeneration bug fix

### DIFF
--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -449,11 +449,10 @@ bool RosType::emitType(RosTypeCodeGen& gen,
     if (!gen.endDeclare()) return false;
 
     if (!gen.beginConstruct()) return false;
+    bool isFirst = true;
     for (int i=0; i<(int)subRosType.size(); i++) {
-        if (!gen.initField(subRosType[i])) return false;
-        if (i != (int)subRosType.size() -1) {
-            if (!gen.nextInitConstruct(subRosType[i])) return false;
-        } else {
+        if (!gen.initField(subRosType[i], isFirst)) return false;
+        if (i == (int)subRosType.size() -1) {
             if (!gen.endInitConstruct()) return false;
         }
     }

--- a/src/idls/rosmsg/src/RosType.h
+++ b/src/idls/rosmsg/src/RosType.h
@@ -219,8 +219,7 @@ public:
     virtual bool endDeclare() { return true; }
 
     virtual bool beginConstruct() { return true; }
-    virtual bool initField(const RosField& field) { return true; }
-    virtual bool nextInitConstruct(const RosField& field) { return true; }
+    virtual bool initField(const RosField& field, bool &isFirstToInit) { return true; }
     virtual bool endInitConstruct() { return true; }
     virtual bool constructField(const RosField& field) { return true; }
     virtual bool endConstruct() { return true; }

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -185,13 +185,20 @@ bool RosTypeCodeGenYarp::endDeclare() {
 }
 
 bool RosTypeCodeGenYarp::beginConstruct() {
-    fprintf(out,"  %s() :\n", className.c_str());
+    fprintf(out,"  %s()", className.c_str());
     return true;
 }
 
-bool RosTypeCodeGenYarp::initField(const RosField& field) {
+bool RosTypeCodeGenYarp::initField(const RosField& field, bool &isFirstToInit) {
 
     if (!field.isConst()) {
+        if (isFirstToInit) {
+            fprintf(out, " :\n");
+            isFirstToInit = false;
+        } else {
+            fprintf(out, ",\n");
+        }
+
         if (field.isArray || !field.isPrimitive) {
             fprintf(out, "    %s()", field.rosName.c_str());
         } else {
@@ -202,12 +209,6 @@ bool RosTypeCodeGenYarp::initField(const RosField& field) {
     return true;
 }
 
-bool RosTypeCodeGenYarp::nextInitConstruct(const RosField& field) {
-    if (!field.isConst()) {
-        fprintf(out,",\n");
-    }
-    return true;
-}
 
 bool RosTypeCodeGenYarp::endInitConstruct() {
    fprintf(out,"\n  {\n");

--- a/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
+++ b/src/idls/rosmsg/src/RosTypeCodeGenYarp.h
@@ -54,8 +54,7 @@ public:
     virtual bool endDeclare() override;
 
     virtual bool beginConstruct() override;
-    virtual bool initField(const RosField& field) override;
-    virtual bool nextInitConstruct(const RosField& field) override;
+    virtual bool initField(const RosField& field, bool &isFirstToInit) override;
     virtual bool endInitConstruct() override;
     virtual bool constructField(const RosField& field) override;
     virtual bool endConstruct() override;


### PR DESCRIPTION
Previous code was generating problems when the message had constant fields declared as last fields.
This fix provides support for this case and also for void messages or messages with only constant fields.