### PR TITLE
Bindings: Disable extended analog sensor interfaces in CSharp

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -776,7 +776,7 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 // These views are currently disabled in SWIG + java generator since they are
 // useless without the EXTENDED_ANALOG_SENSOR_INTERFACE part.
 // See also https://github.com/robotology/yarp/issues/1770
-#if !defined(SWIGJAVA)
+#if !defined(SWIGJAVA) and !defined(SWIGCSHARP)
     CAST_POLYDRIVER_TO_INTERFACE(IThreeAxisGyroscopes)
     CAST_POLYDRIVER_TO_INTERFACE(IThreeAxisLinearAccelerometers)
     CAST_POLYDRIVER_TO_INTERFACE(IThreeAxisMagnetometers)
@@ -1074,7 +1074,7 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 // This is part is currently broken in SWIG + java generator since SWIG 3.0.3
 // (last swig version tested: 3.0.12)
 // See also https://github.com/robotology/yarp/issues/1770
-#if !defined(SWIGJAVA)
+#if !defined(SWIGJAVA) and !defined(SWIGCSHARP)
     %extend yarp::dev::IThreeAxisGyroscopes {EXTENDED_ANALOG_SENSOR_INTERFACE(ThreeAxisGyroscope)}
     %extend yarp::dev::IThreeAxisLinearAccelerometers {EXTENDED_ANALOG_SENSOR_INTERFACE(ThreeAxisLinearAccelerometer)}
     %extend yarp::dev::IThreeAxisMagnetometers {EXTENDED_ANALOG_SENSOR_INTERFACE(ThreeAxisMagnetometer)}

--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -11,6 +11,7 @@ Bug Fixes
 ### Bindings
 
 * Usage of methods that take in input a yarp::sig::Vector in bindings has been fixed ( https://github.com/robotology/yarp/pull/1828 ).
+* Disable extended analog sensor interfaces in C# to allow compilation of these bindings ( https://github.com/robotology/yarp/pull/1830 ).
 
 
 Contributors


### PR DESCRIPTION
See https://github.com/robotology/yarp/issues/1770, same fix as in https://github.com/robotology/yarp/pull/1817 (which was for Java)