### PR TITLE
Fix subdevice not being created for BatteryWrapper

### DIFF
--- a/src/devices/BatteryWrapper/BatteryWrapper.cpp
+++ b/src/devices/BatteryWrapper/BatteryWrapper.cpp
@@ -36,6 +36,7 @@ BatteryWrapper::BatteryWrapper() : RateThread(DEFAULT_THREAD_PERIOD)
 
 BatteryWrapper::~BatteryWrapper()
 {
+    threadRelease();
     battery_p = nullptr;
 }
 

--- a/src/devices/BatteryWrapper/BatteryWrapper.h
+++ b/src/devices/BatteryWrapper/BatteryWrapper.h
@@ -1,6 +1,6 @@
-/*
+ /*
  * Copyright (C) 2015 Istituto Italiano di Tecnologia (IIT)
- * Authors: Marco Randazzo <marco.randazzo@iit.it>
+ * Authors: Marco Randazzo <marco.randazzo@iit.it>, David Estevez <destevez@ing.uc3m.es>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LICENSE
  */
 
@@ -70,8 +70,6 @@ public:
     void attach(yarp::dev::IBattery *s);
     void detach();
 
-    bool threadInit() override;
-    void threadRelease() override;
     void run() override;
 
 private:
@@ -87,6 +85,17 @@ private:
 
     bool initialize_YARP(yarp::os::Searchable &config);
     virtual bool read(yarp::os::ConnectionReader& connection) override;
+
+    // Default usage
+    // Open the wrapper only, the attach method needs to be called before using it
+    bool openDeferredAttach(yarp::os::Searchable &prop);
+
+    // If a subdevice parameter is given to the wrapper, it will
+    // open it and and attach to it immediatly.
+    yarp::dev::PolyDriver *subDeviceOwned;
+    bool openAndAttachSubDevice(yarp::os::Searchable &prop);
+
+ bool ownDevices;
 
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 };


### PR DESCRIPTION
Hi!

I've been developing a new IBattery device but couldn't get it to work properly. After a closer inspection to the YARP code, I found out that the code for the BatteryWrapper was not creating the corresponding subdevice, and that's why I couldn't get my device to work. 

I've changed the BatteryWrapper based on other wrappers (such as the AnalogWrapper or the ControlBoardWrapper), fixing the issue, and now it works.

This PR contains the aforementioned fix.