### PR TITLE
RangeFinder2DClient: removed unused parameter

### DIFF
--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
@@ -177,16 +177,6 @@ bool yarp::dev::Rangefinder2DClient::open(yarp::os::Searchable &config)
         return false;
     }
 
-    if (config.check("period"))
-    {
-        _rate = config.find("period").asInt32();
-    }
-    else
-    {
-        yError("Rangefinder2DClient::open() missing period parameter");
-        return false;
-    }
-
     std::string local_rpc = local;
     local_rpc += "/rpc:o";
     std::string remote_rpc = remote;

--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
@@ -84,7 +84,6 @@ protected:
     std::string remote;
     yarp::os::Stamp lastTs; //used by IPreciselyTimed
     std::string deviceId;
-    int _rate;
 
     double scan_angle_min;
     double scan_angle_max;


### PR DESCRIPTION
Device had a mandatory input parameter that was not used in the code.