### PR TITLE
Storing binary files for ImageOf<PixelFloat>

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -102,6 +102,11 @@ New Features
 * Added a Timer class to execute a static or member function in a separate
   thread after a period x, every y milliseconds, for z times or w seconds.
 
+#### YARP_sig
+
+* `yarp::sig::file::[read|write](ImageOf<PixelFloat>&)` services
+  refactored to store data in binary formats.
+
 
 ### Tools
 

--- a/src/libYARP_sig/include/yarp/sig/ImageFile.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageFile.h
@@ -40,7 +40,6 @@ namespace yarp {
             bool YARP_sig_API read(ImageOf<PixelMono>& dest,
                                    const yarp::os::ConstString& src);
 
-            // plain text format
             bool YARP_sig_API read(ImageOf<PixelFloat>& dest,
                                    const yarp::os::ConstString& src);
 
@@ -54,7 +53,6 @@ namespace yarp {
             bool YARP_sig_API write(const ImageOf<PixelMono>& src,
                                     const yarp::os::ConstString& dest);
 
-            // plain text format
             bool YARP_sig_API write(const ImageOf<PixelFloat>& src,
                                     const yarp::os::ConstString& dest);
 


### PR DESCRIPTION
Read/write services over `ImageOf<PixelFloat>` do produce binary files now. We should definitely gain something in terms of performance.