### PR TITLE
Add support for carrier specification on registration

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -68,6 +68,10 @@ New Features
 * Improve how parameters are given to the chosen carrier for a connection: 
   all parameters given both on registration and on connect command are collected 
   and made available in the connection initialization step.
+* Added support for register a contact with an associated carrier different from
+  tcp. If the chosen carrier provides a custom yarp::os::Face implementation this
+  becomes the handler of incoming connections. In any case the carrier becomes the
+  default for future connections.
 
 #### `YARP_dev`
 

--- a/src/libYARP_OS/src/NameClient.cpp
+++ b/src/libYARP_OS/src/NameClient.cpp
@@ -331,6 +331,10 @@ Contact NameClient::registerName(const ConstString& name, const Contact& suggest
         if (typ!="*") {
             cmd.addString(typ);
         }
+    } else {
+        if (suggest.getCarrier()!="") {
+            cmd.addString(suggest.getCarrier().c_str());
+        }
     }
     Bottle reply;
     send(cmd, reply);

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -232,11 +232,6 @@ static int enactConnection(const Contact& src,
     if (c2.getPort()<=0) {
         c2 = NetworkBase::queryName(c2.getName());
     }
-    if (c2.getCarrier()!="tcp") {
-        YARP_SPRINTF2(Logger::get(), debug, "would have asked %s: %s",
-                      src.toString().c_str(), cmd.toString().c_str());
-        return 1;
-    }
 
     YARP_SPRINTF2(Logger::get(), debug, "** asking %s: %s",
                   src.toString().c_str(), cmd.toString().c_str());


### PR DESCRIPTION
This patch should allow to open a port with an associated custom carrier different from tcp, if this carrier is available and it provides a custom implementation of `yarp::os::Face` that can replace default handshake.
Example:
```
yarp::os::Port p;
yarp::os::Contact c("/port", "carrier");
p.open(c);
```