### PR TITLE
Include cmath if std::nan is used

### DIFF
--- a/src/devices/localization2DServer/Localization2DServer.cpp
+++ b/src/devices/localization2DServer/Localization2DServer.cpp
@@ -31,7 +31,7 @@
 #include <yarp/dev/IFrameTransform.h>
 #include "Localization2DServer.h"
 
-#include <math.h>
+#include <cmath>
 
 /*! \file Localization2DServer.cpp */
 


### PR DESCRIPTION
In the Localization2DServer.cpp file, the std::nan function is used. This function is defined in the cmath header ( https://en.cppreference.com/w/cpp/numeric/math/nan ).
Before this commit the math.h header (that only defines nan in the global namespace, not std::nan) was included instead of cmath.
This can create a compilation failure or not depending on the platform due to transitive inclusion of cmath in the other included headers.