### PR TITLE
Fix SWIG preprocessor issue with VOCABs in enums

### DIFF
--- a/bindings/lua/tests/CMakeLists.txt
+++ b/bindings/lua/tests/CMakeLists.txt
@@ -26,3 +26,4 @@ endmacro()
 
 add_lua_unit_test(test_bottle_and_property.lua)
 add_lua_unit_test(test_resource_finder.lua)
+add_lua_unit_test(test_vocab.lua)

--- a/bindings/lua/tests/test_vocab.lua
+++ b/bindings/lua/tests/test_vocab.lua
@@ -1,0 +1,25 @@
+#!/usr/bin/lua
+
+-- Copyright: (C) 2018 Juan G Victores
+-- Author: Juan G Victores
+-- Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+require("yarp")
+
+function test_vocab()
+  vocab = yarp.Vocab.encode("abcd")
+  assert("number" == type(vocab))
+  assert(1684234849 == vocab)
+  assert("abcd" == yarp.Vocab.decode(vocab))
+end
+
+function test_vocab_pixel_types_enum()
+  assert("number" == type(yarp.VOCAB_PIXEL_RGB))
+  assert(6449010 == yarp.VOCAB_PIXEL_RGB) -- VOCAB3
+  assert(761423730 == yarp.VOCAB_PIXEL_RGB_SIGNED) -- VOCAB4 with '-' 
+  assert(909209453 == yarp.VOCAB_PIXEL_MONO16) -- VOCAB4 with '1' and '6'
+end
+
+test_vocab()
+test_vocab_pixel_types_enum()
+

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -14,6 +14,8 @@
 
 %module(directors="1") yarp
 
+%define SWIG_PREPROCESSOR_SHOULD_SKIP_THIS %enddef
+
 %import "yarp/conf/api.h"
 
 #if !defined (SWIGMATLAB)

--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -60,6 +60,7 @@ Bug Fixes
 * Added `SWIG_PREPROCESSOR_SHOULD_SKIP_THIS` to avoid the SWIG preprocessor from
   parsing `VOCAB`. This avoids hacks required for compilation of bindings (hacks
   removed), and enables the correct generation of `VOCAB`s inside `enum`s.
+* Added `test_vocab.lua` to catch regressions on `VOCAB` in the future.
 
 Contributors
 ------------

--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -57,6 +57,9 @@ Bug Fixes
 ### Bindings
 
 * Fixed out of source builds.
+* Added `SWIG_PREPROCESSOR_SHOULD_SKIP_THIS` to avoid the SWIG preprocessor from
+  parsing `VOCAB`. This avoids hacks required for compilation of bindings (hacks
+  removed), and enables the correct generation of `VOCAB`s inside `enum`s.
 
 Contributors
 ------------

--- a/src/libYARP_OS/include/yarp/os/PortInfo.h
+++ b/src/libYARP_OS/include/yarp/os/PortInfo.h
@@ -36,8 +36,7 @@ public:
         PORTINFO_NULL = 0,
 
         /// Information about an incoming or outgoing connection.
-        /// SWIG currently has bug if 'c' used in this macro!
-        PORTINFO_CONNECTION = VOCAB4(99/*c*/, 'o', 'n', 'n'),
+        PORTINFO_CONNECTION = VOCAB4('c', 'o', 'n', 'n'),
 
         /// Unspecified information.
         PORTINFO_MISC = VOCAB4('m', 'i', 's', 'c')

--- a/src/libYARP_OS/include/yarp/os/Vocab.h
+++ b/src/libYARP_OS/include/yarp/os/Vocab.h
@@ -19,7 +19,9 @@ namespace yarp {
 
 // We need a macro for efficient switching.
 // Use as, for example, VOCAB('s','e','t')
+#ifndef SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
 #define VOCAB(a,b,c,d) ((((int)(d))<<24)+(((int)(c))<<16)+(((int)(b))<<8)+((int)(a)))
+#endif // SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
 #define VOCAB4(a,b,c,d) VOCAB((a),(b),(c),(d))
 #define VOCAB3(a,b,c) VOCAB((a),(b),(c),(0))
 #define VOCAB2(a,b) VOCAB((a),(b),(0),(0))

--- a/src/libYARP_dev/include/yarp/dev/IPidControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPidControl.h
@@ -25,7 +25,7 @@ namespace yarp
             VOCAB_PIDTYPE_POSITION = VOCAB3('p', 'o', 's'),
             VOCAB_PIDTYPE_VELOCITY = VOCAB3('v', 'e', 'l'),
             VOCAB_PIDTYPE_TORQUE   = VOCAB3('t', 'r', 'q'),
-            VOCAB_PIDTYPE_CURRENT  = VOCAB3(99/*'c'*/, 'u', 'r') // SWIG bug
+            VOCAB_PIDTYPE_CURRENT  = VOCAB3('c', 'u', 'r')
         };
     }
 }

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -45,10 +45,10 @@ enum YarpVocabPixelTypesEnum
     VOCAB_PIXEL_MONO16 = VOCAB4('m','o','1','6'),
     VOCAB_PIXEL_RGB = VOCAB3('r','g','b'),
     VOCAB_PIXEL_RGBA = VOCAB4('r','g','b','a'),
-    VOCAB_PIXEL_BGRA = VOCAB4(98/*'b'*/,'g','r','a'), /* SWIG BUG */
+    VOCAB_PIXEL_BGRA = VOCAB4('b','g','r','a'),
     VOCAB_PIXEL_INT = VOCAB3('i','n','t'),
     VOCAB_PIXEL_HSV = VOCAB3('h','s','v'),
-    VOCAB_PIXEL_BGR = VOCAB3(98/*'b'*/,'g','r'), /* SWIG BUG */
+    VOCAB_PIXEL_BGR = VOCAB3('b','g','r'),
     VOCAB_PIXEL_MONO_SIGNED = VOCAB4('s','i','g','n'),
     VOCAB_PIXEL_RGB_SIGNED = VOCAB4('r','g','b','-'),
     VOCAB_PIXEL_RGB_INT = VOCAB4('r','g','b','i'),
@@ -57,8 +57,8 @@ enum YarpVocabPixelTypesEnum
     VOCAB_PIXEL_HSV_FLOAT = VOCAB4('h','s','v','.'),
     VOCAB_PIXEL_ENCODING_BAYER_GRBG8 = VOCAB4('g', 'r', 'b', 'g'),   //grbg8
     VOCAB_PIXEL_ENCODING_BAYER_GRBG16 = VOCAB4('g', 'r', '1', '6'),  //grbg16
-    VOCAB_PIXEL_ENCODING_BAYER_BGGR8 = VOCAB4(98/*'b'*/, 'g', 'g', 'r'),     //bggr8
-    VOCAB_PIXEL_ENCODING_BAYER_BGGR16 = VOCAB4(98/*'b'*/, 'g', '1', '6'),  //bggr16
+    VOCAB_PIXEL_ENCODING_BAYER_BGGR8 = VOCAB4('b', 'g', 'g', 'r'),     //bggr8
+    VOCAB_PIXEL_ENCODING_BAYER_BGGR16 = VOCAB4('b', 'g', '1', '6'),  //bggr16
     VOCAB_PIXEL_ENCODING_BAYER_GBRG8 = VOCAB4('g', 'b', 'r', 'g'),  //gbrg8
     VOCAB_PIXEL_ENCODING_BAYER_GBRG16 = VOCAB4('g', 'b', '1', '6'),  //gbrg16
     VOCAB_PIXEL_ENCODING_BAYER_RGGB8 = -VOCAB4('r', 'g', 'g', 'b'),   //rggb8


### PR DESCRIPTION
- SWIG was generating compile errors on `VOCAB`s in `enums`s starting by 'b'/'c'/'d'.
- d7b4099 introduced a hack to avoid SWIG binding compilation errors by substituting `char`s by equivalent `int`s.
- A deep issue was buried :skull:: only `VOCAB`s with that hack were correctly formed.
- In reality, all other `VOCAB`s generated a **copy** of the first `char`, rather than the correct `int` (e.g. `VOCAB_PIXEL_ENCODING_BAYER_GBRG16=VOCAB4('g','b','1','6');` generated `'g'` rather than `909206119`).
- Note this only affected the `VOCAB` in `enum` with SWIG combination.
- TLDR: roboticslab-uc3m/kinematics-dynamics#150 [ where @PeterBowman proposed the `constexpr` solution]
- PR also removes obsolete hacks.

Updates:
- Related: https://github.com/swig/swig/issues/737
- Introduced `SWIG_PREPROCESSOR_SHOULD_SKIP_THIS` to preserve original c-style macro VOCAB.