### PR TITLE
Fix bug in ControlBoardRemapper::getEncoderAccelerations method

### DIFF
--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -28,6 +28,13 @@ Bug Fixes
   if yarpdev was called with `--verbose`. Previously, it used a generic "subdevice"
   identifier.
 
+### Devices
+
+#### `ControlBoardRemapper`
+
+* Fixed `getEncoderAccelerations()` method.
+
+
 Contributors
 ------------
 

--- a/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -1964,7 +1964,7 @@ bool ControlBoardRemapper::getEncoderAccelerations(double *accs)
 
         if (p->iJntEnc)
         {
-            bool ok = p->iJntEnc->getEncoderSpeed(off, accs+l);
+            bool ok = p->iJntEnc->getEncoderAcceleration(off, accs+l);
             ret = ret && ok;
         }
         else


### PR DESCRIPTION
The method was actually returning encoder velocities