### PR TITLE
OS: Refactor a few private methods

### DIFF
--- a/src/libYARP_OS/src/Network.cpp
+++ b/src/libYARP_OS/src/Network.cpp
@@ -256,46 +256,18 @@ static int enactConnection(const Contact& src,
     return ok ? 0 : 1;
 }
 
-
-
-static char* findCarrierParamsPointer(std::string &carrier_name)
-{
-    size_t i = carrier_name.find('+');
-    if (i!=std::string::npos) {
-        return &(carrier_name[i]);
-    }
-    else
-        return nullptr;
-}
-
 static std::string collectParams(Contact &c)
 {
-
     std::string carrier_name = c.getCarrier();
-    char *params_ptr = findCarrierParamsPointer(carrier_name);
-    std::string params;
-    params.clear();
-
-    if(nullptr != params_ptr)
-    {
-        params+=params_ptr;
-    }
-
-    CARRIER_DEBUG("\n ***** SONO NELLA COLLECTPARAMS: carrier=%s, params=%s\n\n ", c.getCarrier().c_str(), params.c_str());
-    return params;
-
+    auto pos = carrier_name.find('+');
+    if (pos != std::string::npos)
+        return carrier_name.substr(pos);
+    return {};
 }
 
-static std::string extractCarrierNameOnly(std::string &carrier_name_with_params)
+static std::string extractCarrierNameOnly(const std::string& carrier_name_with_params)
 {
-
-    std::string carrier_name = carrier_name_with_params;
-    char *c = findCarrierParamsPointer(carrier_name);
-    if(nullptr != c){
-        *c = '\0';
-        carrier_name = carrier_name.c_str();
-    }
-    return carrier_name;
+    return carrier_name_with_params.substr(0, carrier_name_with_params.find('+'));
 }
 
 /*

--- a/src/libYARP_OS/src/ResourceFinder.cpp
+++ b/src/libYARP_OS/src/ResourceFinder.cpp
@@ -143,17 +143,19 @@ public:
         return verbose;
     }
 
-    static std::string extractPath(const char *fname) {
-        std::string s = fname;
-        size_t n = s.rfind('/');
+    static std::string extractPath(const char *fname)
+    {
+        std::string s{fname};
+        auto n = s.rfind('/');
+#if defined(_WIN32)
         if (n == std::string::npos) {
             n = s.rfind('\\');
         }
+#endif
         if (n != std::string::npos) {
-            s[n] = '\0';
-            return std::string(s.c_str());
+            return s.substr(0,n);
         }
-        return "";
+        return {};
     }
 
     bool configure(Property& config, int argc, char *argv[], bool skip)


### PR DESCRIPTION
Current implementation of the `chooseCarrier` method is really confusing.

It accepts a pointer to a `const std::string` and a pointer to a `const yarp::os::Bytes` that can be null, but the method is called wither with the first parameter and the second equal to `nullptr`, or vice versa, therefore I split the method in 2 separate methods, and changed them to use const references instead of pointers.

Anyway, the real problem is that these lines are *really* confusing and hard to understand:

https://github.com/drdanz/yarp/blob/096b771f31599fd06bc5a6f68817be9db199b398/src/libYARP_OS/src/Carriers.cpp#L62-L71

I replaced them with `substr` and recursion.

---

Edit: Added a second commit that does very similar changes in Network.cpp

---

Edit 2: Added a third commit for ResourceFinder 