### PR TITLE
"--help" parameter opens actual device

### DIFF
--- a/src/libYARP_dev/src/PolyDriver.cpp
+++ b/src/libYARP_dev/src/PolyDriver.cpp
@@ -239,7 +239,7 @@ bool PolyDriver::coreOpen(yarp::os::Searchable& prop) {
                 p.fromString(config->toString());
                 p.unput("wrapped");
                 config = &p;
-                if (wrapCreator!=creator) {
+                if (wrapCreator!=creator && !p.check("help")) {
                     p.put("subdevice",str.c_str());
                     p.put("device",wrapper.c_str());
                     p.setMonitor(prop.getMonitor(),


### PR DESCRIPTION
at the moment when a device have a wrapper associated it's impossible to simply see the common help output (the parameter is parsed by the wrapper). this pr fixes this by opening the actual device without automatically wrapping it if the keyword "--help" is provided.

note that if the device doesn't take care of the "help" parameter it will start normally, so this could also be used as a (unwanted) workaround to bypass the wrapping system of yarpdev.