### PR TITLE
getprogname replaced by SystemInfo::getProcessInfo

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -12,28 +12,19 @@ Important Changes
 * All YARP libraries can now be modified and distributed under the terms of the
   BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-### Libraries
-
-* New auto-generated interface libraries for ros messages:
-  * YARP_rosmsg_std_msgs
-  * YARP_rosmsg_actionlib_msgs
-  * YARP_rosmsg_diagnostic_msgs
-  * YARP_rosmsg_geometry_msgs
-  * YARP_rosmsg_nav_msgs
-  * YARP_rosmsg_sensor_msgs
-  * YARP_rosmsg_shape_msgs
-  * YARP_rosmsg_stereo_msgs
-  * YARP_rosmsg_trajectory_msgs
-  * YARP_rosmsg_visualization_msgs
-  * YARP_rosmsg_tf
-  * YARP_rosmsg_tf2_msgs
-  * YARP_rosmsg (includes all the other rosmsg libraries)
-
 #### `YARP_OS`
 
 * The `shmem` carrier is no longer builtin inside `YARP_OS` and it is now a
   plugin.
 * The `Run` class was moved to the new library `YARP_run`
+* `yarp::os::setprogname()` is now deprecated.
+* `yarp::os::getprogname()` is now deprecated.
+* `yarp::os::SystemInfo::getProcessInfo()` now returns info for current process when
+  called without arguments.
+
+#### `YARP_sig`
+
+* The file `yarp/sig/IplImage.h` is deprecated, use opencv headers instead.
 
 #### `YARP_dev`
 
@@ -62,15 +53,31 @@ Important Changes
   * `/yarp/dev/ServerSoundGrabber.h`
   * `/yarp/dev/TestMotor.h`
 
-#### `YARP_sig`
-
-* The file `yarp/sig/IplImage.h` is deprecated, use opencv headers instead.
-
 #### `YARP_manager`
 
 * The following headers were removed:
   * `/yarp/manager/ymm-dir.h`
 
+
+New Features
+------------
+
+### Libraries
+
+* New auto-generated interface libraries for ros messages:
+  * YARP_rosmsg_std_msgs
+  * YARP_rosmsg_actionlib_msgs
+  * YARP_rosmsg_diagnostic_msgs
+  * YARP_rosmsg_geometry_msgs
+  * YARP_rosmsg_nav_msgs
+  * YARP_rosmsg_sensor_msgs
+  * YARP_rosmsg_shape_msgs
+  * YARP_rosmsg_stereo_msgs
+  * YARP_rosmsg_trajectory_msgs
+  * YARP_rosmsg_visualization_msgs
+  * YARP_rosmsg_tf
+  * YARP_rosmsg_tf2_msgs
+  * YARP_rosmsg (includes all the other rosmsg libraries)
 
 ### Tools
 

--- a/src/libYARP_OS/include/yarp/os/Os.h
+++ b/src/libYARP_OS/include/yarp/os/Os.h
@@ -37,13 +37,16 @@ YARP_OS_API const char* getenv(const char* var);
  */
 YARP_OS_API int getpid();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 /**
  * @brief Portable wrapper for the setprogname() function.
  *
  * Set the program name.
  *
  * @param[in] progname the program name
+ * @deprecated Since YARP 3.0.0.
  */
+YARP_DEPRECATED
 YARP_OS_API void setprogname(const char* progname);
 
 /**
@@ -53,8 +56,11 @@ YARP_OS_API void setprogname(const char* progname);
  *
  * @param[out] progname the program name
  * @param size The size of the @c progname array
+ * @deprecated Since YARP 3.0.0. Use yarp::os::SystemInfo::getProcessInfo().name.
  */
+YARP_DEPRECATED_MSG("This method is deprecated. Use yarp::os::SystemInfo::getProcessInfo().name instead")
 YARP_OS_API void getprogname(char* progname, size_t size);
+#endif // YARP_NO_DEPRECATED
 
 /**
  * @brief Portable wrapper for the gethostname() function.

--- a/src/libYARP_OS/include/yarp/os/SystemInfo.h
+++ b/src/libYARP_OS/include/yarp/os/SystemInfo.h
@@ -158,10 +158,10 @@ public:
      * @brief gets the operating system process information given by its PID.
      * If the information cannot be retrieved, ProcessInfo.pid is set to -1
      * otherwise, it is equal to the given PID as parameter.
-     * @param pid the process (task) PID
+     * @param pid the process (task) PID, or 0 for current process
      * @return ProcessInfo
      */
-    static ProcessInfo getProcessInfo(int pid);
+    static ProcessInfo getProcessInfo(int pid = 0);
 
     //static NetworkInfo getNetworkInfo();
 };

--- a/src/libYARP_OS/src/LogForwarder.cpp
+++ b/src/libYARP_OS/src/LogForwarder.cpp
@@ -11,6 +11,7 @@
 #include <yarp/os/Os.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
+#include <yarp/os/SystemInfo.h>
 
 yarp::os::LogForwarder* yarp::os::LogForwarder::instance = nullptr;
 yarp::os::Semaphore *yarp::os::LogForwarder::sem = nullptr;
@@ -60,10 +61,11 @@ yarp::os::LogForwarder::LogForwarder()
     outputPort = new yarp::os::BufferedPort<yarp::os::Bottle>;
     char host_name [MAX_STRING_SIZE]; //unsafe
     yarp::os::gethostname(host_name, MAX_STRING_SIZE);
-    char prog_name [MAX_STRING_SIZE]; //unsafe
-    yarp::os::getprogname(prog_name, MAX_STRING_SIZE);
-    int pid = yarp::os::getpid();
-    sprintf(logPortName, "/log/%s/%s/%d", host_name, prog_name, pid);  //unsafe, better to use snprintf when available
+
+    yarp::os::SystemInfo::ProcessInfo processInfo = yarp::os::SystemInfo::getProcessInfo();
+
+    std::snprintf(logPortName, MAX_STRING_SIZE, "/log/%s/%s/%d", host_name, processInfo.name.c_str(), processInfo.pid);
+
     if (outputPort->open(logPortName) == false)
     {
         printf("LogForwarder error while opening port %s\n", logPortName);

--- a/src/libYARP_OS/src/NetworkClock.cpp
+++ b/src/libYARP_OS/src/NetworkClock.cpp
@@ -8,6 +8,7 @@
 
 #include <yarp/os/NetworkClock.h>
 #include <yarp/os/SystemClock.h>
+#include <yarp/os/SystemInfo.h>
 #include <yarp/os/NestedContact.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/impl/Logger.h>
@@ -79,14 +80,11 @@ bool NetworkClock::open(const ConstString& clockSourcePortName, ConstString loca
         yarp::os::gethostname(hostName, MAX_STRING_SIZE);
         hostName[strlen(hostName)] = '\0';      // manually set the null terminator, so it is ok in any case
 
-        char progName [MAX_STRING_SIZE];
-        yarp::os::getprogname(progName, MAX_STRING_SIZE);
-        progName[strlen(progName)] = '\0';      // manually set the null terminator, so it is ok in any case
-        int pid = yarp::os::getpid();
+        yarp::os::SystemInfo::ProcessInfo processInfo = yarp::os::SystemInfo::getProcessInfo();
 
         localPortName = "/";
         // Ports may be anonymous to not pollute the yarp name list
-        localPortName += ConstString(hostName) + "/" + ConstString(progName) + "/" + ConstString(std::to_string(pid)) + "/clock:i";
+        localPortName += ConstString(hostName) + "/" + processInfo.name + "/" + ConstString(std::to_string(processInfo.pid)) + "/clock:i";
     }
 
     // if receiving port cannot be opened, return false.

--- a/src/libYARP_OS/src/Os.cpp
+++ b/src/libYARP_OS/src/Os.cpp
@@ -64,6 +64,7 @@ int yarp::os::getpid()
     return pid;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 void yarp::os::setprogname(const char *progname)
 {
 #ifdef YARP_HAS_ACE
@@ -90,6 +91,7 @@ void yarp::os::getprogname(char* progname, size_t size)
     YARP_UNUSED(size);
 #endif
 }
+#endif // YARP_NO_DEPRECATED
 
 
 void yarp::os::gethostname(char* hostname, size_t size)

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2230,12 +2230,11 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                                     sched_prop.put("priority", this->getPriority());
                                     sched_prop.put("policy", this->getPolicy());
 
-                                    int pid =  getPid();
-                                    SystemInfo::ProcessInfo info = SystemInfo::getProcessInfo(pid);
+                                    SystemInfo::ProcessInfo info = SystemInfo::getProcessInfo();
                                     Bottle& proc = result.addList();
                                     proc.addString("process");
                                     Property& proc_prop = proc.addDict();
-                                    proc_prop.put("pid", pid);
+                                    proc_prop.put("pid", info.pid);
                                     proc_prop.put("name", (info.pid !=-1) ? info.name : "unknown");
                                     proc_prop.put("arguments", (info.pid !=-1) ? info.arguments : "unknown");
                                     proc_prop.put("priority", info.schedPriority);

--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -158,13 +158,8 @@ public:
         return "";
     }
 
-    bool configure(Property& config, int argc, char *argv[], bool skip) {
-        if (argc>0) {
-            if (argv[0]!=nullptr) {
-                yarp::os::setprogname(argv[0]);
-            }
-        }
-
+    bool configure(Property& config, int argc, char *argv[], bool skip)
+    {
         Property p;
         p.fromCommand(argc, argv, skip);
 

--- a/src/libYARP_OS/src/SystemInfo.cpp
+++ b/src/libYARP_OS/src/SystemInfo.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <yarp/os/SystemInfo.h>
 #include <yarp/os/SystemInfoSerializer.h>
+#include <yarp/os/Os.h>
+
 using namespace yarp::os;
 
 #if defined(__linux__)
@@ -770,7 +772,13 @@ SystemInfo::LoadInfo SystemInfo::getLoadInfo()
 }
 
 
-SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid) {
+SystemInfo::ProcessInfo SystemInfo::getProcessInfo(int pid)
+{
+    // If not specified, get information for current process
+    if (pid == 0) {
+        pid = yarp::os::getpid();
+    }
+
     SystemInfo::ProcessInfo info;
     info.pid = -1; // invalid
     info.schedPolicy = -1;

--- a/tests/libYARP_OS/SystemInfoTest.cpp
+++ b/tests/libYARP_OS/SystemInfoTest.cpp
@@ -48,8 +48,14 @@ public:
         report(0, ConstString(str.str()));
 
         emptyAndClearString();
-        report(0, "Getting (system dependent) process 1 info:");
+        report(0, "Getting (system dependent) process info for process 1:");
         SystemInfo::ProcessInfo prctinfo = SystemInfo::getProcessInfo(1);
+        str << "Name: " << prctinfo.name << ", arguments: " << prctinfo.arguments << ", PID: " << prctinfo.pid << ", scheduler policy: " << prctinfo.schedPolicy << ", scheduler priority: " << prctinfo.schedPriority << ".\n";
+        report(0, ConstString(str.str()));
+
+        emptyAndClearString();
+        report(0, "Getting (system dependent) process info for current process:");
+        prctinfo = SystemInfo::getProcessInfo();
         str << "Name: " << prctinfo.name << ", arguments: " << prctinfo.arguments << ", PID: " << prctinfo.pid << ", scheduler policy: " << prctinfo.schedPolicy << ", scheduler priority: " << prctinfo.schedPriority << ".\n";
         report(0, ConstString(str.str()));
 


### PR DESCRIPTION
This PR replaces #1606 

Deprecated yarp::os::setprogname()
Deprecated yarp::os::getprogname(), superseded by yarp::os::getprocessname()
Removed all occurrences of yarp::os::setprogname() in yarp
Replaced all occurrences of yarp::os::getprogname() in yarp with yarp::os::getprocessname()