### PR TITLE
Deprecate RateThread in favour of PeriodicThread 

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -271,6 +271,8 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %enddef
 %define YARP_OS_DEPRECATED_API
 %enddef
+%define YARP_OS_DEPRECATED_API_MSG(msg)
+%enddef
 %define YARP_DISABLE_DEPRECATED_WARNING
 %enddef
 %define YARP_DISABLE_DLL_INTERFACE_WARNING
@@ -369,7 +371,10 @@ namespace yarp {
 %include <yarp/os/Searchable.h>
 %include <yarp/os/Semaphore.h>
 %include <yarp/os/Thread.h>
+%include <yarp/os/PeriodicThread.h>
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 %include <yarp/os/RateThread.h>
+#endif
 %include <yarp/os/Time.h>
 %include <yarp/os/RFModule.h>
 %include <yarp/os/Stamp.h>

--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -86,6 +86,10 @@ Important Changes
   * `Companion::exists()` has been removed unifying its code with
     `NetworkBase::exists()`.
   * `readString()` function has been deprecated in `NetworkBase`.
+* `RateThread` has been deprecated in favour of the new class `PeriodicThread`.
+  Note that `RateThread` used the period in msec(int), `PeriodicThread`
+  requires the period in sec(double), so remember to consider a x1000 factor
+  when migrate the code.
 
 #### `YARP_dev`
 

--- a/example/game/game_clientmt/main.cpp
+++ b/example/game/game_clientmt/main.cpp
@@ -15,14 +15,14 @@
 
 #include <yarp/os/all.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 
 #include <yarp/os/Time.h>
 using namespace yarp::os;
 
 const char SERVER_NAME[]="/game";
-const int PLAYER_RATE=500;
+const double PLAYER_PERIOD=0.5;
 
 const char UP[]="up";
 const char DOWN[]="down";
@@ -31,12 +31,12 @@ const char LEFT[]="left";
 const char FIRE[]="fire";
 const char GO[]="go";
 
-class MyPlayer: public RateThread
+class MyPlayer: public PeriodicThread
 {
 public:
     std::default_random_engine randengine;
 
-    MyPlayer(const char *n, int rate):RateThread(rate)
+    MyPlayer(const char *n, double period):PeriodicThread(period)
     {
         myX=0;
         myY=0;
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
   
     Network yarp;
 
-    MyPlayer *player = new MyPlayer(argv[1], PLAYER_RATE);
+    MyPlayer *player = new MyPlayer(argv[1], PLAYER_PERIOD);
   
     if(atoi(argv[2])==0)
         player->setShooter(0);

--- a/example/os/rateThreadTiming.cpp
+++ b/example/os/rateThreadTiming.cpp
@@ -7,11 +7,11 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-// rate thread example -nat
+// periodic thread example -nat
 
 #include <stdio.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Thread.h>
 #include <yarp/os/Network.h>
@@ -23,13 +23,13 @@ using namespace yarp::sig;
 
 const int NROWS=20;
 const int NCOLS=20;
-const int THREAD_PERIOD=15;
+const double THREAD_PERIOD=0.015;
 const int MAIN_WAIT=100;
 
-class Thread1 : public RateThread {
+class Thread1 : public PeriodicThread {
     Matrix m;
 public:
-	Thread1(int r):RateThread(r){}
+    Thread1(double p):PeriodicThread(p){}
     virtual bool threadInit()
 	{ 
 		printf("Starting thread1\n");
@@ -53,8 +53,8 @@ public:
     {
         if (getIterations()==10)
             {
-                double estP=getEstPeriod();
-                double estU=getEstUsed();
+                double estP=getEstimatedPeriod();
+                double estU=getEstimatedUsed();
                 fprintf(stderr, "Thread1 est dT:%.3lf[ms]\n", estP);
                 fprintf(stderr, "Thread1 est used:%.3lf[ms]\n", estU);
                 resetStat();

--- a/example/os/ratethread.cpp
+++ b/example/os/ratethread.cpp
@@ -7,20 +7,20 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-// rate thread example -nat
+// periodic thread example -nat
 
 #include <stdio.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Thread.h>
 #include <yarp/os/Network.h>
 
 using namespace yarp::os;
 
-class Thread1 : public RateThread {
+class Thread1 : public PeriodicThread {
 public:
-	Thread1(int r):RateThread(r){}
+    Thread1(double p):PeriodicThread(p){}
     virtual bool threadInit()
 	{
 		printf("Starting thread1\n");
@@ -48,9 +48,9 @@ public:
 	}
 };
 
-class Thread2: public RateThread {
+class Thread2: public PeriodicThread {
 public:
-	Thread2(int r):RateThread(r){}
+    Thread2(double p):PeriodicThread(p){}
 	virtual bool threadInit()
 	{
 		printf("Starting thread2\n");
@@ -80,10 +80,10 @@ public:
 
 int main() {
     yarp::os::Network network;
-    Thread1 t1(500);  //run every 500ms
-	Thread2 t2(1000); //run every 1s
-	printf("thread1 rate is %d[ms]\n", 500);
-	printf("thread2 rate is %d[ms]\n", 1000);
+    Thread1 t1(0.500);  //run every 500ms
+    Thread2 t2(1.000); //run every 1s
+    printf("thread1 period is %d[ms]\n", 500);
+    printf("thread2 period is %d[ms]\n", 1000);
 
 	printf("Starting threads...\n");
     bool ok=t1.start();
@@ -95,8 +95,8 @@ int main() {
         }
 
     Time::delay(3);
-    printf("Thread1 ran %d times, estimated rate: %.lf[ms]\n", t1.getIterations(), t1.getEstPeriod());
-    printf("Thread2 ran %d times, estimated rate: %.lf[ms]\n", t2.getIterations(), t2.getEstPeriod());
+    printf("Thread1 ran %d times, estimated period: %.lf[ms]\n", t1.getIterations(), t1.getEstimatedPeriod());
+    printf("Thread2 ran %d times, estimated period: %.lf[ms]\n", t2.getIterations(), t2.getEstimatedPeriod());
 
     printf("suspending threads...\n");
 	t1.suspend();
@@ -112,11 +112,11 @@ int main() {
 	printf("\n");
 
 
-	printf("Changing thread1 rate to %d[ms]\n", 250);
-	printf("Changing thread2 rate to %d[ms]\n", 500);
+    printf("Changing thread1 period to %d[ms]\n", 250);
+    printf("Changing thread2 period to %d[ms]\n", 500);
 
-	t1.setRate(250);
-    t2.setRate(500);
+    t1.setPeriod(0.250);
+    t2.setPeriod(0.500);
 
 	printf("Resuming threads...\n");
     t1.resetStat();
@@ -126,8 +126,8 @@ int main() {
 
 	Time::delay(3);
     
-    printf("Thread1 ran %d times, estimated rate: %.lf[ms]\n", t1.getIterations(), t1.getEstPeriod());
-    printf("Thread2 ran %d times, estimated rate: %.lf[ms]\n", t2.getIterations(), t2.getEstPeriod());
+    printf("Thread1 ran %d times, estimated period: %.lf[ms]\n", t1.getIterations(), t1.getEstimatedPeriod());
+    printf("Thread2 ran %d times, estimated period: %.lf[ms]\n", t2.getIterations(), t2.getEstimatedPeriod());
     t1.stop();
     t2.stop();
     printf("stopped\n");

--- a/example/profiling/CMakeLists.txt
+++ b/example/profiling/CMakeLists.txt
@@ -34,34 +34,34 @@ add_executable(bottle_test bottle_test.cpp)
 target_link_libraries(bottle_test ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(bottle_test ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()
 
 add_executable(port_latency port_latency.cpp)
 target_link_libraries(port_latency ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(port_latency ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()
 
 add_executable(port_latency_st port_latency_st.cpp)
 target_link_libraries(port_latency_st ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(port_latency_st ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()
 
 add_executable(thread_latency thread_latency.cpp)
 target_link_libraries(thread_latency ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(thread_latency ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()
 
 add_executable(timers timers.cpp)
 target_link_libraries(timers ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(timers ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()
 
 add_executable(rateThreadTiming rateThreadTiming.cpp)
 target_link_libraries(rateThreadTiming ${YARP_LIBRARIES})
 if(USE_PARALLEL_PORT)
   target_link_libraries(rateThreadTiming ${PPEVENTDEBUGGER_LIBRARIES})
-endif
+endif()

--- a/example/profiling/port_latency.cpp
+++ b/example/profiling/port_latency.cpp
@@ -199,13 +199,13 @@ public:
     }
 };
 
-class serverThread: public RateThread
+class serverThread: public PeriodicThread
 {
     BufferedPort<TestData> port;
     unsigned int payload;
 
 public:
-    serverThread():RateThread(100)
+    serverThread():PeriodicThread(0.100)
     {}
 
     void setPayload(unsigned int p)
@@ -221,8 +221,8 @@ public:
         portName+="/port:o";
         port.open(portName.c_str());
 
-        RateThread::setRate(int (period*1000.0+0.5));
-        RateThread::start();
+        PeriodicThread::setPeriod(period);
+        PeriodicThread::start();
     }
 
     void run()

--- a/example/profiling/rateThreadTiming.cpp
+++ b/example/profiling/rateThreadTiming.cpp
@@ -20,7 +20,7 @@
 using namespace yarp::os;
 using namespace std;
 
-const int THREAD_PERIOD=15;
+const double THREAD_PERIOD=0.015;
 const int MAIN_WAIT=10;
 const double THREAD_CPU_TIME=0.1;
 
@@ -29,19 +29,19 @@ const double THREAD_CPU_TIME=0.1;
  * the thread run for a certain time. We measure
  * the real period.
  * Parameters:
- * --period set the periodicity of the thread (ms).
+ * --period set the periodicity of the thread (s).
  * --time the time we wait before quitting (seconds).
  * --iterations how many iterations the thread will do
  * --cpu time spent in thread (percentage)
  * August 08, Lorenzo Natale.
  */
 
-class Thread1 : public RateThread {
+class Thread1 : public PeriodicThread {
     double cpuUsage;
     int iterations;
     std::vector<double> measures;
 public:
-	Thread1(int r=THREAD_PERIOD):RateThread(r)
+    Thread1(double p=THREAD_PERIOD):PeriodicThread(p)
     { 
         cpuUsage=0; 
         iterations=-1;
@@ -109,7 +109,7 @@ public:
 #endif
         
         double time;
-        time=getRate()*cpuUsage/1000; //go to seconds
+        time=getPeriod()*cpuUsage; //go to seconds
 
         double start=Time::now();
         now=start;
@@ -133,21 +133,21 @@ int main(int argc, char **argv) {
     
     p.fromCommand(argc, argv);
 
-    int period=p.check("period", Value(THREAD_PERIOD)).asInt32();
+    double period=p.check("period", Value(THREAD_PERIOD)).asFloat64();
     double time=p.check("time", Value(MAIN_WAIT)).asFloat64();
     double cpuTime=p.check("cpu", Value(THREAD_CPU_TIME)).asFloat64();
     int iterations=p.check("iterations", Value(-1)).asInt32();
 
-    t1.setRate(period);
+    t1.setPeriod(period);
     t1.setCpuTime(cpuTime);
     t1.setIterations(iterations);
 
-    printf("Going to start a thread with period %d[ms]\n", period);
+    printf("Going to start a thread with period %f[s]\n", period);
     if (iterations!=-1)
         printf("Going to wait %d iterations\n", iterations);
     printf("Thread will use %.0lf/100 cpu time\n", cpuTime*100);
 
-    time=(period*(iterations+10))/1000;
+    time=(period*(iterations+10));
 
     printf("Going to wait %.2lf seconds before quitting\n", time);
 

--- a/example/profiling/thread_latency.cpp
+++ b/example/profiling/thread_latency.cpp
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <yarp/os/all.h>
-#include <yarp/os/RateThread.h>
 using namespace yarp::os;
 
 // Thread latency, basic test.
@@ -31,7 +30,7 @@ using namespace std;
 static ppEventDebugger pp(0x378);
 #endif
 
-const int THREAD_PERIOD=20;
+const double THREAD_PERIOD=0.020;
 
 class ThreadB: public Thread
 {
@@ -95,13 +94,13 @@ public:
 
 };
 
-class ThreadA: public RateThread
+class ThreadA: public PeriodicThread
 {
     ThreadB *slave;
     int iterations;
 
 public:
-    ThreadA(int period): RateThread(period)
+    ThreadA(double period): PeriodicThread(period)
     {
         slave=0;
     }
@@ -132,7 +131,7 @@ int main(int argc, char **argv)
     Property p;
     p.fromCommand(argc, argv);
 
-    int period=p.check("period", Value(THREAD_PERIOD)).asInt32();
+    double period=p.check("period", Value(THREAD_PERIOD)).asFloat64();
     int iterations=p.check("iterations", Value(-1)).asInt32();
 
     ThreadB tB;
@@ -144,7 +143,7 @@ int main(int argc, char **argv)
     tB.start();
     tA.start();
 
-    double time=(period*(iterations+10))/1000;
+    double time=(period*(iterations+10));
     Time::delay(time);
 
     tB.stop();  //stop B first, important

--- a/example/profiling/timers.cpp
+++ b/example/profiling/timers.cpp
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <yarp/os/all.h>
-#include <yarp/os/RateThread.h>
 using namespace yarp::os;
 
 // Timers test.

--- a/src/carriers/portmonitor_carrier/lua/MonitorLua.h
+++ b/src/carriers/portmonitor_carrier/lua/MonitorLua.h
@@ -11,7 +11,7 @@
 
 #include <string>
 #include <string>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/RecursiveMutex.h>
 #include "MonitorBinding.h"
 #include "lua_swig.h"
@@ -93,10 +93,10 @@ private:
 
 };
 
-class MonitorTrigger : public yarp::os::RateThread {
+class MonitorTrigger : public yarp::os::PeriodicThread {
 public:
-    MonitorTrigger(MonitorLua* monitor, int period)
-        : yarp::os::RateThread(period) {
+    MonitorTrigger(MonitorLua* monitor, double period)
+        : yarp::os::PeriodicThread(period) {
         MonitorTrigger::monitor = monitor;
     }
     virtual ~MonitorTrigger() { }

--- a/src/carriers/priority_carrier/PriorityCarrier.cpp
+++ b/src/carriers/priority_carrier/PriorityCarrier.cpp
@@ -113,12 +113,12 @@ bool PriorityCarrier::configure(yarp::os::ConnectionState& proto) {
         safe_printf(dummy, 1024, "   virtual: %s\n",
                             (isVirtual)?"yes":"no");
         msg+= dummy;
-        int rate = options.check("rate", Value(10)).asInt32();
-        safe_printf(dummy, 1024, "   db.rate: %dms\n", rate);
+        double rate = options.check("rate", Value(10)).asInt32() / 1000.0;
+        safe_printf(dummy, 1024, "   db.rate: %fs\n", rate);
         msg+= dummy;
         yInfo("%s", msg.c_str());
         debugger.stop();
-        debugger.setRate(rate);
+        debugger.setPeriod(rate);
         debugger.start();
     }
 #endif
@@ -369,7 +369,7 @@ bool PriorityGroup::acceptIncomingData(yarp::os::ConnectionReader& reader,
  */
 
 #ifdef WITH_PRIORITY_DEBUG
-PriorityDebugThread::PriorityDebugThread(PriorityCarrier* carrier) : RateThread(10)
+PriorityDebugThread::PriorityDebugThread(PriorityCarrier* carrier) : PeriodicThread(0.01)
 {
     pcarrier = carrier;
     count = 0;

--- a/src/carriers/priority_carrier/PriorityCarrier.h
+++ b/src/carriers/priority_carrier/PriorityCarrier.h
@@ -15,7 +15,7 @@
 #include <yarp/os/NullConnectionReader.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 
 #include <yarp/sig/Vector.h>
@@ -60,7 +60,7 @@ public:
 
 
 #ifdef WITH_PRIORITY_DEBUG
-class yarp::os::PriorityDebugThread : public yarp::os::RateThread {
+class yarp::os::PriorityDebugThread : public yarp::os::PeriodicThread {
 public:
     PriorityDebugThread(PriorityCarrier* carrier);
     virtual ~PriorityDebugThread();

--- a/src/devices/BatteryWrapper/BatteryWrapper.cpp
+++ b/src/devices/BatteryWrapper/BatteryWrapper.cpp
@@ -28,9 +28,9 @@ yarp::dev::DriverCreator *createBatteryWrapper() {
   * It also creates one rpc port.
   */
 
-BatteryWrapper::BatteryWrapper() : RateThread(DEFAULT_THREAD_PERIOD)
+BatteryWrapper::BatteryWrapper() : PeriodicThread(DEFAULT_THREAD_PERIOD)
 {
-    _rate = DEFAULT_THREAD_PERIOD;
+    _period = DEFAULT_THREAD_PERIOD;
     battery_p = nullptr;
 }
 
@@ -65,10 +65,8 @@ bool BatteryWrapper::attachAll(const PolyDriverList &battery2attach)
         return false;
     }
     attach(battery_p);
-    RateThread::setRate(_rate);
-    RateThread::start();
-
-    return true;
+    PeriodicThread::setPeriod(_period);
+    return PeriodicThread::start();
 }
 
 bool BatteryWrapper::detachAll()
@@ -168,7 +166,7 @@ bool BatteryWrapper::open(yarp::os::Searchable &config)
         return false;
     }
     else
-        _rate = config.find("period").asInt32();
+        _period = config.find("period").asInt32() / 1000.0;
 
     if (!config.check("name"))
     {
@@ -244,12 +242,12 @@ void BatteryWrapper::run()
 bool BatteryWrapper::close()
 {
     yTrace("BatteryWrapper::Close");
-    if (RateThread::isRunning())
+    if (PeriodicThread::isRunning())
     {
-        RateThread::stop();
+        PeriodicThread::stop();
     }
 
-    RateThread::stop();
+    PeriodicThread::stop();
     detachAll();
     return true;
 }

--- a/src/devices/BatteryWrapper/BatteryWrapper.h
+++ b/src/devices/BatteryWrapper/BatteryWrapper.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Property.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Stamp.h>
 
@@ -43,9 +43,9 @@ namespace yarp{
         }
 }
 
-#define DEFAULT_THREAD_PERIOD 20 //ms
+#define DEFAULT_THREAD_PERIOD 0.02 //s
 
-class yarp::dev::BatteryWrapper: public yarp::os::RateThread,
+class yarp::dev::BatteryWrapper: public yarp::os::PeriodicThread,
                                 public yarp::dev::DeviceDriver,
                                 public yarp::dev::IMultipleWrapper,
                                 public yarp::os::PortReader
@@ -82,7 +82,7 @@ private:
     yarp::os::BufferedPort<yarp::os::Bottle> streamingPort;
     yarp::dev::IBattery *battery_p;             // the battery read from
     yarp::os::Stamp lastStateStamp;             // the last reading time stamp
-    int _rate;
+    double _period;
     std::string sensorId;
 
     bool initialize_YARP(yarp::os::Searchable &config);

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Property.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Stamp.h>
 
@@ -45,9 +45,9 @@ namespace yarp{
         }
 }
 
-#define DEFAULT_THREAD_PERIOD 20 //ms
+#define DEFAULT_THREAD_PERIOD 0.02 //s
 
-class yarp::dev::Rangefinder2DWrapper: public yarp::os::RateThread,
+class yarp::dev::Rangefinder2DWrapper: public yarp::os::PeriodicThread,
                                 public yarp::dev::DeviceDriver,
                                 public yarp::dev::IMultipleWrapper,
                                 public yarp::os::PortReader
@@ -87,7 +87,7 @@ private:
     yarp::dev::IRangefinder2D *sens_p;
     yarp::dev::IPreciselyTimed *iTimed;
     yarp::os::Stamp lastStateStamp;
-    int _rate;
+    double _period;
     std::string sensorId;
     double minAngle, maxAngle;
     double minDistance, maxDistance;

--- a/src/devices/depthCamera/depthCameraDriver.h
+++ b/src/devices/depthCamera/depthCameraDriver.h
@@ -13,7 +13,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberControl2.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/all.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/all.h>

--- a/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
+++ b/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
@@ -15,14 +15,14 @@
 using namespace std;
 using namespace yarp::dev;
 
-FakeAnalogSensor::FakeAnalogSensor(int period) : RateThread(period),
+FakeAnalogSensor::FakeAnalogSensor(double period) : PeriodicThread(period),
         mutex(1),
         channelsNum(0),
         status(IAnalogSensor::AS_OK)
 {
     yTrace();
     timeStamp = yarp::os::Time::now();
-};
+}
 
 FakeAnalogSensor::~FakeAnalogSensor()
 {
@@ -57,23 +57,22 @@ bool FakeAnalogSensor::open(yarp::os::Searchable& config)
         return false;
     }
 
-    int period=config.find("period").asInt32();
-    setRate(period);
+    int period=config.find("period").asInt32() / 1000.0;
+    setPeriod(period);
 
     //create the data vector:
     this->channelsNum = 1;
     data.resize(channelsNum);
     data.zero();
 
-    RateThread::start();
-    return true;
+    return PeriodicThread::start();
 }
 
 bool FakeAnalogSensor::close()
 {
     yTrace();
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     return true;
 }

--- a/src/devices/fakeAnalogSensor/fakeAnalogSensor.h
+++ b/src/devices/fakeAnalogSensor/fakeAnalogSensor.h
@@ -9,7 +9,7 @@
 #ifndef YARP_DEVICE_FAKE_ANALOGSENSOR
 #define YARP_DEVICE_FAKE_ANALOGSENSOR
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 
 #include <yarp/dev/all.h>
@@ -33,7 +33,7 @@ namespace yarp{
 */
 
 class yarp::dev::FakeAnalogSensor : public yarp::dev::DeviceDriver,
-                                    public yarp::os::RateThread,
+                                    public yarp::os::PeriodicThread,
                                     public yarp::dev::IAnalogSensor
 {
 private:
@@ -47,7 +47,7 @@ private:
     yarp::sig::Vector       data;
 
 public:
-    FakeAnalogSensor(int period = 20);
+    FakeAnalogSensor(double period = 0.02);
 
     ~FakeAnalogSensor();
 

--- a/src/devices/fakeIMU/fakeIMU.cpp
+++ b/src/devices/fakeIMU/fakeIMU.cpp
@@ -25,7 +25,7 @@ using namespace yarp::math;
  * emulating an IMU
  * @author Alberto Cardellino
  */
-fakeIMU::fakeIMU() : RateThread(DEFAULT_PERIOD)
+fakeIMU::fakeIMU() : PeriodicThread(DEFAULT_PERIOD)
 {
     nchannels = 12;
     dummy_value = 0;
@@ -53,11 +53,11 @@ fakeIMU::~fakeIMU()
 
 bool fakeIMU::open(yarp::os::Searchable &config)
 {
-    int period;
+    double period;
     if( config.check("period"))
     {
-        period = config.find("period").asInt32();
-        setRate(period);
+        period = config.find("period").asInt32() / 1000.0;
+        setPeriod(period);
     }
     else
         yInfo() << "Using default period of " << DEFAULT_PERIOD << " ms";

--- a/src/devices/fakeIMU/fakeIMU.h
+++ b/src/devices/fakeIMU/fakeIMU.h
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/GenericSensorInterfaces.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/os/Stamp.h>
@@ -21,7 +21,7 @@ namespace yarp{
     }
 }
 
-#define DEFAULT_PERIOD 10   //ms
+#define DEFAULT_PERIOD 0.01   //s
 
 /**
 * \brief `fakeIMU` : fake device implementing the device interface tipically implemented by an Inertial Measurement Unit
@@ -40,7 +40,7 @@ namespace yarp{
 */
 class yarp::dev::fakeIMU :  public DeviceDriver,
                             public IGenericSensor,
-                            public yarp::os::RateThread,
+                            public yarp::os::PeriodicThread,
                             public yarp::dev::IPreciselyTimed,
                             public yarp::dev::IThreeAxisGyroscopes,
                             public yarp::dev::IThreeAxisLinearAccelerometers,

--- a/src/devices/fakeLaser/fakeLaser.cpp
+++ b/src/devices/fakeLaser/fakeLaser.cpp
@@ -54,7 +54,7 @@ bool FakeLaser::open(yarp::os::Searchable& config)
     if (br != false)
     {
         yarp::os::Searchable& general_config = config.findGroup("GENERAL");
-        period = general_config.check("Period", Value(50), "Period of the sampling thread").asInt32();
+        period = general_config.check("Period", Value(50), "Period of the sampling thread").asInt32() / 1000.0;
     }
 
     string string_test_mode = config.check("test", Value(string("use_pattern")), "string to select test mode").asString();
@@ -139,13 +139,12 @@ bool FakeLaser::open(yarp::os::Searchable& config)
     yInfo("resolution %f", resolution);
     yInfo("sensors %d", sensorsNum);
     yInfo("test mode: %d", m_test_mode);
-    RateThread::start();
-    return true;
+    return PeriodicThread::start();
 }
 
 bool FakeLaser::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 
     driver.close();
     
@@ -212,7 +211,7 @@ bool FakeLaser::setHorizontalResolution(double step)
 bool FakeLaser::getScanRate(double& rate)
 {
     mutex.wait();
-    rate = 1.0 / (period * 1000);
+    rate = 1.0 / (period);
     mutex.post();
     return true;
 }
@@ -220,7 +219,7 @@ bool FakeLaser::getScanRate(double& rate)
 bool FakeLaser::setScanRate(double rate)
 {
     mutex.wait();
-    period = (int)((1.0 / rate) / 1000.0);
+    period = (1.0 / rate);
     mutex.post();
     return false;
 }

--- a/src/devices/fakeLaser/fakeLaser.h
+++ b/src/devices/fakeLaser/fakeLaser.h
@@ -12,7 +12,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/ILocalization2D.h>
@@ -49,7 +49,7 @@ using namespace yarp::dev;
 * yarpdev --device Rangefinder2DWrapper --subdevice fakeLaser --period 10 --name /ikart/laser:o --test use_mapfile --map_file mymap.map --localization_client /fakeLaser/localizationClient
 */
 
-class FakeLaser : public RateThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class FakeLaser : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
 {
 protected:
     enum test_mode_t { NO_OBSTACLES = 0, USE_PATTERN =1, USE_MAPFILE =2 };
@@ -60,7 +60,7 @@ protected:
     localization_mode_t m_loc_mode;
     yarp::os::Semaphore mutex;
 
-    int period;
+    double period;
     int sensorsNum;
 
     double min_angle;
@@ -87,7 +87,7 @@ protected:
     std::uniform_real_distribution<>* m_dis;
 
 public:
-    FakeLaser(int period = 20) : RateThread(period),
+    FakeLaser(double period = 0.02) : PeriodicThread(period),
         m_test_mode(test_mode_t::NO_OBSTACLES),
         m_loc_mode(localization_mode_t::LOC_NOT_SET),
         mutex(1),

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -354,7 +354,7 @@ bool FakeMotionControl::dealloc()
 }
 
 FakeMotionControl::FakeMotionControl() :
-    RateThread(10.0),
+    PeriodicThread(0.01),
     ImplementControlCalibration<FakeMotionControl, IControlCalibration>(this),
     ImplementAmplifierControl<FakeMotionControl, IAmplifierControl>(this),
     ImplementPidControl(this),

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -23,7 +23,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
@@ -87,7 +87,7 @@ struct ImpedanceParameters
 
 class yarp::dev::FakeMotionControl :    public DeviceDriver,
 //                                         public DeviceResponder,
-                                        public yarp::os::RateThread,
+                                        public yarp::os::PeriodicThread,
                                         public IPidControlRaw,
                                         public IControlCalibrationRaw,
                                         public IAmplifierControlRaw,

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -25,7 +25,7 @@ using namespace std;
 using namespace yarp::os;
 using namespace yarp::dev;
 
-BoschIMU::BoschIMU() : RateThread(20),
+BoschIMU::BoschIMU() : PeriodicThread(0.02),
     verbose(false),
     status(0),
     nChannels(12),
@@ -58,8 +58,8 @@ bool BoschIMU::open(yarp::os::Searchable& config)
         return false;
     }
 
-    int period = config.check("period",Value(10),"Thread period in ms").asInt32();
-    setRate(period);
+    double period = config.check("period",Value(10),"Thread period in ms").asInt32() / 1000.0;
+    setPeriod(period);
 
     nChannels = config.check("channels", Value(12)).asInt32();
 
@@ -111,7 +111,7 @@ bool BoschIMU::open(yarp::os::Searchable& config)
         return false;
     }
 
-    if(!RateThread::start())
+    if(!PeriodicThread::start())
         return false;
 
     return true;
@@ -121,7 +121,7 @@ bool BoschIMU::close()
 {
     yTrace();
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
     return true;
 }
 

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -6,7 +6,7 @@
 #define BOSCH_IMU_DEVICE
 
 #include <yarp/sig/Vector.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/dev/SerialInterfaces.h>
@@ -127,7 +127,7 @@ namespace yarp {
 **/
 
 class yarp::dev::BoschIMU:   public yarp::dev::DeviceDriver,
-                             public yarp::os::RateThread,
+                             public yarp::os::PeriodicThread,
                              public yarp::dev::IGenericSensor
 {
 protected:

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -119,7 +119,7 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     m_laser_data.resize(m_sensorsNum, 0.0);
     m_max_angle = +hfov / 2;
     m_min_angle = -hfov / 2;
-    RateThread::start();
+    PeriodicThread::start();
 
     yInfo("Sensor ready");
     return true;
@@ -127,7 +127,7 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
 
 bool LaserFromDepth::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 
     if(driver.isValid())
         driver.close();

--- a/src/devices/laserFromDepth/laserFromDepth.h
+++ b/src/devices/laserFromDepth/laserFromDepth.h
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IRangefinder2D.h>
@@ -33,7 +33,7 @@ struct Range_t
 
 //---------------------------------------------------------------------------------------------------------------
 
-class LaserFromDepth : public RateThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class LaserFromDepth : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
 {
 protected:
     PolyDriver driver;
@@ -61,7 +61,7 @@ protected:
     yarp::sig::Vector m_laser_data;
 
 public:
-    LaserFromDepth(int period = 10) : RateThread(period),
+    LaserFromDepth(double period = 0.01) : PeriodicThread(period),
         iRGBD(nullptr),
         m_depth_width(0),
         m_depth_height(0),

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -49,7 +49,7 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
 
     //list of mandatory options
     //TODO change comments
-    period = general_config.check("Period", Value(50), "Period of the sampling thread").asInt32();
+    period = general_config.check("Period", Value(50), "Period of the sampling thread").asInt32() / 1000.0;
 
     if (general_config.check("max_angle") == false) { yError() << "Missing max_angle param"; return false; }
     if (general_config.check("min_angle") == false) { yError() << "Missing min_angle param"; return false; }
@@ -86,7 +86,7 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
         laser_mode = GD_MODE;
         yError("Laser_mode not found. Using GD mode (single acquisition)");
     }
-    setRate(period);
+    setPeriod(period);
 
     bool br2 = config.check("SERIAL_PORT_CONFIGURATION");
     if (br2 == false)
@@ -244,13 +244,12 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
         b_ans.clear();
     }
 
-    RateThread::start();
-    return true;
+    return PeriodicThread::start();
 }
 
 bool laserHokuyo::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 
     Bottle b;
     Bottle b_ans;

--- a/src/devices/laserHokuyo/laserHokuyo.h
+++ b/src/devices/laserHokuyo/laserHokuyo.h
@@ -14,7 +14,7 @@
 //#include <cstdio>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Mutex.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IRangefinder2D.h>
@@ -25,7 +25,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class laserHokuyo : public RateThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class laserHokuyo : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
 {
 protected:
     PolyDriver driver;
@@ -34,7 +34,7 @@ protected:
     yarp::os::Mutex mutex;
 
     int cardId;
-    int period;
+    double period;
     int sensorsNum;
     int start_position;
     int end_position;
@@ -74,7 +74,7 @@ protected:
     yarp::sig::Vector laser_data;
 
 public:
-    laserHokuyo(int period=20) : RateThread(period),
+    laserHokuyo(double period = 0.02) : PeriodicThread(period),
         pSerial(nullptr),
         mutex(),
         cardId(0),

--- a/src/devices/map2DServer/Map2DServer.h
+++ b/src/devices/map2DServer/Map2DServer.h
@@ -18,7 +18,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Property.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/sig/Vector.h>

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -18,7 +18,7 @@ namespace yarp {
 namespace dev {
 
 
-MultipleAnalogSensorsServer::MultipleAnalogSensorsServer(): RateThread(20)
+MultipleAnalogSensorsServer::MultipleAnalogSensorsServer(): PeriodicThread(0.02)
 {
 
 }
@@ -49,11 +49,11 @@ bool MultipleAnalogSensorsServer::open(os::Searchable& config)
         return false;
     }
 
-    m_periodInMs = config.find("period").asInt32();
+    m_periodInS = config.find("period").asInt32() / 1000.0;
 
-    if (m_periodInMs <= 0)
+    if (m_periodInS <= 0)
     {
-        yError("MultipleAnalogSensorsClient: period parameter is present (%d) but it is not a positive integer, exiting.", m_periodInMs);
+        yError("MultipleAnalogSensorsClient: period parameter is present (%f) but it is not a positive integer, exiting.", m_periodInS);
         return false;
     }
 
@@ -272,7 +272,7 @@ bool MultipleAnalogSensorsServer::attachAll(const PolyDriverList& p)
     }
 
     // Set rate period
-    ok = this->setRate(m_periodInMs);
+    ok = this->setPeriod(m_periodInS);
     ok = ok && this->start();
 
     return ok;

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -10,7 +10,7 @@
 #ifndef YARP_DEV_MULTIPLEANALOGSENSORSSERVER_MULTIPLEANALOGSENSORSSERVER_H
 #define YARP_DEV_MULTIPLEANALOGSENSORSSERVER_MULTIPLEANALOGSENSORSSERVER_H
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/Wrapper.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -41,12 +41,12 @@ namespace yarp {
  * | name           |      -         | string  | -              |   -           | Yes                         | Prefix of the port opened by this device                          | MUST start with a '/' character |
  * | period         |      -         | int     | ms             |   -           | Yes                          | Refresh period of the broadcasted values in ms                    |  |
  */
-class yarp::dev::MultipleAnalogSensorsServer : public yarp::os::RateThread,
+class yarp::dev::MultipleAnalogSensorsServer : public yarp::os::PeriodicThread,
                                                public yarp::dev::DeviceDriver,
                                                public yarp::dev::IMultipleWrapper,
                                                public MultipleAnalogSensorsMetadata
 {
-    int m_periodInMs{10};
+    double m_periodInS{0.01};
     std::string m_streamingPortName;
     std::string m_RPCPortName;
     yarp::os::BufferedPort<SensorStreamingData> m_streamingPort;

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -17,7 +17,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberControl2.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/all.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/all.h>

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -186,13 +186,12 @@ bool RpLidar::open(yarp::os::Searchable& config)
 //     string info;
 //     bool b_info = HW_getInfo(info);
 
-    RateThread::start();
-    return true;
+    return PeriodicThread::start();
 }
 
 bool RpLidar::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 
     if (!HW_stop())
     {

--- a/src/devices/rpLidar/rpLidar.h
+++ b/src/devices/rpLidar/rpLidar.h
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IRangefinder2D.h>
@@ -159,7 +159,7 @@ struct Range_t
 
 //---------------------------------------------------------------------------------------------------------------
 
-class RpLidar : public RateThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class RpLidar : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
 {
 protected:
     PolyDriver driver;
@@ -186,7 +186,7 @@ protected:
     yarp::sig::Vector laser_data;
 
 public:
-    RpLidar(int period = 10) : RateThread(period),
+    RpLidar(double period = 0.01) : PeriodicThread(period),
         pSerial(nullptr),
         sensorsNum(0),
         min_angle(0.0),

--- a/src/devices/rpLidar2/rpLidar2.cpp
+++ b/src/devices/rpLidar2/rpLidar2.cpp
@@ -72,8 +72,8 @@ bool RpLidar2::open(yarp::os::Searchable& config)
         }
         if (general_config.check("thread_period"))
         {
-            int   thread_period = general_config.find("thread_period").asInt32();
-            this->setRate(thread_period);
+            double thread_period = general_config.find("thread_period").asInt32() / 1000.0;
+            this->setPeriod(thread_period);
         }
     }
     else
@@ -194,7 +194,7 @@ bool RpLidar2::open(yarp::os::Searchable& config)
     yInfo("max_angle %f, min_angle %f", m_max_angle, m_min_angle);
     yInfo("resolution %f",              m_resolution);
     yInfo("sensors %d",                 m_sensorsNum);
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
@@ -202,7 +202,7 @@ bool RpLidar2::close()
 {
     m_drv->stopMotor();
     RPlidarDriver::DisposeDriver(m_drv);
-    RateThread::stop();
+    PeriodicThread::stop();
     yInfo() << "rpLidar closed";
     return true;
 }

--- a/src/devices/rpLidar2/rpLidar2.h
+++ b/src/devices/rpLidar2/rpLidar2.h
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IRangefinder2D.h>
@@ -34,7 +34,7 @@ struct Range_t
 
 //---------------------------------------------------------------------------------------------------------------
 
-class RpLidar2 : public RateThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class RpLidar2 : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
 {
     typedef rp::standalone::rplidar::RPlidarDriver rplidardrv;
 
@@ -61,7 +61,7 @@ protected:
     rplidardrv*           m_drv;
 
 public:
-    RpLidar2(int period = 10) : RateThread(period),
+    RpLidar2(double period = 0.01) : PeriodicThread(period),
         m_sensorsNum(0),
         m_buffer_life(0),
         m_min_angle(0.0),

--- a/src/devices/transformClient/FrameTransformClient.cpp
+++ b/src/devices/transformClient/FrameTransformClient.cpp
@@ -372,12 +372,12 @@ bool yarp::dev::FrameTransformClient::open(yarp::os::Searchable &config)
 
     if (config.check("period"))
     {
-        m_period = config.find("period").asInt32();
+        m_period = config.find("period").asInt32() / 1000.0;
     }
     else
     {
-        m_period = 10;
-        yWarning("FrameTransformClient: using default period of %d ms" , m_period);
+        m_period = 0.010;
+        yWarning("FrameTransformClient: using default period of %f ms" , m_period);
     }
 
     std::string local_rpcServer = m_local_name;
@@ -868,9 +868,9 @@ bool yarp::dev::FrameTransformClient::waitForTransform(const std::string &target
     return true;
 }
 
-FrameTransformClient::FrameTransformClient() : RateThread(10),
+FrameTransformClient::FrameTransformClient() : PeriodicThread(0.01),
     m_transform_storage(nullptr),
-    m_period(0)
+    m_period(0.01)
 {
 }
 

--- a/src/devices/transformClient/FrameTransformClient.h
+++ b/src/devices/transformClient/FrameTransformClient.h
@@ -20,7 +20,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/math/FrameTransform.h>
 #include <yarp/os/RecursiveMutex.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 namespace yarp {
     namespace dev {
@@ -83,7 +83,7 @@ public:
 class yarp::dev::FrameTransformClient: public DeviceDriver,
                                   public IFrameTransform,
                                   public yarp::os::PortReader,
-                                  public yarp::os::RateThread
+                                  public yarp::os::PeriodicThread
 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:
@@ -101,7 +101,7 @@ protected:
     std::string         m_local_name;
     std::string         m_remote_name;
     Transforms_client_storage*    m_transform_storage;
-    int                           m_period;
+    double                        m_period;
     yarp::os::Mutex               m_rpc_mutex;
     struct broadcast_port_t
     {

--- a/src/devices/transformServer/FrameTransformServer.cpp
+++ b/src/devices/transformServer/FrameTransformServer.cpp
@@ -88,7 +88,7 @@ void Transforms_server_storage::clear()
   * FrameTransformServer
   */
 
-FrameTransformServer::FrameTransformServer() : RateThread(DEFAULT_THREAD_PERIOD)
+FrameTransformServer::FrameTransformServer() : PeriodicThread(DEFAULT_THREAD_PERIOD)
 {
     m_period = DEFAULT_THREAD_PERIOD;
     m_enable_publish_ros_tf = false;
@@ -494,11 +494,11 @@ bool FrameTransformServer::open(yarp::os::Searchable &config)
 
     if (!config.check("period"))
     {
-        m_period = 10;
+        m_period = 0.01;
     }
     else
     {
-        m_period = config.find("period").asInt32();
+        m_period = config.find("period").asInt32() / 1000.0;
         yInfo() << "FrameTransformServer: thread period set to:" << m_period;
     }
 
@@ -830,9 +830,9 @@ void FrameTransformServer::run()
 bool FrameTransformServer::close()
 {
     yTrace("FrameTransformServer::Close");
-    if (RateThread::isRunning())
+    if (PeriodicThread::isRunning())
     {
-        RateThread::stop();
+        PeriodicThread::stop();
     }
 
     return true;

--- a/src/devices/transformServer/FrameTransformServer.h
+++ b/src/devices/transformServer/FrameTransformServer.h
@@ -19,7 +19,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Property.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/RpcServer.h>
@@ -57,7 +57,7 @@ namespace yarp
 #define ROSNODENAME "/tfNode"
 #define ROSTOPICNAME_TF "/tf"
 #define ROSTOPICNAME_TF_STATIC "/tf_static"
-#define DEFAULT_THREAD_PERIOD 20 //ms
+#define DEFAULT_THREAD_PERIOD 0.02 //s
 
 class Transforms_server_storage
 {
@@ -76,7 +76,7 @@ public:
      void clear                       ();
 };
 
-class yarp::dev::FrameTransformServer : public yarp::os::RateThread,
+class yarp::dev::FrameTransformServer : public yarp::os::PeriodicThread,
                                    public yarp::dev::DeviceDriver,
                                    public yarp::os::PortReader
 {
@@ -98,7 +98,7 @@ private:
     std::string        m_streamingPortName;
     std::string        m_rpcPortName;
     yarp::os::Stamp              m_lastStateStamp;
-    int                          m_period;
+    double                       m_period;
     yarp::os::Node*              m_rosNode;
     bool                         m_enable_publish_ros_tf;
     bool                         m_enable_subscribe_ros_tf;

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -70,6 +70,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Os.h
                  include/yarp/os/OutputProtocol.h
                  include/yarp/os/OutputStream.h
+                 include/yarp/os/PeriodicThread.h
                  include/yarp/os/Ping.h
                  include/yarp/os/Portable.h
                  include/yarp/os/PortablePair.h
@@ -267,6 +268,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/NullConnectionReader.cpp
                  src/NullConnectionWriter.cpp
                  src/Os.cpp
+                 src/PeriodicThread.cpp
                  src/Ping.cpp
                  src/PlatformTime.cpp
                  src/Portable.cpp

--- a/src/libYARP_OS/include/yarp/os/Time.h
+++ b/src/libYARP_OS/include/yarp/os/Time.h
@@ -10,10 +10,11 @@
 #ifndef YARP_OS_TIME_H
 #define YARP_OS_TIME_H
 
-#include <string>
 #include <yarp/os/Clock.h>
 #include <yarp/os/SystemClock.h>
 #include <yarp/os/NetworkClock.h>
+
+#include <string>
 
 namespace yarp {
 namespace os {

--- a/src/libYARP_OS/include/yarp/os/Time.h
+++ b/src/libYARP_OS/include/yarp/os/Time.h
@@ -19,6 +19,8 @@
 namespace yarp {
 namespace os {
 
+enum class ShouldUseSystemClock { No = 0, Yes = 1 };
+
 enum yarpClockType
 {
     YARP_CLOCK_UNINITIALIZED=-1,

--- a/src/libYARP_OS/include/yarp/os/Timer.h
+++ b/src/libYARP_OS/include/yarp/os/Timer.h
@@ -54,22 +54,22 @@ struct YARP_OS_API yarp::os::YarpTimerEvent
 
 struct YARP_OS_API yarp::os::TimerSettings
 {
-    TimerSettings(double inRate) :
-            rate(inRate),
+    TimerSettings(double inPeriod) :
+            period(inPeriod),
             totalTime(0.0),
             totalRunCount(0),
             tolerance(0.001)
     {
     }
-    TimerSettings(double inRate, size_t count, double seconds) :
-            rate(inRate),
+    TimerSettings(double inPeriod, size_t count, double seconds) :
+            period(inPeriod),
             totalTime(seconds),
             totalRunCount(count),
             tolerance(0.001)
     {
     }
-    TimerSettings(double inRate, size_t count, double seconds, double inTollerance) :
-            rate(inRate),
+    TimerSettings(double inPeriod, size_t count, double seconds, double inTollerance) :
+            period(inPeriod),
             totalTime(seconds),
             totalRunCount(count),
             tolerance(inTollerance)
@@ -78,12 +78,12 @@ struct YARP_OS_API yarp::os::TimerSettings
 
     bool operator==(const TimerSettings& rhs) const
     {
-        return rate == rhs.rate && totalTime == rhs.totalTime && totalRunCount == rhs.totalRunCount && tolerance == rhs.tolerance;
+        return period == rhs.period && totalTime == rhs.totalTime && totalRunCount == rhs.totalRunCount && tolerance == rhs.tolerance;
     }
 
 
     /**
-     * @param rate the rate of the timer in seconds
+     * @param period the period of the timer in seconds
      * @param totalTime the life of the timer in seconds. 0 == infinite.
      *        The lower between totalTime and totalRunCount*rate + execution
      *        delay will stop the timer
@@ -92,7 +92,7 @@ struct YARP_OS_API yarp::os::TimerSettings
      *        delay will stop the timer
      * @param tolerance the tolerance while checking the timer life
      */
-    double rate;
+    double period;
     double totalTime;
     size_t totalRunCount;
     double tolerance;

--- a/src/libYARP_OS/include/yarp/os/all.h
+++ b/src/libYARP_OS/include/yarp/os/all.h
@@ -53,7 +53,7 @@
 #include <yarp/os/LockGuard.h>
 #include <yarp/os/Event.h>
 #include <yarp/os/Thread.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Terminator.h>
 #include <yarp/os/Time.h>
@@ -74,6 +74,7 @@
 
 #ifndef YARP_NO_DEPRECATED // since YARP 3.0.0
 # include <yarp/os/ConstString.h>
+# include <yarp/os/RateThread.h>
 #endif
 
 /**

--- a/src/libYARP_OS/src/PeriodicThread.cpp
+++ b/src/libYARP_OS/src/PeriodicThread.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/SystemClock.h>
+
+#include <yarp/os/impl/ThreadImpl.h>
+#include <yarp/os/impl/Logger.h>
+#include <yarp/os/impl/PlatformTime.h>
+
+#include <cmath>
+#include <mutex>
+
+using namespace yarp::os::impl;
+using namespace yarp::os;
+
+class yarp::os::PeriodicThread::Private : public ThreadImpl
+{
+private:
+    double adaptedPeriod;
+    PeriodicThread* owner;
+    mutable std::mutex mutex;
+
+    double  elapsed;
+    double  sleepPeriod;
+
+    bool suspended;
+    double totalUsed;      //total time taken iterations
+    unsigned int count;    //number of iterations from last reset
+    unsigned int estPIt;   //number of useful iterations for period estimation
+    double totalT;         //time bw run, accumulated
+    double sumTSq;         //cumulative sum sq of estimated period dT
+    double sumUsedSq;      //cumulative sum sq of estimated thread tun
+    double previousRun;    //time when last iteration started
+    double currentRun;     //time when this iteration started
+    bool scheduleReset;
+
+    using NowFuncPtr = double (*)();
+    using DelayFuncPtr = void (*)(double);
+    const NowFuncPtr nowFunc;
+    const DelayFuncPtr delayFunc;
+
+    void _resetStat()
+    {
+        totalUsed=0;
+        count=0;
+        estPIt=0;
+        totalT=0;
+        sumUsedSq=0;
+        sumTSq=0;
+        elapsed=0;
+        scheduleReset=false;
+    }
+
+public:
+
+    Private(PeriodicThread* owner, double p, ShouldUseSystemClock useSystemClock) :
+            adaptedPeriod(p),
+            owner(owner),
+            elapsed(0),
+            sleepPeriod(adaptedPeriod),
+            suspended(false),
+            totalUsed(0),
+            count(0),
+            estPIt(0),
+            totalT(0),
+            sumTSq(0),
+            sumUsedSq(0),
+            previousRun(0),
+            currentRun(0),
+            scheduleReset(false),
+            nowFunc(useSystemClock == ShouldUseSystemClock::Yes ? SystemClock::nowSystem : yarp::os::Time::now),
+            delayFunc(useSystemClock == ShouldUseSystemClock::Yes ? SystemClock::delaySystem: yarp::os::Time::delay)
+    {
+    }
+
+    void resetStat()
+    {
+        scheduleReset=true;
+    }
+
+    double getEstimatedPeriod() const
+    {
+        double ret;
+        lock();
+        if (estPIt==0)
+            ret=0;
+        else
+            ret=(totalT/estPIt);
+        unlock();
+        return ret;
+    }
+
+    void getEstimatedPeriod(double &av, double &std) const
+    {
+        lock();
+        if (estPIt==0) {
+            av=0;
+            std=0;
+        } else {
+            av=totalT/estPIt;
+            if (estPIt>1) {
+                std=sqrt(((1.0/(estPIt-1))*(sumTSq-estPIt*av*av)));
+            } else {
+                std=0;
+            }
+        }
+        unlock();
+    }
+
+    unsigned int getIterations() const
+    {
+        lock();
+        unsigned int ret=count;
+        unlock();
+        return ret;
+    }
+
+    double getEstimatedUsed() const
+    {
+        double ret;
+        lock();
+        if (count<1)
+            ret=0.0;
+        else
+            ret=totalUsed/count;
+        unlock();
+        return ret;
+    }
+
+    void getEstimatedUsed(double &av, double &std) const
+    {
+        lock();
+        if (count<1) {
+            av=0;
+            std=0;
+        } else {
+            av=totalUsed/count;
+            if (count>1) {
+                std=sqrt((1.0/(count-1))*(sumUsedSq-count*av*av));
+            } else {
+                std=0;
+            }
+        }
+        unlock();
+    }
+
+
+
+    void step()
+    {
+        lock();
+        currentRun = nowFunc();
+
+        if (scheduleReset)
+            _resetStat();
+
+        if (count>0)
+        {
+            double dT=(currentRun-previousRun);
+
+            sumTSq+=dT*dT;
+            totalT+=dT;
+
+            if (adaptedPeriod<0)
+                adaptedPeriod=0;
+
+            //fprintf(stderr, "dT:%lf, error %lf, adaptedPeriod: %lf, new:%lf\n", dT, error, saved, adaptedPeriod);
+            estPIt++;
+        }
+
+        previousRun=currentRun;
+        unlock();
+
+        if (!suspended) {
+            owner->run();
+        }
+
+
+        // At the end of each run of updateModule function, the thread is supposed
+        // to be suspended and release CPU to other threads.
+        // Calling a yield here will help the threads to alternate in the execution.
+        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
+        // yield is took into account and the sleep time is correct.
+        yield();
+
+        lock();
+        count++;
+        double elapsed = nowFunc() - currentRun;
+        //save last
+        totalUsed+=elapsed;
+        sumUsedSq+=elapsed*elapsed;
+        unlock();
+
+        sleepPeriod= adaptedPeriod - elapsed; // everything is in [seconds] except period, for it is used in the interface as [ms]
+
+        delayFunc(sleepPeriod);
+    }
+
+    void run() override
+    {
+        while(!isClosing())
+        {
+            step();
+        }
+    }
+
+    bool threadInit() override
+    {
+        return owner->threadInit();
+    }
+
+    void threadRelease() override
+    {
+        owner->threadRelease();
+    }
+
+    bool setPeriod(double period)
+    {
+        adaptedPeriod = period;
+        return true;
+    }
+
+    double getPeriod() const
+    {
+        return adaptedPeriod;
+    }
+
+    bool isSuspended() const
+    {
+        return suspended;
+    }
+
+    void suspend()
+    {
+        suspended=true;
+    }
+
+    void resume()
+    {
+        suspended=false;
+    }
+
+    void afterStart(bool s) override
+    {
+        owner->afterStart(s);
+    }
+
+    void beforeStart() override
+    {
+        owner->beforeStart();
+    }
+
+    void lock() const
+    {
+        mutex.lock();
+    }
+
+    void unlock() const
+    {
+        mutex.unlock();
+    }
+};
+
+
+
+PeriodicThread::PeriodicThread(double period, ShouldUseSystemClock useSystemClock) :
+        mPriv(new Private(this, period, useSystemClock))
+{
+}
+
+PeriodicThread::~PeriodicThread()
+{
+    delete mPriv;
+}
+
+bool PeriodicThread::setPeriod(double period)
+{
+    return mPriv->setPeriod(period);
+}
+
+double PeriodicThread::getPeriod() const
+{
+    return mPriv->getPeriod();
+}
+
+bool PeriodicThread::isSuspended() const
+{
+    return mPriv->isSuspended();
+}
+
+void PeriodicThread::stop()
+{
+    mPriv->close();
+}
+
+void PeriodicThread::askToStop()
+{
+    mPriv->askToClose();
+}
+
+void PeriodicThread::step()
+{
+    mPriv->step();
+}
+
+bool PeriodicThread::start()
+{
+    return mPriv->start();
+}
+
+bool PeriodicThread::isRunning() const
+{
+    return mPriv->isRunning();
+}
+
+void PeriodicThread::suspend()
+{
+    mPriv->suspend();
+}
+
+void PeriodicThread::resume()
+{
+    mPriv->resume();
+}
+
+unsigned int PeriodicThread::getIterations() const
+{
+    return mPriv->getIterations();
+}
+
+double PeriodicThread::getEstimatedPeriod() const
+{
+    return mPriv->getEstimatedPeriod();
+}
+
+double PeriodicThread::getEstimatedUsed() const
+{
+    return mPriv->getEstimatedUsed();
+}
+
+void PeriodicThread::getEstimatedPeriod(double &av, double &std) const
+{
+    mPriv->getEstimatedPeriod(av, std);
+}
+
+void PeriodicThread::getEstimatedUsed(double &av, double &std) const
+{
+    mPriv->getEstimatedUsed(av, std);
+}
+
+void PeriodicThread::resetStat()
+{
+    mPriv->resetStat();
+}
+
+bool PeriodicThread::threadInit()
+{
+    return true;
+}
+
+void PeriodicThread::threadRelease()
+{
+}
+
+void PeriodicThread::beforeStart()
+{
+}
+
+void PeriodicThread::afterStart(bool success)
+{
+    YARP_UNUSED(success);
+}
+
+int PeriodicThread::setPriority(int priority, int policy)
+{
+    return mPriv->setPriority(priority, policy);
+}
+
+int PeriodicThread::getPriority() const
+{
+    return mPriv->getPriority();
+}
+
+int PeriodicThread::getPolicy() const
+{
+    return mPriv->getPolicy();
+}

--- a/src/libYARP_OS/src/RateThread.cpp
+++ b/src/libYARP_OS/src/RateThread.cpp
@@ -6,8 +6,8 @@
  * This software may be modified and distributed under the terms of the
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
-
 #include <yarp/os/RateThread.h>
+
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/SystemClock.h>
@@ -21,405 +21,100 @@
 using namespace yarp::os::impl;
 using namespace yarp::os;
 
-class yarp::os::RateThread::Private : public ThreadImpl
-{
-private:
-    float period_ms;
-    double adaptedPeriod;
-    RateThread& owner;
-    Semaphore mutex;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 
-    bool useSystemClock;   // force to use the system clock. Used by SystemRateThread only
-
-    double  elapsed;
-    double  sleepPeriod;
-
-    bool suspended;
-    double totalUsed;      //total time taken iterations
-    unsigned int count;    //number of iterations from last reset
-    unsigned int estPIt;   //number of useful iterations for period estimation
-    double totalT;         //time bw run, accumulated
-    double sumTSq;         //cumulative sum sq of estimated period dT
-    double sumUsedSq;      //cumulative sum sq of estimated thread tun
-    double previousRun;    //time when last iteration started
-    double currentRun;     //time when this iteration started
-    bool scheduleReset;
-
-    void _resetStat()
-    {
-        totalUsed=0;
-        count=0;
-        estPIt=0;
-        totalT=0;
-        sumUsedSq=0;
-        sumTSq=0;
-        elapsed=0;
-        scheduleReset=false;
-    }
-
-public:
-
-    Private(RateThread& owner, int p) :
-            period_ms((float)p),
-            adaptedPeriod(period_ms/1000.0),
-            owner(owner),
-            useSystemClock(false),
-            elapsed(0),
-            sleepPeriod(adaptedPeriod),
-            suspended(false),
-            totalUsed(0),
-            count(0),
-            estPIt(0),
-            totalT(0),
-            sumTSq(0),
-            sumUsedSq(0),
-            previousRun(0),
-            currentRun(0),
-            scheduleReset(false)
-    {
-    }
-
-    void initWithSystemClock()
-    {
-        useSystemClock = true;
-    }
-
-    void resetStat()
-    {
-        scheduleReset=true;
-    }
-
-    double getEstPeriod()
-    {
-        double ret;
-        lock();
-        if (estPIt==0)
-            ret=0;
-        else
-            ret=(totalT/estPIt) *1000;
-        unlock();
-        return ret;
-    }
-
-    void getEstPeriod(double &av, double &std)
-    {
-        lock();
-        if (estPIt==0) {
-            av=0;
-            std=0;
-        } else {
-            av=totalT/estPIt;
-            if (estPIt>1) {
-                std=sqrt(((1.0/(estPIt-1))*(sumTSq-estPIt*av*av))) *1000;  // av is computed in [secs], while user expects data in [ms]
-            } else {
-                std=0;
-            }
-            av*=1000;    // av is computed in [secs], while user expects data in [ms]
-        }
-        unlock();
-    }
-
-    unsigned int getIterations()
-    {
-        lock();
-        unsigned int ret=count;
-        unlock();
-        return ret;
-    }
-
-    double getEstUsed()
-    {
-        double ret;
-        lock();
-        if (count<1)
-            ret=0.0;
-        else
-            ret=totalUsed/count*1000;
-        unlock();
-        return ret;
-    }
-
-    void getEstUsed(double &av, double &std)
-    {
-        lock();
-        if (count<1) {
-            av=0;
-            std=0;
-        } else {
-            av=totalUsed/count;
-            if (count>1) {
-                std=sqrt((1.0/(count-1))*(sumUsedSq-count*av*av)) *1000;
-            } else {
-                std=0;
-            }
-            av*=1000;
-        }
-        unlock();
-    }
-
-
-    void singleStep()
-    {
-        lock();
-        currentRun = Time::now();
-
-        if (scheduleReset)
-            _resetStat();
-
-        if (count>0) {
-            double dT=(currentRun-previousRun);
-            sumTSq+=dT*dT;
-            totalT+=dT;
-            if (adaptedPeriod<0)
-                adaptedPeriod=0;
-
-            //fprintf(stderr, "dT:%lf, error %lf, adaptedPeriod: %lf, new:%lf\n", dT, error, saved, adaptedPeriod);
-            estPIt++;
-        }
-
-        previousRun=currentRun;
-        unlock();
-
-        if (!suspended) {
-            owner.run();
-        }
-
-
-        // At the end of each run of updateModule function, the thread is supposed
-        // to be suspended and release CPU to other threads.
-        // Calling a yield here will help the threads to alternate in the execution.
-        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
-        // yield is took into account and the sleep time is correct.
-        yield();
-
-        lock();
-        count++;
-        double elapsed = yarp::os::Time::now() - currentRun;
-        //save last
-        totalUsed+=elapsed;
-        sumUsedSq+=elapsed*elapsed;
-        unlock();
-
-        sleepPeriod= adaptedPeriod - elapsed; // everything is in [seconds] except period, for it is used in the interface as [ms]
-
-        yarp::os::Time::delay(sleepPeriod);
-    }
-
-    void run() override
-    {
-        adaptedPeriod = period_ms/1000.0;   //  divide by 1000 because user's period is [ms] while all the rest is [secs]
-        while(!isClosing())
-        {
-            if(useSystemClock)
-                singleStepSystem();
-            else
-                singleStep();
-        }
-    }
-
-    void singleStepSystem()
-    {
-        lock();
-        currentRun = SystemClock::nowSystem();
-
-        if (scheduleReset)
-            _resetStat();
-
-        if (count>0)
-        {
-            double dT=(currentRun-previousRun); // *1000;
-
-            sumTSq+=dT*dT;
-            totalT+=dT;
-
-            if (adaptedPeriod<0)
-                adaptedPeriod=0;
-
-            estPIt++;
-        }
-
-        previousRun=currentRun;
-        unlock();
-
-        if (!suspended)
-        {
-            owner.run();
-        }
-
-
-        // At the end of each run of updateModule function, the thread is supposed
-        // to be suspended and release CPU to other threads.
-        // Calling a yield here will help the threads to alternate in the execution.
-        // Note: call yield BEFORE computing elapsed time, so that any time spent due to
-        // yield is took into account and the sleep time is correct.
-        yield();
-
-        lock();
-        count++;
-        double elapsed = SystemClock::nowSystem() - currentRun;
-        //save last
-        totalUsed+=elapsed;
-        sumUsedSq+=elapsed*elapsed;
-        unlock();
-
-        sleepPeriod= adaptedPeriod - elapsed;  //  all time computatio are done in [sec]
-
-        SystemClock::delaySystem(sleepPeriod);
-    }
-
-    bool threadInit() override
-    {
-        return owner.threadInit();
-    }
-
-    void threadRelease() override
-    {
-        owner.threadRelease();
-    }
-
-    bool setRate(int p)
-    {
-        period_ms=(float)p;
-        adaptedPeriod = period_ms/1000.0;   //  divide by 1000 because user's period is [ms] while all the rest is [secs]
-        return true;
-    }
-
-    double getRate()
-    {
-        return period_ms;
-    }
-
-    bool isSuspended()
-    {
-        return suspended;
-    }
-
-    void suspend()
-    {
-        suspended=true;
-    }
-
-    void resume()
-    {
-        suspended=false;
-    }
-
-    void afterStart(bool s) override
-    {
-        owner.afterStart(s);
-    }
-
-    void beforeStart() override
-    {
-        owner.beforeStart();
-    }
-
-    void lock()
-    {
-        mutex.wait();
-    }
-
-    void unlock()
-    {
-        mutex.post();
-    }
-};
-
-
-
-RateThread::RateThread(int period) : mPriv(new Private(*this, period))
+RateThread::RateThread(int period) :
+        PeriodicThread(period / 1000.0)
 {
 }
 
 RateThread::~RateThread()
 {
-    delete mPriv;
 }
 
 bool RateThread::setRate(int period)
 {
-    return mPriv->setRate(period);
+    return PeriodicThread::setPeriod(period / 1000.0);
 }
 
 double RateThread::getRate()
 {
-    return mPriv->getRate();
+    return PeriodicThread::getPeriod() * 1000;
 }
 
 bool RateThread::isSuspended()
 {
-    return mPriv->isSuspended();
-}
-
-bool RateThread::join(double seconds)
-{
-    return ((ThreadImpl*)mPriv)->join(seconds);
+    return PeriodicThread::isSuspended();
 }
 
 void RateThread::stop()
 {
-    ((ThreadImpl*)mPriv)->close();
+    PeriodicThread::stop();
 }
 
 void RateThread::askToStop()
 {
-    ((ThreadImpl*)mPriv)->askToClose();
+    PeriodicThread::askToStop();
 }
 
 bool RateThread::step()
 {
-    mPriv->singleStep();
+    PeriodicThread::step();
     return true;
 }
 
 bool RateThread::start()
 {
-    return ((ThreadImpl*)mPriv)->start();
+    return PeriodicThread::start();
 }
 
 bool RateThread::isRunning()
 {
-    return ((ThreadImpl*)mPriv)->isRunning();
+    return PeriodicThread::isRunning();
 }
 
 void RateThread::suspend()
 {
-    mPriv->suspend();
+    PeriodicThread::suspend();
 }
 
 void RateThread::resume()
 {
-    mPriv->resume();
+    PeriodicThread::resume();
 }
 
 unsigned int RateThread::getIterations()
 {
-    return mPriv->getIterations();
+    return PeriodicThread::getIterations();
 }
 
 double RateThread::getEstPeriod()
 {
-    return mPriv->getEstPeriod();
+    return PeriodicThread::getEstimatedPeriod() * 1000;
 }
 
 double RateThread::getEstUsed()
 {
-    return mPriv->getEstUsed();
+    return PeriodicThread::getEstimatedUsed() * 1000;
 }
 
 void RateThread::getEstPeriod(double &av, double &std)
 {
-    mPriv->getEstPeriod(av, std);
+    PeriodicThread::getEstimatedPeriod(av, std);
+    av*=1000;
+    std*=1000;
 }
 
 void RateThread::getEstUsed(double &av, double &std)
 {
-    mPriv->getEstUsed(av, std);
+    PeriodicThread::getEstimatedUsed(av, std);
+    av*=1000;
+    std*=1000;
 }
 
 void RateThread::resetStat()
 {
-    mPriv->resetStat();
+    PeriodicThread::resetStat();
 }
 
 bool RateThread::threadInit()
@@ -440,52 +135,53 @@ void RateThread::afterStart(bool success)
 
 int RateThread::setPriority(int priority, int policy)
 {
-    return ((ThreadImpl*)mPriv)->setPriority(priority, policy);
+    return PeriodicThread::setPriority(priority, policy);
 }
 
 int RateThread::getPriority()
 {
-    return ((ThreadImpl*)mPriv)->getPriority();
+    return PeriodicThread::getPriority();
 }
 
 int RateThread::getPolicy()
 {
-    return ((ThreadImpl*)mPriv)->getPolicy();
+    return PeriodicThread::getPolicy();
 }
 
 //
 //  System Rate Thread
 //
 
-SystemRateThread::SystemRateThread(int period) : RateThread(period)
+SystemRateThread::SystemRateThread(int period) : PeriodicThread(period/1000.0, ShouldUseSystemClock::Yes)
 {
-    mPriv->initWithSystemClock();
 }
 
 SystemRateThread::~SystemRateThread()
-{ }
+{
+}
 
 bool SystemRateThread::stepSystem()
 {
-    RateThread::mPriv->singleStepSystem();
+    step();
     return true;
 }
 
+#endif
 
-RateThreadWrapper::RateThreadWrapper(): RateThread(0)
+RateThreadWrapper::RateThreadWrapper(): PeriodicThread(0)
 {
     helper = nullptr;
     owned = false;
 }
 
 
-RateThreadWrapper::RateThreadWrapper(Runnable *helper): RateThread(0)
+RateThreadWrapper::RateThreadWrapper(Runnable *helper): PeriodicThread(0)
 {
     this->helper = helper;
     owned = true;
 }
 
-RateThreadWrapper::RateThreadWrapper(Runnable& helper): RateThread(0)
+RateThreadWrapper::RateThreadWrapper(Runnable& helper): PeriodicThread(0)
 {
     this->helper = &helper;
     owned = false;
@@ -525,18 +221,18 @@ bool RateThreadWrapper::attach(Runnable *helper)
 
 bool RateThreadWrapper::open(double framerate, bool polling)
 {
-    int period = 0;
+    double period = 0.0;
     if (framerate>0) {
-        period=(int) (0.5+1000.0/framerate);
+        period=(1.0/framerate);
         YARP_SPRINTF2(Logger::get(), info,
-                      "Setting framerate to: %.0lf[Hz] (thread period %d[ms])\n",
+                      "Setting framerate to: %.0lf[Hz] (thread period %f[s])\n",
                       framerate, period);
     } else {
         YARP_SPRINTF0(Logger::get(), info,
                       "No framerate specified, polling the device");
-        period=0; //continuous
+        period=0.0; //continuous
     }
-    RateThread::setRate(period);
+    PeriodicThread::setPeriod(period);
     if (!polling) {
         start();
     }
@@ -545,12 +241,12 @@ bool RateThreadWrapper::open(double framerate, bool polling)
 
 void RateThreadWrapper::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 }
 
 void RateThreadWrapper::stop()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
 }
 
 void RateThreadWrapper::run()

--- a/src/libYARP_OS/src/SystemInfo.cpp
+++ b/src/libYARP_OS/src/SystemInfo.cpp
@@ -58,7 +58,7 @@ extern char **environ;
 # pragma comment(lib, "wbemuuid.lib")  // for get process arguments from pid
 #endif
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 
 #include <vector>
@@ -114,11 +114,11 @@ bool getCpuEntry(const char* tag, const char *buff, std::string& value)
 #endif
 
 
-#if defined(_WIN32)
-class CpuLoadCollector: public yarp::os::SystemRateThread
+#if  defined(_WIN32)
+class CpuLoadCollector: public yarp::os::PeriodicThread
 {
 public:
-    CpuLoadCollector():SystemRateThread(5000)
+    CpuLoadCollector():PeriodicThread(5.000, ShouldUseSystemClock::Yes)
     {
        firstRun = true;
        load.cpuLoad1 = 0.0;

--- a/src/libYARP_OS/src/Timer.cpp
+++ b/src/libYARP_OS/src/Timer.cpp
@@ -7,7 +7,7 @@
 */
 
 #include <yarp/os/Timer.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Time.h>
 #include <cmath>
 #include <map>
@@ -101,12 +101,12 @@ public:
     }
 };
 
-class TimerSingleton : public yarp::os::RateThread
+class TimerSingleton : public yarp::os::PeriodicThread
 {
     std::mutex mu;
     std::map<size_t, MonoThreadTimer*> timers;
     TimerSingleton() :
-            RateThread(0)
+            PeriodicThread(0.0)
     {
     }
 
@@ -180,7 +180,7 @@ void TimerSingleton::run()
 }
 
 class ThreadedTimer : public yarp::os::Timer::PrivateImpl,
-                      public yarp::os::RateThread
+                      public yarp::os::PeriodicThread
 {
     typedef yarp::os::Timer::TimerCallback TimerCallback;
     virtual void run() override;
@@ -189,7 +189,7 @@ class ThreadedTimer : public yarp::os::Timer::PrivateImpl,
 
 public:
     ThreadedTimer(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) :
-            PrivateImpl(sett, call, mutex), RateThread((int)(sett.period * 1000))
+            PrivateImpl(sett, call, mutex), PeriodicThread(sett.period)
     {
     }
 
@@ -207,7 +207,8 @@ public:
     virtual bool stepTimer() override
     {
         singleStep = true;
-        return step();
+        step();
+        return true;
     }
 
     virtual void stopTimer() override

--- a/src/libYARP_OS/src/Timer.cpp
+++ b/src/libYARP_OS/src/Timer.cpp
@@ -189,7 +189,7 @@ class ThreadedTimer : public yarp::os::Timer::PrivateImpl,
 
 public:
     ThreadedTimer(TimerSettings sett, TimerCallback call, yarp::os::Mutex* mutex = nullptr) :
-            PrivateImpl(sett, call, mutex), RateThread((int)(sett.rate * 1000))
+            PrivateImpl(sett, call, mutex), RateThread((int)(sett.period * 1000))
     {
     }
 
@@ -256,8 +256,8 @@ YarpTimerEvent yarp::os::Timer::PrivateImpl::getEventNow(unsigned int iteration)
     YarpTimerEvent event;
 
     event.currentReal = yarp::os::Time::now();
-    event.currentExpected = m_startStamp + iteration * m_settings.rate;
-    event.lastExpected = event.currentExpected - m_settings.rate;
+    event.currentExpected = m_startStamp + iteration * m_settings.period;
+    event.lastExpected = event.currentExpected - m_settings.period;
     event.lastReal = m_lastReal;
     event.lastDuration = event.currentReal - m_lastReal;
     event.runCount = iteration;

--- a/src/libYARP_dev/include/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/include/yarp/dev/IJoypadController.h
@@ -12,7 +12,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <map>
 #include <vector>
 
@@ -201,7 +201,7 @@ public:
 
 
 
-class YARP_dev_API yarp::dev::IJoypadEventDriven : yarp::os::RateThread,
+class YARP_dev_API yarp::dev::IJoypadEventDriven : yarp::os::PeriodicThread,
                                                    public yarp::dev::IJoypadController
 {
 private:
@@ -253,8 +253,10 @@ public:
 
 
     IJoypadEventDriven();
-
-    IJoypadEventDriven(int rate);
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+    explicit IJoypadEventDriven(YARP_DEPRECATED_MSG("Use IJoypadEventDriven(double)") int rate);
+#endif
+    explicit IJoypadEventDriven(double period);
 
     virtual bool threadInit() override final;
     virtual void run() override final;

--- a/src/libYARP_dev/src/IJoypadController.cpp
+++ b/src/libYARP_dev/src/IJoypadController.cpp
@@ -21,13 +21,17 @@ using namespace yarp::os;
 
 #define JoyData yarp::dev::IJoypadEvent::joyData
 
-yarp::dev::IJoypadEventDriven::IJoypadEventDriven() : IJoypadEventDriven(10){}
+yarp::dev::IJoypadEventDriven::IJoypadEventDriven() : IJoypadEventDriven(0.01){}
 
-yarp::dev::IJoypadEventDriven::IJoypadEventDriven(int rate) : RateThread(rate)
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+yarp::dev::IJoypadEventDriven::IJoypadEventDriven(int rate) : IJoypadEventDriven(rate / 1000.0) {}
+#endif
+yarp::dev::IJoypadEventDriven::IJoypadEventDriven(double period) : PeriodicThread(period),
+                                                                   m_event(nullptr),
+                                                                   EventDrivenEnabled(false)
 {
-    EventDrivenEnabled = false;
-    m_event = nullptr;
 }
+
 
 bool isEqual(const float& a, const float& b, const float& tolerance)
 {

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -153,7 +153,7 @@ AnalogPortEntry &AnalogPortEntry::operator =(const AnalogPortEntry &alt)
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 // Constructor used when there is only one output port
-AnalogWrapper::AnalogWrapper(const char* name, int rate): RateThread(rate)
+AnalogWrapper::AnalogWrapper(const char* name, int rate): PeriodicThread(rate / 1000.0)
 {
     // init ROS struct
     useROS          = ROS_disabled;
@@ -179,14 +179,14 @@ bool AnalogWrapper::createPort(const char* name, int rate)
     analogPorts[0].length = -1; // max length
     analogPorts[0].port_name = std::string(name);
     setHandlers();
-    setRate(rate);
+    setPeriod(rate / 1000.0);
     return true;
 }
 
 #ifndef YARP_NO_DEPRECATED // since YARP 2.3.70
 // Contructor used when one or more output ports are specified
 AnalogWrapper::AnalogWrapper(const std::vector<AnalogPortEntry>& _analogPorts, int rate):
-    RateThread(rate),
+    PeriodicThread(rate / 1000.0),
     _rate(rate),
     sensorId("AnalogServer"),
     useROS(ROS_disabled),
@@ -207,12 +207,12 @@ bool AnalogWrapper::createPorts(const std::vector<AnalogPortEntry>& _analogPorts
     analogSensor_p=nullptr;
     this->analogPorts=_analogPorts;
     setHandlers();
-    setRate(rate);
+    setPeriod(rate / 1000.0);
     return true;
 }
 
 AnalogWrapper::AnalogWrapper() :
-        RateThread(DEFAULT_THREAD_PERIOD),
+        PeriodicThread(DEFAULT_THREAD_PERIOD / 1000.0),
         ownDevices(false),
         subDeviceOwned(nullptr)
 {
@@ -297,8 +297,8 @@ bool AnalogWrapper::openAndAttachSubDevice(Searchable &prop)
     }
 
     attach(analogSensor_p);
-    RateThread::setRate(_rate);
-    return RateThread::start();
+    PeriodicThread::setPeriod(_rate / 1000.0);
+    return PeriodicThread::start();
 }
 
 
@@ -340,8 +340,8 @@ bool AnalogWrapper::attachAll(const PolyDriverList &analog2attach)
         return false;
     }
     attach(analogSensor_p);
-    RateThread::setRate(_rate);
-    return RateThread::start();
+    PeriodicThread::setPeriod(_rate / 1000.0);
+    return PeriodicThread::start();
 }
 
 bool AnalogWrapper::detachAll()
@@ -916,9 +916,9 @@ void AnalogWrapper::run()
 bool AnalogWrapper::close()
 {
     yTrace("AnalogWrapper::Close");
-    if (RateThread::isRunning())
+    if (PeriodicThread::isRunning())
     {
-        RateThread::stop();
+        PeriodicThread::stop();
     }
 
     detachAll();

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.h
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.h
@@ -22,7 +22,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Property.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Stamp.h>
 
@@ -168,7 +168,7 @@ namespace yarp{
 
 
 
-class yarp::dev::AnalogWrapper: public yarp::os::RateThread,
+class yarp::dev::AnalogWrapper: public yarp::os::PeriodicThread,
                                 public yarp::dev::DeviceDriver,
                                 public yarp::dev::IMultipleWrapper
 {

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -19,7 +19,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Vocab.h>
 
@@ -255,7 +255,7 @@ public:
  */
 
 class yarp::dev::ControlBoardWrapper:   public yarp::dev::DeviceDriver,
-                                        public yarp::os::RateThread,
+                                        public yarp::os::PeriodicThread,
                                         public yarp::dev::IPidControl,
                                         public yarp::dev::IPositionControl,
                                         public yarp::dev::IPositionDirect,
@@ -322,7 +322,7 @@ private:
     int               controlledJoints;
     int               base;         // to be removed
     int               top;          // to be removed
-    int               period;       // thread rate for publishing data
+    double            period;       // thread rate for publishing data
     bool              _verb;        // make it work and propagate to subdevice if --subdevice option is used
 
     yarp::os::Bottle getOptions();
@@ -370,7 +370,7 @@ public:
     bool verbose() const { return _verb; }
 
     /* Return id of this device */
-    std::string getId() { return partName; };
+    std::string getId() { return partName; }
 
     /**
     * Default open() method.

--- a/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.h
+++ b/src/libYARP_dev/src/devices/JoypadControlClient/JoypadControlClient.h
@@ -8,10 +8,9 @@
 
 #include <yarp/dev/IJoypadController.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <vector>
 #include <JoypadControlNetUtils.h>
-#include <yarp/os/RateThread.h>
 
 /**
 * @ingroup dev_impl_network_clients
@@ -36,10 +35,10 @@ namespace yarp
     }
 }
 
-class yarp::dev::JoypadControlWatchdog : public yarp::os::RateThread
+class yarp::dev::JoypadControlWatchdog : public yarp::os::PeriodicThread
 {
 public:
-    JoypadControlWatchdog() : RateThread(250) {}
+    JoypadControlWatchdog() : PeriodicThread(0.250) {}
     virtual ~JoypadControlWatchdog() = default;
 
 

--- a/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.h
+++ b/src/libYARP_dev/src/devices/JoypadControlServer/JoypadControlServer.h
@@ -9,7 +9,7 @@
 #ifndef YARP_DEV_JOYPADCONTROLSERVER_JOYPADCONTROLSERVER_H
 #define YARP_DEV_JOYPADCONTROLSERVER_JOYPADCONTROLSERVER_H
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IJoypadController.h>
 #include <yarp/dev/Wrapper.h>
@@ -49,7 +49,7 @@ public:
 class yarp::dev::JoypadControlServer: public yarp::dev::DeviceDriver,
                                       public yarp::dev::IWrapper,
                                       public yarp::dev::IMultipleWrapper,
-                                      public yarp::os::RateThread
+                                      public yarp::os::PeriodicThread
 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -59,7 +59,7 @@ class yarp::dev::JoypadControlServer: public yarp::dev::DeviceDriver,
     #define JoyPort yarp::dev::JoypadControl::JoyPort
 
 
-    unsigned int                    m_rate;
+    double                          m_period;
     JoypadCtrlParser                m_parser;
     yarp::dev::IJoypadController*   m_device;
     yarp::os::Port                  m_rpcPort;

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -170,7 +170,7 @@ bool RGBDSensorParser::respond(const Bottle& cmd, Bottle& response)
 
 
 RGBDSensorWrapper::RGBDSensorWrapper() :
-    RateThread(DEFAULT_THREAD_PERIOD),
+    PeriodicThread(DEFAULT_THREAD_PERIOD),
     rosNode(nullptr),
     nodeSeq(0),
     period(DEFAULT_THREAD_PERIOD),
@@ -251,7 +251,7 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
             yInfo() << "RGBDSensorWrapper: using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "ms";
     }
     else
-        period = config.find("period").asInt32();
+        period = config.find("period").asInt32() / 1000.0;
 
     Bottle &rosGroup = config.findGroup("ROS");
     if(rosGroup.isNull())
@@ -551,14 +551,14 @@ bool RGBDSensorWrapper::attachAll(const PolyDriverList &device2attach)
     if(!attach(sensor_p))
         return false;
 
-    RateThread::setRate(period);
-    return RateThread::start();
+    PeriodicThread::setPeriod(period);
+    return PeriodicThread::start();
 }
 
 bool RGBDSensorWrapper::detachAll()
 {
-    if (yarp::os::RateThread::isRunning())
-        yarp::os::RateThread::stop();
+    if (yarp::os::PeriodicThread::isRunning())
+        yarp::os::PeriodicThread::stop();
 
     //check if we already instantiated a subdevice previously
     if (isSubdeviceOwned)
@@ -590,8 +590,8 @@ bool RGBDSensorWrapper::attach(yarp::dev::IRGBDSensor *s)
         }
     }
 
-    RateThread::setRate(period);
-    return RateThread::start();
+    PeriodicThread::setPeriod(period);
+    return PeriodicThread::start();
 }
 
 bool RGBDSensorWrapper::attach(PolyDriver* poly)
@@ -613,8 +613,8 @@ bool RGBDSensorWrapper::attach(PolyDriver* poly)
         yError() << "RGBD wrapper: error configuring interfaces for parsers";
         return false;
     }
-    RateThread::setRate(period);
-    return RateThread::start();
+    PeriodicThread::setPeriod(period);
+    return PeriodicThread::start();
 }
 
 bool RGBDSensorWrapper::detach()

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 
 
@@ -57,7 +57,7 @@ namespace yarp{
     }
 }
 
-#define DEFAULT_THREAD_PERIOD   30 //ms
+#define DEFAULT_THREAD_PERIOD   0.03 //m
 
 // Following three definitions would fit better in a header file
 // shared between client and server ... where to place it?
@@ -128,7 +128,7 @@ public:
 class yarp::dev::RGBDSensorWrapper: public yarp::dev::DeviceDriver,
                                     public yarp::dev::IWrapper,
                                     public yarp::dev::IMultipleWrapper,
-                                    public yarp::os::RateThread
+                                    public yarp::os::PeriodicThread
 {
 private:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -180,7 +180,7 @@ private:
 
     // Image data specs
     // int hDim, vDim;
-    UInt                           period;
+    double                         period;
     std::string                    sensorId;
     yarp::dev::IRGBDSensor*        sensor_p;
     yarp::dev::IFrameGrabberControls* fgCtrl;

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -13,7 +13,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Semaphore.h>
@@ -48,7 +48,7 @@ namespace yarp{
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-const int DIAGNOSTIC_THREAD_RATE=1000;
+const int DIAGNOSTIC_THREAD_PERIOD=1.000;
 const double TIMEOUT=0.5;
 
 inline bool getTimeStamp(Bottle &bot, Stamp &st)
@@ -72,13 +72,13 @@ struct yarp::dev::ProtocolVersion
 };
 
 
-class DiagnosticThread: public RateThread
+class DiagnosticThread: public PeriodicThread
 {
     StateExtendedInputPort *owner;
     std::string ownerName;
 
 public:
-    DiagnosticThread(int r): RateThread(r)
+    DiagnosticThread(double r): PeriodicThread(r)
     { owner=nullptr; }
 
     void setOwner(StateExtendedInputPort *o)
@@ -1158,7 +1158,7 @@ public:
 
         if (config.check("diagnostic"))
         {
-            diagnosticThread = new DiagnosticThread(DIAGNOSTIC_THREAD_RATE);
+            diagnosticThread = new DiagnosticThread(DIAGNOSTIC_THREAD_PERIOD);
             diagnosticThread->setOwner(&extendedIntputStatePort);
             diagnosticThread->start();
         }

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.cpp
@@ -191,7 +191,7 @@ bool yarp::dev::impl::ServerGrabberResponder::respond(const os::Bottle &command,
 
 // **********ServerGrabber**********
 
-ServerGrabber::ServerGrabber():RateThread(DEFAULT_THREAD_PERIOD), period(DEFAULT_THREAD_PERIOD) {
+ServerGrabber::ServerGrabber():PeriodicThread(DEFAULT_THREAD_PERIOD), period(DEFAULT_THREAD_PERIOD) {
     responder = nullptr;
     responder2 =nullptr;
     rgbVis_p = nullptr;
@@ -362,7 +362,7 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
 {
     if(config.check("period","refresh period(in ms) of the broadcasted values through yarp ports")
             && config.find("period").isInt32())
-        period = config.find("period").asInt32();
+        period = config.find("period").asInt32() / 1000.0;
     else
         yWarning()<<"ServerGrabber: period parameter not found, using default of"<< DEFAULT_THREAD_PERIOD << "ms";
     if((config.check("subdevice")) && (config.check("left_config") || config.check("right_config")))
@@ -937,8 +937,8 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
         }
     }
 
-    RateThread::setRate(period);
-    ret = RateThread::start();
+    PeriodicThread::setPeriod(period);
+    ret = PeriodicThread::start();
 
     return ret;
 }
@@ -953,8 +953,8 @@ bool ServerGrabber::detachAll()
 }
 void ServerGrabber::stopThread()
 {
-    if (yarp::os::RateThread::isRunning())
-        yarp::os::RateThread::stop();
+    if (yarp::os::PeriodicThread::isRunning())
+        yarp::os::PeriodicThread::stop();
 
     rgbVis_p       = nullptr;
     rgbVis_p2      = nullptr;

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
@@ -22,11 +22,10 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/IVisualParamsImpl.h>
-#include <yarp/os/RateThread.h>
 #include <yarp/dev/Wrapper.h>
 namespace yarp {
     namespace dev {
@@ -85,7 +84,7 @@ typedef struct
 
 } Configuration;
 
-#define DEFAULT_THREAD_PERIOD   30 //ms
+#define DEFAULT_THREAD_PERIOD   0.03 //s
 
 
 /**
@@ -181,10 +180,10 @@ typedef struct
 class YARP_dev_API yarp::dev::ServerGrabber : public DeviceDriver,
             public yarp::dev::IWrapper,
             public yarp::dev::IMultipleWrapper,
-            public yarp::os::RateThread
+            public yarp::os::PeriodicThread
 {
 private:
-    int period;
+    double period;
     int count, count2;
     yarp::dev::impl::ServerGrabberResponder* responder;
     yarp::dev::impl::ServerGrabberResponder* responder2;

--- a/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+++ b/src/libYARP_dev/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
@@ -19,7 +19,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Vocab.h>
 
 #include <yarp/dev/PolyDriver.h>

--- a/src/libYARP_logger/include/yarp/logger/YarpLogger.h
+++ b/src/libYARP_logger/include/yarp/logger/YarpLogger.h
@@ -17,7 +17,7 @@
 #include <yarp/os/Vocab.h>
 
 #include <yarp/os/Thread.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 
 #include <list>
@@ -185,10 +185,10 @@ class yarp::yarpLogger::LogEntry
 class yarp::yarpLogger::LoggerEngine
 {
     //private class
-    class logger_thread : public yarp::os::SystemRateThread
+    class logger_thread : public yarp::os::PeriodicThread
     {
         public:
-        logger_thread (std::string _portname, int _rate=10, int _log_list_max_size=100);
+        logger_thread (std::string _portname, double _period=0.01, int _log_list_max_size=100);
         public:
         yarp::os::Semaphore  mutex;
         unsigned int         log_list_max_size;

--- a/src/libYARP_logger/src/YarpLogger.cpp
+++ b/src/libYARP_logger/src/YarpLogger.cpp
@@ -201,7 +201,7 @@ std::string LoggerEngine::logger_thread::getPortName()
     return logger_portName;
 }
 
-LoggerEngine::logger_thread::logger_thread (std::string _portname, int _rate,  int _log_list_max_size) : SystemRateThread(_rate)
+LoggerEngine::logger_thread::logger_thread (std::string _portname, double _period,  int _log_list_max_size) : PeriodicThread(_period, ShouldUseSystemClock::Yes)
 {
         logger_portName              = _portname;
         log_list_max_size            = _log_list_max_size;
@@ -447,8 +447,7 @@ void LoggerEngine::stop_discover()
 
 LoggerEngine::LoggerEngine(std::string portName)
 {
-    int thread_rate = 10;
-    log_updater=new logger_thread (portName,thread_rate);
+    log_updater=new logger_thread (portName, 0.01);
     logging = false;
     discovering = false;
 }

--- a/src/libYARP_manager/include/yarp/manager/executable.h
+++ b/src/libYARP_manager/include/yarp/manager/executable.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 #include <yarp/os/Semaphore.h>
 
@@ -27,8 +27,8 @@ namespace yarp {
 namespace manager {
 
 
-#define DEF_PERIOD      100  //ms
-#define WDOG_PERIOD     5000 //ms
+#define DEF_PERIOD      0.1  //s
+#define WDOG_PERIOD     5.0 //s
 
 typedef enum __RSTATE {
     SUSPENDED,
@@ -194,12 +194,12 @@ private:
 };
 
 
-class ConcurentRateWrapper: public yarp::os::RateThread
+class ConcurentRateWrapper: public yarp::os::PeriodicThread
 {
 public:
 
     ConcurentRateWrapper(Executable* ptrExecutable, ExecutableFuncPtr ptrLabor)
-    : RateThread(WDOG_PERIOD), labor(ptrLabor), executable(ptrExecutable) { }
+    : PeriodicThread(WDOG_PERIOD), labor(ptrLabor), executable(ptrExecutable) { }
 
     virtual ~ConcurentRateWrapper() { if(isRunning()) stop(); }
 

--- a/src/libYARP_manager/include/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/localbroker.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Property.h>
 #include <string>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 
 #include <yarp/manager/broker.h>

--- a/src/libYARP_manager/include/yarp/manager/yarpbroker.h
+++ b/src/libYARP_manager/include/yarp/manager/yarpbroker.h
@@ -18,7 +18,7 @@
 #include <yarp/os/Property.h>
 #include <string>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 // FIXME Do not use yarp/os/impl in .h files
 #include <yarp/os/SystemInfo.h>
@@ -34,7 +34,7 @@ namespace manager {
 /**
  * Class Broker
  */
-class YarpBroker: public Broker, public yarp::os::RateThread {
+class YarpBroker: public Broker, public yarp::os::PeriodicThread {
 
 public:
     YarpBroker();

--- a/src/libYARP_manager/src/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarpbroker.cpp
@@ -22,7 +22,7 @@
 #define RUN_TIMEOUT             10.0        //seconds
 #define STOP_TIMEOUT            15.0
 #define KILL_TIMEOUT            10.0
-#define EVENT_THREAD_PERIOD     500
+#define EVENT_THREAD_PERIOD     0.5 //seconds
 
 #if defined(_WIN32)
     #define SIGKILL 9
@@ -41,7 +41,7 @@ using namespace std;
 using namespace yarp::manager;
 
 
-YarpBroker::YarpBroker() : RateThread(EVENT_THREAD_PERIOD)
+YarpBroker::YarpBroker() : PeriodicThread(EVENT_THREAD_PERIOD)
 {
     bOnlyConnector = bInitialized = false;
     ID = generateID();
@@ -56,8 +56,8 @@ YarpBroker::~YarpBroker()
 
 void YarpBroker::fini()
 {
-    if(RateThread::isRunning())
-        RateThread::stop();
+    if(PeriodicThread::isRunning())
+        PeriodicThread::stop();
     //port.close();
 }
 
@@ -204,9 +204,9 @@ bool YarpBroker::start()
         {
             if(strStdioUUID.size())
             {
-                if(RateThread::isRunning())
-                    RateThread::stop();
-                RateThread::start();
+                if(PeriodicThread::isRunning())
+                    PeriodicThread::stop();
+                PeriodicThread::start();
             }
             return true;
         }
@@ -253,7 +253,7 @@ bool YarpBroker::stop()
     {
         if(running() == 0)
         {
-            RateThread::stop();
+            PeriodicThread::stop();
             return true;
         }
     }
@@ -262,7 +262,7 @@ bool YarpBroker::stop()
     strError += strCmd;
     strError += " on ";
     strError += strHost;
-    RateThread::stop();
+    PeriodicThread::stop();
     return false;
 }
 
@@ -301,7 +301,7 @@ bool YarpBroker::kill()
     {
         if(running() == 0)
         {
-            RateThread::stop();
+            PeriodicThread::stop();
             return true;
         }
     }
@@ -310,7 +310,7 @@ bool YarpBroker::kill()
     strError += strCmd;
     strError += " on ";
     strError += strHost;
-    RateThread::stop();
+    PeriodicThread::stop();
     return false;
 }
 

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -267,7 +267,7 @@ private:
 
 
 /**************************************************************************/
-class DumpThread : public RateThread
+class DumpThread : public PeriodicThread
 {
 private:
     DumpQueue      &buf;
@@ -300,7 +300,7 @@ private:
 public:
     DumpThread(DumpType _type, DumpQueue &Q, const string &_dirName, int szToWrite,
                bool _saveData, bool _videoOn, const string &_videoType) :
-        RateThread(50),
+        PeriodicThread(0.05),
         buf(Q),
         type(_type),
         dirName(_dirName),

--- a/src/yarpdataplayer/include/worker.h
+++ b/src/yarpdataplayer/include/worker.h
@@ -22,7 +22,7 @@
 
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/ImageFile.h>
 #include "include/utils.h"
 #include <yarp/os/Event.h>
@@ -113,7 +113,7 @@ public:
 
 //};
 /**********************************************************/
-class MasterThread : public QObject,  public yarp::os::RateThread
+class MasterThread : public QObject,  public yarp::os::PeriodicThread
 {
 
     friend class Utilities;

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -267,7 +267,7 @@ void WorkerClass::setManager(Utilities *utilities)
 /**********************************************************/
 MasterThread::MasterThread(Utilities *utilities, int numPart, QMainWindow *gui, QObject *parent) :
     QObject(parent),
-    RateThread (2),
+    PeriodicThread (0.002),
     utilities(utilities),
     numPart(numPart),
     timePassed(0.0),
@@ -369,7 +369,7 @@ void MasterThread::runNormally()
         }
     }
     
-    this->setRate( (int) (2 / utilities->speed) );
+    this->setPeriod( (2 / utilities->speed) / 1000.0 );
     for (int i=0; i < numPart; i++){
        // virtualTime += utilities->partDetails[i].worker->getFrameRate()/4.16;//0.0024;
     }
@@ -445,7 +445,7 @@ void MasterThread::pause()
 /**********************************************************/
 void MasterThread::resume()
 {
-    RateThread::resume();
+    PeriodicThread::resume();
 }
 
 /**********************************************************/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 cmake_dependent_option(YARP_DISABLE_FAILING_TESTS OFF "Disable tests that fail randomly due to race conditions"
                        "NOT ${CMAKE_VERSION} VERSION_LESS 3.9;YARP_COMPILE_TESTS" OFF)
 mark_as_advanced(YARP_DISABLE_FAILING_TESTS)
-set(FAILING_TESTS OS::RateThreadTest
+set(FAILING_TESTS OS::PeriodicThreadTest
                   dev::ControlBoardRemapperTest
                   dev::FrameTransformClientTest)
 

--- a/tests/libYARP_OS/PeriodicThreadTest.cpp
+++ b/tests/libYARP_OS/PeriodicThreadTest.cpp
@@ -7,8 +7,8 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/impl/NameServer.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Time.h>
@@ -404,7 +404,7 @@ public:
         busy.stop();
         checkTrue(true, "Negative delay on reteThread is safe.");
     }
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+
     void testRunnable()
     {
         report(0, "Testing runnable");
@@ -423,7 +423,6 @@ public:
 
         report(0, "successful");
     }
-#endif
 
 
     void testSimTime() {

--- a/tests/libYARP_OS/PeriodicThreadTest.cpp
+++ b/tests/libYARP_OS/PeriodicThreadTest.cpp
@@ -7,6 +7,7 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/RateThread.h>
 #include <yarp/os/impl/NameServer.h>
 #include <yarp/os/Network.h>
@@ -47,9 +48,9 @@ public:
     }
 };
 
-class RateThreadTest : public UnitTest {
+class PeriodicThreadTest : public UnitTest {
 private:
-    class RateThread1: public RateThread
+    class PeriodicThread1: public PeriodicThread
     {
     public:
         double t1;
@@ -58,7 +59,7 @@ private:
         double period;
         int n;
 
-        RateThread1(int r): RateThread(r){}
+        PeriodicThread1(double r): PeriodicThread(r){}
 
         virtual bool threadInit() override
         {
@@ -85,38 +86,47 @@ private:
         virtual void threadRelease() override
         {
             if (n>0)
-                period=1000*average/(n-1);
+                period=average/(n-1);
             else
                 period=0;
         }
 
     };
 
-    class RateThread2: public RateThread
+    class PeriodicThread2: public PeriodicThread
     {
     public:
         bool fail;
         int state;
 
-        RateThread2(int r): RateThread(r),fail(false),state(-1){}
+        PeriodicThread2(double r) :
+                PeriodicThread(r),
+                fail(false),
+                state(-1)
+        {
+        }
 
         void threadWillFail(bool f)
-        {fail=f;}
+        {
+            fail = f;
+        }
 
         virtual bool threadInit() override
         {
-            state=-1;
+            state = -1;
             return !fail;
         }
 
         virtual void afterStart(bool s) override
         {
-            if (s)
+            if (s) {
                 state=0;
+            }
         }
 
         virtual void run() override
-        {}
+        {
+        }
 
         virtual void threadRelease() override
         {
@@ -124,13 +134,13 @@ private:
         }
     };
 
-    class RateThread3: public RateThread
+    class PeriodicThread3: public PeriodicThread
     {
     public:
         bool fail;
         int state;
 
-        RateThread3(int r): RateThread(r),fail(false),state(-1){}
+        PeriodicThread3(double r): PeriodicThread(r),fail(false),state(-1){}
 
         void threadWillFail(bool f)
         {
@@ -164,12 +174,12 @@ private:
         }
     };
 
-    class RateThread4: public RateThread
+    class PeriodicThread4: public PeriodicThread
     {
     public:
         int count;
 
-        RateThread4(int r): RateThread(r),count(10){}
+        PeriodicThread4(double r): PeriodicThread(r),count(10){}
 
         virtual void run() override
         {
@@ -177,17 +187,17 @@ private:
 
                //terminate when count is zero
                if (count==0)
-                   RateThread::askToStop();
+                   PeriodicThread::askToStop();
         }
 
     };
 
-    class RateThread5: public RateThread
+    class PeriodicThread5: public PeriodicThread
     {
     public:
         int count;
 
-        RateThread5(int r): RateThread(r),count(0){}
+        PeriodicThread5(double r): PeriodicThread(r),count(0){}
 
         virtual void run() override {
             count++;
@@ -200,12 +210,12 @@ private:
      * The delay will be a negative number.
      * Check that thread does not hangs forever.
      */
-    class BusyThread: public RateThread
+    class BusyThread: public PeriodicThread
     {
     public:
         int count;
 
-        BusyThread(int r): RateThread(r),count(0){}
+        BusyThread(double r): PeriodicThread(r),count(0){}
 
         virtual void run() override {
             printf("BusyThread running ...\n");
@@ -213,11 +223,11 @@ private:
         }
     };
 
-    class AskForStopThread : public RateThread {
+    class AskForStopThread : public PeriodicThread {
     public:
         bool done;
 
-        AskForStopThread() : RateThread(100) {
+        AskForStopThread() : PeriodicThread(0.1) {
             done = false;
         }
 
@@ -265,12 +275,12 @@ private:
     };
 
 public:
-    virtual std::string getName() override { return "RateThreadTest"; }
+    virtual std::string getName() override { return "PeriodicThreadTest"; }
 
-    double test(int rate, double delay)
+    double test(double period, double delay)
     {
         double estPeriod=0;
-        RateThread1 *thread1=new RateThread1(rate);
+        PeriodicThread1 *thread1=new PeriodicThread1(period);
 
         thread1->start();
         Time::delay(delay);
@@ -285,7 +295,7 @@ public:
     void testInitSuccessFailure()
     {
         report(0,"checking init failure/success notification");
-        RateThread2 t(200);
+        PeriodicThread2 t(0.200);
         t.threadWillFail(false);
         t.start();
         checkTrue(t.isRunning(), "thread is running");
@@ -304,7 +314,7 @@ public:
     void testInitReleaseSynchro()
     {
         report(0,"Checking init/release synchronization");
-        RateThread3 t(200);
+        PeriodicThread3 t(0.200);
         t.threadWillFail(false);
         // if start does not wait for threadRelease/threadInit, a race condition
         // will be detected
@@ -321,7 +331,7 @@ public:
         report(0,"done");
     }
 
-    void testRateThread() {
+    void testPeriodicThread() {
         report(0,"testing rate thread precision");
         report(0,"setting high res scheduler (this affects only windows)");
 
@@ -332,35 +342,35 @@ public:
 
         //try plausible rates
         double desiredPeriod, actualPeriod;
-        desiredPeriod = 15;
-        sprintf(message, "Thread1 requested period: %d[ms]", (int)desiredPeriod);
+        desiredPeriod = 0.015;
+        sprintf(message, "Thread1 requested period: %f[s]", desiredPeriod);
         report(0, message);
         actualPeriod = test(desiredPeriod, 1);
         if( (actualPeriod > (desiredPeriod*(1-acceptedThreshold))) && (actualPeriod < (desiredPeriod * (1+acceptedThreshold))) )
             success = true;
-        sprintf(message, "Thread1 estimated period: %.2lf[ms]", actualPeriod);
+        sprintf(message, "Thread1 estimated period: %f[s]", actualPeriod);
         report(0, message);
         sprintf(message, "Period NOT within range of %d%%", (int)(acceptedThreshold*100));
         if(!success)  YARP_WARN(Logger::get(), message);
 
-        desiredPeriod = 10;
-        sprintf(message, "Thread2 requested period: %d[ms]", (int)desiredPeriod);
+        desiredPeriod = 0.010;
+        sprintf(message, "Thread2 requested period: %f[s]", desiredPeriod);
         report(0, message);
         actualPeriod = test(desiredPeriod, 1);
         if( (actualPeriod > (desiredPeriod*(1-acceptedThreshold))) && (actualPeriod < (desiredPeriod * (1+acceptedThreshold))) )
             success = true;
-        sprintf(message, "Thread2 estimated period: %.2lf[ms]", actualPeriod);
+        sprintf(message, "Thread2 estimated period: %f[s]", actualPeriod);
         report(0, message);
         sprintf(message, "Period NOT within range of %d%%", (int)(acceptedThreshold*100));
         if(!success)  YARP_WARN(Logger::get(), message);
 
-        desiredPeriod = 1;
-        sprintf(message, "Thread3 requested period: %d[ms]", (int)desiredPeriod);
+        desiredPeriod = 0.001;
+        sprintf(message, "Thread3 requested period: %f[s]", desiredPeriod);
         report(0, message);
         actualPeriod = test(desiredPeriod, 1);
         if( (actualPeriod > (desiredPeriod*(1-acceptedThreshold))) && (actualPeriod < (desiredPeriod * (1+acceptedThreshold))) )
             success = true;
-        sprintf(message, "Thread3 estimated period: %.2lf[ms]", actualPeriod);
+        sprintf(message, "Thread3 estimated period: %f[s]", actualPeriod);
         report(0, message);
         sprintf(message, "Period NOT within range of %d%%", (int)(acceptedThreshold*100));
         if(!success)  YARP_WARN(Logger::get(), message);
@@ -368,7 +378,7 @@ public:
         report(0, "successful");
 
         report(0, "Testing askToStop() function");
-        RateThread4 thread(10);
+        PeriodicThread4 thread(0.010);
         thread.start();
 
         bool running=true;
@@ -388,20 +398,20 @@ public:
         Time::delay(-2);
         checkTrue(true, "Negative Time::delay() and delaySystem() is safe.");
 
-        BusyThread  busy(10);
+        BusyThread  busy(0.010);
         busy.start();
         SystemClock::delaySystem(2);
         busy.stop();
         checkTrue(true, "Negative delay on reteThread is safe.");
     }
-
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
     void testRunnable()
     {
         report(0, "Testing runnable");
 
         Runnable1 foo;
         RateThreadWrapper t;
-        t.setRate(100);
+        t.setPeriod(0.1);
         t.attach(foo);
         t.start();
         checkTrue(t.isRunning(), "thread is running");
@@ -413,6 +423,7 @@ public:
 
         report(0, "successful");
     }
+#endif
 
 
     void testSimTime() {
@@ -421,7 +432,7 @@ public:
         Time::useCustomClock(&clock);
         checkTrue(Time::isCustomClock(), "isCustomClock is true");
         checkTrue(Time::getClockType() == YARP_CLOCK_CUSTOM, "getClockType is YARP_CLOCK_CUSTOM");
-        RateThread5 thread(100*1000); // 100 secs
+        PeriodicThread5 thread(100*1000); // 100 secs
         thread.start();
         SystemClock clk;
         for (int i=0; i<20; i++) {
@@ -460,15 +471,15 @@ public:
         testInitSuccessFailure();
         testInitReleaseSynchro();
         testRunnable();
-        testRateThread();
+        testPeriodicThread();
         testSimTime();
         testStartAskForStopStart();
     }
 };
 
-static RateThreadTest theRateThreadTest;
+static PeriodicThreadTest thePeriodicThreadTest;
 
-UnitTest& getRateThreadTest() {
-    return theRateThreadTest;
+UnitTest& getPeriodicThreadTest() {
+    return thePeriodicThreadTest;
 }
 

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -10,7 +10,7 @@
 #include <yarp/os/Port.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Thread.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/PortReaderBuffer.h>
@@ -53,7 +53,7 @@ namespace yarp {
  * A fake device for testing closure after a prepare of a closed port.
  */
 class yarp::dev::BrokenDevice : public DeviceDriver,
-                                public yarp::os::RateThread
+                                public yarp::os::PeriodicThread
 {
 private:
 
@@ -61,17 +61,17 @@ public:
     /**
      * Constructor.
      */
-    BrokenDevice():RateThread(30), img(nullptr){}
+    BrokenDevice():PeriodicThread(0.03), img(nullptr){}
 
     virtual bool close() override
     {
         pImg.close();
-        RateThread::stop();
+        PeriodicThread::stop();
         return true;
 
     }
 
-    virtual bool open(yarp::os::Searchable& config) override { return RateThread::start(); }
+    virtual bool open(yarp::os::Searchable& config) override { return PeriodicThread::start(); }
 
     //RateThread
     bool threadInit() override { return true; }
@@ -92,10 +92,10 @@ private:
 
 };
 
-class TcpTestServer : public RateThread
+class TcpTestServer : public PeriodicThread
 {
 public:
-    TcpTestServer() : RateThread(20)
+    TcpTestServer() : PeriodicThread(0.02)
     {
 
     }
@@ -1532,7 +1532,7 @@ public:
     }
 
     void testPrepareDeadlock(){
-        report(0,"testing the deadlock when you close a device(RateThread) after the prepare of a closed port");
+        report(0,"testing the deadlock when you close a device(PeriodicThread) after the prepare of a closed port");
         yarp::dev::PolyDriver p;
         Property prop;
         prop.put("device","brokenDevice");

--- a/tests/libYARP_OS/TestList.h
+++ b/tests/libYARP_OS/TestList.h
@@ -46,7 +46,7 @@ extern yarp::os::impl::UnitTest& getVocabTest();
 extern yarp::os::impl::UnitTest& getValueTest();
 extern yarp::os::impl::UnitTest& getPortablePairTest();
 extern yarp::os::impl::UnitTest& getTerminatorTest();
-extern yarp::os::impl::UnitTest& getRateThreadTest();
+extern yarp::os::impl::UnitTest& getPeriodicThreadTest();
 extern yarp::os::impl::UnitTest& getStampTest();
 extern yarp::os::impl::UnitTest& getRFModuleTest();
 extern yarp::os::impl::UnitTest& getPortReaderBufferTest();
@@ -80,7 +80,7 @@ public:
         root.add(getStreamConnectionReaderTest());
         root.add(getBufferedConnectionWriterTest());
         root.add(getThreadTest());
-        root.add(getRateThreadTest());
+        root.add(getPeriodicThreadTest());
         root.add(getProtocolTest());
         root.add(getNameServerTest());
         root.add(getPortCoreTest());

--- a/tests/libYARP_sig/ImageTest.cpp
+++ b/tests/libYARP_sig/ImageTest.cpp
@@ -24,7 +24,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/impl/Logger.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 #include "TestList.h"
 
@@ -33,12 +33,12 @@ using namespace yarp::sig;
 using namespace yarp::sig::draw;
 using namespace yarp::os;
 
-class readWriteTest : public yarp::os::RateThread
+class readWriteTest : public yarp::os::PeriodicThread
 {
     yarp::os::Port p;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> image;
 public:
-    readWriteTest() : RateThread(10) {}
+    readWriteTest() : PeriodicThread(0.01) {}
 
     yarp::sig::ImageOf<yarp::sig::PixelRgb> getImage()
     {


### PR DESCRIPTION
This PR deprecates `yarp::os::RateThread` in favour of `yarp::os::PeriodicThread`.
The main reason is that`RateThread` was afflicted by an ambigouity about the concept of `rate`.

:warning: Note that `RateThread` used the period in msec(int), `PeriodicThread`
requires the period in sec(double), so remember to consider a **x1000** factor
when migrate the code.

`demoRedBall` tested successfully on the `iCub_SIM`.

please review code.