### PR TITLE
Fix yarp::OS::getprogname

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -78,15 +78,6 @@ YARP_OS_API const char* getenv(const char* var);
 YARP_OS_API int getpid();
 
 /**
- * @brief Portable wrapper for the setprogname() function.
- *
- * Set the program name.
- *
- * @param[in] progname the program name
- */
-YARP_OS_API void setprogname(const char* progname);
-
-/**
  * @brief Portable wrapper for the getprogname() function.
  *
  * Get the program name.

--- a/src/libYARP_OS/src/Os.cpp
+++ b/src/libYARP_OS/src/Os.cpp
@@ -14,6 +14,7 @@
 #include <yarp/os/impl/PlatformSysStat.h>
 #include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/SystemInfo.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -98,31 +99,12 @@ int yarp::os::getpid()
     return pid;
 }
 
-void yarp::os::setprogname(const char *progname)
-{
-#ifdef YARP_HAS_ACE
-    ACE_OS::setprogname(ACE::basename(progname));
-#else
-    // not available
-    YARP_UNUSED(progname);
-#endif
-}
-
 
 void yarp::os::getprogname(char* progname, size_t size)
 {
-#ifdef YARP_HAS_ACE
-    const char* tmp = ACE_OS::getprogname();
-    if (std::strlen(tmp)==0) {
-        std::strncpy(progname, "no_progname", size);
-    } else {
-        std::strncpy(progname, tmp, size);
-    }
-#else
-    // not available
-    *progname = '\0';
-    YARP_UNUSED(size);
-#endif
+    int pid = yarp::os::getpid();
+    yarp::os::SystemInfo::ProcessInfo info = yarp::os::SystemInfo::getProcessInfo(pid);
+    std::strncpy(progname, info.name.c_str(), size);
 }
 
 

--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -159,13 +159,8 @@ public:
         return "";
     }
 
-    bool configure(Property& config, int argc, char *argv[], bool skip) {
-        if (argc>0) {
-            if (argv[0]!=nullptr) {
-                yarp::os::setprogname(argv[0]);
-            }
-        }
-
+    bool configure(Property& config, int argc, char *argv[], bool skip)
+    {
         Property p;
         p.fromCommand(argc, argv, skip);
 


### PR DESCRIPTION
This PR fixes the implementation of yarp::OS::getprogname() that is not working on Windows. 
Indeed, the method was just a wrapper for an ACE function that was ok on Linux, but was not implemented for Windows (it was just able to return a string previously set by yarp::OS::setprogname()).

The new implementations is now a wrapper around yarp::os::SystemInfo::getProcessInfo(), which is correctly implemented using a windows.h function call. I was tempted to remove yarp::OS::getprogname() completely, but I left it for backward compatibility.

Instead, I removed yarp::OS::setprogname() because it is neither useful nor meaningful to me.

To be tested on MAC_OS.