### PR TITLE
Actually pass monitor object to wrapped subdevices in CBW

### DIFF
--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -23,6 +23,10 @@ Bug Fixes
 #### `YARP_dev`
 
 * ControlBoardWrapper now correctly passes on any monitoring to wrapped subdevices.
+* Subdevices wrapped by ControlBoardWrapper are now identified by their actual name
+  by the monitor object, that is, their name will be displayed on the command line
+  if yarpdev was called with `--verbose`. Previously, it used a generic "subdevice"
+  identifier.
 
 Contributors
 ------------

--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -14,14 +14,15 @@ Bug Fixes
 
 * Fixed bottle handling.
 
-Bug Fixes
----------
-
 ### Libraries
 
 #### `YARP_sig`
 
 * Fixed bug in yarp::sig::Sound operator '+='
+
+#### `YARP_dev`
+
+* ControlBoardWrapper now correctly passes on any monitoring to wrapped subdevices.
 
 Contributors
 ------------

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -628,9 +628,10 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     subDeviceOwned = new PolyDriver;
     p.fromString(prop.toString().c_str());
 
-    p.setMonitor(prop.getMonitor(), "subdevice"); // pass on any monitoring
+    std::string subdevice = prop.find("subdevice").asString();
+    p.setMonitor(prop.getMonitor(), subdevice.c_str()); // pass on any monitoring
     p.unput("device");
-    p.put("device",prop.find("subdevice").asString());  // subdevice was already checked before
+    p.put("device", subdevice);  // subdevice was already checked before
 
     // if error occour during open, quit here.
     yDebug("opening controlBoardWrapper2 subdevice\n");
@@ -672,7 +673,7 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     SubDevice *tmpDevice=device.getSubdevice(0);
     tmpDevice->setVerbose(_verb);
 
-    std::string subDevName ((partName + "_" + prop.find("subdevice").asString().c_str()));
+    std::string subDevName ((partName + "_" + subdevice.c_str()));
     if (!tmpDevice->configure(base, top, controlledJoints, subDevName, this) )
     {
         yError() <<"configure of subdevice ret false";

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -435,6 +435,7 @@ bool ControlBoardWrapper::open(Searchable& config)
     if(prop.check("subdevice"))
     {
         ownDevices=true;
+        prop.setMonitor(config.getMonitor());
         if(! openAndAttachSubDevice(prop))
         {
             yError("ControlBoardWrapper: error while opening subdevice\n");


### PR DESCRIPTION
Subdevice options did not show up on stdout when using `yarpdev --verbose`. A missing `Searchable::setMonitor` call prevented the monitor object from being passed on to any wrapped device. By the way, the *subdevice* generic name has been replaced so that the actual device name is picked by said monitor.