### PR TITLE
Improve using of parameters in carriers

### DIFF
--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -129,9 +129,9 @@ static int noteDud(const Contact& src)
 
 //#define DEBUG_CONNECT_CARRIER
 #ifdef DEBUG_CONNECT_CARRIER
-# define CARRIER_DEBUG(fmt, args...)    fprintf(stderr, fmt, ## args)
+# define CARRIER_DEBUG(fmt, ...)    fprintf(stderr, fmt, ##__VA_ARGS__)
 #else
-# define CARRIER_DEBUG(fmt, args...)
+# define CARRIER_DEBUG(fmt, ...)
 #endif
 
 static int enactConnection(const Contact& src,


### PR DESCRIPTION
Currently, if source or destination port is not competent (ie it can't perform yarp handshaking), carrier's paramters given in connect command are lost.

Since could be usefull to specify some resize paramters for h264 carrier in connect command, I needed to change how the parameters are passed to the carrier.

now if user gives following commands:

```
yarp name register /srcPort MyCarrier+param1.value1 IP PORTNUM
yarp name register /dstPort MyCarrier+param2.value2 IP PORTNUM
yarp connect /srcPort /dstPort MyCarrier+param3.value3
```

The used carrier contains all three parameters: +param1.value1+param2.value2+param3.value3.

We decided that Network object does NOT any check on parameters: their verification will be done in the carrier. 