### PR TITLE
Remove directory separator substitution in the <package>.ini plugin manifest

### DIFF
--- a/cmake/YarpInstallationHelpers.cmake
+++ b/cmake/YarpInstallationHelpers.cmake
@@ -89,14 +89,8 @@ type \"@_type@\"
 
   set(_path "${CMAKE_BINARY_DIR}/${${YCPI_INSTALL_VARS_PREFIX}_DYNAMIC_PLUGINS_INSTALL_DIR}") # (build tree)
   configure_file("${_in_file}" "${_build_file}" @ONLY)
-  if(WIN32)
-    string(REPLACE "/" "\\" _path ${_path})
-  endif()
 
   set(_path "${CMAKE_INSTALL_PREFIX}/${${YCPI_INSTALL_VARS_PREFIX}_DYNAMIC_PLUGINS_INSTALL_DIR}") # (install tree)
-  if(WIN32)
-    string(REPLACE "/" "\\" _path ${_path})
-  endif()
   configure_file("${_in_file}" "${_install_file}" @ONLY)
   install(FILES "${_install_file}"
           RENAME ${_package}.ini


### PR DESCRIPTION
Partial revert of  https://github.com/robotology/yarp/pull/1841, fix https://github.com/robotology/yarp/issues/1866 .

The issue was tricky to spot, because even if the directory separator substitution was added for both the build and install manifest, it was not actually affecting the build manifest as it was done **after** the line `configure_file("${_in_file}" "${_build_file}" @ONLY).

It is still necessary to investigate why `path.d` manifests and plugin libraries manifest need different directory separators (the actual root behind https://github.com/robotology/yarp/pull/1841). I think this is probably related to how this two files are  **consumed**, rather than how they are **generated** but I think this can be done after we actually fix the serious bug https://github.com/robotology/yarp/issues/1866 .
