### PR TITLE
ServerGrabberDual: fix error while handling RPC calls for right image

### DIFF
--- a/doc/release/v2_3_70_2.md
+++ b/doc/release/v2_3_70_2.md
@@ -33,6 +33,10 @@ Bug Fixes
 * Fixed append to wrong string in `BufferedConnectionWriter.h`.
 * Fixed `yarp::os::ConstString::getline` for MSVC (#1357).
 
+#### YARP_dev
+
+* Fixed RPC calls when connecting to right image port (split mode on)
+
 ### Tools
 
 * Added the fallback port in `yarpserver` also if `yarp`

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -206,6 +206,7 @@ yarp::dev::impl::ServerGrabberResponder::ServerGrabberResponder(bool _left) :
 {}
 
 yarp::dev::impl::ServerGrabberResponder::~ServerGrabberResponder(){}
+
 bool yarp::dev::impl::ServerGrabberResponder::configure(yarp::dev::ServerGrabber* _server)
 {
     if(_server)
@@ -217,7 +218,10 @@ bool yarp::dev::impl::ServerGrabberResponder::configure(yarp::dev::ServerGrabber
     return false;
 }
 bool yarp::dev::impl::ServerGrabberResponder::respond(const os::Bottle &command, os::Bottle &reply){
-    return server->respond(command,reply,left,false);
+    if(server)
+        return server->respond(command,reply,left,false);
+    else
+        return false;
 }
 
 // **********ServerGrabber**********
@@ -258,7 +262,6 @@ ServerGrabber::ServerGrabber():RateThread(DEFAULT_THREAD_PERIOD), period(DEFAULT
     isSubdeviceOwned=false;
     count = 0;
     count2 = 0;
-
 }
 
 ServerGrabber::~ServerGrabber()
@@ -278,15 +281,19 @@ bool ServerGrabber::close() {
     pImg.close();
     rpcPort.interrupt();
     rpcPort.close();
+
     if(responder){
         delete responder;
         responder=YARP_NULLPTR;
     }
-    if(param.twoCameras && param.split)
+
+    if(param.split)
     {
         pImg2.interrupt();
         pImg2.close();
     }
+
+
     if(param.twoCameras)
     {
         rpcPort2.interrupt();
@@ -300,19 +307,18 @@ bool ServerGrabber::close() {
         delete poly;
         poly=YARP_NULLPTR;
     }
-    if(param.twoCameras)
+
+    if(responder2)
     {
-        if(responder2)
-        {
-            delete responder2;
-            responder=YARP_NULLPTR;
-        }
-        if(isSubdeviceOwned && poly2)
-        {
-            poly2->close();
-            delete poly2;
-            poly2=YARP_NULLPTR;
-        }
+        delete responder2;
+        responder=YARP_NULLPTR;
+    }
+
+    if(isSubdeviceOwned && poly2)
+    {
+        poly2->close();
+        delete poly2;
+        poly2=YARP_NULLPTR;
     }
     isSubdeviceOwned=false;
     if (p2!=YARP_NULLPTR) {
@@ -437,6 +443,7 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
         responder2 = new yarp::dev::impl::ServerGrabberResponder(false);
         if(!responder2->configure(this))
             return false;
+
         rpcPort_Name  = rootName + "/left/rpc";
         rpcPort2_Name  = rootName + "/right/rpc";
         if(param.split)
@@ -460,8 +467,11 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
     }
     else
     {
-        if(param.splitterMode)
+        if(param.split)
         {
+            responder2 = new yarp::dev::impl::ServerGrabberResponder(false);
+            if(!responder2->configure(this))
+                return false;
             pImg_Name = rootName + "/left";
             pImg2_Name = rootName + "/right";
         }
@@ -494,11 +504,10 @@ bool ServerGrabber::initialize_YARP(yarp::os::Searchable &params)
         yError() << "ServerGrabber: unable to open rpc Port" << rpcPort_Name.c_str();
         bRet = false;
     }
-
     rpcPort.setReader(*responder);
+
     pImg.promiseType(Type::byName("yarp/image"));
     pImg.setWriteOnly();
-
     if(!pImg.open(pImg_Name.c_str()))
     {
         yError() << "ServerGrabber: unable to open image streaming Port" << pImg_Name.c_str();
@@ -515,17 +524,17 @@ bool ServerGrabber::initialize_YARP(yarp::os::Searchable &params)
         }
         rpcPort2.setReader(*responder2);
     }
-    if((param.twoCameras && param.split) || param.splitterMode)
+    if(param.split)
     {
         pImg2.promiseType(Type::byName("yarp/image"));
         pImg2.setWriteOnly();
+
         if(!pImg2.open(pImg2_Name.c_str()))
         {
             yError() << "ServerGrabber: unable to open image streaming Port" << pImg2_Name.c_str();
             bRet = false;
         }
-        if(!param.splitterMode)
-            pImg2.setReader(*responder2);
+        pImg2.setReader(*responder2);
     }
 
     return bRet;


### PR DESCRIPTION
RPC were not working when connectiong to the right image port, in case split is set to true.