### PR TITLE
Remove persistency to network clock connection

### DIFF
--- a/src/libYARP_OS/src/NetworkClock.cpp
+++ b/src/libYARP_OS/src/NetworkClock.cpp
@@ -56,9 +56,8 @@ NetworkClock::~NetworkClock() {
     }
 
     listMutex.unlock();
-    yarp::os::ContactStyle style;
-    style.persistent = true;
-    NetworkBase::disconnect(clockName, port.getName(), style);
+    /* Persistent connections some times don't work, so use plain connection */
+    NetworkBase::disconnect(clockName, port.getName());
 }
 
 
@@ -68,9 +67,8 @@ bool NetworkClock::open(const ConstString& clockSourcePortName, ConstString loca
     port.setReader(*this);
     NestedContact nc(clockSourcePortName);
     clockName = clockSourcePortName;
-    yarp::os::ContactStyle style;
-    style.persistent = true;
 
+    /* Persistent connections some times don't work, so use plain connection*/
     if(localPortName == "")
     {
         const int MAX_STRING_SIZE = 255;
@@ -96,9 +94,7 @@ bool NetworkClock::open(const ConstString& clockSourcePortName, ConstString loca
     if (nc.getNestedName()=="")
     {
         Contact src = NetworkBase::queryName(clockSourcePortName);
-
-
-        ret = NetworkBase::connect(clockSourcePortName, port.getName(), style);
+        ret = NetworkBase::connect(clockSourcePortName, port.getName());
 
         if(!src.isValid())
             fprintf(stderr,"Cannot find time port \"%s\"; for a time topic specify \"%s@\"\n", clockSourcePortName.c_str(), clockSourcePortName.c_str());


### PR DESCRIPTION
As requested in #1437, the network clock does not use persistent connection anymore.
It has been reported they do not correctly connect from time to time, so a plain connection is used instead.