### PR TITLE
Patch for C++11 delay(0)

### DIFF
--- a/src/libYARP_OS/include/yarp/os/RFModule.h
+++ b/src/libYARP_OS/include/yarp/os/RFModule.h
@@ -52,6 +52,15 @@ public:
      * work could be done during this call, or it could just check the
      * state of a thread running in the background.
      *
+     * The thread calls the updateModule() function every <period> seconds.
+     * At the end of each run, the thread will sleep the amounth of time
+     * required, taking into account the time spent inside the loop function.
+     * Example:  requested period is 10ms, the updateModule() function take
+     * 3ms to be executed, the thread will sleep for 7ms.
+     *
+     * Note: after each run is completed, the thread will call a yield()
+     * in order to facilitate other threads to run.
+     *
      * @return true iff module should continue
     */
     virtual bool updateModule() = 0;

--- a/src/libYARP_OS/include/yarp/os/RateThread.h
+++ b/src/libYARP_OS/include/yarp/os/RateThread.h
@@ -60,6 +60,14 @@ public:
 
     /**
      * Loop function. This is the thread itself.
+     * The thread calls the run() function every <period> ms.
+     * At the end of each run, the thread will sleep the amounth of time
+     * required, taking into account the time spent inside the loop function.
+     * Example:  requested period is 10ms, the run() function take 3ms to
+     * be executed, the thread will sleep for 7ms.
+     *
+     * Note: after each run is completed, the thread will call a yield()
+     * in order to facilitate other threads to run.
      */
     virtual void run() = 0;
 

--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -307,6 +307,13 @@ int RFModule::runModule() {
             break;
         }
 
+        // At the end of each run of updateModule function, the thread is supposed
+        // to be suspended and release CPU to other threads.
+        // Calling a yield here will help the threads to alternate in the execution.
+        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
+        // yield is took into account and the sleep time is correct.
+        yarp::os::Time::yield();
+
         // The module is stopped for getPeriod() seconds.
         // If getPeriod() returns a time > 1 second, we check every second if
         // the module stopping, and eventually we exit the main loop.

--- a/src/libYARP_OS/src/RateThread.cpp
+++ b/src/libYARP_OS/src/RateThread.cpp
@@ -13,7 +13,6 @@
 
 #include <yarp/os/Time.h>
 #include <yarp/os/SystemClock.h>
-
 #include <cmath> //sqrt
 
 //added threadRelease/threadInit methods and synchronization -nat
@@ -165,18 +164,24 @@ public:
             owner.run();
         }
 
-        count++;
+
+        // At the end of each run of updateModule function, the thread is supposed
+        // to be suspended and release CPU to other threads.
+        // Calling a yield here will help the threads to alternate in the execution.
+        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
+        // yield is took into account and the sleep time is correct.
+        yield();
+
         lock();
-
+        count++;
         double elapsed = yarp::os::Time::now() - currentRun;
-
         //save last
         totalUsed+=elapsed;
         sumUsedSq+=elapsed*elapsed;
         unlock();
 
         sleepPeriod= adaptedPeriod - elapsed; // everything is in [seconds] except period, for it is used in the interface as [ms]
-        // Check if sleepPeriod is negative here or inside the delay (or both?)
+
         yarp::os::Time::delay(sleepPeriod);
     }
 
@@ -220,18 +225,24 @@ public:
             owner.run();
         }
 
-        count++;
+
+        // At the end of each run of updateModule function, the thread is supposed
+        // to be suspended and release CPU to other threads.
+        // Calling a yield here will help the threads to alternate in the execution.
+        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
+        // yield is took into account and the sleep time is correct.
+        yield();
+
         lock();
-
+        count++;
         double elapsed = SystemClock::nowSystem() - currentRun;
-
         //save last
         totalUsed+=elapsed;
         sumUsedSq+=elapsed*elapsed;
         unlock();
 
         sleepPeriod= adaptedPeriod - elapsed;  //  all time computatio are done in [sec]
-        // Check if sleepPeriod is negative here or inside the delay (or both?)
+
         SystemClock::delaySystem(sleepPeriod);
     }
 

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -13,6 +13,7 @@
 #include <yarp/os/impl/SemaphoreImpl.h>
 
 #include <cstdlib>
+#include <thread>
 
 #if defined(YARP_HAS_CXX11)
 #  if defined(YARP_HAS_ACE)
@@ -518,13 +519,5 @@ void ThreadImpl::setDefaultStackSize(int stackSize)
 
 void ThreadImpl::yield()
 {
-#if defined(YARP_HAS_CXX11)
     std::this_thread::yield();
-#elif defined(YARP_HAS_ACE) // Use ACE API
-    ACE_Thread::yield();
-#elif defined(__unix__) // Use the POSIX syscalls
-    pthread_yield();
-#else
-    YARP_ERROR(Logger::get(), "Cannot yield thread without ACE");
-#endif
 }

--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -114,12 +114,7 @@ void Time::turboBoost() {
 }
 
 void Time::yield() {
-#ifdef YARP_HAS_ACE
-    ACE_Time_Value tv(0);
-    ACE_OS::sleep(tv);
-#else
-    sleep(0);
-#endif
+    return yarp::os::Thread::yield();
 }
 
 


### PR DESCRIPTION
After F2F chat with @lornat75 and @pattacini, it has been decided to introduce a patch to restore the same behavior as ACE.

ACE version of `sleep(0)` was forcing a `yield`.
With the introduction of C++11, `sleep(0)` does not force `yield` anymore.
This patch is to reintroduce old behavior and avoid thread starvation.

