### PR TITLE
Move the timeout check from RemoteControlBoard to the stateExtendedReader

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -50,6 +50,7 @@ Bug Fixes
   (#1875).
 * Fixed header inclusion in `ImplementControlLimits2.h`.
 * Fixed interface pointer checks in ControlBoardWrapper.
+* Added timeout check in all data streamed by `*\stateExt:o` ports (#1833).
 
 #### `YARP_companion`
 
@@ -85,6 +86,10 @@ Bug Fixes
 * Fixed memory leak when using `cvLoad(...)`.
 
 ### Devices
+
+#### `RemoteControlBoard`
+
+* Added `timeout` parameter.
 
 #### `realsense2`
 

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -985,6 +985,10 @@ public:
         remote = config.find("remote").asString();
         local = config.find("local").asString();
 
+        if (config.check("timeout"))
+        {
+            extendedIntputStatePort.setTimeout(config.find("timeout").asFloat64());
+        }
         // check the Qos perefernces if available (local and remote)
         yarp::os::QosStyle localQos;
         if (config.check("local_qos")) {

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -49,7 +49,6 @@ namespace yarp{
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 const double DIAGNOSTIC_THREAD_PERIOD=1.000;
-const double TIMEOUT=0.5;
 
 inline bool getTimeStamp(Bottle &bot, Stamp &st)
 {
@@ -1478,10 +1477,6 @@ public:
         extendedPortMutex.lock();
         bool ret = extendedIntputStatePort.getLastSingle(j, VOCAB_ENCODER, v, lastStamp, localArrivalTime);
         extendedPortMutex.unlock();
-
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT) )
-            ret = false;
-
         return ret;
     }
 
@@ -1499,10 +1494,6 @@ public:
         bool ret = extendedIntputStatePort.getLastSingle(j, VOCAB_ENCODER, v, lastStamp, localArrivalTime);
         *t=lastStamp.getTime();
         extendedPortMutex.unlock();
-
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT) )
-            ret = false;
-
         return ret;
     }
 
@@ -1538,10 +1529,6 @@ public:
         bool ret = extendedIntputStatePort.getLastVector(VOCAB_ENCODERS, encs, lastStamp, localArrivalTime);
         std::fill_n(ts, nj, lastStamp.getTime());
         extendedPortMutex.unlock();
-
-        if ( (Time::now()-localArrivalTime) > TIMEOUT)
-            ret=false;
-
         return ret;
     }
     /**
@@ -1750,10 +1737,6 @@ public:
         extendedPortMutex.lock();
         bool ret = extendedIntputStatePort.getLastSingle(j, VOCAB_MOTOR_ENCODER, v, lastStamp, localArrivalTime);
         extendedPortMutex.unlock();
-
-        if(ret && ((Time::now()-localArrivalTime) > TIMEOUT) )
-            ret=false;
-
         return ret;
     }
 
@@ -1771,10 +1754,6 @@ public:
         bool ret = extendedIntputStatePort.getLastSingle(j, VOCAB_MOTOR_ENCODER, v, lastStamp, localArrivalTime);
         *t=lastStamp.getTime();
         extendedPortMutex.unlock();
-
-        if(ret && ((Time::now()-localArrivalTime) > TIMEOUT) )
-            ret=false;
-
         return ret;
     }
 
@@ -1812,10 +1791,6 @@ public:
         bool ret = extendedIntputStatePort.getLastVector(VOCAB_MOTOR_ENCODERS, encs, lastStamp, localArrivalTime);
         std::fill_n(ts, nj, lastStamp.getTime());
         extendedPortMutex.unlock();
-
-        if(ret && ((Time::now()-localArrivalTime) > TIMEOUT) )
-            ret=false;
-
         return ret;
     }
     /**

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -43,10 +43,15 @@ void StateExtendedInputPort::resetStat()
     mutex.unlock();
 }
 
-StateExtendedInputPort::StateExtendedInputPort()
+StateExtendedInputPort::StateExtendedInputPort() : deltaT{0},
+                                                   deltaTMax{0},
+                                                   deltaTMin{1e22},
+                                                   now{Time::now()},
+                                                   prev{now},
+                                                   timeout{0.5},
+                                                   valid{false},
+                                                   count{0}
 {
-    valid=false;
-    resetStat();
 }
 
 void StateExtendedInputPort::init(int numberOfJoints)
@@ -89,6 +94,10 @@ void StateExtendedInputPort::onRead(jointData &v)
     if (!lastStamp.isValid())
         lastStamp.update(now);
     mutex.unlock();
+}
+
+void StateExtendedInputPort::setTimeout(const double& timeout) {
+    this->timeout = timeout;
 }
 
 bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp &stamp, double &localArrivalTime)
@@ -151,7 +160,7 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
             ret = false;
     }
     mutex.unlock();
@@ -183,7 +192,7 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, int *data, Stamp &s
         }
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
             ret = false;
 
     }
@@ -251,7 +260,7 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
             ret = false;
     }
     mutex.unlock();
@@ -283,7 +292,7 @@ bool StateExtendedInputPort::getLastVector(int field, int* data, Stamp& stamp, d
         }
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
             ret = false;
     }
     mutex.unlock();

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -151,6 +151,8 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
+        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+            ret = false;
     }
     mutex.unlock();
 
@@ -181,6 +183,9 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, int *data, Stamp &s
         }
         localArrivalTime=now;
         stamp = lastStamp;
+        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+            ret = false;
+
     }
     mutex.unlock();
     return ret;
@@ -246,6 +251,8 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
+        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+            ret = false;
     }
     mutex.unlock();
 
@@ -276,6 +283,8 @@ bool StateExtendedInputPort::getLastVector(int field, int* data, Stamp& stamp, d
         }
         localArrivalTime=now;
         stamp = lastStamp;
+        if (ret && ( (Time::now()-localArrivalTime) > TIMEOUT_EXT) )
+            ret = false;
     }
     mutex.unlock();
     return ret;

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.h
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.h
@@ -35,7 +35,6 @@
 
 // encoders should arrive at least every 0.5s to be considered valide
 // getEncoders will return false otherwise.
-const double TIMEOUT_EXT=0.5;
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -49,8 +48,9 @@ class StateExtendedInputPort:public yarp::os::BufferedPort<jointData>
     double deltaT;
     double deltaTMax;
     double deltaTMin;
-    double prev;
     double now;
+    double prev;
+    double timeout;
 
     bool valid;
     int count;
@@ -63,6 +63,12 @@ public:
 
     using yarp::os::BufferedPort<jointData>::onRead;
     void onRead(jointData &v) override;
+
+    /**
+     * @brief setTimeout, set the timeout for retrieving data
+     * @param timeout in seconds
+     */
+    void setTimeout(const double& timeout);
 
     // use vocab to identify the data to be read
     // get a value for a single joint


### PR DESCRIPTION
This PR fixes #1833.

With @barbalberto we thought to add timeout check in all data kind streamed by `*\stateExt:o` ports not only for certain(e.g. `getEncoder`).

It is wip because it is more a proposal.
Please review code.