### PR TITLE
Pull up module path tweaks to main config file

### DIFF
--- a/cmake/template/YARPConfig.cmake.in
+++ b/cmake/template/YARPConfig.cmake.in
@@ -129,6 +129,10 @@ if (CMAKE_VERSION VERSION_LESS 3.9)
   endif()
 endif()
 
+# Provide YARP's own module search paths for internal use by find_package()
+set(_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
+
 # Include YARPTargets.cmake file (that includes for now, targets without a
 # specific destination
 if(NOT TARGET YARP::yarpidl_thrift)
@@ -163,6 +167,10 @@ foreach(_yarp_module ${YARP_FIND_COMPONENTS})
   endif()
   list(APPEND YARP_LIBRARIES YARP::YARP_${_yarp_module})
 endforeach()
+
+# Restore the original situation
+set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH})
+unset(_CMAKE_MODULE_PATH)
 
 # Ensure that all requested modules are available
 check_required_components(YARP)

--- a/cmake/template/YARPTargetsStatic.cmake.in
+++ b/cmake/template/YARPTargetsStatic.cmake.in
@@ -34,10 +34,6 @@ if(NOT "${_expected_targets}" STREQUAL "")
   list(REMOVE_DUPLICATES _expected_targets)
 endif()
 
-# Provide YARP's own module search paths for use by find_package()
-set(_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
-
 # Properly find the dependencies. This will force to include all the
 # dependencies also for packages in other exports
 foreach(_target ${_targets})
@@ -56,8 +52,6 @@ foreach(_target ${_targets})
 endforeach()
 
 # Restore the original situation
-set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH})
-unset(_CMAKE_MODULE_PATH)
 unset(YARP_static_hack_FOUND)
 unset(YARP_static_hack_NOT_FOUND_MESSAGE)
 set(CMAKE_FIND_PACKAGE_NAME ${_CMAKE_FIND_PACKAGE_NAME})

--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -12,6 +12,7 @@ Bug Fixes
 ### Build System
 
 * Fixed issue with vtk config files when looking for the `pcl` component
+* Fixed issue with internal YARP component dependencies not being found.
 
 
 ### Libraries


### PR DESCRIPTION
This is a follow up to #1733 for non-static YARP builds, which were prone to cause similar errors in downstreams (see #1736) due to internal dependencies (e.g. TinyXML) not being found.