### PR TITLE
Control board wrapper improvement

### DIFF
--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -286,11 +286,13 @@ private:
 
     bool checkPortName(yarp::os::Searchable &params);
 
+    yarp::rosmsg::sensor_msgs::JointState ros_struct;
 
     yarp::os::BufferedPort<yarp::sig::Vector>  outputPositionStatePort;   // Port /state:o streaming out the encoder positions
     yarp::os::BufferedPort<CommandMessage>     inputStreamingPort;        // Input streaming port for high frequency commands
     yarp::os::Port inputRPCPort;                // Input RPC port for set/get remote calls
     yarp::os::Stamp time;                       // envelope to attach to the state port
+    yarp::sig::Vector times;                    // time for each joint
     yarp::os::Mutex timeMutex;
 
     // Buffer associated to the extendedOutputStatePort port; in this case we will use the type generated

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/SubDevice.h
@@ -117,26 +117,6 @@ public:
 
     bool configure(int wbase, int wtop, int base, int top, int axes, const std::string &id, yarp::dev::ControlBoardWrapper *_parent);
 
-    inline void refreshJointEncoders()
-    {
-        for(int j=base, idx=0; j<(base+axes); j++, idx++)
-        {
-            if(iJntEnc)
-                iJntEnc->getEncoderTimed(j, &subDev_joint_encoders[idx], &jointEncodersTimes[idx]);
-        }
-    }
-
-    inline void refreshMotorEncoders()
-    {
-        for(int j=base, idx=0; j<(base+axes); j++, idx++)
-        {
-            if(iMotEnc)
-                iMotEnc->getMotorEncoderTimed(j, &subDev_motor_encoders[idx], &motorEncodersTimes[idx]);
-        }
-    }
-
-
-
     bool isAttached()
     { return attachedF; }
 

--- a/src/libYARP_dev/src/devices/TestMotor/TestMotor.h
+++ b/src/libYARP_dev/src/devices/TestMotor/TestMotor.h
@@ -329,9 +329,11 @@ public:
 
     bool getEncodersTimed(double *encs, double *time) override
     {
-        bool ret = getEncoders(encs);
-        *time = yarp::os::Time::now();
-        return ret;
+        for (int i=0; i<njoints; i++)
+        {
+            getEncoderTimed(i, &encs[i], &time[i]);
+        }
+        return true;
     }
 
     bool getEncoderSpeed(int j, double *sp) override {


### PR DESCRIPTION
TESTED ON ROBOT

This PR changes how the ControlBoardWrapper refreshes the data from the HW and send them via the output ports state:o and stateExt:o.

This is due to a corner case found, where the position data on the 2 ports were different.
Previous implementation was calling `getEncoders` for one port and `getEncodersTimed` for the other one.
In the low-level device one function was implemented and the other one was not.

Although it is legal for the wrapper to do so (and the bug is actually on the low-level device), it is quite a counter-intuitive and misleading behaviour for the wrapper, and it is better to have a more uniform one.
Since the wrapper during the attach phase enforces the requirement of the `IEncoderTimed` interface only, this is the only one used now.

Furthermore, in the old implemetnation, the `getEncoderXXX` was called up to three times for each run:
- once for state:o
- once for stateExt:o
- once for ROS topic

This was due to the fact that the ports are optional, at runtime the wrapper can be configured to use either YARP port or ROS topic only or both.

Proposed implementation calls getEncoder only once, then the results are stored and sent via ports in the optimal way. This can led to a performance improvement.







