### PR TITLE
move math operators outside yarp::math namespace

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -165,6 +165,8 @@ Important Changes
 * added new utility methods to Quaternion class.
 * method toRotationMatrix() has been renamed to toRotationMatrix4x4() to avoid
   confusion with method toRotationMatrix3x3().
+* operators for `yarp::math::<class>`es have been moved from the `yarp::math` to
+  the global namespace.
 
 ### Tools
 

--- a/src/libYARP_math/include/yarp/math/Math.h
+++ b/src/libYARP_math/include/yarp/math/Math.h
@@ -15,252 +15,254 @@
 #include <yarp/math/api.h>
 #include <yarp/math/Quaternion.h>
 
+/**
+* Mathematical operations.
+*/
+
+/**
+* Addition operator between a scalar and a vector (defined in Math.h).
+* Sum the scalar to all the elements of the vector.
+*/
+YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const double &s);
+
+/**
+* Addition operator between a scalar and a vector (defined in Math.h).
+* Sum the scalar to all the elements of the vector.
+*/
+YARP_math_API yarp::sig::Vector operator+(const double &s, const yarp::sig::Vector &a);
+
+/**
+* Addition operator between a scalar and a vector (defined in Math.h).
+* Sum the scalar to all the elements of the vector.
+*/
+YARP_math_API yarp::sig::Vector& operator+=(yarp::sig::Vector &a, const double &s);
+
+/**
+* Addition operator between vectors, returns a+b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+ * Addition operator between vectors, returns a+b (defined in Math.h).
+ */
+YARP_math_API yarp::sig::Vector& operator+=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Addition operator between matrices, returns a+b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Matrix operator+(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Addition operator between matrices, returns a+b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Matrix& operator+=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Subtraction operator between a vector and a scalar (defined in Math.h).
+* Subtract the scalar to all the elements of the vector.
+*/
+YARP_math_API yarp::sig::Vector operator-(const yarp::sig::Vector &a, const double &s);
+
+/**
+* Subtraction operator between a scalar and a vector (defined in Math.h).
+* Multiply the vector by -1 and sum the scalar to the result.
+*/
+YARP_math_API yarp::sig::Vector operator-(const double &s, const yarp::sig::Vector &a);
+
+/**
+* Subtraction operator between a vector and a scalar (defined in Math.h).
+* Subtract the scalar to all the elements of the vector.
+*/
+YARP_math_API yarp::sig::Vector& operator-=(yarp::sig::Vector &a, const double &s);
+
+/**
+* Subtraction operator between vectors, returns a-b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Vector operator-(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Subtraction operator between vectors, returns a-b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Vector& operator-=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Subtraction operator between matrices, returns a-b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Matrix operator-(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Subtraction operator between matrices, returns a-b (defined in Math.h).
+*/
+YARP_math_API yarp::sig::Matrix& operator-=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Scalar-vector product operator (defined in Math.h).
+* @param k a scalar
+* @param b vector
+* @return k*b
+*/
+YARP_math_API yarp::sig::Vector operator*(double k, const yarp::sig::Vector &b);
+
+/**
+* Vector-scalar product operator (defined in Math.h).
+* @param b a vector
+* @param k a scalar
+* @return b*k
+*/
+YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &b, double k);
+
+/**
+* Vector-scalar product operator (defined in Math.h).
+* @param b a vector
+* @param k a scalar
+* @return b*k
+*/
+YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &b, double k);
+
+/**
+* Vector-matrix product operator (defined in Math.h).
+* @param a is a vector (interpreted as a row)
+* @param m is a matrix
+* @return a*m
+*/
+YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &a,
+    const yarp::sig::Matrix &m);
+
+/**
+* Vector-matrix product operator (defined in Math.h).
+* @param a is a vector (interpreted as a row)
+* @param m is a matrix
+* @return a*m
+*/
+YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &a, const yarp::sig::Matrix &m);
+
+/**
+* Matrix-vector product operator (defined in Math.h).
+* @param a is a vector (interpreted as a column)
+* @param m is a matrix
+* @return m*a
+*/
+ YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Matrix &m,
+    const yarp::sig::Vector &a);
+
+/**
+* Matrix-matrix product operator (defined in Math.h).
+* @param a a matrix
+* @param b a matrix
+* @return a*b
+*/
+YARP_math_API yarp::sig::Matrix operator*(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Matrix-matrix product operator (defined in Math.h).
+* @param a a matrix
+* @param b a matrix
+* @return a*b
+*/
+YARP_math_API yarp::sig::Matrix& operator*=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
+
+/**
+* Scalar-matrix product operator (defined in Math.h).
+* @param k a scalar
+* @param M a matrix
+* @return k*M
+*/
+YARP_math_API yarp::sig::Matrix operator*(const double k, const yarp::sig::Matrix &M);
+
+/**
+* Matrix-scalar product operator (defined in Math.h).
+* @param M a matrix
+* @param k a scalar
+* @return M*k
+*/
+YARP_math_API yarp::sig::Matrix operator*(const yarp::sig::Matrix &M, const double k);
+
+/**
+* Matrix-scalar product operator (defined in Math.h).
+* @param M a matrix
+* @param k a scalar
+* @return M*k
+*/
+YARP_math_API yarp::sig::Matrix& operator*=(yarp::sig::Matrix &M, const double k);
+
+/**
+* Vector-vector element-wise product operator (defined in Math.h).
+* @param a a vector
+* @param b a vector
+* @return a.*b (matlab notation)
+*/
+YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Vector-vector element-wise product operator (defined in Math.h).
+* @param a a vector
+* @param b a vector
+* @return a.*b (matlab notation)
+*/
+YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Quaternion-quaternion hamilton product operator (defined in Math.h).
+* reference: "Stevens, Brian L., Frank L. Lewis, Aircraft Control and Simulation, Wiley–Interscience, 2nd Edition".
+* @param a a quaternion
+* @param b a quaternion
+* @return a*b
+*/
+YARP_math_API yarp::math::Quaternion operator*(const yarp::math::Quaternion& a, const yarp::math::Quaternion& b);
+
+/**
+* Vector-vector element-wise division operator (defined in Math.h).
+* @param a a vector
+* @param b a vector
+* @return a./b (matlab notation)
+*/
+YARP_math_API yarp::sig::Vector operator/(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Vector-vector element-wise division operator (defined in Math.h).
+* @param a a vector
+* @param b a vector
+* @return a./b (matlab notation)
+*/
+YARP_math_API yarp::sig::Vector& operator/=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
+
+/**
+* Vector-scalar division operator (defined in Math.h).
+* @param b a vector
+* @param k a scalar
+* @return b/k
+*/
+YARP_math_API yarp::sig::Vector operator/(const yarp::sig::Vector &b, double k);
+
+/**
+* Vector-scalar division operator (defined in Math.h).
+* @param b a vector
+* @param k a scalar
+* @return b/k
+*/
+YARP_math_API yarp::sig::Vector& operator/=(yarp::sig::Vector &b, double k);
+
+/**
+* Matrix-scalar division operator (defined in Math.h).
+* @param M a matrix
+* @param k a scalar
+* @return M./k (matlab notation)
+*/
+YARP_math_API yarp::sig::Matrix operator/(const yarp::sig::Matrix &M, double k);
+
+/**
+* Matrix-scalar division operator (defined in Math.h).
+* @param M a matrix
+* @param k a scalar
+* @return M./k (matlab notation)
+*/
+YARP_math_API yarp::sig::Matrix& operator/=(yarp::sig::Matrix &M, double k);
+
+
 namespace yarp
 {
-     /**
-     * Mathematical operations.
-     */
     namespace math
     {
-        /**
-        * Addition operator between a scalar and a vector (defined in Math.h).
-        * Sum the scalar to all the elements of the vector.
-        */
-        YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const double &s);
-
-        /**
-        * Addition operator between a scalar and a vector (defined in Math.h).
-        * Sum the scalar to all the elements of the vector.
-        */
-        YARP_math_API yarp::sig::Vector operator+(const double &s, const yarp::sig::Vector &a);
-
-        /**
-        * Addition operator between a scalar and a vector (defined in Math.h).
-        * Sum the scalar to all the elements of the vector.
-        */
-        YARP_math_API yarp::sig::Vector& operator+=(yarp::sig::Vector &a, const double &s);
-
-        /**
-        * Addition operator between vectors, returns a+b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-         * Addition operator between vectors, returns a+b (defined in Math.h).
-         */
-        YARP_math_API yarp::sig::Vector& operator+=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-        * Addition operator between matrices, returns a+b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Matrix operator+(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-        * Addition operator between matrices, returns a+b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Matrix& operator+=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-        * Subtraction operator between a vector and a scalar (defined in Math.h).
-        * Subtract the scalar to all the elements of the vector.
-        */
-        YARP_math_API yarp::sig::Vector operator-(const yarp::sig::Vector &a, const double &s);
-
-        /**
-        * Subtraction operator between a scalar and a vector (defined in Math.h).
-        * Multiply the vector by -1 and sum the scalar to the result.
-        */
-        YARP_math_API yarp::sig::Vector operator-(const double &s, const yarp::sig::Vector &a);
-
-        /**
-        * Subtraction operator between a vector and a scalar (defined in Math.h).
-        * Subtract the scalar to all the elements of the vector.
-        */
-        YARP_math_API yarp::sig::Vector& operator-=(yarp::sig::Vector &a, const double &s);
-
-        /**
-        * Subtraction operator between vectors, returns a-b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Vector operator-(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-        * Subtraction operator between vectors, returns a-b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Vector& operator-=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-        * Subtraction operator between matrices, returns a-b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Matrix operator-(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-        * Subtraction operator between matrices, returns a-b (defined in Math.h).
-        */
-        YARP_math_API yarp::sig::Matrix& operator-=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-        * Scalar-vector product operator (defined in Math.h).
-        * @param k a scalar
-        * @param b vector
-        * @return k*b
-        */
-        YARP_math_API yarp::sig::Vector operator*(double k, const yarp::sig::Vector &b);
-
-        /**
-        * Vector-scalar product operator (defined in Math.h).
-        * @param b a vector
-        * @param k a scalar
-        * @return b*k
-        */
-        YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &b, double k);
-
-        /**
-        * Vector-scalar product operator (defined in Math.h).
-        * @param b a vector
-        * @param k a scalar
-        * @return b*k
-        */
-        YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &b, double k);
-
-        /**
-        * Vector-matrix product operator (defined in Math.h).
-        * @param a is a vector (interpreted as a row)
-        * @param m is a matrix
-        * @return a*m
-        */
-        YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &a,
-            const yarp::sig::Matrix &m);
-
-        /**
-        * Vector-matrix product operator (defined in Math.h).
-        * @param a is a vector (interpreted as a row)
-        * @param m is a matrix
-        * @return a*m
-        */
-        YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &a, const yarp::sig::Matrix &m);
-
-        /**
-        * Matrix-vector product operator (defined in Math.h).
-        * @param a is a vector (interpreted as a column)
-        * @param m is a matrix
-        * @return m*a
-        */
-         YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Matrix &m,
-            const yarp::sig::Vector &a);
-
-        /**
-        * Matrix-matrix product operator (defined in Math.h).
-        * @param a a matrix
-        * @param b a matrix
-        * @return a*b
-        */
-        YARP_math_API yarp::sig::Matrix operator*(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-        * Matrix-matrix product operator (defined in Math.h).
-        * @param a a matrix
-        * @param b a matrix
-        * @return a*b
-        */
-        YARP_math_API yarp::sig::Matrix& operator*=(yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
-
-        /**
-       * Scalar-matrix product operator (defined in Math.h).
-       * @param k a scalar
-       * @param M a matrix
-       * @return k*M
-       */
-        YARP_math_API yarp::sig::Matrix operator*(const double k, const yarp::sig::Matrix &M);
-
-        /**
-       * Matrix-scalar product operator (defined in Math.h).
-       * @param M a matrix
-       * @param k a scalar
-       * @return M*k
-       */
-        YARP_math_API yarp::sig::Matrix operator*(const yarp::sig::Matrix &M, const double k);
-
-        /**
-        * Matrix-scalar product operator (defined in Math.h).
-        * @param M a matrix
-        * @param k a scalar
-        * @return M*k
-        */
-        YARP_math_API yarp::sig::Matrix& operator*=(yarp::sig::Matrix &M, const double k);
-
-        /**
-       * Vector-vector element-wise product operator (defined in Math.h).
-       * @param a a vector
-       * @param b a vector
-       * @return a.*b (matlab notation)
-       */
-        YARP_math_API yarp::sig::Vector operator*(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-       * Vector-vector element-wise product operator (defined in Math.h).
-       * @param a a vector
-       * @param b a vector
-       * @return a.*b (matlab notation)
-       */
-        YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-       * Quaternion-quaternion hamilton product operator (defined in Math.h).
-       * reference: "Stevens, Brian L., Frank L. Lewis, Aircraft Control and Simulation, Wiley–Interscience, 2nd Edition".
-       * @param a a quaternion
-       * @param b a quaternion
-       * @return a*b
-       */
-        YARP_math_API yarp::math::Quaternion operator*(const Quaternion& a, const Quaternion& b);
-
-        /**
-       * Vector-vector element-wise division operator (defined in Math.h).
-       * @param a a vector
-       * @param b a vector
-       * @return a./b (matlab notation)
-       */
-        YARP_math_API yarp::sig::Vector operator/(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-       * Vector-vector element-wise division operator (defined in Math.h).
-       * @param a a vector
-       * @param b a vector
-       * @return a./b (matlab notation)
-       */
-        YARP_math_API yarp::sig::Vector& operator/=(yarp::sig::Vector &a, const yarp::sig::Vector &b);
-
-        /**
-        * Vector-scalar division operator (defined in Math.h).
-        * @param b a vector
-        * @param k a scalar
-        * @return b/k
-        */
-        YARP_math_API yarp::sig::Vector operator/(const yarp::sig::Vector &b, double k);
-
-        /**
-        * Vector-scalar division operator (defined in Math.h).
-        * @param b a vector
-        * @param k a scalar
-        * @return b/k
-        */
-        YARP_math_API yarp::sig::Vector& operator/=(yarp::sig::Vector &b, double k);
-
-        /**
-        * Matrix-scalar division operator (defined in Math.h).
-        * @param M a matrix
-        * @param k a scalar
-        * @return M./k (matlab notation)
-        */
-        YARP_math_API yarp::sig::Matrix operator/(const yarp::sig::Matrix &M, double k);
-
-        /**
-        * Matrix-scalar division operator (defined in Math.h).
-        * @param M a matrix
-        * @param k a scalar
-        * @return M./k (matlab notation)
-        */
-        YARP_math_API yarp::sig::Matrix& operator/=(yarp::sig::Matrix &M, double k);
-
         /**
          * Matrix-Matrix concatenation by column (defined in Math.h).
          * @param m1 a matrix nXm

--- a/src/libYARP_math/src/math.cpp
+++ b/src/libYARP_math/src/math.cpp
@@ -24,18 +24,18 @@ using namespace yarp::sig;
 using namespace yarp::math;
 
 
-Vector yarp::math::operator+(const Vector &a, const double &s)
+Vector operator+(const Vector &a, const double &s)
 {
     Vector ret(a);
     return ret+=s;
 }
 
-Vector yarp::math::operator+(const double &s, const Vector &a)
+Vector operator+(const double &s, const Vector &a)
 {
     return a+s;
 }
 
-Vector& yarp::math::operator+=(Vector &a, const double &s)
+Vector& operator+=(Vector &a, const double &s)
 {
     size_t l = a.size();
     for(size_t i=0; i<l; i++)
@@ -43,13 +43,13 @@ Vector& yarp::math::operator+=(Vector &a, const double &s)
     return a;
 }
 
-Vector yarp::math::operator+(const Vector &a, const Vector &b)
+Vector operator+(const Vector &a, const Vector &b)
 {
     Vector ret(a);
     return ret+=b;
 }
 
-Vector& yarp::math::operator+=(Vector &a, const Vector &b)
+Vector& operator+=(Vector &a, const Vector &b)
 {
     size_t s=a.size();
     yAssert(s==b.size());
@@ -58,13 +58,13 @@ Vector& yarp::math::operator+=(Vector &a, const Vector &b)
     return a;
 }
 
-Matrix yarp::math::operator+(const Matrix &a, const Matrix &b)
+Matrix operator+(const Matrix &a, const Matrix &b)
 {
     Matrix ret(a);
     return ret+=b;
 }
 
-Matrix& yarp::math::operator+=(Matrix &a, const Matrix &b)
+Matrix& operator+=(Matrix &a, const Matrix &b)
 {
     int n=a.cols();
     int m=a.rows();
@@ -75,13 +75,13 @@ Matrix& yarp::math::operator+=(Matrix &a, const Matrix &b)
     return a;
 }
 
-Vector yarp::math::operator-(const Vector &a, const double &s)
+Vector operator-(const Vector &a, const double &s)
 {
     Vector ret(a);
     return ret-=s;
 }
 
-Vector yarp::math::operator-(const double &s, const Vector &a)
+Vector operator-(const double &s, const Vector &a)
 {
     size_t l = a.size();
     Vector ret(l);
@@ -90,7 +90,7 @@ Vector yarp::math::operator-(const double &s, const Vector &a)
     return ret;
 }
 
-Vector& yarp::math::operator-=(Vector &a, const double &s)
+Vector& operator-=(Vector &a, const double &s)
 {
     size_t l = a.size();
     for(size_t i=0; i<l; i++)
@@ -98,13 +98,13 @@ Vector& yarp::math::operator-=(Vector &a, const double &s)
     return a;
 }
 
-Vector yarp::math::operator-(const Vector &a, const Vector &b)
+Vector operator-(const Vector &a, const Vector &b)
 {
     Vector ret(a);
     return ret-=b;
 }
 
-Vector& yarp::math::operator-=(Vector &a, const Vector &b)
+Vector& operator-=(Vector &a, const Vector &b)
 {
     size_t s=a.size();
     yAssert(s==b.size());
@@ -113,13 +113,13 @@ Vector& yarp::math::operator-=(Vector &a, const Vector &b)
     return a;
 }
 
-Matrix yarp::math::operator-(const Matrix &a, const Matrix &b)
+Matrix operator-(const Matrix &a, const Matrix &b)
 {
     Matrix ret(a);
     return ret-=b;
 }
 
-Matrix& yarp::math::operator-=(Matrix &a, const Matrix &b)
+Matrix& operator-=(Matrix &a, const Matrix &b)
 {
     int n=a.cols();
     int m=a.rows();
@@ -131,18 +131,18 @@ Matrix& yarp::math::operator-=(Matrix &a, const Matrix &b)
     return a;
 }
 
-Vector yarp::math::operator*(double k, const Vector &b)
+Vector operator*(double k, const Vector &b)
 {
     return operator*(b,k);
 }
 
-Vector yarp::math::operator*(const Vector &a, double k)
+Vector operator*(const Vector &a, double k)
 {
     Vector ret(a);
     return ret*=k;
 }
 
-Vector& yarp::math::operator*=(Vector &a, double k)
+Vector& operator*=(Vector &a, double k)
 {
     size_t size=a.size();
     for (size_t i = 0; i < size; i++)
@@ -150,7 +150,7 @@ Vector& yarp::math::operator*=(Vector &a, double k)
     return a;
 }
 
-Vector yarp::math::operator*(const Vector &a, const Matrix &m)
+Vector operator*(const Vector &a, const Matrix &m)
 {
     yAssert(a.size()==(size_t)m.rows());
     Vector ret((size_t)m.cols());
@@ -160,7 +160,7 @@ Vector yarp::math::operator*(const Vector &a, const Matrix &m)
     return ret;
 }
 
-Vector& yarp::math::operator*=(Vector &a, const Matrix &m)
+Vector& operator*=(Vector &a, const Matrix &m)
 {
     yAssert(a.size()==(size_t)m.rows());
     Vector a2(a);
@@ -171,7 +171,7 @@ Vector& yarp::math::operator*=(Vector &a, const Matrix &m)
     return a;
 }
 
-Vector yarp::math::operator*(const Matrix &m, const Vector &a)
+Vector operator*(const Matrix &m, const Vector &a)
 {
     yAssert((size_t)m.cols()==a.size());
     Vector ret((size_t)m.rows(),0.0);
@@ -181,7 +181,7 @@ Vector yarp::math::operator*(const Matrix &m, const Vector &a)
     return ret;
 }
 
-Matrix yarp::math::operator*(const Matrix &a, const Matrix &b)
+Matrix operator*(const Matrix &a, const Matrix &b)
 {
     yAssert(a.cols()==b.rows());
     Matrix c(a.rows(), b.cols());
@@ -191,7 +191,7 @@ Matrix yarp::math::operator*(const Matrix &a, const Matrix &b)
     return c;
 }
 
-Matrix& yarp::math::operator*=(Matrix &a, const Matrix &b)
+Matrix& operator*=(Matrix &a, const Matrix &b)
 {
     yAssert(a.cols()==b.rows());
     Matrix a2(a);   // a copy of a
@@ -202,18 +202,18 @@ Matrix& yarp::math::operator*=(Matrix &a, const Matrix &b)
     return a;
 }
 
-Matrix yarp::math::operator*(const double k, const Matrix &M)
+Matrix operator*(const double k, const Matrix &M)
 {
     Matrix res(M);
     return res*=k;
 }
 
-Matrix yarp::math::operator*(const Matrix &M, const double k)
+Matrix operator*(const Matrix &M, const double k)
 {
     return operator*(k,M);
 }
 
-Matrix& yarp::math::operator*=(Matrix &M, const double k)
+Matrix& operator*=(Matrix &M, const double k)
 {
     for (int r=0; r<M.rows(); r++)
         for (int c=0; c<M.cols(); c++)
@@ -221,13 +221,13 @@ Matrix& yarp::math::operator*=(Matrix &M, const double k)
     return M;
 }
 
-Vector yarp::math::operator*(const Vector &a, const Vector &b)
+Vector operator*(const Vector &a, const Vector &b)
 {
     Vector res(a);
     return res*=b;
 }
 
-Vector& yarp::math::operator*=(Vector &a, const Vector &b)
+Vector& operator*=(Vector &a, const Vector &b)
 {
     size_t n =a.length();
     yAssert(n==b.length());
@@ -236,7 +236,7 @@ Vector& yarp::math::operator*=(Vector &a, const Vector &b)
     return a;
 }
 
-Quaternion yarp::math::operator*(const Quaternion& a, const Quaternion& b)
+Quaternion operator*(const Quaternion& a, const Quaternion& b)
 {
     return Quaternion(a.w()*b.x() + a.x()*b.w() + a.y()*b.z() - a.z()*b.y(),
                       a.w()*b.y() + a.y()*b.w() + a.z()*b.x() - a.x()*b.z(),
@@ -244,13 +244,13 @@ Quaternion yarp::math::operator*(const Quaternion& a, const Quaternion& b)
                       a.w()*b.w() - a.x()*b.x() - a.y()*b.y() - a.z()*b.z());
 }
 
-Vector yarp::math::operator/(const Vector &a, const Vector &b)
+Vector operator/(const Vector &a, const Vector &b)
 {
     Vector res(a);
     return res/=b;
 }
 
-Vector& yarp::math::operator/=(Vector &a, const Vector &b)
+Vector& operator/=(Vector &a, const Vector &b)
 {
     size_t n =a.length();
     yAssert(n==b.length());
@@ -259,13 +259,13 @@ Vector& yarp::math::operator/=(Vector &a, const Vector &b)
     return a;
 }
 
-Vector yarp::math::operator/(const Vector &b, double k)
+Vector operator/(const Vector &b, double k)
 {
     Vector res(b);
     return res/=k;
 }
 
-Vector& yarp::math::operator/=(Vector &b, double k)
+Vector& operator/=(Vector &b, double k)
 {
     size_t n=b.length();
     yAssert(k!=0.0);
@@ -274,13 +274,13 @@ Vector& yarp::math::operator/=(Vector &b, double k)
     return b;
 }
 
-Matrix yarp::math::operator/(const Matrix &M, const double k)
+Matrix operator/(const Matrix &M, const double k)
 {
     Matrix res(M);
     return res/=k;
 }
 
-Matrix& yarp::math::operator/=(Matrix &M, const double k)
+Matrix& operator/=(Matrix &M, const double k)
 {
     yAssert(k!=0.0);
     int rows=M.rows();


### PR DESCRIPTION
fixes #1602 