### PR TITLE
Fix depthCamera and RGBDSensorWrapper

### DIFF
--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -26,6 +26,8 @@ Bug Fixes
   by the monitor object, that is, their name will be displayed on the command line
   if yarpdev was called with `--verbose`. Previously, it used a generic "subdevice"
   identifier.
+* Added missing IFrameGrabberControl2 to RGBDSensorWrapper
+* Fixed RGBDSensorWrapper compatibilty with frameGrabberGui2.
 
 
 ### GUIs
@@ -40,6 +42,7 @@ Bug Fixes
 #### `ControlBoardRemapper`
 
 * Fixed `getEncoderAccelerations()` method.
+* Fixed find Openni2 in depthCamera's CMakelists.txt.
 
 ### Bindings
 

--- a/src/devices/depthCamera/CMakeLists.txt
+++ b/src/devices/depthCamera/CMakeLists.txt
@@ -9,7 +9,7 @@ yarp_prepare_plugin(depthCamera
                     TYPE yarp::dev::depthCameraDriver
                     INCLUDE depthCameraDriver.h
                     EXTRA_CONFIG WRAPPER=RGBDSensorWrapper
-                    DEPENDS "CREATE_DEVICE_LIBRARY_MODULES;YARP_HAS_OpenNI2")
+                    DEPENDS "CREATE_DEVICE_LIBRARY_MODULES;YARP_HAS_OPENNI2")
 
 if(ENABLE_depthCamera)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -160,7 +160,7 @@ bool RGBDSensorParser::respond(const Bottle& cmd, Bottle& response)
         default:
         {
             yError() << "RGBD sensor wrapper received a command for a wrong interface " << yarp::os::Vocab::decode(interfaceType);
-            ret = false;
+            return DeviceResponder::respond(cmd,response);
         }
         break;
     }

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -159,7 +159,7 @@ RGBDSensorWrapper::RGBDSensorWrapper() :
     RateThread(DEFAULT_THREAD_PERIOD),
     rosNode(nullptr),
     nodeSeq(0),
-    rate(DEFAULT_THREAD_PERIOD),
+    period(DEFAULT_THREAD_PERIOD),
     sensor_p(nullptr),
     sensorStatus(IRGBDSensor::RGBD_SENSOR_NOT_READY),
     verbose(4),
@@ -235,7 +235,7 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
             yInfo() << "RGBDSensorWrapper: using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "ms";
     }
     else
-        rate = config.find("period").asInt();
+        period = config.find("period").asInt();
 
     Bottle &rosGroup = config.findGroup("ROS");
     if(rosGroup.isNull())
@@ -531,7 +531,7 @@ bool RGBDSensorWrapper::attachAll(const PolyDriverList &device2attach)
     if(!attach(sensor_p))
         return false;
 
-    RateThread::setRate(rate);
+    RateThread::setRate(period);
     return RateThread::start();
 }
 
@@ -561,7 +561,7 @@ bool RGBDSensorWrapper::attach(yarp::dev::IRGBDSensor *s)
         yError() << "RGBD wrapper: error configuring interfaces for parsers";
         return false;
     }
-    RateThread::setRate(rate);
+    RateThread::setRate(period);
     return RateThread::start();
 }
 
@@ -581,7 +581,7 @@ bool RGBDSensorWrapper::attach(PolyDriver* poly)
         yError() << "RGBD wrapper: error configuring interfaces for parsers";
         return false;
     }
-    RateThread::setRate(rate);
+    RateThread::setRate(period);
     return RateThread::start();
 }
 

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -28,6 +28,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
 #include <yarp/dev/IVisualParamsImpl.h>
+#include <yarp/dev/FrameGrabberControl2Impl.h>
 
 // ROS stuff
 #include <yarp/os/Node.h>
@@ -69,12 +70,14 @@ private:
     yarp::dev::IRGBDSensor  *iRGBDSensor;
     yarp::dev::Implement_RgbVisualParams_Parser  rgbParser;
     yarp::dev::Implement_DepthVisualParams_Parser depthParser;
+    yarp::dev::FrameGrabberControls2_Parser fgCtrlParsers;
 
 public:
     RGBDSensorParser();
-    virtual ~RGBDSensorParser() {};
+    virtual ~RGBDSensorParser() {}
     bool configure(IRGBDSensor *interface);
     bool configure(IRgbVisualParams *rgbInterface, IDepthVisualParams *depthInterface);
+    bool configure(IFrameGrabberControls2 *_fgCtrl);
     virtual bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
 };
 
@@ -170,13 +173,14 @@ private:
 //     sensor::depth::RGBDSensor_RPCMgsParser  RPC_parser;
 
     //Helper class for RPCs
-    yarp::dev::RGBDImpl::RGBDSensorParser        parser;
+    yarp::dev::RGBDImpl::RGBDSensorParser        rgbdParser;
 
     // Image data specs
     // int hDim, vDim;
     UInt                           period;
     std::string                    sensorId;
     yarp::dev::IRGBDSensor*        sensor_p;
+    yarp::dev::IFrameGrabberControls2* fgCtrl;
     IRGBDSensor::RGBDSensor_status sensorStatus;
     int                            verbose;
     bool                           use_YARP;

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -174,7 +174,7 @@ private:
 
     // Image data specs
     // int hDim, vDim;
-    UInt                           rate;
+    UInt                           period;
     std::string                    sensorId;
     yarp::dev::IRGBDSensor*        sensor_p;
     IRGBDSensor::RGBDSensor_status sensorStatus;


### PR DESCRIPTION
This PR fixes the CMakelists of `depthCamera` and the compatibility of `RGBDSensorWrapper` with frameGrabberGui2.


Please review code.