### PR TITLE
Bugfix for yarpdev on Windows

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -13,7 +13,7 @@ Important Changes
 #### `YARP_OS`
 
 * Unification of code in `DGramTwoWayStream` for the allocation of write
-  and read buffers (https://github.com/robotology/yarp/issues/899).
+  and read buffers (#899).
 
 Bug Fixes
 ---------
@@ -26,12 +26,15 @@ Bug Fixes
 
 * Fixed truncation of double in `Property::fromString()`.
 * Fixed append to wrong string in `BufferedConnectionWriter.h`.
+* Fixed `yarp::os::ConstString::getline` for MSVC (#1357).
 
 ### Tools
 
 * Added the fallback port in `yarpserver` also if `yarp`
   is compiled without ACE, since we support mcast without
   ACE since `v2.3.70`.
+* Fixed `yarpdev --list` for Windows.
+
 
 Contributors
 ------------

--- a/src/libYARP_OS/include/yarp/os/ConstString.h
+++ b/src/libYARP_OS/include/yarp/os/ConstString.h
@@ -582,11 +582,25 @@ namespace std {
     }
 
     inline std::istream& getline(std::istream& is, yarp::os::ConstString& str, char delim) {
+#ifdef YARP_WRAP_STL_STRING_INLINE
         return getline(is, (std::string&)str, delim);
+#else
+        std::string line;
+        getline(is, line, delim);
+        str = line;
+        return is;
+#endif
     }
 
     inline std::istream& getline(std::istream& is, yarp::os::ConstString& str) {
+#ifdef YARP_WRAP_STL_STRING_INLINE
         return getline(is, (std::string&)str);
+#else
+        std::string line;
+        getline(is, line);
+        str = line;
+        return is;
+#endif
     }
 
 }


### PR DESCRIPTION
Fix `yarp::os::ConstString::getline(...)` to work fine with Windows.
It fixes #1357.