### PR TITLE
Add bindings for Motor encoders interface

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -416,6 +416,7 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IControlMode.h>
 %include <yarp/dev/IControlMode2.h>
 %include <yarp/dev/IEncoders.h>
+%include <yarp/dev/IMotorEncoders.h>
 %include <yarp/dev/ITorqueControl.h>
 %include <yarp/dev/IImpedanceControl.h>
 %include <yarp/dev/IVelocityControl.h>
@@ -726,6 +727,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
         return result;
     }
 
+    yarp::dev::IMotorEncoders *viewIMotorEncoders() {
+        yarp::dev::IMotorEncoders *result;
+        self->view(result);
+        return result;
+    }
+
     yarp::dev::IPidControl *viewIPidControl() {
         yarp::dev::IPidControl *result;
         self->view(result);
@@ -982,6 +989,45 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 
     bool getEncoderAccelerations(std::vector<double>& data) {
         return self->getEncoderAccelerations(&data[0]);
+    }
+}
+
+%extend yarp::dev::IMotorEncoders {
+    int getNumberOfMotorEncoders() {
+        int nbEncs;
+        bool ok = self->getNumberOfMotorEncoders(&nbEncs);
+        if (!ok) return 0;
+        return nbEncs;
+    }
+
+    double getMotorEncoder(int j) {
+        double enc;
+        bool ok = self->getMotorEncoder(j, &enc);
+        if (!ok) return 0;
+        return enc;
+    }
+
+    bool getMotorEncoders(std::vector<double>& encs) {
+        return self->getMotorEncoders(&encs[0]);
+    }
+
+    bool getMotorEncoderTimed(int j, std::vector<double>& enc, std::vector<double>& time) {
+        return self->getMotorEncoderTimed(j, &enc[0], &time[0]);
+    }
+
+    bool getMotorEncodersTimed(std::vector<double>& encs, std::vector<double>& times) {
+        return self->getMotorEncodersTimed(&encs[0], &times[0]);
+    }
+
+    double getMotorEncoderSpeed(int j) {
+        double speed;
+        bool ok = self->getMotorEncoderSpeed(j, &speed);
+        if (!ok) return 0;
+        return speed;
+    }
+
+    bool getMotorEncoderSpeeds(std::vector<double>& speeds) {
+        return self->getMotorEncoderSpeeds(&speeds[0]);
     }
 }
 

--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -160,6 +160,14 @@ New Features
 * Added realsense2 device.
 
 
+### bindings
+
+#### IMotorEncoders interface bindings
+
+* `IMotorEncoders` interface methods can be used to directly monitor the motor shaft position and speed or even to control the motor positions individually when estimating coupled motors friction parameters.
+* Added bindings for the interface IMotorEncoders. The change extends the `yarp::dev::PolyDriver` and the `yarp::dev::IMotorEncoders` classes.
+
+
 Bug Fixes
 ---------
 


### PR DESCRIPTION
This change adds bindings to the interface `IMotorEncoders`.

### Motivations
`IMotorEncoders` interface methods can be used to directly monitor the motor shaft position and speed or even to control the motor positions individually when estimating coupled motors friction parameters.

### Description
The change extends:
- the `yarp::dev::PolyDriver` class adding a wrapping of `viewIMotorEncoders()` which casts the device driver to the `yarp::dev::IMotorEncoders` interface
- the `yarp::dev::IMotorEncoders` interface to deal with parameters that are not correctly translated by **SWIG** (redefinition of `getMotorEncoder`, `getMotorEncoders`, `getMotorEncoderTimed`, `getMotorEncodersTimed`, `getMotorEncoderSpeed`, `getMotorEncoderSpeeds`)
