### PR TITLE
 yarpidl_rosmsg: Add special methods to support timestamps as a double to builtin types

### DIFF
--- a/src/devices/FrameTransformServer/FrameTransformServer.cpp
+++ b/src/devices/FrameTransformServer/FrameTransformServer.cpp
@@ -85,44 +85,6 @@ void Transforms_server_storage::clear()
 }
 
 /**
-  * Helper functions
-  */
-
-inline TickTime normalizeSecNSec(double yarpTimeStamp)
-{
-    uint64_t time;
-    uint64_t nsec_part;
-    uint64_t sec_part;
-    TickTime ret;
-
-    time = (uint64_t)(yarpTimeStamp * 1000000000UL);
-    nsec_part = (time % 1000000000UL);
-    sec_part = (time / 1000000000UL);
-
-    if (sec_part > std::numeric_limits<unsigned int>::max())
-    {
-        yWarning() << "Timestamp exceeded the 64 bit representation, resetting it to 0";
-        sec_part = 0;
-    }
-
-    ret.sec = (yarp::os::NetUint32) sec_part;
-    ret.nsec = (yarp::os::NetUint32) nsec_part;
-    return ret;
-}
-
-inline double normalizeToYarpTime(TickTime rosTimeStamp)
-{
-    double yarptime = rosTimeStamp.sec;
-    if (rosTimeStamp.nsec > 1000000000UL)
-    {
-        yWarning() << "Check on rosTimeStamp.nsec > 1000000000UL failed";
-
-    }
-    yarptime = yarptime + rosTimeStamp.nsec * 1000000000.0;
-    return yarptime;
-}
-
-/**
   * FrameTransformServer
   */
 
@@ -720,9 +682,9 @@ void FrameTransformServer::run()
                         t.rotation.w() = tfs[i].transform.rotation.w;
                         t.src_frame_id = tfs[i].header.frame_id;
                         t.dst_frame_id = tfs[i].child_frame_id;
-                        //@@@ should we use yarp or ROS timestamps? 
+                        //@@@ should we use yarp or ROS timestamps?
                         t.timestamp = yarp::os::Time::now();
-                        //t.timestamp = normalizeToYarpTime(tfs[i].header.stamp); //@@@ is this ok?
+                        //t.timestamp = tfs[i].header.stamp; //@@@ is this ok?
                         (*m_ros_static_transform_storage).set_transform(t);
                     }
                 }
@@ -821,7 +783,7 @@ void FrameTransformServer::run()
                 transform_timed.child_frame_id = (*m_yarp_timed_transform_storage)[i].dst_frame_id;
                 transform_timed.header.frame_id = (*m_yarp_timed_transform_storage)[i].src_frame_id;
                 transform_timed.header.seq = rosMsgCounter;
-                transform_timed.header.stamp = normalizeSecNSec((*m_yarp_timed_transform_storage)[i].timestamp);
+                transform_timed.header.stamp = (*m_yarp_timed_transform_storage)[i].timestamp;
                 transform_timed.transform.rotation.x = (*m_yarp_timed_transform_storage)[i].rotation.x();
                 transform_timed.transform.rotation.y = (*m_yarp_timed_transform_storage)[i].rotation.y();
                 transform_timed.transform.rotation.z = (*m_yarp_timed_transform_storage)[i].rotation.z();
@@ -842,7 +804,7 @@ void FrameTransformServer::run()
                 transform_static.child_frame_id = (*m_yarp_static_transform_storage)[i].dst_frame_id;
                 transform_static.header.frame_id = (*m_yarp_static_transform_storage)[i].src_frame_id;
                 transform_static.header.seq = rosMsgCounter;
-                transform_static.header.stamp = normalizeSecNSec(yarp::os::Time::now()); //@@@check timestamp of static transform?
+                transform_static.header.stamp = yarp::os::Time::now(); //@@@check timestamp of static transform?
                 transform_static.transform.rotation.x = (*m_yarp_static_transform_storage)[i].rotation.x();
                 transform_static.transform.rotation.y = (*m_yarp_static_transform_storage)[i].rotation.y();
                 transform_static.transform.rotation.z = (*m_yarp_static_transform_storage)[i].rotation.z();

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -587,7 +587,7 @@ void Rangefinder2DWrapper::run()
             {
                 sensor_msgs_LaserScan &rosData = rosPublisherPort.prepare();
                 rosData.header.seq = rosMsgCounter++;
-                rosData.header.stamp = normalizeSecNSec(lastStateStamp.getTime());
+                rosData.header.stamp = lastStateStamp.getTime();
                 rosData.header.frame_id = frame_id;
 
                 rosData.angle_min = minAngle * M_PI / 180.0;

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -833,7 +833,7 @@ void AnalogWrapper::run()
                 {
                     geometry_msgs_WrenchStamped rosData;
                     rosData.header.seq = rosMsgCounter++;
-                    rosData.header.stamp = normalizeSecNSec(yarp::os::Time::now());
+                    rosData.header.stamp = yarp::os::Time::now();
                     rosData.header.frame_id = frame_id;
 
                     rosData.wrench.force.x = lastDataRead[0];
@@ -874,7 +874,7 @@ void AnalogWrapper::run()
                         }
                     }
                     rosData.header.seq = rosMsgCounter++;
-                    rosData.header.stamp = normalizeSecNSec(yarp::os::Time::now());
+                    rosData.header.stamp = yarp::os::Time::now();
                     rosPublisherJointPort.write(rosData);
                 }
             }

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -947,7 +947,7 @@ void ControlBoardWrapper::run()
         ros_struct.name=jointNames;
 
         ros_struct.header.seq = rosMsgCounter++;
-        ros_struct.header.stamp = normalizeSecNSec(time.getTime());
+        ros_struct.header.stamp = time.getTime();
 
         rosPublisherPort.write(ros_struct);
     }

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -757,7 +757,7 @@ bool RGBDSensorWrapper::setCamInfo(sensor_msgs_CameraInfo& cameraInfo, const str
 
     cameraInfo.header.frame_id    = frame_id;
     cameraInfo.header.seq         = seq;
-    cameraInfo.header.stamp       = normalizeSecNSec(stamp);
+    cameraInfo.header.stamp       = stamp;
     cameraInfo.width              = sensorType == COLOR_SENSOR ? sensor_p->getRgbWidth() : sensor_p->getDepthWidth();
     cameraInfo.height             = sensorType == COLOR_SENSOR ? sensor_p->getRgbHeight() : sensor_p->getDepthHeight();
     cameraInfo.distortion_model   = distModel;
@@ -850,8 +850,8 @@ bool RGBDSensorWrapper::writeData()
         sensor_msgs_CameraInfo& camInfoD        = rosPublisherPort_depthCaminfo.prepare();
         TickTime                cRosStamp, dRosStamp;
 
-        cRosStamp = normalizeSecNSec(colorStamp.getTime());
-        dRosStamp = normalizeSecNSec(depthStamp.getTime());
+        cRosStamp = colorStamp.getTime();
+        dRosStamp = depthStamp.getTime();
 
         deepCopyImages(colorImage, rColorImage, rosFrameId, cRosStamp, nodeSeq);
         deepCopyImages(depthImage, rDepthImage, rosFrameId, dRosStamp, nodeSeq);

--- a/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.cpp
+++ b/src/libYARP_dev/src/devices/ServerInertial/ServerInertial.cpp
@@ -456,7 +456,7 @@ void yarp::dev::ServerInertial::run()
                 sensor_msgs_Imu &rosData = rosPublisherPort.prepare();
 
                 rosData.header.seq = rosMsgCounter++;
-                rosData.header.stamp = normalizeSecNSec(yarp::os::Time::now());
+                rosData.header.stamp = yarp::os::Time::now();
                 rosData.header.frame_id = frame_id;
 
                 rosData.orientation.x = quaternion[0];

--- a/src/libYARP_dev/src/devices/msgs/ros/include/TickDuration.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/TickDuration.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this TickDuration.msg definition:
+// Generated from the following "duration" native type definition:
 // Instances of this class can be read and written with YARP ports,
 // using a ROS-compatible format.
 
@@ -10,6 +10,8 @@
 #include <vector>
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <climits>
+#include <cstdint>
 #include "TickTime.h"
 #include "std_msgs_Header.h"
 #include "geometry_msgs_Point.h"
@@ -28,6 +30,43 @@ public:
             sec(0),
             nsec(0)
     {
+    }
+
+    TickDuration(double timestamp) :
+            sec(0),
+            nsec(0)
+    {
+        uint64_t time = (uint64_t) (timestamp * 1000000000UL);
+        uint64_t sec_part = (time / 1000000000UL);
+        uint64_t nsec_part = (time % 1000000000UL);
+        if (sec > UINT32_MAX) {
+            yWarning("TickDuration::TickDuration(): Timestamp exceeded the 32 bit representation, resetting it to 0");
+            sec = 0;
+        }
+        sec = static_cast<yarp::os::NetUint32>(sec_part);
+        nsec = static_cast<yarp::os::NetUint32>(nsec_part);
+    }
+
+    TickDuration& operator=(const double timestamp)
+    {
+        uint64_t time = (uint64_t) (timestamp * 1000000000UL);
+        uint64_t sec_part = (time / 1000000000UL);
+        uint64_t nsec_part = (time % 1000000000UL);
+        if (sec > UINT32_MAX) {
+            yWarning("TickDuration::operator=(): Timestamp exceeded the 32 bit representation, resetting it to 0");
+            sec = 0;
+        }
+        sec = static_cast<yarp::os::NetUint32>(sec_part);
+        nsec = static_cast<yarp::os::NetUint32>(nsec_part);
+        return *this;
+    }
+
+    operator double()
+    {
+        if (nsec > 1000000000UL) {
+            yWarning("TickDuration::operator double(): Check on nsec > 1000000000UL failed");
+        }
+        return sec + nsec * 1000000000.0;
     }
 
     void clear()

--- a/src/libYARP_dev/src/devices/msgs/ros/include/TickTime.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/TickTime.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this TickTime.msg definition:
+// Generated from the following "time" native type definition:
 // Instances of this class can be read and written with YARP ports,
 // using a ROS-compatible format.
 
@@ -10,6 +10,8 @@
 #include <vector>
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <climits>
+#include <cstdint>
 
 class TickTime : public yarp::os::idl::WirePortable
 {
@@ -21,6 +23,43 @@ public:
             sec(0),
             nsec(0)
     {
+    }
+
+    TickTime(double timestamp) :
+            sec(0),
+            nsec(0)
+    {
+        uint64_t time = (uint64_t) (timestamp * 1000000000UL);
+        uint64_t sec_part = (time / 1000000000UL);
+        uint64_t nsec_part = (time % 1000000000UL);
+        if (sec > UINT32_MAX) {
+            yWarning("TickTime::TickTime(): Timestamp exceeded the 32 bit representation, resetting it to 0");
+            sec = 0;
+        }
+        sec = static_cast<yarp::os::NetUint32>(sec_part);
+        nsec = static_cast<yarp::os::NetUint32>(nsec_part);
+    }
+
+    TickTime& operator=(const double timestamp)
+    {
+        uint64_t time = (uint64_t) (timestamp * 1000000000UL);
+        uint64_t sec_part = (time / 1000000000UL);
+        uint64_t nsec_part = (time % 1000000000UL);
+        if (sec > UINT32_MAX) {
+            yWarning("TickTime::operator=(): Timestamp exceeded the 32 bit representation, resetting it to 0");
+            sec = 0;
+        }
+        sec = static_cast<yarp::os::NetUint32>(sec_part);
+        nsec = static_cast<yarp::os::NetUint32>(nsec_part);
+        return *this;
+    }
+
+    operator double()
+    {
+        if (nsec > 1000000000UL) {
+            yWarning("TickTime::operator double(): Check on nsec > 1000000000UL failed");
+        }
+        return sec + nsec * 1000000000.0;
     }
 
     void clear()

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Point.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Point.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Point.msg definition:
+// Generated from the following "geometry_msgs/Point" msg definition:
 //   # This contains the position of a point in free space
 //   float64 x
 //   float64 y

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Pose.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Pose.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Pose.msg definition:
+// Generated from the following "geometry_msgs/Pose" msg definition:
 //   # A representation of pose in free space, composed of postion and orientation. 
 //   geometry_msgs/Point position
 //   geometry_msgs/Quaternion orientation// Instances of this class can be read and written with YARP ports,

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Quaternion.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Quaternion.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Quaternion.msg definition:
+// Generated from the following "geometry_msgs/Quaternion" msg definition:
 //   # This represents an orientation in free space in quaternion form.
 //   
 //   float64 x

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Transform.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Transform.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Transform.msg definition:
+// Generated from the following "geometry_msgs/Transform" msg definition:
 //   # This represents the transform between two coordinate frames in free space.
 //   
 //   Vector3 translation

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_TransformStamped.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_TransformStamped.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_TransformStamped.msg definition:
+// Generated from the following "geometry_msgs/TransformStamped" msg definition:
 //   # This expresses a transform from coordinate frame header.frame_id
 //   # to the coordinate frame child_frame_id
 //   #

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Vector3.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Vector3.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Vector3.msg definition:
+// Generated from the following "geometry_msgs/Vector3" msg definition:
 //   # This represents a vector in free space.
 //   
 //   float64 x

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Wrench.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_Wrench.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_Wrench.msg definition:
+// Generated from the following "geometry_msgs/Wrench" msg definition:
 //   # This represents force in free space, separated into
 //   # its linear and angular parts.
 //   Vector3  force

--- a/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_WrenchStamped.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/geometry_msgs_WrenchStamped.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this geometry_msgs_WrenchStamped.msg definition:
+// Generated from the following "geometry_msgs/WrenchStamped" msg definition:
 //   # A wrench with reference coordinate frame and timestamp
 //   Header header
 //   Wrench wrench

--- a/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_MapMetaData.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_MapMetaData.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this nav_msgs_MapMetaData.msg definition:
+// Generated from the following "nav_msgs/MapMetaData" msg definition:
 //   # This hold basic information about the characterists of the OccupancyGrid
 //   
 //   # The time at which the map was loaded

--- a/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_OccupancyGrid.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/nav_msgs_OccupancyGrid.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this nav_msgs_OccupancyGrid.msg definition:
+// Generated from the following "nav_msgs/OccupancyGrid" msg definition:
 //   # This represents a 2-D grid map, in which each cell represents the probability of
 //   # occupancy.
 //   

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_CameraInfo.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_CameraInfo.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_CameraInfo.msg definition:
+// Generated from the following "sensor_msgs/CameraInfo" msg definition:
 //   # This message defines meta information for a camera. It should be in a
 //   # camera namespace on topic "camera_info" and accompanied by up to five
 //   # image topics named:

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Image.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Image.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_Image.msg definition:
+// Generated from the following "sensor_msgs/Image" msg definition:
 //   # This message contains an uncompressed image
 //   # (0, 0) is at top-left corner of image
 //   #

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Imu.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_Imu.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_Imu.msg definition:
+// Generated from the following "sensor_msgs/Imu" msg definition:
 //   # This is a message to hold data from an IMU (Inertial Measurement Unit)
 //   #
 //   # Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_JointState.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_JointState.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_JointState.msg definition:
+// Generated from the following "sensor_msgs/JointState" msg definition:
 //   # This is a message that holds data to describe the state of a set of torque controlled joints.
 //   #
 //   # The state of each joint (revolute or prismatic) is defined by:

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_LaserScan.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_LaserScan.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_LaserScan.msg definition:
+// Generated from the following "sensor_msgs/LaserScan" msg definition:
 //   # Single scan from a planar laser range-finder
 //   #
 //   # If you have another ranging device with different behavior (e.g. a sonar

--- a/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_RegionOfInterest.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/sensor_msgs_RegionOfInterest.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this sensor_msgs_RegionOfInterest.msg definition:
+// Generated from the following "sensor_msgs/RegionOfInterest" msg definition:
 //   # This message is used to specify a region of interest within an image.
 //   #
 //   # When used to specify the ROI setting of the camera when the image was

--- a/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_ColorRGBA.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_ColorRGBA.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this std_msgs_ColorRGBA.msg definition:
+// Generated from the following "std_msgs/ColorRGBA" msg definition:
 //   float32 r
 //   float32 g
 //   float32 b

--- a/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_Header.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/std_msgs_Header.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this std_msgs_Header.msg definition:
+// Generated from the following "std_msgs/Header" msg definition:
 //   [std_msgs/Header]:
 //   # Standard metadata for higher-level stamped data types.
 //   # This is generally used to communicate timestamped data

--- a/src/libYARP_dev/src/devices/msgs/ros/include/tf2_msgs_TFMessage.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/tf2_msgs_TFMessage.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this tf2_msgs_TFMessage.msg definition:
+// Generated from the following "tf2_msgs/TFMessage" msg definition:
 //   geometry_msgs/TransformStamped[] transforms// Instances of this class can be read and written with YARP ports,
 // using a ROS-compatible format.
 

--- a/src/libYARP_dev/src/devices/msgs/ros/include/tf_tfMessage.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/tf_tfMessage.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this tf_tfMessage.msg definition:
+// Generated from the following "tf/tfMessage" msg definition:
 //   geometry_msgs/TransformStamped[] transforms
 // Instances of this class can be read and written with YARP ports,
 // using a ROS-compatible format.

--- a/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_Marker.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_Marker.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this visualization_msgs_Marker.msg definition:
+// Generated from the following "visualization_msgs/Marker" msg definition:
 //   # See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz
 //   
 //   uint8 ARROW=0

--- a/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_MarkerArray.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/visualization_msgs_MarkerArray.h
@@ -1,5 +1,5 @@
 // This is an automatically generated file.
-// Generated from this visualization_msgs_MarkerArray.msg definition:
+// Generated from the following "visualization_msgs/MarkerArray" msg definition:
 //   visualization_msgs/Marker[] markers// Instances of this class can be read and written with YARP ports,
 // using a ROS-compatible format.
 

--- a/src/libYARP_dev/src/devices/msgs/ros/include/yarpRosHelper.h
+++ b/src/libYARP_dev/src/devices/msgs/ros/include/yarpRosHelper.h
@@ -32,32 +32,6 @@ ROSTopicUsageType;
 
 double const PI = 3.1415926535897932384626433;
 
-/**
- * This function has been took from ROS source file
- * http://docs.ros.org/diamondback/api/rostime/html/time_8h_source.html#l00095
- * and modified a bit to cope with yarp time handling in double
- * yarpTimeStamp: input yarp time in double
- * sec: sec part
- * nsec: nano second part
- */
-inline TickTime normalizeSecNSec(double yarpTimeStamp)
-{
-    uint64_t time = (uint64_t) (yarpTimeStamp * 1000000000UL);
-    uint64_t nsec_part = (time % 1000000000UL);
-    uint64_t sec_part = (time / 1000000000UL);
-    TickTime ret;
-
-    if (sec_part > UINT_MAX)
-    {
-        yWarning() << "Timestamp exceeded the 64 bit representation, resetting it to 0";
-        sec_part = 0;
-    }
-
-    ret.sec  = sec_part;
-    ret.nsec = nsec_part;
-    return ret;
-}
-
 /** convert degrees to radiants for ROS messages */
 inline double convertDegreesToRadians(double degrees)
 {


### PR DESCRIPTION
`TickTime` and `TickDuration` now have constructor, assignment operator, and cast operator operator to support timestamps and duration as a double.

This allows to remove the `normalizeSecNSec` and `normalizeToYarpTime` methods used by several devices from the `yarpRosHelper.h` file.

@barbalberto Does this make sense to you?