### PR TITLE
yarpidl_rosmsg: Add --no-recurse option

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -59,10 +59,11 @@ Important Changes
 #### `yarpidl_rosmsg`
 
 * Fixed verbose output.
-* Added new no-cache argument.
-* Added new no-index argument.
+* Added new --no-cache argument.
+* Added new --no-index argument.
 * Fixed generation when message files are in the msg folder.
-
+* Added new --no-recurse argument. This option can be enabled when using
+  `yarp_idl_to_dir` and `yarp_add_idl`, using the `NO_RECURSE` argument.
 
 Contributors
 ------------

--- a/src/idls/rosmsg/src/RosType.h
+++ b/src/idls/rosmsg/src/RosType.h
@@ -129,6 +129,7 @@ public:
     RosType *reply;
     std::string package;
     bool verbose;
+    bool no_recurse;
 
     RosType() :
             isValid(false),
@@ -136,7 +137,8 @@ public:
             arrayLength(-1),
             isStruct(false),
             reply(nullptr),
-            verbose(false)
+            verbose(false),
+            no_recurse(false)
     {
     }
 
@@ -181,6 +183,10 @@ public:
 
     void setVerbose() {
         verbose = true;
+    }
+
+    void setNoRecurse() {
+        no_recurse = true;
     }
 };
 

--- a/src/idls/rosmsg/src/main.cpp
+++ b/src/idls/rosmsg/src/main.cpp
@@ -48,6 +48,8 @@ void show_usage()
     printf("    Do not cache ros msg file\n");
     printf("  --no-index\n");
     printf("    Do not generate the indexALL.txt file\n");
+    printf("  --no-recurse\n");
+    printf("    Generate code only for the selected file, not for its dependencies\n");
     printf("  --verbose\n");
     printf("    Verbose output\n");
     printf("\n");
@@ -134,6 +136,7 @@ int generate_cpp(int argc, char *argv[])
     bool verbose = p.check("verbose");
     bool no_cache = p.check("no-cache");
     bool no_index = p.check("no-index");
+    bool no_recurse = p.check("no-recurse");
 
     fname = argv[argc-1];
 
@@ -157,6 +160,9 @@ int generate_cpp(int argc, char *argv[])
     }
     if (no_index) {
         gen.setNoIndex();
+    }
+    if (no_recurse) {
+        t.setNoRecurse();
     }
 
     if (p.check("out")) {


### PR DESCRIPTION
If this option is enabled, it generates code only for the selected file, not for its dependencies.

The new `NO_RECURSE` argument is now accepted by `yarp_add_idl` and `yarp_idl_to_dir`