### PR TITLE
Fix macOs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ addons:
     - tinyxml
     - libedit
     - qt5
-    - opencv
+    - opencv@2
     - eigen
     - graphviz
     - ccache


### PR DESCRIPTION
This PR should fix macOs build on travis(`opencv 4.0.1`), but I'm afraid it will break the linux ones, I don't know which version of ubuntu and then OpenCV there is in our travis.

On `master` unfortunately it is quite tricky to fix since the new compatibility library `YARP_cv` to handle the `cv::Mat` is only on `devel` and `opencv 4` get rid of `IplImage* cvLoadImage()` in favour of `cv::Mat imread()`

Related to #1672 

Please review code.