### PR TITLE
OS: Pass terminating characters as const char instead of int

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -10,6 +10,14 @@ New Features
 
 ### Libraries
 
+#### `YARP_OS`
+
+* The following methods signatures were changed to accept `const char` instead
+  of `int` as terminating character:
+    * `ConnectionReader::expectText()`
+    * `ConnectionWriter::appendString()`
+    * `InputStream::readLine()`
+
 #### `YARP_dev`
 
 * `yarp::dev::IMap2D::clear()` method renamed to

--- a/src/carriers/bayer_carrier/BayerCarrier.h
+++ b/src/carriers/bayer_carrier/BayerCarrier.h
@@ -109,7 +109,7 @@ public:
         return local->expectBlock(data,len);
     }
 
-    virtual std::string expectText(int terminatingChar = '\n') override {
+    virtual std::string expectText(const char terminatingChar = '\n') override {
         return local->expectText(terminatingChar);
     }
 

--- a/src/libYARP_OS/include/yarp/os/ConnectionReader.h
+++ b/src/libYARP_OS/include/yarp/os/ConnectionReader.h
@@ -58,7 +58,7 @@ public:
      * @param terminatingChar The marker for the end of the text
      * @return the text read from the connection
      */
-    virtual std::string expectText(int terminatingChar = '\n') = 0;
+    virtual std::string expectText(const char terminatingChar = '\n') = 0;
 
     /**
      * Read an integer from the network connection.

--- a/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
@@ -125,7 +125,7 @@ public:
      * @param str the character sequence to send
      * @param terminate the terminating character to use
      */
-    virtual void appendString(const char* str, int terminate = '\n') = 0;
+    virtual void appendString(const char* str, const char terminate = '\n') = 0;
 
     /**
      * Send a block of data to the network connection, without making a copy.

--- a/src/libYARP_OS/include/yarp/os/InputStream.h
+++ b/src/libYARP_OS/include/yarp/os/InputStream.h
@@ -109,7 +109,7 @@ public:
     /**
      * Read a block of text terminated with a specific marker (or EOF).
      */
-    std::string readLine(int terminal = '\n', bool* success = nullptr);
+    std::string readLine(const char terminal = '\n', bool* success = nullptr);
 
     /**
      * Keep reading until buffer is full.

--- a/src/libYARP_OS/include/yarp/os/NullConnectionReader.h
+++ b/src/libYARP_OS/include/yarp/os/NullConnectionReader.h
@@ -29,7 +29,7 @@ private:
 
 public:
     virtual bool expectBlock(char* data, size_t len) override;
-    virtual std::string expectText(int terminatingChar = '\n') override;
+    virtual std::string expectText(const char terminatingChar = '\n') override;
     virtual std::int8_t expectInt8() override;
     virtual std::int16_t expectInt16() override;
     virtual std::int32_t expectInt32() override;

--- a/src/libYARP_OS/include/yarp/os/NullConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/NullConnectionWriter.h
@@ -31,7 +31,7 @@ public:
     virtual void appendInt64(std::int64_t data) override;
     virtual void appendFloat32(yarp::conf::float32_t data) override;
     virtual void appendFloat64(yarp::conf::float64_t data) override;
-    virtual void appendString(const char* str, int terminate = '\n') override;
+    virtual void appendString(const char* str, const char terminate = '\n') override;
     virtual void appendExternalBlock(const char* data, size_t len) override;
     virtual bool isTextMode() const override;
     virtual bool isBareMode() const override;

--- a/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
@@ -133,7 +133,7 @@ public:
     virtual void appendFloat32(yarp::conf::float32_t data) override;
     virtual void appendFloat64(yarp::conf::float64_t data) override;
     virtual void appendBlock(const char* data, size_t len) override;
-    virtual void appendString(const char* str, int terminate = '\n') override;
+    virtual void appendString(const char* str, const char terminate = '\n') override;
     virtual void appendExternalBlock(const char* data, size_t len) override;
 
     /**

--- a/src/libYARP_OS/include/yarp/os/impl/ConnectionRecorder.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ConnectionRecorder.h
@@ -57,7 +57,7 @@ public:
     bool hasReply() const;
 
     virtual bool expectBlock(char* data, size_t len) override;
-    virtual std::string expectText(int terminatingChar) override;
+    virtual std::string expectText(const char terminatingChar) override;
     virtual std::int8_t expectInt8() override;
     virtual std::int16_t expectInt16() override;
     virtual std::int32_t expectInt32() override;
@@ -83,7 +83,7 @@ public:
     virtual void appendInt64(std::int64_t data) override;
     virtual void appendFloat32(yarp::conf::float32_t data) override;
     virtual void appendFloat64(yarp::conf::float64_t data) override;
-    virtual void appendString(const char* str, int terminate) override;
+    virtual void appendString(const char* str, const char terminate) override;
     virtual void appendExternalBlock(const char* data, size_t len) override;
     virtual void declareSizes(int argc, int* argv) override;
     virtual void setReplyHandler(yarp::os::PortReader& reader) override;

--- a/src/libYARP_OS/include/yarp/os/impl/StreamConnectionReader.h
+++ b/src/libYARP_OS/include/yarp/os/impl/StreamConnectionReader.h
@@ -71,7 +71,7 @@ public:
     virtual yarp::conf::float32_t expectFloat32() override;
     virtual yarp::conf::float64_t expectFloat64() override;
     virtual bool expectBlock(char *data, size_t len) override;
-    virtual std::string expectText(int terminatingChar) override;
+    virtual std::string expectText(const char terminatingChar) override;
     virtual bool isTextMode() const override;
     virtual bool isBareMode() const override;
     virtual bool convertTextMode() override;

--- a/src/libYARP_OS/src/BufferedConnectionWriter.cpp
+++ b/src/libYARP_OS/src/BufferedConnectionWriter.cpp
@@ -269,7 +269,7 @@ void BufferedConnectionWriter::appendBlock(const char* data, size_t len)
     appendBlockCopy(yarp::os::Bytes((char*)data, len));
 }
 
-void BufferedConnectionWriter::appendString(const char* str, int terminate)
+void BufferedConnectionWriter::appendString(const char* str, const char terminate)
 {
     if (terminate == '\n') {
         appendLine(str);

--- a/src/libYARP_OS/src/ConnectionRecorder.cpp
+++ b/src/libYARP_OS/src/ConnectionRecorder.cpp
@@ -63,7 +63,7 @@ bool yarp::os::impl::ConnectionRecorder::expectBlock(char* data, size_t len)
     return ok;
 }
 
-std::string yarp::os::impl::ConnectionRecorder::expectText(int terminatingChar)
+std::string yarp::os::impl::ConnectionRecorder::expectText(const char terminatingChar)
 {
     std::string str = reader->expectText(terminatingChar);
     readerStore.appendString(str.c_str(), terminatingChar);
@@ -235,7 +235,7 @@ void yarp::os::impl::ConnectionRecorder::appendFloat64(yarp::conf::float64_t dat
     writerStore.appendFloat64(data);
 }
 
-void yarp::os::impl::ConnectionRecorder::appendString(const char* str, int terminate)
+void yarp::os::impl::ConnectionRecorder::appendString(const char* str, const char terminate)
 {
     writer->appendString(str, terminate);
     writerStore.appendString(str, terminate);

--- a/src/libYARP_OS/src/InputStream.cpp
+++ b/src/libYARP_OS/src/InputStream.cpp
@@ -53,7 +53,7 @@ bool InputStream::setReadTimeout(double timeout)
 
 // slow implementation - only relevant for textmode operation
 
-std::string InputStream::readLine(int terminal, bool* success)
+std::string InputStream::readLine(const char terminal, bool* success)
 {
     std::string buf;
     bool done = false;

--- a/src/libYARP_OS/src/NullConnectionReader.cpp
+++ b/src/libYARP_OS/src/NullConnectionReader.cpp
@@ -16,7 +16,7 @@ bool yarp::os::NullConnectionReader::expectBlock(char *data, size_t len)
     return false;
 }
 
-std::string yarp::os::NullConnectionReader::expectText(int terminatingChar)
+std::string yarp::os::NullConnectionReader::expectText(const char terminatingChar)
 {
     YARP_UNUSED(terminatingChar);
     return "";

--- a/src/libYARP_OS/src/NullConnectionWriter.cpp
+++ b/src/libYARP_OS/src/NullConnectionWriter.cpp
@@ -45,7 +45,7 @@ void yarp::os::NullConnectionWriter::appendFloat64(yarp::conf::float64_t data)
     YARP_UNUSED(data);
 }
 
-void yarp::os::NullConnectionWriter::appendString(const char *str, int terminate)
+void yarp::os::NullConnectionWriter::appendString(const char *str, const char terminate)
 {
     YARP_UNUSED(str);
     YARP_UNUSED(terminate);

--- a/src/libYARP_OS/src/StreamConnectionReader.cpp
+++ b/src/libYARP_OS/src/StreamConnectionReader.cpp
@@ -257,7 +257,7 @@ bool StreamConnectionReader::expectBlock(char *data, size_t len)
     return expectBlock(bytes);
 }
 
-std::string StreamConnectionReader::expectText(int terminatingChar)
+std::string StreamConnectionReader::expectText(const char terminatingChar)
 {
     if (!isGood()) {
         return "";


### PR DESCRIPTION
Change the signature of the following methods:

* `ConnectionReader::expectText()`
* `ConnectionWriter::appendString()`
* `InputStream::readLine()`

**WARNING**: Very small API break, but I sincerely hope that nobody ever used these methods with an int