### PR TITLE
Handle OPTIONAL_COMPONENTS in find_package(YARP)

### DIFF
--- a/cmake/template/YARPConfig.cmake.in
+++ b/cmake/template/YARPConfig.cmake.in
@@ -7,7 +7,6 @@
 
 
 
-include(CMakeFindDependencyMacro)
 include(CMakeDependentOption)
 
 
@@ -149,27 +148,23 @@ endif()
 # Find all requested components
 set(YARP_LIBRARIES YARP::YARP_init)
 foreach(_yarp_module ${YARP_FIND_COMPONENTS})
-  # FIXME Remove this check when CMake 3.9 or later is required
-  if (CMAKE_VERSION VERSION_LESS 3.9)
-    set(_YARP_FIND_PARTS_REQUIRED)
-    if (YARP_FIND_REQUIRED)
-      set(_YARP_FIND_PARTS_REQUIRED REQUIRED)
-    endif()
-    set(_YARP_FIND_PARTS_QUIET)
-    if (YARP_FIND_QUIETLY)
-      set(_YARP_FIND_PARTS_QUIET QUIET)
-    endif()
-    find_package(YARP_${_yarp_module}
-                 ${_YARP_FIND_PARTS_QUIET}
-                 ${_YARP_FIND_PARTS_REQUIRED}
-                 HINTS "${YARP_CMAKECONFIG_DIR}"
-                 NO_DEFAULT_PATH)
-  else()
-    find_dependency(YARP_${_yarp_module}
-                    HINTS "${YARP_CMAKECONFIG_DIR}"
-                    NO_DEFAULT_PATH)
+  set(_YARP_FIND_PART_${_yarp_module}_REQUIRED)
+  # Only propagate REQUIRED if module was not passed to OPTIONAL_COMPONENTS
+  if(YARP_FIND_REQUIRED AND YARP_FIND_REQUIRED_${_yarp_module})
+    set(_YARP_FIND_PART_${_yarp_module}_REQUIRED REQUIRED)
   endif()
-  list(APPEND YARP_LIBRARIES YARP::YARP_${_yarp_module})
+  set(_YARP_FIND_PARTS_QUIET)
+  if(YARP_FIND_QUIETLY)
+    set(_YARP_FIND_PARTS_QUIET QUIET)
+  endif()
+  find_package(YARP_${_yarp_module}
+               ${_YARP_FIND_PARTS_QUIET}
+               ${_YARP_FIND_PART_${_yarp_module}_REQUIRED}
+               HINTS "${YARP_CMAKECONFIG_DIR}"
+               NO_DEFAULT_PATH)
+  if(YARP_${_yarp_module}_FOUND)
+    list(APPEND YARP_LIBRARIES YARP::YARP_${_yarp_module})
+  endif()
 endforeach()
 
 # Restore the original value of the variable

--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -31,7 +31,9 @@ Bug Fixes
   `URL` properties.
 * When using `FeatureSummary`, `find_package(YARP)` no longer adds `YCM` to the
   optional dependencies.
-
+* Fixed behavior of `OPTIONAL_COMPONENTS` in `find_package(YARP)` calls when
+  the `REQUIRED` option was passed on. Now, a YARP bundle will be considered
+  not found if any of such components is missing.
 
 ### Libraries
 


### PR DESCRIPTION
There is no way to make this work with `find_dependency()` since it passes caller's `REQUIRED` option to the underlying `find_package()` call. That is, no error should be raised if an optional component was not
found while issuing a `find_package(YARP REQUIRED ...)` command. See also this related discussion in the CMake's community mailing list: [ref](https://cmake.org/pipermail/cmake/2016-March/062941.html).

Example invocation (tested with YARP static and shared builds):

```cmake
find_package(YARP REQUIRED COMPONENTS OS dev
                           OPTIONAL_COMPONENTS math asdf)
```

CMake issues a diagnostic message for the missing `YARP_asdf` component:

`-- Could NOT find YARP_asdf (missing: YARP_asdf_DIR)`

This is a follow-up proposal to #1715. The CMake <3.9 fix was introduced in #1731.