### PR TITLE
Always place YARP_DEPRECATED before the return type of the function

### DIFF
--- a/src/libYARP_OS/include/yarp/os/PortReaderBufferBase.h
+++ b/src/libYARP_OS/include/yarp/os/PortReaderBufferBase.h
@@ -71,8 +71,8 @@ public:
     void release(void* key);
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 2.3.72
-    void YARP_DEPRECATED setAllowReuse(bool flag = true);
-    void YARP_DEPRECATED release(yarp::os::PortReader* completed);
+    YARP_DEPRECATED void setAllowReuse(bool flag = true);
+    YARP_DEPRECATED void release(yarp::os::PortReader* completed);
 #endif // YARP_NO_DEPRECATED
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS


### PR DESCRIPTION
Compiler specific attributes support being placed also between the return type
and the name of the function, but the C++14 `[[deprecated]]` needs to be placed
before the return type of the function.

Fix (hopefully) https://github.com/robotology/yarp/issues/1531 .