### PR TITLE
[WIP] Change YARP_WRAP_STL_STRING default value on non-MSVC platforms

### DIFF
--- a/cmake/YarpOptions.cmake
+++ b/cmake/YarpOptions.cmake
@@ -325,8 +325,11 @@ endif()
 # yarp::os::ConstString could now be set to std::string, if YARP
 # ever decides to accept STL as a dependency.
 
-
-option(YARP_WRAP_STL_STRING "Do you want the yarp string classes to wrap std::string? (as opposed to being exactly std::string)" ON)
+set(YARP_WRAP_STL_STRING_DEFAULT OFF)
+if(MSVC)
+  set(YARP_WRAP_STL_STRING_DEFAULT ON)
+endif()
+option(YARP_WRAP_STL_STRING "Do you want the yarp string classes to wrap std::string? (as opposed to being exactly std::string)" ${YARP_WRAP_STL_STRING_DEFAULT})
 mark_as_advanced(YARP_WRAP_STL_STRING)
 set(YARP_WRAP_STL_STRING_INLINE_DEFAULT ON)
 if(MSVC)

--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -45,6 +45,9 @@ New Features
 * Added method 'yarp::os::carrier::createFace()', that returns the needed face
   of the carrier. This method is used in carriers::listen and carriers::connect
   in order to open new connection using the correct face.
+* The `YARP_WRAP_STL_STRING` option value is now by default `OFF` on non-MSVC
+  platforms. This means that `yarp::os::ConstString` is now by default a typedef
+  to `std::string` on these platforms.
 
 #### `YARP_dev`
 


### PR DESCRIPTION
This variables makes ConstString a typedef to std::string when set to OFF.

Please note that for existing builds the value is not updated.


Please let me know what you think about this change.