### PR TITLE
Fixed annoying warnings caused by Image.h

### DIFF
--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -33,7 +33,7 @@ namespace yarp {
          * @param pad is the desired padding (e.g. 8 bytes)
          * @return the number of extra bytes to add at the end of the image row
          */
-        inline int PAD_BYTES (size_t len, size_t pad) {
+        inline size_t PAD_BYTES (size_t len, size_t pad) {
             const size_t rem = len % pad;
             return (rem != 0) ? (pad - rem) : rem;
         }


### PR DESCRIPTION
Since `Image.h` gets included within the user code, the type mismatch causes plenty of annoying warnings.

Don't know whether changing the returned type will cause other warnings in cascade though. If so, we could keep the returned type unchanged and then fix the line `38`.