### PR TITLE
Fix missing YARP Matrix and Vector headers

### DIFF
--- a/src/libYARP_eigen/include/yarp/eigen/Eigen.h
+++ b/src/libYARP_eigen/include/yarp/eigen/Eigen.h
@@ -8,6 +8,8 @@
 #define YARP_EIGEN_EIGEN_H
 
 #include <Eigen/Core>
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/Vector.h>
 
 namespace yarp
 {


### PR DESCRIPTION
This PR adds two missing headers in `Eigen.h`:
 1. `#include <yarp/sig/Matrix.h>`
 2. `#include <yarp/sig/Vector.h>`

Without these headers, `Eigen.h` cannot be compiled and users are required to have an implicit order in their header inclusion list.