### PR TITLE
[WIP] Portname validation

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Contact.h
+++ b/src/libYARP_OS/include/yarp/os/Contact.h
@@ -128,6 +128,29 @@ public:
      */
     static Contact fromString(const ConstString& txt);
 
+    /**
+     * @brief isValidRegisteredName
+     *
+     * Checks if a provided name match the syntax of possibly
+     * registered port names. The syntax is defined into the function code.
+     *
+     * @param name char sequence with the name to check
+     * @return true if the name could correspond to a registered contact
+     */
+    static bool isValidRegisteredName(const char* name);
+
+    /**
+     * @brief isValidRegistrationName
+     *
+     * Checks if a provided name is valid to enter registration phase.
+     * Valid syntax includes valid registered names plus anonymous ports
+     * and plain char sequences for topics.
+     *
+     * @param name char sequence with the name to check
+     * @return true if the contact can be registered by YARP network
+     */
+    static bool isValidRegistrationName(const char* name);
+
 /** @} */
 /** @{ */
 

--- a/src/libYARP_OS/src/NestedContact.cpp
+++ b/src/libYARP_OS/src/NestedContact.cpp
@@ -72,9 +72,24 @@ bool NestedContact::fromString(const ConstString& nFullName) {
         nodeName = fullName.substr(0, idx);
         nestedName = fullName.substr(idx+1, fullName.length());
         char ch = nodeName[nodeName.length()-1];
-        if (ch=='-'||ch=='+') {
-            category += ch;
-            nodeName = nodeName.substr(0, nodeName.length()-1);
+        if (ch=='-'||ch=='+'||ch=='1') {
+            size_t offset = 1;
+            bool ok = true;
+            if (ch=='1') {
+                ok = false;
+                if (nodeName.length()>=2) {
+                    char ch0 = nodeName[nodeName.length()-2];
+                    if (ch0=='-'||ch0=='+') {
+                        offset++;
+                        category += ch0;
+                        ok = true;
+                    }
+                }
+            }
+            if (ok) {
+                category += ch;
+                nodeName = nodeName.substr(0, nodeName.length()-offset);
+            }
         }
         return true;
     }

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -354,12 +354,12 @@ static int metaConnect(const ConstString& src,
     CARRIER_DEBUG("DYNAMIC_SRC: name=%s, carrier=%s\n", dynamicSrc.getName().c_str(), dynamicSrc.getCarrier().c_str());
     CARRIER_DEBUG("DYNAMIC_DST: name=%s, carrier=%s\n", dynamicDest.getName().c_str(), dynamicDest.getCarrier().c_str());
 
-    if(!NetworkBase::isValidPortName(dynamicSrc.getName()))
+    if(!Contact::isValidRegisteredName(dynamicSrc.getName().c_str()))
     {
         fprintf(stderr, "Failure: no way to make connection, invalid source '%s'\n", dynamicSrc.getName().c_str());
         return 1;
     }
-    if(!NetworkBase::isValidPortName(dynamicDest.getName()))
+    if(!Contact::isValidRegisteredName(dynamicDest.getName().c_str()))
     {
         fprintf(stderr, "Failure: no way to make connection, invalid destination '%s'\n", dynamicDest.getName().c_str());
         return 1;

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -130,7 +130,7 @@ bool Port::open(const Contact& contact, bool registerName,
     PortCoreAdapter *currentCore = &(IMPL());
     if (currentCore!=nullptr) {
         currentCore->active = false;
-        if (n!="" && (n[0]!='/'||currentCore->includeNode) && n[0]!='=' && n!="..." && n.substr(0, 3)!="...") {
+        if (n!="" && (n[0]!='/'||currentCore->includeNode) && n!="..." && n.substr(0, 3)!="...") {
             if (fakeName==nullptr) {
                 Nodes& nodes = NameClient::getNameClient().getNodes();
                 ConstString node_name = nodes.getActiveName();
@@ -140,7 +140,7 @@ bool Port::open(const Contact& contact, bool registerName,
             }
         }
     }
-    if (n!="" && n[0]!='/'  && n[0]!='=' && n!="..." && n.substr(0, 3)!="...") {
+    if (n!="" && n[0]!='/' && n!="..." && n.substr(0, 3)!="...") {
         if (fakeName==nullptr) {
             YARP_SPRINTF1(Logger::get(), error,
                           "Port name '%s' needs to start with a '/' character",
@@ -148,7 +148,7 @@ bool Port::open(const Contact& contact, bool registerName,
             return false;
         }
     }
-    if (n!="" && n!="..." && n[0]!='=' && n.substr(0, 3)!="...") {
+    if (n!="" && n!="..." && n.substr(0, 3)!="...") {
         if (fakeName==nullptr) {
             ConstString prefix = NetworkBase::getEnvironment("YARP_PORT_PREFIX");
             if (prefix!="") {

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -77,7 +77,10 @@ bool Port::openFake(const ConstString& name)
 
 bool Port::open(const ConstString& name)
 {
-    return open(Contact(name));
+    if(Contact::isValidRegistrationName(name.c_str())) {
+        return open(Contact::fromString(name));
+    }
+    return false;
 }
 
 bool Port::open(const Contact& contact, bool registerName)

--- a/src/libYARP_serversql/src/NameServiceOnTriples.cpp
+++ b/src/libYARP_serversql/src/NameServiceOnTriples.cpp
@@ -273,14 +273,11 @@ bool NameServiceOnTriples::cmdRegister(NameTripleState& act) {
         at++;
     }
     lock();
-    if (port=="..." || (port.length()>0 && port[0]=='=')) {
+    if (port=="...") {
         Contact c(port, carrier, machine, sock);
         c = alloc->completePortName(c);
-        if (port =="...") {
-            port = c.getName();
-        } else {
-            port = c.getName() + port;
-        }
+        port = c.getName();
+
     }
     t.setNameValue("port",port.c_str());
     act.mem.remove_query(t, nullptr);

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -342,6 +342,60 @@ public:
 
     virtual ConstString getName() override { return "PortTest"; }
 
+    void testName() {
+        // good names
+        checkTrue(Contact::isValidRegistrationName(""),                 "Void name is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("..."),              "\"...\" name is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/port"),            "\"/port\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/port:spec"),       "\"/port:spec\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p1/p2"),           "\"/p1/p2\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p1/p2/p3/p4"),     "\"/p1/p2/p3/p4\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p1/p2/p3:any/p4"), "\"/p1/p2/p3:any/p4\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p1/p_2"),          "\"/p1/p_2\" is a good name.");
+        checkTrue(Contact::isValidRegistrationName("/p1/p_2:sp1:ssp2"), "\"/p1/p_2:sp1:ssp2\" is a good name.");
+        checkTrue(Contact::isValidRegistrationName("carr://port"),              "\"carr://port\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("carr://port/port:spec"),    "\"carr://port:spec\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("carr://p1/p2"),             "\"carr://p1/p2\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("fast_carr://p1/p2/p3/p4"),  "\"fast_carr://p1/p2/p3/p4\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1#/p1/p2"),               "\"/n1#/p1/p2\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1+#/p1"),         "\"/n1+#/p1\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1+1#/p1"),        "\"/n1+1#/p1\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1-1#/p1"),        "\"/n1-1#/p1\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1=/p1"),          "\"/n1=/p1\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1=-1/p1"),        "\"/n1=-1/p1\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/n1=+/p1/p2:sp"),   "\"/n1=+/p1/p2:sp\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p@"),              "\"/p@\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p:s@/n~wire"),     "\"/p:s@/n~wire\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/p-1@/n~wire"),     "\"/p-1@/n~wire\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/machine:10005"),   "\"machine:10005\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/mac12.at.domain:10005"),   "\"mac12.at.domain:10005\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("/111.2.30.4:10005"),        "\"111.2.30.4:10005\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("carr://11.12.13.14:10005"), "\"carr://11.12.13.14:10005\" is a good registration name.");
+        checkTrue(Contact::isValidRegistrationName("carr://11.12.13.14:10005/"),"\"carr://11.12.13.14:10005\" is a good registration name.");
+
+        // bad names:
+        checkFalse(Contact::isValidRegistrationName("/"),                   "\"/\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/p space"),            "\"/p space\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/_"),                  "\"/_\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/:"),                  "\"/:\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/p_"),                 "\"/p_\" is a not good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/p/"),                 "\"/p_\" is a not good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/port:"),              "\"/port:\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/str@ng&%port"),       "\"/str@ng&%port\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("str4ng&~c4rr://p1/p2"),"\"str4ng&~c4rr://p1/p2\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("carr:/"),              "\"carr:/ \" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("=+/p1/p2:sp"),         "\"=+/p1/p2:sp\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("#+/p1/p2:sp"),         "\"#+/p1/p2:sp\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/n="),                 "\"/n=\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("/n#"),                 "\"/n#\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("="),                   "\"=\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("#"),                   "\"#\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("@"),                   "\"@\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("machine:10005"),       "\"machine:10005\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("111.2.30.4:abc"),      "\"111.2.30.4:abc\" is not a good registration name.");
+        checkFalse(Contact::isValidRegistrationName("carr:/11.12.13.14:69"),"\"carr:/11.12.13.14:69\" is not a good registration name.");
+    }
+
     void testOpen() {
         report(0,"checking opening and closing ports");
         Port out, in;
@@ -1546,6 +1600,8 @@ public:
 #ifdef BROKEN_TEST
         testTcp();
 #endif
+        testName();
+
         testOpen();
         //bbb testReadBuffer();
         testPair();


### PR DESCRIPTION
While fixing YARP crashes on wrong inputs, after #1470, I tried to define a whitelist of accepted and correctly parsed inputs.
So I would like to propose this PR as an attempt to standardize YARP port names and to start to supply (hopefully) clear documentation about `yarp::os::NestedContact` and other ROS related classes ( #1501).
Consists of adding two functions and calling them on input port names to `Port::open()` and `Network::connect()`.

These two functions together should define the policies to define port names. There should be anything new, I just checked what YARP supports and tried to formalize the input formats accepted.
To define the allowed syntax I checked the code in `Port::open()`, `Contact::fromString()` and `NestedContact::fromString()`, besides the port names used in the tests as a reference for common names.
Let me know if this could be useful or not.

---

So here are the names accepted on registration:
* `""` - blank name is accepted to open anonymous ports.
* `some_topic_name` - no leading slash, this name is accepted and then discarded if there's no active node.
* `...` - this is assigned a temporary port in the sequence /tmp/port/N.

Following syntaxes are accepted both as registration and registered names, and checked by Network::connect()
* `carrier:/port[cat]@node~wire`
* `carrier:/node[cat]#port~wire`
* `carrier:/node=[cat]port~wire`
* `carrier:/machine:NNN/`

Clearly carriers, nodes, wires and category are optional.

Syntax rules for ports and nodes:
* leading '/'
* only letters and numbers
* other whitelisted characters are '_' and ':' to define readable ports like /p_1 or /port:someinfo
* the pattern is repeatable `/p1/p2/p3:s1/p_4/p_5_and_6:s2`
* '_' and ':' cannot be terminating and leading chars after a '/'

Syntax rules for category ([cat]):
* Possible and mutually exclusive categories are `+`, `-`, `+1`, `-1`.

Syntax rules for carriers and wires:
* letters, numbers and '_' without a specific pattern.
~wire is used to specify the type of the communication on topics.

Syntax rules for machines:
* leading '/'
* letters and numbers
* followed by '.' and some other letters and numbers (repeatable pattern)
* followed by ':' and port number
* optional trailing '/'

Behaviour:
The '=', '#' symbols should be equivalent but the position of the category.
'@' syntax is still equivalent with inverted position of node and topic.
Registration names assumed by ports with these syntaxes could be different if you specify or not the category (https://github.com/robotology/yarp/issues/1470#issuecomment-355269018)

One explicit difference with this patch is that @ allows `""` as node name (a node like `/tmp/port/N` is assigned)
while node can't be blank with
* '#'  since in command `yarp read #/port` `#/port` is taken as bash comment.
* '=' since the behaviour is widely broken (#1470)

Error reporting on wrong matches is very basic but in many cases could be useful, if a part of the expression is matched:
```
"/p1/someInvalidNam&/p4" does not match the correct pattern for port definition.
Check for the error in prefix or suffix of the matched name:
/p1/someInvalidNam [&/p4]
```