### PR TITLE
Add check on carriers for yarpserver --ros

### DIFF
--- a/doc/release/v2_3_72_1.md
+++ b/doc/release/v2_3_72_1.md
@@ -34,6 +34,12 @@ Bug Fixes
 * Fixed `RGBDSensorWrapper` compatibilty with `frameGrabberGui2`.
 * Fixed joint remapping in method `getRefVelocity()`.
 
+#### `YARP_serversql`
+
+* Added check if `rossrv`, `tcpros` and `xmlrpc` are installed when
+yarpserver is launched with `--ros` option. (#722)
+
+
 #### `YARP_OS`
 
 * Added timeout parameter in `TcpConnector::connect()` to unify behaviour with the

--- a/src/libYARP_serversql/src/yarpserver.cpp
+++ b/src/libYARP_serversql/src/yarpserver.cpp
@@ -20,6 +20,7 @@
 #include <yarp/os/all.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/RosNameSpace.h>
+#include <yarp/os/Carriers.h>
 
 #include <yarp/name/NameServerManager.h>
 #include <yarp/name/BootstrapServer.h>
@@ -166,6 +167,17 @@ public:
         }
 
         if (options.check("ros") || NetworkBase::getEnvironment("YARP_USE_ROS")!="") {
+            yarp::os::Bottle lst = yarp::os::Carriers::listCarriers();
+            std::string lstStr(lst.toString().c_str());
+            if (lstStr.find("rossrv") == std::string::npos ||
+                lstStr.find("tcpros") == std::string::npos ||
+                lstStr.find("xmlrpc") == std::string::npos) {
+                fprintf(stderr,"Missing one or more required carriers ");
+                fprintf(stderr,"for yarpserver --ros (rossrv, tcpros, xmlrpc).\n");
+                fprintf(stderr,"Run 'yarp connect --list-carriers' to see carriers on your machine\n");
+                fprintf(stderr,"Aborting.\n");
+                return false;
+            }
             ConstString addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
             Contact c = Contact::fromString(addr.c_str());
             if (c.isValid()) {


### PR DESCRIPTION
It fixes #722 .

This PR makes `xmlrpc` `rossrv` `tcpros` carriers mandatory for running `yarpserver --ros`.

Please review code. 