### PR TITLE
Fix tcp connector

### DIFF
--- a/src/libYARP_OS/src/TcpConnector.cpp
+++ b/src/libYARP_OS/src/TcpConnector.cpp
@@ -119,6 +119,7 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
             }
             else if (res > 0)
             {
+                res = 0;
                 // Socket selected for write
                 lon = sizeof(int);
                 if (getsockopt(handle, SOL_SOCKET, SO_ERROR, (void*)(&valopt), &lon) < 0)
@@ -132,7 +133,6 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
                     yError("TcpConnector::connect fail: Error in delayed connection() %d - %s\n", valopt, strerror(valopt));
                     res = -1;
                 }
-                res = 0;
             }
             else
             {

--- a/src/libYARP_OS/src/TcpConnector.cpp
+++ b/src/libYARP_OS/src/TcpConnector.cpp
@@ -130,7 +130,7 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
                 // Check the value returned...
                 if (valopt)
                 {
-                    yError("TcpConnector::connect fail: Error in delayed connection() %d - %s\n", valopt, strerror(valopt));
+                    // connect fail: Error in delayed connection() -> the port doesn't exist
                     res = -1;
                 }
             }


### PR DESCRIPTION
After #1638 `yarp clean` stopped working with `SKIP_ACE=ON`.
This PR fixes this bug.

Please review code.