### PR TITLE
Fix the sensors name remapping in MultipleAnalogSensorsRemapper class

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -97,6 +97,10 @@ Bug Fixes
 * Fixed deadlock on macOS(see IntelRealSense/librealsense:#1855). Actually to
   fix it also are needed these changes IntelRealSense/librealsense:#2022.
 
+#### multipleanalogsensorsremapper
+
+* Fixed sensors name remapping in MultipleAnalogSensorsRemapper class.
+
 Contributors
 ------------
 

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -173,7 +173,7 @@ bool MultipleAnalogSensorsRemapper::genericAttachAll(const MAS_SensorType sensor
             for (size_t s=0; s < nrOfSensorsInSubDevice; s++)
             {
                 std::string name;
-                bool ok = genericGetName(sensorType, s, name, subDeviceVec, getNameMethodPtr);
+                bool ok = MAS_CALL_MEMBER_FN(subDeviceVec[p], getNameMethodPtr)(s,name);
                 if (!ok)
                 {
                     yError() << "MultipleAnalogSensorsRemapper: Failure in getting a name in the device " << polylist[p]->key;


### PR DESCRIPTION
Fixes issue https://github.com/robotology/yarp/issues/1765. Please refer to that link for all the details on the analysis.