### PR TITLE
Tcp carrier performance improvement

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -129,6 +129,9 @@ New Features
   [C++11 Mutex concept](http://en.cppreference.com/w/cpp/concept/Mutex).
 * Added a Timer class to execute a static or member function in a separate
   thread after a period x, every y milliseconds, for z times or w seconds.
+* Improved performance of tcp and fast_tcp carriers. TCP_NODELAY and TCP_CORK
+  has been added in the `SocketTwoWayStream::open()`, in
+  `SocketTwoWayStream::flush` is disabled and then re-enabled.
 
 #### YARP_sig
 

--- a/src/libYARP_OS/src/BufferedConnectionWriter.cpp
+++ b/src/libYARP_OS/src/BufferedConnectionWriter.cpp
@@ -170,6 +170,7 @@ void BufferedConnectionWriter::write(OutputStream& os) {
         yarp::os::ManagedBytes& b = *(lst[i]);
         os.write(b.usedBytes());
     }
+    os.flush();
 }
 
 

--- a/src/libYARP_OS/src/NameClient.cpp
+++ b/src/libYARP_OS/src/NameClient.cpp
@@ -380,6 +380,7 @@ std::string NameClient::send(const std::string& cmd, bool multi)
         std::string cmdn = cmd + "\n";
         Bytes b((char*)cmdn.c_str(), cmdn.length());
         ip->getOutputStream().write(b);
+        ip->getOutputStream().flush();
         bool more = multi;
         while (more) {
             std::string line = "";

--- a/src/libYARP_OS/src/NameserCarrier.cpp
+++ b/src/libYARP_OS/src/NameserCarrier.cpp
@@ -197,6 +197,7 @@ bool yarp::os::impl::NameserCarrier::write(ConnectionState& proto, SizedWriter& 
     std::string target = firstSend?"VER ":"NAME_SERVER ";
     Bytes b((char*)target.c_str(), target.length());
     proto.os().write(b);
+    proto.os().flush();
     std::string txt;
     // ancient nameserver can't deal with quotes
     for (size_t i=0; i<writer.length(); i++) {

--- a/src/libYARP_OS/src/Protocol.cpp
+++ b/src/libYARP_OS/src/Protocol.cpp
@@ -266,6 +266,7 @@ bool Protocol::sendAck() {
     if (delegate==nullptr) return false;
     if (delegate->requireAck()) {
         ok = delegate->sendAck(*this);
+        os().flush();
     }
     getStreams().endPacket();
     return ok;

--- a/src/libYARP_OS/src/SocketTwoWayStream.cpp
+++ b/src/libYARP_OS/src/SocketTwoWayStream.cpp
@@ -85,12 +85,9 @@ int SocketTwoWayStream::open(yarp::os::impl::TcpAcceptor& acceptor) {
 }
 
 void SocketTwoWayStream::updateAddresses() {
-    //int zero = 0;
     int one = 1;
-
+    stream.set_option(IPPROTO_TCP, TCP_NODELAY, &one, sizeof(int));
 #ifdef YARP_HAS_ACE
-    stream.set_option (ACE_IPPROTO_TCP, TCP_NODELAY, &one,
-                       sizeof(int));
     ACE_INET_Addr local, remote;
     stream.get_local_addr(local);
     stream.get_remote_addr(remote);
@@ -101,8 +98,6 @@ void SocketTwoWayStream::updateAddresses() {
     localAddress = Contact(localHostAddress, local.get_port_number());
     remoteAddress = Contact(remoteHostAddress, remote.get_port_number());
 #else
-    stream.set_option (IPPROTO_TCP, TCP_NODELAY, &one,
-                       sizeof(int));
     struct sockaddr local;
     struct sockaddr remote;
     memset(&local, 0, sizeof(local));


### PR DESCRIPTION
This patch increase the performance of `tcp` and `fast_tcp` carrier.

The performance has been measured in terms of latency between sender and receiver(on the same machine) and we improved it by a factor of **2**. 
Now the most used yarp carrier goes ~2 times faster than before :sunglasses:.

It is a small change but that can have a huge impact on yarp, for this reason we want to test it on the robot before merging.

To achieve it we used a magic combination of `TCP_NODELAY`, `TCP_CORK` :crystal_ball: 

For the curious: 
- [TCP protocol](https://en.wikipedia.org/wiki/Transmission_Control_Protocol)
- **TCP_CORK** (since Linux 2.2)
    If set, don't send out partial frames. All queued partial frames are sent when the option is cleared again. This is useful for prepending headers before calling sendfile(2), or for throughput optimization. As currently implemented, there is a 200 millisecond ceiling on the time for which output is corked by TCP_CORK. If this ceiling is reached, then queued data is automatically transmitted. This option can be combined with TCP_NODELAY only since Linux 2.5.71. This option should not be used in code intended to be portable. 
- **TCP_NODELAY**
    If set, disable the Nagle algorithm. This means that segments are always sent as soon as possible, even if there is only a small amount of data. When not set, data is buffered until there is a sufficient amount to send out, thereby avoiding the frequent sending of small packets, which results in poor utilization of the network. This option is overridden by TCP_CORK; however, setting this option forces an explicit flush of pending output, even if TCP_CORK is currently set. 
- [Nagle algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm)

Thanks to @drdanz that started to do this patch years ago.

Please review code. 

 