### PR TITLE
Add extra check during the connect

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -14,6 +14,8 @@ Important Changes
 
 * Unification of code in `DGramTwoWayStream` for the allocation of write
   and read buffers (#899).
+* Added extra checks in the port names in `Network:metaConnect()`, with
+  dedicated error messages.
 
 #### `YARP_math`
 

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -592,6 +592,12 @@ public:
      */
     static bool getConnectionQos(const ConstString& src, const ConstString& dest,
                                  QosStyle& srcStyle, QosStyle& destStyle, bool quiet=true);
+    /**
+     * Checks that the port name doesn't contain invalid characters such as " "
+     * @param portName the name of port
+     * @return true if portName doesn't contain invalid characters
+     */
+    static bool isValidPortName(const ConstString& portName);
 };
 
 /**

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -593,9 +593,9 @@ public:
     static bool getConnectionQos(const ConstString& src, const ConstString& dest,
                                  QosStyle& srcStyle, QosStyle& destStyle, bool quiet=true);
     /**
-     * Checks that the port name doesn't contain invalid characters such as " "
+     * Checks that the port has a valid name.
      * @param portName the name of port
-     * @return true if portName doesn't contain invalid characters
+     * @return true if portName is valid
      */
     static bool isValidPortName(const ConstString& portName);
 };

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -871,6 +871,40 @@ bool NetworkBase::getConnectionQos(const ConstString& src, const ConstString& de
     return true;
 }
 
+bool NetworkBase::isValidPortName(const ConstString& portName)
+{
+    if (portName.empty())
+    {
+        fprintf(stderr, "Failure: invalid port name, the string is empty\n");
+        return false;
+    }
+
+    if (portName == "...")
+    {
+       return true;
+    }
+
+    if (portName.at(0) != '/')
+    {
+        fprintf(stderr, "Failure: invalid port name, missing starting '/' character in %s\n", portName.c_str());
+        return false;
+    }
+
+    if (portName.at(portName.size()-1) == '/')
+    {
+        fprintf(stderr, "Failure: invalid port name, ending '/' in %s not allowed\n", portName.c_str());
+        return false;
+    }
+
+    if (portName.find(" ") != std::string::npos)
+    {
+        fprintf(stderr, "Failure: invalid port name, the string %s contains spaces\n", portName.c_str());
+        return false;
+    }
+
+    return true;
+}
+
 
 bool NetworkBase::write(const Contact& contact,
                        PortWriter& cmd,

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -284,15 +284,20 @@ static int metaConnect(const ConstString& src,
                   dest.c_str(),
                   (mode==YARP_ENACT_CONNECT)?"connect":((mode==YARP_ENACT_DISCONNECT)?"disconnect":"check")
                   );
-    // check if source name and destination name contain spaces
-    if(dest.find(" ") != std::string::npos || src.find(" ") != std::string::npos)
-    {
-        fprintf(stderr, "Failure: no way to make connection %s->%s,\n", src.c_str(), dest.c_str());
-        return 1;
-    }
     // get the expressed contacts, without name server input
     Contact dynamicSrc = Contact::fromString(src);
     Contact dynamicDest = Contact::fromString(dest);
+
+    if(!NetworkBase::isValidPortName(dynamicSrc.getName()))
+    {
+        fprintf(stderr, "Failure: no way to make connection, invalid source '%s'\n", dynamicSrc.getName().c_str());
+        return 1;
+    }
+    if(!NetworkBase::isValidPortName(dynamicDest.getName()))
+    {
+        fprintf(stderr, "Failure: no way to make connection, invalid destination '%s'\n", dynamicDest.getName().c_str());
+        return 1;
+    }
 
     bool topical = style.persistent;
     if (dynamicSrc.getCarrier()=="topic" ||
@@ -875,7 +880,6 @@ bool NetworkBase::isValidPortName(const ConstString& portName)
 {
     if (portName.empty())
     {
-        fprintf(stderr, "Failure: invalid port name, the string is empty\n");
         return false;
     }
 
@@ -886,19 +890,16 @@ bool NetworkBase::isValidPortName(const ConstString& portName)
 
     if (portName.at(0) != '/')
     {
-        fprintf(stderr, "Failure: invalid port name, missing starting '/' character in %s\n", portName.c_str());
         return false;
     }
 
     if (portName.at(portName.size()-1) == '/')
     {
-        fprintf(stderr, "Failure: invalid port name, ending '/' in %s not allowed\n", portName.c_str());
         return false;
     }
 
     if (portName.find(" ") != std::string::npos)
     {
-        fprintf(stderr, "Failure: invalid port name, the string %s contains spaces\n", portName.c_str());
         return false;
     }
 

--- a/tests/libYARP_OS/NetworkTest.cpp
+++ b/tests/libYARP_OS/NetworkTest.cpp
@@ -105,6 +105,10 @@ public:
         checkFalse(Network::connect("/p1","/p3"),"bad connect, not existing destination");
         checkFalse(Network::connect("/p1","/p2 /p3"),"bad connect, invalid destination");
         checkFalse(Network::connect("/p1 /p2","/p2"),"bad connect, invalid source");
+        checkFalse(Network::connect("/p1/", "/p2"),"bad connect, source with ending '/'");
+        checkFalse(Network::connect("/p1", "/p2/"),"bad connect, destination with ending '/'");
+        checkFalse(Network::connect("p1", "/p2"),"bad connect, source without starting '/'");
+        checkFalse(Network::connect("/p1", "p2"),"bad connect, destination without starting '/'");
         p2.close();
         p1.close();
     }


### PR DESCRIPTION
This PR add  the static method `NetworkBase::isValidPortName(...)` that checks that the port name:
- starts with `'/'`.
- doesn't end with `'/'`.
- doesn't contains spaces.

- [x] Test on `iCubGenova01` 
It fixes #1421 .
Please review code.