### PR TITLE
Created wrapper of PortReader to provide port subscribing method.

### DIFF
--- a/src/libYARP_OS/include/yarp/os/Port.h
+++ b/src/libYARP_OS/include/yarp/os/Port.h
@@ -131,6 +131,13 @@ public:
     void setAdminReader(PortReader& reader) override;
 
     /**
+     * Subscribe to port reader new state with given callback.
+     *
+     * @param callback can be provided for example in lambda format [](ConnectionReader& conn){}
+     */
+    void setReaderCallback(const ReaderDataProcessor::readCallback& callback);
+
+    /**
      * Set a creator for readers for port data.
      *
      * Every port that input is received from will be automatically
@@ -258,6 +265,7 @@ public:
 private:
     void* implementation;
     bool owned;
+    ReaderDataProcessor dataProcessor;
 
     void* needImplementation() const;
 

--- a/src/libYARP_OS/include/yarp/os/PortReader.h
+++ b/src/libYARP_OS/include/yarp/os/PortReader.h
@@ -11,6 +11,7 @@
 #define YARP_OS_PORTREADER_H
 
 #include <yarp/os/api.h>
+#include <functional>
 
 namespace yarp {
 namespace os {
@@ -44,6 +45,21 @@ public:
 
     virtual Type getReadType() const;
 };
+
+/**
+ * Port Reader wrapper providing user defined callback instead of inheritance of PortReader
+ *
+ * @see PortReader
+ */
+class ReaderDataProcessor : public PortReader {
+public:
+    typedef std::function<void(ConnectionReader&)> readCallback;
+    virtual void setCallback(const readCallback& callback);
+    virtual bool read(ConnectionReader& data) override;
+private:
+    readCallback _callback;
+};
+
 
 } // namespace os
 } // namespace yarp

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -533,6 +533,11 @@ void Port::enableBackgroundWrite(bool backgroundFlag)
     core.configWaitAfterSend(!backgroundFlag);
 }
 
+void Port::setReaderCallback(const ReaderDataProcessor::readCallback& callback)
+{
+    dataProcessor.setCallback(callback);
+    setReader(dataProcessor);
+}
 
 bool Port::isWriting()
 {

--- a/src/libYARP_OS/src/PortReader.cpp
+++ b/src/libYARP_OS/src/PortReader.cpp
@@ -16,3 +16,11 @@ yarp::os::Type yarp::os::PortReader::getReadType() const
 {
     return Type::anon();
 }
+
+void yarp::os::ReaderDataProcessor::setCallback(const yarp::os::ReaderDataProcessor::readCallback& callback) {
+    _callback = callback;
+}
+bool yarp::os::ReaderDataProcessor::read(ConnectionReader& data) {
+    _callback(data);
+    return true;
+};


### PR DESCRIPTION
Created a wrapper class of PortReader which implements virtual read function, this implementation calls a callback if provided.
There is no implementation to unsubscribe, is that required ?

Fixes #1927