### PR TITLE
Coverity fixes - initializations_5

### DIFF
--- a/src/carriers/tcpros_carrier/TcpRosStream.h
+++ b/src/carriers/tcpros_carrier/TcpRosStream.h
@@ -55,6 +55,9 @@ public:
                  const char *kind) :
             delegate(delegate),
             raw(raw),
+            header(BlobNetworkHeader{0,0,0}),
+            cursor(nullptr),
+            remaining(0),
             phase(0),
             expectTwiddle(service && sender),
             kind(kind),

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlNetUtils.h
@@ -71,14 +71,18 @@ struct yarp::dev::JoypadControl::LoopablePort
     bool                  valid;
     unsigned int          count;
     yarp::os::ConstString name;
+    yarp::os::Contactable* contactable;
+
     virtual ~LoopablePort(){}
-    LoopablePort():valid(false),count(0){}
+    LoopablePort():
+        valid(false),
+        count(0),
+        contactable(nullptr)
+    {}
 
     virtual void useCallback() = 0;
 
     virtual void onTimeout(double sec) = 0;
-
-    yarp::os::Contactable* contactable;
 };
 
 template <typename T>

--- a/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/libYARP_dev/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -31,26 +31,25 @@ yarp::dev::DriverCreator *createRangefinder2DWrapper() {
   * It also creates one rpc port.
   */
 
-Rangefinder2DWrapper::Rangefinder2DWrapper() : RateThread(DEFAULT_THREAD_PERIOD)
-{
-    _rate = DEFAULT_THREAD_PERIOD;
-    sens_p = nullptr;
-
+Rangefinder2DWrapper::Rangefinder2DWrapper() : RateThread(DEFAULT_THREAD_PERIOD),
+    partName("Rangefinder2DWrapper"),
+    sens_p(nullptr),
+    iTimed(nullptr),
+    _rate(DEFAULT_THREAD_PERIOD),
+    minAngle(0),
+    maxAngle(0),
+    minDistance(0),
+    maxDistance(0),
+    resolution(0),
+    isDeviceOwned(false),
     // init ROS data
-    frame_id = "";
-    rosNodeName = "";
-    rosTopicName = "";
-    partName = "Rangefinder2DWrapper";
-    rosNode = nullptr;
-    rosMsgCounter = 0;
-    useROS      = ROS_disabled;
-    minAngle    = 0;
-    maxAngle    = 0;
-    minDistance = 0;
-    maxDistance = 0;
-    resolution  = 0;
-    isDeviceOwned = false;
-}
+    useROS(ROS_disabled),
+    frame_id(""),
+    rosNodeName(""),
+    rosTopicName(""),
+    rosNode(nullptr),
+    rosMsgCounter(0)
+{}
 
 Rangefinder2DWrapper::~Rangefinder2DWrapper()
 {

--- a/src/yarpbatterygui/display.cpp
+++ b/src/yarpbatterygui/display.cpp
@@ -187,17 +187,17 @@ void MainWindow::updateMain()
     return;
 }
 
-MainWindow::MainWindow(yarp::os::ResourceFinder rf, yarp::dev::IBattery* p_ibat, QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
+MainWindow::MainWindow(yarp::os::ResourceFinder rf, yarp::dev::IBattery* p_ibat, QWidget *parent) : QMainWindow(parent),
+    ui(new Ui::MainWindow),
+    ibat(p_ibat),
+    drv(nullptr),
+    connected(false),
+    enable_ask_info(false),
+    voltage(0),
+    charge(0),
+    current(0)
 {
-    ibat = p_ibat;
-    connected = false;
-    enable_ask_info = false;
-    voltage = 0;
-    charge = 0;
-    current = 0;
-
     ui->setupUi(this);
-
     mainTimer = new QTimer(this);
     connect(mainTimer, SIGNAL(timeout()), this, SLOT(updateMain()));
     mainTimer->start(1000*10); //10 seconds

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -136,7 +136,12 @@ class DumpTimeStamp
     bool   txOk;
 
 public:
-    DumpTimeStamp() : rxOk(false), txOk(false) { }
+    DumpTimeStamp() :
+        rxStamp(0.0),
+        txStamp(0.0),
+        rxOk(false),
+        txOk(false)
+    {}
     void setRxStamp(const double stamp) { rxStamp=stamp; rxOk=true; }
     void setTxStamp(const double stamp) { txStamp=stamp; txOk=true; }
     double getStamp() const
@@ -285,9 +290,19 @@ private:
 public:
     DumpThread(DumpType _type, DumpQueue &Q, const string &_dirName, int szToWrite,
                bool _saveData, bool _videoOn, const string &_videoType) :
-               RateThread(50), buf(Q), type(_type), dirName(_dirName),
-               blockSize(szToWrite), saveData(_saveData),
-               videoOn(_videoOn), videoType(_videoType)
+        RateThread(50),
+        buf(Q),
+        type(_type),
+        dirName(_dirName),
+        blockSize(szToWrite),
+        cumulSize(0),
+        counter(0),
+        oldTime(0.0),
+        saveData(_saveData),
+        videoOn(_videoOn),
+        videoType(_videoType),
+        closing(false),
+        t0(0.0)
     {
         infoFile=dirName;
         infoFile+="/info.log";
@@ -507,7 +522,16 @@ private:
     string            portName;
 
 public:
-    DumpModule() { }
+    DumpModule() :
+        q(nullptr),
+        p_bottle(nullptr),
+        p_image(nullptr),
+        t(nullptr),
+        type(bottle),
+        rxTime(false),
+        txTime(false),
+        dwnsample(0)
+    {}
 
     bool configure(ResourceFinder &rf) override
     {

--- a/src/yarplogger/messageWidget.cpp
+++ b/src/yarplogger/messageWidget.cpp
@@ -22,10 +22,10 @@
 #include <QDateTime>
 
 MessageWidget::MessageWidget(QWidget *parent) :
-    QListWidget(parent)
+    QListWidget(parent),
+    contextMenu(nullptr)
 {
     //contextMenu = new QMenu(this);
-
     clearLogAction = new QAction("Clear Log",this);
     saveLogAction = new QAction("Save Log",this);
 
@@ -37,7 +37,6 @@ MessageWidget::MessageWidget(QWidget *parent) :
 
     connect(clearLogAction,SIGNAL(triggered()),this,SLOT(onClearLog()));
     connect(saveLogAction,SIGNAL(triggered()),this,SLOT(onSaveLog()));
-
 }
 
 void MessageWidget::onClearLog()

--- a/src/yarpmanager/src-manager/logwidget.cpp
+++ b/src/yarpmanager/src-manager/logwidget.cpp
@@ -3,10 +3,10 @@
 #include <QCoreApplication>
 
 LogWidget::LogWidget(QWidget *parent) :
-    QListWidget(parent)
+    QListWidget(parent),
+    contextMenu(nullptr)
 {
     //contextMenu = new QMenu(this);
-
     clearLogAction = new QAction("Clear Log",this);
     saveLogAction = new QAction("Save Log",this);
 
@@ -18,7 +18,6 @@ LogWidget::LogWidget(QWidget *parent) :
 
     connect(clearLogAction,SIGNAL(triggered()),this,SLOT(onClearLog()));
     connect(saveLogAction,SIGNAL(triggered()),this,SLOT(onSaveLog()));
-
 }
 
 void LogWidget::onClearLog()


### PR DESCRIPTION
Fixes some 'uninitialized pointer or scalar field' issues raised by Coverity.
Commits are grouped by component.