### PR TITLE
Improve realsense

### DIFF
--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -450,7 +450,11 @@ void realsense2Driver::fallback()
 
 bool realsense2Driver::initializeRealsenseDevice()
 {
-    // TODO get configurations of the device, and read the value from the conf file
+    if (!params_map[rgbRes].isSetting || !params_map[depthRes].isSetting)
+    {
+        yError()<<"realsense2Driver: missing depthResolution or rgbResolution from [SETTINGS]";
+        return false;
+    }
     double colorW = params_map[rgbRes].val[0].asDouble();
     double colorH = params_map[rgbRes].val[1].asDouble();
     double depthW = params_map[depthRes].val[0].asDouble();

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -724,6 +724,7 @@ bool realsense2Driver::setDepthResolution(int width, int height)
         if (m_initialized)
         {
             fallback();
+            return false;
         }
     }
 
@@ -755,7 +756,12 @@ bool realsense2Driver::setRgbResolution(int width, int height)
         }
     }
 
+    if (m_initialized && fail)
+    {
+        fallback();
+        return false;
     }
+
     if (!pipelineRestart())
         return false;
 

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -1198,7 +1198,7 @@ bool realsense2Driver::hasOnOff(  int feature, bool *HasOnOff)
     }
 
     cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
-    if (f == YARP_FEATURE_WHITE_BALANCE || f == YARP_FEATURE_MIRROR)
+    if (f == YARP_FEATURE_WHITE_BALANCE || f == YARP_FEATURE_MIRROR || f == YARP_FEATURE_EXPOSURE)
     {
         *HasOnOff = true;
         return true;
@@ -1225,10 +1225,10 @@ bool realsense2Driver::setActive( int feature, bool onoff)
     switch(feature)
     {
     case YARP_FEATURE_WHITE_BALANCE:
-        b = setOption(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, m_color_sensor, (float) onoff); //TODO check if this exotic conversion works
+        b = setOption(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, m_color_sensor, (float) onoff);
         return b;
     case YARP_FEATURE_EXPOSURE:
-        b = setOption(RS2_OPTION_ENABLE_AUTO_EXPOSURE, m_color_sensor, (float) onoff); //TODO check if this exotic conversion works
+        b = setOption(RS2_OPTION_ENABLE_AUTO_EXPOSURE, m_color_sensor, (float) onoff);
         return b;
     default:
         return false;
@@ -1251,13 +1251,16 @@ bool realsense2Driver::getActive( int feature, bool *isActive)
         yError() << "feature does not have OnOff.. call hasOnOff() to know if a specific feature support OnOff mode";
         return false;
     }
+    float response = 0.0;
     switch(feature)
     {
     case YARP_FEATURE_WHITE_BALANCE:
-        b = getOption(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, m_color_sensor, (float&) isActive); //TODO check if this exotic conversion works
+        b = getOption(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, m_color_sensor, response); //TODO check if this exotic conversion works
+        *isActive = (bool) response;
         return b;
     case YARP_FEATURE_EXPOSURE:
-        b = getOption(RS2_OPTION_ENABLE_AUTO_EXPOSURE, m_color_sensor, (float&) isActive); //TODO check if this exotic conversion works
+        b = getOption(RS2_OPTION_ENABLE_AUTO_EXPOSURE, m_color_sensor, response); //TODO check if this exotic conversion works
+        *isActive = (bool) response;
         return b;
     default:
         return false;

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -1072,11 +1072,29 @@ bool realsense2Driver::setFeature(int feature, double value)
     {
     case YARP_FEATURE_EXPOSURE:
         if(optionPerc2Value(RS2_OPTION_EXPOSURE, m_color_sensor, value, valToSet))
+        {
             b = setOption(RS2_OPTION_EXPOSURE, m_color_sensor, valToSet);
+            if (m_stereoMode)
+            {
+                if(optionPerc2Value(RS2_OPTION_EXPOSURE, m_depth_sensor, value, valToSet))
+                {
+                    b &= setOption(RS2_OPTION_EXPOSURE, m_depth_sensor, valToSet);
+                }
+            }
+        }
         break;
     case YARP_FEATURE_GAIN:
         if(optionPerc2Value(RS2_OPTION_GAIN, m_color_sensor,value, valToSet))
+        {
             b = setOption(RS2_OPTION_GAIN, m_color_sensor, valToSet);
+            if (m_stereoMode)
+            {
+                if(optionPerc2Value(RS2_OPTION_EXPOSURE, m_depth_sensor, value, valToSet))
+                {
+                    b &= setOption(RS2_OPTION_EXPOSURE, m_depth_sensor, valToSet);
+                }
+            }
+        }
         break;
     case YARP_FEATURE_FRAME_RATE:
     {

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -101,8 +101,9 @@ clipPlanes (0.2 10.0)
 
 
 class yarp::dev::realsense2Driver :  public yarp::dev::DeviceDriver,
-                                     public yarp::dev::IRGBDSensor,
-                                     public yarp::dev::IFrameGrabberControls2
+                                     public yarp::dev::IFrameGrabberControls2,
+                                     public yarp::dev::IFrameGrabberImageRaw,
+                                     public yarp::dev::IRGBDSensor
 {
 private:
     typedef yarp::sig::ImageOf<yarp::sig::PixelFloat> depthImage;
@@ -171,6 +172,11 @@ public:
     virtual bool   getMode(   int feature, FeatureMode *mode) override;
     virtual bool   setOnePush(int feature) override;
 
+    //IFrameGrabberImageRaw
+    virtual bool getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image) override;
+    virtual int height() const override;
+    virtual int width() const override;
+
 private:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     //method
@@ -199,7 +205,7 @@ private:
     std::vector<rs2::sensor> m_sensors;
     rs2::sensor* m_depth_sensor;
     rs2::sensor* m_color_sensor;
-    rs2_intrinsics m_depth_intrin, m_color_intrin;
+    rs2_intrinsics m_depth_intrin, m_color_intrin, m_infrared_intrin;
     rs2_extrinsics m_depth_to_color, m_color_to_depth;
 
 
@@ -209,6 +215,8 @@ private:
     yarp::dev::RGBDSensorParamParser* m_paramParser;
     bool m_verbose;
     bool m_initialized;
+    bool m_stereoMode;
+    bool m_needAlignment;
     int m_fps;
     std::vector<cameraFeature_id_t> m_supportedFeatures;
 #endif

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -75,6 +75,7 @@ namespace yarp
  * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
  * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
  * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
+ * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This operation could be heavy, set it to false to increase the fps   |
  * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
  * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minumum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
  *
@@ -91,6 +92,7 @@ depthResolution (640 480)    #Note the parentesys
 rgbResolution   (640 480)
 framerate       30
 enableEmitter   true
+needAlignment   true
 
 [HW_DESCRIPTION]
 clipPlanes (0.2 10.0)

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -1230,7 +1230,7 @@ bool ServerGrabber::threadInit()
             }
             else
             {
-                img_Raw->resize(fgImage->width(),fgImage->height());
+                img_Raw->resize(fgImageRaw->width(), fgImageRaw->height());
             }
         }
     }


### PR DESCRIPTION
This PR introduces some enhancements to the `realsense2` device.

The most important:
- support for stereo stream (@randaz81)
- flag for eventually disable the alignment of the depth over the rgb.

Example of ini file to use the `realsense2` with the `grabberDual` 
```
device         grabberDual
subdevice   realsense2
capabilities  RAW
stereoMode true

[SETTINGS]
rgbResolution       (640 480)
depthResolution   (640 480)
framerate             30
enableEmitter       true

[HW_DESCRIPTION]
```

Please review code