### PR TITLE
change TcpConnector print method to avoid problems with remote logging

### DIFF
--- a/src/libYARP_OS/src/TcpConnector.cpp
+++ b/src/libYARP_OS/src/TcpConnector.cpp
@@ -93,13 +93,13 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
     // Set non-blocking
     if( (arg = fcntl(handle, F_GETFL, NULL)) < 0)
     {
-       yError("TcpConnector::connect fail: Error fcntl(..., F_GETFL) (%s)\n", strerror(errno));
+       std::cerr << "TcpConnector::connect fail: Error fcntl(..., F_GETFL) " << strerror(errno) << std::endl;
        return -1;
     }
     arg |= O_NONBLOCK;
     if( fcntl(handle, F_SETFL, arg) < 0)
     {
-       yError("TcpConnector::connect fail: Error fcntl(..., F_SETFL) (%s)\n", strerror(errno));
+       std::cerr << "TcpConnector::connect fail: Error fcntl(..., F_SETFL) " << strerror(errno) << std::endl;
        return -1;
     }
     // Trying to connect with timeout
@@ -114,7 +114,7 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
             res = select(handle+1, nullptr, &myset, nullptr, timeout);
             if (res < 0 && errno != EINTR)
             {
-                yError("TcpConnector::connect fail: Error connecting %d - %s\n", errno, strerror(errno));
+                std::cerr << "TcpConnector::connect fail: Error connecting " << errno << " " << strerror(errno) << std::endl;
                 res = -1;
             }
             else if (res > 0)
@@ -124,7 +124,7 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
                 lon = sizeof(int);
                 if (getsockopt(handle, SOL_SOCKET, SO_ERROR, (void*)(&valopt), &lon) < 0)
                 {
-                    yError("TcpConnector::connect fail: Error in getsockopt() %d - %s\n", errno, strerror(errno));
+                    std::cerr << "TcpConnector::connect fail: Error in getsockopt() " << errno << " " << strerror(errno) << std::endl;
                     res = -1;
                 }
                 // Check the value returned...
@@ -136,13 +136,13 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
             }
             else
             {
-                yError("TcpConnector::connect fail: Timeout in select() - Cancelling!\n");
+                std::cerr << "TcpConnector::connect fail: Timeout in select() - Cancelling!" << std::endl;
                 res = -1;
             }
         }
         else
         {
-            yError("TcpConnector::connect fail: Error connecting %d - %s\n", errno, strerror(errno));
+            std::cerr << "TcpConnector::connect fail: Error connecting " << errno << " " << strerror(errno) << std::endl;
             res = -1;
         }
     }
@@ -157,13 +157,13 @@ int TcpConnector::connect(TcpStream &new_stream, const Contact& address, YARP_ti
     // Set to blocking mode again...
     if( (arg = fcntl(handle, F_GETFL, nullptr)) < 0)
     {
-       yError("TcpConnector::connect fail: Error fcntl(..., F_GETFL) (%s)\n", strerror(errno));
+       std::cerr << "TcpConnector::connect fail: Error fcntl(..., F_GETFL) " << strerror(errno) << std::endl;
        return -1;
     }
     arg &= (~O_NONBLOCK);
     if( fcntl(handle, F_SETFL, arg) < 0)
     {
-       yError("TcpConnector::connect fail: Error fcntl(..., F_SETFL) (%s)\n", strerror(errno));
+       std::cerr << "TcpConnector::connect fail: Error fcntl(..., F_SETFL) " << strerror(errno) << std::endl;
        return -1;
     }
 


### PR DESCRIPTION
Fixes (another) bug introduced by #1638.