### PR TITLE
IVirtualAnalogSensor methods renamed.

### DIFF
--- a/doc/release/v2_3_72.md
+++ b/doc/release/v2_3_72.md
@@ -77,6 +77,7 @@ New Features
 
 * Added a new interface for visual servoing: `IVisualServoing.h`.
 * `yarp::dev::CanBuffer` now supports a `const` version of `operator[]`.
+* Methods of `yarp::dev::IVirtualAnalogSensor` renamed in order to avoid conflicts with similar methods of `yarp::dev::IAnalogSensor`.
 
 #### `YARP_serversql`
 

--- a/src/libYARP_dev/include/yarp/dev/IVirtualAnalogSensor.h
+++ b/src/libYARP_dev/include/yarp/dev/IVirtualAnalogSensor.h
@@ -44,21 +44,21 @@ public:
      * @param ch channel number.
      * @return VAS_status type.
      */
-    virtual int getState(int ch)=0;
+    virtual VAS_status getVirtualAnalogSensorStatus(int ch)=0;
 
     /**
-     * Get the number of channels of the sensor.
+     * Get the number of channels of the virtual sensor.
      * @return number of channels (0 in case of errors).
      */
-    virtual int getChannels()=0;
+    virtual int getVirtualAnalogSensorChannels()=0;
 
     /**
-     * Set a vector of torque values for virtual sensor
+     * Set a vector of torque values for virtual sensor.
      * @param measure a vector containing the sensor's last readings.
      * @return true if ok, false otherwise.
      */
-    virtual bool updateMeasure(yarp::sig::Vector &measure)=0;
-    virtual bool updateMeasure(int ch, double &measure)=0;
+    virtual bool updateVirtualAnalogSensorMeasure(yarp::sig::Vector &measure)=0;
+    virtual bool updateVirtualAnalogSensorMeasure(int ch, double &measure)=0;
 
 };
 

--- a/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+++ b/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
@@ -61,7 +61,7 @@ namespace yarp{
  *
  * An analog wrapper for virtual device
  * A virtual device is a software emulated device, for example force-torque computed from a real sensor
- * and then relocated to another part of the robot or some kind of estimated meassurement needed by the
+ * and then relocated to another part of the robot or some kind of estimated measurement needed by the
  * robot.
  *
  * This virtual wrapper will open a port and accept the incoming estimated measurement and send them to
@@ -147,7 +147,7 @@ public:
 
     void flushTorques()
     {
-        if (mpSensor) mpSensor->updateMeasure(mTorques);
+        if (mpSensor) mpSensor->updateVirtualAnalogSensorMeasure(mTorques);
     }
 
     const std::string& getKey(){ return mKey; }


### PR DESCRIPTION
Methods of `yarp::dev::IVirtualAnalogSensor` renamed in order to avoid conflicts with similar methods of `yarp::dev::IAnalogSensor`.
This change breaks some compatibility with icub-main and codyco, which need to be changed accordingly.