### PR TITLE
Fix extern/ycm CMakeLists

### DIFF
--- a/extern/ycm/CMakeLists.txt
+++ b/extern/ycm/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT YCM_FOUND)
                       "${CMAKE_CURRENT_LIST_DIR}/ycm-${YCM_REQUIRED_VERSION}/modules"
                       "${CMAKE_CURRENT_LIST_DIR}/ycm-${YCM_REQUIRED_VERSION}/3rdparty")
   if(${CMAKE_VERSION} VERSION_LESS 3.8)
-    list(APPEND YARP_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ycm-${YCM_REQUIRED_VERSION}/cmake-3.8/Modules")
+    list(APPEND YCM_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ycm-${YCM_REQUIRED_VERSION}/cmake-3.8/Modules")
   endif()
 
 


### PR DESCRIPTION
`YARP_MODULE_PATH` was used in place of `YCM_MODULE_PATH` and, as a consequence, CMake 3.8 ycm modules were not added in `CMAKE_MODULE_PATH`.