### PR TITLE
Overload yarp::dev::CanMessage::operator[], add constness for getters

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -72,6 +72,7 @@ New Features
 #### `YARP_dev`
 
 * Added a new interface for visual servoing: `IVisualServoing.h`.
+* `yarp::dev::CanBuffer` now supports a `const` version of `operator[]`.
 
 #### `YARP_serversql`
 

--- a/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
+++ b/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
@@ -86,6 +86,10 @@ class yarp::dev::CanBuffer
         {
             return *data[k];
         }
+    inline const CanMessage &operator[](int k) const
+        {
+            return *data[k];
+        }
 };
 
 class yarp::dev::ICanBufferFactory


### PR DESCRIPTION
Use case:

```c++
// implements yarp::dev::ICanBus::canWrite
bool MyClass::canWrite(const yarp::dev::CanBuffer &msgs, unsigned int size, unsigned int *sent, bool wait)
{
    // ideally, we would like to avoid this:
    //const yarp::dev::CanMessage &msg = const_cast<yarp::dev::CanBuffer &>(msgs)[0];

    // ...and do this instead:
    const yarp::dev::CanMessage &msg = msgs[0];

    // send msg
}
```