### PR TITLE
Fix macos guis compilation

### DIFF
--- a/cmake/YarpOSXUtilities.cmake
+++ b/cmake/YarpOSXUtilities.cmake
@@ -82,6 +82,9 @@ function(YARP_OSX_DUPLICATE_AND_ADD_BUNDLE)
       elseif("${_prop_name}" MATCHES "<.+>")
         # Remove other properties containing "<...>" that are not target properties.
         list(REMOVE_ITEM _all_properties "${_prop_name}")
+      elseif("${_prop_name}" MATCHES "IMPORTED_GLOBAL")
+        # Remove other properties containing "IMPORTED_GLOBAL".
+        list(REMOVE_ITEM _all_properties "${_prop_name}")
       endif()
     endforeach()
 

--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -12,6 +12,10 @@ Bug Fixes
 
 * Fixed build with CMake < 3.4
 
+### CMake Modules
+
+* Removed IMPORTED_GLOBAL property from YarpOSXUtilities.cmake.
+
 
 ### Libraries
 


### PR DESCRIPTION
This PR remove `IMPORTED_GLOBAL` property in `YarpOSXUtilities.cmake` 
This property has been introduced in `cmake 3.11`.

Error: 
```
IMPORTED_GLOBAL property can't be set on non-imported targets
```
CMake documentation : https://cmake.org/cmake/help/v3.11/prop_tgt/IMPORTED_GLOBAL.html
Please review code.