### PR TITLE
[WIP]Log In Yarpmanager

### DIFF
--- a/src/libYARP_OS/src/Run.cpp
+++ b/src/libYARP_OS/src/Run.cpp
@@ -1945,7 +1945,6 @@ int yarp::os::Run::executeCmdStdout(Bottle& msg, Bottle& result, yarp::os::Const
     stdout_startup_info.hStdOutput=GetStdHandle(STD_OUTPUT_HANDLE);
     stdout_startup_info.hStdInput=read_from_pipe_cmd_to_stdout;
     stdout_startup_info.dwFlags|=STARTF_USESTDHANDLES;
-
     BOOL bSuccess=CreateProcess(nullptr,  // command name
                                 (char*)(yarp::os::ConstString("yarprun --log ")+loggerName+yarp::os::ConstString(" --write ")+portName).c_str(), // command line
                                 nullptr,  // process security attributes
@@ -1956,7 +1955,7 @@ int yarp::os::Run::executeCmdStdout(Bottle& msg, Bottle& result, yarp::os::Const
                                 nullptr,  // use parent's current directory
                                 &stdout_startup_info,   // STARTUPINFO pointer
                                 &stdout_process_info);  // receives PROCESS_INFORMATION
-
+    
     if (!bSuccess)
     {
         yarp::os::ConstString strError=yarp::os::ConstString("ABORTED: server=")+mPortName
@@ -2120,6 +2119,7 @@ int yarp::os::Run::executeCmdStdout(Bottle& msg, Bottle& result, yarp::os::Const
                              +yarp::os::ConstString("\n");
 
     result.addString(out.c_str());
+    portName = portName + "/" + std::to_string(stdout_process_info.dwProcessId);
     result.addString(portName.c_str());
     fprintf(stderr, "%s", out.c_str());
 
@@ -3220,6 +3220,8 @@ int yarp::os::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& res
 
                 result.addInt(pid_cmd);
                 result.addString(out.c_str());
+                portName += "/" + int2String(pid_cmd-1);
+                result.addString(portName.c_str());
 
                 fprintf(stderr, "%s", out.c_str());
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager/src-manager/applicationviewwidget.h
@@ -116,6 +116,7 @@ private:
 
 
 private:
+    QTimer* logTimer;
     QMainWindow *builderWindowContainer;
     QDockWidget *builderWidget;
     BuilderWindow *builder;
@@ -174,6 +175,7 @@ private slots:
     void onResourceItemSelectionChanged();
     void onConnectionItemSelectionChanged();
     void onModuleItemSelectionChanged();
+    void updateLogs();
     void selectAllModule();
     void selectAllConnections();
     void selectAllResources();


### PR DESCRIPTION
this pr intend to show the little effort necessary to integrate a log retriever into yarp manager. I've integrated it in the tooltip (that currently shows the last 10 lines of log) as an example, despite it to fullfill already the necessity to quickly check the status of an application (ex. the reason an application failed to start).

from here on, we can discuss what to do. the possibility i thought of are:

1. leave this as less invasive as possible.. showing only the last log lines, just to have a quick feedback from the applications and leaving the deep log inspection to yarplogger (basically leaving it as it is now)

2. integrating some functions of yarp logger but keeping it light and simple, leaving the deep log inspection to yarplogger

3. integrate all the functions of yarplogger, leaving yarplogger usage to the setups where no yarp managers are involved (command line yarprun setups) 


![tooltip](https://user-images.githubusercontent.com/7593650/35502314-ea3c7656-04dc-11e8-8b06-fb63f2f27f17.png)
