### PR TITLE
add timeout support for TcpConnector::connect()

### DIFF
--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -35,6 +35,10 @@ Bug Fixes
 * Fixed `RGBDSensorWrapper` compatibilty with `frameGrabberGui2`.
 * Fixed joint remapping in method `getRefVelocity()`.
 
+#### `YARP_OS`
+
+* Added timeout parameter in `TcpConnector::connect()` to unify behaviour with the
+  `ACE_SOCK_Connector`.
 
 ### GUIs
 

--- a/src/libYARP_OS/include/yarp/os/impl/TcpConnector.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TcpConnector.h
@@ -27,6 +27,7 @@
 
 #include <yarp/os/Contact.h>
 #include <yarp/os/impl/TcpStream.h>
+#include <yarp/os/impl/PlatformTime.h>
 
 
 namespace yarp {
@@ -55,7 +56,8 @@ public:
     virtual ~TcpConnector();
 
     int connect (TcpStream &new_stream,
-                 const yarp::os::Contact &remote_address);
+                 const yarp::os::Contact &remote_address,
+                 YARP_timeval* timeout = nullptr);
 protected:
 
     int open(TcpStream &stream);

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -43,7 +43,22 @@ int SocketTwoWayStream::open(const Contact& address) {
     int result = connector.connect(stream, addr, timeout, ACE_Addr::sap_any, 1);
 #else
     TcpConnector connector;
-    int result = connector.connect(stream, address);
+    int result;
+
+    if (address.hasTimeout())
+    {
+        YARP_timeval timeout;
+        /* set timeout seconds and microseconds */
+        timeout.tv_sec = (int) address.getTimeout();
+        timeout.tv_usec = (address.getTimeout() - (int) address.getTimeout()) * 1000000;
+        result = connector.connect(stream, address, &timeout);
+    }
+    else
+    {
+        result = connector.connect(stream, address, nullptr);
+    }
+
+
 #endif
     if (result>=0) {
         happy = true;

--- a/src/libYARP_OS/src/TcpConnector.cpp
+++ b/src/libYARP_OS/src/TcpConnector.cpp
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <cstdio>
+#include <fcntl.h>
 
 #include <sys/socket.h>
 
@@ -58,7 +59,7 @@ int TcpConnector::open(TcpStream &stream) {
 /**
  * Connect to server
  */
-int TcpConnector::connect(TcpStream &new_stream, const Contact& address) {
+int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_timeval* timeout) {
 //     printf("TCP/IP start in client mode\n");
 //     sockets.set_as_client();
 //     sockets.set_client_sockfd(sockfd);
@@ -79,16 +80,94 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address) {
         inet_pton(AF_INET, address.getHost().c_str(), &servAddr.sin_addr);
     }
 
-    yAssert(new_stream.get_handle() != -1);
+    auto handle = new_stream.get_handle();
 
-    int result = ::connect(new_stream.get_handle(), (sockaddr*) &servAddr, sizeof(servAddr));
+    yAssert(handle != -1);
 
-    if (result < 0) {
-        perror("TcpConnector::connect fail");
+    int res;
+    long arg;
+    fd_set myset;
+    int valopt;
+    socklen_t lon;
+
+    // Set non-blocking
+    if( (arg = fcntl(handle, F_GETFL, NULL)) < 0)
+    {
+       yError("TcpConnector::connect fail: Error fcntl(..., F_GETFL) (%s)\n", strerror(errno));
+       return -1;
+    }
+    arg |= O_NONBLOCK;
+    if( fcntl(handle, F_SETFL, arg) < 0)
+    {
+       yError("TcpConnector::connect fail: Error fcntl(..., F_SETFL) (%s)\n", strerror(errno));
+       return -1;
+    }
+    // Trying to connect with timeout
+    res = ::connect(handle, (sockaddr*) &servAddr, sizeof(servAddr));
+
+    if (res < 0)
+    {
+        if (errno == EINPROGRESS)
+        {
+            FD_ZERO(&myset);
+            FD_SET(handle, &myset);
+            res = select(handle+1, nullptr, &myset, nullptr, timeout);
+            if (res < 0 && errno != EINTR)
+            {
+                yError("TcpConnector::connect fail: Error connecting %d - %s\n", errno, strerror(errno));
+                res = -1;
+            }
+            else if (res > 0)
+            {
+                // Socket selected for write
+                lon = sizeof(int);
+                if (getsockopt(handle, SOL_SOCKET, SO_ERROR, (void*)(&valopt), &lon) < 0)
+                {
+                    yError("TcpConnector::connect fail: Error in getsockopt() %d - %s\n", errno, strerror(errno));
+                    res = -1;
+                }
+                // Check the value returned...
+                if (valopt)
+                {
+                    yError("TcpConnector::connect fail: Error in delayed connection() %d - %s\n", valopt, strerror(valopt));
+                    res = -1;
+                }
+                res = 0;
+            }
+            else
+            {
+                yError("TcpConnector::connect fail: Timeout in select() - Cancelling!\n");
+                res = -1;
+            }
+        }
+        else
+        {
+            yError("TcpConnector::connect fail: Error connecting %d - %s\n", errno, strerror(errno));
+            res = -1;
+        }
+    }
+
+    if (res != 0)
+    {
         char buf[INET_ADDRSTRLEN];
         std::cerr << "Connect [handle=" << new_stream.get_handle() << "] at " << inet_ntop(AF_INET, &servAddr.sin_addr, buf, INET_ADDRSTRLEN) << ":" << servAddr.sin_port << std::endl;
+        return -1;
     }
-    return result;
+
+    // Set to blocking mode again...
+    if( (arg = fcntl(handle, F_GETFL, nullptr)) < 0)
+    {
+       yError("TcpConnector::connect fail: Error fcntl(..., F_GETFL) (%s)\n", strerror(errno));
+       return -1;
+    }
+    arg &= (~O_NONBLOCK);
+    if( fcntl(handle, F_SETFL, arg) < 0)
+    {
+       yError("TcpConnector::connect fail: Error fcntl(..., F_SETFL) (%s)\n", strerror(errno));
+       return -1;
+    }
+
+    return res;
 }
 
 #endif


### PR DESCRIPTION
This is an attempt to fix #1636.

If timeout is not not explicitly set, `select()` function remains blocking with a default timeout of ~1min maintaining behaviour of `TcpConnector::connect()` as before.