### PR TITLE
ControlBoardWrapper: functions for all joints invoke the equivalent device's function for all joints

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -76,6 +76,7 @@ Important Changes
   interface.
 * Removed all control board interfaces methods e.g. `setTorquePid()`,
   `setPositionMode()` etc, marked as deprecated since 2.3.70
+* In ControlBoardWrapper functions for all joints invoke the equivalent function for all joints of motion control device. In the   previous versions, that funcions call the equivalent function single-joint in a for-cicle, so the function for all joints in motion control devices have never been called. So please, check the implementation of function for all joints in your motion control device because now they will be invoked for the fisrt time.
 
 #### `YARP_sig`
 

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -2988,12 +2988,21 @@ bool FakeMotionControl::getRefPositionsRaw(int nj, const int * jnts, double *ref
 // InteractionMode
 bool FakeMotionControl::getInteractionModeRaw(int j, yarp::dev::InteractionModeEnum* _mode)
 {
-    return false;
-}
+    if(verbose > VERY_VERY_VERBOSE)
+        yTrace() << "j: " << j;
+    
+    *_mode = (yarp::dev::InteractionModeEnum)_interactMode[j];
+    return true;}
 
 bool FakeMotionControl::getInteractionModesRaw(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
-    return false;
+    bool ret = true;
+    for(int j=0; j< n_joints; j++)
+    {
+        ret = ret && getInteractionModeRaw(joints[j], &modes[j]);
+    }
+    return ret;
+    
 }
 
 bool FakeMotionControl::getInteractionModesRaw(yarp::dev::InteractionModeEnum* modes)
@@ -3009,18 +3018,34 @@ bool FakeMotionControl::getInteractionModesRaw(yarp::dev::InteractionModeEnum* m
 // con il interaction mode il can ora non lo fa. mentre lo fa per il control mode. perche' diverso?
 bool FakeMotionControl::setInteractionModeRaw(int j, yarp::dev::InteractionModeEnum _mode)
 {
-     return false;
+    if(verbose >= VERY_VERBOSE)
+        yTrace() << "j: " << j << " intercation mode: " << yarp::os::Vocab::decode(_mode);
+    
+    _interactMode[j] = _mode;
+   
+    return true;
 }
 
 
 bool FakeMotionControl::setInteractionModesRaw(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
-    return false;
+    bool ret = true;
+    for(int i=0; i<n_joints; i++)
+    {
+        ret &= setInteractionModeRaw(joints[i], modes[i]);
+    }
+    return ret;
 }
 
 bool FakeMotionControl::setInteractionModesRaw(yarp::dev::InteractionModeEnum* modes)
 {
-    return false;
+    bool ret = true;
+    for(int i=0; i<_njoints; i++)
+    {
+        ret &= setInteractionModeRaw(i, modes[i]);
+    }
+    return ret;
+    
 }
 
 bool FakeMotionControl::getNumberOfMotorsRaw(int* num)

--- a/src/libYARP_dev/include/yarp/dev/IControlLimits2Impl.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlLimits2Impl.h
@@ -31,10 +31,7 @@ class YARP_dev_API yarp::dev::ImplementControlLimits2: public IControlLimits2
 protected:
     IControlLimits2Raw *iLimits2;
     void    *helper;
-    // those data are used as a support, DO NOT RELY on them!
-    int     *temp_int;
-    double  *temp_max;
-    double  *temp_min;
+    int nj;
 
     /**
      * Initialize the internal data and alloc memory.

--- a/src/libYARP_dev/include/yarp/dev/IInteractionModeImpl.h
+++ b/src/libYARP_dev/include/yarp/dev/IInteractionModeImpl.h
@@ -31,8 +31,7 @@ class YARP_dev_API yarp::dev::ImplementInteractionMode : public yarp::dev::IInte
 protected:
     yarp::dev::IInteractionModeRaw *iInteraction;
     void    *helper;                                // class controlBoardHelper, to handle axis map and conversion unit, where needed
-    int     *temp_int;                              // to convert axis number
-    yarp::dev::InteractionModeEnum *temp_modes;     // helper for all joints methods
+    int      nj;                                    //number of controlled axes the driver deals with.
 
     /**
      * Initialize the internal data and alloc memory, smaller version.

--- a/src/libYARP_dev/include/yarp/dev/IPositionControl2Impl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionControl2Impl.h
@@ -30,8 +30,8 @@ class YARP_dev_API yarp::dev::ImplementPositionControl2 : public IPositionContro
 protected:
     IPositionControl2Raw *iPosition2;
     void    *helper;
-    int     *temp_int;
-    double  *temp_double;
+    int nj;
+
     /**
      * Initialize the internal data and alloc memory.
      * @param size is the number of controlled axes the driver deals with.

--- a/src/libYARP_dev/include/yarp/dev/IPositionDirectImpl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionDirectImpl.h
@@ -30,8 +30,7 @@ class YARP_dev_API yarp::dev::ImplementPositionDirect : public yarp::dev::IPosit
 protected:
     IPositionDirectRaw *iPDirect;
     void    *helper;
-    int     *temp_int;
-    double  *temp_double;
+    int nj;
     /**
      * Initialize the internal data and alloc memory.
      * @param size is the number of controlled axes the driver deals with.

--- a/src/libYARP_dev/include/yarp/dev/IVelocityControl2Impl.h
+++ b/src/libYARP_dev/include/yarp/dev/IVelocityControl2Impl.h
@@ -26,10 +26,8 @@ class YARP_dev_API yarp::dev::ImplementVelocityControl2 : public IVelocityContro
 protected:
     IVelocityControl2Raw *iVelocity2;
     void    *helper;
-    int     *temp_int;
-    double  *temp_double;
-    Pid     *tempPids;
-
+    int nj;
+    
     /**
      * Initialize the internal data and alloc memory.
      * @param size is the number of controlled axes the driver deals with.

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
@@ -29,6 +29,7 @@ class YARP_dev_API yarp::dev::ImplementControlMode2: public IControlMode2
     void *helper;
     int *temp_int;
     int *temp_mode;
+    int nj;
 
     yarp::dev::IControlMode2Raw *raw;
 public:

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlMode2.h
@@ -27,8 +27,6 @@ YARP_DISABLE_DEPRECATED_WARNING
 class YARP_dev_API yarp::dev::ImplementControlMode2: public IControlMode2
 {
     void *helper;
-    int *temp_int;
-    int *temp_mode;
     int nj;
 
     yarp::dev::IControlMode2Raw *raw;

--- a/src/libYARP_dev/include/yarp/dev/ImplementCurrentControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementCurrentControl.h
@@ -23,10 +23,7 @@ class YARP_dev_API yarp::dev::ImplementCurrentControl: public ICurrentControl
 protected:
     yarp::dev::ICurrentControlRaw *iCurrentRaw;
     void *helper;
-    double *temp;
-    double *temp2;
-    int    *temp_int;
-    yarp::dev::Pid *tmpPids;
+    int nj;
 
     /**
      * Initialize the internal data and alloc memory.

--- a/src/libYARP_dev/include/yarp/dev/ImplementEncodersTimed.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementEncodersTimed.h
@@ -22,8 +22,7 @@ class YARP_dev_API yarp::dev::ImplementEncodersTimed: public IEncodersTimed
 protected:
     IEncodersTimedRaw *iEncoders;
     void *helper;
-    double *temp;
-    double *temp2;
+    int nj;
 
 
     /**

--- a/src/libYARP_dev/include/yarp/dev/ImplementMotor.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementMotor.h
@@ -22,8 +22,7 @@ class YARP_dev_API yarp::dev::ImplementMotor: public IMotor
 protected:
     IMotorRaw *imotor;
     void *helper;
-    double *temp1;
-    double *temp2;
+    int nj;
 
 
     /**

--- a/src/libYARP_dev/include/yarp/dev/ImplementMotorEncoders.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementMotorEncoders.h
@@ -22,8 +22,7 @@ class YARP_dev_API yarp::dev::ImplementMotorEncoders: public IMotorEncoders
 protected:
     IMotorEncodersRaw *iMotorEncoders;
     void *helper;
-    double *temp;
-    double *temp2;
+    int nj;
 
 
     /**

--- a/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementTorqueControl.h
@@ -24,9 +24,7 @@ class YARP_dev_API yarp::dev::ImplementTorqueControl: public ITorqueControl
 protected:
     yarp::dev::ITorqueControlRaw *iTorqueRaw;
     void *helper;
-    double *temp;
-    double *temp2;
-    int    *temp_int;
+    int nj;
 
     /**
      * Initialize the internal data and alloc memory.

--- a/src/libYARP_dev/src/ControlMode2Impl.cpp
+++ b/src/libYARP_dev/src/ControlMode2Impl.cpp
@@ -13,10 +13,11 @@
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK_DEL if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; return false;}
 
 ImplementControlMode2::ImplementControlMode2(IControlMode2Raw *r):
 temp_int(nullptr),
-temp_mode(nullptr)
+temp_mode(nullptr), nj(0)
 {
     raw=r;
     helper=nullptr;
@@ -26,6 +27,8 @@ bool ImplementControlMode2::initialize(int size, const int *amap)
 {
     if (helper!=nullptr)
         return false;
+    
+    nj = size;
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);
@@ -66,7 +69,6 @@ bool ImplementControlMode2::getControlMode(int j, int *f)
 
 bool ImplementControlMode2::getControlModes(int *modes)
 {
-    int nj = castToMapper(helper)->axes();
     int *tmp=new int [nj];
     bool ret=raw->getControlModesRaw(tmp);
     castToMapper(helper)->toUser(tmp, modes);
@@ -76,14 +78,16 @@ bool ImplementControlMode2::getControlModes(int *modes)
 
 bool ImplementControlMode2::getControlModes(const int n_joint, const int *joints, int *modes)
 {
+    int *tmp_joints=new int [nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK
-        temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
+        MJOINTIDCHECK_DEL
+        tmp_joints[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
-    bool ret = raw->getControlModesRaw(n_joint, temp_int, temp_mode);
-
+    bool ret = raw->getControlModesRaw(n_joint, tmp_joints, modes);
+    
+    delete [] tmp_joints;
     return ret;
 }
 
@@ -96,12 +100,16 @@ bool ImplementControlMode2::setControlMode(const int j, const int mode)
 
 bool ImplementControlMode2::setControlModes(const int n_joint, const int *joints, int *modes)
 {
+    int *tmp_joints=new int [nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK
+        MJOINTIDCHECK_DEL
         temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
-    return raw->setControlModesRaw(n_joint, temp_int, modes);
+    bool ret = raw->setControlModesRaw(n_joint, tmp_joints, modes);
+    
+    delete [] tmp_joints;
+    return ret;
 }
 
 bool ImplementControlMode2::setControlModes(int *modes)

--- a/src/libYARP_dev/src/ControlMode2Impl.cpp
+++ b/src/libYARP_dev/src/ControlMode2Impl.cpp
@@ -15,9 +15,7 @@ using namespace yarp::dev;
 #define MJOINTIDCHECK if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK_DEL if (joints[idx] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; return false;}
 
-ImplementControlMode2::ImplementControlMode2(IControlMode2Raw *r):
-temp_int(nullptr),
-temp_mode(nullptr), nj(0)
+ImplementControlMode2::ImplementControlMode2(IControlMode2Raw *r): nj(0)
 {
     raw=r;
     helper=nullptr;
@@ -27,17 +25,11 @@ bool ImplementControlMode2::initialize(int size, const int *amap)
 {
     if (helper!=nullptr)
         return false;
-    
+
     nj = size;
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);
-
-    temp_int=new int [size];
-    yAssert(temp_int != nullptr);
-
-    temp_mode=new int [size];
-    yAssert(temp_mode != nullptr);
 
     return true;
 }
@@ -55,8 +47,6 @@ bool ImplementControlMode2::uninitialize ()
         helper=nullptr;
     }
 
-    checkAndDestroy(temp_int);
-    checkAndDestroy(temp_mode);
     return true;
 }
 
@@ -104,7 +94,7 @@ bool ImplementControlMode2::setControlModes(const int n_joint, const int *joints
     for(int idx=0; idx<n_joint; idx++)
     {
         MJOINTIDCHECK_DEL
-        temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
+        tmp_joints[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
     bool ret = raw->setControlModesRaw(n_joint, tmp_joints, modes);
     

--- a/src/libYARP_dev/src/CurrentControlImpl.cpp
+++ b/src/libYARP_dev/src/CurrentControlImpl.cpp
@@ -13,6 +13,7 @@
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK_DEL(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; delete [] tmp;return false;}
 #define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementCurrentControl::ImplementCurrentControl(ICurrentControlRaw *tq):nj(0)
@@ -108,7 +109,7 @@ bool ImplementCurrentControl::setRefCurrents(const int n_joint, const int *joint
     int *tmp_joints = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
+        MJOINTIDCHECK_DEL(idx)
         castToMapper(helper)->ampereA2S(t[idx], joints[idx], tmp[idx], tmp_joints[idx]);
     }
     bool ret = iCurrentRaw->setRefCurrentsRaw(n_joint, tmp_joints, tmp);

--- a/src/libYARP_dev/src/CurrentControlImpl.cpp
+++ b/src/libYARP_dev/src/CurrentControlImpl.cpp
@@ -15,15 +15,10 @@ using namespace yarp::dev;
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
-ImplementCurrentControl::ImplementCurrentControl(ICurrentControlRaw *tq)
+ImplementCurrentControl::ImplementCurrentControl(ICurrentControlRaw *tq):nj(0)
 {
     iCurrentRaw = tq;
     helper=nullptr;
-    temp=nullptr;
-//     fake =0;
-    temp2=nullptr;
-    temp_int=nullptr;
-    tmpPids=nullptr;
 }
 
 ImplementCurrentControl::~ImplementCurrentControl()
@@ -35,17 +30,10 @@ bool ImplementCurrentControl::initialize(int size, const int *amap, const double
 {
     if (helper!=nullptr)
         return false;
+    nj=size;
 
     helper = (void *)(new ControlBoardHelper(size, amap, nullptr, nullptr, nullptr, ampsToSens, nullptr, nullptr));
     yAssert (helper != nullptr);
-    temp=new double [size];
-    yAssert (temp != nullptr);
-    temp2=new double [size];
-    yAssert (temp2 != nullptr);
-    temp_int=new int [size];
-    yAssert (temp_int != nullptr);
-    tmpPids=new Pid[size];
-    yAssert (tmpPids!=nullptr);
 
     return true;
 }
@@ -57,11 +45,6 @@ bool ImplementCurrentControl::uninitialize()
         delete castToMapper(helper);
         helper=nullptr;
     }
-    checkAndDestroy(temp);
-    checkAndDestroy(temp2);
-    checkAndDestroy(temp_int);
-    checkAndDestroy(tmpPids);
-
     return true;
 }
 
@@ -85,15 +68,20 @@ bool ImplementCurrentControl::getRefCurrent(int j, double *r)
 bool ImplementCurrentControl::getRefCurrents(double *t)
 {
     bool ret;
-    ret = iCurrentRaw->getRefCurrentsRaw(temp);
-    castToMapper(helper)->ampereS2A(temp,t);
+    double *tmp = new double[nj];
+    ret = iCurrentRaw->getRefCurrentsRaw(tmp);
+    castToMapper(helper)->ampereS2A(tmp,t);
+    delete [] tmp;
     return ret;
 }
 
 bool ImplementCurrentControl::setRefCurrents(const double *t)
 {
-    castToMapper(helper)->ampereA2S(t, temp);
-    return iCurrentRaw->setRefCurrentsRaw(temp);
+    double *tmp = new double[nj];
+    castToMapper(helper)->ampereA2S(t, tmp);
+    bool ret = iCurrentRaw->setRefCurrentsRaw(tmp);
+    delete [] tmp;
+    return ret;
 }
 
 bool ImplementCurrentControl::setRefCurrent(int j, double t)
@@ -107,19 +95,26 @@ bool ImplementCurrentControl::setRefCurrent(int j, double t)
 
 bool ImplementCurrentControl::getCurrents(double *t)
 {
-    bool ret = iCurrentRaw->getCurrentsRaw(temp);
-    castToMapper(helper)->ampereS2A(temp, t);
+    double *tmp = new double[nj];
+    bool ret = iCurrentRaw->getCurrentsRaw(tmp);
+    castToMapper(helper)->ampereS2A(tmp, t);
+    delete [] tmp;
     return ret;
 }
 
 bool ImplementCurrentControl::setRefCurrents(const int n_joint, const int *joints, const double *t)
 {
+    double *tmp = new double[nj];
+    int *tmp_joints = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
         MJOINTIDCHECK(idx)
-        castToMapper(helper)->ampereA2S(t[idx], joints[idx], temp[idx], temp_int[idx]);
+        castToMapper(helper)->ampereA2S(t[idx], joints[idx], tmp[idx], tmp_joints[idx]);
     }
-    return iCurrentRaw->setRefCurrentsRaw(n_joint, temp_int, temp);
+    bool ret = iCurrentRaw->setRefCurrentsRaw(n_joint, tmp_joints, tmp);
+    delete [] tmp;
+    delete [] tmp_joints;
+    return ret;
 }
 
 bool ImplementCurrentControl::getCurrent(int j, double *t)
@@ -136,9 +131,13 @@ bool ImplementCurrentControl::getCurrent(int j, double *t)
 
 bool ImplementCurrentControl::getCurrentRanges(double *min, double *max)
 {
-    bool ret = iCurrentRaw->getCurrentRangesRaw(temp, temp2);
-    castToMapper(helper)->toUser(temp, min);
-    castToMapper(helper)->toUser(temp2, max);
+    double *tmp_min = new double[nj];
+    double *tmp_max = new double[nj];
+    bool ret = iCurrentRaw->getCurrentRangesRaw(tmp_min, tmp_max);
+    castToMapper(helper)->toUser(tmp_min, min);
+    castToMapper(helper)->toUser(tmp_max, max);
+    delete [] tmp_min;
+    delete [] tmp_max;
     return ret;
 }
 

--- a/src/libYARP_dev/src/IControlLimit2sImpl.cpp
+++ b/src/libYARP_dev/src/IControlLimit2sImpl.cpp
@@ -16,10 +16,7 @@ using namespace yarp::dev;
 
 ImplementControlLimits2::ImplementControlLimits2(yarp::dev::IControlLimits2Raw *y) :
     iLimits2(y),
-    helper(nullptr),
-    temp_int(nullptr),
-    temp_max(nullptr),
-    temp_min(nullptr)
+    helper(nullptr),nj(0)
 {
 
 }
@@ -41,10 +38,6 @@ bool ImplementControlLimits2::uninitialize()
         delete castToMapper(helper);
         helper = nullptr;
     }
-    checkAndDestroy(temp_int);
-    checkAndDestroy(temp_min);
-    checkAndDestroy(temp_max);
-
     return true;
 }
 
@@ -55,12 +48,7 @@ bool ImplementControlLimits2::initialize(int size, const int *amap, const double
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
-    temp_max=new double [size];
-    yAssert(temp_max != nullptr);
-    temp_min=new double [size];
-    yAssert(temp_min != nullptr);
-    temp_int=new int [size];
-    yAssert(temp_int != nullptr);
+    nj = size;
     return true;
 }
 

--- a/src/libYARP_dev/src/IInteractionModeImpl.cpp
+++ b/src/libYARP_dev/src/IInteractionModeImpl.cpp
@@ -15,12 +15,12 @@
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK_DEL(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] temp; return false;}
 
 ImplementInteractionMode::ImplementInteractionMode(yarp::dev::IInteractionModeRaw *class_p) :
     iInteraction(class_p),
     helper(nullptr),
-    temp_int(nullptr),
-    temp_modes(nullptr)
+    nj(0)
 {
 
 }
@@ -50,11 +50,7 @@ bool ImplementInteractionMode::initialize(int size, const int *amap, const doubl
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
 
-    temp_int=new int [size];
-    yAssert(temp_int != nullptr);
-
-    temp_modes=new yarp::dev::InteractionModeEnum [size];
-    yAssert(temp_modes != nullptr);
+    nj = size;
     return true;
 }
 
@@ -69,9 +65,6 @@ bool ImplementInteractionMode::uninitialize()
         delete castToMapper(helper);
         helper = nullptr;
     }
-
-    checkAndDestroy(temp_int);
-    checkAndDestroy(temp_modes);
     return true;
 }
 
@@ -83,24 +76,31 @@ bool ImplementInteractionMode::getInteractionMode(int axis, yarp::dev::Interacti
 
 bool ImplementInteractionMode::getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
+    int *temp =  new int [nj];
     for (int i = 0; i < n_joints; i++)
     {
-         MJOINTIDCHECK(i)
-         temp_int[i] = castToMapper(helper)->toHw(joints[i]);
+         MJOINTIDCHECK_DEL(i)
+         temp[i] = castToMapper(helper)->toHw(joints[i]);
     }
-    return iInteraction->getInteractionModesRaw(n_joints, temp_int, modes);
+    bool ret = iInteraction->getInteractionModesRaw(n_joints, temp, modes);
+    delete [] temp;
+    return ret;
 }
 
 bool ImplementInteractionMode::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
+    yarp::dev::InteractionModeEnum *temp_modes=new yarp::dev::InteractionModeEnum [nj];
     if(!iInteraction->getInteractionModesRaw(temp_modes) )
+    {
+        delete [] temp_modes;
         return false;
-
+    }
     for(int idx=0; idx<castToMapper(helper)->axes(); idx++)
     {
         int j = castToMapper(helper)->toUser(idx);
         modes[j] = temp_modes[idx];
     }
+    delete [] temp_modes;
     return true;
 }
 
@@ -112,20 +112,26 @@ bool ImplementInteractionMode::setInteractionMode(int axis, yarp::dev::Interacti
 
 bool ImplementInteractionMode::setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
+    int *temp =  new int [nj];
     for(int idx=0; idx<n_joints; idx++)
     {
-        MJOINTIDCHECK(idx)
-        temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        temp[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
-    return iInteraction->setInteractionModesRaw(n_joints, temp_int, modes);
+    bool ret = iInteraction->setInteractionModesRaw(n_joints, temp, modes);
+    delete [] temp;
+    return ret;
 }
 
 bool ImplementInteractionMode::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
+    yarp::dev::InteractionModeEnum *temp_modes=new yarp::dev::InteractionModeEnum [nj];
     for(int idx=0; idx< castToMapper(helper)->axes(); idx++)
     {
         int j = castToMapper(helper)->toHw(idx);
         modes[j] = temp_modes[idx];
     }
-    return iInteraction->setInteractionModesRaw(temp_modes);
+    bool ret = iInteraction->setInteractionModesRaw(temp_modes);
+    delete [] temp_modes;
+    return ret;
 }

--- a/src/libYARP_dev/src/IMotorImpl.cpp
+++ b/src/libYARP_dev/src/IMotorImpl.cpp
@@ -16,12 +16,10 @@ using namespace yarp::dev;
 
 ////////////////////////
 // Encoder Interface Timed Implementation
-ImplementMotor::ImplementMotor(IMotorRaw *y)
+ImplementMotor::ImplementMotor(IMotorRaw *y):nj(0)
 {
     imotor=y;
     helper = nullptr;
-    temp1=nullptr;
-    temp2=nullptr;
 }
 
 ImplementMotor::~ImplementMotor()
@@ -36,10 +34,8 @@ bool ImplementMotor:: initialize (int size, const int *amap)
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);
-    temp1=new double [size];
-    yAssert (temp1 != nullptr);
-    temp2=new double [size];
-    yAssert (temp2 != nullptr);
+
+    nj=size;
     return true;
 }
 
@@ -54,9 +50,6 @@ bool ImplementMotor::uninitialize ()
         delete castToMapper(helper);
         helper=nullptr;
     }
-
-    checkAndDestroy(temp1);
-    checkAndDestroy(temp2);
 
     return true;
 }

--- a/src/libYARP_dev/src/IPositionControl2Impl.cpp
+++ b/src/libYARP_dev/src/IPositionControl2Impl.cpp
@@ -285,7 +285,7 @@ bool ImplementPositionControl2::getRefAccelerations(double *accs)
     double *refs = new double[nj];
     bool ret=iPosition2->getRefAccelerationsRaw(refs);
     castToMapper(helper)->accE2A_abs(refs, accs);
-    delete refs;
+    delete [] refs;
     return ret;
 }
 
@@ -385,7 +385,6 @@ bool ImplementPositionControl2::getTargetPositions(double* refs)
 bool ImplementPositionControl2::getTargetPositions(const int n_joint, const int* joints, double* refs)
 {
     int * temp = new int [nj];
-    double *trgPos =  new double[nj];
 
     for(int idx=0; idx<n_joint; idx++)
     {
@@ -393,6 +392,7 @@ bool ImplementPositionControl2::getTargetPositions(const int n_joint, const int*
         temp[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
+    double *trgPos =  new double[nj];
     bool ret = iPosition2->getTargetPositionsRaw(n_joint, temp, trgPos);
 
     for(int idx=0; idx<n_joint; idx++)

--- a/src/libYARP_dev/src/IPositionControl2Impl.cpp
+++ b/src/libYARP_dev/src/IPositionControl2Impl.cpp
@@ -15,13 +15,14 @@
 using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK_DEL(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] temp_int; delete [] temp; return false;}
+#define MJOINTIDCHECK_DEL1(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] temp; return false;}
 #define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 
 ImplementPositionControl2::ImplementPositionControl2(IPositionControl2Raw *y) :
     iPosition2(y),
     helper(nullptr),
-    temp_int(nullptr),
-    temp_double(nullptr)
+    nj(0)
 {
 
 }
@@ -47,11 +48,8 @@ bool ImplementPositionControl2::initialize(int size, const int *amap, const doub
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
-    temp_double=new double [size];
-    yAssert(temp_double != nullptr);
 
-    temp_int=new int [size];
-    yAssert(temp_int != nullptr);
+    nj = size;
     return true;
 }
 
@@ -66,8 +64,6 @@ bool ImplementPositionControl2::uninitialize()
         delete castToMapper(helper);
         helper = nullptr;
     }
-    checkAndDestroy(temp_double);
-    checkAndDestroy(temp_int);
 
     return true;
 }
@@ -83,19 +79,27 @@ bool ImplementPositionControl2::positionMove(int j, double ang)
 
 bool ImplementPositionControl2::positionMove(const int n_joint, const int *joints, const double *refs)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        castToMapper(helper)->posA2E(refs[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        castToMapper(helper)->posA2E(refs[idx], joints[idx], temp[idx], temp_int[idx]);
     }
-    return iPosition2->positionMoveRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->positionMoveRaw(n_joint, temp_int, temp);
+    delete [] temp;
+    delete [] temp_int;
+    return ret;
 }
 
 bool ImplementPositionControl2::positionMove(const double *refs)
 {
-    castToMapper(helper)->posA2E(refs, temp_double);
+    double *pos =  new double [nj];
+    castToMapper(helper)->posA2E(refs, pos);
 
-    return iPosition2->positionMoveRaw(temp_double);
+    bool ret = iPosition2->positionMoveRaw(pos);
+    delete [] pos;
+    return ret;
 }
 
 bool ImplementPositionControl2::relativeMove(int j, double delta)
@@ -110,18 +114,26 @@ bool ImplementPositionControl2::relativeMove(int j, double delta)
 
 bool ImplementPositionControl2::relativeMove(const int n_joint, const int *joints, const double *deltas)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        castToMapper(helper)->velA2E(deltas[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        castToMapper(helper)->velA2E(deltas[idx], joints[idx], temp[idx], temp_int[idx]);
     }
-    return iPosition2->relativeMoveRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->relativeMoveRaw(n_joint, temp_int, temp);
+    delete [] temp;
+    delete [] temp_int;
+    return ret;
 }
 
 bool ImplementPositionControl2::relativeMove(const double *deltas)
 {
-    castToMapper(helper)->velA2E(deltas, temp_double);
-    return iPosition2->relativeMoveRaw(temp_double);
+    double *temp = new double[nj];
+    castToMapper(helper)->velA2E(deltas, temp);
+    bool ret = iPosition2->relativeMoveRaw(temp);
+    delete [] temp;
+    return ret;
 }
 
 bool ImplementPositionControl2::checkMotionDone(int j, bool *flag)
@@ -134,13 +146,16 @@ bool ImplementPositionControl2::checkMotionDone(int j, bool *flag)
 
 bool ImplementPositionControl2::checkMotionDone(const int n_joint, const int *joints, bool *flags)
 {
+    int *temp = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
+        MJOINTIDCHECK_DEL1(idx)
+        temp[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
-    return iPosition2->checkMotionDoneRaw(n_joint, temp_int, flags);
+    bool ret = iPosition2->checkMotionDoneRaw(n_joint, temp, flags);
+    delete [] temp;
+    return ret;
 }
 
 bool ImplementPositionControl2::checkMotionDone(bool *flag)
@@ -159,20 +174,28 @@ bool ImplementPositionControl2::setRefSpeed(int j, double sp)
 
 bool ImplementPositionControl2::setRefSpeeds(const int n_joint, const int *joints, const double *spds)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        castToMapper(helper)->velA2E_abs(spds[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        castToMapper(helper)->velA2E_abs(spds[idx], joints[idx], temp[idx], temp_int[idx]);
     }
 
-    return iPosition2->setRefSpeedsRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->setRefSpeedsRaw(n_joint, temp_int, temp);
+    delete [] temp;
+    delete [] temp_int;
+    return ret;
 }
 
 bool ImplementPositionControl2::setRefSpeeds(const double *spds)
 {
-    castToMapper(helper)->velA2E_abs(spds, temp_double);
+    double *refs = new double[nj];
+    castToMapper(helper)->velA2E_abs(spds, refs);
 
-    return iPosition2->setRefSpeedsRaw(temp_double);
+    bool ret = iPosition2->setRefSpeedsRaw(refs);
+    delete [] refs;
+    return ret;
 }
 
 bool ImplementPositionControl2::setRefAcceleration(int j, double acc)
@@ -187,20 +210,29 @@ bool ImplementPositionControl2::setRefAcceleration(int j, double acc)
 
 bool ImplementPositionControl2::setRefAccelerations(const int n_joint, const int *joints, const double *accs)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
+
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        castToMapper(helper)->accA2E_abs(accs[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        castToMapper(helper)->accA2E_abs(accs[idx], joints[idx], temp[idx], temp_int[idx]);
     }
 
-    return iPosition2->setRefAccelerationsRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->setRefAccelerationsRaw(n_joint, temp_int, temp);
+    delete [] temp;
+    delete [] temp_int;
+    return ret;
 }
 
 bool ImplementPositionControl2::setRefAccelerations(const double *accs)
 {
-    castToMapper(helper)->accA2E_abs(accs, temp_double);
+    double *refs = new double[nj];
+    castToMapper(helper)->accA2E_abs(accs, refs);
 
-    return iPosition2->setRefAccelerationsRaw(temp_double);
+    bool ret = iPosition2->setRefAccelerationsRaw(refs);
+    delete [] refs;
+    return ret;
 }
 
 bool ImplementPositionControl2::getRefSpeed(int j, double *ref)
@@ -219,49 +251,63 @@ bool ImplementPositionControl2::getRefSpeed(int j, double *ref)
 
 bool ImplementPositionControl2::getRefSpeeds(const int n_joint, const int *joints, double *spds)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
+
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
+        MJOINTIDCHECK_DEL(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
-    bool ret = iPosition2->getRefSpeedsRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->getRefSpeedsRaw(n_joint, temp_int, temp);
 
     for(int idx=0; idx<n_joint; idx++)
     {
-        spds[idx]=castToMapper(helper)->velE2A_abs(temp_double[idx], temp_int[idx]);
+        spds[idx]=castToMapper(helper)->velE2A_abs(temp[idx], temp_int[idx]);
     }
+    delete [] temp;
+    delete [] temp_int;
     return ret;
 }
 
 bool ImplementPositionControl2::getRefSpeeds(double *spds)
 {
-    bool ret = iPosition2->getRefSpeedsRaw(temp_double);
-    castToMapper(helper)->velE2A_abs(temp_double, spds);
+    double *refs = new double[nj];
+    bool ret = iPosition2->getRefSpeedsRaw(refs);
+    castToMapper(helper)->velE2A_abs(refs, spds);
+    delete [] refs;
     return ret;
 }
 
 bool ImplementPositionControl2::getRefAccelerations(double *accs)
 {
-    bool ret=iPosition2->getRefAccelerationsRaw(temp_double);
-    castToMapper(helper)->accE2A_abs(temp_double, accs);
+    double *refs = new double[nj];
+    bool ret=iPosition2->getRefAccelerationsRaw(refs);
+    castToMapper(helper)->accE2A_abs(refs, accs);
+    delete refs;
     return ret;
 }
 
 bool ImplementPositionControl2::getRefAccelerations(const int n_joint, const int *joints, double *accs)
 {
+    double *temp = new double[nj];
+    int *temp_int = new int[nj];
+
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
+        MJOINTIDCHECK_DEL(idx)
         temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
-    bool ret = iPosition2->getRefAccelerationsRaw(n_joint, temp_int, temp_double);
+    bool ret = iPosition2->getRefAccelerationsRaw(n_joint, temp_int, temp);
 
     for(int idx=0; idx<n_joint; idx++)
     {
-        accs[idx]=castToMapper(helper)->accE2A_abs(temp_double[idx], temp_int[idx]);
+        accs[idx]=castToMapper(helper)->accE2A_abs(temp[idx], temp_int[idx]);
     }
+    delete [] temp;
+    delete [] temp_int;
     return ret;
 }
 
@@ -289,13 +335,16 @@ bool ImplementPositionControl2::stop(int j)
 
 bool ImplementPositionControl2::stop(const int n_joint, const int *joints)
 {
+    int *temp = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        temp_int[idx] = castToMapper(helper)->toHw(joints[idx]);
+        MJOINTIDCHECK_DEL1(idx)
+        temp[idx] = castToMapper(helper)->toHw(joints[idx]);
     }
 
-    return iPosition2->stopRaw(n_joint, temp_int);
+    bool ret = iPosition2->stopRaw(n_joint, temp);
+    delete [] temp;
+    return ret;
 }
 
 bool ImplementPositionControl2::stop()
@@ -326,25 +375,32 @@ bool ImplementPositionControl2::getTargetPosition(const int joint, double* ref)
 
 bool ImplementPositionControl2::getTargetPositions(double* refs)
 {
-    bool ret=iPosition2->getTargetPositionsRaw(temp_double);
-    castToMapper(helper)->posE2A(temp_double, refs);
+    double *trgPos = new double[nj];
+    bool ret=iPosition2->getTargetPositionsRaw(trgPos);
+    castToMapper(helper)->posE2A(trgPos, refs);
+    delete [] trgPos;
     return ret;
 }
 
 bool ImplementPositionControl2::getTargetPositions(const int n_joint, const int* joints, double* refs)
 {
-    for(int idx=0; idx<n_joint; idx++)
-    {
-        MJOINTIDCHECK(idx)
-        temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
-    }
-
-    bool ret = iPosition2->getTargetPositionsRaw(n_joint, temp_int, temp_double);
+    int * temp = new int [nj];
+    double *trgPos =  new double[nj];
 
     for(int idx=0; idx<n_joint; idx++)
     {
-        refs[idx]=castToMapper(helper)->posE2A(temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL1(idx)
+        temp[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
+
+    bool ret = iPosition2->getTargetPositionsRaw(n_joint, temp, trgPos);
+
+    for(int idx=0; idx<n_joint; idx++)
+    {
+        refs[idx]=castToMapper(helper)->posE2A(trgPos[idx], temp[idx]);
+    }
+    delete [] temp;
+    delete [] trgPos;
     return ret;
 }
 /////////////////// End Implement PostionControl2

--- a/src/libYARP_dev/src/IPositionDirectImpl.cpp
+++ b/src/libYARP_dev/src/IPositionDirectImpl.cpp
@@ -16,7 +16,8 @@ using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
-#define MJOINTIDCHECK_DEL(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; return false;}
+#define MJOINTIDCHECK_DEL1(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; return false;}
+#define MJOINTIDCHECK_DEL2(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; delete [] tmp_refs;return false;}
 
 ImplementPositionDirect::ImplementPositionDirect(IPositionDirectRaw *y) :
     iPDirect(y),
@@ -75,7 +76,7 @@ bool ImplementPositionDirect::setPositions(const int n_joint, const int *joints,
     double *tmp_refs = new double [nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK_DEL(idx)
+        MJOINTIDCHECK_DEL2(idx)
         castToMapper(helper)->posA2E(refs[idx], joints[idx], tmp_refs[idx], tmp_joints[idx]);
     }
     bool ret = iPDirect->setPositionsRaw(n_joint, tmp_joints, tmp_refs);
@@ -114,7 +115,7 @@ bool ImplementPositionDirect::getRefPositions(const int n_joint, const int* join
     int * tmp_joints = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK_DEL(idx)
+        MJOINTIDCHECK_DEL1(idx)
         tmp_joints[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 

--- a/src/libYARP_dev/src/IPositionDirectImpl.cpp
+++ b/src/libYARP_dev/src/IPositionDirectImpl.cpp
@@ -16,14 +16,15 @@ using namespace yarp::dev;
 #define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define MJOINTIDCHECK(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
 #define PJOINTIDCHECK(j) if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+#define MJOINTIDCHECK_DEL(i) if (joints[i] >= castToMapper(helper)->axes()){yError("joint id out of bound"); delete [] tmp_joints; return false;}
 
 ImplementPositionDirect::ImplementPositionDirect(IPositionDirectRaw *y) :
     iPDirect(y),
     helper(nullptr),
-    temp_int(nullptr),
-    temp_double(nullptr)
+    nj(0)
 {
 }
+
 
 ImplementPositionDirect::~ImplementPositionDirect()
 {
@@ -38,11 +39,7 @@ bool ImplementPositionDirect::initialize(int size, const int *amap, const double
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
 
-    temp_double=new double [size];
-    yAssert(temp_double != nullptr);
-
-    temp_int=new int [size];
-    yAssert(temp_int != nullptr);
+    nj=size;
     return true;
 }
 
@@ -53,9 +50,6 @@ bool ImplementPositionDirect::uninitialize()
         delete castToMapper(helper);
         helper=nullptr;
     }
-
-    checkAndDestroy(temp_double);
-    checkAndDestroy(temp_int);
 
     return true;
 }
@@ -77,19 +71,29 @@ bool ImplementPositionDirect::setPosition(int j, double ref)
 
 bool ImplementPositionDirect::setPositions(const int n_joint, const int *joints, double *refs)
 {
+    int *tmp_joints =  new int [nj];
+    double *tmp_refs = new double [nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        castToMapper(helper)->posA2E(refs[idx], joints[idx], temp_double[idx], temp_int[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        castToMapper(helper)->posA2E(refs[idx], joints[idx], tmp_refs[idx], tmp_joints[idx]);
     }
-    return iPDirect->setPositionsRaw(n_joint, temp_int, temp_double);
+    bool ret = iPDirect->setPositionsRaw(n_joint, tmp_joints, tmp_refs);
+    delete [] tmp_joints;
+    delete [] tmp_refs;
+    
+    return ret;
 }
 
 bool ImplementPositionDirect::setPositions(const double *refs)
 {
-    castToMapper(helper)->posA2E(refs, temp_double);
+    double *tmp = new double[nj];
+    castToMapper(helper)->posA2E(refs, tmp);
 
-    return iPDirect->setPositionsRaw(temp_double);
+    bool ret = iPDirect->setPositionsRaw(tmp);
+    
+    delete [] tmp;
+    return ret;
 }
 
 bool ImplementPositionDirect::getRefPosition(const int j, double* ref)
@@ -107,25 +111,33 @@ bool ImplementPositionDirect::getRefPosition(const int j, double* ref)
 
 bool ImplementPositionDirect::getRefPositions(const int n_joint, const int* joints, double* refs)
 {
+    int * tmp_joints = new int[nj];
     for(int idx=0; idx<n_joint; idx++)
     {
-        MJOINTIDCHECK(idx)
-        temp_int[idx]=castToMapper(helper)->toHw(joints[idx]);
+        MJOINTIDCHECK_DEL(idx)
+        tmp_joints[idx]=castToMapper(helper)->toHw(joints[idx]);
     }
 
-    bool ret = iPDirect->getRefPositionsRaw(n_joint, temp_int, temp_double);
+    double *tmp_refs = new double[nj];
+    bool ret = iPDirect->getRefPositionsRaw(n_joint, tmp_joints, tmp_refs);
 
     for(int idx=0; idx<n_joint; idx++)
     {
-        refs[idx]=castToMapper(helper)->posE2A(temp_double[idx], temp_int[idx]);
+        refs[idx]=castToMapper(helper)->posE2A(tmp_refs[idx], tmp_joints[idx]);
     }
+    
+    delete [] tmp_joints;
+    delete [] tmp_refs;
+    
     return ret;
 }
 
 bool ImplementPositionDirect::getRefPositions(double* refs)
 {
-    bool ret = iPDirect->getRefPositionsRaw(temp_double);
-    castToMapper(helper)->posE2A(temp_double, refs);
+    double *tmp=new double[nj];
+    bool ret = iPDirect->getRefPositionsRaw(tmp);
+    castToMapper(helper)->posE2A(tmp, refs);
+    delete [] tmp;
     return ret;
 }
 

--- a/src/libYARP_dev/src/PWMControlImpl.cpp
+++ b/src/libYARP_dev/src/PWMControlImpl.cpp
@@ -46,6 +46,12 @@ bool ImplementPWMControl::uninitialize()
         delete castToMapper(helper);
         helper = nullptr;
     }
+    
+    if(dummy != nullptr)
+    {
+        delete[] dummy;
+        dummy = nullptr;
+    }
 
     return true;
 }
@@ -66,8 +72,11 @@ bool ImplementPWMControl::setRefDutyCycle(int j, double duty)
 
 bool ImplementPWMControl::setRefDutyCycles(const double *duty)
 {
-    castToMapper(helper)->dutycycle2PWM(duty, dummy);
-    return raw->setRefDutyCyclesRaw(dummy);
+    double *aux = new double[castToMapper(helper)->axes()];
+    castToMapper(helper)->dutycycle2PWM(duty, aux);
+    bool ret = raw->setRefDutyCyclesRaw(aux);
+    delete [] aux;
+    return ret;
 }
 
 bool ImplementPWMControl::getRefDutyCycle(int j, double *v)
@@ -82,9 +91,10 @@ bool ImplementPWMControl::getRefDutyCycle(int j, double *v)
 
 bool ImplementPWMControl::getRefDutyCycles(double *duty)
 {
-    bool ret;
-    ret = raw->getRefDutyCyclesRaw(dummy);
-    castToMapper(helper)->PWM2dutycycle(dummy, duty);
+    double *aux = new double[castToMapper(helper)->axes()];
+    bool ret = raw->getRefDutyCyclesRaw(aux);
+    castToMapper(helper)->PWM2dutycycle(aux, duty);
+    delete [] aux;
     return ret;
 }
 
@@ -100,8 +110,9 @@ bool ImplementPWMControl::getDutyCycle(int j, double *duty)
 
 bool ImplementPWMControl::getDutyCycles(double *duty)
 {
-    bool ret;
-    ret = raw->getDutyCyclesRaw(dummy);
-    castToMapper(helper)->PWM2dutycycle(dummy, duty);
+    double *aux = new double[castToMapper(helper)->axes()];
+    bool ret = raw->getDutyCyclesRaw(aux);
+    castToMapper(helper)->PWM2dutycycle(aux, duty);
+    delete [] aux;
     return ret;
 }

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -1119,24 +1119,33 @@ bool ControlBoardWrapper::getPidError(const PidControlTypeEnum& pidtype, int j, 
 
 bool ControlBoardWrapper::getPidErrors(const PidControlTypeEnum& pidtype, double *errs)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double * errors = new double [device.maxNumOfJointsInDevices];
+    
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pid->getPidError(pidtype, off+p->base, errs+l);
+            ret = false;
+            break;
+        }
+        if( (p->pid) &&(ret = p->pid->getPidErrors(pidtype, errors)) )
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                errs[juser] = errors[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getPidErrors", p->id, ret);
+            ret =  false;
+            break;
+        }
     }
+    
+    delete[] errors;
     return ret;
 }
 
@@ -1159,24 +1168,33 @@ bool ControlBoardWrapper::getPidOutput(const PidControlTypeEnum& pidtype, int j,
 
 bool ControlBoardWrapper::getPidOutputs(const PidControlTypeEnum& pidtype, double *outs)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *outputs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pid->getPidOutput(pidtype, off+p->base, outs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pid) &&(ret = p->pid->getPidOutputs(pidtype, outputs)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                outs[juser] = outputs[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getPidOutouts", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] outputs;
     return ret;
 }
 
@@ -1215,24 +1233,33 @@ bool ControlBoardWrapper::getPid(const PidControlTypeEnum& pidtype, int j, Pid *
 
 bool ControlBoardWrapper::getPids(const PidControlTypeEnum& pidtype, Pid *pids)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    Pid *pids_device = new Pid[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pid->getPid(pidtype, off+p->base, pids+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pid) &&(ret = p->pid->getPids(pidtype, pids_device)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                pids[juser] = pids_device[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getPids", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete[] pids_device;
     return ret;
 }
 
@@ -1250,25 +1277,35 @@ bool ControlBoardWrapper::getPidReference(const PidControlTypeEnum& pidtype, int
     return false;
 }
 
-bool ControlBoardWrapper::getPidReferences(const PidControlTypeEnum& pidtype, double *refs) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getPidReferences(const PidControlTypeEnum& pidtype, double *refs) 
+{
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pid->getPidReference(pidtype, off+p->base, refs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pid) &&(ret = p->pid->getPidReferences(pidtype, references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                refs[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getPidReferences", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] references;
     return ret;
 }
 
@@ -1287,25 +1324,35 @@ bool ControlBoardWrapper::getPidErrorLimit(const PidControlTypeEnum& pidtype, in
     return false;
 }
 
-bool ControlBoardWrapper::getPidErrorLimits(const PidControlTypeEnum& pidtype, double *limits) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getPidErrorLimits(const PidControlTypeEnum& pidtype, double *limits) 
+{
+    double *lims = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pid->getPidErrorLimit(pidtype, off+p->base, limits+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pid) &&(ret = p->pid->getPidErrorLimits(pidtype, lims)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                limits[juser] = lims[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getPidErrorLimits", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] lims;
     return ret;
 }
 
@@ -1542,26 +1589,35 @@ bool ControlBoardWrapper::getTargetPosition(const int j, double* ref)
 * @param spds pointer to the array that will store the speed values.
 * @return true/false on success/failure.
 */
-bool ControlBoardWrapper::getTargetPositions(double *spds) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getTargetPositions(double *spds) 
+{
+    double *targets = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->pos2)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pos2->getTargetPosition(off+p->base, spds+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pos2) &&(ret = p->pos2->getTargetPositions(targets)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                spds[juser] = targets[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getTargetPositions", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] targets;
     return ret;
 }
 
@@ -1745,29 +1801,37 @@ bool ControlBoardWrapper::checkMotionDone(int j, bool *flag) {
 * @param flag true if the trajectory is terminated, false otherwise
 * @return false on failure
 */
-bool ControlBoardWrapper::checkMotionDone(bool *flag) {
-    bool ret=true;
-    *flag=true;
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::checkMotionDone(bool *flag) 
+{
+    bool *done = new bool[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->pos)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            bool tmpF=false;
-            ret=ret&&p->pos->checkMotionDone(off+p->base, &tmpF);
-            *flag=*flag&&tmpF;
+            ret = false;
+            break;
+        }
+        
+        if( (p->pos2) &&(ret = p->pos2->checkMotionDone(done)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                flag[juser] = done[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("checkMotionDone", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] done;
     return ret;
+    
 }
 
 
@@ -2121,26 +2185,35 @@ bool ControlBoardWrapper::getRefSpeed(int j, double *ref) {
 * @param spds pointer to the array that will store the speed values.
 * @return true/false on success/failure.
 */
-bool ControlBoardWrapper::getRefSpeeds(double *spds) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getRefSpeeds(double *spds) 
+{
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->pos)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pos->getRefSpeed(off+p->base, spds+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pos2) &&(ret = p->pos2->getRefSpeeds(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                spds[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getRefSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] references;
     return ret;
 }
 
@@ -2247,26 +2320,35 @@ bool ControlBoardWrapper::getRefAcceleration(int j, double *acc) {
 * @param accs pointer to the array that will store the acceleration values.
 * @return true/false on success or failure
 */
-bool ControlBoardWrapper::getRefAccelerations(double *accs) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getRefAccelerations(double *accs) 
+{
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->pos)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->pos->getRefAcceleration(off+p->base, accs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->pos2) &&(ret = p->pos2->getRefAccelerations(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                accs[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getRefAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] references;
     return ret;
 }
 
@@ -2601,47 +2683,71 @@ bool ControlBoardWrapper::getEncoder(int j, double *v) {
     return false;
 }
 
-bool ControlBoardWrapper::getEncoders(double *encs) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getEncoders(double *encs) 
+{
+    double *encValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iJntEnc->getEncoder(off+p->base, encs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoders(encValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                encs[juser] = encValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getEncoders", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] encValues;
     return ret;
+    
 }
 
-bool ControlBoardWrapper::getEncodersTimed(double *encs, double *t) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getEncodersTimed(double *encs, double *t)
+{
+    double *encValues = new double[device.maxNumOfJointsInDevices];
+    double *tValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iJntEnc->getEncoderTimed(off+p->base, encs+l, t+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncodersTimed(encValues, tValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                encs[juser] = encValues[jdevice];
+                t[juser] = tValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getEncodersTimed", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] encValues;
+    delete [] tValues;
     return ret;
 }
 
@@ -2677,25 +2783,35 @@ bool ControlBoardWrapper::getEncoderSpeed(int j, double *sp) {
     return false;
 }
 
-bool ControlBoardWrapper::getEncoderSpeeds(double *spds) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getEncoderSpeeds(double *spds)
+{
+    double *sValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iJntEnc->getEncoderSpeed(off+p->base, spds+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoderSpeeds(sValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                spds[juser] = sValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getEncoderSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] sValues;
     return ret;
 }
 
@@ -2717,24 +2833,33 @@ bool ControlBoardWrapper::getEncoderAcceleration(int j, double *acc) {
 
 bool ControlBoardWrapper::getEncoderAccelerations(double *accs)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *aValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iJntEnc->getEncoderAcceleration(off+p->base, accs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoderAccelerations(aValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                accs[juser] = aValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getEncoderAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] aValues;
     return ret;
 }
 
@@ -2760,25 +2885,35 @@ bool ControlBoardWrapper::getTemperature      (int m, double* val) {
     return false;
 }
 
-bool ControlBoardWrapper::getTemperatures     (double *vals) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getTemperatures     (double *vals) 
+{
+    double *temps = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->imotor)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->imotor->getTemperature(off+p->base, vals+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->imotor) &&(ret = p->imotor->getTemperatures(temps)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                vals[juser] = temps[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getTemperatures", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] temps;
     return ret;
 }
 
@@ -3032,47 +3167,71 @@ bool ControlBoardWrapper::getMotorEncoder(int m, double *v) {
     return false;
 }
 
-bool ControlBoardWrapper::getMotorEncoders(double *encs) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getMotorEncoders(double *encs) 
+{
+    
+    double *encValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iMotEnc->getMotorEncoder(off+p->base, encs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoders(encValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                encs[juser] = encValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getMotorEncoders", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] encValues;
     return ret;
 }
 
-bool ControlBoardWrapper::getMotorEncodersTimed(double *encs, double *t) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getMotorEncodersTimed(double *encs, double *t)
+{
+    double *encValues = new double[device.maxNumOfJointsInDevices];
+    double *tValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iMotEnc->getMotorEncoderTimed(off+p->base, encs, t);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncodersTimed(encValues, tValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                encs[juser] = encValues[jdevice];
+                t[juser] = tValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getMotorEncodersTimed", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] encValues;
+    delete [] tValues;
     return ret;
 }
 
@@ -3108,25 +3267,35 @@ bool ControlBoardWrapper::getMotorEncoderSpeed(int m, double *sp) {
     return false;
 }
 
-bool ControlBoardWrapper::getMotorEncoderSpeeds(double *spds) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getMotorEncoderSpeeds(double *spds)
+{
+    double *sValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iMotEnc->getMotorEncoderSpeed(off+p->base, spds+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoderSpeeds(sValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                spds[juser] = sValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getMotorEncoderSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] sValues;
     return ret;
 }
 
@@ -3148,25 +3317,35 @@ bool ControlBoardWrapper::getMotorEncoderAcceleration(int m, double *acc) {
 
 bool ControlBoardWrapper::getMotorEncoderAccelerations(double *accs)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *aValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iMotEnc->getMotorEncoderAcceleration(off+p->base, accs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoderAccelerations(aValues)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                accs[juser] = aValues[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getMotorEncoderAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] aValues;
     return ret;
+    
 }
 
 
@@ -3220,25 +3399,33 @@ bool ControlBoardWrapper::disableAmp(int j)
 
 bool ControlBoardWrapper::getAmpStatus(int *st)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    int *status = new int[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (p && p->amp)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
+        {
+            ret = false;
+            break;
+        }
+        
+        if( (p->amp) &&(ret = p->amp->getAmpStatus(status)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
             {
-
-                st[l]=0;
-                //getAmpStatus for single joint does not exist!!
-                // AMP_STATUS TODO
-                //ret=ret&&p->amp->getAmpStatus(off+p->base, st+l);
+                st[juser] = status[jdevice];
             }
+        }
         else
-            ret=false;
+        {
+            printError("getAmpStatus", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-
+    
+    delete [] status;
     return ret;
 }
 
@@ -3258,24 +3445,33 @@ bool ControlBoardWrapper::getAmpStatus(int j, int *v)
 
 bool ControlBoardWrapper::getCurrents(double *vals)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *currs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->amp)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->amp->getCurrent(off+p->base, vals+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->amp) &&(ret = p->amp->getCurrents(currs)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                vals[juser] = currs[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getCurrents", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] currs;
     return ret;
 }
 
@@ -3752,24 +3948,33 @@ bool ControlBoardWrapper::getJointType(int j, yarp::dev::JointTypeEnum& type)
 
 bool ControlBoardWrapper::getRefTorques(double *refs)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iTorque)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iTorque->getRefTorque(off+p->base, refs+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iTorque) &&(ret = p->iTorque->getRefTorques(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                refs[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getRefTorques", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] references;
     return ret;
 }
 
@@ -3949,25 +4154,35 @@ bool ControlBoardWrapper::getTorque(int j, double *t)
 
 bool ControlBoardWrapper::getTorques(double *t)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *trqs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iTorque)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iTorque->getTorque(off+p->base, t+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iTorque) &&(ret = p->iTorque->getTorques(trqs)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                t[juser] = trqs[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getTorques", p->id, ret);
+            ret = false;
+            break;
+        }
     }
+    
+    delete [] trqs;
     return ret;
+    
  }
 
 bool ControlBoardWrapper::getTorqueRange(int j, double *min, double *max)
@@ -3989,25 +4204,39 @@ bool ControlBoardWrapper::getTorqueRange(int j, double *min, double *max)
 
 bool ControlBoardWrapper::getTorqueRanges(double *min, double *max)
 {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *t_min = new double[device.maxNumOfJointsInDevices];
+    double *t_max = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iTorque)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iTorque->getTorqueRange(off+p->base, min+l, max+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iTorque) &&(ret = p->iTorque->getTorqueRanges(t_min, t_max)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                min[juser] = t_min[jdevice];
+                max[juser] = t_max[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getTorqueRanges", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-    return ret;
- }
+    
+    delete [] t_min;
+    delete [] t_max;
+    return ret; 
+    
+}
 
 bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
 {
@@ -4078,25 +4307,35 @@ bool ControlBoardWrapper::getControlMode(int j, int *mode)
 
 bool ControlBoardWrapper::getControlModes(int *modes)
 {
-   bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    int *all_mode = new int[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMode)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->iMode->getControlMode(off+p->base, modes+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iMode) &&(ret = p->iMode->getControlModes(all_mode)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                modes[juser] = all_mode[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getControlModes", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] all_mode;
+    return ret; 
+    
 }
 
 // iControlMode2
@@ -4317,27 +4556,37 @@ bool ControlBoardWrapper::getRefPosition(const int j, double* ref)
     return false;
 }
 
-bool ControlBoardWrapper::getRefPositions(double *spds) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+bool ControlBoardWrapper::getRefPositions(double *spds) 
+{
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->posDir)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->posDir->getRefPosition(off+p->base, spds+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->posDir) &&(ret = p->posDir->getRefPositions(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                spds[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getRefPositions", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] references;
+    return ret; 
+    
 }
 
 
@@ -4468,29 +4717,35 @@ bool ControlBoardWrapper::getRefVelocity(const int j, double* vel)
 
 bool ControlBoardWrapper::getRefVelocities(double* vels)
 {
-    if(verbose())
-        yTrace();
-
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
+    double *references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->vel2)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret&&p->vel2->getRefVelocity(off+p->base, vels+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->vel2) &&(ret = p->vel2->getRefVelocities(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                vels[juser] = references[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getRefVelocities", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] references;
+    return ret; 
+    
 }
 
 bool ControlBoardWrapper::getRefVelocities(const int n_joints, const int* joints, double* vels)
@@ -4622,25 +4877,35 @@ bool ControlBoardWrapper::getInteractionModes(int n_joints, int *joints, yarp::d
 
 bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
+    
+    yarp::dev::InteractionModeEnum *imodes = new yarp::dev::InteractionModeEnum[device.maxNumOfJointsInDevices];
     bool ret = true;
-
-    for(int j=0; j<controlledJoints; j++)
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off; try{off = device.lut.at(j).offset;} catch(...){yError() << "joint number " << j <<  " out of bound [0-"<< controlledJoints << "] for part " << partName; return false; }
-        int subIndex=device.lut[j].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iInteract)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret=ret && p->iInteract->getInteractionMode(off+p->base, &modes[j]);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iInteract) &&(ret = p->iInteract->getInteractionModes(imodes)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                modes[juser] = imodes[jdevice];
+            }
         }
         else
-            ret=false;
+        {
+            printError("getInteractionModes", p->id, ret);
+            ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] imodes;
+    return ret; 
 }
 
 bool ControlBoardWrapper::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
@@ -4776,25 +5041,35 @@ bool ControlBoardWrapper::getRefDutyCycle(int j, double *v)
 
 bool ControlBoardWrapper::getRefDutyCycles(double *v)
 {
+    double *references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iPWM)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret = ret&&p->iPWM->getRefDutyCycle(off + p->base, v + l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iPWM) &&(ret = p->iPWM->getRefDutyCycles(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                v[juser] = references[jdevice];
+            }
         }
         else
+        {
+            printError("getRefDutyCycles", p->id, ret);
             ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] references;
+    return ret; 
+    
 }
 
 bool ControlBoardWrapper::getDutyCycle(int j, double *v)
@@ -4816,25 +5091,35 @@ bool ControlBoardWrapper::getDutyCycle(int j, double *v)
 
 bool ControlBoardWrapper::getDutyCycles(double *v)
 {
+    double *dutyCicles = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iPWM)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret = ret&&p->iPWM->getDutyCycle(off + p->base, v + l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iPWM) &&(ret = p->iPWM->getDutyCycles(dutyCicles)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                v[juser] = dutyCicles[jdevice];
+            }
         }
         else
+        {
+            printError("getDutyCycles", p->id, ret);
             ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] dutyCicles;
+    return ret; 
+    
 }
 
 
@@ -4865,25 +5150,38 @@ bool ControlBoardWrapper::getCurrentRange(int j, double *min, double *max)
 
 bool ControlBoardWrapper::getCurrentRanges(double *min, double *max)
 {
+    double *c_min = new double[device.maxNumOfJointsInDevices];
+    double *c_max = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iCurr)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret = ret&&p->iCurr->getCurrentRange(off + p->base, min+l, max+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iCurr) &&(ret = p->iCurr->getCurrentRanges(c_min, c_max)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                min[juser] = c_min[jdevice];
+                max[juser] = c_max[jdevice];
+            }
         }
         else
+        {
+            printError("getCurrentRanges", p->id, ret);
             ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] c_min;
+    delete [] c_max;
+    return ret; 
+    
 }
 
 bool ControlBoardWrapper::setRefCurrents(const double *t)
@@ -4963,25 +5261,35 @@ bool ControlBoardWrapper::setRefCurrents(const int n_joint, const int *joints, c
 
 bool ControlBoardWrapper::getRefCurrents(double *t)
 {
+    double *references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
+    for(unsigned int d=0; d<device.subdevices.size(); d++)
     {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        yarp::dev::impl::SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iCurr)
+        yarp::dev::impl::SubDevice *p=device.getSubdevice(d);
+        if(!p)
         {
-            ret = ret&&p->iCurr->getRefCurrent(off + p->base, t+l);
+            ret = false;
+            break;
+        }
+        
+        if( (p->iCurr) &&(ret = p->iCurr->getRefCurrents(references)))
+        {
+            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
+            {
+                t[juser] = references[jdevice];
+            }
         }
         else
+        {
+            printError("getRefCurrents", p->id, ret);
             ret = false;
+            break;
+        }
     }
-    return ret;
+    
+    delete [] references;
+    return ret; 
+    
 }
 
 bool ControlBoardWrapper::getRefCurrent(int j, double *t)

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -343,6 +343,11 @@ private:
     bool openAndAttachSubDevice(yarp::os::Property& prop);
 
     bool ownDevices;
+    inline void printError(std::string func_name, std::string info, bool result)
+    {
+        yError() << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << "returns " << result << "or interface not availables";
+    }
+    
     void calculateMaxNumOfJointsInDevices();
 #endif  //DOXYGEN_SHOULD_SKIP_THIS
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -343,6 +343,7 @@ private:
     bool openAndAttachSubDevice(yarp::os::Property& prop);
 
     bool ownDevices;
+    void calculateMaxNumOfJointsInDevices();
 #endif  //DOXYGEN_SHOULD_SKIP_THIS
 
 public:

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -56,11 +56,13 @@ SubDevice::SubDevice() :
     attachedF(false)
 {}
 
-bool SubDevice::configure(int b, int t, int n, const std::string &key, yarp::dev::ControlBoardWrapper *_parent)
+bool SubDevice::configure(int wb, int wt, int b, int t, int n, const std::string &key, yarp::dev::ControlBoardWrapper *_parent)
 {
     parent = _parent;
     configuredF=false;
-
+    
+    wbase = wb;
+    wtop = wt;
     base=b;
     top=t;
     axes=n;
@@ -283,6 +285,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
                  return false;
     }
 
+    totalAxis = deviceJoints;
     attachedF=true;
     return true;
 }

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
@@ -74,7 +74,10 @@ public:
     std::string id;
     int base;
     int top;
-    int axes;
+    int wbase; //wrapper base
+    int wtop; //wrapper top
+    int axes; //number of used axis of this subdevice
+    int totalAxis; //Numeber of total axis taht the subdevice can control
 
     bool configuredF;
 
@@ -116,7 +119,7 @@ public:
     void detach();
     inline void setVerbose(bool _verbose) {_subDevVerbose = _verbose; }
 
-    bool configure(int base, int top, int axes, const std::string &id, yarp::dev::ControlBoardWrapper *_parent);
+    bool configure(int wbase, int wtop, int base, int top, int axes, const std::string &id, yarp::dev::ControlBoardWrapper *_parent);
 
     inline void refreshJointEncoders()
     {
@@ -152,6 +155,7 @@ struct DevicesLutEntry
 {
     int offset; //an offset, the device is mapped starting from this joint
     int deviceEntry; //index to the joint corresponding subdevice in the list
+    int jointIndexInDev; //the index of joint in the numeration inside the device
 };
 
 
@@ -160,6 +164,7 @@ class yarp::dev::impl::WrappedDevice
 public:
     SubDeviceVector subdevices;
     std::vector<DevicesLutEntry> lut;
+    int maxNumOfJointsInDevices;
 
     inline yarp::dev::impl::SubDevice *getSubdevice(unsigned int i)
     {


### PR DESCRIPTION
Currently, the functions for all joints of control board wrapper call the equivalent function"single joint" "of "impl" layer in a for-cycle on all joints, and it invokes the single joint function of device.

Instead, I needed that the ControlBoardWrapper calls functions for all joints of device in order to make  operational the improvement done in our motion control device "embObjMotionControl", that lets to reduce time for requests to firmware. Therefore, in this branch I modified functions for all joints so that they call the equivalent function for all joints of device. 


When I tested for the first time this branch this issue occurred: https://github.com/robotology/yarp/issues/1660
that I already fixed in this branch. see https://github.com/valegagge/yarp/commit/d3af731b7838f256203737a0c5626572fc85c3bd.


I tested this branch on robot and it is ok.