### PR TITLE
OS/impl/LogForwarder: Heavy refactoring

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -1,4 +1,4 @@
-YARP 3.1.1 (UNRELEASED) Release Notes                                 {#v3_1_1}
+YARP 3.1.1 (UNRELEASED) Release Notes                                  {#v3_1_1}
 =====================================
 
 
@@ -12,25 +12,26 @@ Bug Fixes
 
 #### `YARP_OS`
 
-* Fix `write()` in BufferedPort after interrupting-resuming(#1834).
+* Fixed `write()` in BufferedPort after interrupting-resuming(#1834).
+* Fixed assertion when `YARP_FORWARD_LOG_ENABLE=1` (#1851).
 
 #### YARP_dev
 
-* Fix `IControlLimits.h` not being a self-sufficient header (#1845).
-* Add missing `YARP_dev_API` to `IRobotDescription`.
+* Fixed `IControlLimits.h` not being a self-sufficient header (#1845).
+* Added missing `YARP_dev_API` to `IRobotDescription`.
 
 ### Bindings
 
-* Usage of methods that take in input a yarp::sig::Vector in bindings has been
-  fixed(#1828).
-* Disable extended analog sensor interfaces in C# to allow compilation of these
-  bindings(#1830).
+* Fixed usage of methods that take in input a yarp::sig::Vector in bindings
+  (#1828).
+* Disabled extended analog sensor interfaces in C# to allow compilation of these
+  bindings (#1830).
 
 ### GUIs
 
 #### `yarpdataplayer`
 
-* Fix memory leak when using `cvLoad(...)`.
+* Fixed memory leak when using `cvLoad(...)`.
 
 
 Contributors

--- a/src/libYARP_OS/include/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_OS/include/yarp/os/impl/LogForwarder.h
@@ -10,33 +10,34 @@
 #define YARP_OS_IMPL_LOGFORWARDER_H
 
 #include <yarp/os/api.h>
-#include <yarp/os/BufferedPort.h>
-#include <yarp/os/Network.h>
-#include <yarp/os/Semaphore.h>
+#include <yarp/os/Port.h>
+#include <yarp/os/Mutex.h>
 #include <string>
 
 namespace yarp {
 namespace os {
+namespace impl {
 
-#define MAX_STRING_SIZE 255
-
-class YARP_OS_API LogForwarder
+class YARP_OS_impl_API LogForwarder
 {
     public:
-        static LogForwarder* getInstance();
-        void forward (const std::string& message);
-    protected:
-        LogForwarder();
         ~LogForwarder();
+        static LogForwarder& getInstance();
+
+        void forward (const std::string& message);
+        static void shutdown();
+
     private:
-        static yarp::os::Semaphore *sem;
-        char logPortName[MAX_STRING_SIZE];
-        yarp::os::BufferedPort<yarp::os::Bottle>* outputPort;
-    private:
-        LogForwarder(LogForwarder const&){}
-        LogForwarder& operator=(LogForwarder const&){return *this;}
+        LogForwarder();
+        LogForwarder(LogForwarder const&) = delete;
+        LogForwarder& operator=(LogForwarder const&) = delete;
+
+        yarp::os::Mutex mutex;
+        yarp::os::Port outputPort;
+        static bool started;
 };
 
+} // namespace impl
 } // namespace os
 } // namespace yarp
 

--- a/src/libYARP_OS/src/Log.cpp
+++ b/src/libYARP_OS/src/Log.cpp
@@ -151,7 +151,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
     }
 
     std::stringstream stringstream_buffer;
-    LogForwarder* theForwarder = LogForwarder::getInstance();
+    LogForwarder& theForwarder = LogForwarder::getInstance();
 
     switch (t) {
     case yarp::os::Log::TraceType:
@@ -161,7 +161,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[TRACE]" << func << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
         }
         break;
     case yarp::os::Log::DebugType:
@@ -171,7 +171,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[DEBUG]" << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
         }
         break;
     case yarp::os::Log::InfoType:
@@ -180,7 +180,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[INFO]" << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
         break;
     case yarp::os::Log::WarningType:
             if (verbose_output) {
@@ -188,7 +188,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[WARNING]" << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
         break;
     case yarp::os::Log::ErrorType:
             if (verbose_output) {
@@ -196,7 +196,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[ERROR]" << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
         break;
     case yarp::os::Log::FatalType:
             if (verbose_output) {
@@ -204,7 +204,7 @@ void yarp::os::impl::LogImpl::forward_callback(yarp::os::Log::LogType t,
             } else {
                 stringstream_buffer << "[FATAL]" << msg << std::endl;
             }
-            theForwarder->forward(stringstream_buffer.str());
+            theForwarder.forward(stringstream_buffer.str());
             yarp_print_trace(stderr, file, line);
         break;
     default:

--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -24,6 +24,7 @@
 
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/Logger.h>
+#include <yarp/os/impl/LogForwarder.h>
 #include <yarp/os/impl/NameConfig.h>
 #include <yarp/os/impl/PlatformSignal.h>
 #include <yarp/os/impl/PlatformStdlib.h>
@@ -888,6 +889,11 @@ void NetworkBase::initMinimum(yarp::os::yarpClockType clockType, yarp::os::Clock
 void NetworkBase::finiMinimum()
 {
     if (__yarp_is_initialized == 1) {
+        // The log forwarder needs to be shut down in order to close the
+        // internal port. The shutdown method will do nothing if the
+        // LogForwarded was not used.
+        yarp::os::impl::LogForwarder::shutdown();
+
         Time::useSystemClock();
         yarp::os::impl::Time::removeClock();
 


### PR DESCRIPTION
* Added shutdown method called in Network::finiMinimum (Fixes #1851)
* Use Port instead of BufferedPort
* Write in background and wait at shutdown
* Use fast_tcp instead of tcp
* Call addOutput instead of connect in order to avoid extra useless
  queries
* Avoid duplicate code
* Cleanup