### PR TITLE
Updated/fixed LUA documentation

### DIFF
--- a/doc/yarp_swig.dox
+++ b/doc/yarp_swig.dox
@@ -175,7 +175,7 @@ After \ref yarp_swig_compile, make sure that Octave-Yarp binding library (i.e., 
 @section yarp_swig_lua YARP for Lua
 For Lua on linux, be sure to install Lua development files, e.g. on Debian/Ubuntu:
 \verbatim
-sudo apt-get install lua5.1 liblua5.1-0-dev
+sudo apt-get install lua5.2 liblua5.2-0-dev
 \endverbatim
 
 If you use Windows, try <a href="https://code.google.com/p/luaforwindows/">Lua for Windows</a>,
@@ -183,10 +183,10 @@ an easy-to-use distribution of Lua packed with several useful libraries.
 
 A more generic way (also for OSX users) is to build lua from the source. Lua is implemented in pure
 ANSI C and compiles unmodified in all platforms that have an ANSI C compiler. For example, to compile
-Lua on OSX, download <a href="http://www.lua.org/ftp/lua-5.1.5.tar.gz">Lua 5.1</a> and try:
+Lua on OSX, download <a href="http://www.lua.org/ftp/lua-5.2.0.tar.gz">Lua 5.2.x</a> and try:
 \verbatim
-tar -xvf lua-5.1.x.tar.gz
-cd lua-5.1.x
+tar -xvf lua-5.2.x.tar.gz
+cd lua-5.2.x
 make macosx
 sudo make install
 \endverbatim
@@ -196,7 +196,7 @@ OSX users can also uses Lua binaries from http://lua-users.org/wiki/LuaBinaries
 After \ref yarp_swig_compile, make sure that the Lua-Yarp binding shared library
 (.so/.dll/.dylib/...) is included in your LUA_CPATH environment variable; e.g., on linux:
 \verbatim
-export LUA_CPATH=";;;/path/to/bindings/build/lib/lua/?.so"
+export LUA_CPATH=";;;/path/to/bindings/build/lib/lua/5.2/?.so"
 \endverbatim
 
 


### PR DESCRIPTION
As of now, we've successfully tested `lua5.2` with yarp, plus the path where the binding gets saved is different from what stated in the present doc and thus needs a fix.