### PR TITLE
Add opencv compatibility library

### DIFF
--- a/cmake/template/Doxyfile.in
+++ b/cmake/template/Doxyfile.in
@@ -171,6 +171,8 @@ STRIP_FROM_INC_PATH    = @CMAKE_BINARY_DIR@/src/libYARP_conf/include \
                          @CMAKE_SOURCE_DIR@/src/libYARP_name/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_gsl/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_eigen/include/ \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_pcl/include/ \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_cv/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_rosmsg/idl_generated_code/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_run/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_rtf/include/ \
@@ -812,6 +814,8 @@ INPUT                  = @CMAKE_BINARY_DIR@/src/libYARP_conf/include \
                          @CMAKE_SOURCE_DIR@/src/libYARP_gsl/include \
                          @CMAKE_SOURCE_DIR@/src/libYARP_gsl/src \
                          @CMAKE_SOURCE_DIR@/src/libYARP_eigen/include \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_pcl/include/ \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_cv/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_rosmsg/idl_generated_code/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_run/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_run/src/ \
@@ -2083,6 +2087,8 @@ INCLUDE_PATH           = @CMAKE_BINARY_DIR@/src/libYARP_conf/include \
                          @CMAKE_SOURCE_DIR@/src/libYARP_name/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_gsl/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_eigen/include/ \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_pcl/include/ \
+                         @CMAKE_SOURCE_DIR@/src/libYARP_cv/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_rosmsg/idl_generated_code/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_run/include/ \
                          @CMAKE_SOURCE_DIR@/src/libYARP_rtf/include/ \

--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -72,6 +72,12 @@ New Features
 * Added two methods for computing a `yarp::sig::PointCloud` from depth images:
   - `utils::depthToPC`
   - `utils::depthRgbToPC`
+* Deprecated `getIplImage` and `wrapIplImage` in favour of the new utilities of
+  `YARP_cv`.
+
+#### `YARP_cv`
+
+* Added `YARP_cv`, a conversion library from YARP images to cv::Mat and viceversa.
 
 ### Devices
 * Added `fakeBattery` device

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(libYARP_math)
 add_subdirectory(libYARP_rosmsg)
 add_subdirectory(libYARP_dev)
 add_subdirectory(libYARP_pcl)
+add_subdirectory(libYARP_cv)
 
 # private libraries
 add_subdirectory(libYARP_companion)

--- a/src/libYARP_cv/CMakeLists.txt
+++ b/src/libYARP_cv/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+project(YARP_cv)
+
+set(YARP_cv_HDRS include/yarp/cv/Cv.h
+                 include/yarp/cv/Cv-inl.h)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+             PREFIX "Header Files"
+             FILES ${YARP_cv_HDRS})
+
+add_library(YARP_cv INTERFACE)
+add_library(YARP::YARP_cv ALIAS YARP_cv)
+
+target_include_directories(YARP_cv INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_link_libraries(YARP_cv INTERFACE YARP::YARP_sig)
+list(APPEND YARP_cv_PUBLIC_DEPS YARP_sig)
+
+target_include_directories(YARP_cv SYSTEM INTERFACE ${OPENCV_INCLUDE_DIR})
+target_link_libraries(YARP_cv INTERFACE ${OPENCV_INCLUDE_DIR})
+list(APPEND YARP_cv_PUBLIC_DEPS OpenCV)
+
+
+install(TARGETS YARP_cv
+        EXPORT YARP_cv
+        COMPONENT YARP_cv
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/yarp/cv)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/yarp/cv
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/yarp)
+
+include(YarpInstallBasicPackageFiles)
+yarp_install_basic_package_files(YARP_cv
+                                 DEPENDENCIES ${YARP_cv_PUBLIC_DEPS}
+                                 PRIVATE_DEPENDENCIES ${YARP_cv_PRIVATE_DEPS})

--- a/src/libYARP_cv/include/yarp/cv/Cv-inl.h
+++ b/src/libYARP_cv/include/yarp/cv/Cv-inl.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_CV_CV_INL_H
+#define YARP_CV_CV_INL_H
+
+#include<cassert>
+
+namespace yarp {
+namespace cv {
+
+template <typename T>
+struct type_code;
+
+template<> struct type_code<yarp::sig::PixelMono> : std::integral_constant<int, CV_8UC1> {};
+template<> struct type_code<yarp::sig::PixelMono16> : std::integral_constant<int, CV_16UC1> {};
+template<> struct type_code<yarp::sig::PixelMonoSigned> : std::integral_constant<int, CV_8SC1> {};
+template<> struct type_code<yarp::sig::PixelFloat> : std::integral_constant<int, CV_32FC1> {};
+template<> struct type_code<yarp::sig::PixelInt> : std::integral_constant<int, CV_32SC1> {};
+template<> struct type_code<yarp::sig::PixelBgr> : std::integral_constant<int, CV_8UC3> {};
+template<> struct type_code<yarp::sig::PixelRgb> : std::integral_constant<int, CV_8UC3> {};
+template<> struct type_code<yarp::sig::PixelRgbSigned> : std::integral_constant<int, CV_8SC3> {};
+template<> struct type_code<yarp::sig::PixelRgbFloat> : std::integral_constant<int, CV_32FC3> {};
+template<> struct type_code<yarp::sig::PixelRgbInt> : std::integral_constant<int, CV_32SC3> {};
+template<> struct type_code<yarp::sig::PixelHsv> : std::integral_constant<int, CV_8UC3> {};
+template<> struct type_code<yarp::sig::PixelHsvFloat> : std::integral_constant<int, CV_32FC3> {};
+template<> struct type_code<yarp::sig::PixelRgba> : std::integral_constant<int, CV_8UC4> {};
+template<> struct type_code<yarp::sig::PixelBgra> : std::integral_constant<int, CV_8UC4> {};
+
+// -1 : no conversion required.
+template <typename T>
+struct convert_code_to_cv;
+
+template<> struct convert_code_to_cv<yarp::sig::PixelMono> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelMono16> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelMonoSigned> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelFloat> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelInt> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelBgr> : std::integral_constant<int, -1> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelRgb> : std::integral_constant<int, CV_RGB2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelRgbSigned> : std::integral_constant<int, CV_RGB2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelRgbFloat> : std::integral_constant<int, CV_RGB2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelRgbInt> : std::integral_constant<int, CV_RGB2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelHsv> : std::integral_constant<int, CV_HSV2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelHsvFloat> : std::integral_constant<int, CV_HSV2BGR> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelRgba> : std::integral_constant<int, CV_RGBA2BGRA> {};
+template<> struct convert_code_to_cv<yarp::sig::PixelBgra> : std::integral_constant<int, -1> {};
+
+template <typename T>
+struct convert_code_from_cv;
+
+template<> struct convert_code_from_cv<yarp::sig::PixelMono> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelMono16> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelMonoSigned> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelFloat> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelInt> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelBgr> : std::integral_constant<int, -1> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelRgb> : std::integral_constant<int, CV_BGR2RGB> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelRgbSigned> : std::integral_constant<int, CV_BGR2RGB> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelRgbFloat> : std::integral_constant<int, CV_BGR2RGB> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelRgbInt> : std::integral_constant<int, CV_BGR2RGB> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelHsv> : std::integral_constant<int, CV_BGR2HSV> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelHsvFloat> : std::integral_constant<int, CV_BGR2HSV> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelRgba> : std::integral_constant<int, CV_BGRA2RGBA> {};
+template<> struct convert_code_from_cv<yarp::sig::PixelBgra> : std::integral_constant<int, -1> {};
+
+
+} // namespace cv
+} // namespace yarp
+
+
+template<typename T>
+::cv::Mat yarp::cv::toCvMat(yarp::sig::ImageOf<T>& yarpImage)
+{
+    ::cv::Mat outMat (yarpImage.height(), yarpImage.width(), yarp::cv::type_code<T>::value,
+                      yarpImage.getRawImage(), yarpImage.getRowSize()); // RVO
+    if (convert_code_to_cv<T>::value >= 0)
+    {
+        ::cv::cvtColor(outMat, outMat, convert_code_to_cv<T>::value);
+    }
+    return outMat;
+}
+
+
+template<typename T>
+yarp::sig::ImageOf<T> yarp::cv::fromCvMat(::cv::Mat& cvImage)
+{
+    yarp::sig::ImageOf<T> outImg;
+    assert(yarp::cv::type_code<T>::value == cvImage.type()); // Checking cv::Mat::type() compatibility with the T PixelType
+    if (convert_code_from_cv<T>::value >= 0)
+    {
+        ::cv::cvtColor(cvImage, cvImage, convert_code_from_cv<T>::value);
+    }
+    outImg.setExternal(cvImage.data, cvImage.cols, cvImage.rows);
+    return outImg;
+}
+
+#endif // YARP_CV_CV_INL_H

--- a/src/libYARP_cv/include/yarp/cv/Cv.h
+++ b/src/libYARP_cv/include/yarp/cv/Cv.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_CV_CV_H
+#define YARP_CV_CV_H
+
+#include <yarp/sig/Image.h>
+
+#include <type_traits>
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+namespace yarp {
+namespace cv {
+
+/**
+ * Convert a yarp::sig::ImageOf to a cv::Mat object
+ * @param[in] yarpImage yarp::sig::ImageOf input.
+ * Since the argument is passed as right-reference, the integrity
+ * of the data of the input yarp image is not guaranteed.
+ * @note The output cv::Mat has the default OpenCV color representation:
+ * - 1 channel: GRAY
+ * - 3 channels: BGR
+ * - 4 channel: BGRA
+ * Moreover pay attention on the lifetime of the memory of the input image,
+ * since no copy is involved.
+ * @return the resulting cv::Mat.
+ */
+template<typename T>
+::cv::Mat toCvMat(yarp::sig::ImageOf<T>& yarpImage);
+
+/**
+ * Convert a cv::Mat to a yarp::sig::ImageOf object.
+ * @param[in] cvImage cv::Mat input.
+ * Since the argument is passed as right-reference, the integrity
+ * of the data of the input cv::Mat is not guaranteed.
+ * @note The input cv::Mat's type(e.g. CV_8UC1) must be compatible
+ * with the output yarp image pixel type requested.
+ * E.g.:
+ * - CV_8UC3 -> ImageOf<PixelRgb>/<PixelBgr>/<PixelHsv> OK
+ * - CV_8UC1 -> ImageOf<PixelMono> OK
+ * - CV_8UC3 -> ImageOf<PixelMono> NOT OK
+ * - CV_8UC1 -> ImageOf<PixelRgb>/<PixelBgr>/<PixelHsv> NOT OK
+ * Please pay attention to the number of channels and pixel depth.
+ * Moreover pay attention on the lifetime of the memory of the input image,
+ * since no copy is involved.
+ * @return the resulting yarp::sig::ImageOf.
+ */
+template<typename T>
+yarp::sig::ImageOf<T> fromCvMat(::cv::Mat& cvImage);
+
+} // namespace cv
+} // namespace yarp
+
+#include "Cv-inl.h"
+
+#endif // YARP_CV_CV_H

--- a/src/libYARP_pcl/CMakeLists.txt
+++ b/src/libYARP_pcl/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(YARP::YARP_pcl ALIAS YARP_pcl)
 target_include_directories(YARP_pcl INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_link_libraries(YARP_pcl INTERFACE YARP_sig)
+target_link_libraries(YARP_pcl INTERFACE YARP::YARP_sig)
 list(APPEND YARP_pcl_PUBLIC_DEPS YARP_sig)
 
 target_include_directories(YARP_pcl SYSTEM INTERFACE ${PCL_INCLUDE_DIR})

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -267,12 +267,14 @@ public:
     */
     size_t getRawImageSize() const;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2.0
     /**
      * Returns IPL/OpenCV view of image, if possible.
      * Not possible if the image is the wrong size, with no padding.
      * This method is currently not well documented.
      * @return pointer to an IplImage structure or nullptr
      */
+    YARP_DEPRECATED_MSG("Use yarp::cv::toCvMat instead")
     void *getIplImage();
 
     /**
@@ -281,6 +283,7 @@ public:
      * This method is currently not well documented.
      * @return pointer to an IplImage structure or nullptr
      */
+    YARP_DEPRECATED_MSG("Use yarp::cv::toCvMat instead")
     const void *getIplImage() const;
 
     /**
@@ -294,7 +297,9 @@ public:
      *
      * @param iplImage pointer to an IplImage structure
      */
+    YARP_DEPRECATED_MSG("Use yarp::cv::fromCvMat instead")
     void wrapIplImage(void *iplImage);
+#endif // YARP_NO_DEPRECATED
 
     //void wrapRawImage(void *buf, int imgWidth, int imgHeight);
 

--- a/src/libYARP_sig/src/Image.cpp
+++ b/src/libYARP_sig/src/Image.cpp
@@ -542,6 +542,7 @@ size_t Image::getRawImageSize() const {
     return 0;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2.0
 void *Image::getIplImage() {
     return ((ImageStorage*)implementation)->pImage;
 }
@@ -651,6 +652,7 @@ void Image::wrapIplImage(void *iplImage) {
     }
 }
 
+#endif // YARP_NO_DEPRECATED
 
 
 bool Image::read(yarp::os::ConnectionReader& connection) {

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -130,7 +130,7 @@ public:
         return (fName.str()+" ["+Vocab::decode(code)+"]");
     }
 
-    void *getPtr() override { return p->getIplImage(); }
+    void *getPtr() override { return p->getRawImage(); }
 };
 
 

--- a/src/yarpdataplayer/CMakeLists.txt
+++ b/src/yarpdataplayer/CMakeLists.txt
@@ -94,7 +94,7 @@ if(CREATE_YARPDATAPLAYER)
                                        Qt5::Widgets)
 
   if(YARP_HAS_OPENCV)
-    target_link_libraries(yarpdataplayer ${OpenCV_LIBRARIES})
+    target_link_libraries(yarpdataplayer ${OpenCV_LIBRARIES} YARP_cv)
   endif()
 
   install(TARGETS yarpdataplayer COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/yarpdataplayer/include/worker.h
+++ b/src/yarpdataplayer/include/worker.h
@@ -32,8 +32,9 @@
 #include <QMainWindow>
 
 #ifdef HAS_OPENCV
-  #include <cv.h>
-  #include <highgui.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <yarp/cv/Cv.h>
 #endif
 
 


### PR DESCRIPTION
In late 2018 we have finally a easy way that allow to get a `cv::Mat` from a `yarp::sig::ImageOf` :tada: 

Since there is no way to retrieve the Pixel code from the `cv::Mat` and the default coding is BGR, this library assumes that when converting to yarp image, the cv::Mat has to be BGR, and the cv::Mat obtained from the reversed conversion is BGR.

Converting from OpenCV to Yarp no copies are involved.
In the other direction is quite tricky to understand when OpenCV performs a copy and when not :confused: 

@drdanz and me found a sort of rule behind their choice to copy or not, but maybe it is not important.
The argument of `toCvMat()` is a `&&` a.k.a a right-reference, this means that after this function call the integrity of the data of the input yarp image is no longer guaranteed. Since we can't actually guarantee it :sweat_smile:  

It can be used easily in cmake projects as `cv` component:

```cmake
find_package(YARP REQUIRED
                  COMPONENTS OS
                             conf
                             sig
                             dev
                             cv)
```

Example of usage:

```c++
ImageOf<PixelRgb> inImg;
// Read it from port
cv::Mat cvImg = toCvMat(std::move(inImg));
// Some OpenCV processing
auto yarpImg = fromCvMat<PixelRgb>(std::move(cvImg));
//  Write on a port
```
Last this PR deprecates `getIplImage` and `wrapIplImage` since they are now obsolete.

It is super WIP and all the suggestions of the CV guys are more than welcome.

It fixes #1672 .

It has been tested with different pixel codes (`PixelRgb`, `PixelRgba`, `PixelMono`, `PixelBgr`, `PixelBgra`), and it works :sunglasses: 

Please review code 

