### PR TITLE
Add HierachicalMutex

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -17,6 +17,7 @@ New Features
     * `ConnectionReader::expectText()`
     * `ConnectionWriter::appendString()`
     * `InputStream::readLine()`
+* Add `HierarchicalMutex` class.
 
 #### `YARP_dev`
 

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -33,6 +33,7 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Election.h
                  include/yarp/os/Event.h
                  include/yarp/os/Face.h
+                 include/yarp/os/HierarchicalMutex.h
                  include/yarp/os/IConfig.h
                  include/yarp/os/InputProtocol.h
                  include/yarp/os/InputStream.h
@@ -234,6 +235,7 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/FakeFace.cpp
                  src/FallbackNameClient.cpp
                  src/FallbackNameServer.cpp
+                 src/HierarchicalMutex.cpp
                  src/HttpCarrier.cpp
                  src/IConfig.cpp
                  src/InputStream.cpp

--- a/src/libYARP_OS/include/yarp/os/HierarchicalMutex.h
+++ b/src/libYARP_OS/include/yarp/os/HierarchicalMutex.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_OS_HIERARCHICALMUTEX_H
+#define YARP_OS_HIERARCHICALMUTEX_H
+
+#include <yarp/os/api.h>
+#include <mutex>
+
+namespace yarp {
+namespace os {
+
+/**
+ * @brief The HierarchicalMutex class, implementation taken from
+ * C++ Concurrency in Action of Antony Williams
+ * (see https://www.manning.com/books/c-plus-plus-concurrency-in-action).
+ * It defines a hierarchy among mutexes in order to enforce the lock of
+ * mutexes from the higher value of the lowest value of hierarchy.
+ */
+class YARP_OS_API HierarchicalMutex
+{
+public:
+    /**
+     * @brief Constructor
+     * @param hierarchy value.
+     */
+    explicit HierarchicalMutex(unsigned long value);
+
+    /**
+     * Destructor.
+     */
+    ~HierarchicalMutex();
+
+    /**
+     * Lock the associated resource, waiting if necessary.
+     * Behavior is undefined if called by the thread currently locking
+     * the resource.
+     * Throws a logic_error exception if the decreasing order of locking is violated.
+     */
+    void lock();
+
+    /**
+     * Lock the associated resource if possible.  Don't wait.
+     * Behavior is undefined if called by the thread currently locking
+     * the resource.
+     * Throws a logic_error exception if the decreasing order of locking is violated.
+     * @return true if the associated resource was successfully locked.
+     */
+    bool try_lock();
+
+    /**
+     * Unlock the associated resource.
+     * If the resource is not currently locked by the calling thread,
+     * the behavior is undefined.
+     */
+    void unlock();
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+private:
+    class Private;
+    Private* mPriv;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+};
+
+} // namespace os
+} // namespace yarp
+
+#endif // YARP_OS_HIERARCHICALMUTEX_H

--- a/src/libYARP_OS/src/HierarchicalMutex.cpp
+++ b/src/libYARP_OS/src/HierarchicalMutex.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/HierarchicalMutex.h>
+#include <climits>
+
+using yarp::os::HierarchicalMutex;
+
+class HierarchicalMutex::Private
+{
+    std::mutex internal_mutex;
+    unsigned long const hierarchy_value;
+    unsigned long previous_hierarchy_value;
+    static thread_local unsigned long this_thread_hierarchy_value;
+
+    void check_for_hierarchy_violation()
+    {
+        if(this_thread_hierarchy_value <= hierarchy_value)
+        {
+            throw std::logic_error("mutex hierarchy violated");
+        }
+    }
+    void update_hierarchy_value()
+    {
+        previous_hierarchy_value=this_thread_hierarchy_value;
+        this_thread_hierarchy_value=hierarchy_value;
+    }
+public:
+    explicit Private(unsigned long value):
+        hierarchy_value(value),
+        previous_hierarchy_value(0)
+    {}
+    void lock()
+    {
+        check_for_hierarchy_violation();
+        internal_mutex.lock();
+        update_hierarchy_value();
+    }
+    void unlock()
+    {
+        this_thread_hierarchy_value=previous_hierarchy_value;
+        internal_mutex.unlock();
+    }
+    bool try_lock()
+    {
+        check_for_hierarchy_violation();
+        if(!internal_mutex.try_lock())
+            return false;
+        update_hierarchy_value();
+        return true;
+    }
+};
+
+thread_local unsigned long
+    HierarchicalMutex::Private::this_thread_hierarchy_value(ULONG_MAX);
+
+HierarchicalMutex::HierarchicalMutex(unsigned long value) :
+        mPriv(new Private(value))
+{
+}
+
+HierarchicalMutex::~HierarchicalMutex()
+{
+    delete mPriv;
+}
+
+void HierarchicalMutex::lock()
+{
+    mPriv->lock();
+}
+
+bool HierarchicalMutex::try_lock()
+{
+    return mPriv->try_lock();
+}
+
+void HierarchicalMutex::unlock()
+{
+    mPriv->unlock();
+}


### PR DESCRIPTION
Implementation taken from [C++ Concurrency in Action of Antony Williams](https://www.manning.com/books/c-plus-plus-concurrency-in-action).
It defines a hierarchy among mutexes in order to enforce the lock of
mutexes from the higher value of the lowest value of hierarchy.

An exception is thrown if this order is violated.
It is a proposal, if you think it might be interesting to include in yarp we can merge it.