### PR TITLE
move Companion out of YARP_OS

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -79,6 +79,13 @@ Important Changes
 * `Portable::getType()` became `Portable::getType() const`(#1617).
 * `PortWriter::getWriteType()` became `PortWriter::getWriteType() const`(#1621).
 * `PortReader::getReadType()` became `PortReader::getReadType() const`(#1616).
+* `Companion` has been moved to a dedicated library (#1509). As consequences:
+  * Following functions has been moved from `Companion` to `NetworkBase`:
+    `disconnectInput`, `poll`, `sendMessage`, `wait` (`wait()` has been splitted
+    into two new functions `waitConnection()` and `waitPort()`.
+  * `Companion::exists()` has been removed unifying its code with
+    `NetworkBase::exists()`.
+  * `readString()` function has been deprecated in `NetworkBase`.
 
 #### `YARP_dev`
 
@@ -175,6 +182,10 @@ Important Changes
 * operators for `yarp::math::<class>`es have been moved from the `yarp::math` to
   the global namespace.
 * `libYARP_math` is now enabled by default if `Eigen3` is found.
+
+#### `YARP_companion`
+
+* new library created to isolate the old `yarp::os::Companion`.
 
 ### Tools
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(libYARP_dev)
 add_subdirectory(libYARP_pcl)
 
 # private libraries
+add_subdirectory(libYARP_companion)
 add_subdirectory(libYARP_name)
 add_subdirectory(libYARP_serversql)
 add_subdirectory(libYARP_run)

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -149,7 +149,6 @@ set(YARP_OS_IDL_HDRS include/yarp/os/idl/BareStyle.h
 set(YARP_OS_IMPL_HDRS include/yarp/os/impl/AuthHMAC.h
                       include/yarp/os/impl/BottleImpl.h
                       include/yarp/os/impl/BufferedConnectionWriter.h
-                      include/yarp/os/impl/Companion.h
                       include/yarp/os/impl/DgramTwoWayStream.h
                       include/yarp/os/impl/Dispatcher.h
                       include/yarp/os/impl/FakeFace.h
@@ -199,6 +198,7 @@ set(YARP_OS_IMPL_HDRS include/yarp/os/impl/AuthHMAC.h
                       include/yarp/os/impl/TcpConnector.h
                       include/yarp/os/impl/TcpFace.h
                       include/yarp/os/impl/TcpStream.h
+                      include/yarp/os/impl/Terminal.h
                       include/yarp/os/impl/TextCarrier.h
                       include/yarp/os/impl/ThreadImpl.h
                       include/yarp/os/impl/UdpCarrier.h
@@ -217,7 +217,6 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/Bytes.cpp
                  src/Carrier.cpp
                  src/Carriers.cpp
-                 src/Companion.cpp
                  src/ConnectionReader.cpp
                  src/ConnectionWriter.cpp
                  src/Contactable.cpp
@@ -311,6 +310,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/SystemInfoSerializer.cpp
                  src/TcpCarrier.cpp
                  src/TcpFace.cpp
+                 src/Terminal.cpp
                  src/Terminator.cpp
                  src/TextCarrier.cpp
                  src/Things.cpp

--- a/src/libYARP_OS/include/yarp/os/Network.h
+++ b/src/libYARP_OS/include/yarp/os/Network.h
@@ -175,7 +175,7 @@ public:
      * @param quiet suppress messages displayed during check
      * @return true on success, false on failure
      */
-    static bool exists(const std::string& port, bool quiet = true);
+    static bool exists(const std::string& port, bool quiet = true, bool checkVer = true);
 
     /**
      * Check for a port to be ready and responsive.
@@ -183,7 +183,7 @@ public:
      * @param style options for network communication
      * @return true on success, false on failure
      */
-    static bool exists(const std::string& port, const ContactStyle& style);
+    static bool exists(const std::string& port, const ContactStyle& style, bool checkVer = true);
 
     /**
      * Wait for a port to be ready and responsive.
@@ -192,18 +192,6 @@ public:
      * @return true on success, false on failure
      */
     static bool sync(const std::string& port, bool quiet = true);
-
-    /**
-     * The standard main method for the YARP companion utility.
-     * This method is not thread-safe; it initializes and shuts
-     * down YARP, the effect of which varies between operating
-     * systems.  Do not call this method if there are other
-     * threads using YARP.
-     * @param argc argument count
-     * @param argv command line arguments
-     * @return 0 on success, non-zero on failure
-     */
-    static int main(int argc, char *argv[]);
 
     /**
      * An assertion.  Should be true.  If false, this will be
@@ -333,6 +321,7 @@ public:
      */
     static bool getLocalMode();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
     /**
      * Read a line of arbitrary length from standard input.
      *
@@ -344,8 +333,12 @@ public:
      *
      * @return A string from standard input, without newline or
      * linefeed characters.
+     *
+     * @deprecated since YARP 3.0.0
      */
+    YARP_DEPRECATED
     static std::string readString(bool *eof = nullptr);
+#endif // YARP_NO_DEPRECATED
 
 
     /**
@@ -621,12 +614,73 @@ public:
      */
     static bool getConnectionQos(const std::string& src, const std::string& dest,
                                  QosStyle& srcStyle, QosStyle& destStyle, bool quiet=true);
+
     /**
      * Checks that the port has a valid name.
      * @param portName the name of port
      * @return true if portName is valid
      */
     static bool isValidPortName(const std::string& portName);
+
+    /**
+     * Delays the system until a specified connection is established.
+     * @param source name of the source port of the connection
+     * @param destination name of the dest port of the connection
+     * @param quiet flag for verbosity
+     * @return true when the connection is finally found
+     */
+    static bool waitConnection(const std::string& source,
+                               const std::string& destination,
+                               bool quiet = false);
+
+    /**
+     * Delays the system until a specified port is open.
+     * @param target name of the port to wait for
+     * @param quiet flag for verbosity
+     * @return true when the port is finally open
+     */
+    static bool waitPort(const std::string& target, bool quiet = false);
+
+    /**
+     * Just a reminder to sendMessage with temporary output parameter that will
+     * be discarded.
+     */
+    static int sendMessage(const std::string& port,
+                           yarp::os::PortWriter& writable,
+                           bool silent = false);
+
+    /**
+     * Sends a message to the specified port.
+     * @param port name of destination port
+     * @param writable the object to be written to the port
+     * @param output storage string for the output message received from port
+     * @param quiet flag for verbosity
+     * @return 0 on success
+     */
+    static int sendMessage(const std::string& port,
+                           yarp::os::PortWriter& writable,
+                           std::string& output,
+                           bool quiet);
+
+    /**
+     * Sends a disconnection command to the specified port.
+     * @param src the port to send the command to
+     * @param dest the port that has to be disconnected
+     * @param silent flag for verbosity
+     * @return 0 on success
+     */
+    static int disconnectInput(const std::string& src,
+                               const std::string& dest,
+                               bool silent = false);
+
+    /**
+     * Sends a 'describe yourself' message to a specified port, in order to
+     * receive information about the port and its connections.
+     * @param target the name of the port to be described
+     * @param silent flag for verbosity
+     * @return 0 on success
+     */
+    static int poll(const std::string& target, bool silent = false);
 };
 
 /**

--- a/src/libYARP_OS/include/yarp/os/Ping.h
+++ b/src/libYARP_OS/include/yarp/os/Ping.h
@@ -13,6 +13,8 @@
 #include <cmath>
 #include <string>
 
+#include <yarp/os/api.h>
+
 namespace yarp {
     namespace os {
         class Stat;
@@ -120,7 +122,7 @@ public:
  * non-YARP ports with a compatible protocol.
  *
  */
-class yarp::os::Ping {
+class YARP_OS_API yarp::os::Ping {
 public:
     Ping(const char *target = nullptr) {
         if (target != nullptr) {

--- a/src/libYARP_OS/include/yarp/os/impl/Terminal.h
+++ b/src/libYARP_OS/include/yarp/os/impl/Terminal.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_OS_IMPL_TERMINAL_H
+#define YARP_OS_IMPL_TERMINAL_H
+
+#include <string>
+#include <yarp/os/api.h>
+
+namespace yarp {
+namespace os {
+namespace impl {
+namespace terminal {
+
+YARP_OS_impl_API
+bool EOFreached();
+
+YARP_OS_impl_API
+std::string getStdin();
+
+YARP_OS_impl_API
+std::string readString(bool *eof);
+
+} // terminal
+} // impl
+} // os
+} // yarp
+
+#endif // YARP_OS_IMPL_TERMINAL_H

--- a/src/libYARP_OS/src/NameServer.cpp
+++ b/src/libYARP_OS/src/NameServer.cpp
@@ -18,13 +18,13 @@
 #ifdef YARP_HAS_ACE
 #  include <yarp/os/impl/FallbackNameServer.h>
 #endif
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Value.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
+#include <yarp/conf/version.h>
 
 #include <map>
 #include <set>
@@ -581,7 +581,7 @@ yarp::os::Bottle NameServer::ncmdVersion(int argc, char *argv[]) {
     YARP_UNUSED(argv);
     Bottle response;
     response.addString("version");
-    response.addString(Companion::version().c_str());
+    response.addString(YARP_VERSION);
     return response;
 }
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -18,7 +18,6 @@
 #include <yarp/os/impl/StreamConnectionReader.h>
 #include <yarp/os/Name.h>
 
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
@@ -453,13 +452,13 @@ void PortCore::closeMain()
         if (!done) {
             YARP_DEBUG(log, std::string("requesting removal of connection from ")+
                        removeName);
-            int result = Companion::disconnect(removeName.c_str(),
-                                               getName().c_str(),
-                                               true);
-            if (result!=0) {
-                Companion::disconnectInput(getName().c_str(),
-                                           removeName.c_str(),
-                                           true);
+            bool result = NetworkBase::disconnect(removeName.c_str(),
+                                                  getName().c_str(),
+                                                  true);
+            if (!result) {
+                NetworkBase::disconnectInput(getName().c_str(),
+                                             removeName.c_str(),
+                                             true);
             }
             prevName = removeName;
         }

--- a/src/libYARP_OS/src/PortCoreOutputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreOutputUnit.cpp
@@ -16,7 +16,6 @@
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/Name.h>
-#include <yarp/os/impl/Companion.h>
 
 
 #define YMSG(x) printf x;
@@ -167,7 +166,7 @@ void PortCoreOutputUnit::closeBasic()
                          debug,
                          "output for route %s asking other side to close by out-of-band means",
                          route.toString().c_str());
-            Companion::disconnectInput(route.getToName().c_str(),
+            NetworkBase::disconnectInput(route.getToName().c_str(),
                                        route.getFromName().c_str(), true);
         } else {
             if (op->getConnection().canEscape()) {

--- a/src/libYARP_OS/src/RFModule.cpp
+++ b/src/libYARP_OS/src/RFModule.cpp
@@ -18,6 +18,7 @@
 
 #include <yarp/os/impl/PlatformTime.h>
 #include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/Terminal.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -49,7 +50,7 @@ public:
         yInfo("Listening to terminal (type \"quit\" to stop module).");
         bool isEof = false;
         while (!(isEof || isStopping() || owner.isStopping())) {
-            std::string str = NetworkBase::readString(&isEof);
+            std::string str = yarp::os::impl::terminal::readString(&isEof);
             if (!isEof) {
                 Bottle cmd(str.c_str());
                 Bottle reply;
@@ -102,7 +103,7 @@ public:
 
 
     bool detachTerminal() {
-        yWarning("Critial: stopping thread, this might hang.");
+        yWarning("Critical: stopping thread, this might hang.");
         Thread::stop();
         yWarning("done!");
         return true;

--- a/src/libYARP_OS/src/Terminal.cpp
+++ b/src/libYARP_OS/src/Terminal.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/impl/Terminal.h>
+#include <yarp/os/impl/PlatformUnistd.h>
+#include <yarp/os/impl/PlatformStdio.h>
+
+#include <yarp/os/Port.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Vocab.h>
+
+#include <cstdio>
+
+#ifdef WITH_LIBEDIT
+#include <editline/readline.h>
+char* szLine = (char*)nullptr;
+bool readlineEOF=false;
+#endif // WITH_LIBEDIT
+
+bool yarp::os::impl::terminal::EOFreached()
+{
+#ifdef WITH_LIBEDIT
+    if (yarp::os::impl::isatty(yarp::os::impl::fileno(stdin))) {
+        return readlineEOF;
+    }
+#endif // WITH_LIBEDIT
+    return feof(stdin);
+}
+
+std::string yarp::os::impl::terminal::getStdin() {
+    std::string txt = "";
+
+#ifdef WITH_LIBEDIT
+    if (yarp::os::impl::isatty(yarp::os::impl::fileno(stdin))) {
+        if (szLine) {
+            free(szLine);
+            szLine = (char*)nullptr;
+        }
+
+        szLine = readline(">>");
+        if (szLine && *szLine) {
+            txt = szLine;
+            add_history(szLine);
+        } else if (!szLine) {
+            readlineEOF=true;
+        }
+        return txt;
+    }
+#endif // WITH_LIBEDIT
+
+    bool done = false;
+    char buf[2048];
+    while (!done) {
+        char *result = fgets(buf, sizeof(buf), stdin);
+        if (result != nullptr) {
+            for (unsigned int i=0; i<strlen(buf); i++) {
+                if (buf[i]=='\n') {
+                    buf[i] = '\0';
+                    done = true;
+                    break;
+                }
+            }
+            txt += buf;
+        } else {
+            done = true;
+        }
+    }
+    return txt;
+}
+
+std::string yarp::os::impl::terminal::readString(bool *eof) {
+    bool end = false;
+
+    std::string txt;
+
+    if (!EOFreached()) {
+        txt = getStdin();
+    }
+
+    if (EOFreached()) {
+        end = true;
+    } else if (txt.length()>0 && txt[0]<32 && txt[0]!='\n' &&
+               txt[0]!='\r') {
+        end = true;
+    }
+    if (end) {
+        txt = "";
+    }
+    if (eof != nullptr) {
+        *eof = end;
+    }
+    return txt;
+}

--- a/src/libYARP_OS/src/Terminator.cpp
+++ b/src/libYARP_OS/src/Terminator.cpp
@@ -9,7 +9,6 @@
 
 #include <cstdio>
 #include <yarp/os/impl/SocketTwoWayStream.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/impl/PortCommand.h>
 
 #include <yarp/os/Terminator.h>
@@ -31,7 +30,7 @@ bool Terminator::terminateByName(const char *name) {
         // name doesn't include /quit
         // old mechanism won't work, let's try new
         PortCommand pc('\0', "i");
-        Companion::sendMessage(s, pc, true);
+        NetworkBase::sendMessage(s, pc, true);
         return true;
     }
 

--- a/src/libYARP_companion/CMakeLists.txt
+++ b/src/libYARP_companion/CMakeLists.txt
@@ -1,0 +1,74 @@
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# Copyright (C) 2006-2010 RobotCub Consortium
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+project(YARP_companion)
+
+set(YARP_companion_HDRS include/yarp/companion/yarpcompanion.h)
+
+set(YARP_companion_IMPL_HDRS include/yarp/companion/impl/Companion.h)
+
+set(YARP_companion_SRCS src/Companion.cpp)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+             PREFIX "Source Files"
+             FILES ${YARP_companion_SRCS})
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+             PREFIX "Header Files"
+             FILES ${YARP_companion_HDRS}
+                   ${YARP_companion_IMPL_HDRS})
+
+set_property(GLOBAL APPEND PROPERTY YARP_TREE_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
+get_property(YARP_TREE_INCLUDE_DIRS GLOBAL PROPERTY YARP_TREE_INCLUDE_DIRS)
+
+include_directories(${YARP_TREE_INCLUDE_DIRS})
+if(NOT SKIP_ACE)
+  include_directories(SYSTEM ${ACE_INCLUDE_DIRS})
+endif()
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
+
+add_library(YARP_companion ${YARP_companion_SRCS}
+                           ${YARP_companion_HDRS}
+                           ${YARP_companion_IMPL_HDRS})
+add_library(YARP::YARP_companion ALIAS YARP_companion)
+
+target_include_directories(YARP_companion PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_link_libraries(YARP_companion PUBLIC YARP::YARP_OS)
+
+if(NOT CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 3.1)
+  message(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
+endif()
+if(CMAKE_VERSION VERSION_LESS 3.1)
+  if(DEFINED CXX11_FLAGS)
+    target_compile_options(YARP_math PUBLIC ${CXX11_FLAGS})
+  endif()
+else()
+  target_compile_features(YARP_math PUBLIC cxx_override)
+endif()
+
+if(YARP_HAS_LIBEDIT)
+    add_definitions(-DWITH_LIBEDIT)
+    include_directories(${Libedit_INCLUDE_DIRS})
+    target_link_libraries(YARP_companion PRIVATE ${Libedit_LIBRARIES})
+endif()
+
+set_property(TARGET YARP_companion PROPERTY PUBLIC_HEADER ${YARP_companion_HDRS})
+set_property(TARGET YARP_companion PROPERTY PRIVATE_HEADER ${YARP_companion_IMPL_HDRS})
+
+install(TARGETS YARP_companion
+        EXPORT YARP
+        COMPONENT runtime
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/yarp/companion"
+        PRIVATE_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/yarp/companion/impl")
+
+set_property(GLOBAL APPEND PROPERTY YARP_LIBS YARP_companion)
+set_property(TARGET YARP_companion PROPERTY INCLUDE_DIRS ${YARP_TREE_INCLUDE_DIRS})
+set_property(TARGET YARP_companion PROPERTY FOLDER "Libraries")

--- a/src/libYARP_companion/include/yarp/companion/api.h
+++ b/src/libYARP_companion/include/yarp/companion/api.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_COMPANION_API_H
+#define YARP_COMPANION_API_H
+
+#include <yarp/conf/api.h>
+#ifndef YARP_companion_API
+#  ifdef YARP_companion_EXPORTS
+#    define YARP_companion_API YARP_EXPORT
+#    define YARP_companion_EXTERN YARP_EXPORT_EXTERN
+#  else
+#    define YARP_companion_API YARP_IMPORT
+#    define YARP_companion_EXTERN YARP_IMPORT_EXTERN
+#  endif
+#  define YARP_companion_DEPRECATED_API YARP_DEPRECATED_API
+#endif
+
+#endif // YARP_COMPANION_API_H

--- a/src/libYARP_companion/include/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/include/yarp/companion/impl/Companion.h
@@ -7,9 +7,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_OS_IMPL_COMPANION_H
-#define YARP_OS_IMPL_COMPANION_H
+#ifndef YARP_COMPANION_IMPL_COMPANION_H
+#define YARP_COMPANION_IMPL_COMPANION_H
 
+#include <yarp/companion/api.h>
 #include <yarp/os/PortWriter.h>
 #include <yarp/os/ContactStyle.h>
 #include <yarp/os/Contactable.h>
@@ -19,35 +20,19 @@
 #include <vector>
 #include <cstdio>
 
-// ACE headers may fiddle with main
-#ifdef main
-#undef main
-#endif
 
 namespace yarp {
-    namespace os {
-        namespace impl {
-            class Companion;
-        }
-    }
-}
+namespace companion {
+namespace impl {
 
 /**
  * Implementation of a standard set of YARP utilities.
  */
-class YARP_OS_impl_API yarp::os::impl::Companion {
+class YARP_companion_API Companion
+{
 public:
 
     static std::string version();
-
-    /**
-     * The standard main method for the YARP companion utility.
-     * @param argc Argument count
-     * @param argv Command line arguments
-     * @return 0 on success, non-zero on failure
-     */
-
-    static int main(int argc, char *argv[]);
 
     /**
      * Request that an output port connect to an input port.
@@ -68,22 +53,6 @@ public:
      */
     static int disconnect(const char *src, const char *dest,
                           bool silent = false);
-
-    static int disconnectInput(const char *src, const char *dest,
-                               bool silent = false);
-
-    static int poll(const char *target, bool silent = false);
-
-    static int wait(const char *target, bool silent = false,
-                    const char *target2 = nullptr);
-
-    static int exists(const char *target, bool silent = false) {
-        ContactStyle style;
-        style.quiet = silent;
-        return exists(target, style);
-    }
-
-    static int exists(const char *target, const ContactStyle& style);
 
     /**
      * Create a port to read Bottles and prints them to standard input.
@@ -119,21 +88,9 @@ public:
      */
     static std::string readString(bool *eof=nullptr);
 
+    static Companion& getInstance();
 
-    static int sendMessage(const std::string& port, yarp::os::PortWriter& writable,
-                           bool silent = false) {
-        std::string output;
-        return sendMessage(port, writable, output, silent);
-    }
-
-    static int sendMessage(const std::string& port, yarp::os::PortWriter& writable,
-                           std::string& output,
-                           bool quiet);
-
-
-    static Companion& getInstance() {
-        return instance;
-    }
+    void setAdminMode(bool admin);
 
     int dispatch(const char *name, int argc, char *argv[]);
 
@@ -211,8 +168,6 @@ private:
 
     Companion();
 
-    static Companion instance;
-
     void applyArgs(yarp::os::Contactable& port);
 
     class Entry {
@@ -242,4 +197,9 @@ private:
              const char* tip);
 };
 
-#endif // YARP_OS_IMPL_COMPANION_H
+} // namespace impl
+} // namespace companion
+} // namespace yarp
+
+
+#endif // YARP_COMPANION_IMPL_COMPANION_H

--- a/src/libYARP_companion/include/yarp/companion/yarpcompanion.h
+++ b/src/libYARP_companion/include/yarp/companion/yarpcompanion.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_COMPANION_COMPANION_H
+#define YARP_COMPANION_COMPANION_H
+
+#include <yarp/companion/api.h>
+
+namespace yarp {
+namespace companion {
+
+/**
+ * The standard main method for the YARP companion utility.
+ * @param argc Argument count
+ * @param argv Command line arguments
+ * @return 0 on success, non-zero on failure
+ */
+YARP_companion_API
+int main(int argc, char *argv[]);
+
+} // namespace companion
+} // namespace yarp
+
+
+#endif // YARP_COMPANION_IMPL_COMPANION_H

--- a/src/libYARP_profiler/CMakeLists.txt
+++ b/src/libYARP_profiler/CMakeLists.txt
@@ -40,7 +40,8 @@ if(CREATE_LIB_PROFILER)
                                                   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   target_link_libraries(YARP_profiler PUBLIC YARP::YARP_OS
-                                      PRIVATE YARP::YARP_init)
+                                      PRIVATE YARP::YARP_init
+                                              YARP::YARP_companion)
 
 
   if(NOT CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 3.1)

--- a/src/libYARP_profiler/src/NetworkProfiler.cpp
+++ b/src/libYARP_profiler/src/NetworkProfiler.cpp
@@ -14,7 +14,7 @@
 #include <yarp/os/Port.h>
 #include <yarp/os/OutputProtocol.h>
 #include <yarp/os/Carrier.h>
-#include <yarp/os/impl/Companion.h>
+#include <yarp/companion/impl/Companion.h>
 
 using namespace std;
 using namespace yarp::os;
@@ -239,7 +239,7 @@ bool NetworkProfiler::yarpClean(float timeout) {
     char* argv[2];
     argv[0] = (char*) "--timeout";
     argv[1] = (char*) sstream.str().c_str();
-    yarp::os::impl::Companion::getInstance().cmdClean(2,argv);
+    yarp::companion::impl::Companion::getInstance().cmdClean(2,argv);
     return true;
 }
 

--- a/src/yarp/CMakeLists.txt
+++ b/src/yarp/CMakeLists.txt
@@ -13,7 +13,8 @@ target_include_directories(yarp SYSTEM PRIVATE ${ACE_INCLUDE_DIRS})
 target_link_libraries(yarp YARP::YARP_OS
                            YARP::YARP_init
                            YARP::YARP_serversql
-                           YARP::YARP_run)
+                           YARP::YARP_run
+                           YARP::YARP_companion)
 
 install(TARGETS yarp
         COMPONENT utilities

--- a/src/yarp/yarp.cpp
+++ b/src/yarp/yarp.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <yarp/os/Network.h>
+#include <yarp/companion/yarpcompanion.h>
 #include <yarp/serversql/yarpserversql.h>
 #include <yarp/run/Run.h>
 
@@ -34,6 +35,6 @@ int main(int argc, char *argv[]) {
     }
 
     // call the yarp standard companion
-    return Network::main(argc,argv);
+    yarp::companion::main(argc,argv);
 }
 

--- a/src/yarphear/yarphear.cpp
+++ b/src/yarphear/yarphear.cpp
@@ -20,6 +20,8 @@
 
 #include <yarp/sig/SoundFile.h>
 
+#include <yarp/os/impl/Terminal.h>
+
 using namespace yarp::os;
 using namespace yarp::sig;
 using namespace yarp::sig::file;
@@ -226,7 +228,7 @@ int main(int argc, char *argv[]) {
             yInfo("Type \"help\" for usage\n");
         }
 
-        std::string keys = Network::readString();
+        std::string keys = yarp::os::impl::terminal::readString(nullptr);
         Bottle b(keys);
         std::string cmd = b.get(0).asString();
         if (b.size()==0) {

--- a/tests/libYARP_OS/BinPortableTest.cpp
+++ b/tests/libYARP_OS/BinPortableTest.cpp
@@ -13,14 +13,12 @@
 #include <yarp/os/PortReaderBuffer.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/DummyConnector.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetInt32.h>
 
 #include <yarp/os/impl/UnitTest.h>
-//#include "TestList.h"
 
 using namespace yarp::os::impl;
 using namespace yarp::os;

--- a/tests/libYARP_OS/NameServerTest.cpp
+++ b/tests/libYARP_OS/NameServerTest.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <yarp/os/impl/NameServer.h>
-#include <yarp/os/impl/Companion.h>
 
 #include <yarp/os/impl/UnitTest.h>
 //#include "TestList.h"

--- a/tests/libYARP_OS/PortCoreTest.cpp
+++ b/tests/libYARP_OS/PortCoreTest.cpp
@@ -12,9 +12,9 @@
 #include <yarp/os/Carriers.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/impl/BottleImpl.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/impl/UnitTest.h>
 #include <yarp/os/Network.h>
+#include <yarp/companion/impl/Companion.h>
 //#include "TestList.h"
 
 using namespace yarp::os::impl;
@@ -111,7 +111,7 @@ public:
         sender.send(bot);
         Time::delay(0.3);
         checkEqual(receives,0,"nothing received");
-        Companion::connect("/write", "/read");
+        NetworkBase::connect("/write", "/read");
         Time::delay(0.3);
         report(0,"sending bottle, should receive it this time");
         expectation = bot.toString();
@@ -159,7 +159,7 @@ public:
         sender.send(bot);
         Time::delay(0.3);
         checkEqual(receives,0,"nothing received");
-        Companion::connect("/write", "/read");
+        NetworkBase::connect("/write", "/read");
         Time::delay(0.3);
         report(0,"sending bottle, should receive it this time");
         expectation = bot.toString();

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <yarp/os/Port.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Thread.h>
 #include <yarp/os/RateThread.h>
@@ -20,20 +19,20 @@
 #include <yarp/os/BinPortable.h>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/impl/UnitTest.h>
-
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/PortReport.h>
-
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/PortInfo.h>
+#include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/Drivers.h>
 
 #include <yarp/sig/Image.h>
+
+#include <yarp/companion/impl/Companion.h>
 
 //#include "TestList.h"
 
@@ -1204,7 +1203,7 @@ public:
         writer.start();
         int argc = 2;
         const char *argv[] = {"...","/write"};
-        Companion::getInstance().cmdRead(argc,(char**)argv);
+        yarp::companion::impl::Companion::getInstance().cmdRead(argc,(char**)argv);
         writer.finish();
     }
 

--- a/tests/libYARP_OS/harness.cpp
+++ b/tests/libYARP_OS/harness.cpp
@@ -8,8 +8,8 @@
  */
 
 #include <yarp/os/impl/UnitTest.h>
-
 #include <yarp/os/Network.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Network::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     yarp.queryBypass(nullptr);

--- a/tests/libYARP_dev/harness.cpp
+++ b/tests/libYARP_dev/harness.cpp
@@ -10,13 +10,13 @@
 #include <string>
 #include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/UnitTest.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/Drivers.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -77,7 +77,7 @@ int harness_main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Companion::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     return result;

--- a/tests/libYARP_math/harness.cpp
+++ b/tests/libYARP_math/harness.cpp
@@ -12,7 +12,7 @@
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/Companion.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 //
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Companion::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     return result;

--- a/tests/libYARP_run/harness.cpp
+++ b/tests/libYARP_run/harness.cpp
@@ -8,8 +8,8 @@
  */
 
 #include <yarp/os/impl/UnitTest.h>
-
 #include <yarp/os/Network.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Network::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     yarp.queryBypass(nullptr);

--- a/tests/libYARP_serversql/ServerTest.cpp
+++ b/tests/libYARP_serversql/ServerTest.cpp
@@ -13,7 +13,6 @@
 #include <yarp/os/all.h>
 #include <yarp/os/impl/NameClient.h>
 #include <yarp/os/impl/UnitTest.h>
-#include <yarp/os/impl/Companion.h>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;

--- a/tests/libYARP_serversql/harness.cpp
+++ b/tests/libYARP_serversql/harness.cpp
@@ -10,10 +10,10 @@
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Network.h>
 #include <yarp/serversql/yarpserversql.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Companion::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     delete store;

--- a/tests/libYARP_sig/harness.cpp
+++ b/tests/libYARP_sig/harness.cpp
@@ -10,9 +10,9 @@
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Network.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Companion::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     return result;

--- a/tests/libYARP_wire_rep_utils/harness.cpp
+++ b/tests/libYARP_wire_rep_utils/harness.cpp
@@ -10,9 +10,9 @@
 #include <yarp/os/impl/UnitTest.h>
 
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/impl/Companion.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Network.h>
+#include <yarp/companion/yarpcompanion.h>
 
 #include "TestList.h"
 
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
         }
     }
     if (!done) {
-        Companion::main(argc,argv);
+        yarp::companion::main(argc,argv);
     }
 
     return result;


### PR DESCRIPTION
Fixes #1509 

In order to remove any `libYARP_OS` dependences from the `Companion` some changes were necessary:
* Some `Companion` functions has been moved to `NetworkBase`
    * `disconnectInput`
    * `poll`
    * `sendMessage`
    * `wait` (the `wait()` has been splitted into two new functions `waitConnection()` and `waitPort()` to keep code clean and readable.

* `Companion::exists()` has been removed unifying its code with `NetworkBase::exists()`. A parameter has been added to manage the last check in the function. 

* `readString()` function has been deprecated in `NetworkBase` and its implementation has been moved from `Companion` to a common utility file in OS (`Terminal.h`).

* `libYARP_companion` library has been created which exposes the `main` function from the `yarpcompanion.h` file.  