### PR TITLE
Coverity fixes - initializations_2

### DIFF
--- a/src/libYARP_OS/src/AuthHMAC.cpp
+++ b/src/libYARP_OS/src/AuthHMAC.cpp
@@ -41,7 +41,7 @@ AuthHMAC::AuthHMAC() :
         // return as soon as possible
         return;
     }
-
+    memset(&context, 0, sizeof(HMAC_CONTEXT));
     ConstString key;
     ResourceFinder& rf = NameClient::getNameClient().getResourceFinder();
     ConstString fname;

--- a/src/libYARP_OS/src/SharedLibraryFactory.cpp
+++ b/src/libYARP_OS/src/SharedLibraryFactory.cpp
@@ -13,6 +13,7 @@ yarp::os::SharedLibraryFactory::SharedLibraryFactory() :
         returnValue(0),
         rct(1)
 {
+    memset(&api, 0, sizeof(SharedLibraryClassApi));
 }
 
 yarp::os::SharedLibraryFactory::SharedLibraryFactory(const char *dll_name,

--- a/src/libYARP_OS/src/SystemInfoSerializer.cpp
+++ b/src/libYARP_OS/src/SystemInfoSerializer.cpp
@@ -12,9 +12,11 @@ using namespace yarp::os;
 /**
  * Class SystemInfoSerializer
  */
-SystemInfoSerializer::SystemInfoSerializer() {
-
-}
+SystemInfoSerializer::SystemInfoSerializer() :
+    memory(SystemInfo::MemoryInfo{0,0}),
+    storage(SystemInfo::StorageInfo{0,0}),
+    load(SystemInfo::LoadInfo{.0,.0,.0,0})
+{}
 
 SystemInfoSerializer::~SystemInfoSerializer() {
 

--- a/src/libYARP_dev/include/yarp/dev/RemoteFrameGrabber.h
+++ b/src/libYARP_dev/include/yarp/dev/RemoteFrameGrabber.h
@@ -590,10 +590,12 @@ public:
     /**
      * Constructor.
      */
-    RemoteFrameGrabber() : FrameGrabberControls2_Sender(port), Implement_RgbVisualParams_Sender(port), mutex(1) {
-        lastHeight = 0;
-        lastWidth = 0;
-    }
+    RemoteFrameGrabber() : FrameGrabberControls2_Sender(port), Implement_RgbVisualParams_Sender(port),
+        mutex(1),
+        lastHeight(0),
+        lastWidth(0),
+        Ifirewire(YARP_NULLPTR)
+    {}
 
     virtual bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) YARP_OVERRIDE {
         mutex.wait();

--- a/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
+++ b/src/libYARP_dev/src/devices/FrameTransformClient/FrameTransformClient.cpp
@@ -845,10 +845,10 @@ bool yarp::dev::FrameTransformClient::waitForTransform(const std::string &target
     return true;
 }
 
-FrameTransformClient::FrameTransformClient() : RateThread(10)
-{
-    m_transform_storage = 0;
-}
+FrameTransformClient::FrameTransformClient() : RateThread(10),
+    m_transform_storage(0),
+    m_period(0)
+{}
 
 FrameTransformClient::~FrameTransformClient()
 {

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
@@ -23,12 +23,16 @@ struct yarp::dev::JoypadControl::LoopablePort
     bool                  valid;
     unsigned int          count;
     yarp::os::ConstString name;
+    yarp::os::Contactable* contactable;
+
     virtual ~LoopablePort(){}
-    LoopablePort():valid(false),count(0){}
+
+    LoopablePort() : valid(false),
+                     count(0),
+                     contactable(YARP_NULLPTR)
+    {}
 
     virtual void useCallback() = 0;
-
-    yarp::os::Contactable* contactable;
 };
 
 template <typename T>

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -968,12 +968,14 @@ public:
     /**
      * Constructor.
      */
-    RemoteControlBoard() {
-        nj = 0;
-        njIsKnown = false;
-        writeStrict_singleJoint = true;
-        writeStrict_moreJoints  = false;
-    }
+    RemoteControlBoard() :
+        diagnosticThread(YARP_NULLPTR),
+        writeStrict_singleJoint(true),
+        writeStrict_moreJoints (false),
+        nj(0),
+        njIsKnown(false),
+        protocolVersion(ProtocolVersion{0,0,0})
+    {}
 
     /**
      * Destructor.


### PR DESCRIPTION
Fixes some 'uninitialized pointer or scalar field' issues raised by Coverity.
Affect components
 - libYARP_OS
 - libYARP_dev