### PR TITLE
Fix realsense deadlock on macOS

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -92,6 +92,11 @@ Bug Fixes
 
 * Fixed compilation (#1689).
 
+#### realsense2
+
+* Fixed deadlock on macOS(see IntelRealSense/librealsense:#1855). Actually to
+  fix it also are needed these changes IntelRealSense/librealsense:#2022.
+
 Contributors
 ------------
 

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -376,7 +376,7 @@ bool realsense2Driver::pipelineStartup()
 {
     try
     {
-        m_pipeline.start(m_cfg);
+        m_profile = m_pipeline.start(m_cfg);
     }
     catch (const rs2::error& e)
     {
@@ -480,11 +480,8 @@ bool realsense2Driver::initializeRealsenseDevice()
         m_pipeline.wait_for_frames();
     }
     yInfo()<<"realsense2Driver:....device ready!";
-    // First, create a rs2::context.
-    rs2::device_list devices = m_ctx.query_devices();
 
-    rs2::device selected_device;
-    if (devices.size() == 0)
+    if (m_ctx.query_devices().size() == 0)
     {
         yError() << "realsense2Driver: No device connected, please connect a RealSense device";
 
@@ -497,7 +494,7 @@ bool realsense2Driver::initializeRealsenseDevice()
     {
         //TODO: if more are connected?!
         // Update the selected device
-        m_device = devices[0];
+        m_device = m_profile.get_device();
         if (m_verbose)
             yInfo()<<get_device_information(m_device).c_str();
     }

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -203,6 +203,7 @@ private:
     rs2::context m_ctx;
     rs2::config m_cfg;
     rs2::pipeline m_pipeline;
+    rs2::pipeline_profile m_profile;
     rs2::device  m_device;
     std::vector<rs2::sensor> m_sensors;
     rs2::sensor* m_depth_sensor;


### PR DESCRIPTION
This PR fixes the deadlock on macOS, see IntelRealSense/librealsense#1855

Actually to fix it on macOS, it is necessary also those changes -> IntelRealSense/librealsense#2022.
`librealsense 2.13.0` should include them.

cc @vtikha 