### PR TITLE
pixelsize bug fix

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -15,6 +15,12 @@ Important Changes
 * Optional dependency on RTF now requires version 1.3.3 or later.
 * Dropped `YARP1` support.
 * Changed how JAVA bindings are generated
+* `yarp::sig::image::getIplImage()` now can return a null pointer 
+  (instead of Teminating with an assert) for not valid Ipl image formats
+* `yarp::sig::image::setPixelCode()` now set the pixelSize accordingly (which should not be set).
+  since `yarp::sig::image::setPixelSize()` also sets an arbitrary pixel code equal to negative itself
+  (setPixelSize(3) will set the pixelCode to -3) it should be use only for image with custom formats
+  not covered by a yarp pixelCode.
 
 ### Libraries
 
@@ -113,6 +119,9 @@ Bug Fixes
 
 * Added `unprepare` method to `Publisher`. See `BufferedPort` for documentation on how to use `prepare` and `unprepare` [#1425](https://github.com/robotology/yarp/pull/1425)
 * Optimized `Stamp::read()` and `Stamp::write()` for textMode.
+
+#### `YARP_sig`
+* fixed pixelSize information loss in `fleximage:::read()`
 
 ### GUIs
 

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -632,7 +632,6 @@ string RGBDSensorWrapper::yarp2RosPixelCode(int code)
 void RGBDSensorWrapper::shallowCopyImages(const yarp::sig::FlexImage& src, yarp::sig::FlexImage& dest)
 {
     dest.setPixelCode(src.getPixelCode());
-    dest.setPixelSize(src.getPixelSize());
     dest.setQuantum(src.getQuantum());
     dest.setExternal(src.getRawImage(), src.width(), src.height());
 }

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -867,7 +867,6 @@ void ServerGrabber::split(const yarp::sig::Image& inputImage, yarp::sig::Image& 
 void ServerGrabber::setupFlexImage(const Image &_img, FlexImage &flex_i)
 {
     flex_i.setPixelCode(_img.getPixelCode());
-    flex_i.setPixelSize(_img.getPixelSize());
     flex_i.setQuantum(_img.getQuantum());
     flex_i.setExternal(_img.getRawImage(), _img.width(),_img.height());
 
@@ -1252,7 +1251,6 @@ void ServerGrabber::run()
 void ServerGrabber::shallowCopyImages(const yarp::sig::FlexImage& src, yarp::sig::FlexImage& dest)
 {
     dest.setPixelCode(src.getPixelCode());
-    dest.setPixelSize(src.getPixelSize());
     dest.setQuantum(src.getQuantum());
     dest.setExternal(src.getRawImage(), src.width(), src.height());
 }

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -267,7 +267,7 @@ public:
      * Returns IPL/OpenCV view of image, if possible.
      * Not possible if the image is the wrong size, with no padding.
      * This method is currently not well documented.
-     * @return pointer to an IplImage structure
+     * @return pointer to an IplImage structure or nullptr
      */
     void *getIplImage();
 
@@ -275,7 +275,7 @@ public:
      * Returns IPL/OpenCV view of image, if possible.
      * Not possible if the image is the wrong size, with no padding.
      * This method is currently not well documented.
-     * @return pointer to an IplImage structure
+     * @return pointer to an IplImage structure or nullptr
      */
     const void *getIplImage() const;
 
@@ -346,6 +346,9 @@ protected:
 
     void setPixelCode(int imgPixelCode);
 
+    //pixelCode and pixelsSize should be linked together consistently.
+    //since setPixelCode set also the corresponding pixelSize setPixelSize should not be used at all except for
+    //setting an arbitrary pixelSize with no corresponding pixel code (in that case the pixelCode will be set to -pixelSize).
     void setPixelSize(int imgPixelSize);
 
 
@@ -378,8 +381,12 @@ public:
         Image::setPixelCode(imgPixelCode);
     }
 
+
     void setPixelSize(int imgPixelSize) {
         Image::setPixelSize(imgPixelSize);
+    //pixelCode and pixelsSize should be linked together consistently.
+    //since setPixelCode set also the corresponding pixelSize setPixelSize should not be used at all except for
+    //setting an arbitrary pixelSize with no corresponding pixel code (in that case the pixelCode will be set to -pixelSize).
     }
 
     void setQuantum(int imgQuantum) {

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -12,6 +12,7 @@
 #include <yarp/os/Vocab.h>
 #include <yarp/os/NetUint16.h>
 #include <yarp/sig/api.h>
+#include <map>
 
 namespace yarp {
     /**
@@ -35,6 +36,38 @@ namespace yarp {
     }
 }
 
+// the image types partially reflect the IPL image types.
+// There must be a pixel type for every ImageType entry.
+enum YarpVocabPixelTypesEnum
+{
+    VOCAB_PIXEL_INVALID = 0,
+    VOCAB_PIXEL_MONO = VOCAB4('m','o','n','o'),
+    VOCAB_PIXEL_MONO16 = VOCAB4('m','o','1','6'),
+    VOCAB_PIXEL_RGB = VOCAB3('r','g','b'),
+    VOCAB_PIXEL_RGBA = VOCAB4('r','g','b','a'),
+    VOCAB_PIXEL_BGRA = VOCAB4(98/*'b'*/,'g','r','a'), /* SWIG BUG */
+    VOCAB_PIXEL_INT = VOCAB3('i','n','t'),
+    VOCAB_PIXEL_HSV = VOCAB3('h','s','v'),
+    VOCAB_PIXEL_BGR = VOCAB3(98/*'b'*/,'g','r'), /* SWIG BUG */
+    VOCAB_PIXEL_MONO_SIGNED = VOCAB4('s','i','g','n'),
+    VOCAB_PIXEL_RGB_SIGNED = VOCAB4('r','g','b','-'),
+    VOCAB_PIXEL_RGB_INT = VOCAB4('r','g','b','i'),
+    VOCAB_PIXEL_MONO_FLOAT = VOCAB3('d','e','c'),
+    VOCAB_PIXEL_RGB_FLOAT = VOCAB4('r','g','b','.'),
+    VOCAB_PIXEL_HSV_FLOAT = VOCAB4('h','s','v','.'),
+    VOCAB_PIXEL_ENCODING_BAYER_GRBG8 = VOCAB4('g', 'r', 'b', 'g'),   //grbg8
+    VOCAB_PIXEL_ENCODING_BAYER_GRBG16 = VOCAB4('g', 'r', '1', '6'),  //grbg16
+    VOCAB_PIXEL_ENCODING_BAYER_BGGR8 = VOCAB4(98/*'b'*/, 'g', 'g', 'r'),     //bggr8
+    VOCAB_PIXEL_ENCODING_BAYER_BGGR16 = VOCAB4(98/*'b'*/, 'g', '1', '6'),  //bggr16
+    VOCAB_PIXEL_ENCODING_BAYER_GBRG8 = VOCAB4('g', 'b', 'r', 'g'),  //gbrg8
+    VOCAB_PIXEL_ENCODING_BAYER_GBRG16 = VOCAB4('g', 'b', '1', '6'),  //gbrg16
+    VOCAB_PIXEL_ENCODING_BAYER_RGGB8 = -VOCAB4('r', 'g', 'g', 'b'),   //rggb8
+    VOCAB_PIXEL_ENCODING_BAYER_RGGB16 = VOCAB4('r', 'g', '1', '6'),  //rggb16
+    VOCAB_PIXEL_YUV_420 = VOCAB4('y','u','v','a'),
+    VOCAB_PIXEL_YUV_444 = VOCAB4('y','u','v','b'),
+    VOCAB_PIXEL_YUV_422 = VOCAB4('y','u','v','c'),
+    VOCAB_PIXEL_YUV_411 = VOCAB4('y','u','v','d')
+};
 
 /**
  * \ingroup sig_class
@@ -317,7 +350,7 @@ protected:
 
 
 private:
-
+    static const std::map<YarpVocabPixelTypesEnum, unsigned int> pixelCode2Size;
     int imgWidth, imgHeight, imgPixelSize, imgRowSize, imgPixelCode, imgQuantum;
     bool topIsLow;
 
@@ -355,41 +388,6 @@ public:
 
 private:
 };
-
-
-
-// the image types partially reflect the IPL image types.
-// There must be a pixel type for every ImageType entry.
-enum YarpVocabPixelTypesEnum
-    {
-        VOCAB_PIXEL_INVALID = 0,
-        VOCAB_PIXEL_MONO = VOCAB4('m','o','n','o'),
-        VOCAB_PIXEL_MONO16 = VOCAB4('m','o','1','6'),
-        VOCAB_PIXEL_RGB = VOCAB3('r','g','b'),
-        VOCAB_PIXEL_RGBA = VOCAB4('r','g','b','a'),
-        VOCAB_PIXEL_BGRA = VOCAB4(98/*'b'*/,'g','r','a'), /* SWIG BUG */
-        VOCAB_PIXEL_INT = VOCAB3('i','n','t'),
-        VOCAB_PIXEL_HSV = VOCAB3('h','s','v'),
-        VOCAB_PIXEL_BGR = VOCAB3(98/*'b'*/,'g','r'), /* SWIG BUG */
-        VOCAB_PIXEL_MONO_SIGNED = VOCAB4('s','i','g','n'),
-        VOCAB_PIXEL_RGB_SIGNED = VOCAB4('r','g','b','-'),
-        VOCAB_PIXEL_RGB_INT = VOCAB4('r','g','b','i'),
-        VOCAB_PIXEL_MONO_FLOAT = VOCAB3('d','e','c'),
-        VOCAB_PIXEL_RGB_FLOAT = VOCAB4('r','g','b','.'),
-        VOCAB_PIXEL_HSV_FLOAT = VOCAB4('h','s','v','.'),
-        VOCAB_PIXEL_ENCODING_BAYER_GRBG8 = VOCAB4('g', 'r', 'b', 'g'),   //grbg8
-        VOCAB_PIXEL_ENCODING_BAYER_GRBG16 = VOCAB4('g', 'r', '1', '6'),  //grbg16
-        VOCAB_PIXEL_ENCODING_BAYER_BGGR8 = VOCAB4(98/*'b'*/, 'g', 'g', 'r'),     //bggr8
-        VOCAB_PIXEL_ENCODING_BAYER_BGGR16 = VOCAB4(98/*'b'*/, 'g', '1', '6'),  //bggr16
-        VOCAB_PIXEL_ENCODING_BAYER_GBRG8 = VOCAB4('g', 'b', 'r', 'g'),  //gbrg8
-        VOCAB_PIXEL_ENCODING_BAYER_GBRG16 = VOCAB4('g', 'b', '1', '6'),  //gbrg16
-        VOCAB_PIXEL_ENCODING_BAYER_RGGB8 = -VOCAB4('r', 'g', 'g', 'b'),   //rggb8
-        VOCAB_PIXEL_ENCODING_BAYER_RGGB16 = VOCAB4('r', 'g', '1', '6'),  //rggb16
-        VOCAB_PIXEL_YUV_420 = VOCAB4('y','u','v','a'),
-        VOCAB_PIXEL_YUV_444 = VOCAB4('y','u','v','b'),
-        VOCAB_PIXEL_YUV_422 = VOCAB4('y','u','v','c'),
-        VOCAB_PIXEL_YUV_411 = VOCAB4('y','u','v','d')
-    };
 
 
 
@@ -555,6 +553,9 @@ class yarp::sig::ImageOf : public Image
 private:
     T nullPixel;
 public:
+    ImageOf() : Image() {
+        setPixelCode(getPixelCode());
+    }
 
     virtual int getPixelSize() const override {
         return sizeof(T);

--- a/src/libYARP_sig/src/Sound.cpp
+++ b/src/libYARP_sig/src/Sound.cpp
@@ -131,7 +131,6 @@ void Sound::init(int bytesPerSample) {
     yAssert(implementation!=nullptr);
 
     yAssert(bytesPerSample==2); // that's all thats implemented right now
-    HELPER(implementation).setPixelSize(sizeof(PixelMono16));
     HELPER(implementation).setPixelCode(VOCAB_PIXEL_MONO16);
     HELPER(implementation).setQuantum(2);
 

--- a/src/libYARP_wire_rep_utils/WireImage.cpp
+++ b/src/libYARP_wire_rep_utils/WireImage.cpp
@@ -47,7 +47,6 @@ FlexImage *WireImage::checkForImage(SizedWriter& writer) {
     int h = hdr.height;
     //int row_stride = hdr.imgSize/hdr.height;
     img.setPixelCode(hdr.id);
-    img.setPixelSize(hdr.depth);
     img.setQuantum(hdr.quantum);
     img.setExternal((char*)img_buf,w,h);
     return &img;

--- a/tests/libYARP_sig/ImageTest.cpp
+++ b/tests/libYARP_sig/ImageTest.cpp
@@ -614,10 +614,7 @@ public:
 
 
     virtual void runTests() override {
-#ifdef BROKEN_TEST
         readWrite();
-#endif // BROKEN
-
         testCreate();
         bool netMode = Network::setLocalMode(true);
         testTransmit();


### PR DESCRIPTION
fixes #1408

basically the pixelSize is a datum dependent on the pixel code and have to be always deduced from it, not set manually. we should deprecate the `setPixelSize` method 