### PR TITLE
Fix serialisation / deserialisation of maps in thrift idl

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -20,6 +20,10 @@ Bug Fixes
 * Fixed `IControlLimits.h` not being a self-sufficient header (#1845).
 * Added missing `YARP_dev_API` to `IRobotDescription`.
 
+#### yarpidl_thrift
+
+* Fixed serialisation / deserialisation of maps (#1802).
+
 ### Bindings
 
 * Fixed usage of methods that take in input a yarp::sig::Vector in bindings

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -2565,7 +2565,7 @@ void t_yarp_generator::generate_serialize_map_element(ofstream& out,
   generate_serialize_field(out, &kfield, "");
 
   t_field vfield(tmap->get_val_type(), iter + "->second");
-  generate_serialize_field(out, &vfield, "");
+  generate_serialize_field(out, &vfield, "", "", true);
 
   indent(out) << "if (!writer.writeListEnd()) return false;" << endl;
 }
@@ -2789,7 +2789,7 @@ void t_yarp_generator::generate_deserialize_map_element(ofstream& out,
     declare_field(&fval, false, false, false, true) << " = " <<
     prefix << "[" << key << "];" << endl;
 
-  generate_deserialize_field(out, &fval);
+  generate_deserialize_field(out, &fval, "", "", true);
 
   out <<
     indent() << "reader.readListEnd();" << endl;


### PR DESCRIPTION
This PR proposes an hotfix for https://github.com/robotology/yarp/issues/1802. For the time being I enabled the flag for handling nested objects in the value of the map. I fear that if the key is a nested object (side case though) we might face similar issues.

I didn't do any ad-hoc testing but I used this fix already for a couple of weeks with complex thrifts without any problem.

cc @drdanz @traversaro