### PR TITLE
Fixed issue #1404 about 'yarp server --read command'

### DIFF
--- a/src/libYARP_name/src/BootstrapServer.cpp
+++ b/src/libYARP_name/src/BootstrapServer.cpp
@@ -158,6 +158,14 @@ bool BootstrapServer::configFileBootstrap(yarp::os::Contact& contact,
             }
         }
     }
+    else
+    {
+        if (!conf.isLocalName(conf.getHostName())) {
+            fprintf(stderr,"The address written in config file doesn't belong any interface \n");
+            return false;
+        }
+        suggest.setHost(conf.getHostName());
+    }
 
     bool changed = false;
     if (prev.isValid()) {
@@ -174,7 +182,10 @@ bool BootstrapServer::configFileBootstrap(yarp::os::Contact& contact,
         fprintf(stderr,"  Desired settings:  host %s port %d family %s\n",
                 suggest.getHost().c_str(), suggest.getPort(), "yarp");
         fprintf(stderr,"Please specify '--write' if it is ok to overwrite current settings, or\n");
-        fprintf(stderr,"Please specify '--read' to use the current settings, or\n");
+        if(!configFileRequired)
+            fprintf(stderr,"Please specify '--read' to use the current settings, or\n");
+        else
+            fprintf(stderr,"Please set an existing address in config file, or\n");
         fprintf(stderr,"delete %s\n", conf.getConfigFileName().c_str());
         return false;
     }


### PR DESCRIPTION
If in config file there was a nonexistent IP address then the server started anyway.
Fixes #1404.

This patch should fix this problem: the application warns the user that it cannot start because the IP written in configuration file doesn't exist.