### PR TITLE
OS: Deprecate Port and BufferedPort

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -27,6 +27,8 @@ Important Changes
 * The methods `yarp::os::Mutex::tryLock()` and
   `yarp::os::RecursiveMutex::tryLock()` were deprecated in favour of
   `try_lock()`.
+* The `yarp::os::Port` and `yarp::os::BufferedPort` classes are now deprecated
+  in favour of `yarp::os::Publisher` and `yarp::os::Subscriber`.
 
 #### `YARP_sig`
 

--- a/src/libYARP_OS/include/yarp/os/BufferedPort.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort.h
@@ -17,11 +17,15 @@
 
 
 // Defined in this file:
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 namespace yarp { namespace os { template <typename T> class BufferedPort; }}
+#endif // YARP_NO_DEPRECATED
 
 
 namespace yarp {
 namespace os {
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 
 /**
  * @ingroup comm_class
@@ -62,11 +66,15 @@ namespace os {
  * @li @ref note_ports
  * @li @ref port_expert
  * @li @ref yarp_buffering
+ *
+ * @deprecated since YARP 3.0.0. YARP no longer supports Port and BufferedPort.
+ *             Use yarp::os::Publisher or yarp::os::Subscriber instead.
  */
 template <typename T>
-class BufferedPort : public Contactable,
-                     public TypedReader<T>,
-                     public TypedReaderCallback<T>
+class YARP_DEPRECATED_MSG("YARP no longer supports Port and BufferedPort. Use yarp::os::Publisher or yarp::os::Subscriber instead.")
+BufferedPort : public Contactable,
+               public TypedReader<T>,
+               public TypedReaderCallback<T>
 {
 public:
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.72
@@ -326,5 +334,7 @@ private:
 } // namespace yarp
 
 #include <yarp/os/BufferedPort-inl.h>
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_BUFFEREDPORT_H

--- a/src/libYARP_OS/include/yarp/os/Port.h
+++ b/src/libYARP_OS/include/yarp/os/Port.h
@@ -18,11 +18,14 @@
 #include <yarp/os/PortReaderCreator.h>
 
 // Defined in this file:
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 namespace yarp { namespace os { class Port; }}
+#endif // YARP_NO_DEPRECATED
 
 namespace yarp {
 namespace os {
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 /**
  * @ingroup comm_class
  *
@@ -46,8 +49,13 @@ namespace os {
  * @li @ref note_ports
  * @li @ref port_expert
  * @li @ref yarp_buffering
+ *
+ * @deprecated since YARP 3.0.0. YARP no longer supports Port and BufferedPort.
+ *             Use yarp::os::Publisher or yarp::os::Subscriber instead.
  */
-class YARP_OS_API Port : public UnbufferedContactable
+class
+YARP_OS_DEPRECATED_API_MSG("YARP no longer supports Port and BufferedPort. Use yarp::os::Publisher or yarp::os::Subscriber instead.")
+Port : public UnbufferedContactable
 {
 
 public:
@@ -269,6 +277,8 @@ private:
               const char *fakeName);
 
 };
+
+#endif // YARP_NO_DEPRECATED
 
 } // namespace os
 } // namespace yarp


### PR DESCRIPTION
As discussed at the latest YARP developers meeting with @lornat75, @barbalberto, @pattacini, @vtikha, @randaz81, @traversaro, @Nicogene, @aerydna and @damn1 YARP 3.0 will no longer support `Port` and `BufferedPort`.

This decision comes fro the continuous discussions that arise every few days on why **ROS** is more widely adopted than **YARP** and on whether **YARP** is better than **ROS** or not, and if it is not why we keep using **YARP** for the iCub robot. This lead us to think that the publish-subscribe paradigm is the way to go, and therefore we decided to concentrate our efforts in this direction for the next major release.

This patch deprecates `yarp::os::Port` and `yarp::os::BufferedPort` in favour of `yarp::os::Publisher` and `yarp::os::Subscriber`.

Please note that this is just the first step towards this new direction, and therefore this patch will cause a lot of deprecation warnings even while compiling YARP. In order to fix these, we will move the `Port` and `BufferedPort` classes in the "impl" folder, and use them internally, and we will add a deprecated compatibility class. Anyway this is not ready yet, but we decided to merge this patch as fast as possible, since the YARP 3.0 release is really close, and we want to allow @robotology/all-robotology-developers to migrate their code as soon as possible.

