### PR TITLE
Fix deprecated constructor in IJoypadEventDriven

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -61,7 +61,10 @@ Bug Fixes
 
 #### YARP_dev
 
-* Fixed getCurrent/getCurrents. Now the `stateExt` port is used, and the methods are called through the `iCurrentControl` interface.
+* Fixed getCurrent/getCurrents. Now the `stateExt` port is used, and the methods
+  are called through the `iCurrentControl` interface.
+* Fixed deprecation message placement for the constructor of
+  `IJoypadEventDriven`. It was failing enabling c++14 compiling with gcc(#1747).
 
 #### YARP_math
 

--- a/src/libYARP_dev/include/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/include/yarp/dev/IJoypadController.h
@@ -254,7 +254,12 @@ public:
 
     IJoypadEventDriven();
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+#if defined(_MSC_VER) && _MSC_VER <= 1900 // VS 2015
     explicit IJoypadEventDriven(YARP_DEPRECATED_MSG("Use IJoypadEventDriven(double)") int rate);
+#else
+    YARP_DEPRECATED_MSG("Use IJoypadEventDriven(double)")
+    explicit IJoypadEventDriven(int rate);
+#endif
 #endif
     explicit IJoypadEventDriven(double period);
 


### PR DESCRIPTION
It fixes #1747 

Please review code.