### PR TITLE
Add ImageUtils

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -10,18 +10,28 @@ New Features
 
 ### Libraries
 
-#### YARP_DEV
+#### `YARP_dev`
 
-* yarp::dev::IMap2D::clear() method renamed to yarp::dev::IMap2D::clearAllMaps()
-* yarp::dev::INavigation2D derives from INavigation2DControlActions and INavigation2DTargetActions
+* yarp::dev::IMap2D::clear() method renamed to yarp::dev::IMap2D::clearAllMaps().
+* yarp::dev::INavigation2D derives from INavigation2DControlActions
+  and INavigation2DTargetActions.
 * yarp::dev::INavigation2DControlActions. The following methods have been added:
   getAllNavigationWaypoints(std::vector<yarp::dev::Map2DLocation>& waypoints)
   getCurrentNavigationWaypoint(yarp::dev::Map2DLocation& curr_waypoint)
   getCurrentNavigationMap(yarp::dev::NavigationMapTypeEnum map_type, yarp::dev::MapGrid2D& map)
 * yarp::dev::INavigation2DTargetActions. The following method has been added:
   gotoTargetByRelativeLocation(double x, double y)
-* The following method now accepts a parameter (with default value = infinite for backward compatibility)
+* The following method now accepts a parameter (with default value = infinite
+  for backward compatibility):
   yarp::dev::INavigation2DTargetActions::suspendNavigation(const double time_s= std::numeric_limits<double>::infinity())
+
+#### `YARP_sig`
+
+* Added `ImageUtils.h`, an header containing the following image utilities:
+  - `utils::vertSplit`
+  - `utils::horzSplit`
+  - `utils::vertConcat`
+  - `utils::horzConcat`
 
 #### Devices
 * Added navigation2DServer device, previously belonging to https://github.com/robotology/navigation repository.

--- a/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/libYARP_dev/src/devices/ServerGrabber/ServerGrabber.h
@@ -278,11 +278,7 @@ protected:
 
     void stopThread();
 
-    void split(const yarp::sig::Image& inputImage, yarp::sig::Image& _img, yarp::sig::Image& _img2);
-
     void setupFlexImage(const yarp::sig::Image& img, yarp::sig::FlexImage& flex_i);
-
-    void stitch(yarp::sig::FlexImage& flex_i,const yarp::sig::Image& _img,const yarp::sig::Image& _img2);
 
     void shallowCopyImages(const yarp::sig::FlexImage& src, yarp::sig::FlexImage& dest);
 

--- a/src/libYARP_sig/CMakeLists.txt
+++ b/src/libYARP_sig/CMakeLists.txt
@@ -9,10 +9,11 @@ project(YARP_sig)
 
 set(YARP_sig_HDRS include/yarp/sig/all.h
                   include/yarp/sig/api.h
+                  include/yarp/sig/Image.h
                   include/yarp/sig/ImageDraw.h
                   include/yarp/sig/ImageFile.h
-                  include/yarp/sig/Image.h
                   include/yarp/sig/ImageNetworkHeader.h
+                  include/yarp/sig/ImageUtils.h
                   include/yarp/sig/Matrix.h
                   include/yarp/sig/PointCloud.h
                   include/yarp/sig/PointCloudBase.h
@@ -32,6 +33,7 @@ set(YARP_sig_IMPL_HDRS include/yarp/sig/impl/DeBayer.h
 set(YARP_sig_SRCS src/ImageCopy.cpp
                   src/Image.cpp
                   src/ImageFile.cpp
+                  src/ImageUtils.cpp
                   src/IplImage.cpp
                   src/Matrix.cpp
                   src/PointCloudBase.cpp

--- a/src/libYARP_sig/include/yarp/sig/ImageUtils.h
+++ b/src/libYARP_sig/include/yarp/sig/ImageUtils.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_SIG_IMAGEUTILS_H
+#define YARP_SIG_IMAGEUTILS_H
+
+#include <yarp/sig/Image.h>
+
+namespace yarp {
+namespace sig{
+/**
+ * \ingroup sig_class
+ *
+ * Image utilities.
+ */
+namespace utils
+{
+
+/**
+ * @brief vertSplit, split vertically an image in two images of the same size.
+ * @param inImg[in] image to be vertically split.
+ * @param outImgL[out] left half of inImg.
+ * @param outImgR[out] right half of inImg.
+ * @note The input image must have same height, double width of the output images and same pixel type.
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API vertSplit(const yarp::sig::Image& inImg, yarp::sig::Image& outImgL, yarp::sig::Image& outImgR);
+
+/**
+ * @brief horzSplit, split horizontally an image in two images of the same size.
+ * @param inImg[in] image to be horizontally split.
+ * @param outImgUp[out] top half of inImg.
+ * @param outImgDown[out] bottom half of inImg.
+ * @note The input image must have same height, double width of the output images and same pixel type.
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API horzSplit(const yarp::sig::Image& inImg, yarp::sig::Image& outImgUp, yarp::sig::Image& outImgDown);
+
+/**
+ * @brief horzConcat, concatenate horizontally two images of the same size in one with double width.
+ * @param inImgL[in] input left image.
+ * @param inImgR[in] input right image.
+ * @param outImg[out] result of the horizontal concatenation.
+ * @note The input images must have same dimensions and pixel type, and the output image must have same height and
+ * double width.
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API horzConcat(const yarp::sig::Image& inImgL, const yarp::sig::Image& inImgR, yarp::sig::Image& outImg);
+
+/**
+ * @brief vertConcat, concatenate vertically two images of the same size in one with double height.
+ * @param inImgUp[in] input top image.
+ * @param inImgDown[in] input bottom image.
+ * @param outImg[out] result of the horizontal concatenation.
+ * @note The input images must have same dimensions and pixel type, and the output image must have same width and
+ * double height.
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API vertConcat(const yarp::sig::Image& inImgUp, const yarp::sig::Image& inImgDown, yarp::sig::Image& outImg);
+} // namespace utils
+} // namespace sig
+} // namespace yarp
+
+#endif // YARP_SIG_IMAGEUTILS_H


### PR DESCRIPTION
This PR add  `ImageUtils.h`, an header containing the following image utilities:
  - `utils::vertSplit`
  - `utils::horzSplit`
  - `utils::vertConcat`
  - `utils::horzConcat`

it fixes #1870 

Please review code

