### PR TITLE
Add conversion depthImage->PointCloud

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -58,8 +58,12 @@ New Features
 * Deprecated `VectorOf::getFirst()` in favour of `data()` and `begin()`.
   Use either `data()` if you need the pointer to the first element, or `begin()`
   if you need the iterator.
+* Added `yarp::sig::IntrinsicParams` and `yarp::sig::YarpDistortion` emum.
+* Added two methods for computing a `yarp::sig::PointCloud` from depth images:
+  - `utils::depthToPC`
+  - `utils::depthRgbToPC`
 
-#### Devices
+### Devices
 
 * Added `navigation2DServer` device.
 * Added `localization2DServer` device.

--- a/doc/yarp_pointcloud.dox
+++ b/doc/yarp_pointcloud.dox
@@ -95,6 +95,86 @@ In this case `pc3` will have only the `XYZ` and `Normal` values of `pc1` because
 the `RGBA` values have been lost in the construction of `pc2` that not contains
 the `RGBA` field.
 
+\section depth_to_PC Compute PointClouds from depth images
+
+YARP provides two functions that allow to compute `yarp::sig::PointCloud`s given depth image
+and intrinsic parameters of the camera.
+
+They are included in `yarp/sig/PointCloudUtils.h` and they are:
+- `yarp::sig::utils::depthToPC`
+- `yarp::sig::utils::depthRgbToPC`
+
+Both functions assume that the images are already **undistorted**, no undistortion is
+performed.
+
+`yarp::sig::utilsdepthRgbToPC` needs also the colored frame in order to generate
+a colored PointCloud. It assumes that the the two frames are **aligned**.
+
+You have to use intrinsics parameters of the depth sensor if the depth frame IS NOT aligned with the
+colored one. On the other hand use the intrinsic parameters of the RGB camera if the frames are aligned.
+
+Here an example of usage:
+
+\code {.cpp}
+yarp::sig::ImageOf<yarp::sig::PixelFloat> depth;
+yarp::sig::ImageOf<yarp::sig::PixelRgb> color;
+yarp::os::Property propIntrinsic;
+yarp::sig::IntrinsicParams intrinsic;
+bool aligned{false};
+// check if the frames that are coming are aligned.
+...
+// get the intrinsic parameters from the RGBDClient
+yarp::os::Property conf;
+conf.put("device","RGBDSensorClient");
+conf.put("localImagePort","/clientRgbPort:i");
+conf.put("localDepthPort","/clientDepthPort:i");
+conf.put("localRpcPort","/clientRpcPort");
+conf.put("remoteImagePort","/depthCamera/rgbImage:o");
+conf.put("remoteDepthPort","/depthCamera/depthImage:o");
+conf.put("remoteRpcPort","/depthCamera/rpc:i");
+
+if (!poly.open(conf))
+{
+    yError()<<"Unable to open RGBDClient polydriver";
+    return false;
+}
+
+yarp::dev::IRGBDSensor* iRgbd{nullptr};
+if (!poly.view(iRgbd))
+{
+    yError()<<"Unable to view IRGBD interface";
+    return false;
+}
+
+bool ok{false};
+if (aligned)
+{
+    ok = iRgbd->getRgbIntrinsicParam(propIntrinsics);
+}
+else
+{
+    ok = iRgbd->getDepthIntrinsicParam(propIntrinsics);
+}
+
+yarp::sig::IntrinsicParams intrinsics(propIntrinsics);
+
+// read the images from ports
+
+...
+
+// Compute the PointCloud
+
+yarp::sig::PointCloud<yarp::sig::DataXYZRGBA> pc = yarp::sig::utils::depthRGBToPC<yarp::sig::DataXYZRGBA, yarp::sig::PixelRgb>(depth, color, intrinsics);
+
+\endcode
+
+Or:
+
+\code {.cpp}
+yarp::sig::PointCloud<yarp::sig::DataXYZ> pc = yarp::sig::utils::depthToPC(depth, intrinsics);
+\endcode
+
+
 \section pcl_compatibility PCL compatibility
 
 The yarp::sig::PointCloud class has been implemented to be compatible with 

--- a/src/devices/depthCamera/depthCameraDriver.cpp
+++ b/src/devices/depthCamera/depthCameraDriver.cpp
@@ -642,21 +642,9 @@ bool depthCameraDriver::setRgbMirroring(bool mirror)
     return (ret == mirror);
 }
 
-bool depthCameraDriver::setIntrinsic(Property& intrinsic, const RGBDSensorParamParser::IntrinsicParams& values)
+bool depthCameraDriver::setIntrinsic(Property& intrinsic, const yarp::sig::IntrinsicParams& values)
 {
-    intrinsic.put("focalLengthX",       values.focalLengthX);
-    intrinsic.put("focalLengthY",       values.focalLengthY);
-    intrinsic.put("principalPointX",    values.principalPointX);
-    intrinsic.put("principalPointY",    values.principalPointY);
-
-    intrinsic.put("distortionModel", "plumb_bob");
-    intrinsic.put("k1", values.distortionModel.k1);
-    intrinsic.put("k2", values.distortionModel.k2);
-    intrinsic.put("t1", values.distortionModel.t1);
-    intrinsic.put("t2", values.distortionModel.t2);
-    intrinsic.put("k3", values.distortionModel.k3);
-
-    intrinsic.put("stamp", yarp::os::Time::now());
+    values.toProperty(intrinsic);
     return true;
 }
 

--- a/src/devices/depthCamera/depthCameraDriver.h
+++ b/src/devices/depthCamera/depthCameraDriver.h
@@ -279,7 +279,7 @@ private:
     bool        getImage(depthImage& Frame, Stamp* Stamp, impl::streamFrameListener *sourceFrame);
     bool        setResolution(int w, int h, openni::VideoStream &stream);
     bool        setFOV(double horizontalFov, double verticalFov, openni::VideoStream &stream);
-    bool        setIntrinsic(yarp::os::Property& intrinsic, const RGBDSensorParamParser::IntrinsicParams& values);
+    bool        setIntrinsic(yarp::os::Property& intrinsic, const yarp::sig::IntrinsicParams& values);
     void        settingErrorMsg(const std::string& error, bool& ret);
 
     //properties

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -340,6 +340,16 @@ static size_t bytesPerPixel(const rs2_format format)
     return bytes_per_pixel;
 }
 
+static YarpDistortion rsDistToYarpDist(const rs2_distortion dist)
+{
+    switch (dist) {
+    case RS2_DISTORTION_BROWN_CONRADY:
+        return YarpDistortion::YARP_PLUM_BOB;
+    default:
+        return YarpDistortion::YARP_UNSUPPORTED;
+    }
+
+}
 
 realsense2Driver::realsense2Driver() : m_depth_sensor(nullptr), m_color_sensor(nullptr),
                                        m_paramParser(nullptr), m_verbose(false),
@@ -840,6 +850,8 @@ bool realsense2Driver::setIntrinsic(Property& intrinsic, const rs2_intrinsics &v
     params.focalLengthY       = values.fy;
     params.principalPointX    = values.ppx;
     params.principalPointY    = values.ppy;
+    // distortion model
+    params.distortionModel.type = rsDistToYarpDist(values.model);
     params.distortionModel.k1 = values.coeffs[0];
     params.distortionModel.k2 = values.coeffs[1];
     params.distortionModel.t1 = values.coeffs[2];

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -835,19 +835,17 @@ bool realsense2Driver::setRgbMirroring(bool mirror)
 
 bool realsense2Driver::setIntrinsic(Property& intrinsic, const rs2_intrinsics &values)
 {
-    intrinsic.put("focalLengthX",       values.fx);
-    intrinsic.put("focalLengthY",       values.fy);
-    intrinsic.put("principalPointX",    values.ppx);
-    intrinsic.put("principalPointY",    values.ppy);
-
-    intrinsic.put("distortionModel", "plumb_bob");
-    intrinsic.put("k1", values.coeffs[0]);
-    intrinsic.put("k2", values.coeffs[1]);
-    intrinsic.put("t1", values.coeffs[2]);
-    intrinsic.put("t2", values.coeffs[3]);
-    intrinsic.put("k3", values.coeffs[4]);
-
-    intrinsic.put("stamp", yarp::os::Time::now());
+    yarp::sig::IntrinsicParams params;
+    params.focalLengthX       = values.fx;
+    params.focalLengthY       = values.fy;
+    params.principalPointX    = values.ppx;
+    params.principalPointY    = values.ppy;
+    params.distortionModel.k1 = values.coeffs[0];
+    params.distortionModel.k2 = values.coeffs[1];
+    params.distortionModel.t1 = values.coeffs[2];
+    params.distortionModel.t2 = values.coeffs[3];
+    params.distortionModel.k3 = values.coeffs[4];
+    params.toProperty(intrinsic);
     return true;
 }
 

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -24,7 +24,6 @@ namespace dev {
  * @brief The RGBDSensorParamParser class.
  * This class has been designed to uniform the parsing of RGBD yarp devices.
  */
-
 class YARP_dev_API RGBDSensorParamParser
 {
 public:
@@ -83,7 +82,8 @@ public:
      * RGBD sensor.
      * @return true on success, false otherwise.
      */
-    bool parseParam(yarp::os::Searchable& config, std::vector<RGBDParam *> &params);
+    bool parseParam(const yarp::os::Searchable& config, std::vector<RGBDParam *> &params);
+
     yarp::sig::IntrinsicParams         depthIntrinsic;
     yarp::sig::IntrinsicParams         rgbIntrinsic;
     yarp::sig::Matrix       transformationMatrix;

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -10,6 +10,8 @@
 #include <yarp/sig/Matrix.h>
 #include <yarp/dev/api.h>
 
+#include <yarp/sig/IntrinsicParams.h>
+
 #include <vector>
 
 #ifndef YARP_DEV_RGBDSENSORPARAMPARSER_H
@@ -18,32 +20,14 @@
 namespace yarp {
 namespace dev {
 
+
 class YARP_dev_API RGBDSensorParamParser
 {
 public:
-    struct YARP_dev_API IntrinsicParams
-    {
-        struct YARP_dev_API plum_bob
-        {
-            double k1;
-            double k2;
-            double t1;
-            double t2;
-            double k3;
-            plum_bob(): k1(0.0), k2(0.0),
-                        t1(0.0), t2(0.0),
-                        k3(0.0) {}
-        };
-        double   principalPointX;
-        double   principalPointY;
-        double   focalLengthX;
-        double   focalLengthY;
-        plum_bob distortionModel;
-        bool     isOptional;
-        IntrinsicParams(): principalPointX(0.0), principalPointY(0.0),
-                           focalLengthX(0.0), focalLengthY(0.0),
-                           distortionModel(), isOptional(false) {}
-    };
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2.0
+    YARP_DEPRECATED_TYPEDEF_MSG("Use yarp::sig::IntrinsicParams instead") yarp::sig::IntrinsicParams IntrinsicParams;
+#endif
     struct YARP_dev_API RGBDParam
     {
         RGBDParam() : name("unknown"), isSetting(false), isDescription(false), size(1)
@@ -66,8 +50,8 @@ public:
         YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::vector<yarp::os::Value>) val;
     };
 
-    IntrinsicParams         depthIntrinsic;
-    IntrinsicParams         rgbIntrinsic;
+    yarp::sig::IntrinsicParams         depthIntrinsic;
+    yarp::sig::IntrinsicParams         rgbIntrinsic;
     yarp::sig::Matrix       transformationMatrix;
     bool                    isOptionalExtrinsic;
 

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -84,10 +84,10 @@ public:
      */
     bool parseParam(const yarp::os::Searchable& config, std::vector<RGBDParam *> &params);
 
-    yarp::sig::IntrinsicParams         depthIntrinsic;
-    yarp::sig::IntrinsicParams         rgbIntrinsic;
-    yarp::sig::Matrix       transformationMatrix;
-    bool                    isOptionalExtrinsic;
+    yarp::sig::IntrinsicParams depthIntrinsic;
+    yarp::sig::IntrinsicParams rgbIntrinsic;
+    yarp::sig::Matrix transformationMatrix;
+    bool isOptionalExtrinsic;
 };
 
 } // dev

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -67,10 +67,6 @@ public:
         YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::vector<yarp::os::Value>) val;
     };
 
-    yarp::sig::IntrinsicParams         depthIntrinsic;
-    yarp::sig::IntrinsicParams         rgbIntrinsic;
-    yarp::sig::Matrix       transformationMatrix;
-    bool                    isOptionalExtrinsic;
 
     /**
      * @brief RGBDSensorParamParser, default constructor.
@@ -88,6 +84,10 @@ public:
      * @return true on success, false otherwise.
      */
     bool parseParam(yarp::os::Searchable& config, std::vector<RGBDParam *> &params);
+    yarp::sig::IntrinsicParams         depthIntrinsic;
+    yarp::sig::IntrinsicParams         rgbIntrinsic;
+    yarp::sig::Matrix       transformationMatrix;
+    bool                    isOptionalExtrinsic;
 };
 
 } // dev

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -20,6 +20,10 @@
 namespace yarp {
 namespace dev {
 
+/**
+ * @brief The RGBDSensorParamParser class.
+ * This class has been designed to uniform the parsing of RGBD yarp devices.
+ */
 
 class YARP_dev_API RGBDSensorParamParser
 {
@@ -28,13 +32,26 @@ public:
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.2.0
     YARP_DEPRECATED_TYPEDEF_MSG("Use yarp::sig::IntrinsicParams instead") yarp::sig::IntrinsicParams IntrinsicParams;
 #endif
+    /**
+     * @brief The RGBDParam struct.
+     * A RGBD param has a name, can be a setting or a description for/of the RGBD device.
+     * The value(s) is stored in ad vector of yarp::os::Value.
+     */
     struct YARP_dev_API RGBDParam
     {
+        /**
+         * @brief RGBDParam, default constructor.
+         */
         RGBDParam() : name("unknown"), isSetting(false), isDescription(false), size(1)
         {
             val.resize(size);
         }
 
+        /**
+         * @brief RGBDParam
+         * @param _name, name of the parameter.
+         * @param _size, dimension of the parameter (e.g. the resolution is represented by 2 values).
+         */
         RGBDParam(const std::string& _name, const int _size) : name(_name), isSetting(false),
                                               isDescription(false), size(_size)
         {
@@ -55,10 +72,21 @@ public:
     yarp::sig::Matrix       transformationMatrix;
     bool                    isOptionalExtrinsic;
 
+    /**
+     * @brief RGBDSensorParamParser, default constructor.
+     */
     RGBDSensorParamParser(): depthIntrinsic(), rgbIntrinsic(),
                              transformationMatrix(4,4), isOptionalExtrinsic(true) {
         transformationMatrix.eye();
     }
+
+    /**
+     * @brief parseParam, parse the params stored in a Searchable.
+     * @param config[in], Searchable containing the parameters of the RGDB sensor
+     * @param params[out], vector containing all the description/settings of the
+     * RGBD sensor.
+     * @return true on success, false otherwise.
+     */
     bool parseParam(yarp::os::Searchable& config, std::vector<RGBDParam *> &params);
 };
 

--- a/src/libYARP_dev/src/RGBDSensorParamParser.cpp
+++ b/src/libYARP_dev/src/RGBDSensorParamParser.cpp
@@ -71,7 +71,7 @@ static bool checkParam(const Bottle& settings, const Bottle& description, RGBDSe
 }
 
 
-static bool parseIntrinsic(const Searchable& config, const string& groupName, RGBDSensorParamParser::IntrinsicParams &params)
+static bool parseIntrinsic(const Searchable& config, const string& groupName, yarp::sig::IntrinsicParams &params)
 {
 
     pair<string, double*>          realparam;

--- a/src/libYARP_dev/src/RGBDSensorParamParser.cpp
+++ b/src/libYARP_dev/src/RGBDSensorParamParser.cpp
@@ -152,7 +152,7 @@ static bool parseIntrinsic(const Searchable& config, const string& groupName, ya
     return true;
 }
 
-bool RGBDSensorParamParser::parseParam(Searchable &config, std::vector<RGBDParam*>& params)
+bool RGBDSensorParamParser::parseParam(const Searchable &config, std::vector<RGBDParam*>& params)
 {
     bool ret = true;
 

--- a/src/libYARP_sig/CMakeLists.txt
+++ b/src/libYARP_sig/CMakeLists.txt
@@ -20,6 +20,8 @@ set(YARP_sig_HDRS include/yarp/sig/all.h
                   include/yarp/sig/PointCloudBase.h
                   include/yarp/sig/PointCloudNetworkHeader.h
                   include/yarp/sig/PointCloudTypes.h
+                  include/yarp/sig/PointCloudUtils.h
+                  include/yarp/sig/PointCloudUtils-inl.h
                   include/yarp/sig/SoundFile.h
                   include/yarp/sig/Sound.h
                   include/yarp/sig/Vector.h)
@@ -39,6 +41,7 @@ set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/IplImage.cpp
                   src/Matrix.cpp
                   src/PointCloudBase.cpp
+                  src/PointCloudUtils.cpp
                   src/Sound.cpp
                   src/SoundFile.cpp
                   src/Vector.cpp

--- a/src/libYARP_sig/CMakeLists.txt
+++ b/src/libYARP_sig/CMakeLists.txt
@@ -14,6 +14,7 @@ set(YARP_sig_HDRS include/yarp/sig/all.h
                   include/yarp/sig/ImageFile.h
                   include/yarp/sig/ImageNetworkHeader.h
                   include/yarp/sig/ImageUtils.h
+                  include/yarp/sig/IntrinsicParams.h
                   include/yarp/sig/Matrix.h
                   include/yarp/sig/PointCloud.h
                   include/yarp/sig/PointCloudBase.h
@@ -34,6 +35,7 @@ set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/Image.cpp
                   src/ImageFile.cpp
                   src/ImageUtils.cpp
+                  src/IntrinsicParams.cpp
                   src/IplImage.cpp
                   src/Matrix.cpp
                   src/PointCloudBase.cpp

--- a/src/libYARP_sig/include/yarp/sig/IntrinsicParams.h
+++ b/src/libYARP_sig/include/yarp/sig/IntrinsicParams.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_SIG_INTRINSICPARAMS_H
+#define YARP_SIG_INTRINSICPARAMS_H
+
+#include <yarp/os/Log.h>
+#include <yarp/os/Portable.h>
+#include <yarp/os/Property.h>
+#include <yarp/sig/api.h>
+
+namespace yarp {
+namespace sig {
+/**
+ * @brief The IntrinsicParams struct to handle the intrinsic parameter
+ * of cameras(RGB and RGBD either).
+ */
+struct YARP_sig_API IntrinsicParams : public yarp::os::Portable
+{
+    /**
+     * @brief The plum_bob struct representing the distortion model
+     * of the camera.
+     */
+    struct YARP_sig_API plum_bob
+    {
+        double k1;
+        double k2;
+        double t1;
+        double t2;
+        double k3;
+        plum_bob(): k1(0.0), k2(0.0),
+                    t1(0.0), t2(0.0),
+                    k3(0.0) {}
+    };
+
+    /**
+     * @brief IntrinsicParams, default constructor
+     */
+    IntrinsicParams();
+
+    /**
+     * @brief IntrinsicParams
+     * @param intrinsic, Property containing the value for filling the struct.
+     * @param isOptional, flag to explicitate if it is optional if this struct
+     * is used in parsing.
+     * @note It asserts if the Property is malformed. The distortion model is optional,
+     * fields principalPointX principalPointY focalLengthX focalLengthY are required.
+     */
+    IntrinsicParams(const yarp::os::Property &intrinsic, bool isOptional=false);
+
+    /**
+     * @brief toProperty, convert the struct to a Property.
+     * @param intrinsic[out], Property generated from the struct.
+     */
+    void toProperty(yarp::os::Property& intrinsic) const;
+
+    /**
+     * @brief fromProperty, fill the struct using the data stored in a Property.
+     * @param intrinsic[in], input property.
+     * @note It asserts if the Property is malformed. The distortion model is optional,
+     * fields principalPointX principalPointY focalLengthX focalLengthY are required.
+     */
+    void fromProperty(const yarp::os::Property& intrinsic);
+
+    bool read(yarp::os::ConnectionReader& reader) override;
+    bool write(yarp::os::ConnectionWriter& writer) const override;
+
+    double   principalPointX;
+    double   principalPointY;
+    double   focalLengthX;
+    double   focalLengthY;
+    plum_bob distortionModel;
+    bool     isOptional;
+};
+
+} // namespace sig
+} // namespace yarp
+
+
+
+#endif // YARP_SIG_INTRINSICPARAMS_H

--- a/src/libYARP_sig/include/yarp/sig/IntrinsicParams.h
+++ b/src/libYARP_sig/include/yarp/sig/IntrinsicParams.h
@@ -17,25 +17,47 @@
 namespace yarp {
 namespace sig {
 /**
+ * @brief The YarpDistortion enum to define the
+ * type of the distortion model of the camera.
+ *
+ * In geometric optics, distortion is a deviation from rectilinear projection;
+ * a projection in which straight lines in a scene remain straight in an image.
+ * Although distortion can be irregular or follow many patterns, the most commonly
+ * encountered distortions are radially symmetric. These can be represent by models
+ * that allow us to undistort the images knowing the parameters of the distortion
+ * (k1, k2, t1, t2, k3).
+ */
+enum class YarpDistortion : std::int32_t
+{
+    YARP_DISTORTION_NONE, /**< Rectilinear images. No distortion compensation required. */
+    YARP_PLUM_BOB,        /**< Plumb bob distortion model */
+    YARP_FISH_EYE,        /**< Fish eye distortion model */
+    YARP_UNSUPPORTED,     /**< Unsupported distortion model */
+    YARP_DISTORTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
+};
+
+/**
  * @brief The IntrinsicParams struct to handle the intrinsic parameter
  * of cameras(RGB and RGBD either).
  */
 struct YARP_sig_API IntrinsicParams : public yarp::os::Portable
 {
     /**
-     * @brief The plum_bob struct representing the distortion model
+     * @brief The DistortionModel struct representing the distortion model
      * of the camera.
      */
-    struct YARP_sig_API plum_bob
+    struct YARP_sig_API DistortionModel
     {
         double k1;
         double k2;
         double t1;
         double t2;
         double k3;
-        plum_bob(): k1(0.0), k2(0.0),
-                    t1(0.0), t2(0.0),
-                    k3(0.0) {}
+        YarpDistortion type;
+
+        DistortionModel(): k1(0.0), k2(0.0),
+                           t1(0.0), t2(0.0),
+                           k3(0.0), type(YarpDistortion::YARP_DISTORTION_NONE) {}
     };
 
     /**
@@ -70,11 +92,11 @@ struct YARP_sig_API IntrinsicParams : public yarp::os::Portable
     bool read(yarp::os::ConnectionReader& reader) override;
     bool write(yarp::os::ConnectionWriter& writer) const override;
 
-    double   principalPointX;
-    double   principalPointY;
-    double   focalLengthX;
-    double   focalLengthY;
-    plum_bob distortionModel;
+    double   principalPointX;        /**< Horizontal coordinate of the principal point of the image, as a pixel offset from the left edge */
+    double   principalPointY;        /**< Vertical coordinate of the principal point of the image, as a pixel offset from the top edge */
+    double   focalLengthX;           /**< Result of the product of the physical focal length(mm) and the size sx of the individual imager elements (pixels per mm) */
+    double   focalLengthY;           /**< Result of the product of the physical focal length(mm) and the size sy of the individual imager elements (pixels per mm) */
+    DistortionModel distortionModel; /**< Distortion model of the image */
     bool     isOptional;
 };
 

--- a/src/libYARP_sig/include/yarp/sig/PointCloud.h
+++ b/src/libYARP_sig/include/yarp/sig/PointCloud.h
@@ -120,7 +120,6 @@ public:
      */
     inline T& operator()(size_t u, size_t v)
     {
-        yAssert(isOrganized());
         return m_storage[u + v * width()];
     }
 
@@ -132,7 +131,6 @@ public:
      */
     inline const T& operator()(size_t u, size_t v) const
     {
-        yAssert(isOrganized());
         return m_storage[u + v * width()];
     }
 

--- a/src/libYARP_sig/include/yarp/sig/PointCloudUtils-inl.h
+++ b/src/libYARP_sig/include/yarp/sig/PointCloudUtils-inl.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_SIG_POINTCLOUDUTILS_INL_H
+#define YARP_SIG_POINTCLOUDUTILS_INL_H
+
+template<typename T1, typename T2>
+yarp::sig::PointCloud<T1> yarp::sig::utils::depthRgbToPC(const yarp::sig::ImageOf<yarp::sig::PixelFloat>& depth,
+                                                         const yarp::sig::ImageOf<T2>& color,
+                                                         const yarp::sig::IntrinsicParams& intrinsic)
+{
+    yAssert(depth.width()  != 0);
+    yAssert(depth.height() != 0);
+    yAssert(depth.width()  == color.width());
+    yAssert(depth.height() == color.height());
+    size_t w = depth.width();
+    size_t h = depth.height();
+    yarp::sig::PointCloud<T1> pointCloud;
+    pointCloud.resize(w, h);
+
+    for (size_t u = 0; u < w; ++u) {
+        for (size_t v = 0; v < h; ++v) {
+            // Depth
+            // De-projection equation (pinhole model):
+            //                          x = (u - ppx)/ fx * z
+            //                          y = (v - ppy)/ fy * z
+            //                          z = z
+            pointCloud(u,v).x = (u - intrinsic.principalPointX)/intrinsic.focalLengthX*depth.pixel(u,v);
+            pointCloud(u,v).y = (v - intrinsic.principalPointY)/intrinsic.focalLengthY*depth.pixel(u,v);
+            pointCloud(u,v).z = depth.pixel(u,v);
+
+            if (std::is_same<T1, DataXYZRGBA>::value) {
+                if (std::is_same<T2, PixelRgb>::value  ||
+                    std::is_same<T2, PixelBgr>::value  ||
+                    std::is_same<T2, PixelRgba>::value ||
+                    std::is_same<T2, PixelBgra>::value) {
+                    // Color
+                    pointCloud(u,v).r = color.pixel(u,v).r;
+                    pointCloud(u,v).g = color.pixel(u,v).g;
+                    pointCloud(u,v).b = color.pixel(u,v).b;
+                    if (std::is_same<T2, PixelRgba>::value ||
+                        std::is_same<T2, PixelBgra>::value) {
+                        pointCloud(u,v).a = color.pixel(u,v).a;
+                    }
+                }
+            }
+
+
+        }
+    }
+    return pointCloud;
+}
+
+#endif // YARP_SIG_POINTCLOUDUTILS_INL_H

--- a/src/libYARP_sig/include/yarp/sig/PointCloudUtils.h
+++ b/src/libYARP_sig/include/yarp/sig/PointCloudUtils.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_SIG_POINTCLOUDUTILS_H
+#define YARP_SIG_POINTCLOUDUTILS_H
+
+#include <yarp/sig/Image.h>
+#include <yarp/sig/IntrinsicParams.h>
+#include <yarp/sig/PointCloud.h>
+
+namespace yarp {
+namespace sig{
+/**
+ * \ingroup sig_class
+ *
+ * PointCloud utilities.
+ */
+namespace utils
+{
+
+/**
+ * @brief depthToPC, compute the PointCloud given depth image and the intrinsic parameters of the camera.
+ * @param[in] depth, the input depth image.
+ * @param[in] intrinsic, intrinsic parameter of the camera.
+ * @note the intrinsic parameters are the one of the depth sensor if the depth frame IS NOT aligned with the
+ * colored one. On the other hand use the intrinsic parameters of the RGB camera if the frames are aligned.
+ * @return the pointcloud obtained by the de-projection.
+ */
+YARP_sig_API yarp::sig::PointCloud<yarp::sig::DataXYZ> depthToPC(const yarp::sig::ImageOf<yarp::sig::PixelFloat>& depth,
+                                                                 const yarp::sig::IntrinsicParams& intrinsic);
+
+/**
+ * @brief depthRgbToPC, compute the colored PointCloud given depth image, color image and the intrinsic
+ * parameters of the camera.
+ * @param[in] depth, the input depth image.
+ * @param[in] color, the input color image.
+ * @param[in] intrinsic, intrinsic parameter of the camera.
+ * @note the intrinsic parameters are the one of the depth sensor if the depth frame IS NOT aligned with the
+ * colored one. On the other hand use the intrinsic parameters of the RGB camera if the frames are aligned.
+ * @return the pointcloud obtained by the de-projection.
+ */
+template<typename T1, typename T2>
+yarp::sig::PointCloud<T1> depthRgbToPC(const yarp::sig::ImageOf<yarp::sig::PixelFloat>& depth,
+                                       const yarp::sig::ImageOf<T2>& color,
+                                       const yarp::sig::IntrinsicParams& intrinsic);
+} // namespace utils
+} // namespace sig
+} // namespace yarp
+
+#include <yarp/sig/PointCloudUtils-inl.h>
+
+#endif // YARP_SIG_POINTCLOUDUTILS_H

--- a/src/libYARP_sig/src/IntrinsicParams.cpp
+++ b/src/libYARP_sig/src/IntrinsicParams.cpp
@@ -26,15 +26,18 @@ void IntrinsicParams::toProperty(yarp::os::Property& intrinsic) const
     intrinsic.put("focalLengthY",       focalLengthY);
     intrinsic.put("principalPointX",    principalPointX);
     intrinsic.put("principalPointY",    principalPointY);
+    intrinsic.put("stamp", yarp::os::Time::now());
 
+    if (distortionModel.type != YarpDistortion::YARP_PLUM_BOB) {
+        intrinsic.put("distortionModel", "none");
+        return;
+    }
     intrinsic.put("distortionModel", "plumb_bob");
     intrinsic.put("k1", distortionModel.k1);
     intrinsic.put("k2", distortionModel.k2);
     intrinsic.put("t1", distortionModel.t1);
     intrinsic.put("t2", distortionModel.t2);
     intrinsic.put("k3", distortionModel.k3);
-
-    intrinsic.put("stamp", yarp::os::Time::now());
 }
 
 void IntrinsicParams::fromProperty(const yarp::os::Property& intrinsic)
@@ -49,6 +52,10 @@ void IntrinsicParams::fromProperty(const yarp::os::Property& intrinsic)
     principalPointY = intrinsic.find("principalPointY").asFloat64();
 
     // The distortion parameters are optional
+    if (intrinsic.find("distortionModel").asString() !=  "plumb_bob") {
+        return;
+    }
+    distortionModel.type = YarpDistortion::YARP_PLUM_BOB;
     distortionModel.k1 = intrinsic.check("k1", yarp::os::Value(0.0)).asFloat64();
     distortionModel.k2 = intrinsic.check("k2", yarp::os::Value(0.0)).asFloat64();
     distortionModel.t1 = intrinsic.check("t1", yarp::os::Value(0.0)).asFloat64();

--- a/src/libYARP_sig/src/IntrinsicParams.cpp
+++ b/src/libYARP_sig/src/IntrinsicParams.cpp
@@ -22,10 +22,10 @@ IntrinsicParams::IntrinsicParams(const yarp::os::Property &intrinsic, bool isOpt
 
 void IntrinsicParams::toProperty(yarp::os::Property& intrinsic) const
 {
-    intrinsic.put("focalLengthX",       focalLengthX);
-    intrinsic.put("focalLengthY",       focalLengthY);
-    intrinsic.put("principalPointX",    principalPointX);
-    intrinsic.put("principalPointY",    principalPointY);
+    intrinsic.put("focalLengthX", focalLengthX);
+    intrinsic.put("focalLengthY", focalLengthY);
+    intrinsic.put("principalPointX", principalPointX);
+    intrinsic.put("principalPointY", principalPointY);
     intrinsic.put("stamp", yarp::os::Time::now());
 
     if (distortionModel.type != YarpDistortion::YARP_PLUM_BOB) {

--- a/src/libYARP_sig/src/IntrinsicParams.cpp
+++ b/src/libYARP_sig/src/IntrinsicParams.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/sig/IntrinsicParams.h>
+#include <yarp/os/Time.h>
+
+using namespace yarp::sig;
+
+IntrinsicParams::IntrinsicParams(): principalPointX(0.0), principalPointY(0.0),
+                   focalLengthX(0.0), focalLengthY(0.0),
+                   distortionModel(), isOptional(false) {}
+
+IntrinsicParams::IntrinsicParams(const yarp::os::Property &intrinsic, bool isOptional): isOptional(isOptional)
+{
+    fromProperty(intrinsic);
+}
+
+void IntrinsicParams::toProperty(yarp::os::Property& intrinsic) const
+{
+    intrinsic.put("focalLengthX",       focalLengthX);
+    intrinsic.put("focalLengthY",       focalLengthY);
+    intrinsic.put("principalPointX",    principalPointX);
+    intrinsic.put("principalPointY",    principalPointY);
+
+    intrinsic.put("distortionModel", "plumb_bob");
+    intrinsic.put("k1", distortionModel.k1);
+    intrinsic.put("k2", distortionModel.k2);
+    intrinsic.put("t1", distortionModel.t1);
+    intrinsic.put("t2", distortionModel.t2);
+    intrinsic.put("k3", distortionModel.k3);
+
+    intrinsic.put("stamp", yarp::os::Time::now());
+}
+
+void IntrinsicParams::fromProperty(const yarp::os::Property& intrinsic)
+{
+    yAssert(intrinsic.check("focalLengthX")    &&
+            intrinsic.check("focalLengthY")    &&
+            intrinsic.check("principalPointX") &&
+            intrinsic.check("principalPointY"));
+    focalLengthX    = intrinsic.find("focalLengthX").asFloat64();
+    focalLengthY    = intrinsic.find("focalLengthY").asFloat64();
+    principalPointX = intrinsic.find("principalPointX").asFloat64();
+    principalPointY = intrinsic.find("principalPointY").asFloat64();
+
+    // The distortion parameters are optional
+    distortionModel.k1 = intrinsic.check("k1", yarp::os::Value(0.0)).asFloat64();
+    distortionModel.k2 = intrinsic.check("k2", yarp::os::Value(0.0)).asFloat64();
+    distortionModel.t1 = intrinsic.check("t1", yarp::os::Value(0.0)).asFloat64();
+    distortionModel.t2 = intrinsic.check("t2", yarp::os::Value(0.0)).asFloat64();
+    distortionModel.k3 = intrinsic.check("k3", yarp::os::Value(0.0)).asFloat64();
+}
+
+bool IntrinsicParams::read(yarp::os::ConnectionReader& reader) {
+    yarp::os::Property prop;
+    bool ok = prop.read(reader);
+    if (ok)
+    {
+        fromProperty(prop);
+    }
+    return ok;
+}
+bool IntrinsicParams::write(yarp::os::ConnectionWriter& writer) const {
+    yarp::os::Property prop;
+    toProperty(prop);
+    return prop.write(writer);
+}

--- a/src/libYARP_sig/src/PointCloudUtils.cpp
+++ b/src/libYARP_sig/src/PointCloudUtils.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/sig/PointCloudUtils.h>
+#include <cstring>
+
+using namespace yarp::sig;
+
+PointCloud<DataXYZ> utils::depthToPC(const yarp::sig::ImageOf<PixelFloat> &depth,
+                                     const yarp::sig::IntrinsicParams &intrinsic)
+{
+    yAssert(depth.width()  != 0);
+    yAssert(depth.height() != 0);
+    size_t w = depth.width();
+    size_t h = depth.height();
+    PointCloud<DataXYZ> pointCloud;
+    pointCloud.resize(w, h);
+
+    for (size_t u = 0; u < w; ++u) {
+        for (size_t v = 0; v < h; ++v) {
+            // De-projection equation (pinhole model):
+            //                          x = (u - ppx)/ fx * z
+            //                          y = (v - ppy)/ fy * z
+            //                          z = z
+            pointCloud(u,v).x = (u - intrinsic.principalPointX)/intrinsic.focalLengthX*depth.pixel(u,v);
+            pointCloud(u,v).y = (v - intrinsic.principalPointY)/intrinsic.focalLengthY*depth.pixel(u,v);
+            pointCloud(u,v).z = depth.pixel(u,v);
+        }
+    }
+    return pointCloud;
+}

--- a/tests/libYARP_sig/PointCloudTest.cpp
+++ b/tests/libYARP_sig/PointCloudTest.cpp
@@ -13,7 +13,9 @@
  *
  */
 
+#include <yarp/sig/Image.h>
 #include <yarp/sig/PointCloud.h>
+#include <yarp/sig/PointCloudUtils.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Time.h>
@@ -922,6 +924,28 @@ public:
 
     }
 
+    void depthToPCTest()
+    {
+        report(0,"Testing depthToPC");
+        ImageOf<PixelFloat> depth;
+        size_t width{320};
+        size_t height{240};
+        depth.resize(width, height);
+        IntrinsicParams intp;
+
+        auto pc = utils::depthToPC(depth, intp);
+        checkEqual(pc.width(), depth.width(), "Checking PC width");
+        checkEqual(pc.height(), depth.height(), "Checking PC height");
+        report(0,"Testing depthRgbToPC");
+
+        ImageOf<PixelBgra> color;
+        color.resize(width, height);
+        auto pcCol = utils::depthRgbToPC<DataXYZRGBA, PixelBgra>(depth, color, intp);
+        checkEqual(pcCol.width(), depth.width(), "Checking PC width");
+        checkEqual(pcCol.height(), depth.height(), "Checking PC height");
+
+    }
+
     virtual void runTests() override
     {
         readWriteMatchTest();
@@ -932,6 +956,7 @@ public:
         concatenationTest();
         toFromBottle();
         readWritetoFromBottle();
+        depthToPCTest();
     }
 };
 


### PR DESCRIPTION
Following the request of @claudiofantacci I implemented 2 functions to get `yarp::sig::PointCloud` from depth images given the intrinsic parameters.

These functions have been added in `YARP_math` because I would try to optimize the mathematical operations using eigen or something else, for now they are simple for loops.

In these functions I need the structure `IntrinsicParams` but it was in `YARP_dev` and since `math` cannot depend from `dev` I moved it in `YARP_sig` implementing it as `yarp::os::Portable`. I kept it anyways also in `YARP_dev` as deprecated typedef.

Finally I added the missing documentation for the `RGBDSensorParamParser` (Fixes #1863). 

TODO:

- [x] add #ifdef YARP_NO_DEPRECATED guards
- [x] Optimize for loops:
  - [x] Cache termination condition
  - [ ] Eigen implementation (?)
  - [ ] GPU/CUDA implementation (?)
  - [ ] SSE instructions (?)
  - [ ] OpenMP usage(?)
- [x] Update changelog.
- [ ] Check `depthCamera` functionality
- [x] Check `realsense2` functionality
- [x] Add proper documentation for depthToPC
- [x] Add example in the documentation for the 2 new methods.
- [x] Add documentation for `verbose` and `stereoMode` parameters in `realsene2Driver` (Fixes #1871).
