### PR TITLE
Don't add stray '_' char if bundle name is empty

### DIFF
--- a/cmake/YarpPlugin.cmake
+++ b/cmake/YarpPlugin.cmake
@@ -281,7 +281,11 @@ macro(YARP_PREPARE_PLUGIN _plugin_name)
   endif()
 
   # Set up a flag to enable/disable compilation of this plugin.
-  set(_plugin_fullname "${YARP_PLUGIN_MASTER}_${_plugin_name}")
+  if(NOT YARP_PLUGIN_MASTER STREQUAL "")
+    set(_plugin_fullname "${YARP_PLUGIN_MASTER}_${_plugin_name}")
+  else()
+    set(_plugin_fullname "${_plugin_name}")
+  endif()
 
   if(NOT DEFINED _YPP_DOC)
     set(_feature_doc "${_plugin_name} ${_YPP_CATEGORY}")


### PR DESCRIPTION
Commit 6b02ae4 assumes one would wrap plugin declarations between `yarp_begin_plugin_library()` and `yarp_end_plugin_library()`. However, these make no sense in a DL world, that is, when all we want are
dynamically loaded libraries. In fact, those macros lead to the creation of a dummy (i.e. 'empty', all it does is incrementing a static counter) *static* library with .so extension. Apart from that, a prefix is added to all CMake options associated with YARP plugins these macros encompass. Such prefix was not mandatory, but said commit was not prepared to handle an empty string for its value (and this happens when the aforementioned macros were not used).

TL;DR: regression fix