### PR TITLE
Fix yarpdataplayer memory leak.

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -10,7 +10,7 @@ Bug Fixes
 
 ### Libraries
 
-#### YARP_OS
+#### `YARP_OS`
 
 * Fix `write()` in BufferedPort after interrupting-resuming(#1834).
 
@@ -24,6 +24,12 @@ Bug Fixes
   fixed(#1828).
 * Disable extended analog sensor interfaces in C# to allow compilation of these
   bindings(#1830).
+
+### GUIs
+
+#### `yarpdataplayer`
+
+* Fix memory leak when using `cvLoad(...)`.
 
 
 Contributors


### PR DESCRIPTION
@claudiofantacci  noticed on Windows that yarpdataplayer while streaming continued allocating memory without freeing it.

It checked on Linux and I experienced the same issue see: 

![allocdataplayer](https://user-images.githubusercontent.com/19152494/44907490-5d3e8980-ad18-11e8-9e60-0e49b5fce46e.gif)

Probably it was introduced by the changes necessary to stream `PixelFloat` images (#1650), but I'm not sure.
BTW the code now is more cleaner.
@pattacini or @claudiofantacci could you please check if this patch fix this leak also on windows?

For me now with this patch the memory usage is 23Kbyte fixed.

