### PR TITLE
Timer

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -90,6 +90,8 @@ New Features
 
 * yarp::os::Mutex and yarp::os::RecursiveMutex now implement the
   [C++11 Mutex concept](http://en.cppreference.com/w/cpp/concept/Mutex)
+* Added a Timer class to execute a static or member function in a separate
+  thread after a period x, every y milliseconds, for z times or w seconds.
 
 
 ### Tools

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -113,6 +113,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Things.h
                  include/yarp/os/Thread.h
                  include/yarp/os/Time.h
+                 include/yarp/os/Timer.h
                  include/yarp/os/TwoWayStream.h
                  include/yarp/os/Type.h
                  include/yarp/os/TypedReader.h
@@ -313,6 +314,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/Thread.cpp
                  src/ThreadImpl.cpp
                  src/Time.cpp
+                 src/Timer.cpp
                  src/TwoWayStream.cpp
                  src/Type.cpp
                  src/UdpCarrier.cpp

--- a/src/libYARP_OS/include/yarp/os/Timer.h
+++ b/src/libYARP_OS/include/yarp/os/Timer.h
@@ -1,0 +1,131 @@
+/*
+* Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+* All rights reserved.
+*
+* This software may be modified and distributed under the terms of the
+* BSD-3-Clause license. See the accompanying LICENSE file for details.
+*/
+
+#include <yarp/os/RateThread.h>
+#include <yarp/os/Mutex.h>
+#include <functional>
+#include <chrono>
+
+namespace yarp {
+    namespace os {
+        class Timer;
+        struct YarpTimerEvent;
+        struct TimerSettings;
+    }
+}
+
+struct yarp::os::YarpTimerEvent
+{   
+    /**
+     * @brief lastExpected when the last callback actually happened
+     */
+    double lastExpected;
+
+    /**
+     * @brief lastReal when the last callback actually happened
+     */
+    double lastReal;
+
+    /**
+     * @brief currentExpected this is when the current callback should have been called
+     */
+    double currentExpected;
+
+    /**
+     * @brief currentReal When the current callback is actually being called
+     */
+    double currentReal;
+
+    /**
+     * @brief lastDuration Contains the duration of the last callback
+     */
+    double lastDuration;
+
+    /**
+     * @brief runCount the count of calls
+     */
+    unsigned int runCount;
+};
+
+struct yarp::os::TimerSettings
+{
+    TimerSettings(std::chrono::milliseconds inRate) : rate(inRate), totalTime(0.0), totalRunCount(0), tollerance(0.001){}
+    TimerSettings(std::chrono::milliseconds inRate, size_t count, double seconds) : rate(inRate), totalTime(seconds), totalRunCount(count), tollerance(0.001){}
+    TimerSettings(std::chrono::milliseconds inRate, size_t count, double seconds, double inTollerance)
+        : rate(inRate),
+          totalTime(seconds),
+          totalRunCount(count),
+          tollerance(inTollerance){}
+
+    std::chrono::milliseconds rate;
+    double                    totalTime;
+    size_t                    totalRunCount;
+    double                    tollerance;
+};
+
+class YARP_OS_API yarp::os::Timer : public yarp::os::RateThread {
+    typedef std::function<bool(const yarp::os::YarpTimerEvent&)> TimerCallback;
+    class Private;
+
+    Private* impl;
+
+public:
+
+    /**
+     * @brief Timer constructor
+     * @param rate the call frequency, in milliseconds
+     * @param callback the pointer to the function to call
+     * @param mutex if not nullptr will be locked before calling callback and released just after
+     * @param type sets the timer type, if ONE_SHOT will be called only once. PERIODIC will run periodically
+     */
+    Timer(const yarp::os::TimerSettings& settings, TimerCallback callback, yarp::os::Mutex* mutex = nullptr);
+
+    /**
+     * @brief Timer constructor
+     * @param rate the call frequency, in milliseconds
+     * @param callback the pointer to the member method to call
+     * @param object the pointer to the object
+     * @param mutex if not nullptr will be locked before calling callback and released just after
+     * @param oneshot if true there will be only one call
+     */
+    template<class T>
+    Timer(const  yarp::os::TimerSettings& settings,
+          bool(T::*callback)(const yarp::os::YarpTimerEvent&),
+          T* object,
+          yarp::os::Mutex* mutex = nullptr) :
+        Timer(settings, std::bind(callback, object, std::placeholders::_1), mutex) {}
+
+    /**
+     * const version.
+     */
+    template<class T>
+    Timer(const  yarp::os::TimerSettings& settings,
+          bool(T::*callback)(const yarp::os::YarpTimerEvent&) const,
+          const T* object,
+          yarp::os::Mutex* mutex = nullptr) :
+        Timer(settings, std::bind(callback, object, std::placeholders::_1), mutex) {}
+
+    virtual ~Timer();
+
+    /**
+     * @brief setSettings
+     * @param settings the new settings
+     */
+    void setSettings(const yarp::os::TimerSettings& settings);
+
+    /**
+     * @brief getSettings
+     * @return the current settings
+     */
+    const yarp::os::TimerSettings getSettings();
+
+protected:
+    virtual void beforeStart() override;
+    virtual void run() override;
+};
+

--- a/src/libYARP_OS/include/yarp/os/Timer.h
+++ b/src/libYARP_OS/include/yarp/os/Timer.h
@@ -6,10 +6,9 @@
 * BSD-3-Clause license. See the accompanying LICENSE file for details.
 */
 
-#include <yarp/os/RateThread.h>
 #include <yarp/os/Mutex.h>
-#include <functional>
 #include <chrono>
+#include <functional>
 
 namespace yarp {
     namespace os {
@@ -20,7 +19,7 @@ namespace yarp {
 }
 
 struct yarp::os::YarpTimerEvent
-{   
+{
     /**
      * @brief lastExpected when the last callback actually happened
      */
@@ -32,7 +31,8 @@ struct yarp::os::YarpTimerEvent
     double lastReal;
 
     /**
-     * @brief currentExpected this is when the current callback should have been called
+     * @brief currentExpected this is when the current callback should have been
+     *        called
      */
     double currentExpected;
 
@@ -54,61 +54,107 @@ struct yarp::os::YarpTimerEvent
 
 struct yarp::os::TimerSettings
 {
-    TimerSettings(std::chrono::milliseconds inRate) : rate(inRate), totalTime(0.0), totalRunCount(0), tollerance(0.001){}
-    TimerSettings(std::chrono::milliseconds inRate, size_t count, double seconds) : rate(inRate), totalTime(seconds), totalRunCount(count), tollerance(0.001){}
-    TimerSettings(std::chrono::milliseconds inRate, size_t count, double seconds, double inTollerance)
-        : rate(inRate),
-          totalTime(seconds),
-          totalRunCount(count),
-          tollerance(inTollerance){}
+    TimerSettings(double inRate) :
+            rate(inRate),
+            totalTime(0.0),
+            totalRunCount(0),
+            tolerance(0.001)
+    {
+    }
+    TimerSettings(double inRate, size_t count, double seconds) :
+            rate(inRate),
+            totalTime(seconds),
+            totalRunCount(count),
+            tolerance(0.001)
+    {
+    }
+    TimerSettings(double inRate, size_t count, double seconds, double inTollerance) :
+            rate(inRate),
+            totalTime(seconds),
+            totalRunCount(count),
+            tolerance(inTollerance)
+    {
+    }
 
-    std::chrono::milliseconds rate;
-    double                    totalTime;
-    size_t                    totalRunCount;
-    double                    tollerance;
+    bool operator==(const TimerSettings& rhs) const
+    {
+        return rate == rhs.rate && totalTime == rhs.totalTime && totalRunCount == rhs.totalRunCount && tolerance == rhs.tolerance;
+    }
+
+
+    /**
+    * @param rate the rate of the timer in seconds
+    * @param totalTime the life of the timer in seconds. 0 == infinite.
+    *        The lower between totalTime and totalRunCount*rate + execution
+    *        delay will stop the timer
+    * @param totalRunCount the total count of execution. 0 == infinite.
+    *        The lower between totalTime and totalRunCount*rate + execution
+    *        delay will stop the timer
+    * @param tolerance the tolerance while checking the timer life
+    */
+    double rate;
+    double totalTime;
+    size_t totalRunCount;
+    double tolerance;
 };
 
-class YARP_OS_API yarp::os::Timer : public yarp::os::RateThread {
-    typedef std::function<bool(const yarp::os::YarpTimerEvent&)> TimerCallback;
-    class Private;
-
-    Private* impl;
-
+class YARP_OS_API yarp::os::Timer
+{
 public:
-
+    typedef std::function<bool(const yarp::os::YarpTimerEvent&)> TimerCallback;
+    Timer(const Timer&) = delete;
+    Timer operator=(const Timer&) = delete;
     /**
      * @brief Timer constructor
-     * @param rate the call frequency, in milliseconds
-     * @param callback the pointer to the function to call
-     * @param mutex if not nullptr will be locked before calling callback and released just after
-     * @param type sets the timer type, if ONE_SHOT will be called only once. PERIODIC will run periodically
+     * @param settings the timer settings. see TimerSettings documentation
+     * @param callback the pointer to the function to call. the signature should
+     *        be "bool foo(const yarp::os::YarpTimerEvent&)" and if it return
+     *        false the timer will stop
+     * @param mutex if not nullptr will be locked before calling callback and
+     *        released just after
+     * @param type sets the timer type, if ONE_SHOT will be called only once.
+     *        PERIODIC will run periodically
+     * @param newThread whether the timer should be executed in a his own thread
+     *        or with all the timers with newThread == false (in any case they
+     *        will not run in the main thread)
      */
-    Timer(const yarp::os::TimerSettings& settings, TimerCallback callback, yarp::os::Mutex* mutex = nullptr);
+    Timer(const yarp::os::TimerSettings& settings, TimerCallback callback, bool newThread, yarp::os::Mutex* mutex = nullptr);
 
     /**
      * @brief Timer constructor
-     * @param rate the call frequency, in milliseconds
+     * @param settings the timer settings. see TimerSettings documentation
      * @param callback the pointer to the member method to call
      * @param object the pointer to the object
-     * @param mutex if not nullptr will be locked before calling callback and released just after
-     * @param oneshot if true there will be only one call
+     * @param mutex if not nullptr will be locked before calling callback and
+     *        released just after
+     * @param newThread whether the timer should be executed in a his own thread
+     *        or with all the timers with newThread == false (in any case they
+     *        will not run in the main thread)
      */
-    template<class T>
-    Timer(const  yarp::os::TimerSettings& settings,
-          bool(T::*callback)(const yarp::os::YarpTimerEvent&),
+    template <class T>
+    Timer(const yarp::os::TimerSettings& settings,
+          bool (T::*callback)(const yarp::os::YarpTimerEvent&),
           T* object,
+          bool newThread,
           yarp::os::Mutex* mutex = nullptr) :
-        Timer(settings, std::bind(callback, object, std::placeholders::_1), mutex) {}
+
+            Timer(settings, std::bind(callback, object, std::placeholders::_1), newThread, mutex)
+    {
+    }
 
     /**
      * const version.
      */
-    template<class T>
-    Timer(const  yarp::os::TimerSettings& settings,
-          bool(T::*callback)(const yarp::os::YarpTimerEvent&) const,
+    template <class T>
+    Timer(const yarp::os::TimerSettings& settings,
+          bool (T::*callback)(const yarp::os::YarpTimerEvent&) const,
           const T* object,
+          bool newThread,
           yarp::os::Mutex* mutex = nullptr) :
-        Timer(settings, std::bind(callback, object, std::placeholders::_1), mutex) {}
+
+            Timer(settings, std::bind(callback, object, std::placeholders::_1), newThread, mutex)
+    {
+    }
 
     virtual ~Timer();
 
@@ -124,8 +170,17 @@ public:
      */
     const yarp::os::TimerSettings getSettings();
 
-protected:
-    virtual void beforeStart() override;
-    virtual void run() override;
-};
+    virtual bool start();
 
+    virtual bool step();
+
+    virtual void stop();
+
+    virtual bool isRunning();
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    class PrivateImpl;
+private:
+    PrivateImpl* impl;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+};

--- a/src/libYARP_OS/src/Timer.cpp
+++ b/src/libYARP_OS/src/Timer.cpp
@@ -7,58 +7,302 @@
 */
 
 #include <yarp/os/Timer.h>
+#include <yarp/os/RateThread.h>
 #include <yarp/os/Time.h>
 #include <cmath>
+#include <map>
+#include <mutex>
+
 using namespace yarp::os;
-class Timer::Private
+
+//disclaimer: the following inheritance little madness is for avoiding critical copy and paste code and
+//avoiding data inconsistence(example: RateThread::GetIterations() and runTimes)
+
+class yarp::os::Timer::PrivateImpl
 {
-    typedef yarp::os::Timer::TimerCallback TimerCallback;
+protected:
+    yarp::os::YarpTimerEvent getEventNow(unsigned int iteration);
+
+    bool runTimer(unsigned int iteration, YarpTimerEvent event);
+
 public:
-    Private(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) : m_settings(sett), m_callback(call), m_mutex(mutex){}
+    typedef yarp::os::Timer::TimerCallback TimerCallback;
+
+    PrivateImpl(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) :
+            m_settings(sett),
+            m_callback(call),
+            m_mutex(mutex)
+    {
+    }
+
+    virtual ~PrivateImpl()
+    {
+    }
+
+    virtual bool startTimer() = 0;
+
+    virtual void stopTimer() = 0;
+
+    virtual bool stepTimer() = 0;
+
+    virtual bool timerIsRunning() = 0;
+
+
+    TimerSettings    m_settings;
     TimerCallback    m_callback{nullptr};
     double           m_startStamp{0.0},
                      m_lastReal{0.0};
-    unsigned int     m_runCount{0};
     yarp::os::Mutex* m_mutex;
-    TimerSettings    m_settings;
 };
 
-Timer::Timer(const TimerSettings& settings, TimerCallback callback, Mutex* mutex) :
-    RateThread(settings.rate.count()),
-    impl(new Private(settings, callback, mutex)){}
-
-void Timer::beforeStart()
+class MonoThreadTimer : public yarp::os::Timer::PrivateImpl
 {
-    impl->m_startStamp = yarp::os::Time::now();
-}
+public:
+    MonoThreadTimer(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr);
+    ~MonoThreadTimer();
+    bool         m_active{ false };
+    unsigned int m_runTimes{1};
+    int          m_id{-1};
 
-void Timer::run()
-{
-    if(getIterations() == 0)
+    virtual yarp::os::YarpTimerEvent getEventNow()
     {
-        yarp::os::Time::delay(getRate() * 0.001);
+        return PrivateImpl::getEventNow(m_runTimes);
     }
 
+    virtual bool startTimer() override
+    {
+        m_startStamp = yarp::os::Time::now();
+        m_active     = true;
+        return true;
+    }
+
+    virtual void stopTimer() override
+    {
+        m_active = false;
+    }
+
+    virtual bool stepTimer() override
+    {
+        return step(getEventNow(), true);
+    }
+
+    virtual bool step(YarpTimerEvent event, bool singleStep)
+    {
+        bool m_active = runTimer(m_runTimes, event);
+        if (!singleStep) {
+            m_runTimes++;
+        }
+        return m_active;
+    }
+
+    virtual bool timerIsRunning() override
+    {
+        return m_active;
+    }
+};
+
+class TimerSingleton : public yarp::os::RateThread
+{
+    std::mutex mu;
+    std::map<int, MonoThreadTimer*> timers;
+    TimerSingleton() :
+            RateThread(0)
+    {
+    }
+
+    virtual void run() override;
+
+    virtual ~TimerSingleton()
+    {
+        stop();
+    }
+
+public:
+    //reminder: int c++11 static variables'inside function are guaranteed to be lazy initialized and atomic
+    static TimerSingleton& self()
+    {
+        static TimerSingleton instance;
+        return instance;
+    }
+
+    int addTimer(MonoThreadTimer* t)
+    {
+        mu.lock();
+        timers[timers.size()] = t;
+        mu.unlock();
+        return timers.size() - 1;
+    }
+
+    void removeTimer(int id)
+    {
+        mu.lock();
+        timers.erase(id);
+        mu.unlock();
+    }
+
+    unsigned int getTimerCount()
+    {
+        return timers.size();
+    }
+};
+
+MonoThreadTimer::MonoThreadTimer(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex) :
+        PrivateImpl(sett, call, mutex)
+{
+    TimerSingleton& singlInstance = TimerSingleton::self();
+    m_id = singlInstance.addTimer(this);
+    if (!singlInstance.isRunning()) {
+        singlInstance.start();
+    }
+}
+
+MonoThreadTimer::~MonoThreadTimer()
+{
+    TimerSingleton& singlInstance = TimerSingleton::self();
+    singlInstance.removeTimer(m_id);
+    if (!singlInstance.getTimerCount()) {
+        singlInstance.stop();
+    }
+}
+
+void TimerSingleton::run()
+{
+    mu.lock();
+    for (auto t : timers) {
+        MonoThreadTimer& timer = *t.second;
+        YarpTimerEvent tEvent = timer.getEventNow();
+        if (timer.m_active && tEvent.currentReal > tEvent.currentExpected) {
+            timer.m_active = timer.step(tEvent, false);
+            timer.m_lastReal = tEvent.currentReal;
+        }
+    }
+    mu.unlock();
+}
+
+class ThreadedTimer : public yarp::os::Timer::PrivateImpl,
+                      public yarp::os::RateThread
+{
+    typedef yarp::os::Timer::TimerCallback TimerCallback;
+    virtual void run() override;
+    virtual bool threadInit() override;
+    bool singleStep{ false };
+
+public:
+    ThreadedTimer(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) :
+            PrivateImpl(sett, call, mutex), RateThread(sett.rate * 1000)
+    {
+    }
+
+    virtual ~ThreadedTimer()
+    {
+        stop();
+    }
+
+    virtual bool startTimer() override
+    {
+        m_startStamp = yarp::os::Time::now();
+        return start();
+    }
+
+    virtual bool stepTimer() override
+    {
+        singleStep = true;
+        return step();
+    }
+
+    virtual void stopTimer() override
+    {
+        return stop();
+    }
+
+    virtual bool timerIsRunning() override
+    {
+        return isRunning();
+    }
+};
+
+bool ThreadedTimer::threadInit()
+{
+    m_startStamp = yarp::os::Time::now();
+    return true;
+}
+
+//the newThread parameter is not in the settings for it to be unmutable and only checked by the constructor
+Timer::Timer(const TimerSettings& settings, TimerCallback callback, bool newThread, Mutex* mutex) :
+        //added cast for incompatible operand error
+        impl(newThread ? dynamic_cast<PrivateImpl*>(new ThreadedTimer(settings, callback, mutex))
+                       : dynamic_cast<PrivateImpl*>(new MonoThreadTimer(settings, callback, mutex)))
+{
+}
+
+bool Timer::start()
+{
+
+    return impl->startTimer();
+}
+
+bool Timer::step()
+{
+    return impl->stepTimer();
+}
+
+void Timer::stop()
+{
+    impl->stopTimer();
+}
+
+YarpTimerEvent yarp::os::Timer::PrivateImpl::getEventNow(unsigned int iteration)
+{
     YarpTimerEvent event;
 
-    event.currentReal     = yarp::os::Time::now();
-    event.currentExpected = impl->m_startStamp + getIterations() * getRate() * 0.001;
-    event.lastExpected    = event.currentExpected - getRate() * 0.001;
-    event.lastReal        = impl->m_lastReal;
-    event.lastDuration    = event.currentReal - impl->m_lastReal;
-    event.runCount        = getIterations();
+    event.currentReal = yarp::os::Time::now();
+    event.currentExpected = m_startStamp + iteration * m_settings.rate;
+    event.lastExpected = event.currentExpected - m_settings.rate;
+    event.lastReal = m_lastReal;
+    event.lastDuration = event.currentReal - m_lastReal;
+    event.runCount = iteration;
+    return event;
+}
 
-    if(impl->m_mutex) impl->m_mutex->lock();
+bool yarp::os::Timer::PrivateImpl::runTimer(unsigned int iteration, YarpTimerEvent event)
+{
+    if (m_mutex) {
+        m_mutex->lock();
+    }
 
-    if(!impl->m_callback(event)) askToStop();
+    if (!m_callback(event)) {
+        return false;
+    }
 
-    if(impl->m_mutex) impl->m_mutex->unlock();
+    if (m_mutex) {
+        m_mutex->unlock();
+    }
 
-    impl->m_lastReal = event.currentReal;
+    m_lastReal = event.currentReal;
 
-    if((impl->m_settings.totalRunCount != 0 && impl->m_settings.totalRunCount >= getIterations()+1) ||
-       (impl->m_settings.totalTime > 0.00001 && fabs(impl->m_settings.totalTime - impl->m_startStamp) > impl->m_settings.tollerance ))
-    {
+    double timerAge = (yarp::os::Time::now() - m_startStamp);
+
+    //totalRunCount == 0 ----> infinite run count. follows the run count of the timer
+    bool stop(m_settings.totalRunCount != 0 && m_settings.totalRunCount <= iteration);
+
+    //totalTime == 0 ----> infinite time. follows the age check for the timer
+    stop |= m_settings.totalTime > 0.00001 && (m_settings.totalTime - timerAge) < m_settings.tolerance;
+
+    if (stop) {
+        return false;
+    }
+
+    return true;
+}
+
+void ThreadedTimer::run()
+{
+    if (getIterations() == 0 && !singleStep) {
+        return;
+    }
+    singleStep = false;
+    YarpTimerEvent event = getEventNow(this->getIterations());
+    if (!runTimer(this->getIterations(), event)) {
         askToStop();
     }
 }
@@ -71,6 +315,11 @@ void Timer::setSettings(const TimerSettings& settings)
 const TimerSettings Timer::getSettings()
 {
     return impl->m_settings;
+}
+
+bool Timer::isRunning()
+{
+    return impl->timerIsRunning();
 }
 
 Timer::~Timer()

--- a/src/libYARP_OS/src/Timer.cpp
+++ b/src/libYARP_OS/src/Timer.cpp
@@ -1,0 +1,79 @@
+/*
+* Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+* All rights reserved.
+*
+* This software may be modified and distributed under the terms of the
+* BSD-3-Clause license. See the accompanying LICENSE file for details.
+*/
+
+#include <yarp/os/Timer.h>
+#include <yarp/os/Time.h>
+#include <cmath>
+using namespace yarp::os;
+class Timer::Private
+{
+    typedef yarp::os::Timer::TimerCallback TimerCallback;
+public:
+    Private(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) : m_settings(sett), m_callback(call), m_mutex(mutex){}
+    TimerCallback    m_callback{nullptr};
+    double           m_startStamp{0.0},
+                     m_lastReal{0.0};
+    unsigned int     m_runCount{0};
+    yarp::os::Mutex* m_mutex;
+    TimerSettings    m_settings;
+};
+
+Timer::Timer(const TimerSettings& settings, TimerCallback callback, Mutex* mutex) :
+    RateThread(settings.rate.count()),
+    impl(new Private(settings, callback, mutex)){}
+
+void Timer::beforeStart()
+{
+    impl->m_startStamp = yarp::os::Time::now();
+}
+
+void Timer::run()
+{
+    if(getIterations() == 0)
+    {
+        yarp::os::Time::delay(getRate() * 0.001);
+    }
+
+    YarpTimerEvent event;
+
+    event.currentReal     = yarp::os::Time::now();
+    event.currentExpected = impl->m_startStamp + getIterations() * getRate() * 0.001;
+    event.lastExpected    = event.currentExpected - getRate() * 0.001;
+    event.lastReal        = impl->m_lastReal;
+    event.lastDuration    = event.currentReal - impl->m_lastReal;
+    event.runCount        = getIterations();
+
+    if(impl->m_mutex) impl->m_mutex->lock();
+
+    if(!impl->m_callback(event)) askToStop();
+
+    if(impl->m_mutex) impl->m_mutex->unlock();
+
+    impl->m_lastReal = event.currentReal;
+
+    if((impl->m_settings.totalRunCount != 0 && impl->m_settings.totalRunCount >= getIterations()+1) ||
+       (impl->m_settings.totalTime > 0.00001 && fabs(impl->m_settings.totalTime - impl->m_startStamp) > impl->m_settings.tollerance ))
+    {
+        askToStop();
+    }
+}
+
+void Timer::setSettings(const TimerSettings& settings)
+{
+    impl->m_settings = settings;
+}
+
+const TimerSettings Timer::getSettings()
+{
+    return impl->m_settings;
+}
+
+Timer::~Timer()
+{
+    delete impl;
+}

--- a/tests/libYARP_OS/TestList.h
+++ b/tests/libYARP_OS/TestList.h
@@ -60,6 +60,7 @@ extern yarp::os::impl::UnitTest& getPublisherTest();
 extern yarp::os::impl::UnitTest& getLogTest();
 extern yarp::os::impl::UnitTest& getLogStreamTest();
 extern yarp::os::impl::UnitTest& getMessageStackTest();
+extern yarp::os::impl::UnitTest& getTimerTest();
 extern yarp::os::impl::UnitTest& getUnitTestTest();
 
 extern yarp::os::impl::UnitTest& getSystemInfoTest();
@@ -106,6 +107,7 @@ public:
         root.add(getLogTest());
         root.add(getLogStreamTest());
         root.add(getMessageStackTest());
+        root.add(getTimerTest());
         root.add(getUnitTestTest());
         root.add(getSystemInfoTest());
     }

--- a/tests/libYARP_OS/TimerTest.cpp
+++ b/tests/libYARP_OS/TimerTest.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+#include <yarp/os/ConstString.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/impl/UnitTest.h>
+#include <yarp/os/Timer.h>
+#include <yarp/os/Time.h>
+#include <string>
+#include <yarp/os/LogStream.h>
+#include <cmath>
+
+using namespace yarp::os;
+using namespace yarp::os::impl;
+using namespace std;
+
+class TimerTest : public UnitTest {
+
+    bool         timingTestResult{false};
+    double       startTime{0};
+    double       timingTolerance{0.1};
+    double       spinDuration{0.5};
+    unsigned int runCount{ 1 };
+
+public:
+    virtual ConstString getName() override { return "TimerTest"; }
+
+    //please note that the return values of the callbacks does not rappresent the result of the tests but simply keeps the timer alive..
+    bool timingCallback(const YarpTimerEvent& timings)
+    {
+        timingTestResult = true; //the callback has been called
+        double now = yarp::os::Time::now();
+        vector<pair<std::function<bool()>, string>> checks //checks vector.. add new lines here to add new checks
+        {
+            {[&timings, this]       { return timings.currentExpected - startTime + spinDuration * runCount; }, "currentExpected error"},
+            {[&timings, this, &now] { return fabs(now - timings.currentReal) < 0.0001; }, "currentReal error"},
+            {[&timings, this]       { return runCount == 1 || (timings.lastDuration - spinDuration) < timingTolerance; }, "lastDuration error"},
+            {[&timings, this, &now] { return fabs((now - timings.lastExpected) - spinDuration) < timingTolerance; }, "lastExpexted error"},
+            {[&timings, this]       { return runCount == 1 || fabs(timings.lastExpected - timings.lastReal) < timingTolerance; }, "lastReal error"},
+            {[&timings, this]       { return timings.runCount == runCount; }, "runCount error"}
+        };
+
+        for (auto& c : checks)
+        {
+            timingTestResult = c.first();
+            if (!timingTestResult)
+            {
+                yError() << c.second;
+                return false;
+            }
+        }
+        runCount++;
+        return true;
+    }
+
+    bool monoMultiThreadCallback(const YarpTimerEvent& timings)
+    {
+        return true;
+    }
+
+    void timingTest(bool multiThread)
+    {
+        Timer timing(TimerSettings(spinDuration), &TimerTest::timingCallback, this, multiThread);
+        startTime = yarp::os::Time::now();
+        timing.start();
+        yarp::os::Time::delay(5);
+        timing.stop();
+        checkTrue(timingTestResult, (string((multiThread ? "MultiThread " : "MonoThread ")) + string("timing test")).c_str());
+    }
+
+    void monoMultiThreadTest(bool multiThread)
+    {
+        int threadCount = yarp::os::Thread::getCount();
+        vector<Timer*> timers
+        {
+            new Timer({0.5},&TimerTest::monoMultiThreadCallback, this, multiThread),
+            new Timer({0.4},&TimerTest::monoMultiThreadCallback, this, multiThread),
+            new Timer({0.3},&TimerTest::monoMultiThreadCallback, this, multiThread)
+        };
+
+        for (auto& t : timers)
+        {
+            t->start();
+        }
+
+        if (multiThread)
+            checkTrue(yarp::os::Thread::getCount() - threadCount == 3, "multiThread test");
+        else
+            checkTrue(yarp::os::Thread::getCount() - threadCount == 1, "singleThread test");
+
+        for (auto& t : timers)
+        {
+            t->stop();
+            delete t;
+        }
+    }
+
+    void apiTest(bool multiThread)
+    {
+        int i{ 0 }, j{ 0 };
+        Timer t(TimerSettings(0.1, 3, 10), [&i](const YarpTimerEvent& timings) {i++; return true; }, multiThread);
+        Timer t2(TimerSettings(0.1, 10, 0.4), [&j](const YarpTimerEvent& timings) {j++; return true; }, multiThread);
+
+        checkTrue(t.getSettings() == TimerSettings(0.1, 3, 10), "API getSettings check");
+        checkFalse(t.isRunning(), "API isRunning check");
+        t.step();
+        checkTrue(i == 1, "API step check");
+        t.start();
+        t2.start();
+        checkTrue(t.isRunning() && t2.isRunning(), "API start check");
+        yarp::os::Time::delay(1);
+        checkTrue(2 < j && j < 5, "time expiration");
+        checkTrue(i == 4, "run count expiration");
+        checkFalse(t.isRunning() || t2.isRunning(), "timers automatically stopped");
+    }
+
+    virtual void runTests() override
+    {
+        //fails with valgrind for valgrind slowing down the system
+        //timingTest(true);
+        //runCount = 1;
+        //timingTest(false);
+
+        apiTest(true);
+        apiTest(false);
+        monoMultiThreadTest(true);
+        monoMultiThreadTest(false);
+    }
+};
+
+
+static TimerTest theTimerTest;
+
+UnitTest& getTimerTest() {
+    return theTimerTest;
+}


### PR DESCRIPTION
added a `Timer` class to execute static functions or member methods in a separate thread every [rate] seconds. It can can be a very quick alternative to defining and using a `RateThread` derived class.

Examples:

the following example will spawn a RateThread with a rate of 1 second executing a function
```
yarp::os::Timer timer(1000.0, &MyStaticCallback);
timer->start();
```

the following example will spawn a RateThread with a rate of 1 second executing a member function
```
yarp::os::Timer timer(1000.0, &MyClass::MyCallback, this);
timer->start();
```
the following example will also provide a mutex that will be locked before the call and unlock just after
```
yarp::os::Timer timer(1000.0, &MyClass::MyCallback, this, myMutex);
timer->start();
```
the following will execute the callback only once after 1 second
```
yarp::os::Timer timer(1000.0, &MyClass::MyCallback, this, myMutex, /*oneshot*/ true);
timer->start();
```