### PR TITLE
Fix imu bosh i2c

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -73,6 +73,7 @@ Bug Fixes
 #### `imuBosch_BNO055`
 
 * Fixed runtime linking issue.
+* Fixed shifted read from i2c.
 
 Contributors
 ------------

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -62,6 +62,7 @@ BoschIMU::BoschIMU() : PeriodicThread(0.02),
     i2c_flag(false),
     checkError(false),
     fd(0),
+    responseOffset(0),
     readFunc(&BoschIMU::sendReadCommandSer),
     totMessagesRead(0),
     errs(0)
@@ -97,6 +98,10 @@ bool BoschIMU::open(yarp::os::Searchable& config)
     i2c_flag = config.check("i2c");
 
     readFunc = i2c_flag ? &BoschIMU::sendReadCommandI2c : &BoschIMU::sendReadCommandSer;
+
+    // In case of reading through serial the first two bytes of the response are the ack, so
+    // they need to be discarded when publishing the data.
+    responseOffset = i2c_flag ? 0 : 2;
 
     if (i2c_flag)
     {
@@ -590,7 +595,7 @@ void BoschIMU::run()
         // Correctly construct int16 data
         for(int i=0; i<16; i++)
         {
-            raw_data[i] = response[3+ i*2] << 8 | response[2 +i*2];
+            raw_data[i] = response[responseOffset+1+i*2] << 8 | response[responseOffset+i*2];
         }
 
         // Get quaternion

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -165,6 +165,7 @@ protected:
     bool                        checkError;
 
     int                         fd;
+    size_t                      responseOffset;
     yarp::os::ResourceFinder    rf;
 
     using ReadFuncPtr = bool (BoschIMU::*)(unsigned char, int, unsigned char*, std::string);


### PR DESCRIPTION
Despite the serial, i2c does not put the ack in the first 2 bytes of the
response, so they are not to be discarded.

This device is not tested by CI

