### PR TITLE
Add move semantic in yarp image

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -87,6 +87,7 @@ New Features
   - `utils::depthRgbToPC`
 * Deprecated `getIplImage` and `wrapIplImage` in favour of the new utilities of
   `YARP_cv`.
+* Added move semantics in `yarp::sig::Image`.
 
 #### `YARP_cv`
 

--- a/src/libYARP_cv/include/yarp/cv/Cv-inl.h
+++ b/src/libYARP_cv/include/yarp/cv/Cv-inl.h
@@ -90,11 +90,22 @@ template<typename T>
 template<typename T>
 yarp::sig::ImageOf<T> yarp::cv::fromCvMat(::cv::Mat& cvImage)
 {
+    constexpr size_t align_8_bytes = 8;
+    constexpr size_t align_4_bytes = 4;
+
     yarp::sig::ImageOf<T> outImg;
-    assert(yarp::cv::type_code<T>::value == cvImage.type()); // Checking cv::Mat::type() compatibility with the T PixelType
+    // Checking cv::Mat::type() compatibility with the T PixelType
+    assert(yarp::cv::type_code<T>::value == cvImage.type());
     if (convert_code_from_cv<T>::value >= 0)
     {
         ::cv::cvtColor(cvImage, cvImage, convert_code_from_cv<T>::value);
+    }
+    // Check the cv::Mat alignment
+    if (cvImage.step % align_8_bytes == 0) {
+        outImg.setQuantum(align_8_bytes);
+    }
+    else if (cvImage.step % align_4_bytes == 0) {
+        outImg.setQuantum(align_4_bytes);
     }
     outImg.setExternal(cvImage.data, cvImage.cols, cvImage.rows);
     return outImg;

--- a/src/libYARP_sig/include/yarp/sig/Image.h
+++ b/src/libYARP_sig/include/yarp/sig/Image.h
@@ -100,6 +100,21 @@ public:
     Image(const Image& alt);
 
     /**
+     * @brief Move constructor.
+     *
+     * @param other the Image to be moved
+     */
+    Image(Image&& other) noexcept;
+
+    /**
+     * @brief Move assignment operator.
+     *
+     * @param other the Image to be moved
+     * @return this object
+     */
+    Image& operator=(Image &&other) noexcept;
+
+    /**
      * Destructor.
      */
     virtual ~Image();

--- a/src/libYARP_sig/src/Image.cpp
+++ b/src/libYARP_sig/src/Image.cpp
@@ -800,6 +800,21 @@ Image::Image(const Image& alt) : Portable() {
     copy(alt);
 }
 
+Image::Image(Image&& other) noexcept
+    : implementation(other.implementation)
+{
+    other.implementation = nullptr;
+    synchronize();
+}
+
+Image& Image::operator=(Image&& other) noexcept
+{
+    Image moved(std::move(other));
+    std::swap(moved.implementation, implementation);
+    synchronize();
+    return *this;
+}
+
 
 const Image& Image::operator=(const Image& alt) {
     copy(alt);


### PR DESCRIPTION
This PR add move semantic in `yarp::sig::Image`.

Moreover it fixes a alignment issue in the `YARP_cv` library.
Please review code.