### PR TITLE
Fix #1658 for iKart

### DIFF
--- a/src/libYARP_dev/src/devices/BatteryClient/BatteryClient.cpp
+++ b/src/libYARP_dev/src/devices/BatteryClient/BatteryClient.cpp
@@ -198,7 +198,7 @@ bool yarp::dev::BatteryClient::open(yarp::os::Searchable &config)
     ConstString local_rpc = local;
     local_rpc += "/rpc:o";
     ConstString remote_rpc = remote;
-    remote_rpc += "/rpc:i";
+    //remote_rpc += "/rpc:i";
 
     if (!inputPort.open(local.c_str()))
     {


### PR DESCRIPTION
This fixes #1658 for iKart. Adding `/rpc:i` to the port name makes the port name invalid, so I commented out this line.
Please review. Thanks, Tobi