### PR TITLE
Fix rplidar2 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -404,6 +404,9 @@ before_script:
   # OpenCV on travis is built with C++98 ABI.
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then if [ "$CC" == "clang" ]; then export YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DYARP_USE_OPENCV=OFF"; fi; fi
 
+    # Build rplidar2 on linux
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -D-DENABLE_yarpmod_rpLidar2=ON"; fi
+
   # Avoid building Qt5 guis twice on macOS.
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then YARP_CMAKE_OPTIONS="${YARP_CMAKE_OPTIONS} -DYARP_DISABLE_OSX_BUNDLES=ON"; fi
 

--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -86,6 +86,12 @@ Bug Fixes
 * Fixed double free during the closure. It has been introduced by #1685
   (commit 02abf63).
 
+### Devices
+
+#### rplidar2
+
+* Fixed compilation (#1689).
+
 Contributors
 ------------
 

--- a/extern/rplidar/sdk/src/rplidar_driver.cpp
+++ b/extern/rplidar/sdk/src/rplidar_driver.cpp
@@ -525,7 +525,11 @@ u_result RPlidarDriverSerialImpl::grabScanData(rplidar_response_measurement_node
 {
     switch (_dataEvt.wait(timeout))
     {
-    case rp::hal::Event::EVENT_TIMEOUT:
+    // This static cast is necessary for the compilation
+    // because the return value of "wait(..)"
+    // is unsigned but EVENT_TIMEOUT = -1. We will keep
+    // it until they will fix the bug in the sdk.
+    case static_cast<ulong> (rp::hal::Event::EVENT_TIMEOUT):
         count = 0;
         return RESULT_OPERATION_TIMEOUT;
     case rp::hal::Event::EVENT_OK:

--- a/src/devices/rpLidar2/CMakeLists.txt
+++ b/src/devices/rpLidar2/CMakeLists.txt
@@ -7,7 +7,8 @@
 yarp_prepare_plugin(rpLidar2
                     CATEGORY device
                     TYPE RpLidar2
-                    INCLUDE rpLidar2.h)
+                    INCLUDE rpLidar2.h
+                    DEPENDS "NOT APPLE")
 
 if(NOT SKIP_rpLidar2)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
This static cast is necessary for the compilation because the return value of "wait(..)" is unsigned but EVENT_TIMEOUT = -1. We will keep it until they will fix the bug in the sdk.(fixes #1689)

Moreover add NOT APPLE as dependency of the device since some bugs in the sdk make it impossible to compile on macOs(see https://travis-ci.org/robotology/yarp/jobs/402720473 for example)