### PR TITLE
add IPositionDirect binding, extend basic methods

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -421,6 +421,7 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IAnalogSensor.h>
 %include <yarp/dev/FrameGrabberControl2.h>
 %include <yarp/dev/IPidControl.h>
+%include <yarp/dev/IPositionDirect.h>
 
 #if !defined(SWIGCHICKEN) && !defined(SWIGALLEGROCL)
   %template(DVector) std::vector<double>;
@@ -795,6 +796,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
         return result;
     }
 
+    yarp::dev::IPositionDirect *viewIPositionDirect() {
+        yarp::dev::IPositionDirect *result;
+        self->view(result);
+        return result;
+    }
+
     // you'll need to add an entry for every interface you wish
     // to use
 }
@@ -1061,6 +1068,18 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
     }
 }
 
+%extend yarp::dev::IPositionDirect {
+    int getAxes() {
+        int buffer;
+        bool ok = self->getAxes(&buffer);
+        if (!ok) return 0;
+        return buffer;
+    }
+
+    bool setPositions(std::vector<double>& data) {
+        return self->setPositions(&data[0]);
+    }
+}
 
 %extend yarp::sig::Vector {
 


### PR DESCRIPTION
This PR adds `IPositionDirect` SWIG bindings, and extends some basic methods.

We have several use cases where we would like to have `IPositionDirect` in Python: A common setup is during simulations for Evolutionary Strategies and/or (Deep) Reinforcement Learning. We want instant movements and do not care about intermediate trajectories. The current hack is via `IPositionControl::setRefSpeed` > `IControlLimits2::setVelLimits`. However, the `IPositionDirect` interface seems much more appropriate.

Here is some code with which it has been tested (unfortunately requires https://github.com/roboticslab-uc3m/openrave-yarp-plugins; some day we will have a very complete FakeControlboard that implements all of these methods):
```python
import yarp
options = yarp.Property()
options.put('device','YarpOpenraveControlboard')
options.put('env','/usr/local/share/teo-openrave-models/contexts/openrave/teo/teo.robot.xml')
options.put('view',1)
options.put('robotIndex',0)
options.put('manipulatorIndex',0)
dd = yarp.PolyDriver()
dd.open(options)

cm2 = dd.viewIControlMode2()
i = yarp.IVector(2)
i[0] = yarp.Vocab_encode('posd')
i[1] = yarp.Vocab_encode('posd')
cm2.setControlModes(i)

pd = dd.viewIPositionDirect()
pd.setPosition(0,15)
pd.setPosition(1,10)

d = yarp.DVector(2,0.0)
pd.setPositions(d)

dd.close()
```