### PR TITLE
Coverity fixes - initializations_1

### DIFF
--- a/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegDecompression.cpp
@@ -12,6 +12,7 @@
 
 #include <csetjmp>
 #include <cstdio>
+#include <cstring>
 
 #if defined(_WIN32)
 #define INT32 long  // jpeg's definition
@@ -123,7 +124,10 @@ public:
     MjpegDecompressionHelper() :
             active(false),
             readEnvelopeCallback(NULL),
-            readEnvelopeCallbackData(NULL) {
+            readEnvelopeCallbackData(NULL)
+    {
+        memset(&cinfo, 0, sizeof(jpeg_decompress_struct));
+        memset(&jerr, 0, sizeof(net_error_mgr));
     }
 
     bool setReadEnvelopeCallback(yarp::os::InputStream::readEnvelopeCallbackType callback,

--- a/src/carriers/mjpeg_carrier/MjpegStream.h
+++ b/src/carriers/mjpeg_carrier/MjpegStream.h
@@ -52,6 +52,7 @@ private:
 public:
     MjpegStream(TwoWayStream *delegate, bool sender, bool autocompress) :
             delegate(delegate),
+            blobHeader(BlobNetworkHeader{0,0,0}),
             phase(0),
             cursor(NULL),
             remaining(0),
@@ -59,8 +60,8 @@ public:
             firstRound(true),
             autocompress(autocompress),
             readEnvelopeCallback(NULL),
-            readEnvelopeCallbackData(NULL) {
-    }
+            readEnvelopeCallbackData(NULL)
+    {}
 
     virtual ~MjpegStream() {
         if (delegate!=NULL) {

--- a/src/devices/ffmpeg/FfmpegWriter.h
+++ b/src/devices/ffmpeg/FfmpegWriter.h
@@ -43,9 +43,22 @@ class yarp::dev::FfmpegWriter : public IFrameWriterImage,
 {
 public:
 
-    FfmpegWriter() {
+    FfmpegWriter() :
+        fmt(YARP_NULLPTR),
+        oc(YARP_NULLPTR),
+        audio_st(YARP_NULLPTR),
+        video_st(YARP_NULLPTR),
+        audio_pts(0.0),
+        video_pts(0.0),
+        picture(YARP_NULLPTR),
+        tmp_picture(YARP_NULLPTR),
+        video_outbuf(YARP_NULLPTR),
+        frame_count(0),
+        video_outbuf_size(0),
+        ready(false),
+        delayed(false)
+    {
         system_resource = NULL;
-        ready = false;
     }
 
     virtual bool open(yarp::os::Searchable & config) override;

--- a/src/devices/openni2/OpenNI2DeviceDriverServer.cpp
+++ b/src/devices/openni2/OpenNI2DeviceDriverServer.cpp
@@ -8,14 +8,27 @@
 #include "OpenNI2SkeletonTracker.h"
 #include "OpenNI2DeviceDriverServer.h"
 
-yarp::dev::OpenNI2DeviceDriverServer::OpenNI2DeviceDriverServer()
-{
+yarp::dev::OpenNI2DeviceDriverServer::OpenNI2DeviceDriverServer() :
+    skeletonPort(YARP_NULLPTR),
+    receivingPort(YARP_NULLPTR),
+    depthFramePort(YARP_NULLPTR),
+    imageFramePort(YARP_NULLPTR),
+    skeleton(YARP_NULLPTR),
+    withOpenPorts(false),
 #ifdef OPENNI2_DRIVER_USES_NITE2
-    userTracking = true;
+    userTracking(true),
 #else
-    userTracking = false;
+    userTracking(false),
 #endif
-}
+    colorON(false),
+    depthMirrorON(false),
+    rgbMirrorON(false),
+    oniPlayback(false),
+    oniRecord(false),
+    loop(false),
+    frameSync(false),
+    imageRegistration(false)
+{}
 
 yarp::dev::OpenNI2DeviceDriverServer::~OpenNI2DeviceDriverServer()
 {

--- a/src/devices/openni2/OpenNI2SkeletonTracker.cpp
+++ b/src/devices/openni2/OpenNI2SkeletonTracker.cpp
@@ -27,7 +27,9 @@ OpenNI2SkeletonTracker::OpenNI2SkeletonTracker(bool withTracking, bool withColor
     depthVideoMode(DEFAULT_DEPTH_MODE),
     colorVideoMode(DEFAULT_COLOR_MODE),
     pDevice(YARP_NULLPTR),
-    playbackControl(YARP_NULLPTR)
+    playbackControl(YARP_NULLPTR),
+    depthInfo(YARP_NULLPTR),
+    colorInfo(YARP_NULLPTR)
 {
     if (colorMode <= 11 && colorMode >= 0){
     colorVideoMode=colorMode;

--- a/src/devices/portaudio/PortAudioDeviceDriver.cpp
+++ b/src/devices/portaudio/PortAudioDeviceDriver.cpp
@@ -9,7 +9,9 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <portaudio.h>
+
 
 #include <yarp/os/Time.h>
 
@@ -121,18 +123,22 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
     return paAbort;
 }
 
-PortAudioDeviceDriver::PortAudioDeviceDriver()
+PortAudioDeviceDriver::PortAudioDeviceDriver() :
+    stream(0),
+    err(paNoError),
+    i(0),
+    numSamples(0),
+    numBytes(0),
+    system_resource(NULL),
+    numChannels(0),
+    frequency(0),
+    loopBack(false),
+    renderMode(RENDER_APPEND)
 {
-    system_resource = NULL;
-    numSamples = 0;
-    numChannels = 0;
-    loopBack = false;
-    frequency = 0;
-    err = paNoError;
-    dataBuffers.playData = 0;
-    dataBuffers.recData = 0;
-    renderMode = RENDER_APPEND;
-    stream = 0;
+    memset(&inputParameters, 0, sizeof(PaStreamParameters));
+    memset(&outputParameters, 0, sizeof(PaStreamParameters));
+    memset(&dataBuffers, 0, sizeof(circularDataBuffers));
+    memset(&driverConfig, 0, sizeof(PortAudioDeviceDriverSettings));
 }
 
 PortAudioDeviceDriver::~PortAudioDeviceDriver()

--- a/src/devices/rpLidar2/rpLidar2.h
+++ b/src/devices/rpLidar2/rpLidar2.h
@@ -61,9 +61,22 @@ protected:
     rplidardrv*           m_drv;
 
 public:
-    RpLidar2(int period = 10) : RateThread(period)
-    {
-    }
+    RpLidar2(int period = 10) : RateThread(period),
+        m_sensorsNum(0),
+        m_buffer_life(0),
+        m_min_angle(0.0),
+        m_max_angle(0.0),
+        m_min_distance(0.0),
+        m_max_distance(0.0),
+        m_resolution(0.0),
+        m_clip_max_enable(false),
+        m_clip_min_enable(false),
+        m_do_not_clip_infinity_enable(false),
+        m_inExpressMode(false),
+        m_pwm_val(0),
+        m_device_status(DEVICE_OK_STANBY),
+        m_drv(YARP_NULLPTR)
+    {}
 
 
     ~RpLidar2()


### PR DESCRIPTION
Fixes some 'uninitialized pointer or scalar field' issues raised by Coverity.
Affect components
 - carriers
 - devices