### PR TITLE
small fix in RGBDSensorWrapper

### DIFF
--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -303,8 +303,8 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
         rosStringParam.emplace_back(rosFrameId,     frameId_param           );
         rosStringParam.emplace_back(colorTopicName, colorTopicName_param    );
         rosStringParam.emplace_back(depthTopicName, depthTopicName_param    );
-        rosStringParam.emplace_back(cInfoTopicName, depthInfoTopicName_param);
-        rosStringParam.emplace_back(dInfoTopicName, colorInfoTopicName_param);
+        rosStringParam.emplace_back(cInfoTopicName, colorInfoTopicName_param);
+        rosStringParam.emplace_back(dInfoTopicName, depthInfoTopicName_param);
 
         for (i = 0; i < rosStringParam.size(); i++)
         {

--- a/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/libYARP_dev/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -50,8 +50,8 @@ namespace yarp{
             const std::string nodeName_param           = "ROS_nodeName";
             const std::string colorTopicName_param     = "ROS_colorTopicName";
             const std::string depthTopicName_param     = "ROS_depthTopicName";
-            const std::string depthInfoTopicName_param = "ROS_colorInfoTopicName";
-            const std::string colorInfoTopicName_param = "ROS_depthInfoTopicName";
+            const std::string depthInfoTopicName_param = "ROS_depthInfoTopicName";
+            const std::string colorInfoTopicName_param = "ROS_colorInfoTopicName";
             class RGBDSensorParser;
         }
     }


### PR DESCRIPTION
swapped the init strings of color and depth parameters in order to maintain their meaning