### PR TITLE
Register YARP's own module paths before loading components in static builds

### DIFF
--- a/cmake/template/YARPTargetsStatic.cmake.in
+++ b/cmake/template/YARPTargetsStatic.cmake.in
@@ -34,6 +34,10 @@ if(NOT "${_expected_targets}" STREQUAL "")
   list(REMOVE_DUPLICATES _expected_targets)
 endif()
 
+# Provide YARP's own module search paths for use by find_package()
+set(_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
+
 # Properly find the dependencies. This will force to include all the
 # dependencies also for packages in other exports
 foreach(_target ${_targets})
@@ -52,6 +56,8 @@ foreach(_target ${_targets})
 endforeach()
 
 # Restore the original situation
+set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH})
+unset(_CMAKE_MODULE_PATH)
 unset(YARP_static_hack_FOUND)
 unset(YARP_static_hack_NOT_FOUND_MESSAGE)
 set(CMAKE_FIND_PACKAGE_NAME ${_CMAKE_FIND_PACKAGE_NAME})


### PR DESCRIPTION
Regression, #1715 introduced one implicit `find_package()` call per (public or private) external dependency of each YARP component. In static builds, this issue hit some private deps such as Libedit and Eigen that couldn't be found on system while issuing a `find_package(YARP)` call. Internal Find&lt;pkg&gt;.cmake modules may be used in order to locate these packages on system.

From https://github.com/robotology/yarp/pull/1715#issuecomment-395065930:

> I'm unable to configure the OS examples (`example/os/`) while using statically linked YARP:
>
> ```
> ~/git/yarp/example/os/build (devel % u=)$ cmake .
> CMake Error at /usr/share/cmake-3.5/Modules/CMakeFindDependencyMacro.cmake:65 (find_package):
>   By not providing "FindLibedit.cmake" in CMAKE_MODULE_PATH this project has
>   asked CMake to find a package configuration file provided by "Libedit", but
>   CMake did not find one.
> 
>   Could not find a package configuration file provided by "Libedit" with any
>   of the following names:
> 
>     LibeditConfig.cmake
>     libedit-config.cmake
> 
>   Add the installation prefix of "Libedit" to CMAKE_PREFIX_PATH or set
>   "Libedit_DIR" to a directory containing one of the above files.  If
>   "Libedit" provides a separate development package or SDK, be sure it has
>   been installed.
> Call Stack (most recent call first):
>   /usr/local/lib/cmake/YARP_OS/YARP_OSConfig.cmake:25 (find_dependency)
>   /usr/local/lib/cmake/YARP/YARPTargetsStatic.cmake:42 (find_package)
>   /usr/local/lib/cmake/YARP/YARPConfig.cmake:165 (include)
>   CMakeLists.txt:13 (find_package)
> 
> 
> -- Configuring incomplete, errors occurred!
> ```
> 
> There are several errors like this one at [the latest Travis builds with `TRAVIS_STATIC=TRUE`](https://travis-ci.org/robotology/yarp/jobs/387342762) caused by YARP's components not being able to find Libedit (or any other **private** dependency). In fact, there *is* at least one FindLibedit.cmake file located at YARP's module search paths, i.e. `YARP_MODULE_PATH`, but it's never exported to `CMAKE_MODULE_PATH` and therefore never found by `find_dependency()` commands recently introduced in each YARP_&lt;component&gt;Config.cmake file, as shown above.