### PR TITLE
Complement to fix on yarp::sig::Vector for Python and Matlab bindings

### DIFF
--- a/bindings/macrosForMultipleAnalogSensors.i
+++ b/bindings/macrosForMultipleAnalogSensors.i
@@ -41,11 +41,11 @@ RESET_CONSTANTS_IN_EXTENDED_ANALOG_SENSOR_INTERFACE
 #endif
 
 #if OrientationSensor_EXTENDED_INTERFACE
-    double get ## sensor ## MeasureAsRollPitchYaw(int sens_index, yarp::sig::Vector& rpy) const {
+    double get ## sensor ## MeasureAsRollPitchYaw(int sens_index, yarp::sig::VectorOf<double>& rpy) const {
         double timestamp;
         bool ok = self->get ## sensor ## MeasureAsRollPitchYaw(sens_index, rpy, timestamp);
 #else
-    double get ## sensor ## Measure(int sens_index, yarp::sig::Vector& out) const {
+    double get ## sensor ## Measure(int sens_index, yarp::sig::VectorOf<double>& out) const {
         double timestamp;
         bool ok = self->get ## sensor ## Measure(sens_index, out, timestamp);
 #endif

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -443,6 +443,10 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IPositionDirect.h>
 %include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
+inline %{
+typedef yarp::sig::VectorOf<double> Vector;
+%}
+
 #if !defined(SWIGCHICKEN) && !defined(SWIGALLEGROCL)
   %template(DVector) std::vector<double>;
   %template(BVector) std::vector<bool>;

--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -5,6 +5,13 @@ YARP 3.1.1 (UNRELEASED) Release Notes                                 {#v3_1_1}
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+v3.1.1%22).
 
+Bug Fixes
+---------
+
+### Bindings
+
+* Usage of methods that take in input a yarp::sig::Vector in bindings has been fixed ( https://github.com/robotology/yarp/pull/1828 ).
+
 
 Contributors
 ------------


### PR DESCRIPTION
This change fixes Python bindings generation which was broken due to the redefinition of `yarp::sig::Vector` (https://github.com/robotology/yarp/commit/2417c7d5e50aebca2ca8532fb40e7084262d50e8). For further information please refer to https://github.com/robotology/yarp/issues/1826.

This change also adds left over fixes on the Matlab bindings of Multiple Analog Sensors Interfaces using `yarp::sig::Vector` type input parameters. The fix https://github.com/robotology/yarp/pull/1811 had missed the following section https://github.com/robotology/yarp/blob/5aa3f580a75d9a356731cae4b232dfe8783de53b/bindings/macrosForMultipleAnalogSensors.i#L43-L51
