### PR TITLE
Specify a different name for the node name and the yarprun server name in the yarpmanager

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -44,6 +44,16 @@ New Features
 * Added `navigation2DServer` device.
 * Added `localization2DServer` device.
 
+New Features
+------------
+
+### GUIs
+
+#### `yarpmanager`
+
+* Allow to specify an address for every host in the `cluster-config.xml` file. 
+  This allow to use host names that cannot be resolved automatically by the network.
+
 Contributors
 ------------
 

--- a/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
+++ b/src/libYARP_manager/include/yarp/manager/xmlclusterloader.h
@@ -20,6 +20,7 @@ namespace manager {
 struct ClusterNode
 {
     std::string name = "";
+    std::string address = "";
     bool display = false;
     std::string displayValue = "none";
     std::string user = "";

--- a/src/libYARP_manager/src/xmlclusterloader.cpp
+++ b/src/libYARP_manager/src/xmlclusterloader.cpp
@@ -133,6 +133,15 @@ bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
         }
         cluster.nodes.push_back(c_node);
 
+        if (node->Attribute("address"))
+        {
+            c_node.address = node->Attribute("address");
+        }
+        else
+        {
+            c_node.address = c_node.name;
+        }
+
 
     }
     _cluster = cluster;

--- a/src/libYARP_manager/src/xmlclusterloader.cpp
+++ b/src/libYARP_manager/src/xmlclusterloader.cpp
@@ -131,7 +131,6 @@ bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
         {
             c_node.ssh_options = node->Attribute("ssh-options");
         }
-        cluster.nodes.push_back(c_node);
 
         if (node->Attribute("address"))
         {
@@ -141,6 +140,7 @@ bool XmlClusterLoader::parseXmlFile(Cluster &_cluster)
         {
             c_node.address = c_node.name;
         }
+        cluster.nodes.push_back(c_node);
 
 
     }

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -102,7 +102,7 @@ void ClusterWidget::init()
     for (size_t i = 0; i<cluster.nodes.size(); i++)
     {
         ClusterNode node = cluster.nodes[i];
-        addRow(node.name, node.displayValue, node.user, node.onOff, node.log, i);
+        addRow(node.name, node.displayValue, node.user, node.address, node.onOff, node.log, i);
     }
 
     //check if all the nodes are up
@@ -246,7 +246,7 @@ void ClusterWidget::onRunSelected()
             cmdRunYarprun = cmdRunYarprun + " 'export DISPLAY=" + node.displayValue + " && ";
 
         }
-        if (qobject_cast<QCheckBox*>(ui->nodestreeWidget->itemWidget((QTreeWidgetItem *)it, 4))->isChecked())
+        if (qobject_cast<QCheckBox*>(ui->nodestreeWidget->itemWidget((QTreeWidgetItem *)it, 5))->isChecked())
         {
             cmdRunYarprun = cmdRunYarprun + " yarprun --server "+ portName  + " --log 2>&1 2>/tmp/yarprunserver.log";
         }
@@ -396,16 +396,17 @@ void ClusterWidget::onNodeSelectionChanged()
 
 
 void ClusterWidget::addRow(const std::string& name,const std::string& display,
-                           const std::string& user, bool onOff, bool log, int id)
+                           const std::string& user, const std::string& address,
+                           bool onOff, bool log, int id)
 {
     QStringList stringList;
-    stringList <<""<< QString(name.c_str()) << QString(display.c_str()) << QString(user.c_str())<< "" <<QString(std::to_string(id).c_str());
+    stringList <<""<< QString(name.c_str()) << QString(display.c_str()) << QString(user.c_str()) << QString(address.c_str())<< "" <<QString(std::to_string(id).c_str());
     QTreeWidgetItem* it = new QTreeWidgetItem(stringList);
     ui->nodestreeWidget->addTopLevelItem(it);
-    ui->nodestreeWidget->setItemWidget((QTreeWidgetItem *) it, 4, new QCheckBox(this));
+    ui->nodestreeWidget->setItemWidget((QTreeWidgetItem *) it, 5, new QCheckBox(this));
 
     //initialize checkboxes
-    qobject_cast<QCheckBox*>(ui->nodestreeWidget->itemWidget((QTreeWidgetItem *)it, 4))->setChecked(log);
+    qobject_cast<QCheckBox*>(ui->nodestreeWidget->itemWidget((QTreeWidgetItem *)it, 5))->setChecked(log);
 
     //initialize icon
     if (onOff)

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -240,7 +240,7 @@ void ClusterWidget::onRunSelected()
             continue;
         }
 
-        string cmdRunYarprun = getSSHCmd(node.user, node.name, node.ssh_options);
+        string cmdRunYarprun = getSSHCmd(node.user, node.address, node.ssh_options);
         if (node.display)
         {
             cmdRunYarprun = cmdRunYarprun + " 'export DISPLAY=" + node.displayValue + " && ";
@@ -293,7 +293,7 @@ void ClusterWidget::onStopSelected()
             portName = "/" + portName;
         }
 
-        string cmdStopYarprun = getSSHCmd(node.user, node.name, node.ssh_options);
+        string cmdStopYarprun = getSSHCmd(node.user, node.address, node.ssh_options);
 
         cmdStopYarprun = cmdStopYarprun + " yarprun --exit --on "+ portName + " &";
 
@@ -325,7 +325,7 @@ void ClusterWidget::onKillSelected()
             continue;
         }
 
-        string cmdKillYarprun = getSSHCmd(node.user, node.name, node.ssh_options);
+        string cmdKillYarprun = getSSHCmd(node.user, node.address, node.ssh_options);
 
         cmdKillYarprun = cmdKillYarprun + " killall -9 yarprun &";
 
@@ -357,7 +357,7 @@ void ClusterWidget::onExecute()
         int itr = it->text(5).toInt();
         ClusterNode node = cluster.nodes[itr];
 
-        string cmdExecute = getSSHCmd(node.user, node.name, node.ssh_options);
+        string cmdExecute = getSSHCmd(node.user, node.address, node.ssh_options);
 
         cmdExecute = cmdExecute + " "+ ui->lineEditExecute->text().toStdString();
 

--- a/src/yarpmanager/src-manager/clusterWidget.h
+++ b/src/yarpmanager/src-manager/clusterWidget.h
@@ -53,7 +53,7 @@ public:
 
 private:
     void addRow(const std::string& name="", const std::string& display="none",
-                const std::string& user="", bool onOff=false, bool log=true, int id=0);
+                const std::string& user="", const std::string& address="", bool onOff=false, bool log=true, int id=0);
     std::string getSSHCmd(const std::string& user, const std::string& host, const std::string& ssh_options);
     bool checkNameserver();
     bool checkNode(const std::string& name);

--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -329,6 +329,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_12">
          <item>
           <widget class="CustomTreeWidget" name="nodestreeWidget">
+           <property name="columnCount">
+            <number>6</number>
+           </property>
            <column>
             <property name="text">
              <string>Status</string>
@@ -347,6 +350,11 @@
            <column>
             <property name="text">
              <string>User</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Address</string>
             </property>
            </column>
            <column>
@@ -436,11 +444,6 @@
         </spacer>
        </item>
       </layout>
-      <zorder>line_5</zorder>
-      <zorder>line_2</zorder>
-      <zorder>line</zorder>
-      <zorder>label_6</zorder>
-      <zorder>line_3</zorder>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Fix https://github.com/robotology/yarp/issues/1893

Maybe also the graphic should be modified, adding a column with the address. It would be even better if it could be modified from the GUI, but I don't really know what to touch.