### PR TITLE
Modernize vector

### DIFF
--- a/bindings/python/tests/test_vector.py
+++ b/bindings/python/tests/test_vector.py
@@ -24,7 +24,12 @@ class VectorTest(unittest.TestCase):
         mat.eye()
         vecTest = yarp.Vector(mat.getRow(0))
         self.assertEqual(vecTest.size(), 3)
-
+        # Initializer list constructor
+        vec2 = yarp.Vector([1.0, 2.0, 3.0])
+        self.assertEqual(vec2.size(), 3)
+        self.assertEqual(vec2.get(0), 1.0)
+        self.assertEqual(vec2.get(1), 2.0)
+        self.assertEqual(vec2.get(2), 3.0)
 
 
 if __name__ == '__main__':

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -222,6 +222,7 @@
 %ignore yarp::sig::Image::getIplImage() const;
 %ignore yarp::sig::Image::getReadType() const;
 %ignore yarp::sig::VectorOf<double>::getType() const;
+%ignore yarp::sig::VectorOf<double>::VectorOf(std::initializer_list<double>);
 %ignore yarp::os::Property::put(const char *,Value *);
 %ignore yarp::os::Bottle::add(Value *);
 %rename(toString) std::string::operator const char *() const;
@@ -607,6 +608,10 @@ typedef yarp::os::BufferedPort<Vector> BufferedPortVector;
 %template(BufferedPortSound) yarp::os::BufferedPort<yarp::sig::Sound >;
 
 %template(Vector) yarp::sig::VectorOf<double>;
+#if SWIG_VERSION < 0x030012
+%rename(VectorIterator) yarp::sig::VectorOf<double>::iterator;
+%rename(VectorConstIterator) yarp::sig::VectorOf<double>::const_iterator;
+#endif
 %template(TypedReaderVector) yarp::os::TypedReader<yarp::sig::VectorOf<double> >;
 %template(TypedReaderCallbackVector) yarp::os::TypedReaderCallback<yarp::sig::VectorOf<double> >;
 %template(BufferedPortVector) yarp::os::BufferedPort<yarp::sig::VectorOf<double> >;
@@ -1088,6 +1093,18 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 #endif
 
 %extend yarp::sig::VectorOf<double> {
+
+    // This in not a real constructor actually, it is converted by swig to a function returning a pointer.
+    // See: http://www.swig.org/Doc3.0/CPlusPlus11.html#CPlusPlus11_initializer_lists
+    VectorOf<double>(const std::vector<double>& values)
+    {
+        VectorOf<double>* newVec = new VectorOf<double>(0);
+        newVec->reserve(values.size());
+        for (const auto& element : values) {
+            newVec->push_back(element);
+        }
+        return newVec;
+    }
 
     double get(int j)
     {

--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -35,6 +35,10 @@ Bug Fixes
 
 * Fixed `api.h` installation.
 
+#### `YARP_sig`
+
+* Fixed element contruction when calling `VectorOf<T>::push_back()`.
+
 ### Tools
 
 #### yarpidl_thrift

--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -38,14 +38,21 @@ New Features
   - `utils::horzSplit`
   - `utils::vertConcat`
   - `utils::horzConcat`
+* Added the following methods to `VectorOf`:
+  - VectorOf(std::initializer_list<T>)
+  - begin(), end(), cbegin(), cend()
+  - reserve(size_t)
+  - capacity()
+  - push_back(T&&)
+  - emplace_back(_Args...)
+* Deprecated `VectorOf::getFirst()` in favour of `data()` and `begin()`.
+  Use either `data()` if you need the pointer to the first element, or `begin()`
+  if you need the iterator.
 
 #### Devices
 
 * Added `navigation2DServer` device.
 * Added `localization2DServer` device.
-
-New Features
-------------
 
 ### GUIs
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -930,17 +930,17 @@ void ControlBoardWrapper::run()
         yarp_struct.controlMode.resize(controlledJoints);
         yarp_struct.interactionMode.resize(controlledJoints);
 
-        yarp_struct.jointPosition_isValid       = getEncoders(yarp_struct.jointPosition.getFirst());
-        yarp_struct.jointVelocity_isValid       = getEncoderSpeeds(yarp_struct.jointVelocity.getFirst());
-        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.getFirst());
-        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.getFirst());
-        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.getFirst());
-        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.getFirst());
-        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.getFirst());
-        yarp_struct.pwmDutycycle_isValid        = getDutyCycles(yarp_struct.pwmDutycycle.getFirst());
-        yarp_struct.current_isValid             = getCurrents(yarp_struct.current.getFirst());
-        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.getFirst());
-        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.getFirst());
+        yarp_struct.jointPosition_isValid       = getEncoders(yarp_struct.jointPosition.data());
+        yarp_struct.jointVelocity_isValid       = getEncoderSpeeds(yarp_struct.jointVelocity.data());
+        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.data());
+        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.data());
+        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
+        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
+        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.data());
+        yarp_struct.pwmDutycycle_isValid        = getDutyCycles(yarp_struct.pwmDutycycle.data());
+        yarp_struct.current_isValid             = getCurrents(yarp_struct.current.data());
+        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.data());
+        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.data());
 
         extendedOutputStatePort.setEnvelope(time);
         extendedOutputState_buffer.write();

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2742,7 +2742,7 @@ public:
         double localArrivalTime=0.0;
 
         extendedPortMutex.lock();
-        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.controlMode.getFirst(), lastStamp, localArrivalTime);
+        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.controlMode.data(), lastStamp, localArrivalTime);
         if(ret)
         {
             for (int i = 0; i < n_joint; i++)
@@ -2928,7 +2928,7 @@ public:
         double localArrivalTime=0.0;
 
         extendedPortMutex.lock();
-        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.interactionMode.getFirst(), lastStamp, localArrivalTime);
+        bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.interactionMode.data(), lastStamp, localArrivalTime);
         if(ret)
         {
             for (int i = 0; i < n_joints; i++)

--- a/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/libYARP_dev/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -196,47 +196,47 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
         {
             case VOCAB_ENCODERS:
                 ret = last.jointPosition_isValid;
-                memcpy(data, last.jointPosition.getFirst(), last.jointPosition.size() * last.jointPosition.getElementSize() );
+                memcpy(data, last.jointPosition.data(), last.jointPosition.size() * last.jointPosition.getElementSize() );
             break;
 
             case VOCAB_ENCODER_SPEEDS:
                 ret = last.jointVelocity_isValid;
-                memcpy(data, last.jointVelocity.getFirst(), last.jointVelocity.size() * last.jointVelocity.getElementSize() );
+                memcpy(data, last.jointVelocity.data(), last.jointVelocity.size() * last.jointVelocity.getElementSize() );
             break;
 
             case VOCAB_ENCODER_ACCELERATIONS:
                 ret = last.jointAcceleration_isValid;
-                memcpy(data, last.jointAcceleration.getFirst(), last.jointAcceleration.size() * last.jointAcceleration.getElementSize() );
+                memcpy(data, last.jointAcceleration.data(), last.jointAcceleration.size() * last.jointAcceleration.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODERS:
                 ret = last.motorPosition_isValid;
-                memcpy(data, last.motorPosition.getFirst(), last.motorPosition.size() * last.motorPosition.getElementSize() );
+                memcpy(data, last.motorPosition.data(), last.motorPosition.size() * last.motorPosition.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODER_SPEEDS:
                 ret = last.motorVelocity_isValid;
-                memcpy(data, last.motorVelocity.getFirst(), last.motorVelocity.size() * last.motorVelocity.getElementSize() );
+                memcpy(data, last.motorVelocity.data(), last.motorVelocity.size() * last.motorVelocity.getElementSize() );
             break;
 
             case VOCAB_MOTOR_ENCODER_ACCELERATIONS:
                 ret = last.motorAcceleration_isValid;
-                memcpy(data, last.motorAcceleration.getFirst(), last.motorAcceleration.size() * last.motorAcceleration.getElementSize() );
+                memcpy(data, last.motorAcceleration.data(), last.motorAcceleration.size() * last.motorAcceleration.getElementSize() );
             break;
 
             case VOCAB_TRQS:
                 ret = last.torque_isValid;
-                memcpy(data, last.torque.getFirst(), last.torque.size() * last.torque.getElementSize() );
+                memcpy(data, last.torque.data(), last.torque.size() * last.torque.getElementSize() );
             break;
 
             case VOCAB_PWMCONTROL_PWM_OUTPUTS:
                 ret = last.pwmDutycycle_isValid;
-                memcpy(data, last.pwmDutycycle.getFirst(), last.pwmDutycycle.size() * last.pwmDutycycle.getElementSize());
+                memcpy(data, last.pwmDutycycle.data(), last.pwmDutycycle.size() * last.pwmDutycycle.getElementSize());
             break;
 
             case VOCAB_AMP_CURRENTS:
                 ret = last.current_isValid;
-                memcpy(data, last.current.getFirst(), last.current.size() * last.current.getElementSize());
+                memcpy(data, last.current.data(), last.current.size() * last.current.getElementSize());
                 break;
 
             default:
@@ -262,12 +262,12 @@ bool StateExtendedInputPort::getLastVector(int field, int* data, Stamp& stamp, d
         {
             case VOCAB_CM_CONTROL_MODES:
                 ret = last.controlMode_isValid;
-                memcpy(data, last.controlMode.getFirst(), last.controlMode.size() * last.controlMode.getElementSize());
+                memcpy(data, last.controlMode.data(), last.controlMode.size() * last.controlMode.getElementSize());
             break;
 
             case VOCAB_INTERACTION_MODES:
                 ret = last.interactionMode_isValid;
-                memcpy(data, last.interactionMode.getFirst(), last.interactionMode.size() * last.interactionMode.getElementSize());
+                memcpy(data, last.interactionMode.data(), last.interactionMode.size() * last.interactionMode.getElementSize());
             break;
 
             default:

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -12,8 +12,10 @@
 
 #include <cstring>
 #include <cstddef> //defines size_t
-#include <yarp/os/Portable.h>
+#include <memory>
 #include <string>
+
+#include <yarp/os/Portable.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/Type.h>
 
@@ -141,6 +143,18 @@ public:
     VectorOf(size_t size) : bytes(size*sizeof(T)) {
         bytes.setUsed(size*sizeof(T));
         _updatePointers();
+    }
+
+    /**
+     * @brief Initializer list constructor.
+     * @param[in] values, list of values with which initialize the Vector.
+     */
+    VectorOf(std::initializer_list<T> values) : bytes(values.size()*sizeof(T))
+    {
+        bytes.setUsed(values.size()*sizeof(T));
+        len = values.size();
+        _updatePointers();
+        std::uninitialized_copy(values.begin(), values.end(), first);
     }
 
     /**

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -133,6 +133,9 @@ private:
     }
 
 public:
+    typedef T* iterator;
+    typedef const T* const_iterator;
+
     VectorOf() {
         bytes.allocate(16*sizeof(T)); // preallocate space for 16 elements
         bytes.setUsed(0);
@@ -482,6 +485,37 @@ public:
 
     }
 
+    /**
+     * @brief Returns an iterator to the beginning of the VectorOf
+     * @note At the moment iterator is implemented as a pointer, it may change in the future.
+     * For this reason it should not be used as a pointer to the data, use data() instead.
+     */
+    iterator begin() noexcept {
+        return first;
+    }
+
+    /**
+     * @brief Returns an iterator to the end of the VectorOf
+     */
+    iterator end() noexcept {
+        return first + len;
+    }
+
+    /**
+     * @brief Returns a const iterator to the beginning of the VectorOf
+     * @note At the moment iterator is implemented as a pointer, it may change in the future.
+     * For this reason it should not be used as a pointer to the data, use data() instead.
+     */
+    const_iterator cbegin() const noexcept {
+        return first;
+    }
+
+    /**
+     * @brief Returns a const iterator to the end of the VectorOf.
+     */
+    const_iterator cend() const noexcept {
+        return first + len;
+    }
     void clear() {
         bytes.clear();
         bytes.setUsed(0);

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -309,7 +309,8 @@ public:
         bytes.allocateOnNeed(bytes.used()+sizeof(T),bytes.length()*2+sizeof(T));
         bytes.setUsed(bytes.used()+sizeof(T));
         _updatePointers();
-        first[len-1] = elem;
+        new (&((*this)[len-1])) T(elem); // non-allocating placement operator new
+    }
 
     /**
      * @brief Move a new element in the vector: size is changed

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -310,6 +310,29 @@ public:
         bytes.setUsed(bytes.used()+sizeof(T));
         _updatePointers();
         first[len-1] = elem;
+
+    /**
+     * @brief Move a new element in the vector: size is changed
+     * @param elem, element to be moved.
+     */
+    inline void push_back (T&& elem)
+    {
+        this->emplace_back(std::move(elem));
+    }
+
+    /**
+     * @brief Construct a new element in the vector: size is changed
+     * @param args, arguments to be forwarded for constructing the new element.
+     * @return the reference to the new element contructed.
+     */
+    template<typename... _Args>
+    inline T& emplace_back(_Args&&... args)
+    {
+        bytes.allocateOnNeed(bytes.used()+sizeof(T),bytes.length()*2+sizeof(T));
+        bytes.setUsed(bytes.used()+sizeof(T));
+        _updatePointers();
+        new (&((*this)[len-1])) T(std::forward<_Args>(args)...); // non-allocating placement operator new
+        return (*this)[len-1];
     }
 
     /**

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -292,6 +292,16 @@ public:
     }
 
     /**
+     * @brief reserve, increase the capacity of the vector to a value that's greater or equal to size.
+     * If size is greater than the current capacity(), new storage is allocated, otherwise the method does nothing.
+     * @param size, new size of the vector.
+     */
+    void reserve(size_t size) {
+        bytes.allocateOnNeed(size*sizeof(T),size*sizeof(T));
+        _updatePointers();
+    }
+
+    /**
     * Push a new element in the vector: size is changed
     */
     inline void push_back (const T &elem)
@@ -364,6 +374,14 @@ public:
     */
     inline size_t length() const
     { return this->size();}
+
+    /**
+     * @brief capacity
+     * @return the number of elements that the container has currently allocated space for.
+     */
+    inline size_t capacity() const {
+        return bytes.length()/sizeof(T);
+    }
 
     /**
     * Zero the elements of the vector.

--- a/src/libYARP_sig/include/yarp/sig/Vector.h
+++ b/src/libYARP_sig/include/yarp/sig/Vector.h
@@ -230,16 +230,21 @@ public:
     {
         return bytes.get();
     }
-
+#ifndef YARP_NO_DEPRECATED // since YARP 3.2.0
+    YARP_DEPRECATED_MSG("Use either data() if you need the pointer to the first element,"
+                        " or cbegin() if you need the iterator")
     inline const T *getFirst() const
     {
         return first;
     }
 
+    YARP_DEPRECATED_MSG("Use either data() if you need the pointer to the first element,"
+                        " or begin() if you need the iterator")
     inline T *getFirst()
     {
         return first;
     }
+#endif // YARP_NO_DEPRECATED
 
     /**
     * Return a pointer to the first element of the vector.

--- a/tests/libYARP_sig/VectorOfTest.cpp
+++ b/tests/libYARP_sig/VectorOfTest.cpp
@@ -161,12 +161,22 @@ public:
 
     }
 
+    void checkInitializerListConctor() {
+        report(0,"Checking the functionalities of the initializer list constructor");
+        VectorOf<int> v{1, 2, 3};
+        checkTrue(v.size() == (size_t) 3, "Checking size");
+
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v[1] == 2, "Checking data consistency");
+        checkTrue(v[2] == 3, "Checking data consistency");
+    }
 
 
     virtual void runTests() override {
         Network::setLocalMode(true);
         checkSendReceiveInt();
         testToString();
+        checkInitializerListConctor();
         Network::setLocalMode(false);
     }
 };

--- a/tests/libYARP_sig/VectorOfTest.cpp
+++ b/tests/libYARP_sig/VectorOfTest.cpp
@@ -171,12 +171,30 @@ public:
         checkTrue(v[2] == 3, "Checking data consistency");
     }
 
+    void checkRangeFor() {
+        report(0,"Checking the the for range based");
+        VectorOf<int> v{0,1,2,3,4};
+        int i = 0;
+        for(const auto& el:v) {
+            checkTrue(el==i,"Checking data consistency");
+            i++;
+        }
+        report(0,"Checking the std::transform");
+        std::transform(v.begin(), v.end(), v.begin(), [](int i) { return i*2; });
+        checkTrue(v[0] == 0, "Checking data consistency");
+        checkTrue(v[1] == 2, "Checking data consistency");
+        checkTrue(v[2] == 4, "Checking data consistency");
+        checkTrue(v[3] == 6, "Checking data consistency");
+        checkTrue(v[4] == 8, "Checking data consistency");
+    }
+
 
     virtual void runTests() override {
         Network::setLocalMode(true);
         checkSendReceiveInt();
         testToString();
         checkInitializerListConctor();
+        checkRangeFor();
         Network::setLocalMode(false);
     }
 };

--- a/tests/libYARP_sig/VectorOfTest.cpp
+++ b/tests/libYARP_sig/VectorOfTest.cpp
@@ -15,6 +15,7 @@
 #include <yarp/sig/Vector.h>
 
 //#include <vector>
+#include <algorithm>
 
 #include <yarp/gsl/impl/gsl_structs.h>
 
@@ -188,6 +189,34 @@ public:
         checkTrue(v[4] == 8, "Checking data consistency");
     }
 
+    void checkReserve() {
+        report(0,"Checking reserve()");
+        VectorOf<int> v(0);
+        checkTrue(v.size() == (size_t) 0, "Checking size() after constructor");
+        checkTrue(v.capacity() == (size_t) 0, "Checking memory allocated after constructor");
+        v.push_back(1);
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v.size() == (size_t) 1, "Checking size() after push_back");
+        checkTrue(v.capacity() == (size_t) 1, "Checking capacity() after push_back");
+        v.reserve(10);
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v.size() == (size_t) 1, "The memory has been allocated but the vector is empty");
+        checkTrue(v.capacity() == (size_t) 10, "Checking memory allocated");
+        v.push_back(2);
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v[1] == 2, "Checking data consistency");
+        checkTrue(v.size() == (size_t) 2, "Checking size() after push_back");
+        checkTrue(v.capacity() == (size_t) 10, "Checking capacity() after push_back");
+        v.resize(11);
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v[1] == 2, "Checking data consistency");
+        checkTrue(v.size() == (size_t) 11, "Checking size() after resize()");
+        checkTrue(v.capacity() == (size_t) 11, "Checking size() after resize()");
+        v.resize(1);
+        checkTrue(v[0] == 1, "Checking data consistency");
+        checkTrue(v.size() == (size_t) 1, "Checking size() after push_back");
+        checkTrue(v.capacity() == (size_t) 11, "Checking capacity() after push_back");
+    }
 
     virtual void runTests() override {
         Network::setLocalMode(true);
@@ -195,6 +224,7 @@ public:
         testToString();
         checkInitializerListConctor();
         checkRangeFor();
+        checkReserve();
         Network::setLocalMode(false);
     }
 };

--- a/tests/libYARP_sig/VectorTest.cpp
+++ b/tests/libYARP_sig/VectorTest.cpp
@@ -350,6 +350,16 @@ public:
         checkTrue(v.data()!=nullptr, "size 2 => non-null data()");
     }
 
+    void checkInitializerListConctor() {
+        report(0,"Checking the functionalities of the initializer list constructor");
+        Vector v{1.0, 2.0, 3.0};
+        checkTrue(v.size() == (size_t) 3, "Checking size");
+
+        checkTrue(v[0] == 1.0, "Checking data consistency");
+        checkTrue(v[1] == 2.0, "Checking data consistency");
+        checkTrue(v[2] == 3.0, "Checking data consistency");
+    }
+
     virtual void runTests() override {
         Network::setLocalMode(true);
         checkFormat();
@@ -360,6 +370,7 @@ public:
         checkGsl();
         checkResize();
         checkEmpty();
+        checkInitializerListConctor();
         Network::setLocalMode(false);
     }
 };

--- a/tests/libYARP_sig/VectorTest.cpp
+++ b/tests/libYARP_sig/VectorTest.cpp
@@ -15,6 +15,7 @@
 #include <yarp/os/Time.h>
 
 //#include <vector>
+#include <algorithm>
 
 #include <yarp/gsl/Gsl.h>
 #include <yarp/gsl/impl/gsl_structs.h>
@@ -360,6 +361,24 @@ public:
         checkTrue(v[2] == 3.0, "Checking data consistency");
     }
 
+    void checkRangeFor() {
+        report(0,"Checking the the for range based");
+        Vector v{0.0, 1.0, 2.0, 3.0, 4.0};
+        double i = 0.0;
+        for(const auto& el:v) {
+            checkTrue(el==i,"Checking data consistency");
+            i+=1.0;
+        }
+
+        report(0,"Checking the std::transform");
+        std::transform(v.begin(), v.end(), v.begin(), [](double d) { return d*2; });
+        checkTrue(v[0] == 0.0, "Checking data consistency");
+        checkTrue(v[1] == 2.0, "Checking data consistency");
+        checkTrue(v[2] == 4.0, "Checking data consistency");
+        checkTrue(v[3] == 6.0, "Checking data consistency");
+        checkTrue(v[4] == 8.0, "Checking data consistency");
+    }
+
     virtual void runTests() override {
         Network::setLocalMode(true);
         checkFormat();
@@ -371,6 +390,7 @@ public:
         checkResize();
         checkEmpty();
         checkInitializerListConctor();
+        checkRangeFor();
         Network::setLocalMode(false);
     }
 };


### PR DESCRIPTION
This PR modernize *our* Vector.

It adds:
1. constructor with `initializer_list`: `Vector {1.0, 2.0, 3.0}`
2.  `reserve()` and `capacity()`
3. `push_back(&&)`
4. `emplace_back(_Args ..)`
5. `begin()`, `cbegin()`, `end()`, `cend()`
6. deprecate `getFirst()` in favour of begin() or data().

now begin() and data() are the same because the `VectorOf::iterator` is an alias of `T*`, but one day we could implement a proper `iterator` and they will diverge.

Implementing `begin()` and `end()` allow to use the yarp vector in the stl algorithm and use for range based (`for(auto el : v)`)

It fixes #1898
It fixes #1899 

Relatives tests have been added
Please review code
