### PR TITLE
Fix multi namespace

### DIFF
--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -58,6 +58,7 @@ Bug Fixes
 * Fixed SharedLibraryClass::getContent(). Now a const and a non const version
   are available.
 * Fixed SharedLibraryClassFactory::destroy(). Now it is const like create().
+* Added initialization of `MultiNameSpace` in `Network::initMinimum`.
 
 #### YARP_dev
 

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -867,12 +867,15 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
         // make sure system is actually able to do things fast
         yarp::os::impl::Time::startTurboBoost();
 
-        __yarp_is_initialized++;
+        // MultiNameSpace is a c++11 singleton and need to be initialized
+        // before the first port that is opened and it has to exist until
+        // the last port is closed.
+        getNameSpace();
+
         if(yarp::os::Time::getClockType() == YARP_CLOCK_UNINITIALIZED)
             NetworkBase::yarpClockInit(clockType, nullptr);
-    } else {
-        __yarp_is_initialized++;
     }
+    __yarp_is_initialized++;
 }
 
 void NetworkBase::finiMinimum()


### PR DESCRIPTION
Multinamespace is a c++11 singleton(since #1699)  and need to be initialized
before the first port that is opened and it has to exist until
the last port is closed.

Please review code.
This PR is a firs step for the documentation of the `Network` object see #1670