### PR TITLE
[WIP] Quaternion and other math-related classes moved from libYARP_Math to libYARP_sig

### DIFF
--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
@@ -12,7 +12,7 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/dev/IFrameTransform.h>
 #include <yarp/math/Math.h>
-#include <yarp/math/FrameTransform.h>
+#include <yarp/sig/FrameTransform.h>
 
 #include <limits>
 #include <cmath>

--- a/src/devices/fakeLaser/fakeLaser.cpp
+++ b/src/devices/fakeLaser/fakeLaser.cpp
@@ -13,7 +13,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/math/Vec2D.h>
+#include <yarp/sig/Vec2D.h>
 #include <iostream>
 #include <limits>
 #include <cstring>

--- a/src/devices/map2DServer/Map2DServer.cpp
+++ b/src/devices/map2DServer/Map2DServer.cpp
@@ -671,7 +671,7 @@ bool Map2DServer::open(yarp::os::Searchable &config)
         map.setSize_in_cells(map_ros->info.width,map_ros->info.height);
         map.setResolution( map_ros->info.resolution);
         map.setMapName(map_name);
-        yarp::math::Quaternion quat(map_ros->info.origin.orientation.x,
+        yarp::sig::Quaternion quat(map_ros->info.origin.orientation.x,
                                     map_ros->info.origin.orientation.y,
                                     map_ros->info.origin.orientation.z,
                                     map_ros->info.origin.orientation.w);
@@ -800,7 +800,7 @@ bool Map2DServer::updateVizMarkers()
     yarp::rosmsg::visualization_msgs::Marker marker;
     yarp::rosmsg::TickTime    tt;
     yarp::sig::Vector         rpy(3);
-    yarp::math::Quaternion    q;
+    yarp::sig::Quaternion    q;
 
     yarp::rosmsg::visualization_msgs::MarkerArray& markers = m_rosPublisherPort_markers.prepare();
     markers.markers.clear();

--- a/src/devices/transformClient/FrameTransformClient.cpp
+++ b/src/devices/transformClient/FrameTransformClient.cpp
@@ -8,6 +8,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/LockGuard.h>
+#include <yarp/math/Math.h>
 
 /*! \file FrameTransformClient.cpp */
 
@@ -171,7 +172,7 @@ size_t   Transforms_client_storage::size()
     return m_transforms.size();
 }
 
-yarp::math::FrameTransform& Transforms_client_storage::operator[]   (std::size_t idx)
+yarp::sig::FrameTransform& Transforms_client_storage::operator[]   (std::size_t idx)
 {
     RecursiveLockGuard l(m_mutex);
     return m_transforms[idx];
@@ -838,7 +839,7 @@ bool yarp::dev::FrameTransformClient::transformPose(const std::string &target_fr
     return true;
 }
 
-bool yarp::dev::FrameTransformClient::transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion)
+bool yarp::dev::FrameTransformClient::transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Quaternion &input_quaternion, yarp::sig::Quaternion &transformed_quaternion)
 {
     yarp::sig::Matrix m(4, 4);
     if (!getTransform(target_frame_id, source_frame_id, m))

--- a/src/devices/transformClient/FrameTransformClient.h
+++ b/src/devices/transformClient/FrameTransformClient.h
@@ -18,7 +18,7 @@
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Time.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/math/FrameTransform.h>
+#include <yarp/sig/FrameTransform.h>
 #include <yarp/os/RecursiveMutex.h>
 #include <yarp/os/PeriodicThread.h>
 
@@ -49,18 +49,18 @@ private:
     int              m_state;
     int              m_count;
 
-    std::vector <yarp::math::FrameTransform> m_transforms;
+    std::vector <yarp::sig::FrameTransform> m_transforms;
 
 public:
     yarp::os::RecursiveMutex  m_mutex;
     size_t   size();
-    yarp::math::FrameTransform& operator[]   (std::size_t idx);
+    yarp::sig::FrameTransform& operator[]   (std::size_t idx);
     void clear();
 
 public:
     Transforms_client_storage (std::string port_name);
     ~Transforms_client_storage ( );
-    bool     set_transform(yarp::math::FrameTransform t);
+    bool     set_transform(yarp::sig::FrameTransform t);
     bool     delete_transform(std::string t1, std::string t2);
 
     inline void resetStat();
@@ -140,7 +140,7 @@ public:
      bool     deleteTransform(const std::string &target_frame_id, const std::string &source_frame_id) override;
      bool     transformPoint(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, yarp::sig::Vector &transformed_point) override;
      bool     transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, yarp::sig::Vector &transformed_pose) override;
-     bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) override;
+     bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Quaternion &input_quaternion, yarp::sig::Quaternion &transformed_quaternion) override;
      bool     waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) override;
 
      FrameTransformClient();

--- a/src/devices/transformServer/FrameTransformServer.cpp
+++ b/src/devices/transformServer/FrameTransformServer.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <limits>
 #include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/math/Math.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/LockGuard.h>

--- a/src/devices/transformServer/FrameTransformServer.h
+++ b/src/devices/transformServer/FrameTransformServer.h
@@ -35,7 +35,7 @@
 #include <yarp/dev/IFrameTransform.h>
 #include <string>
 
-#include <yarp/math/FrameTransform.h>
+#include <yarp/sig/FrameTransform.h>
 
 #include <yarp/rosmsg/geometry_msgs/TransformStamped.h>
 #include <yarp/rosmsg/tf2_msgs/TFMessage.h>
@@ -62,17 +62,17 @@ namespace yarp
 class Transforms_server_storage
 {
 private:
-    std::vector <yarp::math::FrameTransform> m_transforms;
+    std::vector <yarp::sig::FrameTransform> m_transforms;
     yarp::os::Mutex  m_mutex;
 
 public:
      Transforms_server_storage()      {}
      ~Transforms_server_storage()     {}
-     bool     set_transform           (yarp::math::FrameTransform t);
+     bool     set_transform           (yarp::sig::FrameTransform t);
      bool     delete_transform        (int id);
      bool     delete_transform        (std::string t1, std::string t2);
      inline size_t   size()                                             { return m_transforms.size(); }
-     inline yarp::math::FrameTransform& operator[]   (std::size_t idx)  { return m_transforms[idx]; }
+     inline yarp::sig::FrameTransform& operator[]   (std::size_t idx)  { return m_transforms[idx]; }
      void clear                       ();
 };
 

--- a/src/libYARP_dev/include/yarp/dev/IFrameTransform.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameTransform.h
@@ -12,7 +12,7 @@
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/sig/Matrix.h>
-#include <yarp/math/Quaternion.h>
+#include <yarp/sig/Quaternion.h>
 #include <vector>
 
 namespace yarp {
@@ -148,7 +148,7 @@ public:
     * @param transformed_quaternion the returned quaternion (x y z w)
     * @return true/false
     */
-    virtual bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) = 0;
+    virtual bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Quaternion &input_quaternion, yarp::sig::Quaternion &transformed_quaternion) = 0;
 
     /**
      Block until a transform from source_frame_id to target_frame_id is possible or it times out.

--- a/src/libYARP_dev/include/yarp/dev/Map2DLocation.h
+++ b/src/libYARP_dev/include/yarp/dev/Map2DLocation.h
@@ -10,7 +10,7 @@
 #define YARP_DEV_MAP2DLOCATION_H
 
 #include <yarp/os/Portable.h>
-#include <yarp/math/Vec2D.h>
+#include <yarp/sig/Vec2D.h>
 #include <yarp/dev/api.h>
 #include <sstream>
 #include <string>

--- a/src/libYARP_dev/include/yarp/dev/MapGrid2D.h
+++ b/src/libYARP_dev/include/yarp/dev/MapGrid2D.h
@@ -12,7 +12,7 @@
 #include <yarp/os/Portable.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/math/Vec2D.h>
+#include <yarp/sig/Vec2D.h>
 #include <yarp/dev/api.h>
 
 /**
@@ -26,8 +26,8 @@ namespace yarp
         {
             public:
             typedef yarp::sig::PixelMono CellData;
-            typedef yarp::math::Vec2D<int> XYCell;
-            typedef yarp::math::Vec2D<double> XYWorld;
+            typedef yarp::sig::Vec2D<int> XYCell;
+            typedef yarp::sig::Vec2D<double> XYWorld;
             enum map_flags
             {
                 MAP_CELL_FREE=0,

--- a/src/libYARP_dev/src/MapGrid2D.cpp
+++ b/src/libYARP_dev/src/MapGrid2D.cpp
@@ -10,6 +10,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/sig/ImageFile.h>
 #include <yarp/os/LogStream.h>
+#include <yarp/math/Math.h>
 #include <algorithm>
 #include <fstream>
 #include <cmath>

--- a/src/libYARP_math/CMakeLists.txt
+++ b/src/libYARP_math/CMakeLists.txt
@@ -22,10 +22,7 @@ if (YARP_HAS_MATH_LIB)
                      include/yarp/math/RandnVector.h
                      include/yarp/math/RandScalar.h
                      include/yarp/math/RandVector.h
-                     include/yarp/math/SVD.h
-                     include/yarp/math/Quaternion.h
-                     include/yarp/math/Vec2D.h
-                     include/yarp/math/FrameTransform.h)
+                     include/yarp/math/SVD.h)
 
   set(YARP_math_IMPL_HDRS)
 

--- a/src/libYARP_math/include/yarp/math/Math.h
+++ b/src/libYARP_math/include/yarp/math/Math.h
@@ -13,7 +13,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/api.h>
-#include <yarp/math/Quaternion.h>
+#include <yarp/sig/Quaternion.h>
 
 /**
 * Mathematical operations.
@@ -208,7 +208,7 @@ YARP_math_API yarp::sig::Vector& operator*=(yarp::sig::Vector &a, const yarp::si
 * @param b a quaternion
 * @return a*b
 */
-YARP_math_API yarp::math::Quaternion operator*(const yarp::math::Quaternion& a, const yarp::math::Quaternion& b);
+YARP_math_API yarp::sig::Quaternion operator*(const yarp::sig::Quaternion& a, const yarp::sig::Quaternion& b);
 
 /**
 * Vector-vector element-wise division operator (defined in Math.h).

--- a/src/libYARP_math/src/FrameTransform.cpp
+++ b/src/libYARP_math/src/FrameTransform.cpp
@@ -6,22 +6,40 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/math/FrameTransform.h>
-
+#include <yarp/sig/FrameTransform.h>
+#include <yarp/math/Math.h>
 #include <cstdio>
 
-std::string yarp::math::FrameTransform::toString()
+using namespace yarp::sig;
+using namespace yarp::math;
+
+void FrameTransform::rotFromRPY(double R, double P, double Y)
 {
-    char buff[1024];
-    sprintf(buff, "%s -> %s \n tran: %f %f %f \n rot: %f %f %f %f \n\n",
-                  src_frame_id.c_str(),
-                  dst_frame_id.c_str(),
-                  translation.tX,
-                  translation.tY,
-                  translation.tZ,
-                  rotation.x(),
-                  rotation.y(),
-                  rotation.z(),
-                  rotation.w());
-    return std::string(buff);
+    double               rot[3] = { R, P, Y };
+    size_t               i = 3;
+    yarp::sig::Vector    rotV;
+    yarp::sig::Matrix    rotM;
+    rotV = yarp::sig::Vector(i, rot);
+    rotM = rpy2dcm(rotV);
+    rotation.fromRotationMatrix(rotM);
+}
+
+yarp::sig::Vector FrameTransform::getRPYRot() const
+{
+    yarp::sig::Vector rotV;
+    yarp::sig::Matrix rotM;
+    rotM = rotation.toRotationMatrix4x4();
+    rotV = dcm2rpy(rotM);
+    return rotV;
+}
+
+yarp::sig::Matrix FrameTransform::toMatrix() const
+{
+    yarp::sig::Vector rotV;
+    yarp::sig::Matrix t_mat(4, 4);
+    t_mat = rotation.toRotationMatrix4x4();
+    t_mat[0][3] = translation.tX;
+    t_mat[1][3] = translation.tY;
+    t_mat[2][3] = translation.tZ;
+    return t_mat;
 }

--- a/src/libYARP_math/src/Quaternion.cpp
+++ b/src/libYARP_math/src/Quaternion.cpp
@@ -6,151 +6,14 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/math/Quaternion.h>
+#include <yarp/sig/Quaternion.h>
 #include <yarp/math/Math.h>
 #include <cmath>
 #include <cstdio>
 
+using namespace yarp::sig;
 using namespace yarp::math;
-
-YARP_BEGIN_PACK
-class QuaternionPortContentHeader
-{
-public:
-    yarp::os::NetInt32 listTag;
-    yarp::os::NetInt32 listLen;
-    QuaternionPortContentHeader() : listTag(0), listLen(0) {}
-};
-YARP_END_PACK
-
-Quaternion::Quaternion()
-{
-    internal_data[0] = 1;
-    internal_data[1] = 0;
-    internal_data[2] = 0;
-    internal_data[3] = 0;
-}
-
-Quaternion::Quaternion(double x, double y, double z, double w)
-{
-    internal_data[0] = w;
-    internal_data[1] = x;
-    internal_data[2] = y;
-    internal_data[3] = z;
-}
-
-Quaternion::Quaternion(const Quaternion &l)
-{
-    internal_data[0] = l.w();
-    internal_data[1] = l.x();
-    internal_data[2] = l.y();
-    internal_data[3] = l.z();
-}
-
-const double* Quaternion::data() const
-{
-    return internal_data;
-}
-
-double* Quaternion::data()
-{
-    return internal_data;
-}
-
-yarp::sig::Vector Quaternion::toVector()  const
-{
-    yarp::sig::Vector v(4);
-    v[0] = internal_data[0];
-    v[1] = internal_data[1];
-    v[2] = internal_data[2];
-    v[3] = internal_data[3];
-    return v;
-}
-
-double Quaternion::w() const
-{
-    return internal_data[0];
-}
-
-double Quaternion::x() const
-{
-    return internal_data[1];
-}
-
-double Quaternion::y() const
-{
-    return internal_data[2];
-}
-
-double Quaternion::z() const
-{
-    return internal_data[3];
-}
-
-double& Quaternion::w()
-{
-    return internal_data[0];
-}
-
-double& Quaternion::x()
-{
-    return internal_data[1];
-}
-
-double& Quaternion::y()
-{
-    return internal_data[2];
-}
-
-double& Quaternion::z()
-{
-    return internal_data[3];
-}
-
-bool Quaternion::read(yarp::os::ConnectionReader& connection)
-{
-    // auto-convert text mode interaction
-    connection.convertTextMode();
-    QuaternionPortContentHeader header;
-    bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
-
-    if (header.listLen == 4 &&  header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
-    {
-        this->internal_data[0] = connection.expectFloat64();
-        this->internal_data[1] = connection.expectFloat64();
-        this->internal_data[2] = connection.expectFloat64();
-        this->internal_data[3] = connection.expectFloat64();
-    }
-    else
-    {
-        return false;
-    }
-
-    return !connection.isError();
-}
-
-bool Quaternion::write(yarp::os::ConnectionWriter& connection)
-{
-    QuaternionPortContentHeader header;
-
-    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64);
-    header.listLen = 4;
-
-    connection.appendBlock((char*)&header, sizeof(header));
-
-    connection.appendFloat64(this->internal_data[0]);
-    connection.appendFloat64(this->internal_data[1]);
-    connection.appendFloat64(this->internal_data[2]);
-    connection.appendFloat64(this->internal_data[3]);
-
-    // if someone is foolish enough to connect in text mode,
-    // let them see something readable.
-    connection.convertTextMode();
-
-    return !connection.isError();
-}
-
+/*
 void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
 {
     if ((R.rows()<3) || (R.cols()<3))
@@ -206,7 +69,7 @@ void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
         internal_data[2] = (R(1, 0) + R(0, 1))*sqdip1;
         internal_data[3] = (R(0, 2) + R(2, 0))*sqdip1;
     }
-}
+}*/
 
 yarp::sig::Matrix Quaternion::toRotationMatrix4x4() const
 {
@@ -299,34 +162,3 @@ yarp::sig::Vector Quaternion::toAxisAngle()
     return v;
 }
 
-double Quaternion::abs()
-{
-    return sqrt(internal_data[0] * internal_data[0] +
-                internal_data[1] * internal_data[1] +
-                internal_data[2] * internal_data[2] +
-                internal_data[3] * internal_data[3]);
-}
-
-void Quaternion::normalize()
-{
-    double length = abs();
-    internal_data[0] /= length;
-    internal_data[1] /= length;
-    internal_data[2] /= length;
-    internal_data[3] /= length;
-    return;
-}
-
-double Quaternion::arg()
-{
-    return atan2(sqrt(internal_data[1] * internal_data[1] +
-                      internal_data[2] * internal_data[2] +
-                      internal_data[3] * internal_data[3]),
-                 internal_data[0]);
-}
-
-Quaternion Quaternion::inverse() const
-{
-    //                     w                  x                 y                  z
-    return Quaternion(internal_data[0], -internal_data[1], -internal_data[2], -internal_data[3]);
-}

--- a/src/libYARP_math/src/Vec2D.cpp
+++ b/src/libYARP_math/src/Vec2D.cpp
@@ -6,7 +6,7 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/math/Vec2D.h>
+#include <yarp/sig/Vec2D.h>
 #include <yarp/math/Math.h>
 #include <sstream>
 #include <cmath>
@@ -15,143 +15,12 @@
 // network stuff
 #include <yarp/os/NetInt32.h>
 
+using namespace yarp::sig;
 using namespace yarp::math;
 
-YARP_BEGIN_PACK
-class Vec2DPortContentHeader
-{
-public:
-    yarp::os::NetInt32 listTag;
-    yarp::os::NetInt32 listLen;
-    Vec2DPortContentHeader() : listTag(0), listLen(0) {}
-};
-YARP_END_PACK
-
-namespace yarp {
-namespace math {
-template<>
-bool Vec2D<double>::read(yarp::os::ConnectionReader& connection)
-{
-    // auto-convert text mode interaction
-    connection.convertTextMode();
-    Vec2DPortContentHeader header;
-    bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
-
-    if (header.listLen == 2 && header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
-    {
-        this->x = connection.expectFloat64();
-        this->y = connection.expectFloat64();
-    }
-    else
-    {
-        return false;
-    }
-
-    return !connection.isError();
-}
-
-template<>
-bool Vec2D<int>::read(yarp::os::ConnectionReader& connection)
-{
-    // auto-convert text mode interaction
-    connection.convertTextMode();
-    Vec2DPortContentHeader header;
-    bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
-
-    if (header.listLen == 2 && header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_INT32))
-    {
-        this->x = connection.expectInt32();
-        this->y = connection.expectInt32();
-    }
-    else
-    {
-        return false;
-    }
-
-    return !connection.isError();
-}
-
-template<>
-bool Vec2D<double>::write(yarp::os::ConnectionWriter& connection)
-{
-    Vec2DPortContentHeader header;
-
-    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64);
-    header.listLen = 2;
-
-    connection.appendBlock((char*)&header, sizeof(header));
-
-    connection.appendFloat64(this->x);
-    connection.appendFloat64(this->y);
-
-    connection.convertTextMode();
-
-    return !connection.isError();
-}
-
-template<>
-bool Vec2D<int>::write(yarp::os::ConnectionWriter& connection)
-{
-    Vec2DPortContentHeader header;
-
-    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_INT32);
-    header.listLen = 2;
-
-    connection.appendBlock((char*)&header, sizeof(header));
-
-    connection.appendInt32(this->x);
-    connection.appendInt32(this->y);
-
-    connection.convertTextMode();
-
-    return !connection.isError();
-}
-
-} // namespace math
-} // namespace yarp
-
-
+/*
 template <typename T>
-std::string yarp::math::Vec2D<T>::toString(int precision, int width) const
-{
-    std::ostringstream stringStream;
-    stringStream.precision(precision);
-    stringStream.width(width);
-    stringStream << std::string("x:") << x << std::string(" y:") << y;
-    return stringStream.str();
-}
-
-template <typename T>
-T yarp::math::Vec2D<T>::norm() const
-{
-    return T(sqrt(x*x + y*y));
-}
-
-//constructors
-template <typename T>
-yarp::math::Vec2D<T>::Vec2D() : x(0), y(0)
-{
-}
-
-template <typename T>
-yarp::math::Vec2D<T>::Vec2D(const yarp::sig::Vector& v)
-{
-    yAssert(v.size() == 2);
-    x = T(v[0]);
-    y = T(v[1]);
-}
-
-template <typename T>
-yarp::math::Vec2D<T>::Vec2D(const T& x_value, const T& y_value)
-{
-    x = x_value;
-    y = y_value;
-}
-
-template <typename T>
- yarp::math::Vec2D<T>  operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<T> rhs)
+ yarp::sig::Vec2D<T>  operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<T> rhs)
 {
     yAssert(lhs.rows() == 2 && lhs.cols() == 2);
     T x = rhs.x; T y = rhs.y;
@@ -161,21 +30,21 @@ template <typename T>
 }
 
 template <typename T>
-yarp::math::Vec2D<T> operator + (yarp::math::Vec2D<T> lhs, const yarp::math::Vec2D<T>& rhs)
+yarp::sig::Vec2D<T> operator + (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs)
 {
     lhs += rhs;
     return lhs;
 }
 
 template <typename T>
-yarp::math::Vec2D<T> operator - (yarp::math::Vec2D<T> lhs, const yarp::math::Vec2D<T>& rhs)
+yarp::sig::Vec2D<T> operator - (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs)
 {
     lhs -= rhs;
     return lhs;
 }
 
 template <typename T>
-yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator+=(const yarp::math::Vec2D<T>& rhs)
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator+=(const yarp::sig::Vec2D<T>& rhs)
 {
     this->x += rhs.x;
     this->y += rhs.y;
@@ -183,7 +52,7 @@ yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator+=(const yarp::math::Vec2D<T
 }
 
 template <typename T>
-yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator-=(const yarp::math::Vec2D<T>& rhs)
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator-=(const yarp::sig::Vec2D<T>& rhs)
 {
     this->x -= rhs.x;
     this->y -= rhs.y;
@@ -191,7 +60,7 @@ yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator-=(const yarp::math::Vec2D<T
 }
 
 template <typename T>
-yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator =(const yarp::math::Vec2D<T>& rhs)
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator =(const yarp::sig::Vec2D<T>& rhs)
 {
     if (this != &rhs)
     {
@@ -202,7 +71,7 @@ yarp::math::Vec2D<T>& yarp::math::Vec2D<T>::operator =(const yarp::math::Vec2D<T
 }
 
 template <typename T>
-bool yarp::math::Vec2D<T>::operator ==(const yarp::math::Vec2D<T>& rhs)
+bool yarp::sig::Vec2D<T>::operator ==(const yarp::sig::Vec2D<T>& rhs)
 {
     if (this->x == rhs.x &&
         this->y == rhs.y) return true;
@@ -210,19 +79,20 @@ bool yarp::math::Vec2D<T>::operator ==(const yarp::math::Vec2D<T>& rhs)
 }
 
 template <typename T>
-bool yarp::math::Vec2D<T>::operator !=(const yarp::math::Vec2D<T>& rhs)
+bool yarp::sig::Vec2D<T>::operator !=(const yarp::sig::Vec2D<T>& rhs)
 {
     if (this->x == rhs.x &&
         this->y == rhs.y) return false;
     return true;
 }
 
-template yarp::math::Vec2D<double> YARP_math_API operator + (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
-template yarp::math::Vec2D<int>    YARP_math_API operator + (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
-template yarp::math::Vec2D<double> YARP_math_API operator - (yarp::math::Vec2D<double> lhs, const yarp::math::Vec2D<double>& rhs);
-template yarp::math::Vec2D<int>    YARP_math_API operator - (yarp::math::Vec2D<int> lhs, const yarp::math::Vec2D<int>& rhs);
-template yarp::math::Vec2D<double> YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<double> rhs);
-template yarp::math::Vec2D<int>    YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<int> rhs);
+template yarp::sig::Vec2D<double> YARP_sig_API operator + (yarp::sig::Vec2D<double> lhs, const yarp::sig::Vec2D<double>& rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator + (yarp::sig::Vec2D<int> lhs, const yarp::sig::Vec2D<int>& rhs);
+template yarp::sig::Vec2D<double> YARP_sig_API operator - (yarp::sig::Vec2D<double> lhs, const yarp::sig::Vec2D<double>& rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator - (yarp::sig::Vec2D<int> lhs, const yarp::sig::Vec2D<int>& rhs);
+template yarp::sig::Vec2D<double> YARP_sig_API operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<double> rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<int> rhs);
 
-template class YARP_math_API yarp::math::Vec2D<double>;
-template class YARP_math_API yarp::math::Vec2D<int>;
+template class YARP_sig_API yarp::sig::Vec2D<double>;
+template class YARP_sig_API yarp::sig::Vec2D<int>;
+*/

--- a/src/libYARP_math/src/math.cpp
+++ b/src/libYARP_math/src/math.cpp
@@ -10,7 +10,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/math/Math.h>
 #include <yarp/math/SVD.h>
-#include <yarp/math/Quaternion.h>
+#include <yarp/sig/Quaternion.h>
 
 #include <yarp/eigen/Eigen.h>
 

--- a/src/libYARP_sig/CMakeLists.txt
+++ b/src/libYARP_sig/CMakeLists.txt
@@ -20,7 +20,10 @@ set(YARP_sig_HDRS include/yarp/sig/all.h
                   include/yarp/sig/PointCloudTypes.h
                   include/yarp/sig/SoundFile.h
                   include/yarp/sig/Sound.h
-                  include/yarp/sig/Vector.h)
+                  include/yarp/sig/Vector.h
+                  include/yarp/sig/FrameTransform.h
+                  include/yarp/sig/Quaternion.h
+                  include/yarp/sig/Vec2D.h)
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.0.0
   list(APPEND YARP_sig_HDRS include/yarp/sig/IplImage.h)
@@ -38,7 +41,10 @@ set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/Sound.cpp
                   src/SoundFile.cpp
                   src/Vector.cpp
-                  src/DeBayer.cpp)
+                  src/DeBayer.cpp
+                  src/Vec2D.cpp
+                  src/Quaternion.cpp
+                  src/FrameTransform.cpp)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
              PREFIX "Source Files"

--- a/src/libYARP_sig/include/yarp/sig/FrameTransform.h
+++ b/src/libYARP_sig/include/yarp/sig/FrameTransform.h
@@ -6,20 +6,19 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_MATH_TRANSFORM_H
-#define YARP_MATH_TRANSFORM_H
+#ifndef YARP_SIG_TRANSFORM_H
+#define YARP_SIG_TRANSFORM_H
 
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
-#include <yarp/math/api.h>
-#include <yarp/math/Math.h>
-#include <yarp/math/Quaternion.h>
+#include <yarp/sig/api.h>
+#include <yarp/sig/Quaternion.h>
 
 namespace yarp
 {
-    namespace math
+    namespace sig
     {
-        class YARP_math_API FrameTransform
+        class YARP_sig_API FrameTransform
         {
             public:
             YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::string) src_frame_id;
@@ -77,36 +76,9 @@ namespace yarp
                 translation.set(X, Y, Z);
             }
 
-            void rotFromRPY(double R, double P, double Y)
-            {
-                double               rot[3] = { R, P, Y };
-                size_t               i = 3;
-                yarp::sig::Vector    rotV;
-                yarp::sig::Matrix    rotM;
-                rotV = yarp::sig::Vector(i, rot);
-                rotM = rpy2dcm(rotV);
-                rotation.fromRotationMatrix(rotM);
-            }
-
-            yarp::sig::Vector getRPYRot() const
-            {
-                yarp::sig::Vector rotV;
-                yarp::sig::Matrix rotM;
-                rotM = rotation.toRotationMatrix4x4();
-                rotV = dcm2rpy(rotM);
-                return rotV;
-            }
-
-            yarp::sig::Matrix toMatrix() const
-            {
-                yarp::sig::Vector rotV;
-                yarp::sig::Matrix t_mat(4,4);
-                t_mat = rotation.toRotationMatrix4x4();
-                t_mat[0][3] = translation.tX;
-                t_mat[1][3] = translation.tY;
-                t_mat[2][3] = translation.tZ;
-                return t_mat;
-            }
+            void rotFromRPY(double R, double P, double Y);
+            yarp::sig::Vector getRPYRot() const;
+            yarp::sig::Matrix toMatrix() const;
 
             bool fromMatrix(const yarp::sig::Matrix& mat)
             {

--- a/src/libYARP_sig/include/yarp/sig/Quaternion.h
+++ b/src/libYARP_sig/include/yarp/sig/Quaternion.h
@@ -6,10 +6,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_QUATERNION
-#define YARP_QUATERNION
+#ifndef YARP_SIG_QUATERNION
+#define YARP_SIG_QUATERNION
 
-#include <yarp/math/api.h>
+#include <yarp/sig/api.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/Portable.h>
@@ -18,12 +18,12 @@
 #include <yarp/os/NetInt32.h>
 
 namespace yarp {
-    namespace math {
+    namespace sig {
         class Quaternion;
     }
 }
 
-class YARP_math_API yarp::math::Quaternion : public yarp::os::Portable
+class YARP_sig_API yarp::sig::Quaternion : public yarp::os::Portable
 {
     double internal_data[4]; // stored as [w x y z]
 
@@ -105,16 +105,6 @@ public:
     *
     */
     void fromRotationMatrix(const yarp::sig::Matrix &R);
-
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-    /**
-     * Converts a quaternion to a rotation matrix.
-     *
-     * @deprecated since YARP 3.0.0. Use toRotationMatrix4x4 instead.
-     */
-    YARP_DEPRECATED_MSG("Use toRotationMatrix4x4 instead")
-    yarp::sig::Matrix toRotationMatrix() const { return toRotationMatrix4x4(); }
-#endif
 
     /**
     * Converts a quaternion to a rotation matrix.

--- a/src/libYARP_sig/include/yarp/sig/Vec2D.h
+++ b/src/libYARP_sig/include/yarp/sig/Vec2D.h
@@ -6,20 +6,20 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_MATH_VEC2D_H
-#define YARP_MATH_VEC2D_H
+#ifndef YARP_SIG_VEC2D_H
+#define YARP_SIG_VEC2D_H
 
-#include <yarp/math/api.h>
+#include <yarp/sig/api.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/Portable.h>
 #include <type_traits>
 
 namespace yarp {
-namespace math {
+namespace sig {
 
 template <typename T>
-class YARP_math_API Vec2D : public yarp::os::Portable
+class YARP_sig_API Vec2D : public yarp::os::Portable
 {
     static_assert (std::is_same<int, T>::value ||
                    std::is_same<double, T>::value, "Vec2D can be specialized only as int, double");
@@ -70,11 +70,11 @@ public:
     }
 
     //operators
-    yarp::math::Vec2D<T>& operator+=(const yarp::math::Vec2D<T>& rhs);
-    yarp::math::Vec2D<T>& operator-=(const yarp::math::Vec2D<T>& rhs);
-    yarp::math::Vec2D<T>& operator =(const yarp::math::Vec2D<T>& rhs);
-    bool operator == (const yarp::math::Vec2D<T>& rhs);
-    bool operator != (const yarp::math::Vec2D<T>& rhs);
+    yarp::sig::Vec2D<T>& operator+=(const yarp::sig::Vec2D<T>& rhs);
+    yarp::sig::Vec2D<T>& operator-=(const yarp::sig::Vec2D<T>& rhs);
+    yarp::sig::Vec2D<T>& operator =(const yarp::sig::Vec2D<T>& rhs);
+    bool operator == (const yarp::sig::Vec2D<T>& rhs);
+    bool operator != (const yarp::sig::Vec2D<T>& rhs);
 };
 
 } // namespace math
@@ -82,12 +82,12 @@ public:
 
 //operators
 template <typename T>
-yarp::math::Vec2D<T> YARP_math_API operator + (yarp::math::Vec2D<T> lhs, const yarp::math::Vec2D<T>& rhs);
+yarp::sig::Vec2D<T> YARP_sig_API operator + (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs);
 
 template <typename T>
-yarp::math::Vec2D<T> YARP_math_API operator - (yarp::math::Vec2D<T> lhs, const yarp::math::Vec2D<T>& rhs);
+yarp::sig::Vec2D<T> YARP_sig_API operator - (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs);
 
 template <typename T>
-yarp::math::Vec2D<T> YARP_math_API operator * (const yarp::sig::Matrix& lhs, yarp::math::Vec2D<T> rhs);
+yarp::sig::Vec2D<T> YARP_sig_API operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<T> rhs);
 
 #endif // YARP_MATH_VEC2D_H

--- a/src/libYARP_sig/src/FrameTransform.cpp
+++ b/src/libYARP_sig/src/FrameTransform.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/sig/FrameTransform.h>
+
+#include <cstdio>
+
+using namespace yarp::sig;
+
+std::string yarp::sig::FrameTransform::toString()
+{
+    char buff[1024];
+    sprintf(buff, "%s -> %s \n tran: %f %f %f \n rot: %f %f %f %f \n\n",
+                  src_frame_id.c_str(),
+                  dst_frame_id.c_str(),
+                  translation.tX,
+                  translation.tY,
+                  translation.tZ,
+                  rotation.x(),
+                  rotation.y(),
+                  rotation.z(),
+                  rotation.w());
+    return std::string(buff);
+}

--- a/src/libYARP_sig/src/Quaternion.cpp
+++ b/src/libYARP_sig/src/Quaternion.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/sig/Quaternion.h>
+#include <cmath>
+#include <cstdio>
+
+using namespace yarp::sig;
+
+YARP_BEGIN_PACK
+class QuaternionPortContentHeader
+{
+public:
+    yarp::os::NetInt32 listTag;
+    yarp::os::NetInt32 listLen;
+    QuaternionPortContentHeader() : listTag(0), listLen(0) {}
+};
+YARP_END_PACK
+
+Quaternion::Quaternion()
+{
+    internal_data[0] = 1;
+    internal_data[1] = 0;
+    internal_data[2] = 0;
+    internal_data[3] = 0;
+}
+
+Quaternion::Quaternion(double x, double y, double z, double w)
+{
+    internal_data[0] = w;
+    internal_data[1] = x;
+    internal_data[2] = y;
+    internal_data[3] = z;
+}
+
+Quaternion::Quaternion(const Quaternion &l)
+{
+    internal_data[0] = l.w();
+    internal_data[1] = l.x();
+    internal_data[2] = l.y();
+    internal_data[3] = l.z();
+}
+
+const double* Quaternion::data() const
+{
+    return internal_data;
+}
+
+double* Quaternion::data()
+{
+    return internal_data;
+}
+
+yarp::sig::Vector Quaternion::toVector()  const
+{
+    yarp::sig::Vector v(4);
+    v[0] = internal_data[0];
+    v[1] = internal_data[1];
+    v[2] = internal_data[2];
+    v[3] = internal_data[3];
+    return v;
+}
+
+double Quaternion::w() const
+{
+    return internal_data[0];
+}
+
+double Quaternion::x() const
+{
+    return internal_data[1];
+}
+
+double Quaternion::y() const
+{
+    return internal_data[2];
+}
+
+double Quaternion::z() const
+{
+    return internal_data[3];
+}
+
+double& Quaternion::w()
+{
+    return internal_data[0];
+}
+
+double& Quaternion::x()
+{
+    return internal_data[1];
+}
+
+double& Quaternion::y()
+{
+    return internal_data[2];
+}
+
+double& Quaternion::z()
+{
+    return internal_data[3];
+}
+
+bool Quaternion::read(yarp::os::ConnectionReader& connection)
+{
+    // auto-convert text mode interaction
+    connection.convertTextMode();
+    QuaternionPortContentHeader header;
+    bool ok = connection.expectBlock((char*)&header, sizeof(header));
+    if (!ok) return false;
+
+    if (header.listLen == 4 &&  header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
+    {
+        this->internal_data[0] = connection.expectFloat64();
+        this->internal_data[1] = connection.expectFloat64();
+        this->internal_data[2] = connection.expectFloat64();
+        this->internal_data[3] = connection.expectFloat64();
+    }
+    else
+    {
+        return false;
+    }
+
+    return !connection.isError();
+}
+
+bool Quaternion::write(yarp::os::ConnectionWriter& connection)
+{
+    QuaternionPortContentHeader header;
+
+    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64);
+    header.listLen = 4;
+
+    connection.appendBlock((char*)&header, sizeof(header));
+
+    connection.appendFloat64(this->internal_data[0]);
+    connection.appendFloat64(this->internal_data[1]);
+    connection.appendFloat64(this->internal_data[2]);
+    connection.appendFloat64(this->internal_data[3]);
+
+    // if someone is foolish enough to connect in text mode,
+    // let them see something readable.
+    connection.convertTextMode();
+
+    return !connection.isError();
+}
+
+void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
+{
+    if ((R.rows()<3) || (R.cols()<3))
+    {
+        yError("fromRotationMatrix() failed, matrix should be >= 3x3");
+        yAssert(R.rows() >= 3 && R.cols() >= 3);
+    }
+
+    double tr = R(0, 0) + R(1, 1) + R(2, 2);
+
+    if (tr>0.0)
+    {
+        double sqtrp1 = sqrt(tr + 1.0);
+        double sqtrp12 = 2.0*sqtrp1;
+        internal_data[0] = 0.5*sqtrp1;
+        internal_data[1] = (R(2, 1) - R(1, 2)) / sqtrp12;
+        internal_data[2] = (R(0, 2) - R(2, 0)) / sqtrp12;
+        internal_data[3] = (R(1, 0) - R(0, 1)) / sqtrp12;
+    }
+    else if ((R(1, 1)>R(0, 0)) && (R(1, 1)>R(2, 2)))
+    {
+        double sqdip1 = sqrt(R(1, 1) - R(0, 0) - R(2, 2) + 1.0);
+        internal_data[2] = 0.5*sqdip1;
+
+        if (sqdip1>0.0)
+            sqdip1 = 0.5 / sqdip1;
+
+        internal_data[0] = (R(0, 2) - R(2, 0))*sqdip1;
+        internal_data[1] = (R(1, 0) + R(0, 1))*sqdip1;
+        internal_data[3] = (R(2, 1) + R(1, 2))*sqdip1;
+    }
+    else if (R(2, 2)>R(0, 0))
+    {
+        double sqdip1 = sqrt(R(2, 2) - R(0, 0) - R(1, 1) + 1.0);
+        internal_data[3] = 0.5*sqdip1;
+
+        if (sqdip1>0.0)
+            sqdip1 = 0.5 / sqdip1;
+
+        internal_data[0] = (R(1, 0) - R(0, 1))*sqdip1;
+        internal_data[1] = (R(0, 2) + R(2, 0))*sqdip1;
+        internal_data[2] = (R(2, 1) + R(1, 2))*sqdip1;
+    }
+    else
+    {
+        double sqdip1 = sqrt(R(0, 0) - R(1, 1) - R(2, 2) + 1.0);
+        internal_data[1] = 0.5*sqdip1;
+
+        if (sqdip1>0.0)
+            sqdip1 = 0.5 / sqdip1;
+
+        internal_data[0] = (R(2, 1) - R(1, 2))*sqdip1;
+        internal_data[2] = (R(1, 0) + R(0, 1))*sqdip1;
+        internal_data[3] = (R(0, 2) + R(2, 0))*sqdip1;
+    }
+}
+
+std::string Quaternion::toString(int precision, int width)
+{
+    std::string ret = "";
+    char tmp[350];
+    if (width<0)
+    {
+        sprintf(tmp, "w=% .*lf\t", precision, internal_data[0]);   ret += tmp;
+        sprintf(tmp, "x=% .*lf\t", precision, internal_data[1]);   ret += tmp;
+        sprintf(tmp, "y=% .*lf\t", precision, internal_data[2]);   ret += tmp;
+        sprintf(tmp, "z=% .*lf\t", precision, internal_data[3]);   ret += tmp;
+    }
+    else
+    {
+        sprintf(tmp, "w=% *.*lf ", width, precision, internal_data[0]);    ret += tmp;
+        sprintf(tmp, "x=% *.*lf ", width, precision, internal_data[1]);    ret += tmp;
+        sprintf(tmp, "y=% *.*lf ", width, precision, internal_data[2]);    ret += tmp;
+        sprintf(tmp, "z=% *.*lf ", width, precision, internal_data[3]);    ret += tmp;
+    }
+
+    return ret.substr(0, ret.length() - 1);
+}
+
+double Quaternion::abs()
+{
+    return sqrt(internal_data[0] * internal_data[0] +
+                internal_data[1] * internal_data[1] +
+                internal_data[2] * internal_data[2] +
+                internal_data[3] * internal_data[3]);
+}
+
+void Quaternion::normalize()
+{
+    double length = abs();
+    internal_data[0] /= length;
+    internal_data[1] /= length;
+    internal_data[2] /= length;
+    internal_data[3] /= length;
+    return;
+}
+
+double Quaternion::arg()
+{
+    return atan2(sqrt(internal_data[1] * internal_data[1] +
+                      internal_data[2] * internal_data[2] +
+                      internal_data[3] * internal_data[3]),
+                 internal_data[0]);
+}
+
+Quaternion Quaternion::inverse() const
+{
+    //                     w                  x                 y                  z
+    return Quaternion(internal_data[0], -internal_data[1], -internal_data[2], -internal_data[3]);
+}

--- a/src/libYARP_sig/src/Vec2D.cpp
+++ b/src/libYARP_sig/src/Vec2D.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/sig/Vec2D.h>
+#include <sstream>
+#include <cmath>
+#include <cstdio>
+
+// network stuff
+#include <yarp/os/NetInt32.h>
+
+using namespace yarp::sig;
+
+YARP_BEGIN_PACK
+class Vec2DPortContentHeader
+{
+public:
+    yarp::os::NetInt32 listTag;
+    yarp::os::NetInt32 listLen;
+    Vec2DPortContentHeader() : listTag(0), listLen(0) {}
+};
+YARP_END_PACK
+
+namespace yarp {
+namespace sig {
+template<>
+bool Vec2D<double>::read(yarp::os::ConnectionReader& connection)
+{
+    // auto-convert text mode interaction
+    connection.convertTextMode();
+    Vec2DPortContentHeader header;
+    bool ok = connection.expectBlock((char*)&header, sizeof(header));
+    if (!ok) return false;
+
+    if (header.listLen == 2 && header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
+    {
+        this->x = connection.expectFloat64();
+        this->y = connection.expectFloat64();
+    }
+    else
+    {
+        return false;
+    }
+
+    return !connection.isError();
+}
+
+template<>
+bool Vec2D<int>::read(yarp::os::ConnectionReader& connection)
+{
+    // auto-convert text mode interaction
+    connection.convertTextMode();
+    Vec2DPortContentHeader header;
+    bool ok = connection.expectBlock((char*)&header, sizeof(header));
+    if (!ok) return false;
+
+    if (header.listLen == 2 && header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_INT32))
+    {
+        this->x = connection.expectInt32();
+        this->y = connection.expectInt32();
+    }
+    else
+    {
+        return false;
+    }
+
+    return !connection.isError();
+}
+
+template<>
+bool Vec2D<double>::write(yarp::os::ConnectionWriter& connection)
+{
+    Vec2DPortContentHeader header;
+
+    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64);
+    header.listLen = 2;
+
+    connection.appendBlock((char*)&header, sizeof(header));
+
+    connection.appendFloat64(this->x);
+    connection.appendFloat64(this->y);
+
+    connection.convertTextMode();
+
+    return !connection.isError();
+}
+
+template<>
+bool Vec2D<int>::write(yarp::os::ConnectionWriter& connection)
+{
+    Vec2DPortContentHeader header;
+
+    header.listTag = (BOTTLE_TAG_LIST | BOTTLE_TAG_INT32);
+    header.listLen = 2;
+
+    connection.appendBlock((char*)&header, sizeof(header));
+
+    connection.appendInt32(this->x);
+    connection.appendInt32(this->y);
+
+    connection.convertTextMode();
+
+    return !connection.isError();
+}
+
+} // namespace sig
+} // namespace yarp
+
+
+template <typename T>
+std::string yarp::sig::Vec2D<T>::toString(int precision, int width) const
+{
+    std::ostringstream stringStream;
+    stringStream.precision(precision);
+    stringStream.width(width);
+    stringStream << std::string("x:") << x << std::string(" y:") << y;
+    return stringStream.str();
+}
+
+template <typename T>
+T yarp::sig::Vec2D<T>::norm() const
+{
+    return T(sqrt(x*x + y*y));
+}
+
+//constructors
+template <typename T>
+yarp::sig::Vec2D<T>::Vec2D() : x(0), y(0)
+{
+}
+
+template <typename T>
+yarp::sig::Vec2D<T>::Vec2D(const yarp::sig::Vector& v)
+{
+    yAssert(v.size() == 2);
+    x = T(v[0]);
+    y = T(v[1]);
+}
+
+template <typename T>
+yarp::sig::Vec2D<T>::Vec2D(const T& x_value, const T& y_value)
+{
+    x = x_value;
+    y = y_value;
+}
+
+template <typename T>
+ yarp::sig::Vec2D<T>  operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<T> rhs)
+{
+    yAssert(lhs.rows() == 2 && lhs.cols() == 2);
+    T x = rhs.x; T y = rhs.y;
+    rhs.x = T(lhs[0][0] * x + lhs[0][1] * y);
+    rhs.y = T(lhs[1][0] * x + lhs[1][1] * y);
+    return rhs;
+}
+
+template <typename T>
+yarp::sig::Vec2D<T> operator + (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs)
+{
+    lhs += rhs;
+    return lhs;
+}
+
+template <typename T>
+yarp::sig::Vec2D<T> operator - (yarp::sig::Vec2D<T> lhs, const yarp::sig::Vec2D<T>& rhs)
+{
+    lhs -= rhs;
+    return lhs;
+}
+
+template <typename T>
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator+=(const yarp::sig::Vec2D<T>& rhs)
+{
+    this->x += rhs.x;
+    this->y += rhs.y;
+    return *this;
+}
+
+template <typename T>
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator-=(const yarp::sig::Vec2D<T>& rhs)
+{
+    this->x -= rhs.x;
+    this->y -= rhs.y;
+    return *this;
+}
+
+template <typename T>
+yarp::sig::Vec2D<T>& yarp::sig::Vec2D<T>::operator =(const yarp::sig::Vec2D<T>& rhs)
+{
+    if (this != &rhs)
+    {
+        x = rhs.x;
+        y = rhs.y;
+    }
+    return *this;
+}
+
+template <typename T>
+bool yarp::sig::Vec2D<T>::operator ==(const yarp::sig::Vec2D<T>& rhs)
+{
+    if (this->x == rhs.x &&
+        this->y == rhs.y) return true;
+    return false;
+}
+
+template <typename T>
+bool yarp::sig::Vec2D<T>::operator !=(const yarp::sig::Vec2D<T>& rhs)
+{
+    if (this->x == rhs.x &&
+        this->y == rhs.y) return false;
+    return true;
+}
+
+template yarp::sig::Vec2D<double> YARP_sig_API operator + (yarp::sig::Vec2D<double> lhs, const yarp::sig::Vec2D<double>& rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator + (yarp::sig::Vec2D<int> lhs, const yarp::sig::Vec2D<int>& rhs);
+template yarp::sig::Vec2D<double> YARP_sig_API operator - (yarp::sig::Vec2D<double> lhs, const yarp::sig::Vec2D<double>& rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator - (yarp::sig::Vec2D<int> lhs, const yarp::sig::Vec2D<int>& rhs);
+template yarp::sig::Vec2D<double> YARP_sig_API operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<double> rhs);
+template yarp::sig::Vec2D<int>    YARP_sig_API operator * (const yarp::sig::Matrix& lhs, yarp::sig::Vec2D<int> rhs);
+
+template class YARP_sig_API yarp::sig::Vec2D<double>;
+template class YARP_sig_API yarp::sig::Vec2D<int>;

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -17,7 +17,7 @@
 #include <yarp/dev/Wrapper.h>
 #include <yarp/os/Time.h>
 #include <yarp/math/Math.h>
-#include <yarp/math/FrameTransform.h>
+#include <yarp/sig/FrameTransform.h>
 #include <yarp/os/LogStream.h>
 #define M_PI 3.14159265358979323846
 #include<cmath>
@@ -50,7 +50,7 @@ public:
         return true;
     }
 
-    bool isEqual(const yarp::math::Quaternion& q1, const yarp::math::Quaternion& q2, double precision)
+    bool isEqual(const yarp::sig::Quaternion& q1, const yarp::sig::Quaternion& q2, double precision)
     {
         yarp::sig::Vector v1 = q1.toVector();
         yarp::sig::Vector v2 = q2.toVector();
@@ -217,7 +217,7 @@ public:
         //test 6
         yarp::sig::Vector in_point1(3), out_point1(3), verPoint1(4);
         yarp::sig::Vector in_pose1(6),  out_pose1(6),  verPose(6);
-        yarp::math::Quaternion in_quat1,  out_quat1,   verQuat;
+        yarp::sig::Quaternion in_quat1,  out_quat1,   verQuat;
 
         in_quat1.fromRotationMatrix(m4);
 

--- a/tests/libYARP_math/Vec2DTest.cpp
+++ b/tests/libYARP_math/Vec2DTest.cpp
@@ -16,7 +16,7 @@
 
 #include <yarp/math/Math.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/math/Vec2D.h>
+#include <yarp/sig/Vec2D.h>
 
 #include <yarp/os/Time.h>
 #include <yarp/os/LogStream.h>


### PR DESCRIPTION
The declaration of following yarp classes have been moved from libYARP_math to libYARP_sig.

Quaternion
FrameTransform
Vec2D

The implementation of methods which do not use libYARP_math functionalities are defined in libYARP_sig, libYARP_math otherwise.