### PR TITLE
Declare serial as a wrapper of itself

### DIFF
--- a/src/libYARP_dev/src/devices/ServerSerial/ServerSerial.cpp
+++ b/src/libYARP_dev/src/devices/ServerSerial/ServerSerial.cpp
@@ -16,7 +16,7 @@
 // needed for the driver factory.
 yarp::dev::DriverCreator *createServerSerial() {
     return new yarp::dev::DriverCreatorOf<yarp::dev::ServerSerial>("serial",
-                                                                   "",
+                                                                   "serial",
                                                                    "yarp::dev::ServerSerial");
 }
 


### PR DESCRIPTION
This is necessary to avoid the issue described in https://github.com/robotology/yarp/issues/1705 .