### PR TITLE
Move doxygen detaileddescription section before memberdecl

### DIFF
--- a/doc/yarp-doxygen-layout.xml
+++ b/doc/yarp-doxygen-layout.xml
@@ -32,6 +32,7 @@
     <includes visible="$SHOW_INCLUDE_FILES"/>
     <inheritancegraph visible="$CLASS_GRAPH"/>
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <nestedclasses visible="yes" title=""/>
       <publictypes title=""/>
@@ -66,7 +67,6 @@
       <related title="" subtitle=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
@@ -88,6 +88,7 @@
   <!-- Layout definition for a namespace page -->
   <namespace>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <nestednamespaces visible="yes" title=""/>
       <constantgroups visible="yes" title=""/>
@@ -98,7 +99,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
@@ -116,6 +116,7 @@
     <includegraph visible="$INCLUDE_GRAPH"/>
     <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
     <sourcelink visible="yes"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <classes visible="yes" title=""/>
       <namespaces visible="yes" title=""/>
@@ -127,7 +128,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <defines title=""/>
@@ -143,6 +143,7 @@
   <group>
     <briefdescription visible="yes"/>
     <groupgraph visible="$GROUP_GRAPHS"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>
       <dirs visible="yes" title=""/>
@@ -164,7 +165,6 @@
       <friends title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <pagedocs/>
       <inlineclasses title=""/>
@@ -189,10 +189,10 @@
   <directory>
     <briefdescription visible="yes"/>
     <directorygraph visible="yes"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <dirs visible="yes"/>
       <files visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
   </directory>
 </doxygenlayout>


### PR DESCRIPTION
This drastically improves the readability in HTML output, especially for
classes (such as the device implementation) that expose a lot of methods/attributes.

# Examples 

## `ControlBoardRemapper`
Before: 
![before-cbrm](https://user-images.githubusercontent.com/1857049/39575490-03a35004-4edb-11e8-8a0e-a6670b902071.png)

After:
![after-cbrm](https://user-images.githubusercontent.com/1857049/39575501-103a3116-4edb-11e8-9f9b-95b0fa8ccf16.png)

## `Multiple Analog Sensor Interfaces`
Before: 
![masi-before](https://user-images.githubusercontent.com/1857049/39575516-2171aefa-4edb-11e8-96b1-284ccb285667.png)


After:
![after-masi](https://user-images.githubusercontent.com/1857049/39575528-2df2ca9c-4edb-11e8-9891-cafb51897847.png)
