### PR TITLE
[WIP] Failing test for yarp::os::Time::NetworkClock

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -343,7 +343,7 @@ else()
   endif()
 endif()
 
-set(RTF_REQUIRED_VERSION 1.3.3)
+set(RTF_REQUIRED_VERSION 1.3.4)
 find_package(RTF ${RTF_REQUIRED_VERSION} QUIET)
 checkandset_dependency(RTF)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,7 +170,10 @@ if(YARP_COMPILE_TESTS)
     add_subdirectory(integration)
   endif()
 
-
+  # RTF-based tests
+  if(YARP_COMPILE_RTF_ADDONS)
+    add_subdirectory(rtf)
+  endif()
 
   yarp_deprecated_option(TEST_yarpidl_rosmsg) # Since YARP 2.3.70
   yarp_deprecated_option(TEST_yarpidl_thrift) # Since YARP 2.3.70

--- a/tests/rtf/CMakeLists.txt
+++ b/tests/rtf/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+add_subdirectory(NetworkClock)

--- a/tests/rtf/NetworkClock/CMakeLists.txt
+++ b/tests/rtf/NetworkClock/CMakeLists.txt
@@ -7,8 +7,8 @@ rtf_add_plugin(NetworkClockTest SOURCES NetworkClockTest.cpp)
 # add_library(NetworkClockTest MODULE NetworkClockTest.cpp)
 target_link_libraries(NetworkClockTest YARP_init YARP_OS YARP_rtf ${RTF_LIBRARIES})
 rtf_add_suite(NAME NetworkClockTest
-              FIXTURE rtf_fixturemanager_yarpserver --silent
-              FIXTURE rtf_fixturemanager_yarpmanager --fixture ${CMAKE_CURRENT_SOURCE_DIR}/fixture-network-clock.xml
-              TEST NetworkClockTest TYPE dll
+              RTF_FIXTURE rtf_fixturemanager_yarpserver --silent
+              RTF_FIXTURE rtf_fixturemanager_yarpmanager --fixture ${CMAKE_CURRENT_SOURCE_DIR}/fixture-network-clock.xml
+              RTF_TEST NetworkClockTest TYPE dll
               VERBOSE)
 set_tests_properties(NetworkClockTest PROPERTIES TIMEOUT 30.0)

--- a/tests/rtf/NetworkClock/CMakeLists.txt
+++ b/tests/rtf/NetworkClock/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
+# Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+add_definitions(-DSHLIBPP_FILTER_API)
+rtf_add_plugin(NetworkClockTest SOURCES NetworkClockTest.cpp)
+# add_library(NetworkClockTest MODULE NetworkClockTest.cpp)
+target_link_libraries(NetworkClockTest YARP_init YARP_OS YARP_rtf ${RTF_LIBRARIES})
+rtf_add_suite(NAME NetworkClockTest
+              FIXTURE rtf_fixturemanager_yarpserver --silent
+              FIXTURE rtf_fixturemanager_yarpmanager --fixture ${CMAKE_CURRENT_SOURCE_DIR}/fixture-network-clock.xml
+              TEST NetworkClockTest TYPE dll
+              VERBOSE)
+set_tests_properties(NetworkClockTest PROPERTIES TIMEOUT 30.0)

--- a/tests/rtf/NetworkClock/NetworkClockTest.cpp
+++ b/tests/rtf/NetworkClock/NetworkClockTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 iCub Facility, Istituto Italiano di Tecnologia (IIT)
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <cmath>
+#include <string>
+
+#include <rtf/Asserter.h>
+#include <rtf/TestAssert.h>
+#include <rtf/dll/Plugin.h>
+
+#include <yarp/rtf/TestCase.h>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/NetworkClock.h>
+
+using namespace std;
+using namespace RTF;
+
+/**********************************************************************/
+class NetworkClockTest : public yarp::rtf::TestCase
+{
+    yarp::os::NetworkClock * m_simClock;
+    std::string extClockName;
+    std::string localPortName;
+
+public:
+    /******************************************************************/
+    NetworkClockTest() :
+            TestCase("NetworkClockTest"),
+            m_simClock(nullptr)
+    {
+    }
+
+    /******************************************************************/
+    virtual ~NetworkClockTest()
+    {
+    }
+
+    /******************************************************************/
+    virtual bool setup(yarp::os::Property& property)
+    {
+        RTF_TEST_REPORT("Opening simulation clock, if it exists");
+        yarp::os::Network::init();
+        extClockName = "/clock";
+        localPortName = "/NetworkClockTest/clock";
+        RTF_ASSERT_ERROR_IF_FALSE(yarp::os::Network::exists(extClockName.c_str()), "/clock port not found");
+        m_simClock = new yarp::os::NetworkClock();
+        RTF_ASSERT_ERROR_IF_FALSE(m_simClock, "Simulation clock not correctly allocated.");
+        RTF_ASSERT_ERROR_IF_FALSE(m_simClock->open(extClockName.c_str(), localPortName.c_str()), "Simulation clock not correctly opened");
+        return true;
+    }
+
+    /******************************************************************/
+    virtual void tearDown()
+    {
+        RTF_TEST_REPORT("Closing simulation clock");
+        delete m_simClock;
+        m_simClock = nullptr;
+
+        yarp::os::Network::fini();
+    }
+
+    /******************************************************************/
+    virtual void run()
+    {
+        for(int i=0; i < 10; i++)
+        {
+            if (m_simClock->isValid())
+            {
+                // If the clock is valid, exit from the for loop
+                break;
+            }
+            RTF_TEST_REPORT("NetworkClock still not valid.");
+            yarp::os::SystemClock::delaySystem(1.0);
+        }
+
+        RTF_TEST_FAIL_IF_FALSE(m_simClock->isValid(), "NetworkClock is not valid after 10 system seconds, test failing.");
+
+        // Explicitly connect the ports and try again
+        yarp::os::Network::connect(extClockName.c_str(), localPortName.c_str());
+        yarp::os::SystemClock::delaySystem(1.0);
+        RTF_TEST_FAIL_IF_FALSE(m_simClock->isValid(), "NetworkClock is not valid even after an explicit (non persistent) connection.");
+
+        if (m_simClock->isValid())
+        {
+            RTF_TEST_REPORT("NetworkClock is valid after explicit connection.");
+        }
+
+    }
+};
+
+PREPARE_PLUGIN(NetworkClockTest)

--- a/tests/rtf/NetworkClock/fixture-network-clock.xml
+++ b/tests/rtf/NetworkClock/fixture-network-clock.xml
@@ -1,0 +1,13 @@
+<application>
+    <name>fixture-network-clock</name>
+    <description>Fixture for publishing a NetworkClock on the /clock port.</description>
+    <version>1.0</version>
+    <authors>
+        <author email="silvio.traversaro@iit.it">Silvio Traversaro</author>
+    </authors>
+    <module>
+        <name>yarp</name>
+        <parameters>clock --name /clock</parameters>
+        <node>localhost</node>
+    </module>
+</application>


### PR DESCRIPTION
See  https://github.com/robotology/yarp/issues/1437 . 
Requires https://github.com/robotology/robot-testing/pull/88 .