### PR TITLE
Fixed the missing bindings in `yarp.Vector` class

### DIFF
--- a/bindings/matlab/vectors_fromTo_matlab.i
+++ b/bindings/matlab/vectors_fromTo_matlab.i
@@ -99,9 +99,9 @@ RESET_CONSTANTS_IN_TO_MATLAB
     RESET(0)
 }
 
-%extend yarp::sig::Vector {
+%extend yarp::sig::VectorOf<double> {
     TO_MATLAB(double,mxCreateDoubleMatrix)
-    FROM_MATLAB(double,double,mxCreateDoubleMatrix,yarp::sig::Vector)
+    FROM_MATLAB(double,double,mxCreateDoubleMatrix,yarp::sig::VectorOf<double>)
     RESET(0)
 }
 

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -411,6 +411,10 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/FrameGrabberInterfaces.h>
 %include <yarp/dev/AudioVisualInterfaces.h>
 %include <yarp/dev/ControlBoardInterfaces.h>
+%include <yarp/dev/IAxisInfo.h>
+%include <yarp/dev/IAmplifierControl.h>
+%include <yarp/dev/IControlDebug.h>
+%include <yarp/dev/IControlLimits.h>
 %include <yarp/dev/ControlBoardPid.h>
 %include <yarp/dev/CartesianControl.h>
 %include <yarp/dev/GazeControl.h>

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -221,7 +221,7 @@
 %ignore yarp::sig::Image::getRow(int) const;
 %ignore yarp::sig::Image::getIplImage() const;
 %ignore yarp::sig::Image::getReadType() const;
-%ignore yarp::sig::Vector::getType() const;
+%ignore yarp::sig::VectorOf<double>::getType() const;
 %ignore yarp::os::Property::put(const char *,Value *);
 %ignore yarp::os::Bottle::add(Value *);
 %rename(toString) std::string::operator const char *() const;
@@ -531,9 +531,9 @@ typedef yarp::os::BufferedPort<Sound> BufferedPortSound;
 %}
 
 %{
-typedef yarp::os::TypedReader<yarp::sig::Vector> TypedReaderVector;
-typedef yarp::os::TypedReaderCallback<yarp::sig::Vector> TypedReaderCallbackVector;
-typedef yarp::os::BufferedPort<yarp::sig::Vector> BufferedPortVector;
+typedef yarp::os::TypedReader<yarp::sig::VectorOf<double>> TypedReaderVector;
+typedef yarp::os::TypedReaderCallback<yarp::sig::VectorOf<double>> TypedReaderCallbackVector;
+typedef yarp::os::BufferedPort<yarp::sig::VectorOf<double>> BufferedPortVector;
 %}
 
 %feature("notabstract") ImageRgb;
@@ -598,9 +598,9 @@ typedef yarp::os::BufferedPort<yarp::sig::Vector> BufferedPortVector;
 %template(TypedReaderCallbackSound) yarp::os::TypedReaderCallback<yarp::sig::Sound>;
 %template(BufferedPortSound) yarp::os::BufferedPort<yarp::sig::Sound >;
 
-%template(TypedReaderVector) yarp::os::TypedReader<yarp::sig::Vector >;
-%template(TypedReaderCallbackVector) yarp::os::TypedReaderCallback<yarp::sig::Vector>;
-%template(BufferedPortVector) yarp::os::BufferedPort<yarp::sig::Vector >;
+%template(TypedReaderVector) yarp::os::TypedReader<yarp::sig::VectorOf<double> >;
+%template(TypedReaderCallbackVector) yarp::os::TypedReaderCallback<yarp::sig::VectorOf<double>>;
+%template(BufferedPortVector) yarp::os::BufferedPort<yarp::sig::VectorOf<double> >;
 
 // Add getPixel and setPixel methods to access float values
 %extend yarp::sig::ImageOf<yarp::sig::PixelFloat> {
@@ -1066,7 +1066,7 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 %extend yarp::dev::IEncoderArrays {EXTENDED_ANALOG_SENSOR_INTERFACE(EncoderArray)}
 %extend yarp::dev::ISkinPatches {EXTENDED_ANALOG_SENSOR_INTERFACE(SkinPatch)}
 
-%extend yarp::sig::Vector {
+%extend yarp::sig::VectorOf<double> {
 
     double get(int j)
     {
@@ -1318,8 +1318,8 @@ public:
         return self->cast_as<yarp::os::Property>();
     }
 
-    yarp::sig::Vector* asVector() {
-        return self->cast_as<yarp::sig::Vector>();
+    yarp::sig::VectorOf<double>* asVector() {
+        return self->cast_as<yarp::sig::VectorOf<double>>();
     }
 
     yarp::sig::Matrix* asMatrix() {

--- a/src/libYARP_dev/include/yarp/dev/all.h
+++ b/src/libYARP_dev/include/yarp/dev/all.h
@@ -16,6 +16,10 @@
 #include <yarp/dev/CartesianControl.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
+#include <yarp/dev/IAxisInfo.h>
+#include <yarp/dev/IAmplifierControl.h>
+#include <yarp/dev/IControlDebug.h>
+#include <yarp/dev/IControlLimits.h>
 #include <yarp/dev/ControlBoardPid.h>
 #include <yarp/dev/DataSource.h>
 #include <yarp/dev/DeviceDriver.h>


### PR DESCRIPTION
The binding class yarp.Vector is missing some methods since `yarp::sig::Vector` was made a typedef of `yarp::sig::VectorOf<double>`, and the change https://github.com/robotology/yarp/commit/2417c7d5e50aebca2ca8532fb40e7084262d50e8 fixed the ruby bindings generation.
Refer to issue https://github.com/robotology/yarp/issues/1809.

**The Fix:** replace every instance of `yarp::sig::Vector` by `yarp::sig::VectorOf<double>` in yarp.i. and `matlab/vectors_fromTo_matlab.i`.

For further details on the analysis, refer to https://github.com/robotology/yarp/issues/1809#issuecomment-406811352.