### PR TITLE
Fix header inclusion (ImplementControlLimits.h)

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -48,6 +48,7 @@ Bug Fixes
 * Added missing `YARP_dev_API` to `IRobotDescription`.
 * Made optional the view of `IFrameGrabberControls` in `RGBDSensorWrapper`
   (#1875).
+* Fixed header inclusion in `ImplementControlLimits2.h`.
 
 #### `YARP_companion`
 

--- a/src/libYARP_dev/include/yarp/dev/ImplementControlLimits2.h
+++ b/src/libYARP_dev/include/yarp/dev/ImplementControlLimits2.h
@@ -10,7 +10,7 @@
 #define YARP_DEV_ICONTROLLIMITS2IMPL_H
 
 
-#include <yarp/dev/IControlLimitsImpl.h>
+#include <yarp/dev/ImplementControlLimits.h>
 #include <yarp/dev/api.h>
 #include <yarp/os/Log.h>
 


### PR DESCRIPTION
This patch solves ~~two issues~~:

* Broken header inclusion in `ImplementControlLimits2.h`.
* ~~Missing `ImplementControlLimits2.h` in `ControlBoardInterfacesImpl.h`. This used to work prior to YARP 3.0, hence I'm identifying it as a regression. Moreover, I preferred to remove `ImplementControlMode.h` so that it's treated equally with everything else. Alternatively, use deprecation macros:~~
  ```c++
  #ifndef YARP_NO_DEPRECATED
  #include <yarp/dev/ImplementControlLimits2.h> // and so on
  #else
  #include <yarp/dev/ImplementControlLimits.h> // and so on
  #endif
  ```
  (I'm not sure whether it makes sense since those deprecated headers are being installed anyway. Dropping this idea in case it's worth investigating further.)
  **Edit:** dropped from the final patchset (https://github.com/PeterBowman/yarp/commit/401e02126b5f0eee4c370fed4a7627e16b0d7a6f).