### PR TITLE
Fix server expectText stuck

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/NameserCarrier.h
+++ b/src/libYARP_OS/include/yarp/os/impl/NameserCarrier.h
@@ -47,6 +47,8 @@ public:
     virtual void beginPacket() override;
     virtual void endPacket() override;
 
+    virtual bool setReadTimeout(double timeout) override;
+
     using yarp::os::InputStream::read;
     virtual YARP_SSIZE_T read(const yarp::os::Bytes& b) override;
 };

--- a/src/libYARP_OS/src/NameserCarrier.cpp
+++ b/src/libYARP_OS/src/NameserCarrier.cpp
@@ -64,6 +64,11 @@ void yarp::os::impl::NameserTwoWayStream::endPacket() {
     delegate->endPacket();
 }
 
+bool yarp::os::impl::NameserTwoWayStream::setReadTimeout(double timeout)
+{
+    return delegate->getInputStream().setReadTimeout(timeout);
+}
+
 YARP_SSIZE_T yarp::os::impl::NameserTwoWayStream::read(const Bytes& b) {
     // assume it is ok for name_ser to go byte-by-byte
     // since this protocol will be phased out

--- a/src/libYARP_OS/src/StreamConnectionReader.cpp
+++ b/src/libYARP_OS/src/StreamConnectionReader.cpp
@@ -247,7 +247,9 @@ yarp::os::ConstString StreamConnectionReader::expectText(int terminatingChar)
     }
     yAssert(in!=nullptr);
     bool lsuccess = false;
+    in->setReadTimeout(2.0);
     ConstString result = in->readLine(terminatingChar, &lsuccess);
+    in->setReadTimeout(0.0);
     if (lsuccess) {
         messageLen -= result.length()+1;
     }


### PR DESCRIPTION
Related to #1542 this could be a less invasive fix than placing a default timeout on the stream.
Unless we want to go for https://github.com/robotology/yarp/issues/1542#issuecomment-368011127, let me know.
On the fly I also moved [StreamConnectionReader] implementation from h to cpp. 