### PR TITLE
Fix VOCAB_CURRENT_REF_GROUP message parser

### DIFF
--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -169,6 +169,7 @@ Important Changes
   `IPositionDirectRaw::setPositionsRaw(const int, const int*, const double*)`.
 * `IPositionDirect::setPositions(const int, const int*, double*)` became
   `IPositionDirect::setPositions(const int, const int*, const double*)`(#1351).
+* Fix `VOCAB_CURRENT_REF_GROUP` message parser
 
 #### `YARP_sig`
 

--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -169,7 +169,7 @@ Important Changes
   `IPositionDirectRaw::setPositionsRaw(const int, const int*, const double*)`.
 * `IPositionDirect::setPositions(const int, const int*, double*)` became
   `IPositionDirect::setPositions(const int, const int*, const double*)`(#1351).
-* Fix `VOCAB_CURRENT_REF_GROUP` message parser
+* Fix `VOCAB_CURRENT_REF_GROUP` message parser (#1734)
 
 #### `YARP_sig`
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/StreamingMessagesParser.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/StreamingMessagesParser.cpp
@@ -140,8 +140,8 @@ void StreamingMessagesParser::onRead(CommandMessage& v)
                 {
                     if (stream_ICurrent)
                     {
-                        int n_joints = b.get(1).asInt32();
-                        Bottle *jlut = b.get(2).asList();
+                        int n_joints = b.get(2).asInt32();
+                        Bottle *jlut = b.get(3).asList();
                         if (((int)jlut->size() != n_joints) && ((int)cmdVector.size() != n_joints))
                         {
                             yError("Received VOCAB_CURRENT_REF_GROUP size of joints vector or currents vector does not match the selected joint number\n");


### PR DESCRIPTION
The use of [`setRefCurrents(const int n_joint, const int *joints, const double *refs)`](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp#L4460) method in the `ControlBoardRemapper` was causing `SEGMENTATION FAULT` because of the message send by the [`RemoteControlBoard`](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp#L3241) is not parsed correctly by the [StreamingMessagesParser](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/devices/ControlBoardWrapper/StreamingMessagesParser.cpp#L140).

The message that is sent is: 
`[VOCAB_CURRENTCONTROL_INTERFACE VOCAB_CURRENT_REF_GROUP n_joint joinLUT]`
while the parser was reading n_joint and joinLUT from the `bottle` respectively at position 1 and 2.

@traversaro 