### PR TITLE
Define YARP_HAS_MATH_LIB locally (libYARP_math), then export to parent scope

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -29,6 +29,11 @@ Bug Fixes
 
 ### Libraries
 
+#### YARP_math
+
+* Fixed a regression in the build system that prevented YARP from being
+  compiled if Eigen3 was available.
+
 #### YARP_pcl
 
 * Fixed missing isDense parmeter.

--- a/src/libYARP_math/CMakeLists.txt
+++ b/src/libYARP_math/CMakeLists.txt
@@ -5,10 +5,13 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-set(YARP_HAS_MATH_LIB FALSE PARENT_SCOPE)
+set(YARP_HAS_MATH_LIB FALSE)
 if (CREATE_LIB_MATH)
-  set(YARP_HAS_MATH_LIB TRUE PARENT_SCOPE)
+  set(YARP_HAS_MATH_LIB TRUE)
 endif()
+
+# Export this variable to the caller
+set(YARP_HAS_MATH_LIB ${YARP_HAS_MATH_LIB} PARENT_SCOPE)
 
 if (YARP_HAS_MATH_LIB)
 


### PR DESCRIPTION
`set(<var> <value> PARENT_SCOPE)` defines `<var>` in the parent scope *only*, at least in CMake 3.5. There is a slight change in the behavior of this command in CMake 3.7, but should not affect the result, see docs for `set()`:

* https://cmake.org/cmake/help/v3.5/command/set.html#set-normal-variable
* https://cmake.org/cmake/help/v3.7/command/set.html#set-normal-variable

This is a regression introduced by #1715. On Xenial (CMake 3.5) with libeigen3-dev and YARP 3.0, configuring YARP **from scratch** (make sure to delete `CMakeCache.txt`) leads to errors like such:

```
[...]
-- Configuring done
CMake Error at cmake/YarpPlugin.cmake:524 (add_library):
  Target "yarp_transformClient" links to target "YARP::YARP_math" but the
  target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
Call Stack (most recent call first):
  src/devices/transformClient/CMakeLists.txt:17 (yarp_add_plugin)

[...same error, different plugins...]
-- Generating done
```

Despite the successful configuration step, the build fails due to math headers not being found. Also, YARP_math targets are not exported (nor even created). This issue disappears after configuring YARP a second time.