### PR TITLE
Broker switching in yarpmanager

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -148,6 +148,8 @@ Bug Fixes
   with the available carriers.
 * Added modifiers column in the connection list for portmonitors.
 * Added automatic ports/resources refresh after `run/stop/kill`.
+* Added the possibility to switch broker run-time, from `LocalBroker` to
+  `YarpBroker` and viceversa.
 
 #### yarpdataplayer
 

--- a/src/libYARP_manager/include/yarp/manager/executable.h
+++ b/src/libYARP_manager/include/yarp/manager/executable.h
@@ -41,6 +41,13 @@ typedef enum __RSTATE {
     STUNKNOWN
 } RSTATE;
 
+enum class BrokerType
+{
+    invalid,
+    local,
+    yarp
+};
+
 
 class MEvent{
 
@@ -89,7 +96,12 @@ public:
     ResourceContainer& getResources(void) { return resources; }
 
     RSTATE state(void);
+    BrokerType getBrokerType();
+    bool shouldChangeBroker();
     Broker* getBroker(void) { return broker; }
+    void setAndInitializeBroker(Broker* _broker);
+    void removeBroker(void) { if (broker) delete broker;}
+
     MEvent* getEvent(void) { return event; }
     const char* getCommand(void) { return strCommand.c_str(); }
     const char* getParam(void) { return strParam.c_str(); }

--- a/src/libYARP_manager/include/yarp/manager/manager.h
+++ b/src/libYARP_manager/include/yarp/manager/manager.h
@@ -19,7 +19,6 @@
 namespace yarp {
 namespace manager {
 
-
 /**
  * Class Manager
  */
@@ -87,6 +86,7 @@ public:
     const char* defaultBroker(void) { return strDefBroker.c_str(); }
     ExecutablePContainer& getExecutables(void) { return runnables; }
     Executable* getExecutableById(size_t id);
+    bool switchBroker(size_t id);
     CnnContainer& getConnections(void) { return connections;}
     ResourcePContainer& getResources(void) { return resources; }
     const char* getApplicationName(void) { return strAppName.c_str(); }
@@ -148,6 +148,7 @@ private:
     bool timeout(double base, double t);
     bool updateResource(GenericResource* resource);
     Broker* createBroker(Module* module);
+    bool removeBroker(Executable* exe);
 };
 
 } // namespace yarp

--- a/src/libYARP_manager/src/executable.cpp
+++ b/src/libYARP_manager/src/executable.cpp
@@ -8,6 +8,7 @@
 
 
 #include <yarp/manager/executable.h>
+#include <yarp/manager/yarpbroker.h>
 
 using namespace yarp::manager;
 
@@ -45,8 +46,7 @@ Executable::~Executable()
     delete stopWrapper;
     delete killWrapper;
     delete execMachine;
-    if(broker)
-        delete broker;
+    removeBroker();
 }
 
 
@@ -164,6 +164,48 @@ RSTATE Executable::state()
 
     std::cerr<<"Unknown state!"<<std::endl;
     return STUNKNOWN;
+}
+
+BrokerType Executable::getBrokerType()
+{
+    if (broker == nullptr)
+    {
+        return BrokerType::invalid;
+    }
+    else if (dynamic_cast<YarpBroker*>(broker))
+    {
+        return BrokerType::yarp;
+    }
+    else
+    {
+        return BrokerType::local;
+    }
+
+}
+
+bool Executable::shouldChangeBroker()
+{
+    if (getBrokerType() == BrokerType::local &&
+        strHost != "localhost")
+    {
+       return true;
+    }
+    else if (getBrokerType() == BrokerType::yarp &&
+             strHost == "localhost")
+    {
+        return true;
+    }
+    return false;
+
+}
+
+void Executable::setAndInitializeBroker(Broker *_broker)
+{
+    if (_broker)
+    {
+        broker = _broker;
+        initialize();
+    }
 }
 
 bool Executable::startWatchDog() {

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -452,14 +452,7 @@ void ApplicationViewWidget::onModuleItemSelectionChanged()
         if (all) {
             modAttachAction->setEnabled(true);
         }
-//        if (ui->moduleList->currentItem()->text(3) == "localhost")
-//        {
-//            modAttachAction->setEnabled(true);
-//        }
-//        else
-//        {
-//            modAttachAction->setEnabled(false);
-//        }
+
         modAssignAction->setEnabled(true);
         modRefreshAction->setEnabled(true);
 
@@ -654,11 +647,6 @@ void ApplicationViewWidget::updateApplicationWindow()
         else
             it = new CustomTreeWidgetItem(appNode,l);
 
-        if (host=="localhost")
-        {
-            it->setTextColor(3,QColor("#A0A0A0"));
-        }
-
         //it->setFlags(it->flags() | Qt::ItemIsEditable);
         it->setData(0,Qt::UserRole,yarp::manager::MODULE);
         it->setIcon(0,QIcon(":/close.svg"));
@@ -770,7 +758,6 @@ void ApplicationViewWidget::onModuleItemChanged(QTreeWidgetItem *it,int col)
     if (!(tmp & Qt::ItemIsEditable)) {
         return;
     }
-    qDebug() << "CHANGED " << it->text(col);
 }
 
 /*! \brief Called when an item has been double clicked */
@@ -800,7 +787,7 @@ bool ApplicationViewWidget::isEditable(QTreeWidgetItem *it,int col)
                }
            }
            if (col == 3) {
-                if (it->text(3) != "localhost" && it->text(2) == "stopped") {
+                if (it->text(2) == "stopped") {
                     return true;
                 }
            }


### PR DESCRIPTION
This PR introduces the possibility to switch broker for launching modules.
It makes possible to switch from `localhost` to `yarprun` and viceversa without the necessity to change the xml and reload the application.

It fixes #1471.

TODO before merging:

- [x] Investigate to possible problems with the watchdog
- [x] Add changelog
- [x] Test the switching with a "big" application on a robot setup.