### PR TITLE
Friday night cleanup (Network, Time)

### DIFF
--- a/example/dev/simple_motor_client.cpp
+++ b/example/dev/simple_motor_client.cpp
@@ -85,8 +85,7 @@ int main(int argc, char *argv[])
     }
 
     Network yarp;
-	Time::turboBoost();
-    
+
     char name[1024];
     Value& v = options.find("robot");
     Value& part = options.find("part");

--- a/example/os/rateThreadTiming.cpp
+++ b/example/os/rateThreadTiming.cpp
@@ -74,7 +74,6 @@ public:
 int main() {
     yarp::os::Network network;
     Thread1 t1(THREAD_PERIOD);
-    Time::turboBoost();
     t1.start(); 
 
     Time::delay(MAIN_WAIT);

--- a/example/portaudio/sound_sender_file_chunks.cpp
+++ b/example/portaudio/sound_sender_file_chunks.cpp
@@ -30,7 +30,6 @@ int main(int argc, char *argv[])
 {
     //open the network
     Network yarp;
-    yarp::os::Time::turboBoost();
 
     //open the output port
 #ifdef USE_PORTS

--- a/example/profiling/rateThreadTiming.cpp
+++ b/example/profiling/rateThreadTiming.cpp
@@ -127,6 +127,7 @@ public:
 };
 
 int main(int argc, char **argv) {
+    Network yarp;
     Property p;
     Thread1 t1;
     
@@ -136,8 +137,6 @@ int main(int argc, char **argv) {
     double time=p.check("time", Value(MAIN_WAIT)).asFloat64();
     double cpuTime=p.check("cpu", Value(THREAD_CPU_TIME)).asFloat64();
     int iterations=p.check("iterations", Value(-1)).asInt32();
-
-    Time::turboBoost();
 
     t1.setRate(period);
     t1.setCpuTime(cpuTime);

--- a/example/profiling/thread_latency.cpp
+++ b/example/profiling/thread_latency.cpp
@@ -129,7 +129,6 @@ public:
 int main(int argc, char **argv) 
 {
     Network yarp;
-    Time::turboBoost();
     Property p;
     p.fromCommand(argc, argv);
 

--- a/src/devices/fakeLaser/fakeLaser.cpp
+++ b/src/devices/fakeLaser/fakeLaser.cpp
@@ -139,7 +139,6 @@ bool FakeLaser::open(yarp::os::Searchable& config)
     yInfo("resolution %f", resolution);
     yInfo("sensors %d", sensorsNum);
     yInfo("test mode: %d", m_test_mode);
-    Time::turboBoost();
     RateThread::start();
     return true;
 }

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -87,8 +87,6 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
 
     }
 
-    Time::turboBoost();
-
     Property prop;
     if(!config.check("RGBD_SENSOR_CLIENT"))
     {

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -244,7 +244,6 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
         b_ans.clear();
     }
 
-    Time::turboBoost();
     RateThread::start();
     return true;
 }

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -120,7 +120,6 @@ bool RpLidar::open(yarp::os::Searchable& config)
     yInfo("max_angle %f, min_angle %f", max_angle, min_angle);
     yInfo("resolution %f", resolution);
     yInfo("sensors %d", sensorsNum);
-    Time::turboBoost();
 
     yarp::os::Searchable& general_config = config.findGroup("GENERAL");
     bool ok = general_config.check("Serial_Configuration");

--- a/src/devices/rpLidar2/rpLidar2.cpp
+++ b/src/devices/rpLidar2/rpLidar2.cpp
@@ -194,7 +194,6 @@ bool RpLidar2::open(yarp::os::Searchable& config)
     yInfo("max_angle %f, min_angle %f", m_max_angle, m_min_angle);
     yInfo("resolution %f",              m_resolution);
     yInfo("sensors %d",                 m_sensorsNum);
-    Time::turboBoost();
     RateThread::start();
     return true;
 }

--- a/src/libYARP_OS/include/yarp/os/Time.h
+++ b/src/libYARP_OS/include/yarp/os/Time.h
@@ -56,15 +56,6 @@ public:
     static void yield();
 
     /**
-     * For OS where it makes sense sets the scheduler to be called more often.
-     * This sets the scheduler to be run to the maximum possible rate based
-     * on the capability of the hardware.
-     * Specifically, on Microsoft Windows, high resolution scheduling is
-     * used.
-     */
-    static void turboBoost();
-
-    /**
      *
      * Configure YARP to use system time (this is the default).
      */
@@ -144,6 +135,21 @@ public:
      *
      */
     static bool isValid();
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+    /**
+     * For OS where it makes sense sets the scheduler to be called more often.
+     * This sets the scheduler to be run to the maximum possible rate based
+     * on the capability of the hardware.
+     * Specifically, on Microsoft Windows, high resolution scheduling is
+     * used.
+     *
+     * @deprecated Since YARP 3.0.0
+     */
+    YARP_DEPRECATED
+    static void turboBoost();
+#endif
+
 };
 
 #endif // YARP_OS_TIME_H

--- a/src/libYARP_OS/include/yarp/os/Time.h
+++ b/src/libYARP_OS/include/yarp/os/Time.h
@@ -16,140 +16,124 @@
 #include <yarp/os/NetworkClock.h>
 
 namespace yarp {
-    namespace os {
-        class Time;
+namespace os {
 
-        typedef enum {
-            YARP_CLOCK_UNINITIALIZED=-1,
-            YARP_CLOCK_DEFAULT,
-            YARP_CLOCK_SYSTEM,
-            YARP_CLOCK_NETWORK,
-            YARP_CLOCK_CUSTOM
-        } yarpClockType;
-    }
-}
+enum yarpClockType
+{
+    YARP_CLOCK_UNINITIALIZED=-1,
+    YARP_CLOCK_DEFAULT,
+    YARP_CLOCK_SYSTEM,
+    YARP_CLOCK_NETWORK,
+    YARP_CLOCK_CUSTOM
+};
 
-/**
- * \ingroup key_class
- *
+/*
  * Services related to time -- delay, current time.
  */
-class YARP_OS_API yarp::os::Time {
-public:
-    /**
-     * Wait for a certain number of seconds.  This may be fractional.
-     * @param seconds the duration of the delay, in seconds
-     */
-    static void delay(double seconds);
+namespace Time {
 
-    /**
-     * Return the current time in seconds, relative to an arbitrary
-     * starting point.
-     * @return the time in seconds
-     */
-    static double now();
+/**
+ * Wait for a certain number of seconds.  This may be fractional.
+ * @param seconds the duration of the delay, in seconds
+ */
+YARP_OS_API void delay(double seconds);
 
-    /**
-     * The calling thread releases its remaining quantum upon calling
-     * this function.
-     */
-    static void yield();
+/**
+ * Return the current time in seconds, relative to an arbitrary
+ * starting point.
+ * @return the time in seconds
+ */
+YARP_OS_API double now();
 
-    /**
-     *
-     * Configure YARP to use system time (this is the default).
-     */
-    static void useSystemClock();
+/**
+ * The calling thread releases its remaining quantum upon calling
+ * this function.
+ */
+YARP_OS_API void yield();
 
-    /**
-     *
-     * Configure YARP to read time from a specified topic.  The
-     * same effect can also be achieved using the YARP_CLOCK
-     * environment variable.  Topic should provide two integers,
-     * time in seconds followed by residual in nanoseconds.
-     * If yarp is configured according to \ref yarp_with_ros,
-     * then ROS /clock topic will work.
-     *
-     * \see yarp::os::NetworkClock
-     *
-     * return true on success, false on failure. Possible causes of
-     * failure are invalid port name or address conflict.
-     *
-     * Throws assert in case of failure
-     */
-    static void useNetworkClock(const std::string& clock, std::string localPortName="");
+/**
+ * Configure YARP to use system time (this is the default).
+ */
+YARP_OS_API void useSystemClock();
 
-    /**
-     *
-     * Configure YARP clients to use a custom clock source provided by the
-     * user. The Clock source must implement the yarp::os::Clock interface.
-     * This function check clock->isValid() to verify the source is working
-     * properly.
-     *
-     * Possible causes of failure are: clock pointer invalid or isValid() false.
-     *
-     * Throws assert in case of failure
-     */
-    static void useCustomClock(Clock *clock);
+/**
+ * Configure YARP to read time from a specified topic.  The
+ * same effect can also be achieved using the YARP_CLOCK
+ * environment variable.  Topic should provide two integers,
+ * time in seconds followed by residual in nanoseconds.
+ * If yarp is configured according to @ref yarp_with_ros,
+ * then ROS /clock topic will work.
+ *
+ * @see yarp::os::NetworkClock
+ *
+ * return true on success, false on failure. Possible causes of
+ * failure are invalid port name or address conflict.
+ *
+ * Throws assert in case of failure
+ */
+YARP_OS_API void useNetworkClock(const std::string& clock, std::string localPortName="");
 
-    /**
-     *
-     * Check if YARP is providing system time.
-     *
-     */
-    static bool isSystemClock();
+/**
+ * Configure YARP clients to use a custom clock source provided by the
+ * user. The Clock source must implement the yarp::os::Clock interface.
+ * This function check clock->isValid() to verify the source is working
+ * properly.
+ *
+ * Possible causes of failure are: clock pointer invalid or isValid() false.
+ *
+ * Throws assert in case of failure
+ */
+YARP_OS_API void useCustomClock(Clock *clock);
 
-    /**
-     *
-     * Check if YARP is providing network time.
-     *
-     */
-    static bool isNetworkClock();
+/**
+ * Check if YARP is providing system time.
+ */
+YARP_OS_API bool isSystemClock();
 
-    /**
-     *
-     * Check if YARP is using a user-defined custom time.
-     *
-     */
-    static bool isCustomClock();
+/**
+ * Check if YARP is providing network time.
+ */
+YARP_OS_API bool isNetworkClock();
 
-    /**
-     * \return enum type with the current clock type used
-     */
-    static yarpClockType getClockType();
+/**
+ * Check if YARP is using a user-defined custom time.
+ */
+YARP_OS_API bool isCustomClock();
 
-    /**
-     *
-     * Converts clock type enum into string.
-     * @type Convert specified enum into string.
-     *
-     * clockTypeToString
-     */
-     static std::string clockTypeToString(yarpClockType type);
+/**
+ * @return enum type with the current clock type used
+ */
+YARP_OS_API yarpClockType getClockType();
 
-    /**
-     *
-     * Check if time is valid (non-zero).  If a network clock is
-     * in use and no timestamp has yet been received, this
-     * method will return false.
-     *
-     */
-    static bool isValid();
+/**
+ * Converts clock type enum into string.
+ * @param type Convert specified enum into string.
+ */
+YARP_OS_API std::string clockTypeToString(yarpClockType type);
+
+/**
+ * Check if time is valid (non-zero).  If a network clock is
+ * in use and no timestamp has yet been received, this
+ * method will return false.
+ */
+YARP_OS_API bool isValid();
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-    /**
-     * For OS where it makes sense sets the scheduler to be called more often.
-     * This sets the scheduler to be run to the maximum possible rate based
-     * on the capability of the hardware.
-     * Specifically, on Microsoft Windows, high resolution scheduling is
-     * used.
-     *
-     * @deprecated Since YARP 3.0.0
-     */
-    YARP_DEPRECATED
-    static void turboBoost();
+/**
+ * For OS where it makes sense sets the scheduler to be called more often.
+ * This sets the scheduler to be run to the maximum possible rate based
+ * on the capability of the hardware.
+ * Specifically, on Microsoft Windows, high resolution scheduling is
+ * used.
+ *
+ * @deprecated Since YARP 3.0.0
+ */
+YARP_DEPRECATED
+YARP_OS_API void turboBoost();
 #endif
 
-};
+} // namespace Time
+} // namespace os
+} // namespace yarp
 
 #endif // YARP_OS_TIME_H

--- a/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
@@ -9,12 +9,23 @@
 #ifndef YARP_OS_IMPL_TIMEIMPL_H
 #define YARP_OS_IMPL_TIMEIMPL_H
 
-#include <yarp/os/Time.h>
-
 namespace yarp {
 namespace os {
 namespace impl {
-    void removeClock();
+namespace Time {
+
+void removeClock();
+
+/**
+ * For OS where it makes sense sets the scheduler to be called more often.
+ * This sets the scheduler to be run to the maximum possible rate based
+ * on the capability of the hardware.
+ * Specifically, on Microsoft Windows, high resolution scheduling is
+ * used.
+ */
+void turboBoost();
+
+} // namespace Time
 } // namespace impl
 } // namespace os
 } // namespace yarp

--- a/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/TimeImpl.h
@@ -22,8 +22,14 @@ void removeClock();
  * on the capability of the hardware.
  * Specifically, on Microsoft Windows, high resolution scheduling is
  * used.
+ *
+ * @warning According to https://msdn.microsoft.com/en-us/library/vs/alm/dd757624(v=vs.85).aspx
+ *          timeBeginPeriod (called in startTurboBoost) affects a global Windows
+ *          setting and should be matched with a call to timeEndPeriod (called
+ *          in endTurboBoost).
  */
-void turboBoost();
+void startTurboBoost();
+void endTurboBoost();
 
 } // namespace Time
 } // namespace impl

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -787,7 +787,7 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
         }
 
         // make sure system is actually able to do things fast
-        yarp::os::impl::Time::turboBoost();
+        yarp::os::impl::Time::startTurboBoost();
 
         __yarp_is_initialized++;
         if(yarp::os::Time::getClockType() == YARP_CLOCK_UNINITIALIZED)
@@ -802,6 +802,10 @@ void NetworkBase::finiMinimum()
     if (__yarp_is_initialized == 1) {
         Time::useSystemClock();
         yarp::os::impl::Time::removeClock();
+
+        // reset system timer resolution
+        yarp::os::impl::Time::endTurboBoost();
+
     }
     if (__yarp_is_initialized > 0) {
         __yarp_is_initialized--;

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -11,32 +11,24 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Carriers.h>
-#include <string>
-#include <yarp/os/DummyConnector.h>
-#include <yarp/os/InputStream.h>
 #include <yarp/os/MultiNameSpace.h>
 #include <yarp/os/NameSpace.h>
 #include <yarp/os/OutputProtocol.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Route.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/Thread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/YarpPlugin.h>
 #include <yarp/os/Face.h>
 
-#include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/Companion.h>
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/NameClient.h>
 #include <yarp/os/impl/NameConfig.h>
 #include <yarp/os/impl/PlatformSignal.h>
 #include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformStdio.h>
 #include <yarp/os/impl/PortCommand.h>
-#include <yarp/os/impl/StreamConnectionReader.h>
-#include <yarp/os/impl/ThreadImpl.h>
 #include <yarp/os/impl/TimeImpl.h>
 
 #ifdef YARP_HAS_ACE
@@ -50,6 +42,8 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
+#include <string>
 
 using namespace yarp::os::impl;
 using namespace yarp::os;
@@ -767,9 +761,10 @@ public:
 #endif
 
 
-void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock *custom) {
+void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock *custom)
+{
     YARP_UNUSED(custom);
-    if (__yarp_is_initialized==0) {
+    if (__yarp_is_initialized == 0) {
         // Broken pipes need to be dealt with through other means
         yarp::os::impl::signal(SIGPIPE, SIG_IGN);
 
@@ -797,17 +792,20 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
         __yarp_is_initialized++;
         if(yarp::os::Time::getClockType() == YARP_CLOCK_UNINITIALIZED)
             NetworkBase::yarpClockInit(clockType, nullptr);
-    }
-    else
+    } else {
         __yarp_is_initialized++;
+    }
 }
 
-void NetworkBase::finiMinimum() {
-    if (__yarp_is_initialized==1) {
+void NetworkBase::finiMinimum()
+{
+    if (__yarp_is_initialized == 1) {
         Time::useSystemClock();
         yarp::os::impl::Time::removeClock();
     }
-    if (__yarp_is_initialized>0) __yarp_is_initialized--;
+    if (__yarp_is_initialized > 0) {
+        __yarp_is_initialized--;
+    }
 }
 
 void yarp::os::NetworkBase::yarpClockInit(yarp::os::yarpClockType clockType, Clock *custom)

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -793,7 +793,7 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
         }
 
         // make sure system is actually able to do things fast
-        Time::turboBoost();
+        yarp::os::impl::Time::turboBoost();
 
         __yarp_is_initialized++;
         if(yarp::os::Time::getClockType() == YARP_CLOCK_UNINITIALIZED)
@@ -806,7 +806,7 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
 void NetworkBase::finiMinimum() {
     if (__yarp_is_initialized==1) {
         Time::useSystemClock();
-        yarp::os::impl::removeClock();
+        yarp::os::impl::Time::removeClock();
     }
     if (__yarp_is_initialized>0) __yarp_is_initialized--;
 }

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -776,8 +776,7 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
 #ifdef YARP_HAS_ACE
         YARP_ACE::init();
 #endif
-        BottleImpl::getNull();
-        Bottle::getNullBottle();
+
         std::string quiet = getEnvironment("YARP_QUIET");
         Bottle b2(quiet.c_str());
         if (b2.get(0).asInt32()>0) {

--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -26,20 +26,20 @@
 using namespace yarp::os;
 using yarp::os::impl::Logger;
 
+namespace {
+
 static bool clock_owned = false;
 static bool network_clock_ok = false;
 static Clock *pclock = nullptr;
 static yarpClockType yarp_clock_type  = YARP_CLOCK_UNINITIALIZED;
 
-namespace {
 static std::mutex& getTimeMutex()
 {
     static std::mutex mutex;
     return mutex;
 }
-} // namespace
 
-void printNoClock_ErrorMessage()
+static void printNoClock_ErrorMessage()
 {
     YARP_ERROR(Logger::get(), "\n Warning an issue has been found, please update the code.\n \
     Clock is not initialized: This means YARP framework has not been properly initialized. \n \
@@ -79,6 +79,8 @@ static Clock *getClock()
     }
     return pclock;
 }
+} // namespace
+
 
 void yarp::os::impl::Time::removeClock()
 {

--- a/src/libYARP_OS/src/Time.cpp
+++ b/src/libYARP_OS/src/Time.cpp
@@ -91,13 +91,23 @@ void yarp::os::impl::Time::removeClock()
     yarp_clock_type = YARP_CLOCK_UNINITIALIZED;
 }
 
-void yarp::os::impl::Time::turboBoost()
+void yarp::os::impl::Time::startTurboBoost()
 {
 #if defined(_WIN32)
     // only does something on Microsoft Windows
     TIMECAPS tm;
     timeGetDevCaps(&tm, sizeof(TIMECAPS));
     timeBeginPeriod(tm.wPeriodMin);
+#endif
+}
+
+void yarp::os::impl::Time::endTurboBoost()
+{
+#if defined(_WIN32)
+    // only does something on Microsoft Windows
+    TIMECAPS tm;
+    timeGetDevCaps(&tm, sizeof(TIMECAPS));
+    timeEndPeriod(tm.wPeriodMin);
 #endif
 }
 
@@ -120,7 +130,7 @@ double Time::now() {
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 void Time::turboBoost()
 {
-    return yarp::os::impl::Time::turboBoost();
+    return yarp::os::impl::Time::startTurboBoost();
 }
 #endif // YARP_NO_DEPRECATED
 

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -535,8 +535,6 @@ public:
 
     bool configure(ResourceFinder &rf) override
     {
-        Time::turboBoost();
-
         portName=rf.check("name",Value("/dump")).asString().c_str();
         if (portName[0]!='/')
             portName="/"+portName;

--- a/src/yarprobotinterface/main.cpp
+++ b/src/yarprobotinterface/main.cpp
@@ -37,8 +37,6 @@ int main(int argc, char *argv[])
     //    yWarning() << "Cannot lock memory swapping (check superuser permission)";
 #endif //ICUB_USE_REALTIME_LINUX
 
-    yarp::os::Time::turboBoost();
-
     yarp::os::ResourceFinder &rf(yarp::os::ResourceFinder::getResourceFinderSingleton());
     rf.setVerbose();
     rf.setDefaultConfigFile("yarprobotinterface.ini");

--- a/tests/libYARP_OS/RateThreadTest.cpp
+++ b/tests/libYARP_OS/RateThreadTest.cpp
@@ -328,7 +328,6 @@ public:
         bool success = false;
         double acceptedThreshold = 0.10;
 
-        Time::turboBoost();
         char message[255];
 
         //try plausible rates


### PR DESCRIPTION
* Remove unneeded calls to Time::turboBoost() (already called in initMinimum())
* OS/Time: Deprecate turboBoost() (called automatically by Network)
* OS: Make Time a namespace (it was an useless instantiable class with just static methods)
* OS/Network: Remove Bottle and BottleImpl initialization (no longer necessary)
* OS/Network: Reset system timer resolution at the end of the execution. According to https://msdn.microsoft.com/en-us/library/vs/alm/dd757624(v=vs.85).aspx `timeBeginPeriod` (called in startTurboBoost`) affects a global Windows setting and should be matched with a call to  `timeEndPeriod` (called inendTurboBoost).