### PR TITLE
os/impl/Logger: Remove ACE implementation

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/Logger.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Logger.h
@@ -16,20 +16,10 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/impl/PlatformStdio.h>
 
-#ifdef YARP_HAS_ACE
-# include <ace/Log_Priority.h>
-# include <ace/Log_Msg_Callback.h>
-// In one of these files or their inclusions, there is a definition of "main"
-// for WIN32
-# ifdef main
-#  undef main
-# endif
-#else
-#  define LM_DEBUG      04
-#  define LM_INFO      010
-#  define LM_WARNING   040
-#  define LM_ERROR    0200
-#endif
+#define YARP_LM_DEBUG      04
+#define YARP_LM_INFO      010
+#define YARP_LM_WARNING   040
+#define YARP_LM_ERROR    0200
 
 
 namespace yarp {
@@ -38,28 +28,19 @@ namespace impl {
 
 /**
  * This is a wrapper for message logging.
- * This is currently a sad mixture of the java yarp logging mechanism
- * and ACE.
  */
 class YARP_OS_impl_API Logger : public yarp::os::Log
-#ifdef YARP_HAS_ACE
-                              , public ACE_Log_Msg_Callback
-#endif
 {
 public:
     enum Level {
-        MAJOR_DEBUG=LM_INFO,
-        DEFAULT_WARN=LM_INFO
+        MAJOR_DEBUG=YARP_LM_INFO,
+        DEFAULT_WARN=YARP_LM_INFO
     };
 
     Logger(const char *prefix, Logger *parent = nullptr);
     Logger(const char *prefix, Logger& parent);
 
     static Logger& get();
-
-#ifdef YARP_HAS_ACE
-    virtual void log(ACE_Log_Record& log_record) override;
-#endif
 
     void println(const ConstString& txt);
     void internal_debug(const ConstString& txt);

--- a/src/libYARP_OS/src/Logger.cpp
+++ b/src/libYARP_OS/src/Logger.cpp
@@ -10,15 +10,11 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/ThreadImpl.h>
+#include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Network.h>
 
 #include <cstdio>
-
-#ifdef YARP_HAS_ACE
-# include <ace/Log_Msg.h>
-# include <ace/Log_Record.h>
-#endif
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -32,14 +28,6 @@ Logger::Logger(const char *prefix, Logger *parent) :
         pid(yarp::os::getpid()),
         stream(nullptr)
 {
-#ifdef YARP_HAS_ACE
-    if (parent == nullptr) {
-        ACE_Log_Msg *acer = ACE_Log_Msg::instance();
-        acer->set_flags(8);
-        acer->clr_flags(1);
-        acer->msg_callback(this);
-    }
-#endif
 }
 
 
@@ -60,15 +48,6 @@ Logger& Logger::get()
     return instance;
 }
 
-
-#ifdef YARP_HAS_ACE
-void Logger::log(ACE_Log_Record& log_record)
-{
-    show(log_record.type(), log_record.msg_data());
-}
-#endif
-
-
 void Logger::println(const ConstString& txt)
 {
     internal_debug(txt);
@@ -77,31 +56,31 @@ void Logger::println(const ConstString& txt)
 
 void Logger::internal_debug(const ConstString& txt)
 {
-    show(LM_DEBUG, txt);
+    show(YARP_LM_DEBUG, txt);
 }
 
 
 void Logger::internal_info(const ConstString& txt)
 {
-    show(LM_INFO, txt);
+    show(YARP_LM_INFO, txt);
 }
 
 
 void Logger::internal_warning(const ConstString& txt)
 {
-    show(LM_WARNING, txt);
+    show(YARP_LM_WARNING, txt);
 }
 
 
 void Logger::internal_error(const ConstString& txt)
 {
-    show(LM_ERROR, txt);
+    show(YARP_LM_ERROR, txt);
 }
 
 
 void Logger::internal_fail(const ConstString& txt)
 {
-    show(LM_ERROR, txt);
+    show(YARP_LM_ERROR, txt);
     std::exit(1);
 }
 
@@ -109,35 +88,35 @@ void Logger::internal_fail(const ConstString& txt)
 void Logger::internal_debug(const char *txt)
 {
     ConstString stxt(txt);
-    show(LM_DEBUG, stxt);
+    show(YARP_LM_DEBUG, stxt);
 }
 
 
 void Logger::internal_info(const char *txt)
 {
     ConstString stxt(txt);
-    show(LM_INFO, stxt);
+    show(YARP_LM_INFO, stxt);
 }
 
 
 void Logger::internal_warning(const char *txt)
 {
     ConstString stxt(txt);
-    show(LM_WARNING, stxt);
+    show(YARP_LM_WARNING, stxt);
 }
 
 
 void Logger::internal_error(const char *txt)
 {
     ConstString stxt(txt);
-    show(LM_ERROR, stxt);
+    show(YARP_LM_ERROR, stxt);
 }
 
 
 void Logger::internal_fail(const char *txt)
 {
     ConstString stxt(txt);
-    show(LM_ERROR, stxt);
+    show(YARP_LM_ERROR, stxt);
     std::exit(1);
 }
 
@@ -210,7 +189,7 @@ void Logger::show(unsigned YARP_INT32 level, const ConstString& txt)
     }
     if (parent == nullptr) {
         if (level>=low) {
-            if (inLevel<=LM_DEBUG) {
+            if (inLevel<=YARP_LM_DEBUG) {
                 fprintf(stream, "%s(%04lx): %s\n",
                                 prefix.c_str(),
                                 ThreadImpl::getKeyOfCaller(),


### PR DESCRIPTION
Currently we have 2 different implementations for the "deprecated" internal `yarp::os::impl::Logger` class (that at some point will be removed and replaced with the newer `yInfo`, `yDebug` etc. logging methods). One implementation uses "standard" c methods, and works on every platform since it does not require any non-portable library, the other one uses ACE adding a callback and it requires ACE initialization in `Network`. Both implementation have been used and we never had complains about the non-ACE version, I don't think the callback is actually used anywhere.

In this patch the ACE/callback implementation is removed, since I believe it is unused.

The defines were renamed, since otherwise they would conflict when including Logger.h in the same file with an ACE header.

@lornat75 Please let me know if you know something more about this Logger class, and if you think there is some reason why the ACE implementation should not be removed.