### PR TITLE
Fix BufferedPort::write() after interrupt-resume

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -8,6 +8,12 @@ A (partial) list of bug fixed and issues resolved in this release can be found
 Bug Fixes
 ---------
 
+### Libraries
+
+#### YARP_OS
+
+* Fix `write()` in BufferedPort after interrupting-resuming(#1834).
+
 ### Bindings
 
 * Usage of methods that take in input a yarp::sig::Vector in bindings has been

--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -10,8 +10,10 @@ Bug Fixes
 
 ### Bindings
 
-* Usage of methods that take in input a yarp::sig::Vector in bindings has been fixed ( https://github.com/robotology/yarp/pull/1828 ).
-* Disable extended analog sensor interfaces in C# to allow compilation of these bindings ( https://github.com/robotology/yarp/pull/1830 ).
+* Usage of methods that take in input a yarp::sig::Vector in bindings has been
+  fixed(#1828).
+* Disable extended analog sensor interfaces in C# to allow compilation of these
+  bindings(#1830).
 
 
 Contributors

--- a/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
@@ -176,7 +176,7 @@ T* yarp::os::BufferedPort<T>::lastRead()
 template <typename T>
 bool yarp::os::BufferedPort<T>::isClosed()
 {
-    return reader.isClosed();
+    return !port.isOpen();
 }
 
 template <typename T>

--- a/tests/libYARP_OS/PortTest.cpp
+++ b/tests/libYARP_OS/PortTest.cpp
@@ -1246,6 +1246,48 @@ public:
     }
 
 
+    void testBuffInterrupt() {
+        report(0,"checking interrupt for BufferedPort...");
+        BufferedPort<Bottle> input, output;
+        input.open("/in");
+        output.open("/out");
+        checkTrue(yarp::os::Network::connect("/out","/in"),"checking connection");
+
+        Bottle& botOut1 = output.prepare();
+        botOut1.clear();
+        botOut1.addInt32(0);
+        output.writeStrict();
+
+        yarp::os::Time::delay(0.1);
+
+        Bottle *botIn1 = input.read();
+        checkTrue(botIn1!=nullptr,"Inserted message received");
+        if (botIn1)
+        {
+            checkEqual(botIn1->get(0).asInt32(),0,"Checking data validity");
+        }
+
+        report(0,"interrupting...");
+        output.interrupt();
+        report(0,"resuming...");
+        output.resume();
+
+        Bottle& botOut2 = output.prepare();
+        botOut2.clear();
+        botOut2.addInt32(1);
+        output.writeStrict();
+
+        yarp::os::Time::delay(0.1);
+
+        Bottle *botIn2 = input.read();
+        checkTrue(botIn2!=nullptr,"Inserted message received");
+        checkEqual(botIn2->get(0).asInt32(),1,"Checking data validity");
+
+        output.close();
+        input.close();
+    }
+
+
     void testInterruptInputReaderBuf() {
         report(0,"checking interrupt on input side...");
         PortReaderBuffer<Bottle> buf;
@@ -1585,6 +1627,7 @@ public:
         testReportsWithRpcClient();
 
         testInterrupt();
+        testBuffInterrupt();
 
         testInterruptReply();
 


### PR DESCRIPTION
This PR fixes #1834.
Moreover it add a test to check this fix.

`read()` worked after interrupt/resume because it checks `port.isOpen()`

Please review code.