### PR TITLE
yarpidl_rosmsg fixes and unit tests

### DIFF
--- a/cmake/YarpIDL.cmake
+++ b/cmake/YarpIDL.cmake
@@ -11,14 +11,9 @@
 # optionally storing the list of source/header files in the supplied
 # variables. Call as:
 #
-#   yarp_idl_to_dir(foo.thrift foo [NO_RECURSE])
-#   yarp_idl_to_dir(foo.thrift foo [NO_RECURSE] SOURCES HEADERS)
-#   yarp_idl_to_dir(foo.thrift foo [NO_RECURSE] SOURCES HEADERS INCLUDE_PATHS)
-#
-# If the ``NO_RECURSE`` option is set, the --no-recurse option is
-# passed to ``yarpidl_rosmsg``, hence generating code only for the
-# selected files, not for their dependencies.
-#
+#   yarp_idl_to_dir(foo.thrift foo)
+#   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS)
+#   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS INCLUDE_PATHS)
 #
 # yarp_add_idl
 # ------------
@@ -26,7 +21,7 @@
 # Take one or more IDL files and generate code at build time.
 # Files will be regenerated whenever the IDL file changes.
 #
-#   yarp_add_idl(<var> [NO_RECURSE] <file> [file [...]])
+#   yarp_add_idl(<var> <file> [file [...]])
 #
 # The <var> variable, will contain the generated files, and can be
 # added to the an add_executable or add_library call. For example:
@@ -36,10 +31,6 @@
 #                    file3.srv)
 #   yarp_add_idl(THRIFT_GEN_FILES ${THRIFT_FILES})
 #   add_executable(foo main.cpp ${THRIFT_GEN_FILES})
-#
-# If the ``NO_RECURSE`` option is set, the --no-recurse option is
-# passed to ``yarpidl_rosmsg``, hence generating code only for the
-# selected files, not for their dependencies.
 
 
 # Avoid multiple inclusions of this file
@@ -50,14 +41,6 @@ endif()
 function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
   # Store optional output variable(s).
   set(out_vars ${ARGN})
-
-  # If the first not named argument (ARGV2) is "NO_RECURSE", it is removed from
-  # the out_vars list, and the --no-recurse option is passed to yarpidl_rosmsg
-  set(_no_recurse )
-  if ("${ARGV2}" STREQUAL "NO_RECURSE")
-    list(REMOVE_AT out_vars 0)
-    set(_no_recurse --no-recurse)
-  endif()
 
   # Make sure output_dir variable is visible when expanding templates.
   set(output_dir ${output_dir})
@@ -159,7 +142,7 @@ function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
         set(_verbose --verbose)
         set(_output_quiet )
       endif()
-      set(cmd "${YARPIDL_rosmsg_LOCATION}" --no-ros true --no-cache ${_verbose} ${_no_recurse} --out "${dir}" "${yarpidl_file}")
+      set(cmd "${YARPIDL_rosmsg_LOCATION}" --no-ros true --no-cache ${_verbose} --out "${dir}" "${yarpidl_file}")
     endif()
 
     # Go ahead and generate files.
@@ -320,20 +303,13 @@ function(_YARP_IDL_ROSMSG_TO_FILE_LIST file path pkg basename ext gen_srcs_var g
 endfunction()
 
 
-function(YARP_ADD_IDL var first_file)
+function(YARP_ADD_IDL var)
 
   # Ensure that the output variable is empty
   unset(${var})
   unset(include_dirs)
 
-  if("${first_file}" STREQUAL "NO_RECURSE")
-    set(_files ${ARGN})
-    set(_no_recurse --no-recurse)
-  else()
-    set(_files "${first_file}" ${ARGN})
-    set(_no_recurse )
-  endif()
-
+  set(_files ${ARGN})
   foreach(file ${_files})
 
     # Ensure that the filename is relative to the current source directory
@@ -402,7 +378,7 @@ function(YARP_ADD_IDL var first_file)
       if(YARPIDL_rosmsg_VERBOSE)
         set(_verbose --verbose)
       endif()
-      set(cmd ${YARPIDL_rosmsg_COMMAND} --no-ros true --no-cache --no-index ${_verbose} ${_no_recurse} --out "${CMAKE_CURRENT_BINARY_DIR}/include" "${file}")
+      set(cmd ${YARPIDL_rosmsg_COMMAND} --no-ros true --no-cache --no-index ${_verbose} --out "${CMAKE_CURRENT_BINARY_DIR}/include" "${file}")
     endif()
 
     # Prepare copy command (thrift only) and populate output variable

--- a/doc/release/v3_0_1.md
+++ b/doc/release/v3_0_1.md
@@ -13,11 +13,25 @@ Important Changes
 * The `idl_tools` component is now required in order to use `yarp_idl_to_dir`
   and `yarp_add_idl`.
 
+#### YARP_rosmsg
+
+* Removed all `getTypeText()` and `typeText()` methods, replaced by
+  `static constexpr const char* typeText` variable.
 
 New Features
 ------------
 
 * Python and ruby bindings tests are now integrated with ctest
+
+### Libraries
+
+#### YARP_rosmsg
+
+* Added `static constexpr const char* typeName`,
+  `static constexpr const char* typeChecksum` and
+  `static constexpr const char* typeText` variables to all generated
+  classes.
+
 
 ### Tools
 
@@ -51,6 +65,7 @@ Bug Fixes
   not found if any of such components is missing.
 * Plugins not enabled due to missing dependencies are now shown in `ccmake` and
   `cmake-gui` together with a list of dependencies that are not satisfied.
+* Removed the NO_RECURSE argument to `yarp_idl_to_dir` and `yarp_add_idl`.
 
 
 ### Libraries
@@ -87,6 +102,18 @@ Bug Fixes
 #### YARP_sig
 
 * Fixed negative vocab(#1749).
+
+#### YARP_rosmsg
+
+* Fixed `message_definition` property for all classes.
+
+
+### Tools
+
+#### yarpidl_rosmsg
+
+* Removed the --no-recurse option.
+* The `message_definition` property is now properly generated.
 
 
 ### GUIs

--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -177,125 +177,120 @@ bool RosType::read(const char *tname, RosTypeSearch& env, RosTypeCodeGen& gen,
     }
 
     bool ok = true;
-    if (nesting == 0 || !no_recurse) {
-        std::string path = env.findFile(base.c_str());
-        rosPath = path;
+    std::string path = env.findFile(base.c_str());
+    rosPath = path;
 
-        FILE *fin = fopen((env.getTargetDirectory() + "/" + path).c_str(),"r");
-        if (!fin) {
-            fin = fopen(path.c_str(),"r");
-        }
-        if (!fin) {
-            fprintf(stderr, "[type] FAILED to open %s\n", path.c_str());
-            std::exit(1);
-        }
+    FILE *fin = fopen((env.getTargetDirectory() + "/" + path).c_str(),"r");
+    if (!fin) {
+        fin = fopen(path.c_str(),"r");
+    }
+    if (!fin) {
+        fprintf(stderr, "[type] FAILED to open %s\n", path.c_str());
+        std::exit(1);
+    }
 
-        if (verbose) {
-            fprintf(stderr,"[type]%s BEGIN %s\n", indent.c_str(), path.c_str());
-        }
-        char *result = nullptr;
-        txt = "";
-        source = "";
+    if (verbose) {
+        fprintf(stderr,"[type]%s BEGIN %s\n", indent.c_str(), path.c_str());
+    }
+    char *result = nullptr;
+    txt = "";
+    source = "";
 
-        RosType *cursor = this;
-        char buf[2048];
-        do {
-            result = fgets(buf,sizeof(buf),fin);
-            if (result==nullptr) break;
-            txt += "//   ";
-            txt += result;
-            source += result;
-            int len = (int)strlen(result);
-            for (int i=0; i<len; i++) {
-                if (result[i]=='\n') {
-                    result[i] = '\0';
-                    break;
-                }
+    RosType *cursor = this;
+    char buf[2048];
+    do {
+        result = fgets(buf,sizeof(buf),fin);
+        if (result==nullptr) break;
+        txt += "//   ";
+        txt += result;
+        source += result;
+        int len = (int)strlen(result);
+        for (int i=0; i<len; i++) {
+            if (result[i]=='\n') {
+                result[i] = '\0';
+                break;
             }
-            std::string row = result;
-            std::vector<std::string> msg = normalizedMessage(row);
-            if (msg.size()==0) { continue; }
-            if (msg[0] == "---") {
-                if (verbose) {
-                    printf("--- reply ---\n");
-                }
-                cursor->isValid = ok;
-                ok = true;
-                cursor->reply = new RosType();
-                cursor->reply->verbose = verbose;
-                cursor->reply->no_recurse = no_recurse;
-                cursor = cursor->reply;
-                cursor->rosType = rosType + "Reply";
-                continue;
-            }
-            bool have_const = false;
-            std::string const_txt = "";
-            if (msg.size()>2) {
-                if (msg[2]=="=") {
-                    have_const = true;
-                    //printf("Not worrying about: %s\n", row.c_str());
-                    //continue;
-                    const_txt = msg[3];
-                }
-            }
-            if (msg.size()!=2 && !have_const) {
-                if (msg.size()>0) {
-                    if (msg[0][0]!='[') {
-                        if (verbose) {
-                            fprintf(stderr,"[type] skip %s\n", row.c_str());
-                        }
-                        ok = false;
-                    }
-                }
-                continue;
-            }
-            std::string t = msg[0];
-            std::string n = msg[1];
+        }
+        std::string row = result;
+        std::vector<std::string> msg = normalizedMessage(row);
+        if (msg.size()==0) { continue; }
+        if (msg[0] == "---") {
             if (verbose) {
-                fprintf(stderr,"[type]%s   %s %s", indent.c_str(), t.c_str(), n.c_str());
-                if (const_txt!="") {
-                    fprintf(stderr," = %s", const_txt.c_str());
+                printf("--- reply ---\n");
+            }
+            cursor->isValid = ok;
+            ok = true;
+            cursor->reply = new RosType();
+            cursor->reply->verbose = verbose;
+            cursor = cursor->reply;
+            cursor->rosType = rosType + "Reply";
+            continue;
+        }
+        bool have_const = false;
+        std::string const_txt = "";
+        if (msg.size()>2) {
+            if (msg[2]=="=") {
+                have_const = true;
+                //printf("Not worrying about: %s\n", row.c_str());
+                //continue;
+                const_txt = msg[3];
+            }
+        }
+        if (msg.size()!=2 && !have_const) {
+            if (msg.size()>0) {
+                if (msg[0][0]!='[') {
+                    if (verbose) {
+                        fprintf(stderr,"[type] skip %s\n", row.c_str());
+                    }
+                    ok = false;
                 }
-                fprintf(stderr,"\n");
             }
-            RosType sub;
-            sub.verbose = verbose;
-            sub.no_recurse = no_recurse;
-            sub.package = package;
-            if (!sub.read(t.c_str(),env,gen,nesting+1)) {
-                if (!no_recurse) {
-                    fprintf(stderr, "[type]%s Type not complete: %s\n",
-                            indent.c_str(),
-                            row.c_str());
-                    ok = no_recurse;
-                }
-            }
-
-            sub.rosName = n;
-            const_txt.erase(0,const_txt.find_first_not_of(" \t"));
-            if (const_txt.find_first_of(" \t#")!=std::string::npos) {
-                const_txt = const_txt.substr(0,const_txt.find_first_of(" \t#"));
-            }
-            sub.initializer = const_txt;
-            cursor->subRosType.push_back(sub);
-        } while (result!=nullptr);
+            continue;
+        }
+        std::string t = msg[0];
+        std::string n = msg[1];
         if (verbose) {
-            fprintf(stderr,"[type]%s END %s\n", indent.c_str(), path.c_str());
-        }
-        fclose(fin);
-
-        if (rosType == "Header" || rosType == "std_msgs/Header") {
-            std::string preamble = "[std_msgs/Header]:";
-            if (source.find(preamble)==0) {
-                source = source.substr(preamble.length()+1,source.length());
+            fprintf(stderr,"[type]%s   %s %s", indent.c_str(), t.c_str(), n.c_str());
+            if (const_txt!="") {
+                fprintf(stderr," = %s", const_txt.c_str());
             }
+            fprintf(stderr,"\n");
+        }
+        RosType sub;
+        sub.verbose = verbose;
+        sub.package = package;
+        if (!sub.read(t.c_str(), env, gen, nesting+1)) {
+            fprintf(stderr, "[type]%s Type not complete: %s\n",
+                    indent.c_str(),
+                    row.c_str());
+            ok = false;
         }
 
-        isValid = ok;
-        if (!isValid) {
-            fprintf(stderr, "[type]%s Check failed: %s\n", indent.c_str(), tname);
+        sub.rosName = n;
+        const_txt.erase(0,const_txt.find_first_not_of(" \t"));
+        if (const_txt.find_first_of(" \t#")!=std::string::npos) {
+            const_txt = const_txt.substr(0,const_txt.find_first_of(" \t#"));
+        }
+        sub.initializer = const_txt;
+        cursor->subRosType.push_back(sub);
+    } while (result!=nullptr);
+    if (verbose) {
+        fprintf(stderr,"[type]%s END %s\n", indent.c_str(), path.c_str());
+    }
+    fclose(fin);
+
+    if (rosType == "Header" || rosType == "std_msgs/Header") {
+        std::string preamble = "[std_msgs/Header]:";
+        if (source.find(preamble)==0) {
+            source = source.substr(preamble.length()+1,source.length());
         }
     }
+
+    isValid = ok;
+    if (!isValid) {
+        fprintf(stderr, "[type]%s Check failed: %s\n", indent.c_str(), tname);
+    }
+
     return isValid;
 }
 
@@ -391,10 +386,8 @@ bool RosType::emitType(RosTypeCodeGen& gen,
     }
 
     for (RosType& e : subRosType) {
-        if (!no_recurse) {
-            if (!e.emitType(gen,state)) {
-                return false;
-            }
+        if (!e.emitType(gen,state)) {
+            return false;
         }
 
         if (e.isConst()) {

--- a/src/idls/rosmsg/src/RosType.cpp
+++ b/src/idls/rosmsg/src/RosType.cpp
@@ -116,6 +116,7 @@ bool RosType::read(const char *tname, RosTypeSearch& env, RosTypeCodeGen& gen,
                 isPrimitive = false;
                 RosType t1;
                 t1.rosType = "uint32";
+                t1.rosRawType = "uint32";
                 t1.rosName = "sec";
                 t1.isPrimitive = true;
                 t1.isRosPrimitive = true;
@@ -124,6 +125,7 @@ bool RosType::read(const char *tname, RosTypeSearch& env, RosTypeCodeGen& gen,
                 subRosType.push_back(t1);
                 RosType t2;
                 t2.rosType = "uint32";
+                t2.rosRawType = "uint32";
                 t2.rosName = "nsec";
                 t2.isPrimitive = true;
                 t2.isRosPrimitive = true;

--- a/src/idls/rosmsg/src/RosType.h
+++ b/src/idls/rosmsg/src/RosType.h
@@ -106,7 +106,6 @@ public:
     RosType *reply;
     std::string package;
     bool verbose;
-    bool no_recurse;
 
     RosType() :
             isValid(false),
@@ -116,8 +115,7 @@ public:
             isRosPrimitive(false),
             isStruct(false),
             reply(nullptr),
-            verbose(false),
-            no_recurse(false)
+            verbose(false)
     {
     }
 
@@ -163,10 +161,6 @@ public:
 
     void setVerbose() {
         verbose = true;
-    }
-
-    void setNoRecurse() {
-        no_recurse = true;
     }
 };
 

--- a/src/idls/rosmsg/src/main.cpp
+++ b/src/idls/rosmsg/src/main.cpp
@@ -47,8 +47,6 @@ void show_usage()
     printf("    Do not cache ros msg file\n");
     printf("  --no-index\n");
     printf("    Do not generate the indexALL.txt file\n");
-    printf("  --no-recurse\n");
-    printf("    Generate code only for the selected file, not for its dependencies\n");
     printf("  --verbose\n");
     printf("    Verbose output\n");
     printf("\n");
@@ -135,7 +133,6 @@ int generate_cpp(int argc, char *argv[])
     bool verbose = p.check("verbose");
     bool no_cache = p.check("no-cache");
     bool no_index = p.check("no-index");
-    bool no_recurse = p.check("no-recurse");
 
     fname = argv[argc-1];
 
@@ -156,9 +153,6 @@ int generate_cpp(int argc, char *argv[])
         env.setVerbose();
         t.setVerbose();
         gen.setVerbose();
-    }
-    if (no_recurse) {
-        t.setNoRecurse();
     }
 
     if (p.check("out")) {

--- a/src/libYARP_OS/include/yarp/os/impl/UnitTest.h
+++ b/src/libYARP_OS/include/yarp/os/impl/UnitTest.h
@@ -71,7 +71,7 @@ public:
              typename T2,
              typename = typename std::enable_if<is_supported<T1>::value && is_supported<T2>::value>::type>
     bool checkEqualImpl(T1 x, T2 y,
-                        const char *desc,
+                        const std::string& desc,
                         const char *txt1,
                         const char *txt2,
                         const char *fname,
@@ -90,14 +90,14 @@ public:
     }
 
     bool checkEqualishImpl(double x, double y,
-                           const char *desc,
+                           const std::string& desc,
                            const char *txt1,
                            const char *txt2,
                            const char *fname,
                            int fline);
 
     bool checkEqualImpl(const std::string& x, const std::string& y,
-                        const char *desc,
+                        const std::string& desc,
                         const char *txt1,
                         const char *txt2,
                         const char *fname,

--- a/src/libYARP_OS/src/UnitTest.cpp
+++ b/src/libYARP_OS/src/UnitTest.cpp
@@ -188,7 +188,7 @@ void UnitTest::stopTestSystem() {
 }
 
 bool UnitTest::checkEqualishImpl(double x, double y,
-                                 const char *desc,
+                                 const std::string& desc,
                                  const char *txt1,
                                  const char *txt2,
                                  const char *fname,
@@ -207,7 +207,7 @@ bool UnitTest::checkEqualishImpl(double x, double y,
 
 
 bool UnitTest::checkEqualImpl(const std::string& x, const std::string& y,
-                              const char *desc,
+                              const std::string& desc,
                               const char *txt1,
                               const char *txt2,
                               const char *fname,

--- a/src/libYARP_rosmsg/CMakeLists.txt
+++ b/src/libYARP_rosmsg/CMakeLists.txt
@@ -23,14 +23,12 @@ macro(_yarp_choose_idl _prefix)
        NOT ALLOW_IDL_GENERATION AND
        YARP_COMPILE_EXECUTABLES)
       yarp_add_idl(${_prefix}_GEN_FILES
-#                   NO_RECURSE # Temporarily disable until the md5sum generated is correct
                    ${ARGN})
       set(${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
     else()
       foreach(_msg ${ARGN})
         yarp_idl_to_dir(${_msg}
                         "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
-#                        NO_RECURSE # Temporarily disable until the md5sum generated is correct
                         ${_prefix}_GEN_SRCS
                         ${_prefix}_GEN_HDRS
                         ${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS)

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickDuration.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickDuration.h
@@ -175,7 +175,7 @@ public:
     yarp::os::Type getType() const override
     {
         yarp::os::Type typ = yarp::os::Type::byName("TickDuration", "TickDuration");
-        typ.addProperty("md5sum", yarp::os::Value("4f8dc7710c22b42c7b09295dcda33fa0"));
+        typ.addProperty("md5sum", yarp::os::Value("4771ad66fef816d2e4bead2f45a1cde6"));
         typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
         return typ;
     }

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickDuration.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickDuration.h
@@ -159,24 +159,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::TickDuration> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::TickDuration> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "TickDuration";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::TickDuration::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4771ad66fef816d2e4bead2f45a1cde6";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("TickDuration", "TickDuration");
-        typ.addProperty("md5sum", yarp::os::Value("4771ad66fef816d2e4bead2f45a1cde6"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickTime.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickTime.h
@@ -159,24 +159,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::TickTime> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::TickTime> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "TickTime";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::TickTime::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4771ad66fef816d2e4bead2f45a1cde6";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("TickTime", "TickTime");
-        typ.addProperty("md5sum", yarp::os::Value("4771ad66fef816d2e4bead2f45a1cde6"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickTime.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/TickTime.h
@@ -175,7 +175,7 @@ public:
     yarp::os::Type getType() const override
     {
         yarp::os::Type typ = yarp::os::Type::byName("TickTime", "TickTime");
-        typ.addProperty("md5sum", yarp::os::Value("4f8dc7710c22b42c7b09295dcda33fa0"));
+        typ.addProperty("md5sum", yarp::os::Value("4771ad66fef816d2e4bead2f45a1cde6"));
         typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
         return typ;
     }

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalID.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalID.h
@@ -147,10 +147,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::actionlib_msgs::GoalID> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::actionlib_msgs::GoalID> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "actionlib_msgs/GoalID";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "302881f31927c1df708a2dbab0e80ee8";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # The stamp should store the time at which this goal was requested.\n\
 # It is used by an action server when it tries to preempt all\n\
 # goals that were requested before a certain time\n\
@@ -161,20 +165,13 @@ time stamp\n\
 # specified must be unique.\n\
 string id\n\
 \n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::actionlib_msgs::GoalID::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("actionlib_msgs/GoalID", "actionlib_msgs/GoalID");
-        typ.addProperty("md5sum", yarp::os::Value("302881f31927c1df708a2dbab0e80ee8"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalStatus.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalStatus.h
@@ -208,10 +208,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::actionlib_msgs::GoalStatus> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::actionlib_msgs::GoalStatus> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "actionlib_msgs/GoalStatus";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d388f9b87b3c471f784434d671988d4a";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 GoalID goal_id\n\
 uint8 status\n\
 uint8 PENDING         = 0   # The goal has yet to be processed by the action server\n\
@@ -235,23 +239,26 @@ uint8 LOST            = 9   # An action client can determine that a goal is LOST
 #Allow for the user to associate a string with GoalStatus for debugging\n\
 string text\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: actionlib_msgs/GoalID\n\
-") + yarp::rosmsg::actionlib_msgs::GoalID::typeText();
-    }
+# The stamp should store the time at which this goal was requested.\n\
+# It is used by an action server when it tries to preempt all\n\
+# goals that were requested before a certain time\n\
+time stamp\n\
+\n\
+# The id provides a way to associate feedback and\n\
+# result message with specific goal requests. The id\n\
+# specified must be unique.\n\
+string id\n\
+\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::actionlib_msgs::GoalStatus::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("actionlib_msgs/GoalStatus", "actionlib_msgs/GoalStatus");
-        typ.addProperty("md5sum", yarp::os::Value("d388f9b87b3c471f784434d671988d4a"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalStatusArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/actionlib_msgs/GoalStatusArray.h
@@ -160,35 +160,83 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::actionlib_msgs::GoalStatusArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::actionlib_msgs::GoalStatusArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "actionlib_msgs/GoalStatusArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8b2b82f13216d0a8ea88bd3af735e619";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Stores the statuses for goals that are currently being tracked\n\
 # by an action server\n\
 Header header\n\
 GoalStatus[] status_list\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: actionlib_msgs/GoalStatus\n\
-") + yarp::rosmsg::actionlib_msgs::GoalStatus::typeText();
-    }
+GoalID goal_id\n\
+uint8 status\n\
+uint8 PENDING         = 0   # The goal has yet to be processed by the action server\n\
+uint8 ACTIVE          = 1   # The goal is currently being processed by the action server\n\
+uint8 PREEMPTED       = 2   # The goal received a cancel request after it started executing\n\
+                            #   and has since completed its execution (Terminal State)\n\
+uint8 SUCCEEDED       = 3   # The goal was achieved successfully by the action server (Terminal State)\n\
+uint8 ABORTED         = 4   # The goal was aborted during execution by the action server due\n\
+                            #    to some failure (Terminal State)\n\
+uint8 REJECTED        = 5   # The goal was rejected by the action server without being processed,\n\
+                            #    because the goal was unattainable or invalid (Terminal State)\n\
+uint8 PREEMPTING      = 6   # The goal received a cancel request after it started executing\n\
+                            #    and has not yet completed execution\n\
+uint8 RECALLING       = 7   # The goal received a cancel request before it started executing,\n\
+                            #    but the action server has not yet confirmed that the goal is canceled\n\
+uint8 RECALLED        = 8   # The goal received a cancel request before it started executing\n\
+                            #    and was successfully cancelled (Terminal State)\n\
+uint8 LOST            = 9   # An action client can determine that a goal is LOST. This should not be\n\
+                            #    sent over the wire by an action server\n\
+\n\
+#Allow for the user to associate a string with GoalStatus for debugging\n\
+string text\n\
+\n\
+\n\
+================================================================================\n\
+MSG: actionlib_msgs/GoalID\n\
+# The stamp should store the time at which this goal was requested.\n\
+# It is used by an action server when it tries to preempt all\n\
+# goals that were requested before a certain time\n\
+time stamp\n\
+\n\
+# The id provides a way to associate feedback and\n\
+# result message with specific goal requests. The id\n\
+# specified must be unique.\n\
+string id\n\
+\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::actionlib_msgs::GoalStatusArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("actionlib_msgs/GoalStatusArray", "actionlib_msgs/GoalStatusArray");
-        typ.addProperty("md5sum", yarp::os::Value("8b2b82f13216d0a8ea88bd3af735e619"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/AddDiagnostics.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/AddDiagnostics.h
@@ -138,10 +138,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::AddDiagnostics> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::AddDiagnostics> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/AddDiagnostics";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c26cf6e164288fbc6050d74f838bcdf0";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This service is used as part of the process for loading analyzers at runtime,\n\
 # and should be used by a loader script or program, not as a standalone service.\n\
 # Information about dynamic addition of analyzers can be found at\n\
@@ -169,20 +173,13 @@ bool success\n\
 \n\
 # Message with additional information about the success or failure\n\
 string message\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::AddDiagnostics::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/AddDiagnostics", "diagnostic_msgs/AddDiagnostics");
-        typ.addProperty("md5sum", yarp::os::Value("c26cf6e164288fbc6050d74f838bcdf0"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/AddDiagnosticsReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/AddDiagnosticsReply.h
@@ -131,24 +131,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::AddDiagnosticsReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::AddDiagnosticsReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/AddDiagnosticsReply";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::AddDiagnosticsReply::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "937c9679a518e3a18d831e57125ea522";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/AddDiagnosticsReply", "diagnostic_msgs/AddDiagnosticsReply");
-        typ.addProperty("md5sum", yarp::os::Value("937c9679a518e3a18d831e57125ea522"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/DiagnosticArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/DiagnosticArray.h
@@ -157,32 +157,64 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::DiagnosticArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::DiagnosticArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/DiagnosticArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "60810da900de1dd6ddd437c3503511da";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message is used to send diagnostic information about the state of the robot\n\
 Header header #for timestamp\n\
-DiagnosticStatus[] status # an array of components being reported on") + std::string("\n\
+DiagnosticStatus[] status # an array of components being reported on\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: diagnostic_msgs/DiagnosticStatus\n\
-") + yarp::rosmsg::diagnostic_msgs::DiagnosticStatus::typeText();
-    }
+# This message holds the status of an individual component of the robot.\n\
+# \n\
+\n\
+# Possible levels of operations\n\
+byte OK=0\n\
+byte WARN=1\n\
+byte ERROR=2\n\
+byte STALE=3\n\
+\n\
+byte level # level of operation enumerated above \n\
+string name # a description of the test/component reporting\n\
+string message # a description of the status\n\
+string hardware_id # a hardware unique string\n\
+KeyValue[] values # an array of values associated with the status\n\
+\n\
+\n\
+================================================================================\n\
+MSG: diagnostic_msgs/KeyValue\n\
+string key # what to label this value when viewing\n\
+string value # a value to track over time\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::DiagnosticArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/DiagnosticArray", "diagnostic_msgs/DiagnosticArray");
-        typ.addProperty("md5sum", yarp::os::Value("60810da900de1dd6ddd437c3503511da"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/DiagnosticStatus.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/DiagnosticStatus.h
@@ -252,10 +252,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::DiagnosticStatus> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::DiagnosticStatus> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/DiagnosticStatus";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d0ce08bc6e5ba34c7754f563a9cabaf1";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message holds the status of an individual component of the robot.\n\
 # \n\
 \n\
@@ -271,23 +275,18 @@ string message # a description of the status\n\
 string hardware_id # a hardware unique string\n\
 KeyValue[] values # an array of values associated with the status\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: diagnostic_msgs/KeyValue\n\
-") + yarp::rosmsg::diagnostic_msgs::KeyValue::typeText();
-    }
+string key # what to label this value when viewing\n\
+string value # a value to track over time\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::DiagnosticStatus::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/DiagnosticStatus", "diagnostic_msgs/DiagnosticStatus");
-        typ.addProperty("md5sum", yarp::os::Value("d0ce08bc6e5ba34c7754f563a9cabaf1"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/KeyValue.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/KeyValue.h
@@ -139,26 +139,23 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::KeyValue> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::KeyValue> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/KeyValue";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cf57fdc6617a881a88c16e768132149c";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 string key # what to label this value when viewing\n\
 string value # a value to track over time\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::KeyValue::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/KeyValue", "diagnostic_msgs/KeyValue");
-        typ.addProperty("md5sum", yarp::os::Value("cf57fdc6617a881a88c16e768132149c"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/SelfTest.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/SelfTest.h
@@ -94,28 +94,25 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::SelfTest> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::SelfTest> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/SelfTest";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d41d8cd98f00b204e9800998ecf8427e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 ---\n\
 string id\n\
 byte passed\n\
 DiagnosticStatus[] status\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::SelfTest::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/SelfTest", "diagnostic_msgs/SelfTest");
-        typ.addProperty("md5sum", yarp::os::Value("d41d8cd98f00b204e9800998ecf8427e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/SelfTestReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/diagnostic_msgs/SelfTestReply.h
@@ -173,27 +173,44 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::diagnostic_msgs::SelfTestReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::diagnostic_msgs::SelfTestReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-") + std::string("\n\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "diagnostic_msgs/SelfTestReply";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ac21b1bab7ab17546986536c22eb34e9";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
 ================================================================================\n\
 MSG: diagnostic_msgs/DiagnosticStatus\n\
-") + yarp::rosmsg::diagnostic_msgs::DiagnosticStatus::typeText();
-    }
+# This message holds the status of an individual component of the robot.\n\
+# \n\
+\n\
+# Possible levels of operations\n\
+byte OK=0\n\
+byte WARN=1\n\
+byte ERROR=2\n\
+byte STALE=3\n\
+\n\
+byte level # level of operation enumerated above \n\
+string name # a description of the test/component reporting\n\
+string message # a description of the status\n\
+string hardware_id # a hardware unique string\n\
+KeyValue[] values # an array of values associated with the status\n\
+\n\
+\n\
+================================================================================\n\
+MSG: diagnostic_msgs/KeyValue\n\
+string key # what to label this value when viewing\n\
+string value # a value to track over time\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::diagnostic_msgs::SelfTestReply::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("diagnostic_msgs/SelfTestReply", "diagnostic_msgs/SelfTestReply");
-        typ.addProperty("md5sum", yarp::os::Value("ac21b1bab7ab17546986536c22eb34e9"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Accel.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Accel.h
@@ -139,30 +139,37 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Accel> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Accel> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Accel";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "9f195f881246fdfa2798d1d3eebca84a";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses acceleration in free space broken into its linear and angular parts.\n\
 Vector3  linear\n\
 Vector3  angular\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Accel::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Accel", "geometry_msgs/Accel");
-        typ.addProperty("md5sum", yarp::os::Value("9f195f881246fdfa2798d1d3eebca84a"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelStamped.h
@@ -140,33 +140,61 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::AccelStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::AccelStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/AccelStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d8a98a5d81351b6eb0578c78557e7659";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # An accel with reference coordinate frame and timestamp\n\
 Header header\n\
 Accel accel\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Accel\n\
-") + yarp::rosmsg::geometry_msgs::Accel::typeText();
-    }
+# This expresses acceleration in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::AccelStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/AccelStamped", "geometry_msgs/AccelStamped");
-        typ.addProperty("md5sum", yarp::os::Value("d8a98a5d81351b6eb0578c78557e7659"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelWithCovariance.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelWithCovariance.h
@@ -156,10 +156,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::AccelWithCovariance> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::AccelWithCovariance> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/AccelWithCovariance";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ad5a718d699c6be72a02b8d6a139f334";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses acceleration in free space with uncertainty.\n\
 \n\
 Accel accel\n\
@@ -169,23 +173,32 @@ Accel accel\n\
 # In order, the parameters are:\n\
 # (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
 float64[36] covariance\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Accel\n\
-") + yarp::rosmsg::geometry_msgs::Accel::typeText();
-    }
+# This expresses acceleration in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::AccelWithCovariance::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/AccelWithCovariance", "geometry_msgs/AccelWithCovariance");
-        typ.addProperty("md5sum", yarp::os::Value("ad5a718d699c6be72a02b8d6a139f334"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelWithCovarianceStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/AccelWithCovarianceStamped.h
@@ -140,33 +140,73 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::AccelWithCovarianceStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::AccelWithCovarianceStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/AccelWithCovarianceStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "96adb295225031ec8d57fb4251b0a886";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents an estimated accel with reference coordinate frame and timestamp.\n\
 Header header\n\
 AccelWithCovariance accel\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/AccelWithCovariance\n\
-") + yarp::rosmsg::geometry_msgs::AccelWithCovariance::typeText();
-    }
+# This expresses acceleration in free space with uncertainty.\n\
+\n\
+Accel accel\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Accel\n\
+# This expresses acceleration in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::AccelWithCovarianceStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/AccelWithCovarianceStamped", "geometry_msgs/AccelWithCovarianceStamped");
-        typ.addProperty("md5sum", yarp::os::Value("96adb295225031ec8d57fb4251b0a886"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Inertia.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Inertia.h
@@ -253,10 +253,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Inertia> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Inertia> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Inertia";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1d26e4bb6c83ff141c5cf0d883c2b0fe";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Mass [kg]\n\
 float64 m\n\
 \n\
@@ -273,23 +277,26 @@ float64 ixz\n\
 float64 iyy\n\
 float64 iyz\n\
 float64 izz\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Inertia::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Inertia", "geometry_msgs/Inertia");
-        typ.addProperty("md5sum", yarp::os::Value("1d26e4bb6c83ff141c5cf0d883c2b0fe"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/InertiaStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/InertiaStamped.h
@@ -139,32 +139,73 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::InertiaStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::InertiaStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/InertiaStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ddee48caeab5a966c5e8d166654a9ac7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 Header header\n\
 Inertia inertia\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Inertia\n\
-") + yarp::rosmsg::geometry_msgs::Inertia::typeText();
-    }
+# Mass [kg]\n\
+float64 m\n\
+\n\
+# Center of mass [m]\n\
+geometry_msgs/Vector3 com\n\
+\n\
+# Inertia Tensor [kg-m^2]\n\
+#     | ixx ixy ixz |\n\
+# I = | ixy iyy iyz |\n\
+#     | ixz iyz izz |\n\
+float64 ixx\n\
+float64 ixy\n\
+float64 ixz\n\
+float64 iyy\n\
+float64 iyz\n\
+float64 izz\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::InertiaStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/InertiaStamped", "geometry_msgs/InertiaStamped");
-        typ.addProperty("md5sum", yarp::os::Value("ddee48caeab5a966c5e8d166654a9ac7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Point.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Point.h
@@ -143,28 +143,25 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Point> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Point> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Point";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4a842b65f413084dc2b10fb484ea7f17";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This contains the position of a point in free space\n\
 float64 x\n\
 float64 y\n\
 float64 z\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Point", "geometry_msgs/Point");
-        typ.addProperty("md5sum", yarp::os::Value("4a842b65f413084dc2b10fb484ea7f17"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Point32.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Point32.h
@@ -10,7 +10,7 @@
 
 // Generated from the following "geometry_msgs/Point32" msg definition:
 //   # This contains the position of a point in free space(with 32 bits of precision).
-//   # It is recommended to use Point wherever possible instead of Point32.
+//   # It is recommeded to use Point wherever possible instead of Point32.  
 //   # 
 //   # This recommendation is to promote interoperability.  
 //   #
@@ -149,12 +149,16 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Point32> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Point32> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Point32";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cc153912f1453b708d221682bc23d9ac";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This contains the position of a point in free space(with 32 bits of precision).\n\
-# It is recommended to use Point wherever possible instead of Point32.  \n\
+# It is recommeded to use Point wherever possible instead of Point32.  \n\
 # \n\
 # This recommendation is to promote interoperability.  \n\
 #\n\
@@ -163,20 +167,14 @@ public:
 \n\
 float32 x\n\
 float32 y\n\
-float32 z");
-    }
+float32 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Point32::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Point32", "geometry_msgs/Point32");
-        typ.addProperty("md5sum", yarp::os::Value("cc153912f1453b708d221682bc23d9ac"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PointStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PointStamped.h
@@ -140,33 +140,49 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PointStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PointStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PointStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c63aecb41bfdfd6b7e1fac37c7cbe7bf";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a Point with reference coordinate frame and timestamp\n\
 Header header\n\
 Point point\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PointStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PointStamped", "geometry_msgs/PointStamped");
-        typ.addProperty("md5sum", yarp::os::Value("c63aecb41bfdfd6b7e1fac37c7cbe7bf"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Polygon.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Polygon.h
@@ -131,29 +131,37 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Polygon> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Polygon> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Polygon";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cd60a26494a087f577976f0329fa120e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 #A specification of a polygon where the first and last points are assumed to be connected\n\
 Point32[] points\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point32\n\
-") + yarp::rosmsg::geometry_msgs::Point32::typeText();
-    }
+# This contains the position of a point in free space(with 32 bits of precision).\n\
+# It is recommeded to use Point wherever possible instead of Point32.  \n\
+# \n\
+# This recommendation is to promote interoperability.  \n\
+#\n\
+# This message is designed to take up less space when sending\n\
+# lots of points at once, as in the case of a PointCloud.  \n\
+\n\
+float32 x\n\
+float32 y\n\
+float32 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Polygon::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Polygon", "geometry_msgs/Polygon");
-        typ.addProperty("md5sum", yarp::os::Value("cd60a26494a087f577976f0329fa120e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PolygonStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PolygonStamped.h
@@ -140,33 +140,61 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PolygonStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PolygonStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PolygonStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c6be8f7dc3bee7fe9e8d296070f53340";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a Polygon with reference coordinate frame and timestamp\n\
 Header header\n\
 Polygon polygon\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Polygon\n\
-") + yarp::rosmsg::geometry_msgs::Polygon::typeText();
-    }
+#A specification of a polygon where the first and last points are assumed to be connected\n\
+Point32[] points\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point32\n\
+# This contains the position of a point in free space(with 32 bits of precision).\n\
+# It is recommeded to use Point wherever possible instead of Point32.  \n\
+# \n\
+# This recommendation is to promote interoperability.  \n\
+#\n\
+# This message is designed to take up less space when sending\n\
+# lots of points at once, as in the case of a PointCloud.  \n\
+\n\
+float32 x\n\
+float32 y\n\
+float32 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PolygonStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PolygonStamped", "geometry_msgs/PolygonStamped");
-        typ.addProperty("md5sum", yarp::os::Value("c6be8f7dc3bee7fe9e8d296070f53340"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Pose.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Pose.h
@@ -140,33 +140,40 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Pose> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Pose> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Pose";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "e45d45a5a1ce597b249e23fb30fc871f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # A representation of pose in free space, composed of position and orientation. \n\
 Point position\n\
 Quaternion orientation\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText() + std::string("\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Quaternion\n\
-") + yarp::rosmsg::geometry_msgs::Quaternion::typeText();
-    }
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Pose", "geometry_msgs/Pose");
-        typ.addProperty("md5sum", yarp::os::Value("e45d45a5a1ce597b249e23fb30fc871f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Pose2D.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Pose2D.h
@@ -143,28 +143,26 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Pose2D> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Pose2D> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Pose2D";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "938fa65709584ad8e77d238529be13b8";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses a position and orientation on a 2D manifold.\n\
 \n\
 float64 x\n\
 float64 y\n\
-float64 theta");
-    }
+float64 theta\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Pose2D::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Pose2D", "geometry_msgs/Pose2D");
-        typ.addProperty("md5sum", yarp::os::Value("938fa65709584ad8e77d238529be13b8"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseArray.h
@@ -160,35 +160,66 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PoseArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PoseArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PoseArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "916c28c5764443f268b296bb671b9d97";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # An array of poses with a header for global reference.\n\
 \n\
 Header header\n\
 \n\
 Pose[] poses\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PoseArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PoseArray", "geometry_msgs/PoseArray");
-        typ.addProperty("md5sum", yarp::os::Value("916c28c5764443f268b296bb671b9d97"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseStamped.h
@@ -140,33 +140,64 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PoseStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PoseStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PoseStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d3812c3cbc69362b77dc0b19b345f8f5";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # A Pose with reference coordinate frame and timestamp\n\
 Header header\n\
 Pose pose\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PoseStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PoseStamped", "geometry_msgs/PoseStamped");
-        typ.addProperty("md5sum", yarp::os::Value("d3812c3cbc69362b77dc0b19b345f8f5"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseWithCovariance.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseWithCovariance.h
@@ -156,10 +156,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PoseWithCovariance> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PoseWithCovariance> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PoseWithCovariance";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c23e848cf1b7533a8d7c259073a97e6f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a pose in free space with uncertainty.\n\
 \n\
 Pose pose\n\
@@ -169,23 +173,35 @@ Pose pose\n\
 # In order, the parameters are:\n\
 # (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
 float64[36] covariance\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PoseWithCovariance::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PoseWithCovariance", "geometry_msgs/PoseWithCovariance");
-        typ.addProperty("md5sum", yarp::os::Value("c23e848cf1b7533a8d7c259073a97e6f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseWithCovarianceStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/PoseWithCovarianceStamped.h
@@ -141,34 +141,77 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::PoseWithCovarianceStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::PoseWithCovarianceStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/PoseWithCovarianceStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "953b798c0f514ff060a53a3498ce6246";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses an estimated pose with a reference coordinate frame and timestamp\n\
 \n\
 Header header\n\
 PoseWithCovariance pose\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/PoseWithCovariance\n\
-") + yarp::rosmsg::geometry_msgs::PoseWithCovariance::typeText();
-    }
+# This represents a pose in free space with uncertainty.\n\
+\n\
+Pose pose\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::PoseWithCovarianceStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/PoseWithCovarianceStamped", "geometry_msgs/PoseWithCovarianceStamped");
-        typ.addProperty("md5sum", yarp::os::Value("953b798c0f514ff060a53a3498ce6246"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Quaternion.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Quaternion.h
@@ -163,30 +163,27 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Quaternion> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Quaternion> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Quaternion";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "a779879fadf0160734f906b8c19c7004";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents an orientation in free space in quaternion form.\n\
 \n\
 float64 x\n\
 float64 y\n\
 float64 z\n\
 float64 w\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Quaternion::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Quaternion", "geometry_msgs/Quaternion");
-        typ.addProperty("md5sum", yarp::os::Value("a779879fadf0160734f906b8c19c7004"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/QuaternionStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/QuaternionStamped.h
@@ -141,34 +141,52 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::QuaternionStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::QuaternionStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/QuaternionStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "e57f1e547e0e1fd13504588ffc8334e2";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents an orientation with reference coordinate frame and timestamp.\n\
 \n\
 Header header\n\
 Quaternion quaternion\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Quaternion\n\
-") + yarp::rosmsg::geometry_msgs::Quaternion::typeText();
-    }
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::QuaternionStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/QuaternionStamped", "geometry_msgs/QuaternionStamped");
-        typ.addProperty("md5sum", yarp::os::Value("e57f1e547e0e1fd13504588ffc8334e2"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Transform.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Transform.h
@@ -141,34 +141,46 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Transform> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Transform> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Transform";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ac9eff44abf714214112b05d54a3cf9b";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents the transform between two coordinate frames in free space.\n\
 \n\
 Vector3 translation\n\
 Quaternion rotation\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText() + std::string("\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
 ================================================================================\n\
 MSG: geometry_msgs/Quaternion\n\
-") + yarp::rosmsg::geometry_msgs::Quaternion::typeText();
-    }
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Transform::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Transform", "geometry_msgs/Transform");
-        typ.addProperty("md5sum", yarp::os::Value("ac9eff44abf714214112b05d54a3cf9b"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TransformStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TransformStamped.h
@@ -173,10 +173,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::TransformStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::TransformStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/TransformStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "b5764a33bfeb3588febc2682852579b0";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses a transform from coordinate frame header.frame_id\n\
 # to the coordinate frame child_frame_id\n\
 #\n\
@@ -187,26 +191,59 @@ public:
 Header header\n\
 string child_frame_id # the frame id of the child frame\n\
 Transform transform\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Transform\n\
-") + yarp::rosmsg::geometry_msgs::Transform::typeText();
-    }
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::TransformStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/TransformStamped", "geometry_msgs/TransformStamped");
-        typ.addProperty("md5sum", yarp::os::Value("b5764a33bfeb3588febc2682852579b0"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Twist.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Twist.h
@@ -139,30 +139,37 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Twist> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Twist> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Twist";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "9f195f881246fdfa2798d1d3eebca84a";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses velocity in free space broken into its linear and angular parts.\n\
 Vector3  linear\n\
 Vector3  angular\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Twist::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Twist", "geometry_msgs/Twist");
-        typ.addProperty("md5sum", yarp::os::Value("9f195f881246fdfa2798d1d3eebca84a"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistStamped.h
@@ -140,33 +140,61 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::TwistStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::TwistStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/TwistStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "98d34b0043a2093cf9d9345ab6eef12e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # A twist with reference coordinate frame and timestamp\n\
 Header header\n\
 Twist twist\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Twist\n\
-") + yarp::rosmsg::geometry_msgs::Twist::typeText();
-    }
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::TwistStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/TwistStamped", "geometry_msgs/TwistStamped");
-        typ.addProperty("md5sum", yarp::os::Value("98d34b0043a2093cf9d9345ab6eef12e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistWithCovariance.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistWithCovariance.h
@@ -156,10 +156,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::TwistWithCovariance> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::TwistWithCovariance> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/TwistWithCovariance";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1fe8a28e6890a4cc3ae4c3ca5c7d82e6";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This expresses velocity in free space with uncertainty.\n\
 \n\
 Twist twist\n\
@@ -169,23 +173,32 @@ Twist twist\n\
 # In order, the parameters are:\n\
 # (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
 float64[36] covariance\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Twist\n\
-") + yarp::rosmsg::geometry_msgs::Twist::typeText();
-    }
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::TwistWithCovariance::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/TwistWithCovariance", "geometry_msgs/TwistWithCovariance");
-        typ.addProperty("md5sum", yarp::os::Value("1fe8a28e6890a4cc3ae4c3ca5c7d82e6"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistWithCovarianceStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/TwistWithCovarianceStamped.h
@@ -140,33 +140,73 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::TwistWithCovarianceStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::TwistWithCovarianceStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/TwistWithCovarianceStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8927a1a12fb2607ceea095b2dc440a96";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents an estimated twist with reference coordinate frame and timestamp.\n\
 Header header\n\
 TwistWithCovariance twist\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/TwistWithCovariance\n\
-") + yarp::rosmsg::geometry_msgs::TwistWithCovariance::typeText();
-    }
+# This expresses velocity in free space with uncertainty.\n\
+\n\
+Twist twist\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Twist\n\
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::TwistWithCovarianceStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/TwistWithCovarianceStamped", "geometry_msgs/TwistWithCovarianceStamped");
-        typ.addProperty("md5sum", yarp::os::Value("8927a1a12fb2607ceea095b2dc440a96"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Vector3.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Vector3.h
@@ -148,10 +148,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Vector3> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Vector3> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Vector3";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4a842b65f413084dc2b10fb484ea7f17";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a vector in free space. \n\
 # It is only meant to represent a direction. Therefore, it does not\n\
 # make sense to apply a translation to it (e.g., when applying a \n\
@@ -161,20 +165,14 @@ public:
 \n\
 float64 x\n\
 float64 y\n\
-float64 z");
-    }
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Vector3", "geometry_msgs/Vector3");
-        typ.addProperty("md5sum", yarp::os::Value("4a842b65f413084dc2b10fb484ea7f17"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Vector3Stamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Vector3Stamped.h
@@ -140,33 +140,55 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Vector3Stamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Vector3Stamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Vector3Stamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "7b324c7325e683bf02a9b14b01090ec7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a Vector3 with reference coordinate frame and timestamp\n\
 Header header\n\
 Vector3 vector\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Vector3Stamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Vector3Stamped", "geometry_msgs/Vector3Stamped");
-        typ.addProperty("md5sum", yarp::os::Value("7b324c7325e683bf02a9b14b01090ec7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Wrench.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/Wrench.h
@@ -140,31 +140,38 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::Wrench> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::Wrench> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/Wrench";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4f539cf138b23283b520fd271b567936";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents force in free space, separated into\n\
 # its linear and angular parts.\n\
 Vector3  force\n\
 Vector3  torque\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::Wrench::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/Wrench", "geometry_msgs/Wrench");
-        typ.addProperty("md5sum", yarp::os::Value("4f539cf138b23283b520fd271b567936"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/WrenchStamped.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/geometry_msgs/WrenchStamped.h
@@ -140,33 +140,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::geometry_msgs::WrenchStamped> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::geometry_msgs::WrenchStamped> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "geometry_msgs/WrenchStamped";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d78d3cb249ce23087ade7e7d0c40cfa7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # A wrench with reference coordinate frame and timestamp\n\
 Header header\n\
 Wrench wrench\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Wrench\n\
-") + yarp::rosmsg::geometry_msgs::Wrench::typeText();
-    }
+# This represents force in free space, separated into\n\
+# its linear and angular parts.\n\
+Vector3  force\n\
+Vector3  torque\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::geometry_msgs::WrenchStamped::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("geometry_msgs/WrenchStamped", "geometry_msgs/WrenchStamped");
-        typ.addProperty("md5sum", yarp::os::Value("d78d3cb249ce23087ade7e7d0c40cfa7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetMap.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetMap.h
@@ -93,27 +93,24 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::GetMap> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::GetMap> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/GetMap";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d41d8cd98f00b204e9800998ecf8427e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Get the map as a nav_msgs/OccupancyGrid\n\
 ---\n\
 nav_msgs/OccupancyGrid map\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::GetMap::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/GetMap", "nav_msgs/GetMap");
-        typ.addProperty("md5sum", yarp::os::Value("d41d8cd98f00b204e9800998ecf8427e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetMapReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetMapReply.h
@@ -111,27 +111,90 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::GetMapReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::GetMapReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-") + std::string("\n\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/GetMapReply";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6cdd0a18e0aff5b0a3ca2326a89b54ff";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
 ================================================================================\n\
 MSG: nav_msgs/OccupancyGrid\n\
-") + yarp::rosmsg::nav_msgs::OccupancyGrid::typeText();
-    }
+# This represents a 2-D grid map, in which each cell represents the probability of\n\
+# occupancy.\n\
+\n\
+Header header \n\
+\n\
+#MetaData for the map\n\
+MapMetaData info\n\
+\n\
+# The map data, in row-major order, starting with (0,0).  Occupancy\n\
+# probabilities are in the range [0,100].  Unknown is -1.\n\
+int8[] data\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: nav_msgs/MapMetaData\n\
+# This hold basic information about the characterists of the OccupancyGrid\n\
+\n\
+# The time at which the map was loaded\n\
+time map_load_time\n\
+# The map resolution [m/cell]\n\
+float32 resolution\n\
+# Map width [cells]\n\
+uint32 width\n\
+# Map height [cells]\n\
+uint32 height\n\
+# The origin of the map [m, m, rad].  This is the real-world pose of the\n\
+# cell (0,0) in the map.\n\
+geometry_msgs/Pose origin\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::GetMapReply::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/GetMapReply", "nav_msgs/GetMapReply");
-        typ.addProperty("md5sum", yarp::os::Value("6cdd0a18e0aff5b0a3ca2326a89b54ff"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetPlan.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetPlan.h
@@ -167,10 +167,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::GetPlan> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::GetPlan> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/GetPlan";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "e25a43e0752bcca599a8c2eef8282df8";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Get a plan from the current position to the goal Pose \n\
 \n\
 # The start pose for the plan\n\
@@ -184,23 +188,59 @@ geometry_msgs/PoseStamped goal\n\
 float32 tolerance\n\
 ---\n\
 nav_msgs/Path plan\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/PoseStamped\n\
-") + yarp::rosmsg::geometry_msgs::PoseStamped::typeText();
-    }
+# A Pose with reference coordinate frame and timestamp\n\
+Header header\n\
+Pose pose\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::GetPlan::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/GetPlan", "nav_msgs/GetPlan");
-        typ.addProperty("md5sum", yarp::os::Value("e25a43e0752bcca599a8c2eef8282df8"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetPlanReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GetPlanReply.h
@@ -111,27 +111,73 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::GetPlanReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::GetPlanReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-") + std::string("\n\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/GetPlanReply";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "0002bc113c0259d71f6cf8cbc9430e18";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
 ================================================================================\n\
 MSG: nav_msgs/Path\n\
-") + yarp::rosmsg::nav_msgs::Path::typeText();
-    }
+#An array of poses that represents a Path for a robot to follow\n\
+Header header\n\
+geometry_msgs/PoseStamped[] poses\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/PoseStamped\n\
+# A Pose with reference coordinate frame and timestamp\n\
+Header header\n\
+Pose pose\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::GetPlanReply::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/GetPlanReply", "nav_msgs/GetPlanReply");
-        typ.addProperty("md5sum", yarp::os::Value("0002bc113c0259d71f6cf8cbc9430e18"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GridCells.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/GridCells.h
@@ -196,35 +196,51 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::GridCells> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::GridCells> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/GridCells";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "b9e4f5df6d28e272ebde00a3994830f5";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 #an array of cells in a 2D grid\n\
 Header header\n\
 float32 cell_width\n\
 float32 cell_height\n\
 geometry_msgs/Point[] cells\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::GridCells::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/GridCells", "nav_msgs/GridCells");
-        typ.addProperty("md5sum", yarp::os::Value("b9e4f5df6d28e272ebde00a3994830f5"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/MapMetaData.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/MapMetaData.h
@@ -203,10 +203,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::MapMetaData> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::MapMetaData> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/MapMetaData";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "10cfc8a2818024d3248802c00c95f11b";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This hold basic information about the characterists of the OccupancyGrid\n\
 \n\
 # The time at which the map was loaded\n\
@@ -219,23 +223,35 @@ uint32 width\n\
 uint32 height\n\
 # The origin of the map [m, m, rad].  This is the real-world pose of the\n\
 # cell (0,0) in the map.\n\
-geometry_msgs/Pose origin") + std::string("\n\
+geometry_msgs/Pose origin\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::MapMetaData::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/MapMetaData", "nav_msgs/MapMetaData");
-        typ.addProperty("md5sum", yarp::os::Value("10cfc8a2818024d3248802c00c95f11b"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/OccupancyGrid.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/OccupancyGrid.h
@@ -183,10 +183,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::OccupancyGrid> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::OccupancyGrid> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/OccupancyGrid";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "3381f2d731d4076ec5c71b0759edbe4e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents a 2-D grid map, in which each cell represents the probability of\n\
 # occupancy.\n\
 \n\
@@ -198,26 +202,68 @@ MapMetaData info\n\
 # The map data, in row-major order, starting with (0,0).  Occupancy\n\
 # probabilities are in the range [0,100].  Unknown is -1.\n\
 int8[] data\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: nav_msgs/MapMetaData\n\
-") + yarp::rosmsg::nav_msgs::MapMetaData::typeText();
-    }
+# This hold basic information about the characterists of the OccupancyGrid\n\
+\n\
+# The time at which the map was loaded\n\
+time map_load_time\n\
+# The map resolution [m/cell]\n\
+float32 resolution\n\
+# Map width [cells]\n\
+uint32 width\n\
+# Map height [cells]\n\
+uint32 height\n\
+# The origin of the map [m, m, rad].  This is the real-world pose of the\n\
+# cell (0,0) in the map.\n\
+geometry_msgs/Pose origin\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::OccupancyGrid::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/OccupancyGrid", "nav_msgs/OccupancyGrid");
-        typ.addProperty("md5sum", yarp::os::Value("3381f2d731d4076ec5c71b0759edbe4e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/Odometry.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/Odometry.h
@@ -196,10 +196,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::Odometry> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::Odometry> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/Odometry";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cd5e73d190d741a2f92e81eda573aca7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This represents an estimate of a position and velocity in free space.  \n\
 # The pose in this message should be specified in the coordinate frame given by header.frame_id.\n\
 # The twist in this message should be specified in the coordinate frame given by the child_frame_id\n\
@@ -207,29 +211,96 @@ Header header\n\
 string child_frame_id\n\
 geometry_msgs/PoseWithCovariance pose\n\
 geometry_msgs/TwistWithCovariance twist\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/PoseWithCovariance\n\
-") + yarp::rosmsg::geometry_msgs::PoseWithCovariance::typeText() + std::string("\n\
+# This represents a pose in free space with uncertainty.\n\
+\n\
+Pose pose\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/TwistWithCovariance\n\
-") + yarp::rosmsg::geometry_msgs::TwistWithCovariance::typeText();
-    }
+# This expresses velocity in free space with uncertainty.\n\
+\n\
+Twist twist\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Twist\n\
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::Odometry::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/Odometry", "nav_msgs/Odometry");
-        typ.addProperty("md5sum", yarp::os::Value("cd5e73d190d741a2f92e81eda573aca7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/Path.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/Path.h
@@ -158,33 +158,70 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::Path> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::Path> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/Path";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6227e2b7e9cce15051f669a5e197bbf7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 #An array of poses that represents a Path for a robot to follow\n\
 Header header\n\
 geometry_msgs/PoseStamped[] poses\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/PoseStamped\n\
-") + yarp::rosmsg::geometry_msgs::PoseStamped::typeText();
-    }
+# A Pose with reference coordinate frame and timestamp\n\
+Header header\n\
+Pose pose\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::Path::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/Path", "nav_msgs/Path");
-        typ.addProperty("md5sum", yarp::os::Value("6227e2b7e9cce15051f669a5e197bbf7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/SetMap.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/SetMap.h
@@ -143,36 +143,115 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::SetMap> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::SetMap> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/SetMap";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "91149a20d7be299b87c340df8cc94fd4";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Set a new map together with an initial pose\n\
 nav_msgs/OccupancyGrid map\n\
 geometry_msgs/PoseWithCovarianceStamped initial_pose\n\
 ---\n\
 bool success\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: nav_msgs/OccupancyGrid\n\
-") + yarp::rosmsg::nav_msgs::OccupancyGrid::typeText() + std::string("\n\
+# This represents a 2-D grid map, in which each cell represents the probability of\n\
+# occupancy.\n\
+\n\
+Header header \n\
+\n\
+#MetaData for the map\n\
+MapMetaData info\n\
+\n\
+# The map data, in row-major order, starting with (0,0).  Occupancy\n\
+# probabilities are in the range [0,100].  Unknown is -1.\n\
+int8[] data\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: nav_msgs/MapMetaData\n\
+# This hold basic information about the characterists of the OccupancyGrid\n\
+\n\
+# The time at which the map was loaded\n\
+time map_load_time\n\
+# The map resolution [m/cell]\n\
+float32 resolution\n\
+# Map width [cells]\n\
+uint32 width\n\
+# Map height [cells]\n\
+uint32 height\n\
+# The origin of the map [m, m, rad].  This is the real-world pose of the\n\
+# cell (0,0) in the map.\n\
+geometry_msgs/Pose origin\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/PoseWithCovarianceStamped\n\
-") + yarp::rosmsg::geometry_msgs::PoseWithCovarianceStamped::typeText();
-    }
+# This expresses an estimated pose with a reference coordinate frame and timestamp\n\
+\n\
+Header header\n\
+PoseWithCovariance pose\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/PoseWithCovariance\n\
+# This represents a pose in free space with uncertainty.\n\
+\n\
+Pose pose\n\
+\n\
+# Row-major representation of the 6x6 covariance matrix\n\
+# The orientation parameters use a fixed-axis representation.\n\
+# In order, the parameters are:\n\
+# (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)\n\
+float64[36] covariance\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::SetMap::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/SetMap", "nav_msgs/SetMap");
-        typ.addProperty("md5sum", yarp::os::Value("91149a20d7be299b87c340df8cc94fd4"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/SetMapReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/nav_msgs/SetMapReply.h
@@ -105,24 +105,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::nav_msgs::SetMapReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::nav_msgs::SetMapReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "nav_msgs/SetMapReply";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::nav_msgs::SetMapReply::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "358e233cde0c8a8bcfea4ce193f8fc15";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("nav_msgs/SetMapReply", "nav_msgs/SetMapReply");
-        typ.addProperty("md5sum", yarp::os::Value("358e233cde0c8a8bcfea4ce193f8fc15"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/BatteryState.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/BatteryState.h
@@ -492,10 +492,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::BatteryState> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::BatteryState> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/BatteryState";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "476f837fa6771f6e16e3bf4ef96f8770";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 \n\
 # Constants are chosen to match the enums in the linux kernel\n\
 # defined in include/linux/power_supply.h as of version 3.7\n\
@@ -545,23 +549,31 @@ float32[] cell_voltage   # An array of individual cell voltages for each cell in
                          # If individual voltages unknown but number of cells known set each to NaN\n\
 string location          # The location into which the battery is inserted. (slot number or plug)\n\
 string serial_number     # The best approximation of the battery serial number\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::BatteryState::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/BatteryState", "sensor_msgs/BatteryState");
-        typ.addProperty("md5sum", yarp::os::Value("476f837fa6771f6e16e3bf4ef96f8770"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/CameraInfo.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/CameraInfo.h
@@ -509,10 +509,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::CameraInfo> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::CameraInfo> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/CameraInfo";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c9a58c1b0b154e0e6da7578cb991d214";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message defines meta information for a camera. It should be in a\n\
 # camera namespace on topic \"camera_info\" and accompanied by up to five\n\
 # image topics named:\n\
@@ -644,26 +648,53 @@ uint32 binning_y\n\
 # The default setting of roi (all values 0) is considered the same as\n\
 #  full resolution (roi.width = width, roi.height = height).\n\
 RegionOfInterest roi\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/RegionOfInterest\n\
-") + yarp::rosmsg::sensor_msgs::RegionOfInterest::typeText();
-    }
+# This message is used to specify a region of interest within an image.\n\
+#\n\
+# When used to specify the ROI setting of the camera when the image was\n\
+# taken, the height and width fields should either match the height and\n\
+# width fields for the associated image; or height = width = 0\n\
+# indicates that the full resolution image was captured.\n\
+\n\
+uint32 x_offset  # Leftmost pixel of the ROI\n\
+                 # (0 if the ROI includes the left edge of the image)\n\
+uint32 y_offset  # Topmost pixel of the ROI\n\
+                 # (0 if the ROI includes the top edge of the image)\n\
+uint32 height    # Height of ROI\n\
+uint32 width     # Width of ROI\n\
+\n\
+# True if a distinct rectified ROI should be calculated from the \"raw\"\n\
+# ROI in this message. Typically this should be False if the full image\n\
+# is captured (ROI not used), and True if a subwindow is captured (ROI\n\
+# used).\n\
+bool do_rectify\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::CameraInfo::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/CameraInfo", "sensor_msgs/CameraInfo");
-        typ.addProperty("md5sum", yarp::os::Value("c9a58c1b0b154e0e6da7578cb991d214"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/ChannelFloat32.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/ChannelFloat32.h
@@ -170,10 +170,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::ChannelFloat32> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::ChannelFloat32> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/ChannelFloat32";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "3d40139cdd33dfedcb71ffeeeb42ae7f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message is used by the PointCloud message to hold optional data\n\
 # associated with each point in the cloud. The length of the values\n\
 # array should be the same as the length of the points array in the\n\
@@ -198,20 +202,13 @@ string name\n\
 # The values array should be 1-1 with the elements of the associated\n\
 # PointCloud.\n\
 float32[] values\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::ChannelFloat32::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/ChannelFloat32", "sensor_msgs/ChannelFloat32");
-        typ.addProperty("md5sum", yarp::os::Value("3d40139cdd33dfedcb71ffeeeb42ae7f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/CompressedImage.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/CompressedImage.h
@@ -185,10 +185,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::CompressedImage> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::CompressedImage> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/CompressedImage";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8f7a12909da2c9d3332d540a0977563f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message contains a compressed image\n\
 \n\
 Header header        # Header timestamp should be acquisition time of image\n\
@@ -202,23 +206,31 @@ string format        # Specifies the format of the data\n\
                      #   Acceptable values:\n\
                      #     jpeg, png\n\
 uint8[] data         # Compressed image buffer\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::CompressedImage::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/CompressedImage", "sensor_msgs/CompressedImage");
-        typ.addProperty("md5sum", yarp::os::Value("8f7a12909da2c9d3332d540a0977563f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/FluidPressure.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/FluidPressure.h
@@ -158,10 +158,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::FluidPressure> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::FluidPressure> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/FluidPressure";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "804dc5cea1c5306d6a2eb80b9833befe";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
  # Single pressure reading.  This message is appropriate for measuring the\n\
  # pressure inside of a fluid (air, water, etc).  This also includes\n\
  # atmospheric or barometric pressure.\n\
@@ -173,23 +177,31 @@ public:
 \n\
  float64 fluid_pressure  # Absolute pressure reading in Pascals.\n\
 \n\
- float64 variance        # 0 is interpreted as variance unknown") + std::string("\n\
+ float64 variance        # 0 is interpreted as variance unknown\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::FluidPressure::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/FluidPressure", "sensor_msgs/FluidPressure");
-        typ.addProperty("md5sum", yarp::os::Value("804dc5cea1c5306d6a2eb80b9833befe"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Illuminance.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Illuminance.h
@@ -167,10 +167,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Illuminance> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Illuminance> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Illuminance";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8cf5febb0952fca9d650c3d11a81a188";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
  # Single photometric illuminance measurement.  Light should be assumed to be\n\
  # measured along the sensor's x-axis (the area of detection is the y-z plane).\n\
  # The illuminance should have a 0 or positive value and be received with\n\
@@ -191,23 +195,31 @@ public:
 \n\
  float64 illuminance     # Measurement of the Photometric Illuminance in Lux.\n\
 \n\
- float64 variance        # 0 is interpreted as variance unknown") + std::string("\n\
+ float64 variance        # 0 is interpreted as variance unknown\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Illuminance::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Illuminance", "sensor_msgs/Illuminance");
-        typ.addProperty("md5sum", yarp::os::Value("8cf5febb0952fca9d650c3d11a81a188"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Image.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Image.h
@@ -271,10 +271,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Image> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Image> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Image";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "060021388200f6f0f447d0fcd9c64743";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message contains an uncompressed image\n\
 # (0, 0) is at top-left corner of image\n\
 #\n\
@@ -302,23 +306,31 @@ string encoding       # Encoding of pixels -- channel meaning, ordering, size\n\
 uint8 is_bigendian    # is this data bigendian?\n\
 uint32 step           # Full row length in bytes\n\
 uint8[] data          # actual matrix data, size is (step * rows)\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Image::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Image", "sensor_msgs/Image");
-        typ.addProperty("md5sum", yarp::os::Value("060021388200f6f0f447d0fcd9c64743"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Imu.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Imu.h
@@ -320,10 +320,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Imu> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Imu> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Imu";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6a62c6daae103f4ff57a132d6f95cec2";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This is a message to hold data from an IMU (Inertial Measurement Unit)\n\
 #\n\
 # Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec\n\
@@ -348,29 +352,53 @@ float64[9] angular_velocity_covariance # Row major about x, y, z axes\n\
 \n\
 geometry_msgs/Vector3 linear_acceleration\n\
 float64[9] linear_acceleration_covariance # Row major x, y z \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Quaternion\n\
-") + yarp::rosmsg::geometry_msgs::Quaternion::typeText() + std::string("\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Imu::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Imu", "sensor_msgs/Imu");
-        typ.addProperty("md5sum", yarp::os::Value("6a62c6daae103f4ff57a132d6f95cec2"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JointState.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JointState.h
@@ -287,10 +287,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::JointState> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::JointState> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/JointState";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "3066dcd76a6cfaef579bd0f34173e9fd";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This is a message that holds data to describe the state of a set of torque controlled joints. \n\
 #\n\
 # The state of each joint (revolute or prismatic) is defined by:\n\
@@ -317,23 +321,31 @@ string[] name\n\
 float64[] position\n\
 float64[] velocity\n\
 float64[] effort\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::JointState::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/JointState", "sensor_msgs/JointState");
-        typ.addProperty("md5sum", yarp::os::Value("3066dcd76a6cfaef579bd0f34173e9fd"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Joy.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Joy.h
@@ -185,31 +185,43 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Joy> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Joy> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Joy";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "5a9ea5f83505693b71e785041e67a8bb";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Reports the state of a joysticks axes and buttons.\n\
 Header header           # timestamp in the header is the time the data is received from the joystick\n\
 float32[] axes          # the axes measurements from a joystick\n\
 int32[] buttons         # the buttons measurements from a joystick \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Joy::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Joy", "sensor_msgs/Joy");
-        typ.addProperty("md5sum", yarp::os::Value("5a9ea5f83505693b71e785041e67a8bb"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JoyFeedback.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JoyFeedback.h
@@ -163,10 +163,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::JoyFeedback> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::JoyFeedback> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/JoyFeedback";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "f4dcd73460360d98f36e55ee7f2e46f1";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Declare of the type of feedback\n\
 uint8 TYPE_LED    = 0\n\
 uint8 TYPE_RUMBLE = 1\n\
@@ -182,20 +186,13 @@ uint8 id\n\
 # actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.\n\
 float32 intensity\n\
 \n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::JoyFeedback::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/JoyFeedback", "sensor_msgs/JoyFeedback");
-        typ.addProperty("md5sum", yarp::os::Value("f4dcd73460360d98f36e55ee7f2e46f1"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JoyFeedbackArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/JoyFeedbackArray.h
@@ -130,28 +130,40 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::JoyFeedbackArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::JoyFeedbackArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/JoyFeedbackArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cde5730a895b1fc4dee6f91b754b213d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message publishes values for multiple feedback at once. \n\
-JoyFeedback[] array") + std::string("\n\
+JoyFeedback[] array\n\
 ================================================================================\n\
 MSG: sensor_msgs/JoyFeedback\n\
-") + yarp::rosmsg::sensor_msgs::JoyFeedback::typeText();
-    }
+# Declare of the type of feedback\n\
+uint8 TYPE_LED    = 0\n\
+uint8 TYPE_RUMBLE = 1\n\
+uint8 TYPE_BUZZER = 2\n\
+\n\
+uint8 type\n\
+\n\
+# This will hold an id number for each type of each feedback.\n\
+# Example, the first led would be id=0, the second would be id=1\n\
+uint8 id\n\
+\n\
+# Intensity of the feedback, from 0.0 to 1.0, inclusive.  If device is\n\
+# actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.\n\
+float32 intensity\n\
+\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::JoyFeedbackArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/JoyFeedbackArray", "sensor_msgs/JoyFeedbackArray");
-        typ.addProperty("md5sum", yarp::os::Value("cde5730a895b1fc4dee6f91b754b213d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/LaserEcho.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/LaserEcho.h
@@ -124,28 +124,26 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::LaserEcho> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::LaserEcho> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/LaserEcho";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8bc5ae449b200fba4d552b4225586696";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message is a submessage of MultiEchoLaserScan and is not intended\n\
 # to be used separately.\n\
 \n\
 float32[] echoes  # Multiple values of ranges or intensities.\n\
-                  # Each array represents data from the same angle increment.");
-    }
+                  # Each array represents data from the same angle increment.\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::LaserEcho::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/LaserEcho", "sensor_msgs/LaserEcho");
-        typ.addProperty("md5sum", yarp::os::Value("8bc5ae449b200fba4d552b4225586696"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/LaserScan.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/LaserScan.h
@@ -336,10 +336,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::LaserScan> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::LaserScan> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/LaserScan";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "90c7ef2dc6895d81024acba2ac42f369";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Single scan from a planar laser range-finder\n\
 #\n\
 # If you have another ranging device with different behavior (e.g. a sonar\n\
@@ -369,23 +373,31 @@ float32[] ranges         # range data [m] (Note: values < range_min or > range_m
 float32[] intensities    # intensity data [device-specific units].  If your\n\
                          # device does not provide intensities, please leave\n\
                          # the array empty.\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::LaserScan::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/LaserScan", "sensor_msgs/LaserScan");
-        typ.addProperty("md5sum", yarp::os::Value("90c7ef2dc6895d81024acba2ac42f369"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MagneticField.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MagneticField.h
@@ -194,10 +194,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::MagneticField> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::MagneticField> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/MagneticField";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "2f3b0b43eed0c9501de0fa3ff89a45aa";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
  # Measurement of the Magnetic Field vector at a specific location.\n\
 \n\
  # If the covariance of the measurement is known, it should be filled in\n\
@@ -219,26 +223,44 @@ public:
                                       # put NaNs in the components not reported.\n\
 \n\
  float64[9] magnetic_field_covariance # Row major about x, y, z axes\n\
-                                      # 0 is interpreted as variance unknown") + std::string("\n\
+                                      # 0 is interpreted as variance unknown\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText();
-    }
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::MagneticField::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/MagneticField", "sensor_msgs/MagneticField");
-        typ.addProperty("md5sum", yarp::os::Value("2f3b0b43eed0c9501de0fa3ff89a45aa"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MultiDOFJointState.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MultiDOFJointState.h
@@ -314,10 +314,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::MultiDOFJointState> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::MultiDOFJointState> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/MultiDOFJointState";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "690f272f0640d2631c305eeb8301e59d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Representation of state for joints with multiple degrees of freedom, \n\
 # following the structure of JointState.\n\
 #\n\
@@ -344,32 +348,72 @@ string[] joint_names\n\
 geometry_msgs/Transform[] transforms\n\
 geometry_msgs/Twist[] twist\n\
 geometry_msgs/Wrench[] wrench\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Transform\n\
-") + yarp::rosmsg::geometry_msgs::Transform::typeText() + std::string("\n\
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Twist\n\
-") + yarp::rosmsg::geometry_msgs::Twist::typeText() + std::string("\n\
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Wrench\n\
-") + yarp::rosmsg::geometry_msgs::Wrench::typeText();
-    }
+# This represents force in free space, separated into\n\
+# its linear and angular parts.\n\
+Vector3  force\n\
+Vector3  torque\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::MultiDOFJointState::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/MultiDOFJointState", "sensor_msgs/MultiDOFJointState");
-        typ.addProperty("md5sum", yarp::os::Value("690f272f0640d2631c305eeb8301e59d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MultiEchoLaserScan.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/MultiEchoLaserScan.h
@@ -354,10 +354,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::MultiEchoLaserScan> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::MultiEchoLaserScan> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/MultiEchoLaserScan";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6fefb0c6da89d7c8abe4b339f5c2f8fb";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Single scan from a multi-echo planar laser range-finder\n\
 #\n\
 # If you have another ranging device with different behavior (e.g. a sonar\n\
@@ -388,26 +392,39 @@ LaserEcho[] ranges       # range data [m] (Note: NaNs, values < range_min or > r
                          # -Inf measurements are too close to determine exact distance.\n\
 LaserEcho[] intensities  # intensity data [device-specific units].  If your\n\
                          # device does not provide intensities, please leave\n\
-                         # the array empty.") + std::string("\n\
+                         # the array empty.\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/LaserEcho\n\
-") + yarp::rosmsg::sensor_msgs::LaserEcho::typeText();
-    }
+# This message is a submessage of MultiEchoLaserScan and is not intended\n\
+# to be used separately.\n\
+\n\
+float32[] echoes  # Multiple values of ranges or intensities.\n\
+                  # Each array represents data from the same angle increment.\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::MultiEchoLaserScan::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/MultiEchoLaserScan", "sensor_msgs/MultiEchoLaserScan");
-        typ.addProperty("md5sum", yarp::os::Value("6fefb0c6da89d7c8abe4b339f5c2f8fb"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/NavSatFix.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/NavSatFix.h
@@ -303,10 +303,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::NavSatFix> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::NavSatFix> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/NavSatFix";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "2d3a8cd499b9b4a0249fb98fd05cfa48";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Navigation Satellite fix for any Global Navigation Satellite System\n\
 #\n\
 # Specified using the WGS 84 reference ellipsoid\n\
@@ -353,26 +357,56 @@ uint8 COVARIANCE_TYPE_DIAGONAL_KNOWN = 2\n\
 uint8 COVARIANCE_TYPE_KNOWN = 3\n\
 \n\
 uint8 position_covariance_type\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/NavSatStatus\n\
-") + yarp::rosmsg::sensor_msgs::NavSatStatus::typeText();
-    }
+# Navigation Satellite fix status for any Global Navigation Satellite System\n\
+\n\
+# Whether to output an augmented fix is determined by both the fix\n\
+# type and the last time differential corrections were received.  A\n\
+# fix is valid when status >= STATUS_FIX.\n\
+\n\
+int8 STATUS_NO_FIX =  -1        # unable to fix position\n\
+int8 STATUS_FIX =      0        # unaugmented fix\n\
+int8 STATUS_SBAS_FIX = 1        # with satellite-based augmentation\n\
+int8 STATUS_GBAS_FIX = 2        # with ground-based augmentation\n\
+\n\
+int8 status\n\
+\n\
+# Bits defining which Global Navigation Satellite System signals were\n\
+# used by the receiver.\n\
+\n\
+uint16 SERVICE_GPS =     1\n\
+uint16 SERVICE_GLONASS = 2\n\
+uint16 SERVICE_COMPASS = 4      # includes BeiDou.\n\
+uint16 SERVICE_GALILEO = 8\n\
+\n\
+uint16 service\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::NavSatFix::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/NavSatFix", "sensor_msgs/NavSatFix");
-        typ.addProperty("md5sum", yarp::os::Value("2d3a8cd499b9b4a0249fb98fd05cfa48"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/NavSatStatus.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/NavSatStatus.h
@@ -167,10 +167,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::NavSatStatus> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::NavSatStatus> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/NavSatStatus";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "331cdbddfa4bc96ffc3b9ad98900a54c";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Navigation Satellite fix status for any Global Navigation Satellite System\n\
 \n\
 # Whether to output an augmented fix is determined by both the fix\n\
@@ -193,20 +197,13 @@ uint16 SERVICE_COMPASS = 4      # includes BeiDou.\n\
 uint16 SERVICE_GALILEO = 8\n\
 \n\
 uint16 service\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::NavSatStatus::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/NavSatStatus", "sensor_msgs/NavSatStatus");
-        typ.addProperty("md5sum", yarp::os::Value("331cdbddfa4bc96ffc3b9ad98900a54c"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointCloud.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointCloud.h
@@ -213,10 +213,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::PointCloud> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::PointCloud> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/PointCloud";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d8e9c3f5afbdd8a130fd1d2763945fca";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message holds a collection of 3d points, plus optional additional\n\
 # information about each point.\n\
 \n\
@@ -231,29 +235,71 @@ geometry_msgs/Point32[] points\n\
 # and the data in each channel should correspond 1:1 with each point.\n\
 # Channel names in common practice are listed in ChannelFloat32.msg.\n\
 ChannelFloat32[] channels\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point32\n\
-") + yarp::rosmsg::geometry_msgs::Point32::typeText() + std::string("\n\
+# This contains the position of a point in free space(with 32 bits of precision).\n\
+# It is recommeded to use Point wherever possible instead of Point32.  \n\
+# \n\
+# This recommendation is to promote interoperability.  \n\
+#\n\
+# This message is designed to take up less space when sending\n\
+# lots of points at once, as in the case of a PointCloud.  \n\
+\n\
+float32 x\n\
+float32 y\n\
+float32 z\n\
 ================================================================================\n\
 MSG: sensor_msgs/ChannelFloat32\n\
-") + yarp::rosmsg::sensor_msgs::ChannelFloat32::typeText();
-    }
+# This message is used by the PointCloud message to hold optional data\n\
+# associated with each point in the cloud. The length of the values\n\
+# array should be the same as the length of the points array in the\n\
+# PointCloud, and each value should be associated with the corresponding\n\
+# point.\n\
+\n\
+# Channel names in existing practice include:\n\
+#   \"u\", \"v\" - row and column (respectively) in the left stereo image.\n\
+#              This is opposite to usual conventions but remains for\n\
+#              historical reasons. The newer PointCloud2 message has no\n\
+#              such problem.\n\
+#   \"rgb\" - For point clouds produced by color stereo cameras. uint8\n\
+#           (R,G,B) values packed into the least significant 24 bits,\n\
+#           in order.\n\
+#   \"intensity\" - laser or pixel intensity.\n\
+#   \"distance\"\n\
+\n\
+# The channel name should give semantics of the channel (e.g.\n\
+# \"intensity\" instead of \"value\").\n\
+string name\n\
+\n\
+# The values array should be 1-1 with the elements of the associated\n\
+# PointCloud.\n\
+float32[] values\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::PointCloud::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/PointCloud", "sensor_msgs/PointCloud");
-        typ.addProperty("md5sum", yarp::os::Value("d8e9c3f5afbdd8a130fd1d2763945fca"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointCloud2.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointCloud2.h
@@ -329,10 +329,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::PointCloud2> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::PointCloud2> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/PointCloud2";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1158d486dd51d683ce2f1be655c3c181";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message holds a collection of N-dimensional points, which may\n\
 # contain additional information such as normals, intensity, etc. The\n\
 # point data is stored as a binary blob, its layout described by the\n\
@@ -360,26 +364,49 @@ uint32  row_step     # Length of a row in bytes\n\
 uint8[] data         # Actual point data, size is (row_step*height)\n\
 \n\
 bool is_dense        # True if there are no invalid points\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/PointField\n\
-") + yarp::rosmsg::sensor_msgs::PointField::typeText();
-    }
+# This message holds the description of one point entry in the\n\
+# PointCloud2 message format.\n\
+uint8 INT8    = 1\n\
+uint8 UINT8   = 2\n\
+uint8 INT16   = 3\n\
+uint8 UINT16  = 4\n\
+uint8 INT32   = 5\n\
+uint8 UINT32  = 6\n\
+uint8 FLOAT32 = 7\n\
+uint8 FLOAT64 = 8\n\
+\n\
+string name      # Name of field\n\
+uint32 offset    # Offset from start of point struct\n\
+uint8  datatype  # Datatype enumeration, see above\n\
+uint32 count     # How many elements in the field\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::PointCloud2::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/PointCloud2", "sensor_msgs/PointCloud2");
-        typ.addProperty("md5sum", yarp::os::Value("1158d486dd51d683ce2f1be655c3c181"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointField.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/PointField.h
@@ -204,10 +204,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::PointField> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::PointField> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/PointField";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "268eacb2962780ceac86cbd17e328150";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message holds the description of one point entry in the\n\
 # PointCloud2 message format.\n\
 uint8 INT8    = 1\n\
@@ -223,20 +227,13 @@ string name      # Name of field\n\
 uint32 offset    # Offset from start of point struct\n\
 uint8  datatype  # Datatype enumeration, see above\n\
 uint32 count     # How many elements in the field\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::PointField::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/PointField", "sensor_msgs/PointField");
-        typ.addProperty("md5sum", yarp::os::Value("268eacb2962780ceac86cbd17e328150"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Range.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Range.h
@@ -246,10 +246,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Range> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Range> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Range";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c005c34273dc426c67a020a87bc24148";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Single range reading from an active ranger that emits energy and reports\n\
 # one range reading that is valid along an arc at the distance measured. \n\
 # This message is  not appropriate for laser scanners. See the LaserScan\n\
@@ -289,23 +293,31 @@ float32 range           # range data [m]\n\
                         # -Inf represents a detection within fixed distance.\n\
                         # (Detection too close to the sensor to quantify)\n\
                         # +Inf represents no detection within the fixed distance.\n\
-                        # (Object out of range)") + std::string("\n\
+                        # (Object out of range)\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Range::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Range", "sensor_msgs/Range");
-        typ.addProperty("md5sum", yarp::os::Value("c005c34273dc426c67a020a87bc24148"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/RegionOfInterest.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/RegionOfInterest.h
@@ -196,10 +196,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::RegionOfInterest> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::RegionOfInterest> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/RegionOfInterest";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "bdb633039d588fcccb441a4d43ccfe09";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This message is used to specify a region of interest within an image.\n\
 #\n\
 # When used to specify the ROI setting of the camera when the image was\n\
@@ -219,20 +223,13 @@ uint32 width     # Width of ROI\n\
 # is captured (ROI not used), and True if a subwindow is captured (ROI\n\
 # used).\n\
 bool do_rectify\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::RegionOfInterest::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/RegionOfInterest", "sensor_msgs/RegionOfInterest");
-        typ.addProperty("md5sum", yarp::os::Value("bdb633039d588fcccb441a4d43ccfe09"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/RelativeHumidity.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/RelativeHumidity.h
@@ -158,10 +158,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::RelativeHumidity> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::RelativeHumidity> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/RelativeHumidity";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8730015b05955b7e992ce29a2678d90f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
  # Single reading from a relative humidity sensor.  Defines the ratio of partial\n\
  # pressure of water vapor to the saturated vapor pressure at a temperature.\n\
 \n\
@@ -173,23 +177,31 @@ public:
                            # 0.0 is no partial pressure of water vapor\n\
                            # 1.0 represents partial pressure of saturation\n\
 \n\
- float64 variance          # 0 is interpreted as variance unknown") + std::string("\n\
+ float64 variance          # 0 is interpreted as variance unknown\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::RelativeHumidity::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/RelativeHumidity", "sensor_msgs/RelativeHumidity");
-        typ.addProperty("md5sum", yarp::os::Value("8730015b05955b7e992ce29a2678d90f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/SetCameraInfo.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/SetCameraInfo.h
@@ -123,10 +123,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::SetCameraInfo> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::SetCameraInfo> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/SetCameraInfo";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ee34be01fdeee563d0d99cd594d5581d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # This service requests that a camera stores the given CameraInfo \n\
 # as that camera's calibration information.\n\
 #\n\
@@ -139,23 +143,187 @@ sensor_msgs/CameraInfo camera_info # The camera_info to store\n\
 ---\n\
 bool success          # True if the call succeeded\n\
 string status_message # Used to give details about success\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/CameraInfo\n\
-") + yarp::rosmsg::sensor_msgs::CameraInfo::typeText();
-    }
+# This message defines meta information for a camera. It should be in a\n\
+# camera namespace on topic \"camera_info\" and accompanied by up to five\n\
+# image topics named:\n\
+#\n\
+#   image_raw - raw data from the camera driver, possibly Bayer encoded\n\
+#   image            - monochrome, distorted\n\
+#   image_color      - color, distorted\n\
+#   image_rect       - monochrome, rectified\n\
+#   image_rect_color - color, rectified\n\
+#\n\
+# The image_pipeline contains packages (image_proc, stereo_image_proc)\n\
+# for producing the four processed image topics from image_raw and\n\
+# camera_info. The meaning of the camera parameters are described in\n\
+# detail at http://www.ros.org/wiki/image_pipeline/CameraInfo.\n\
+#\n\
+# The image_geometry package provides a user-friendly interface to\n\
+# common operations using this meta information. If you want to, e.g.,\n\
+# project a 3d point into image coordinates, we strongly recommend\n\
+# using image_geometry.\n\
+#\n\
+# If the camera is uncalibrated, the matrices D, K, R, P should be left\n\
+# zeroed out. In particular, clients may assume that K[0] == 0.0\n\
+# indicates an uncalibrated camera.\n\
+\n\
+#######################################################################\n\
+#                     Image acquisition info                          #\n\
+#######################################################################\n\
+\n\
+# Time of image acquisition, camera coordinate frame ID\n\
+Header header    # Header timestamp should be acquisition time of image\n\
+                 # Header frame_id should be optical frame of camera\n\
+                 # origin of frame should be optical center of camera\n\
+                 # +x should point to the right in the image\n\
+                 # +y should point down in the image\n\
+                 # +z should point into the plane of the image\n\
+\n\
+\n\
+#######################################################################\n\
+#                      Calibration Parameters                         #\n\
+#######################################################################\n\
+# These are fixed during camera calibration. Their values will be the #\n\
+# same in all messages until the camera is recalibrated. Note that    #\n\
+# self-calibrating systems may \"recalibrate\" frequently.              #\n\
+#                                                                     #\n\
+# The internal parameters can be used to warp a raw (distorted) image #\n\
+# to:                                                                 #\n\
+#   1. An undistorted image (requires D and K)                        #\n\
+#   2. A rectified image (requires D, K, R)                           #\n\
+# The projection matrix P projects 3D points into the rectified image.#\n\
+#######################################################################\n\
+\n\
+# The image dimensions with which the camera was calibrated. Normally\n\
+# this will be the full camera resolution in pixels.\n\
+uint32 height\n\
+uint32 width\n\
+\n\
+# The distortion model used. Supported models are listed in\n\
+# sensor_msgs/distortion_models.h. For most cameras, \"plumb_bob\" - a\n\
+# simple model of radial and tangential distortion - is sufficient.\n\
+string distortion_model\n\
+\n\
+# The distortion parameters, size depending on the distortion model.\n\
+# For \"plumb_bob\", the 5 parameters are: (k1, k2, t1, t2, k3).\n\
+float64[] D\n\
+\n\
+# Intrinsic camera matrix for the raw (distorted) images.\n\
+#     [fx  0 cx]\n\
+# K = [ 0 fy cy]\n\
+#     [ 0  0  1]\n\
+# Projects 3D points in the camera coordinate frame to 2D pixel\n\
+# coordinates using the focal lengths (fx, fy) and principal point\n\
+# (cx, cy).\n\
+float64[9]  K # 3x3 row-major matrix\n\
+\n\
+# Rectification matrix (stereo cameras only)\n\
+# A rotation matrix aligning the camera coordinate system to the ideal\n\
+# stereo image plane so that epipolar lines in both stereo images are\n\
+# parallel.\n\
+float64[9]  R # 3x3 row-major matrix\n\
+\n\
+# Projection/camera matrix\n\
+#     [fx'  0  cx' Tx]\n\
+# P = [ 0  fy' cy' Ty]\n\
+#     [ 0   0   1   0]\n\
+# By convention, this matrix specifies the intrinsic (camera) matrix\n\
+#  of the processed (rectified) image. That is, the left 3x3 portion\n\
+#  is the normal camera intrinsic matrix for the rectified image.\n\
+# It projects 3D points in the camera coordinate frame to 2D pixel\n\
+#  coordinates using the focal lengths (fx', fy') and principal point\n\
+#  (cx', cy') - these may differ from the values in K.\n\
+# For monocular cameras, Tx = Ty = 0. Normally, monocular cameras will\n\
+#  also have R = the identity and P[1:3,1:3] = K.\n\
+# For a stereo pair, the fourth column [Tx Ty 0]' is related to the\n\
+#  position of the optical center of the second camera in the first\n\
+#  camera's frame. We assume Tz = 0 so both cameras are in the same\n\
+#  stereo image plane. The first camera always has Tx = Ty = 0. For\n\
+#  the right (second) camera of a horizontal stereo pair, Ty = 0 and\n\
+#  Tx = -fx' * B, where B is the baseline between the cameras.\n\
+# Given a 3D point [X Y Z]', the projection (x, y) of the point onto\n\
+#  the rectified image is given by:\n\
+#  [u v w]' = P * [X Y Z 1]'\n\
+#         x = u / w\n\
+#         y = v / w\n\
+#  This holds for both images of a stereo pair.\n\
+float64[12] P # 3x4 row-major matrix\n\
+\n\
+\n\
+#######################################################################\n\
+#                      Operational Parameters                         #\n\
+#######################################################################\n\
+# These define the image region actually captured by the camera       #\n\
+# driver. Although they affect the geometry of the output image, they #\n\
+# may be changed freely without recalibrating the camera.             #\n\
+#######################################################################\n\
+\n\
+# Binning refers here to any camera setting which combines rectangular\n\
+#  neighborhoods of pixels into larger \"super-pixels.\" It reduces the\n\
+#  resolution of the output image to\n\
+#  (width / binning_x) x (height / binning_y).\n\
+# The default values binning_x = binning_y = 0 is considered the same\n\
+#  as binning_x = binning_y = 1 (no subsampling).\n\
+uint32 binning_x\n\
+uint32 binning_y\n\
+\n\
+# Region of interest (subwindow of full camera resolution), given in\n\
+#  full resolution (unbinned) image coordinates. A particular ROI\n\
+#  always denotes the same window of pixels on the camera sensor,\n\
+#  regardless of binning settings.\n\
+# The default setting of roi (all values 0) is considered the same as\n\
+#  full resolution (roi.width = width, roi.height = height).\n\
+RegionOfInterest roi\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: sensor_msgs/RegionOfInterest\n\
+# This message is used to specify a region of interest within an image.\n\
+#\n\
+# When used to specify the ROI setting of the camera when the image was\n\
+# taken, the height and width fields should either match the height and\n\
+# width fields for the associated image; or height = width = 0\n\
+# indicates that the full resolution image was captured.\n\
+\n\
+uint32 x_offset  # Leftmost pixel of the ROI\n\
+                 # (0 if the ROI includes the left edge of the image)\n\
+uint32 y_offset  # Topmost pixel of the ROI\n\
+                 # (0 if the ROI includes the top edge of the image)\n\
+uint32 height    # Height of ROI\n\
+uint32 width     # Width of ROI\n\
+\n\
+# True if a distinct rectified ROI should be calculated from the \"raw\"\n\
+# ROI in this message. Typically this should be False if the full image\n\
+# is captured (ROI not used), and True if a subwindow is captured (ROI\n\
+# used).\n\
+bool do_rectify\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::SetCameraInfo::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/SetCameraInfo", "sensor_msgs/SetCameraInfo");
-        typ.addProperty("md5sum", yarp::os::Value("ee34be01fdeee563d0d99cd594d5581d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/SetCameraInfoReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/SetCameraInfoReply.h
@@ -131,24 +131,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::SetCameraInfoReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::SetCameraInfoReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/SetCameraInfoReply";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::SetCameraInfoReply::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "2ec6f3eff0161f4257b808b12bc830c2";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/SetCameraInfoReply", "sensor_msgs/SetCameraInfoReply");
-        typ.addProperty("md5sum", yarp::os::Value("2ec6f3eff0161f4257b808b12bc830c2"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Temperature.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/Temperature.h
@@ -154,10 +154,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::Temperature> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::Temperature> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/Temperature";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ff71b307acdbe7c871a5a6d7ed359100";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
  # Single temperature reading.\n\
 \n\
  Header header           # timestamp is the time the temperature was measured\n\
@@ -165,23 +169,31 @@ public:
 \n\
  float64 temperature     # Measurement of the Temperature in Degrees Celsius\n\
 \n\
- float64 variance        # 0 is interpreted as variance unknown") + std::string("\n\
+ float64 variance        # 0 is interpreted as variance unknown\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::Temperature::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/Temperature", "sensor_msgs/Temperature");
-        typ.addProperty("md5sum", yarp::os::Value("ff71b307acdbe7c871a5a6d7ed359100"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/TimeReference.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/sensor_msgs/TimeReference.h
@@ -170,10 +170,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::sensor_msgs::TimeReference> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::sensor_msgs::TimeReference> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "sensor_msgs/TimeReference";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "fded64a0265108ba86c3d38fb11c0c16";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Measurement from an external time source not actively synchronized with the system clock.\n\
 \n\
 Header header    # stamp is system time for which measurement was valid\n\
@@ -181,23 +185,31 @@ Header header    # stamp is system time for which measurement was valid\n\
 \n\
 time   time_ref  # corresponding time from this external source\n\
 string source    # (optional) name of time source\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText();
-    }
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::sensor_msgs::TimeReference::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("sensor_msgs/TimeReference", "sensor_msgs/TimeReference");
-        typ.addProperty("md5sum", yarp::os::Value("fded64a0265108ba86c3d38fb11c0c16"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/Mesh.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/Mesh.h
@@ -180,10 +180,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::shape_msgs::Mesh> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::shape_msgs::Mesh> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "shape_msgs/Mesh";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1ffdae9486cd3316a121c578b47a85cc";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Definition of a mesh\n\
 \n\
 # list of triangles; the index values refer to positions in vertices[]\n\
@@ -191,26 +195,25 @@ MeshTriangle[] triangles\n\
 \n\
 # the actual vertices that make up the mesh\n\
 geometry_msgs/Point[] vertices\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: shape_msgs/MeshTriangle\n\
-") + yarp::rosmsg::shape_msgs::MeshTriangle::typeText() + std::string("\n\
+# Definition of a triangle's vertices\n\
+uint32[3] vertex_indices\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::shape_msgs::Mesh::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("shape_msgs/Mesh", "shape_msgs/Mesh");
-        typ.addProperty("md5sum", yarp::os::Value("1ffdae9486cd3316a121c578b47a85cc"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/MeshTriangle.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/MeshTriangle.h
@@ -123,26 +123,23 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::shape_msgs::MeshTriangle> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::shape_msgs::MeshTriangle> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "shape_msgs/MeshTriangle";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "23688b2e6d2de3d32fe8af104a903253";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Definition of a triangle's vertices\n\
 uint32[3] vertex_indices\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::shape_msgs::MeshTriangle::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("shape_msgs/MeshTriangle", "shape_msgs/MeshTriangle");
-        typ.addProperty("md5sum", yarp::os::Value("23688b2e6d2de3d32fe8af104a903253"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/Plane.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/Plane.h
@@ -129,10 +129,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::shape_msgs::Plane> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::shape_msgs::Plane> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "shape_msgs/Plane";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "2c1b92ed8f31492f8e73f6a4a44ca796";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Representation of a plane, using the plane equation ax + by + cz + d = 0\n\
 \n\
 # a := coef[0]\n\
@@ -141,20 +145,13 @@ public:
 # d := coef[3]\n\
 \n\
 float64[4] coef\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::shape_msgs::Plane::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("shape_msgs/Plane", "shape_msgs/Plane");
-        typ.addProperty("md5sum", yarp::os::Value("2c1b92ed8f31492f8e73f6a4a44ca796"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/SolidPrimitive.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/shape_msgs/SolidPrimitive.h
@@ -216,10 +216,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::shape_msgs::SolidPrimitive> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::shape_msgs::SolidPrimitive> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "shape_msgs/SolidPrimitive";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d8f8cbc74c5ff283fca29569ccefb45d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Define box, sphere, cylinder, cone \n\
 # All shapes are defined to have their bounding boxes centered around 0,0,0.\n\
 \n\
@@ -262,20 +266,13 @@ uint8 CYLINDER_RADIUS=1\n\
 \n\
 uint8 CONE_HEIGHT=0\n\
 uint8 CONE_RADIUS=1\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::shape_msgs::SolidPrimitive::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("shape_msgs/SolidPrimitive", "shape_msgs/SolidPrimitive");
-        typ.addProperty("md5sum", yarp::os::Value("d8f8cbc74c5ff283fca29569ccefb45d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Bool.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Bool.h
@@ -106,25 +106,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Bool> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Bool> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Bool";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8b94c1b53db61fb6aed406028ad6332a";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 bool data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Bool::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Bool", "std_msgs/Bool");
-        typ.addProperty("md5sum", yarp::os::Value("8b94c1b53db61fb6aed406028ad6332a"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Byte.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Byte.h
@@ -104,25 +104,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Byte> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Byte> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Byte";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ad736a2e8818154c487bb80fe42ce43b";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 byte data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Byte::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Byte", "std_msgs/Byte");
-        typ.addProperty("md5sum", yarp::os::Value("ad736a2e8818154c487bb80fe42ce43b"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/ByteMultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/ByteMultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::ByteMultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::ByteMultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/ByteMultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "70ea476cbcfd65ac2f68f3cda1e891fe";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 byte[]            data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::ByteMultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/ByteMultiArray", "std_msgs/ByteMultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("70ea476cbcfd65ac2f68f3cda1e891fe"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Char.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Char.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Char> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Char> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-char data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Char";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Char::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1bf77f25acecdedba0e224b162199717";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+char data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Char", "std_msgs/Char");
-        typ.addProperty("md5sum", yarp::os::Value("1bf77f25acecdedba0e224b162199717"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/ColorRGBA.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/ColorRGBA.h
@@ -161,28 +161,25 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::ColorRGBA> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::ColorRGBA> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/ColorRGBA";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "a29a96539573343b1310c73607334b00";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 float32 r\n\
 float32 g\n\
 float32 b\n\
 float32 a\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::ColorRGBA::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/ColorRGBA", "std_msgs/ColorRGBA");
-        typ.addProperty("md5sum", yarp::os::Value("a29a96539573343b1310c73607334b00"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Duration.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Duration.h
@@ -112,25 +112,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Duration> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Duration> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Duration";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "3e286caf4241d664e55f3ad380e2ae46";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 duration data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Duration::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Duration", "std_msgs/Duration");
-        typ.addProperty("md5sum", yarp::os::Value("3e286caf4241d664e55f3ad380e2ae46"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Empty.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Empty.h
@@ -90,24 +90,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Empty> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Empty> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Empty";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Empty::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d41d8cd98f00b204e9800998ecf8427e";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Empty", "std_msgs/Empty");
-        typ.addProperty("md5sum", yarp::os::Value("d41d8cd98f00b204e9800998ecf8427e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float32.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float32.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Float32> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Float32> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-float32 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Float32";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Float32::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "73fcbf46b49191e672908e50842a83d4";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+float32 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Float32", "std_msgs/Float32");
-        typ.addProperty("md5sum", yarp::os::Value("73fcbf46b49191e672908e50842a83d4"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float32MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float32MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Float32MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Float32MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Float32MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6a40e0ffa6a17a503ac3f8616991b1f6";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 float32[]         data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Float32MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Float32MultiArray", "std_msgs/Float32MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("6a40e0ffa6a17a503ac3f8616991b1f6"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float64.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float64.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Float64> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Float64> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-float64 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Float64";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Float64::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "fdb28210bfa9d7c91146260178d9a584";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+float64 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Float64", "std_msgs/Float64");
-        typ.addProperty("md5sum", yarp::os::Value("fdb28210bfa9d7c91146260178d9a584"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float64MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Float64MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Float64MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Float64MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Float64MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4b7d974086d4060e7db4613a7e6c3ba4";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 float64[]         data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Float64MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Float64MultiArray", "std_msgs/Float64MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("4b7d974086d4060e7db4613a7e6c3ba4"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Header.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Header.h
@@ -170,10 +170,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Header> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Header> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Header";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "2176decaecbce78abc3b96ef049fabed";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Standard metadata for higher-level stamped data types.\n\
 # This is generally used to communicate timestamped data \n\
 # in a particular coordinate frame.\n\
@@ -189,20 +193,13 @@ time stamp\n\
 # 0: no frame\n\
 # 1: global frame\n\
 string frame_id\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Header::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Header", "std_msgs/Header");
-        typ.addProperty("md5sum", yarp::os::Value("2176decaecbce78abc3b96ef049fabed"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int16.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int16.h
@@ -104,25 +104,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int16> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int16> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int16";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "8524586e34fbd7cb1c08c5f5f1ca0e57";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 int16 data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int16::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int16", "std_msgs/Int16");
-        typ.addProperty("md5sum", yarp::os::Value("8524586e34fbd7cb1c08c5f5f1ca0e57"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int16MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int16MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int16MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int16MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int16MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d9338d7f523fcb692fae9d0a0e9f067c";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 int16[]           data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int16MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int16MultiArray", "std_msgs/Int16MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("d9338d7f523fcb692fae9d0a0e9f067c"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int32.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int32.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int32> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int32> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-int32 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int32";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int32::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "da5909fbe378aeaf85e547e830cc1bb7";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+int32 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int32", "std_msgs/Int32");
-        typ.addProperty("md5sum", yarp::os::Value("da5909fbe378aeaf85e547e830cc1bb7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int32MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int32MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int32MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int32MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int32MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1d99f79f8b325b44fee908053e9c945b";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 int32[]           data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int32MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int32MultiArray", "std_msgs/Int32MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("1d99f79f8b325b44fee908053e9c945b"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int64.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int64.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int64> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int64> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-int64 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int64";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int64::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "34add168574510e6e17f5d23ecc077ef";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+int64 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int64", "std_msgs/Int64");
-        typ.addProperty("md5sum", yarp::os::Value("34add168574510e6e17f5d23ecc077ef"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int64MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int64MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int64MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int64MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int64MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "54865aa6c65be0448113a2afc6a49270";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 int64[]           data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int64MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int64MultiArray", "std_msgs/Int64MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("54865aa6c65be0448113a2afc6a49270"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int8.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int8.h
@@ -104,25 +104,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int8> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int8> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int8";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "27ffa0c9c4b8fb8492252bcad9e5c57b";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 int8 data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int8::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int8", "std_msgs/Int8");
-        typ.addProperty("md5sum", yarp::os::Value("27ffa0c9c4b8fb8492252bcad9e5c57b"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int8MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Int8MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Int8MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Int8MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Int8MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d7c1af35a1b4781bbe79e03dd94b7c13";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 int8[]            data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Int8MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Int8MultiArray", "std_msgs/Int8MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("d7c1af35a1b4781bbe79e03dd94b7c13"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/MultiArrayDimension.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/MultiArrayDimension.h
@@ -149,26 +149,24 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::MultiArrayDimension> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::MultiArrayDimension> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/MultiArrayDimension";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4cd0c83a8683deae40ecdac60e53bfa8";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 string label   # label of given dimension\n\
 uint32 size    # size of given dimension (in type units)\n\
-uint32 stride  # stride of given dimension");
-    }
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::MultiArrayDimension::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/MultiArrayDimension", "std_msgs/MultiArrayDimension");
-        typ.addProperty("md5sum", yarp::os::Value("4cd0c83a8683deae40ecdac60e53bfa8"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/MultiArrayLayout.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/MultiArrayLayout.h
@@ -173,10 +173,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::MultiArrayLayout> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::MultiArrayLayout> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/MultiArrayLayout";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "0fed2a11c13e11c5571b4e2a995a91a3";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # The multiarray declares a generic multi-dimensional array of a\n\
 # particular data type.  Dimensions are ordered from outer most\n\
 # to inner most.\n\
@@ -203,23 +207,19 @@ uint32 data_offset        # padding elements at front of data\n\
 # dim[2].stride = 3\n\
 #\n\
 # multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayDimension\n\
-") + yarp::rosmsg::std_msgs::MultiArrayDimension::typeText();
-    }
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/MultiArrayLayout", "std_msgs/MultiArrayLayout");
-        typ.addProperty("md5sum", yarp::os::Value("0fed2a11c13e11c5571b4e2a995a91a3"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/String.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/String.h
@@ -112,25 +112,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::String> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::String> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/String";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "992ce8a1687cec8c8bd883ec73ca41d1";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 string data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::String::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/String", "std_msgs/String");
-        typ.addProperty("md5sum", yarp::os::Value("992ce8a1687cec8c8bd883ec73ca41d1"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Time.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/Time.h
@@ -112,25 +112,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::Time> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::Time> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/Time";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "cd7166c74c552c311fbcc2fe5a7bc289";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 time data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::Time::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/Time", "std_msgs/Time");
-        typ.addProperty("md5sum", yarp::os::Value("cd7166c74c552c311fbcc2fe5a7bc289"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt16.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt16.h
@@ -104,25 +104,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt16> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt16> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt16";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1df79edf208b629fe6b81923a544552d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 uint16 data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt16::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt16", "std_msgs/UInt16");
-        typ.addProperty("md5sum", yarp::os::Value("1df79edf208b629fe6b81923a544552d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt16MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt16MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt16MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt16MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt16MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "52f264f1c973c4b73790d384c6cb4484";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 uint16[]            data        # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt16MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt16MultiArray", "std_msgs/UInt16MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("52f264f1c973c4b73790d384c6cb4484"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt32.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt32.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt32> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt32> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-uint32 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt32";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt32::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "304a39449588c7f8ce2df6e8001c5fce";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+uint32 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt32", "std_msgs/UInt32");
-        typ.addProperty("md5sum", yarp::os::Value("304a39449588c7f8ce2df6e8001c5fce"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt32MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt32MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt32MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt32MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt32MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4d6a180abc9be191b96a7eda6c8a233d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 uint32[]          data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt32MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt32MultiArray", "std_msgs/UInt32MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("4d6a180abc9be191b96a7eda6c8a233d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt64.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt64.h
@@ -103,24 +103,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt64> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt64> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-uint64 data");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt64";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt64::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1b2a79973e8bf53d7b53acb71299cb57";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+uint64 data\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt64", "std_msgs/UInt64");
-        typ.addProperty("md5sum", yarp::os::Value("1b2a79973e8bf53d7b53acb71299cb57"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt64MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt64MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt64MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt64MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt64MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "6088f127afb1d6c72927aa1247e945af";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 uint64[]          data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt64MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt64MultiArray", "std_msgs/UInt64MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("6088f127afb1d6c72927aa1247e945af"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt8.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt8.h
@@ -104,25 +104,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt8> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt8> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt8";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "7c8164229e7d2c17eb95e9231617fdee";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 uint8 data\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt8::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt8", "std_msgs/UInt8");
-        typ.addProperty("md5sum", yarp::os::Value("7c8164229e7d2c17eb95e9231617fdee"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt8MultiArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/std_msgs/UInt8MultiArray.h
@@ -152,33 +152,62 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::std_msgs::UInt8MultiArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::std_msgs::UInt8MultiArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "std_msgs/UInt8MultiArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "82373f1612381bb6ee473b5cd6f5d89c";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Please look at the MultiArrayLayout message definition for\n\
 # documentation on all multiarrays.\n\
 \n\
 MultiArrayLayout  layout        # specification of data layout\n\
 uint8[]           data          # array of data\n\
 \n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/MultiArrayLayout\n\
-") + yarp::rosmsg::std_msgs::MultiArrayLayout::typeText();
-    }
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::std_msgs::UInt8MultiArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("std_msgs/UInt8MultiArray", "std_msgs/UInt8MultiArray");
-        typ.addProperty("md5sum", yarp::os::Value("82373f1612381bb6ee473b5cd6f5d89c"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/stereo_msgs/DisparityImage.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/stereo_msgs/DisparityImage.h
@@ -282,10 +282,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::stereo_msgs::DisparityImage> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::stereo_msgs::DisparityImage> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "stereo_msgs/DisparityImage";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "04a177815f75271039fa21f16acad8c9";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Separate header for compatibility with current TimeSynchronizer.\n\
 # Likely to be removed in a later release, use image.header instead.\n\
 Header header\n\
@@ -315,29 +319,83 @@ float32 max_disparity\n\
 # Smallest allowed disparity increment. The smallest achievable depth range\n\
 # resolution is delta_Z = (Z^2/fT)*delta_d.\n\
 float32 delta_d\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/Image\n\
-") + yarp::rosmsg::sensor_msgs::Image::typeText() + std::string("\n\
+# This message contains an uncompressed image\n\
+# (0, 0) is at top-left corner of image\n\
+#\n\
+\n\
+Header header        # Header timestamp should be acquisition time of image\n\
+                     # Header frame_id should be optical frame of camera\n\
+                     # origin of frame should be optical center of cameara\n\
+                     # +x should point to the right in the image\n\
+                     # +y should point down in the image\n\
+                     # +z should point into to plane of the image\n\
+                     # If the frame_id here and the frame_id of the CameraInfo\n\
+                     # message associated with the image conflict\n\
+                     # the behavior is undefined\n\
+\n\
+uint32 height         # image height, that is, number of rows\n\
+uint32 width          # image width, that is, number of columns\n\
+\n\
+# The legal values for encoding are in file src/image_encodings.cpp\n\
+# If you want to standardize a new string format, join\n\
+# ros-users@lists.sourceforge.net and send an email proposing a new encoding.\n\
+\n\
+string encoding       # Encoding of pixels -- channel meaning, ordering, size\n\
+                      # taken from the list of strings in include/sensor_msgs/image_encodings.h\n\
+\n\
+uint8 is_bigendian    # is this data bigendian?\n\
+uint32 step           # Full row length in bytes\n\
+uint8[] data          # actual matrix data, size is (step * rows)\n\
+\n\
 ================================================================================\n\
 MSG: sensor_msgs/RegionOfInterest\n\
-") + yarp::rosmsg::sensor_msgs::RegionOfInterest::typeText();
-    }
+# This message is used to specify a region of interest within an image.\n\
+#\n\
+# When used to specify the ROI setting of the camera when the image was\n\
+# taken, the height and width fields should either match the height and\n\
+# width fields for the associated image; or height = width = 0\n\
+# indicates that the full resolution image was captured.\n\
+\n\
+uint32 x_offset  # Leftmost pixel of the ROI\n\
+                 # (0 if the ROI includes the left edge of the image)\n\
+uint32 y_offset  # Topmost pixel of the ROI\n\
+                 # (0 if the ROI includes the top edge of the image)\n\
+uint32 height    # Height of ROI\n\
+uint32 width     # Width of ROI\n\
+\n\
+# True if a distinct rectified ROI should be calculated from the \"raw\"\n\
+# ROI in this message. Typically this should be False if the full image\n\
+# is captured (ROI not used), and True if a subwindow is captured (ROI\n\
+# used).\n\
+bool do_rectify\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::stereo_msgs::DisparityImage::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("stereo_msgs/DisparityImage", "stereo_msgs/DisparityImage");
-        typ.addProperty("md5sum", yarp::os::Value("04a177815f75271039fa21f16acad8c9"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/FrameGraph.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/FrameGraph.h
@@ -92,26 +92,23 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf::FrameGraph> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf::FrameGraph> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf/FrameGraph";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d41d8cd98f00b204e9800998ecf8427e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 ---\n\
 string dot_graph\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf::FrameGraph::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf/FrameGraph", "tf/FrameGraph");
-        typ.addProperty("md5sum", yarp::os::Value("d41d8cd98f00b204e9800998ecf8427e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/FrameGraphReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/FrameGraphReply.h
@@ -111,24 +111,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf::FrameGraphReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf::FrameGraphReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf/FrameGraphReply";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf::FrameGraphReply::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "c4af9ac907e58e906eb0b6e3c58478c0";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf/FrameGraphReply", "tf/FrameGraphReply");
-        typ.addProperty("md5sum", yarp::os::Value("c4af9ac907e58e906eb0b6e3c58478c0"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/tfMessage.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf/tfMessage.h
@@ -130,28 +130,81 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf::tfMessage> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf::tfMessage> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf/tfMessage";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "94810edda583a504dfda3829e70d7eec";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 geometry_msgs/TransformStamped[] transforms\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/TransformStamped\n\
-") + yarp::rosmsg::geometry_msgs::TransformStamped::typeText();
-    }
+# This expresses a transform from coordinate frame header.frame_id\n\
+# to the coordinate frame child_frame_id\n\
+#\n\
+# This message is mostly used by the \n\
+# <a href=\"http://wiki.ros.org/tf\">tf</a> package. \n\
+# See its documentation for more information.\n\
+\n\
+Header header\n\
+string child_frame_id # the frame id of the child frame\n\
+Transform transform\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Transform\n\
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf::tfMessage::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf/tfMessage", "tf/tfMessage");
-        typ.addProperty("md5sum", yarp::os::Value("94810edda583a504dfda3829e70d7eec"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/FrameGraph.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/FrameGraph.h
@@ -92,26 +92,23 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf2_msgs::FrameGraph> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf2_msgs::FrameGraph> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf2_msgs/FrameGraph";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d41d8cd98f00b204e9800998ecf8427e";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 ---\n\
 string frame_yaml\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf2_msgs::FrameGraph::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf2_msgs/FrameGraph", "tf2_msgs/FrameGraph");
-        typ.addProperty("md5sum", yarp::os::Value("d41d8cd98f00b204e9800998ecf8427e"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/FrameGraphReply.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/FrameGraphReply.h
@@ -111,24 +111,22 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf2_msgs::FrameGraphReply> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf2_msgs::FrameGraphReply> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
-");
-    }
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf2_msgs/FrameGraphReply";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf2_msgs::FrameGraphReply::typeText();
-    }
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "437ea58e9463815a0d511c7326b686b0";
 
-    // Name the class, ROS will need this
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
+\n\
+";
+
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf2_msgs/FrameGraphReply", "tf2_msgs/FrameGraphReply");
-        typ.addProperty("md5sum", yarp::os::Value("437ea58e9463815a0d511c7326b686b0"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/TF2Error.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/TF2Error.h
@@ -160,10 +160,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf2_msgs::TF2Error> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf2_msgs::TF2Error> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf2_msgs/TF2Error";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "bc6848fd6fd750c92e38575618a4917d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 uint8 NO_ERROR = 0\n\
 uint8 LOOKUP_ERROR = 1\n\
 uint8 CONNECTIVITY_ERROR = 2\n\
@@ -174,20 +178,13 @@ uint8 TRANSFORM_ERROR = 6\n\
 \n\
 uint8 error\n\
 string error_string\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf2_msgs::TF2Error::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf2_msgs/TF2Error", "tf2_msgs/TF2Error");
-        typ.addProperty("md5sum", yarp::os::Value("bc6848fd6fd750c92e38575618a4917d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/TFMessage.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/tf2_msgs/TFMessage.h
@@ -130,28 +130,81 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::tf2_msgs::TFMessage> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::tf2_msgs::TFMessage> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "tf2_msgs/TFMessage";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "94810edda583a504dfda3829e70d7eec";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 geometry_msgs/TransformStamped[] transforms\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/TransformStamped\n\
-") + yarp::rosmsg::geometry_msgs::TransformStamped::typeText();
-    }
+# This expresses a transform from coordinate frame header.frame_id\n\
+# to the coordinate frame child_frame_id\n\
+#\n\
+# This message is mostly used by the \n\
+# <a href=\"http://wiki.ros.org/tf\">tf</a> package. \n\
+# See its documentation for more information.\n\
+\n\
+Header header\n\
+string child_frame_id # the frame id of the child frame\n\
+Transform transform\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Transform\n\
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::tf2_msgs::TFMessage::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("tf2_msgs/TFMessage", "tf2_msgs/TFMessage");
-        typ.addProperty("md5sum", yarp::os::Value("94810edda583a504dfda3829e70d7eec"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/JointTrajectory.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/JointTrajectory.h
@@ -202,32 +202,53 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::trajectory_msgs::JointTrajectory> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::trajectory_msgs::JointTrajectory> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "trajectory_msgs/JointTrajectory";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "65b4f94a94d1ed67169da35a02f33d3f";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 Header header\n\
 string[] joint_names\n\
-JointTrajectoryPoint[] points") + std::string("\n\
+JointTrajectoryPoint[] points\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: trajectory_msgs/JointTrajectoryPoint\n\
-") + yarp::rosmsg::trajectory_msgs::JointTrajectoryPoint::typeText();
-    }
+# Each trajectory point specifies either positions[, velocities[, accelerations]]\n\
+# or positions[, effort] for the trajectory to be executed.\n\
+# All specified values are in the same order as the joint names in JointTrajectory.msg\n\
+\n\
+float64[] positions\n\
+float64[] velocities\n\
+float64[] accelerations\n\
+float64[] effort\n\
+duration time_from_start\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::trajectory_msgs::JointTrajectory::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("trajectory_msgs/JointTrajectory", "trajectory_msgs/JointTrajectory");
-        typ.addProperty("md5sum", yarp::os::Value("65b4f94a94d1ed67169da35a02f33d3f"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/JointTrajectoryPoint.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/JointTrajectoryPoint.h
@@ -260,10 +260,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::trajectory_msgs::JointTrajectoryPoint> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::trajectory_msgs::JointTrajectoryPoint> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "trajectory_msgs/JointTrajectoryPoint";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "f3cd1e1c4d320c79d6985c904ae5dcd3";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Each trajectory point specifies either positions[, velocities[, accelerations]]\n\
 # or positions[, effort] for the trajectory to be executed.\n\
 # All specified values are in the same order as the joint names in JointTrajectory.msg\n\
@@ -273,20 +277,13 @@ float64[] velocities\n\
 float64[] accelerations\n\
 float64[] effort\n\
 duration time_from_start\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::trajectory_msgs::JointTrajectoryPoint::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("trajectory_msgs/JointTrajectoryPoint", "trajectory_msgs/JointTrajectoryPoint");
-        typ.addProperty("md5sum", yarp::os::Value("f3cd1e1c4d320c79d6985c904ae5dcd3"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/MultiDOFJointTrajectory.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/MultiDOFJointTrajectory.h
@@ -210,10 +210,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectory> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectory> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "trajectory_msgs/MultiDOFJointTrajectory";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ef145a45a5f47b77b7f5cdde4b16c942";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # The header is used to specify the coordinate frame and the reference time for the trajectory durations\n\
 Header header\n\
 \n\
@@ -224,26 +228,78 @@ Header header\n\
 \n\
 string[] joint_names\n\
 MultiDOFJointTrajectoryPoint[] points\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: trajectory_msgs/MultiDOFJointTrajectoryPoint\n\
-") + yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectoryPoint::typeText();
-    }
+# Each multi-dof joint can specify a transform (up to 6 DOF)\n\
+geometry_msgs/Transform[] transforms\n\
+\n\
+# There can be a velocity specified for the origin of the joint \n\
+geometry_msgs/Twist[] velocities\n\
+\n\
+# There can be an acceleration specified for the origin of the joint \n\
+geometry_msgs/Twist[] accelerations\n\
+\n\
+duration time_from_start\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Transform\n\
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Twist\n\
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectory::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("trajectory_msgs/MultiDOFJointTrajectory", "trajectory_msgs/MultiDOFJointTrajectory");
-        typ.addProperty("md5sum", yarp::os::Value("ef145a45a5f47b77b7f5cdde4b16c942"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/MultiDOFJointTrajectoryPoint.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/trajectory_msgs/MultiDOFJointTrajectoryPoint.h
@@ -252,10 +252,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectoryPoint> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectoryPoint> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "trajectory_msgs/MultiDOFJointTrajectoryPoint";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "3ebe08d1abd5b65862d50e09430db776";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Each multi-dof joint can specify a transform (up to 6 DOF)\n\
 geometry_msgs/Transform[] transforms\n\
 \n\
@@ -266,26 +270,47 @@ geometry_msgs/Twist[] velocities\n\
 geometry_msgs/Twist[] accelerations\n\
 \n\
 duration time_from_start\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Transform\n\
-") + yarp::rosmsg::geometry_msgs::Transform::typeText() + std::string("\n\
+# This represents the transform between two coordinate frames in free space.\n\
+\n\
+Vector3 translation\n\
+Quaternion rotation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Twist\n\
-") + yarp::rosmsg::geometry_msgs::Twist::typeText();
-    }
+# This expresses velocity in free space broken into its linear and angular parts.\n\
+Vector3  linear\n\
+Vector3  angular\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::trajectory_msgs::MultiDOFJointTrajectoryPoint::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("trajectory_msgs/MultiDOFJointTrajectoryPoint", "trajectory_msgs/MultiDOFJointTrajectoryPoint");
-        typ.addProperty("md5sum", yarp::os::Value("3ebe08d1abd5b65862d50e09430db776"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/ImageMarker.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/ImageMarker.h
@@ -460,10 +460,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::ImageMarker> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::ImageMarker> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/ImageMarker";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "1de93c67ec8858b831025a08fbf1b35c";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 uint8 CIRCLE=0\n\
 uint8 LINE_STRIP=1\n\
 uint8 LINE_LIST=2\n\
@@ -487,29 +491,45 @@ duration lifetime       # How long the object should last before being automatic
 \n\
 \n\
 geometry_msgs/Point[] points # used for LINE_STRIP/LINE_LIST/POINTS/etc., 2D in pixel coords\n\
-std_msgs/ColorRGBA[] outline_colors # a color for each line, point, etc.") + std::string("\n\
+std_msgs/ColorRGBA[] outline_colors # a color for each line, point, etc.\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText() + std::string("\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/ColorRGBA\n\
-") + yarp::rosmsg::std_msgs::ColorRGBA::typeText();
-    }
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::ImageMarker::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/ImageMarker", "visualization_msgs/ImageMarker");
-        typ.addProperty("md5sum", yarp::os::Value("1de93c67ec8858b831025a08fbf1b35c"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarker.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarker.h
@@ -321,10 +321,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarker> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarker> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarker";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "dd86d22909d5a3364b384492e35c10af";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Time/frame info.\n\
 # If header.time is set to 0, the marker will be retransformed into\n\
 # its frame on each timestep. You will receive the pose feedback\n\
@@ -351,32 +355,256 @@ MenuEntry[] menu_entries\n\
 \n\
 # List of controls displayed for this marker.\n\
 InteractiveMarkerControl[] controls\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText() + std::string("\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/MenuEntry\n\
-") + yarp::rosmsg::visualization_msgs::MenuEntry::typeText() + std::string("\n\
+# MenuEntry message.\n\
+\n\
+# Each InteractiveMarker message has an array of MenuEntry messages.\n\
+# A collection of MenuEntries together describe a\n\
+# menu/submenu/subsubmenu/etc tree, though they are stored in a flat\n\
+# array.  The tree structure is represented by giving each menu entry\n\
+# an ID number and a \"parent_id\" field.  Top-level entries are the\n\
+# ones with parent_id = 0.  Menu entries are ordered within their\n\
+# level the same way they are ordered in the containing array.  Parent\n\
+# entries must appear before their children.\n\
+\n\
+# Example:\n\
+# - id = 3\n\
+#   parent_id = 0\n\
+#   title = \"fun\"\n\
+# - id = 2\n\
+#   parent_id = 0\n\
+#   title = \"robot\"\n\
+# - id = 4\n\
+#   parent_id = 2\n\
+#   title = \"pr2\"\n\
+# - id = 5\n\
+#   parent_id = 2\n\
+#   title = \"turtle\"\n\
+#\n\
+# Gives a menu tree like this:\n\
+#  - fun\n\
+#  - robot\n\
+#    - pr2\n\
+#    - turtle\n\
+\n\
+# ID is a number for each menu entry.  Must be unique within the\n\
+# control, and should never be 0.\n\
+uint32 id\n\
+\n\
+# ID of the parent of this menu entry, if it is a submenu.  If this\n\
+# menu entry is a top-level entry, set parent_id to 0.\n\
+uint32 parent_id\n\
+\n\
+# menu / entry title\n\
+string title\n\
+\n\
+# Arguments to command indicated by command_type (below)\n\
+string command\n\
+\n\
+# Command_type stores the type of response desired when this menu\n\
+# entry is clicked.\n\
+# FEEDBACK: send an InteractiveMarkerFeedback message with menu_entry_id set to this entry's id.\n\
+# ROSRUN: execute \"rosrun\" with arguments given in the command field (above).\n\
+# ROSLAUNCH: execute \"roslaunch\" with arguments given in the command field (above).\n\
+uint8 FEEDBACK=0\n\
+uint8 ROSRUN=1\n\
+uint8 ROSLAUNCH=2\n\
+uint8 command_type\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/InteractiveMarkerControl\n\
-") + yarp::rosmsg::visualization_msgs::InteractiveMarkerControl::typeText();
-    }
+# Represents a control that is to be displayed together with an interactive marker\n\
+\n\
+# Identifying string for this control.\n\
+# You need to assign a unique value to this to receive feedback from the GUI\n\
+# on what actions the user performs on this control (e.g. a button click).\n\
+string name\n\
+\n\
+\n\
+# Defines the local coordinate frame (relative to the pose of the parent\n\
+# interactive marker) in which is being rotated and translated.\n\
+# Default: Identity\n\
+geometry_msgs/Quaternion orientation\n\
+\n\
+\n\
+# Orientation mode: controls how orientation changes.\n\
+# INHERIT: Follow orientation of interactive marker\n\
+# FIXED: Keep orientation fixed at initial state\n\
+# VIEW_FACING: Align y-z plane with screen (x: forward, y:left, z:up).\n\
+uint8 INHERIT = 0 \n\
+uint8 FIXED = 1\n\
+uint8 VIEW_FACING = 2\n\
+\n\
+uint8 orientation_mode\n\
+\n\
+# Interaction mode for this control\n\
+# \n\
+# NONE: This control is only meant for visualization; no context menu.\n\
+# MENU: Like NONE, but right-click menu is active.\n\
+# BUTTON: Element can be left-clicked.\n\
+# MOVE_AXIS: Translate along local x-axis.\n\
+# MOVE_PLANE: Translate in local y-z plane.\n\
+# ROTATE_AXIS: Rotate around local x-axis.\n\
+# MOVE_ROTATE: Combines MOVE_PLANE and ROTATE_AXIS.\n\
+uint8 NONE = 0 \n\
+uint8 MENU = 1\n\
+uint8 BUTTON = 2\n\
+uint8 MOVE_AXIS = 3 \n\
+uint8 MOVE_PLANE = 4\n\
+uint8 ROTATE_AXIS = 5\n\
+uint8 MOVE_ROTATE = 6\n\
+# \"3D\" interaction modes work with the mouse+SHIFT+CTRL or with 3D cursors.\n\
+# MOVE_3D: Translate freely in 3D space.\n\
+# ROTATE_3D: Rotate freely in 3D space about the origin of parent frame.\n\
+# MOVE_ROTATE_3D: Full 6-DOF freedom of translation and rotation about the cursor origin.\n\
+uint8 MOVE_3D = 7\n\
+uint8 ROTATE_3D = 8\n\
+uint8 MOVE_ROTATE_3D = 9\n\
+\n\
+uint8 interaction_mode\n\
+\n\
+\n\
+# If true, the contained markers will also be visible\n\
+# when the gui is not in interactive mode.\n\
+bool always_visible\n\
+\n\
+\n\
+# Markers to be displayed as custom visual representation.\n\
+# Leave this empty to use the default control handles.\n\
+#\n\
+# Note: \n\
+# - The markers can be defined in an arbitrary coordinate frame,\n\
+#   but will be transformed into the local frame of the interactive marker.\n\
+# - If the header of a marker is empty, its pose will be interpreted as \n\
+#   relative to the pose of the parent interactive marker.\n\
+Marker[] markers\n\
+\n\
+\n\
+# In VIEW_FACING mode, set this to true if you don't want the markers\n\
+# to be aligned with the camera view point. The markers will show up\n\
+# as in INHERIT mode.\n\
+bool independent_marker_orientation\n\
+\n\
+\n\
+# Short description (< 40 characters) of what this control does,\n\
+# e.g. \"Move the robot\". \n\
+# Default: A generic description based on the interaction mode\n\
+string description\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/Marker\n\
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarker::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarker", "visualization_msgs/InteractiveMarker");
-        typ.addProperty("md5sum", yarp::os::Value("dd86d22909d5a3364b384492e35c10af"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerControl.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerControl.h
@@ -399,10 +399,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerControl> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerControl> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarkerControl";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "b3c81e785788195d1840b86c28da1aac";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Represents a control that is to be displayed together with an interactive marker\n\
 \n\
 # Identifying string for this control.\n\
@@ -480,26 +484,119 @@ bool independent_marker_orientation\n\
 # e.g. \"Move the robot\". \n\
 # Default: A generic description based on the interaction mode\n\
 string description\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Quaternion\n\
-") + yarp::rosmsg::geometry_msgs::Quaternion::typeText() + std::string("\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/Marker\n\
-") + yarp::rosmsg::visualization_msgs::Marker::typeText();
-    }
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarkerControl::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarkerControl", "visualization_msgs/InteractiveMarkerControl");
-        typ.addProperty("md5sum", yarp::os::Value("b3c81e785788195d1840b86c28da1aac"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerFeedback.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerFeedback.h
@@ -357,10 +357,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarkerFeedback";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "ab0f1eee058667e28c19ff3ffc3f4b78";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Time/frame info.\n\
 Header header\n\
 \n\
@@ -403,29 +407,53 @@ uint32 menu_entry_id\n\
 # will be relative to the frame listed in the header.\n\
 geometry_msgs/Point mouse_point\n\
 bool mouse_point_valid\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText() + std::string("\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarkerFeedback", "visualization_msgs/InteractiveMarkerFeedback");
-        typ.addProperty("md5sum", yarp::os::Value("ab0f1eee058667e28c19ff3ffc3f4b78"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerInit.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerInit.h
@@ -187,10 +187,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerInit> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerInit> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarkerInit";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d5f2c5045a72456d228676ab91048734";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Identifying string. Must be unique in the topic namespace\n\
 # that this server works on.\n\
 string server_id\n\
@@ -205,23 +209,285 @@ uint64 seq_num\n\
 \n\
 # All markers.\n\
 InteractiveMarker[] markers\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/InteractiveMarker\n\
-") + yarp::rosmsg::visualization_msgs::InteractiveMarker::typeText();
-    }
+# Time/frame info.\n\
+# If header.time is set to 0, the marker will be retransformed into\n\
+# its frame on each timestep. You will receive the pose feedback\n\
+# in the same frame.\n\
+# Otherwise, you might receive feedback in a different frame.\n\
+# For rviz, this will be the current 'fixed frame' set by the user.\n\
+Header header\n\
+\n\
+# Initial pose. Also, defines the pivot point for rotations.\n\
+geometry_msgs/Pose pose\n\
+\n\
+# Identifying string. Must be globally unique in\n\
+# the topic that this message is sent through.\n\
+string name\n\
+\n\
+# Short description (< 40 characters).\n\
+string description\n\
+\n\
+# Scale to be used for default controls (default=1).\n\
+float32 scale\n\
+\n\
+# All menu and submenu entries associated with this marker.\n\
+MenuEntry[] menu_entries\n\
+\n\
+# List of controls displayed for this marker.\n\
+InteractiveMarkerControl[] controls\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/MenuEntry\n\
+# MenuEntry message.\n\
+\n\
+# Each InteractiveMarker message has an array of MenuEntry messages.\n\
+# A collection of MenuEntries together describe a\n\
+# menu/submenu/subsubmenu/etc tree, though they are stored in a flat\n\
+# array.  The tree structure is represented by giving each menu entry\n\
+# an ID number and a \"parent_id\" field.  Top-level entries are the\n\
+# ones with parent_id = 0.  Menu entries are ordered within their\n\
+# level the same way they are ordered in the containing array.  Parent\n\
+# entries must appear before their children.\n\
+\n\
+# Example:\n\
+# - id = 3\n\
+#   parent_id = 0\n\
+#   title = \"fun\"\n\
+# - id = 2\n\
+#   parent_id = 0\n\
+#   title = \"robot\"\n\
+# - id = 4\n\
+#   parent_id = 2\n\
+#   title = \"pr2\"\n\
+# - id = 5\n\
+#   parent_id = 2\n\
+#   title = \"turtle\"\n\
+#\n\
+# Gives a menu tree like this:\n\
+#  - fun\n\
+#  - robot\n\
+#    - pr2\n\
+#    - turtle\n\
+\n\
+# ID is a number for each menu entry.  Must be unique within the\n\
+# control, and should never be 0.\n\
+uint32 id\n\
+\n\
+# ID of the parent of this menu entry, if it is a submenu.  If this\n\
+# menu entry is a top-level entry, set parent_id to 0.\n\
+uint32 parent_id\n\
+\n\
+# menu / entry title\n\
+string title\n\
+\n\
+# Arguments to command indicated by command_type (below)\n\
+string command\n\
+\n\
+# Command_type stores the type of response desired when this menu\n\
+# entry is clicked.\n\
+# FEEDBACK: send an InteractiveMarkerFeedback message with menu_entry_id set to this entry's id.\n\
+# ROSRUN: execute \"rosrun\" with arguments given in the command field (above).\n\
+# ROSLAUNCH: execute \"roslaunch\" with arguments given in the command field (above).\n\
+uint8 FEEDBACK=0\n\
+uint8 ROSRUN=1\n\
+uint8 ROSLAUNCH=2\n\
+uint8 command_type\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/InteractiveMarkerControl\n\
+# Represents a control that is to be displayed together with an interactive marker\n\
+\n\
+# Identifying string for this control.\n\
+# You need to assign a unique value to this to receive feedback from the GUI\n\
+# on what actions the user performs on this control (e.g. a button click).\n\
+string name\n\
+\n\
+\n\
+# Defines the local coordinate frame (relative to the pose of the parent\n\
+# interactive marker) in which is being rotated and translated.\n\
+# Default: Identity\n\
+geometry_msgs/Quaternion orientation\n\
+\n\
+\n\
+# Orientation mode: controls how orientation changes.\n\
+# INHERIT: Follow orientation of interactive marker\n\
+# FIXED: Keep orientation fixed at initial state\n\
+# VIEW_FACING: Align y-z plane with screen (x: forward, y:left, z:up).\n\
+uint8 INHERIT = 0 \n\
+uint8 FIXED = 1\n\
+uint8 VIEW_FACING = 2\n\
+\n\
+uint8 orientation_mode\n\
+\n\
+# Interaction mode for this control\n\
+# \n\
+# NONE: This control is only meant for visualization; no context menu.\n\
+# MENU: Like NONE, but right-click menu is active.\n\
+# BUTTON: Element can be left-clicked.\n\
+# MOVE_AXIS: Translate along local x-axis.\n\
+# MOVE_PLANE: Translate in local y-z plane.\n\
+# ROTATE_AXIS: Rotate around local x-axis.\n\
+# MOVE_ROTATE: Combines MOVE_PLANE and ROTATE_AXIS.\n\
+uint8 NONE = 0 \n\
+uint8 MENU = 1\n\
+uint8 BUTTON = 2\n\
+uint8 MOVE_AXIS = 3 \n\
+uint8 MOVE_PLANE = 4\n\
+uint8 ROTATE_AXIS = 5\n\
+uint8 MOVE_ROTATE = 6\n\
+# \"3D\" interaction modes work with the mouse+SHIFT+CTRL or with 3D cursors.\n\
+# MOVE_3D: Translate freely in 3D space.\n\
+# ROTATE_3D: Rotate freely in 3D space about the origin of parent frame.\n\
+# MOVE_ROTATE_3D: Full 6-DOF freedom of translation and rotation about the cursor origin.\n\
+uint8 MOVE_3D = 7\n\
+uint8 ROTATE_3D = 8\n\
+uint8 MOVE_ROTATE_3D = 9\n\
+\n\
+uint8 interaction_mode\n\
+\n\
+\n\
+# If true, the contained markers will also be visible\n\
+# when the gui is not in interactive mode.\n\
+bool always_visible\n\
+\n\
+\n\
+# Markers to be displayed as custom visual representation.\n\
+# Leave this empty to use the default control handles.\n\
+#\n\
+# Note: \n\
+# - The markers can be defined in an arbitrary coordinate frame,\n\
+#   but will be transformed into the local frame of the interactive marker.\n\
+# - If the header of a marker is empty, its pose will be interpreted as \n\
+#   relative to the pose of the parent interactive marker.\n\
+Marker[] markers\n\
+\n\
+\n\
+# In VIEW_FACING mode, set this to true if you don't want the markers\n\
+# to be aligned with the camera view point. The markers will show up\n\
+# as in INHERIT mode.\n\
+bool independent_marker_orientation\n\
+\n\
+\n\
+# Short description (< 40 characters) of what this control does,\n\
+# e.g. \"Move the robot\". \n\
+# Default: A generic description based on the interaction mode\n\
+string description\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/Marker\n\
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarkerInit::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarkerInit", "visualization_msgs/InteractiveMarkerInit");
-        typ.addProperty("md5sum", yarp::os::Value("d5f2c5045a72456d228676ab91048734"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerPose.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerPose.h
@@ -172,10 +172,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerPose> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerPose> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarkerPose";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "a6e6833209a196a38d798dadb02c81f8";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Time/frame info.\n\
 Header header\n\
 \n\
@@ -185,26 +189,53 @@ geometry_msgs/Pose pose\n\
 # Identifying string. Must be globally unique in\n\
 # the topic that this message is sent through.\n\
 string name\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText();
-    }
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarkerPose::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarkerPose", "visualization_msgs/InteractiveMarkerPose");
-        typ.addProperty("md5sum", yarp::os::Value("a6e6833209a196a38d798dadb02c81f8"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerUpdate.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/InteractiveMarkerUpdate.h
@@ -317,10 +317,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerUpdate> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::InteractiveMarkerUpdate> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/InteractiveMarkerUpdate";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "710d308d0a9276d65945e92dd30b3946";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # Identifying string. Must be unique in the topic namespace\n\
 # that this server works on.\n\
 string server_id\n\
@@ -352,26 +356,297 @@ InteractiveMarkerPose[] poses\n\
 \n\
 #Names of markers to be erased\n\
 string[] erases\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/InteractiveMarker\n\
-") + yarp::rosmsg::visualization_msgs::InteractiveMarker::typeText() + std::string("\n\
+# Time/frame info.\n\
+# If header.time is set to 0, the marker will be retransformed into\n\
+# its frame on each timestep. You will receive the pose feedback\n\
+# in the same frame.\n\
+# Otherwise, you might receive feedback in a different frame.\n\
+# For rviz, this will be the current 'fixed frame' set by the user.\n\
+Header header\n\
+\n\
+# Initial pose. Also, defines the pivot point for rotations.\n\
+geometry_msgs/Pose pose\n\
+\n\
+# Identifying string. Must be globally unique in\n\
+# the topic that this message is sent through.\n\
+string name\n\
+\n\
+# Short description (< 40 characters).\n\
+string description\n\
+\n\
+# Scale to be used for default controls (default=1).\n\
+float32 scale\n\
+\n\
+# All menu and submenu entries associated with this marker.\n\
+MenuEntry[] menu_entries\n\
+\n\
+# List of controls displayed for this marker.\n\
+InteractiveMarkerControl[] controls\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/MenuEntry\n\
+# MenuEntry message.\n\
+\n\
+# Each InteractiveMarker message has an array of MenuEntry messages.\n\
+# A collection of MenuEntries together describe a\n\
+# menu/submenu/subsubmenu/etc tree, though they are stored in a flat\n\
+# array.  The tree structure is represented by giving each menu entry\n\
+# an ID number and a \"parent_id\" field.  Top-level entries are the\n\
+# ones with parent_id = 0.  Menu entries are ordered within their\n\
+# level the same way they are ordered in the containing array.  Parent\n\
+# entries must appear before their children.\n\
+\n\
+# Example:\n\
+# - id = 3\n\
+#   parent_id = 0\n\
+#   title = \"fun\"\n\
+# - id = 2\n\
+#   parent_id = 0\n\
+#   title = \"robot\"\n\
+# - id = 4\n\
+#   parent_id = 2\n\
+#   title = \"pr2\"\n\
+# - id = 5\n\
+#   parent_id = 2\n\
+#   title = \"turtle\"\n\
+#\n\
+# Gives a menu tree like this:\n\
+#  - fun\n\
+#  - robot\n\
+#    - pr2\n\
+#    - turtle\n\
+\n\
+# ID is a number for each menu entry.  Must be unique within the\n\
+# control, and should never be 0.\n\
+uint32 id\n\
+\n\
+# ID of the parent of this menu entry, if it is a submenu.  If this\n\
+# menu entry is a top-level entry, set parent_id to 0.\n\
+uint32 parent_id\n\
+\n\
+# menu / entry title\n\
+string title\n\
+\n\
+# Arguments to command indicated by command_type (below)\n\
+string command\n\
+\n\
+# Command_type stores the type of response desired when this menu\n\
+# entry is clicked.\n\
+# FEEDBACK: send an InteractiveMarkerFeedback message with menu_entry_id set to this entry's id.\n\
+# ROSRUN: execute \"rosrun\" with arguments given in the command field (above).\n\
+# ROSLAUNCH: execute \"roslaunch\" with arguments given in the command field (above).\n\
+uint8 FEEDBACK=0\n\
+uint8 ROSRUN=1\n\
+uint8 ROSLAUNCH=2\n\
+uint8 command_type\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/InteractiveMarkerControl\n\
+# Represents a control that is to be displayed together with an interactive marker\n\
+\n\
+# Identifying string for this control.\n\
+# You need to assign a unique value to this to receive feedback from the GUI\n\
+# on what actions the user performs on this control (e.g. a button click).\n\
+string name\n\
+\n\
+\n\
+# Defines the local coordinate frame (relative to the pose of the parent\n\
+# interactive marker) in which is being rotated and translated.\n\
+# Default: Identity\n\
+geometry_msgs/Quaternion orientation\n\
+\n\
+\n\
+# Orientation mode: controls how orientation changes.\n\
+# INHERIT: Follow orientation of interactive marker\n\
+# FIXED: Keep orientation fixed at initial state\n\
+# VIEW_FACING: Align y-z plane with screen (x: forward, y:left, z:up).\n\
+uint8 INHERIT = 0 \n\
+uint8 FIXED = 1\n\
+uint8 VIEW_FACING = 2\n\
+\n\
+uint8 orientation_mode\n\
+\n\
+# Interaction mode for this control\n\
+# \n\
+# NONE: This control is only meant for visualization; no context menu.\n\
+# MENU: Like NONE, but right-click menu is active.\n\
+# BUTTON: Element can be left-clicked.\n\
+# MOVE_AXIS: Translate along local x-axis.\n\
+# MOVE_PLANE: Translate in local y-z plane.\n\
+# ROTATE_AXIS: Rotate around local x-axis.\n\
+# MOVE_ROTATE: Combines MOVE_PLANE and ROTATE_AXIS.\n\
+uint8 NONE = 0 \n\
+uint8 MENU = 1\n\
+uint8 BUTTON = 2\n\
+uint8 MOVE_AXIS = 3 \n\
+uint8 MOVE_PLANE = 4\n\
+uint8 ROTATE_AXIS = 5\n\
+uint8 MOVE_ROTATE = 6\n\
+# \"3D\" interaction modes work with the mouse+SHIFT+CTRL or with 3D cursors.\n\
+# MOVE_3D: Translate freely in 3D space.\n\
+# ROTATE_3D: Rotate freely in 3D space about the origin of parent frame.\n\
+# MOVE_ROTATE_3D: Full 6-DOF freedom of translation and rotation about the cursor origin.\n\
+uint8 MOVE_3D = 7\n\
+uint8 ROTATE_3D = 8\n\
+uint8 MOVE_ROTATE_3D = 9\n\
+\n\
+uint8 interaction_mode\n\
+\n\
+\n\
+# If true, the contained markers will also be visible\n\
+# when the gui is not in interactive mode.\n\
+bool always_visible\n\
+\n\
+\n\
+# Markers to be displayed as custom visual representation.\n\
+# Leave this empty to use the default control handles.\n\
+#\n\
+# Note: \n\
+# - The markers can be defined in an arbitrary coordinate frame,\n\
+#   but will be transformed into the local frame of the interactive marker.\n\
+# - If the header of a marker is empty, its pose will be interpreted as \n\
+#   relative to the pose of the parent interactive marker.\n\
+Marker[] markers\n\
+\n\
+\n\
+# In VIEW_FACING mode, set this to true if you don't want the markers\n\
+# to be aligned with the camera view point. The markers will show up\n\
+# as in INHERIT mode.\n\
+bool independent_marker_orientation\n\
+\n\
+\n\
+# Short description (< 40 characters) of what this control does,\n\
+# e.g. \"Move the robot\". \n\
+# Default: A generic description based on the interaction mode\n\
+string description\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/Marker\n\
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/InteractiveMarkerPose\n\
-") + yarp::rosmsg::visualization_msgs::InteractiveMarkerPose::typeText();
-    }
+# Time/frame info.\n\
+Header header\n\
+\n\
+# Initial pose. Also, defines the pivot point for rotations.\n\
+geometry_msgs/Pose pose\n\
+\n\
+# Identifying string. Must be globally unique in\n\
+# the topic that this message is sent through.\n\
+string name\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::InteractiveMarkerUpdate::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/InteractiveMarkerUpdate", "visualization_msgs/InteractiveMarkerUpdate");
-        typ.addProperty("md5sum", yarp::os::Value("710d308d0a9276d65945e92dd30b3946"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/Marker.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/Marker.h
@@ -566,10 +566,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::Marker> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::Marker> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/Marker";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "4048c9de2a16f4ae8e0538085ebf1b97";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
 \n\
 uint8 ARROW=0\n\
@@ -614,35 +618,72 @@ string text\n\
 # NOTE: only used for MESH_RESOURCE markers\n\
 string mesh_resource\n\
 bool mesh_use_embedded_materials\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: std_msgs/Header\n\
-") + yarp::rosmsg::std_msgs::Header::typeText() + std::string("\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Pose\n\
-") + yarp::rosmsg::geometry_msgs::Pose::typeText() + std::string("\n\
-================================================================================\n\
-MSG: geometry_msgs/Vector3\n\
-") + yarp::rosmsg::geometry_msgs::Vector3::typeText() + std::string("\n\
-================================================================================\n\
-MSG: std_msgs/ColorRGBA\n\
-") + yarp::rosmsg::std_msgs::ColorRGBA::typeText() + std::string("\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
 ================================================================================\n\
 MSG: geometry_msgs/Point\n\
-") + yarp::rosmsg::geometry_msgs::Point::typeText();
-    }
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::Marker::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/Marker", "visualization_msgs/Marker");
-        typ.addProperty("md5sum", yarp::os::Value("4048c9de2a16f4ae8e0538085ebf1b97"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/MarkerArray.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/MarkerArray.h
@@ -130,28 +130,128 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::MarkerArray> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::MarkerArray> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/MarkerArray";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "d155b9ce5188fbaf89745847fd5882d7";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 Marker[] markers\n\
-") + std::string("\n\
+\n\
 ================================================================================\n\
 MSG: visualization_msgs/Marker\n\
-") + yarp::rosmsg::visualization_msgs::Marker::typeText();
-    }
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::MarkerArray::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/MarkerArray", "visualization_msgs/MarkerArray");
-        typ.addProperty("md5sum", yarp::os::Value("d155b9ce5188fbaf89745847fd5882d7"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/MenuEntry.h
+++ b/src/libYARP_rosmsg/idl_generated_code/include/yarp/rosmsg/visualization_msgs/MenuEntry.h
@@ -254,10 +254,14 @@ public:
     typedef yarp::os::idl::BareStyle<yarp::rosmsg::visualization_msgs::MenuEntry> rosStyle;
     typedef yarp::os::idl::BottleStyle<yarp::rosmsg::visualization_msgs::MenuEntry> bottleStyle;
 
-    // Give source text for class, ROS will need this
-    static std::string typeText()
-    {
-        return std::string("\
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "visualization_msgs/MenuEntry";
+
+    // The checksum for this message, ROS will need this
+    static constexpr const char* typeChecksum = "b90ec63024573de83b57aa93eb39be2d";
+
+    // The source text for this message, ROS will need this
+    static constexpr const char* typeText = "\
 # MenuEntry message.\n\
 \n\
 # Each InteractiveMarker message has an array of MenuEntry messages.\n\
@@ -312,20 +316,13 @@ uint8 FEEDBACK=0\n\
 uint8 ROSRUN=1\n\
 uint8 ROSLAUNCH=2\n\
 uint8 command_type\n\
-");
-    }
+";
 
-    std::string getTypeText() const
-    {
-        return yarp::rosmsg::visualization_msgs::MenuEntry::typeText();
-    }
-
-    // Name the class, ROS will need this
     yarp::os::Type getType() const override
     {
-        yarp::os::Type typ = yarp::os::Type::byName("visualization_msgs/MenuEntry", "visualization_msgs/MenuEntry");
-        typ.addProperty("md5sum", yarp::os::Value("b90ec63024573de83b57aa93eb39be2d"));
-        typ.addProperty("message_definition", yarp::os::Value(getTypeText()));
+        yarp::os::Type typ = yarp::os::Type::byName(typeName, typeName);
+        typ.addProperty("md5sum", yarp::os::Value(typeChecksum));
+        typ.addProperty("message_definition", yarp::os::Value(typeText));
         return typ;
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ if(YARP_COMPILE_TESTS)
 
   set(targets OS
               sig
+              rosmsg
               dev
               serversql
               run)
@@ -114,6 +115,7 @@ if(YARP_COMPILE_TESTS)
     target_link_libraries(${EXE} YARP::YARP_OS
                                  YARP::YARP_init
                                  YARP::YARP_sig
+                                 YARP::YARP_rosmsg
                                  YARP::YARP_dev
                                  YARP::YARP_serversql
                                  YARP::YARP_run

--- a/tests/libYARP_rosmsg/ROSPropertiesTest.cpp
+++ b/tests/libYARP_rosmsg/ROSPropertiesTest.cpp
@@ -1,0 +1,639 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/impl/UnitTest.h>
+
+#include <yarp/rosmsg/std_msgs/Int32.h>
+#include <yarp/rosmsg/std_msgs/String.h>
+#include <yarp/rosmsg/std_msgs/Header.h>
+#include <yarp/rosmsg/std_msgs/UInt8MultiArray.h>
+#include <yarp/rosmsg/std_msgs/Time.h>
+#include <yarp/rosmsg/visualization_msgs/Marker.h>
+#include <yarp/rosmsg/visualization_msgs/InteractiveMarker.h>
+#include <yarp/rosmsg/visualization_msgs/InteractiveMarkerFeedback.h>
+
+#include <iostream>
+
+using namespace yarp::os;
+using namespace yarp::os::impl;
+
+class ROSPropertiesTest : public yarp::os::impl::UnitTest
+{
+public:
+    virtual std::string getName() const override { return "ROSPropertiesTest"; }
+
+    template <typename T>
+    void checkName(std::string expectedName)
+    {
+        T msg;
+        yarp::os::Type t = msg.getType();
+        report(0, std::string("Checking name for ") + t.getName());
+        checkEqual(t.getName(),
+                   expectedName,
+                   std::string("name for ") + t.getName() + " is correct");
+        report(0, std::string("Checking name on wire for ") + t.getName());
+        checkEqual(t.getNameOnWire(),
+                   expectedName,
+                   std::string("name on wire for ") + t.getName() + " is correct");
+    }
+
+    template <typename T>
+    void checkMd5sum(std::string expectedMd5sum)
+    {
+        T msg;
+        yarp::os::Type t = msg.getType();
+        report(0, std::string("Checking md5 for ") + t.getName());
+        checkEqual(t.readProperties().find("md5sum").asString(),
+                   expectedMd5sum,
+                   std::string("md5sum for ") + t.getName() + " is correct");
+    }
+
+    template <typename T>
+    void checkDefinition(std::string expectedDefinition)
+    {
+        T msg;
+        yarp::os::Type t = msg.getType();
+        report(0, std::string("Checking message definition for ") + t.getName());
+        checkEqual(t.readProperties().find("message_definition").asString(),
+                   expectedDefinition,
+                   std::string("message definition for ") + t.getName() + " is correct");
+    }
+
+
+    virtual void runTests() override
+    {
+        // The expected md5sums and definitions can be found in ROS headers
+        // std_msgs/Int32
+        checkName<yarp::rosmsg::std_msgs::Int32>("std_msgs/Int32");
+        checkMd5sum<yarp::rosmsg::std_msgs::Int32>("da5909fbe378aeaf85e547e830cc1bb7");
+        checkDefinition<yarp::rosmsg::std_msgs::Int32>(
+"int32 data\n\
+");
+
+        // std_msgs/String
+        checkName<yarp::rosmsg::std_msgs::String>("std_msgs/String");
+        checkMd5sum<yarp::rosmsg::std_msgs::String>("992ce8a1687cec8c8bd883ec73ca41d1");
+        checkDefinition<yarp::rosmsg::std_msgs::String>(
+"string data\n\
+");
+
+        // std_msgs/Header
+        checkName<yarp::rosmsg::std_msgs::Header>("std_msgs/Header");
+        checkMd5sum<yarp::rosmsg::std_msgs::Header>("2176decaecbce78abc3b96ef049fabed");
+        checkDefinition<yarp::rosmsg::std_msgs::Header>(
+"# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+");
+
+        // std_msgs/Header
+        checkName<yarp::rosmsg::std_msgs::UInt8MultiArray>("std_msgs/UInt8MultiArray");
+        checkMd5sum<yarp::rosmsg::std_msgs::UInt8MultiArray>("82373f1612381bb6ee473b5cd6f5d89c");
+        checkDefinition<yarp::rosmsg::std_msgs::UInt8MultiArray>(
+"# Please look at the MultiArrayLayout message definition for\n\
+# documentation on all multiarrays.\n\
+\n\
+MultiArrayLayout  layout        # specification of data layout\n\
+uint8[]           data          # array of data\n\
+\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayLayout\n\
+# The multiarray declares a generic multi-dimensional array of a\n\
+# particular data type.  Dimensions are ordered from outer most\n\
+# to inner most.\n\
+\n\
+MultiArrayDimension[] dim # Array of dimension properties\n\
+uint32 data_offset        # padding elements at front of data\n\
+\n\
+# Accessors should ALWAYS be written in terms of dimension stride\n\
+# and specified outer-most dimension first.\n\
+# \n\
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]\n\
+#\n\
+# A standard, 3-channel 640x480 image with interleaved color channels\n\
+# would be specified as:\n\
+#\n\
+# dim[0].label  = \"height\"\n\
+# dim[0].size   = 480\n\
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)\n\
+# dim[1].label  = \"width\"\n\
+# dim[1].size   = 640\n\
+# dim[1].stride = 3*640 = 1920\n\
+# dim[2].label  = \"channel\"\n\
+# dim[2].size   = 3\n\
+# dim[2].stride = 3\n\
+#\n\
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/MultiArrayDimension\n\
+string label   # label of given dimension\n\
+uint32 size    # size of given dimension (in type units)\n\
+uint32 stride  # stride of given dimension\n\
+");
+
+        // std_msgs/Time
+        checkName<yarp::rosmsg::std_msgs::Time>("std_msgs/Time");
+        checkMd5sum<yarp::rosmsg::std_msgs::Time>("cd7166c74c552c311fbcc2fe5a7bc289");
+        checkDefinition<yarp::rosmsg::std_msgs::Time>(
+"time data\n\
+");
+
+        // visualization_msgs/Marker
+        checkName<yarp::rosmsg::visualization_msgs::Marker>("visualization_msgs/Marker");
+        checkMd5sum<yarp::rosmsg::visualization_msgs::Marker>("4048c9de2a16f4ae8e0538085ebf1b97");
+        checkDefinition<yarp::rosmsg::visualization_msgs::Marker>(
+"# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+");
+
+        // visualization_msgs/InteractiveMarker
+        checkName<yarp::rosmsg::visualization_msgs::InteractiveMarker>("visualization_msgs/InteractiveMarker");
+        checkMd5sum<yarp::rosmsg::visualization_msgs::InteractiveMarker>("dd86d22909d5a3364b384492e35c10af");
+        checkDefinition<yarp::rosmsg::visualization_msgs::InteractiveMarker>(
+"# Time/frame info.\n\
+# If header.time is set to 0, the marker will be retransformed into\n\
+# its frame on each timestep. You will receive the pose feedback\n\
+# in the same frame.\n\
+# Otherwise, you might receive feedback in a different frame.\n\
+# For rviz, this will be the current 'fixed frame' set by the user.\n\
+Header header\n\
+\n\
+# Initial pose. Also, defines the pivot point for rotations.\n\
+geometry_msgs/Pose pose\n\
+\n\
+# Identifying string. Must be globally unique in\n\
+# the topic that this message is sent through.\n\
+string name\n\
+\n\
+# Short description (< 40 characters).\n\
+string description\n\
+\n\
+# Scale to be used for default controls (default=1).\n\
+float32 scale\n\
+\n\
+# All menu and submenu entries associated with this marker.\n\
+MenuEntry[] menu_entries\n\
+\n\
+# List of controls displayed for this marker.\n\
+InteractiveMarkerControl[] controls\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/MenuEntry\n\
+# MenuEntry message.\n\
+\n\
+# Each InteractiveMarker message has an array of MenuEntry messages.\n\
+# A collection of MenuEntries together describe a\n\
+# menu/submenu/subsubmenu/etc tree, though they are stored in a flat\n\
+# array.  The tree structure is represented by giving each menu entry\n\
+# an ID number and a \"parent_id\" field.  Top-level entries are the\n\
+# ones with parent_id = 0.  Menu entries are ordered within their\n\
+# level the same way they are ordered in the containing array.  Parent\n\
+# entries must appear before their children.\n\
+\n\
+# Example:\n\
+# - id = 3\n\
+#   parent_id = 0\n\
+#   title = \"fun\"\n\
+# - id = 2\n\
+#   parent_id = 0\n\
+#   title = \"robot\"\n\
+# - id = 4\n\
+#   parent_id = 2\n\
+#   title = \"pr2\"\n\
+# - id = 5\n\
+#   parent_id = 2\n\
+#   title = \"turtle\"\n\
+#\n\
+# Gives a menu tree like this:\n\
+#  - fun\n\
+#  - robot\n\
+#    - pr2\n\
+#    - turtle\n\
+\n\
+# ID is a number for each menu entry.  Must be unique within the\n\
+# control, and should never be 0.\n\
+uint32 id\n\
+\n\
+# ID of the parent of this menu entry, if it is a submenu.  If this\n\
+# menu entry is a top-level entry, set parent_id to 0.\n\
+uint32 parent_id\n\
+\n\
+# menu / entry title\n\
+string title\n\
+\n\
+# Arguments to command indicated by command_type (below)\n\
+string command\n\
+\n\
+# Command_type stores the type of response desired when this menu\n\
+# entry is clicked.\n\
+# FEEDBACK: send an InteractiveMarkerFeedback message with menu_entry_id set to this entry's id.\n\
+# ROSRUN: execute \"rosrun\" with arguments given in the command field (above).\n\
+# ROSLAUNCH: execute \"roslaunch\" with arguments given in the command field (above).\n\
+uint8 FEEDBACK=0\n\
+uint8 ROSRUN=1\n\
+uint8 ROSLAUNCH=2\n\
+uint8 command_type\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/InteractiveMarkerControl\n\
+# Represents a control that is to be displayed together with an interactive marker\n\
+\n\
+# Identifying string for this control.\n\
+# You need to assign a unique value to this to receive feedback from the GUI\n\
+# on what actions the user performs on this control (e.g. a button click).\n\
+string name\n\
+\n\
+\n\
+# Defines the local coordinate frame (relative to the pose of the parent\n\
+# interactive marker) in which is being rotated and translated.\n\
+# Default: Identity\n\
+geometry_msgs/Quaternion orientation\n\
+\n\
+\n\
+# Orientation mode: controls how orientation changes.\n\
+# INHERIT: Follow orientation of interactive marker\n\
+# FIXED: Keep orientation fixed at initial state\n\
+# VIEW_FACING: Align y-z plane with screen (x: forward, y:left, z:up).\n\
+uint8 INHERIT = 0 \n\
+uint8 FIXED = 1\n\
+uint8 VIEW_FACING = 2\n\
+\n\
+uint8 orientation_mode\n\
+\n\
+# Interaction mode for this control\n\
+# \n\
+# NONE: This control is only meant for visualization; no context menu.\n\
+# MENU: Like NONE, but right-click menu is active.\n\
+# BUTTON: Element can be left-clicked.\n\
+# MOVE_AXIS: Translate along local x-axis.\n\
+# MOVE_PLANE: Translate in local y-z plane.\n\
+# ROTATE_AXIS: Rotate around local x-axis.\n\
+# MOVE_ROTATE: Combines MOVE_PLANE and ROTATE_AXIS.\n\
+uint8 NONE = 0 \n\
+uint8 MENU = 1\n\
+uint8 BUTTON = 2\n\
+uint8 MOVE_AXIS = 3 \n\
+uint8 MOVE_PLANE = 4\n\
+uint8 ROTATE_AXIS = 5\n\
+uint8 MOVE_ROTATE = 6\n\
+# \"3D\" interaction modes work with the mouse+SHIFT+CTRL or with 3D cursors.\n\
+# MOVE_3D: Translate freely in 3D space.\n\
+# ROTATE_3D: Rotate freely in 3D space about the origin of parent frame.\n\
+# MOVE_ROTATE_3D: Full 6-DOF freedom of translation and rotation about the cursor origin.\n\
+uint8 MOVE_3D = 7\n\
+uint8 ROTATE_3D = 8\n\
+uint8 MOVE_ROTATE_3D = 9\n\
+\n\
+uint8 interaction_mode\n\
+\n\
+\n\
+# If true, the contained markers will also be visible\n\
+# when the gui is not in interactive mode.\n\
+bool always_visible\n\
+\n\
+\n\
+# Markers to be displayed as custom visual representation.\n\
+# Leave this empty to use the default control handles.\n\
+#\n\
+# Note: \n\
+# - The markers can be defined in an arbitrary coordinate frame,\n\
+#   but will be transformed into the local frame of the interactive marker.\n\
+# - If the header of a marker is empty, its pose will be interpreted as \n\
+#   relative to the pose of the parent interactive marker.\n\
+Marker[] markers\n\
+\n\
+\n\
+# In VIEW_FACING mode, set this to true if you don't want the markers\n\
+# to be aligned with the camera view point. The markers will show up\n\
+# as in INHERIT mode.\n\
+bool independent_marker_orientation\n\
+\n\
+\n\
+# Short description (< 40 characters) of what this control does,\n\
+# e.g. \"Move the robot\". \n\
+# Default: A generic description based on the interaction mode\n\
+string description\n\
+\n\
+================================================================================\n\
+MSG: visualization_msgs/Marker\n\
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz\n\
+\n\
+uint8 ARROW=0\n\
+uint8 CUBE=1\n\
+uint8 SPHERE=2\n\
+uint8 CYLINDER=3\n\
+uint8 LINE_STRIP=4\n\
+uint8 LINE_LIST=5\n\
+uint8 CUBE_LIST=6\n\
+uint8 SPHERE_LIST=7\n\
+uint8 POINTS=8\n\
+uint8 TEXT_VIEW_FACING=9\n\
+uint8 MESH_RESOURCE=10\n\
+uint8 TRIANGLE_LIST=11\n\
+\n\
+uint8 ADD=0\n\
+uint8 MODIFY=0\n\
+uint8 DELETE=2\n\
+uint8 DELETEALL=3\n\
+\n\
+Header header                        # header for time/frame information\n\
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object\n\
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later\n\
+int32 type 		                       # Type of object\n\
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects\n\
+geometry_msgs/Pose pose                 # Pose of the object\n\
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)\n\
+std_msgs/ColorRGBA color             # Color [0.0-1.0]\n\
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever\n\
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep\n\
+\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+geometry_msgs/Point[] points\n\
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)\n\
+#number of colors must either be 0 or equal to the number of points\n\
+#NOTE: alpha is not yet used\n\
+std_msgs/ColorRGBA[] colors\n\
+\n\
+# NOTE: only used for text markers\n\
+string text\n\
+\n\
+# NOTE: only used for MESH_RESOURCE markers\n\
+string mesh_resource\n\
+bool mesh_use_embedded_materials\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Vector3\n\
+# This represents a vector in free space. \n\
+# It is only meant to represent a direction. Therefore, it does not\n\
+# make sense to apply a translation to it (e.g., when applying a \n\
+# generic rigid transformation to a Vector3, tf2 will only apply the\n\
+# rotation). If you want your data to be translatable too, use the\n\
+# geometry_msgs/Point message instead.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+================================================================================\n\
+MSG: std_msgs/ColorRGBA\n\
+float32 r\n\
+float32 g\n\
+float32 b\n\
+float32 a\n\
+");
+
+        // visualization_msgs/InteractiveMarkerFeedback
+        checkName<yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback>("visualization_msgs/InteractiveMarkerFeedback");
+        checkMd5sum<yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback>("ab0f1eee058667e28c19ff3ffc3f4b78");
+        checkDefinition<yarp::rosmsg::visualization_msgs::InteractiveMarkerFeedback>(
+"# Time/frame info.\n\
+Header header\n\
+\n\
+# Identifying string. Must be unique in the topic namespace.\n\
+string client_id\n\
+\n\
+# Feedback message sent back from the GUI, e.g.\n\
+# when the status of an interactive marker was modified by the user.\n\
+\n\
+# Specifies which interactive marker and control this message refers to\n\
+string marker_name\n\
+string control_name\n\
+\n\
+# Type of the event\n\
+# KEEP_ALIVE: sent while dragging to keep up control of the marker\n\
+# MENU_SELECT: a menu entry has been selected\n\
+# BUTTON_CLICK: a button control has been clicked\n\
+# POSE_UPDATE: the pose has been changed using one of the controls\n\
+uint8 KEEP_ALIVE = 0\n\
+uint8 POSE_UPDATE = 1\n\
+uint8 MENU_SELECT = 2\n\
+uint8 BUTTON_CLICK = 3\n\
+\n\
+uint8 MOUSE_DOWN = 4\n\
+uint8 MOUSE_UP = 5\n\
+\n\
+uint8 event_type\n\
+\n\
+# Current pose of the marker\n\
+# Note: Has to be valid for all feedback types.\n\
+geometry_msgs/Pose pose\n\
+\n\
+# Contains the ID of the selected menu entry\n\
+# Only valid for MENU_SELECT events.\n\
+uint32 menu_entry_id\n\
+\n\
+# If event_type is BUTTON_CLICK, MOUSE_DOWN, or MOUSE_UP, mouse_point\n\
+# may contain the 3 dimensional position of the event on the\n\
+# control.  If it does, mouse_point_valid will be true.  mouse_point\n\
+# will be relative to the frame listed in the header.\n\
+geometry_msgs/Point mouse_point\n\
+bool mouse_point_valid\n\
+\n\
+================================================================================\n\
+MSG: std_msgs/Header\n\
+# Standard metadata for higher-level stamped data types.\n\
+# This is generally used to communicate timestamped data \n\
+# in a particular coordinate frame.\n\
+# \n\
+# sequence ID: consecutively increasing ID \n\
+uint32 seq\n\
+#Two-integer timestamp that is expressed as:\n\
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')\n\
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')\n\
+# time-handling sugar is provided by the client library\n\
+time stamp\n\
+#Frame this data is associated with\n\
+# 0: no frame\n\
+# 1: global frame\n\
+string frame_id\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Pose\n\
+# A representation of pose in free space, composed of position and orientation. \n\
+Point position\n\
+Quaternion orientation\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Point\n\
+# This contains the position of a point in free space\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+\n\
+================================================================================\n\
+MSG: geometry_msgs/Quaternion\n\
+# This represents an orientation in free space in quaternion form.\n\
+\n\
+float64 x\n\
+float64 y\n\
+float64 z\n\
+float64 w\n\
+");
+    }
+};
+
+static ROSPropertiesTest theROSPropertiesTest;
+
+yarp::os::impl::UnitTest& getROSPropertiesTest()
+{
+    return theROSPropertiesTest;
+}

--- a/tests/libYARP_rosmsg/TestList.h
+++ b/tests/libYARP_rosmsg/TestList.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef HARNESS_ROSMSG_TESTLIST_H
+#define HARNESS_ROSMSG_TESTLIST_H
+
+#include <yarp/os/impl/UnitTest.h>
+#include <iostream>
+
+
+extern yarp::os::impl::UnitTest& getROSPropertiesTest();
+
+class TestList
+{
+public:
+    static void collectTests()
+    {
+        yarp::os::impl::UnitTest& root = yarp::os::impl::UnitTest::getRoot();
+        root.add(getROSPropertiesTest());
+    }
+};
+
+#endif // HARNESS_ROSMSG_TESTLIST_H

--- a/tests/libYARP_rosmsg/harness.cpp
+++ b/tests/libYARP_rosmsg/harness.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/conf/system.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/impl/UnitTest.h>
+
+#include <yarp/os/impl/Logger.h>
+#include <yarp/companion/yarpcompanion.h>
+
+#include "TestList.h"
+
+using namespace yarp::os;
+using namespace yarp::os::impl;
+
+int main(int argc, char *argv[])
+{
+    yarp::os::Network yarp;
+
+    bool done = false;
+    int result = 0;
+
+    if (argc>1) {
+        int verbosity = 0;
+        while (std::string(argv[1])==std::string("verbose")) {
+            verbosity++;
+            argc--;
+            argv++;
+        }
+        if (verbosity>0) {
+            Logger::get().setVerbosity(verbosity);
+        }
+
+        if (std::string(argv[1])==std::string("regression")) {
+            done = true;
+            UnitTest::startTestSystem();
+            TestList::collectTests();  // just in case automation doesn't work
+            if (argc>2) {
+                result = UnitTest::getRoot().run(argc-2,argv+2);
+            } else {
+                result = UnitTest::getRoot().run();
+            }
+            UnitTest::stopTestSystem();
+        }
+    }
+    if (!done) {
+        yarp::companion::main(argc,argv);
+    }
+
+    return result;
+}


### PR DESCRIPTION
* Remove `NO_RECURSE` option.
* Fix `message_definition`
* Add unit tests checking a few messages to ensure that `checksum` and `message_definition` are not broken by future changes. Expected output is taken from headers generated by ROS

API is slightly changed, see release notes for details.