### PR TITLE
Fix get Current/get Currents using stateExt and iCurrentControl

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -43,6 +43,10 @@ Bug Fixes
   are available.
 * Fixed SharedLibraryClassFactory::destroy(). Now it is const like create().
 
+#### YARP_dev
+
+* Fixed getCurrent/getCurrents. Now the `stateExt` port is used, and the methods are called through the `iCurrentControl` interface.
+
 #### YARP_math
 
 * Fixed a regression in the build system that prevented YARP from being

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2282,25 +2282,6 @@ public:
     }
 
     /**
-     * Read the electric current going to all motors.
-     * @param vals pointer to storage for the output values
-     * @return hopefully true, false in bad luck.
-     */
-    virtual bool getCurrents(double *vals) override {
-        return get1VDA(VOCAB_AMP_CURRENTS, vals);
-    }
-
-    /**
-     * Read the electric current going to a given motor.
-     * @param m motor number
-     * @param val pointer to storage for the output value
-     * @return probably true, might return false in bad time
-     */
-    virtual bool getCurrent(int j, double *val) override {
-        return get1V1I1D(VOCAB_AMP_CURRENT, j, val);
-    }
-
-    /**
      * Set the maximum electric current going to a given motor. The behavior
      * of the board/amplifier when this limit is reached depends on the
      * implementation.
@@ -3259,13 +3240,34 @@ public:
         return true;
     }
 
-//    virtual bool getCurrent(int j, double *t)
-//    {
-//    }
+    /**
+     * Read the electric current going to all motors.
+     * @param vals pointer to storage for the output values
+     * @return hopefully true, false in bad luck.
+     */
+    virtual bool getCurrents(double *vals) override
+    {
+        double localArrivalTime=0.0;
+        extendedPortMutex.lock();
+        bool ret = extendedIntputStatePort.getLastVector(VOCAB_AMP_CURRENTS, vals, lastStamp, localArrivalTime);
+        extendedPortMutex.unlock();
+        return ret;
+    }
 
-//    virtual bool getCurrents(double *t)
-//    {
-//    }
+    /**
+     * Read the electric current going to a given motor.
+     * @param m motor number
+     * @param val pointer to storage for the output value
+     * @return probably true, might return false in bad time
+     */
+    virtual bool getCurrent(int j, double *val) override
+    {
+        double localArrivalTime=0.0;
+        extendedPortMutex.lock();
+        bool ret = extendedIntputStatePort.getLastSingle(j, VOCAB_AMP_CURRENT, val, lastStamp, localArrivalTime);
+        extendedPortMutex.unlock();
+        return ret;
+    }
 
     virtual bool getCurrentRange(int j, double *min, double *max) override
     {

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -139,7 +139,7 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp
                 *data = last.pwmDutycycle[j];
             break;
 
-            case VOCAB_AMP_CURRENTS:
+            case VOCAB_AMP_CURRENT:
                 ret = last.current_isValid;
                 *data = last.current[j];
                 break;


### PR DESCRIPTION
Fix the implementation of `getCurrent` and `getCurrents` methods in the `RemoteControlBoard` using the `stateExt:o` port.

The implementation has been modified also in the `ControlBoardWrapper` in order to use the `ICurrentControl` interface methods.