### PR TITLE
new Frame Transform interfaces + ovrdevice refactoring

### DIFF
--- a/doc/release/devel.md
+++ b/doc/release/devel.md
@@ -1,0 +1,37 @@
+YARP devel (UNRELEASED)                                                {#v3_2_0}
+=======================
+
+[TOC]
+
+YARP devel Release Notes
+========================
+
+
+Important Changes
+-----------------
+
+
+New Features
+------------
+
+### Libraries
+
+#### `YARP_dev`
+
+* Added IFrameSource and IFrameSet interfaces in order to refactor the frame transform software stack.
+* Added ImplementIFrameSource, a default implementation to reuse the mathematical part of IFrameSource in several devices.
+
+### Devices
+
+* Added `FrameReceiver` device
+* Added `FrameBroadcaster` device
+* Refactored `OVRDevice` with the new FrameTransform stack
+
+Contributors
+------------
+
+This is a list of people that contributed to this release (generated from the
+git history using `git shortlog -ens --no-merges v3.1.0..v3.2.0`):
+
+```
+```

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -64,6 +64,8 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(usbCamera)
   add_subdirectory(fakeLocalizerDevice)
   add_subdirectory(fakeNavigationDevice)
+  add_subdirectory(FrameReceiver)
+  add_subdirectory(FrameBroadcaster)
 
   # We can also suck in other device libraries built the same way.
   # We seek an ExternalModules.cmake file either in the conf directory

--- a/src/devices/FrameBroadcaster/CMakeLists.txt
+++ b/src/devices/FrameBroadcaster/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(FrameBroadcaster
+                    CATEGORY device
+                    TYPE yarp::dev::FrameBroadcaster
+                    INCLUDE FrameBroadcaster.h)
+
+if(ENABLE_FrameBroadcaster)
+
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+  yarp_add_plugin(yarp_FrameBroadcaster FrameBroadcaster.cpp
+                                        FrameBroadcaster.h)
+
+   target_link_libraries(yarp_FrameBroadcaster PRIVATE YARP::YARP_OS
+                                                       YARP::YARP_sig
+                                                       YARP::YARP_dev
+                                                       YARP::YARP_math
+                                                       YARP_rosmsg)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_OS
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_math
+                                                      YARP_rosmsg)
+
+  yarp_install(TARGETS yarp_FrameBroadcaster
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_FrameBroadcaster PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
+++ b/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
@@ -23,7 +23,8 @@ using namespace yarp::rosmsg::tf2_msgs;
 inline void BottleaddFrame(TFMessage& b, const yarp::math::FrameTransform& frame)
 {
 
-    auto& submsg = yarp::rosmsg::  geometry_msgs::TransformStamped();
+    yarp::rosmsg::geometry_msgs::TransformStamped submsg;
+
     submsg.child_frame_id          = frame.frameId;
     submsg.header.frame_id         = frame.parentFrame;
     submsg.transform.rotation.w    = frame.rotation.w();
@@ -77,7 +78,11 @@ bool FrameBroadcaster::open(yarp::os::Searchable& params)
     };
 
     static int id = 0;
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+    n = std::unique_ptr<yarp::os::Node>(new yarp::os::Node("/frameBroadcaster" + std::to_string(id)));
+#else
     n = std::make_unique<yarp::os::Node>("/frameBroadcaster" + std::to_string(id));
+#endif
     id++;
 
     if(params.check("help"))
@@ -155,8 +160,11 @@ bool FrameBroadcaster::open(yarp::os::Searchable& params)
 bool FrameBroadcaster::openAndAttachSubDevice(Searchable& prop)
 {
     Property p;
-
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+    m_subDeviceOwned = unique_ptr<PolyDriver>(new PolyDriver);
+#else
     m_subDeviceOwned = std::make_unique<PolyDriver>();
+#endif
 
     p.fromString(prop.toString());
     p.setMonitor(prop.getMonitor(), "subdevice"); // pass on any monitoring

--- a/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
+++ b/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameBroadcaster.h"
+#include <map>
+#include <vector>
+#include <yarp/os/LogStream.h>
+#include <yarp/rosmsg/geometry_msgs/TransformStamped.h>
+
+#define DEFAULT_THREAD_PERIOD   0.010 //s
+
+using namespace std;
+using namespace yarp::dev;
+using namespace yarp::os;
+using namespace yarp::sig;
+using namespace yarp::rosmsg::tf2_msgs;
+
+inline void BottleaddFrame(TFMessage& b, const yarp::math::FrameTransform& frame)
+{
+
+    auto& submsg = yarp::rosmsg::  geometry_msgs::TransformStamped();
+    submsg.child_frame_id          = frame.frameId;
+    submsg.header.frame_id         = frame.parentFrame;
+    submsg.transform.rotation.w    = frame.rotation.w();
+    submsg.transform.rotation.x    = frame.rotation.x();
+    submsg.transform.rotation.y    = frame.rotation.y();
+    submsg.transform.rotation.z    = frame.rotation.z();
+    submsg.transform.translation.x = frame.translation.tX;
+    submsg.transform.translation.y = frame.translation.tY;
+    submsg.transform.translation.z = frame.translation.tZ;
+    submsg.header.stamp            = frame.timestamp;
+    b.transforms.push_back(submsg);
+}
+
+inline void sendFrameContainer(yarp::os::Publisher<TFMessage>& port, const std::vector<yarp::math::FrameTransform>& frames)
+//inline void sendFrameContainer(yarp::os::BufferedPort<TFMessage>& port, const std::vector<yarp::math::FrameTransform>& frames)
+{
+    auto& msg = port.prepare();
+    msg.clear();
+    for (auto& frame : frames)
+    {
+        BottleaddFrame(msg, frame);
+    }
+    port.write();
+}
+
+FrameBroadcaster::FrameBroadcaster() : PeriodicThread(DEFAULT_THREAD_PERIOD)
+{
+}
+
+bool FrameBroadcaster::open(yarp::os::Searchable& params)
+{
+    sendFrames = [this](IFrameSource * fs)
+    {
+        if (!fs)
+            return false;
+
+        if (!port.getOutputCount())
+            return false;
+        portMutex.lock();
+        if (shouldClose)
+        {
+            port.close();
+            fs->unsetCallback(callbackId);
+            portMutex.unlock();
+            return false;
+        }
+
+        sendFrameContainer(port, fs->getAllFrames());
+        portMutex.unlock();
+        return true;
+    };
+
+    static int id = 0;
+    n = std::make_unique<yarp::os::Node>("/frameBroadcaster" + std::to_string(id));
+    id++;
+
+    if(params.check("help"))
+    {
+        yInfo() << "parameters:\n\n" <<
+                   "period             - refresh period of the broadcasted values in ms.. default" << DEFAULT_THREAD_PERIOD * 1000<< "\n"
+                   "topic              - topic to publish data to, e.g. /oculus\n" <<
+                   "eventBased         - don't start a thread and sends frame from the caller thread" <<
+                   "subdevice          - name of the subdevice to open\n";
+        return false;
+    }
+    std::string rootName;
+    if (!params.check("period", "refresh period of the broadcasted values in ms"))
+    {
+        yInfo() << "FrameReceiver: using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "s";
+    }
+    else
+    {
+        m_period = params.find("period").asInt32() / 1000.0;
+    }
+
+    rootName = params.check("topic",Value("/"), "starting '/' if needed.").asString();
+
+    if (!params.check("topic", "Prefix name of the ports opened by the FrameBroadcaster."))
+    {
+        yError() << "FrameBroadcaster: missing 'name' parameter. Check you configuration file; it must be like:";
+        yError() << "   topic:         topic to publish data to, e.g. /oculus";
+        return false;
+    }
+
+    eventBased = params.check("eventBased");
+
+    rootName = params.find("topic").asString();
+
+    if (!port.topic(rootName))
+    //if(!port.open(rootName))
+    {
+        yError("FrameBroadcaster: error while opening topic\n");
+        return false;
+    }
+    // check if we need to create subdevice or if they are
+    // passed later on thorugh attachAll()
+    if(params.check("subdevice"))
+    {
+        m_isSubdeviceOwned=true;
+        if(!openAndAttachSubDevice(params))
+        {
+            yError("FrameBroadcaster: error while opening subdevice\n");
+            return false;
+        }
+    }
+    else
+    {
+        m_isSubdeviceOwned = false;
+    }
+    
+    if (!m_device)
+        return true;
+
+    auto ret = m_device->setCallback(sendFrames);
+    if (!ret.valid)
+    {
+        PeriodicThread::setPeriod(m_period);
+        PeriodicThread::start();
+        eventBased = false;
+    }
+    else
+    {
+        callbackId = ret.value;
+    }
+    
+    return true;
+}
+
+bool FrameBroadcaster::openAndAttachSubDevice(Searchable& prop)
+{
+    Property p;
+
+    m_subDeviceOwned = std::make_unique<PolyDriver>();
+
+    p.fromString(prop.toString());
+    p.setMonitor(prop.getMonitor(), "subdevice"); // pass on any monitoring
+    p.unput("device");
+    p.put("device",prop.find("subdevice").asString());  // subdevice was already checked before
+
+    // if errors occurred during open, quit here.
+    m_subDeviceOwned->open(p);
+
+    if (!m_subDeviceOwned->isValid())
+    {
+        yError("FrameBroadcaster: opening subdevice... FAILED\n");
+        return false;
+    }
+    m_isSubdeviceOwned = true;
+    if(!attach(m_subDeviceOwned.get()))
+        return false;
+
+    return true;
+}
+
+bool FrameBroadcaster::attach(PolyDriver* poly)
+{
+    if(poly)
+        poly->view(m_device);
+
+    if(m_device == nullptr)
+    {
+        yError() << "JoypadControlServer: attached device has no valid IJoypadController interface.";
+        return false;
+    }
+    return true;
+}
+
+bool FrameBroadcaster::attach(yarp::dev::IFrameSource* s)
+{
+    if(s == nullptr)
+    {
+        yError() << "FrameBroadcaster: attached device has no valid IFrameSource interface.";
+        return false;
+    }
+    m_device = s;
+    return true;
+}
+
+bool FrameBroadcaster::detach()
+{
+    m_device = nullptr;
+    return true;
+}
+
+bool FrameBroadcaster::threadInit()
+{
+    // Get interface from attached device if any.
+    return true;
+}
+
+void FrameBroadcaster::threadRelease()
+{
+    // Detach() calls stop() which in turns calls this functions, therefore no calls to detach here!
+}
+
+void FrameBroadcaster::run()
+{
+    if(!callbackId)
+        sendFrames(m_device);
+    portMutex.lock();
+    sendFrameContainer(port, internalFrames);
+    portMutex.unlock();
+}
+
+bool FrameBroadcaster::attachAll(const PolyDriverList& p)
+{
+    if (p.size() != 1)
+    {
+        yError("FrameBroadcaster: cannot attach more than one device");
+        return false;
+    }
+
+    yarp::dev::PolyDriver* Idevice2attach = p[0]->poly;
+    if(p[0]->key == "IFrameSource")
+    {
+        yInfo() << "FrameBroadcaster: Good name!";
+    }
+    else
+    {
+        yInfo() << "FrameBroadcaster: Bad name!";
+    }
+
+    if (!Idevice2attach->isValid())
+    {
+        yError() << "FrameBroadcaster: Device " << p[0]->key << " to attach to is not valid ... cannot proceed";
+        return false;
+    }
+
+    Idevice2attach->view(m_device);
+    if(!attach(m_device))
+        return false;
+
+    return true;
+}
+
+bool FrameBroadcaster::detachAll()
+{
+    if (yarp::os::PeriodicThread::isRunning())
+        yarp::os::PeriodicThread::stop();
+
+    //check if we already instantiated a subdevice previously
+    if (m_isSubdeviceOwned)
+        return false;
+
+    m_device = nullptr;
+    return true;
+}
+
+bool FrameBroadcaster::close()
+{
+    detachAll();
+    shouldClose = true;
+    while (port.isWriting())
+    {
+        yarp::os::Time::delay(0.05);
+    }
+    // close subdevice if it was created inside the open (--subdevice option)
+    if(m_isSubdeviceOwned)
+    {
+        if(m_subDeviceOwned)m_subDeviceOwned->close();
+
+        m_device           = nullptr;
+        m_isSubdeviceOwned = false;
+    }
+    return true;
+}
+
+bool FrameBroadcaster::clear()
+{
+    auto ret = internalFrames.size();
+    internalFrames.clear();
+    return ret;
+}
+
+bool FrameBroadcaster::setTransform (const yarp::math::FrameTransform& frame)
+{
+    if (eventBased && !this->isRunning())
+    {
+        start();
+    }
+
+    for (auto& f : internalFrames)
+    {
+        if (f.frameId == frame.frameId)
+        {
+            if (f.parentFrame == frame.parentFrame)
+            {
+                portMutex.lock();
+                f = frame;
+
+                if (!PeriodicThread::isRunning())
+                    sendFrameContainer(port, { frame });
+
+                portMutex.unlock();
+                return true;
+            }
+            else
+                return false;
+        }
+    }
+
+    portMutex.lock();
+    internalFrames.emplace_back(frame);
+    if (!PeriodicThread::isRunning())
+        sendFrameContainer(port, {frame});
+    portMutex.unlock();
+    return true;
+}
+
+void FrameBroadcaster::setTransforms(const std::vector<yarp::math::FrameTransform>& frames, bool append)
+{
+    if (eventBased && !this->isRunning())
+    {
+        start();
+    }
+
+    portMutex.lock();
+    if (append)
+        internalFrames.insert(std::end(internalFrames), std::begin(frames), std::end(frames));
+    else
+        internalFrames = frames;
+    if (!PeriodicThread::isRunning())
+        sendFrameContainer(port, frames);
+    portMutex.unlock();
+}
+
+bool FrameBroadcaster::deleteTransform (const std::string &frame_id)
+{
+    portMutex.lock();
+    for (auto i = internalFrames.begin(); i < internalFrames.end(); i++)
+        if (i->frameId == frame_id)
+        {
+            internalFrames.erase(i);
+            portMutex.unlock();
+            return true;
+        }
+
+    portMutex.unlock();
+    return false;
+}

--- a/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
+++ b/src/devices/FrameBroadcaster/FrameBroadcaster.cpp
@@ -12,8 +12,6 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/rosmsg/geometry_msgs/TransformStamped.h>
 
-#define DEFAULT_THREAD_PERIOD   0.010 //s
-
 using namespace std;
 using namespace yarp::dev;
 using namespace yarp::os;
@@ -50,7 +48,7 @@ inline void sendFrameContainer(yarp::os::Publisher<TFMessage>& port, const std::
     port.write();
 }
 
-FrameBroadcaster::FrameBroadcaster() : PeriodicThread(DEFAULT_THREAD_PERIOD)
+FrameBroadcaster::FrameBroadcaster() : PeriodicThread(defaultThreadPeriod)
 {
 }
 
@@ -88,7 +86,7 @@ bool FrameBroadcaster::open(yarp::os::Searchable& params)
     if(params.check("help"))
     {
         yInfo() << "parameters:\n\n" <<
-                   "period             - refresh period of the broadcasted values in ms.. default" << DEFAULT_THREAD_PERIOD * 1000<< "\n"
+                   "period             - refresh period of the broadcasted values in ms.. default" << defaultThreadPeriod * 1000<< "\n"
                    "topic              - topic to publish data to, e.g. /oculus\n" <<
                    "eventBased         - don't start a thread and sends frame from the caller thread" <<
                    "subdevice          - name of the subdevice to open\n";
@@ -97,7 +95,7 @@ bool FrameBroadcaster::open(yarp::os::Searchable& params)
     std::string rootName;
     if (!params.check("period", "refresh period of the broadcasted values in ms"))
     {
-        yInfo() << "FrameReceiver: using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "s";
+        yInfo() << "FrameReceiver: using default 'period' parameter of " << defaultThreadPeriod << "s";
     }
     else
     {
@@ -180,10 +178,7 @@ bool FrameBroadcaster::openAndAttachSubDevice(Searchable& prop)
         return false;
     }
     m_isSubdeviceOwned = true;
-    if(!attach(m_subDeviceOwned.get()))
-        return false;
-
-    return true;
+    return attach(m_subDeviceOwned.get());
 }
 
 bool FrameBroadcaster::attach(PolyDriver* poly)
@@ -261,10 +256,7 @@ bool FrameBroadcaster::attachAll(const PolyDriverList& p)
     }
 
     Idevice2attach->view(m_device);
-    if(!attach(m_device))
-        return false;
-
-    return true;
+    return attach(m_device);
 }
 
 bool FrameBroadcaster::detachAll()

--- a/src/devices/FrameBroadcaster/FrameBroadcaster.h
+++ b/src/devices/FrameBroadcaster/FrameBroadcaster.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_JOYPADCONTROLSERVER_FRAMEBROADCASTER_H
+#define YARP_DEV_JOYPADCONTROLSERVER_FRAMEBROADCASTER_H
+#define DEFAULT_THREAD_PERIOD   0.010 //s
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IFrameSource.h>
+#include <yarp/rosmsg/tf2_msgs/TFMessage.h>
+#include <yarp/dev/IFrameSet.h>
+#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/PolyDriverList.h>
+#include <yarp/os/Publisher.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Node.h>
+#include <mutex>
+#include <map>
+
+namespace yarp
+{
+    namespace dev
+    {
+        class FrameBroadcaster;
+    }
+}
+
+class yarp::dev::FrameBroadcaster : public yarp::dev::IFrameSet,
+                                    public yarp::dev::DeviceDriver,
+                                    public yarp::dev::IWrapper,
+                                    public yarp::dev::IMultipleWrapper,
+                                    public yarp::os::PeriodicThread
+{
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+    double                                  m_period{ DEFAULT_THREAD_PERIOD };
+    yarp::dev::IFrameSource*                m_device{nullptr};
+    std::unique_ptr<yarp::dev::PolyDriver>  m_subDeviceOwned{nullptr};
+    bool                                    m_isSubdeviceOwned{false};
+    std::string                             m_name;
+    bool                                    shouldClose{false};
+    std::mutex                              portMutex;
+    std::vector<yarp::math::FrameTransform> internalFrames;
+    bool                                    eventBased{false};
+    std::unique_ptr<yarp::os::Node>         n;
+    yarp::os::Publisher<yarp::rosmsg::tf2_msgs::TFMessage> port;
+    //yarp::os::BufferedPort<yarp::rosmsg::tf2_msgs::TFMessage> port;
+    std::function<bool(yarp::dev::IFrameSource*)> sendFrames;
+    int callbackId{0};
+
+    bool openAndAttachSubDevice(yarp::os::Searchable& prop);
+
+#endif //DOXYGEN_SHOULD_SKIP_THIS
+
+public:
+    FrameBroadcaster();
+
+    bool open(yarp::os::Searchable& params) override;
+    bool close() override;
+    bool attachAll(const yarp::dev::PolyDriverList& p) override;
+    bool detachAll() override;
+    bool attach(yarp::dev::PolyDriver* poly) override;
+    bool attach(yarp::dev::IFrameSource* s);
+    bool detach() override;
+    bool threadInit() override;
+    void threadRelease() override;
+    void run() override;
+
+    virtual bool clear () override;
+    virtual bool setTransform (const yarp::math::FrameTransform& frame) override;
+    virtual void setTransforms (const std::vector<yarp::math::FrameTransform>& frames, bool append = false) override;
+    virtual bool deleteTransform (const std::string &frame_id) override;
+
+
+};
+
+#endif
+
+

--- a/src/devices/FrameBroadcaster/FrameBroadcaster.h
+++ b/src/devices/FrameBroadcaster/FrameBroadcaster.h
@@ -8,7 +8,7 @@
 
 #ifndef YARP_DEV_JOYPADCONTROLSERVER_FRAMEBROADCASTER_H
 #define YARP_DEV_JOYPADCONTROLSERVER_FRAMEBROADCASTER_H
-#define DEFAULT_THREAD_PERIOD   0.010 //s
+constexpr double defaultThreadPeriod = 0.010; //s
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IFrameSource.h>
@@ -39,7 +39,7 @@ class yarp::dev::FrameBroadcaster : public yarp::dev::IFrameSet,
 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-    double                                  m_period{ DEFAULT_THREAD_PERIOD };
+    double                                  m_period{ defaultThreadPeriod };
     yarp::dev::IFrameSource*                m_device{nullptr};
     std::unique_ptr<yarp::dev::PolyDriver>  m_subDeviceOwned{nullptr};
     bool                                    m_isSubdeviceOwned{false};

--- a/src/devices/FrameReceiver/CMakeLists.txt
+++ b/src/devices/FrameReceiver/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(FrameReceiver
+                    CATEGORY device
+                    TYPE yarp::dev::FrameReceiver
+                    INCLUDE FrameReceiver.h)
+
+if(ENABLE_FrameReceiver)
+
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+  yarp_add_plugin(yarp_FrameReceiver FrameReceiver.cpp
+                                     FrameReceiver.h)
+
+  target_link_libraries(yarp_FrameReceiver PRIVATE YARP::YARP_OS
+                                                   YARP::YARP_sig
+                                                   YARP::YARP_dev
+                                                   YARP::YARP_math
+                                                   YARP_rosmsg)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_OS
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_math
+                                                      YARP_rosmsg)
+
+  yarp_install(TARGETS yarp_FrameReceiver
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_FrameReceiver PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/FrameReceiver/FrameReceiver.cpp
+++ b/src/devices/FrameReceiver/FrameReceiver.cpp
@@ -19,8 +19,6 @@ using namespace yarp::math;
 using namespace yarp::rosmsg::tf2_msgs;
 void PortCallback::onRead(TFMessage& msg)
 {
-    int i = 0;
-
     FrameTransform ft;
     owner->cacheValid = false;
     fvecguard.lock();
@@ -38,10 +36,9 @@ void PortCallback::onRead(TFMessage& msg)
 #if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
         ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1000000000;
 #else
-        ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1'000'000'000;
+        ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1'000'000'000.0;
 #endif
         fvec[ft.frameId] = ft;
-        i++;
     }
     fvecguard.unlock();
 

--- a/src/devices/FrameReceiver/FrameReceiver.cpp
+++ b/src/devices/FrameReceiver/FrameReceiver.cpp
@@ -20,7 +20,6 @@ using namespace yarp::rosmsg::tf2_msgs;
 void PortCallback::onRead(TFMessage& msg)
 {
     int i = 0;
-    Bottle* submsg{ nullptr };
 
     FrameTransform ft;
     owner->cacheValid = false;
@@ -36,7 +35,11 @@ void PortCallback::onRead(TFMessage& msg)
         ft.rotation.x()   = submsg.transform.rotation.x;
         ft.rotation.y()   = submsg.transform.rotation.y;
         ft.rotation.z()   = submsg.transform.rotation.z;
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+        ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1000000000;
+#else
         ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1'000'000'000;
+#endif
         fvec[ft.frameId] = ft;
         i++;
     }
@@ -69,7 +72,11 @@ void FrameReceiver::updateFrameContainer(FrameEditor& fs)
 bool FrameReceiver::open(yarp::os::Searchable& params)
 {
     static int id = 0;
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+    n = std::unique_ptr<yarp::os::Node>(new yarp::os::Node("/frameReceiver" + std::to_string(id)));
+#else
     n = std::make_unique<yarp::os::Node>("/frameReceiver" + std::to_string(id));
+#endif
     id++;
     if(params.check("help"))
     {

--- a/src/devices/FrameReceiver/FrameReceiver.cpp
+++ b/src/devices/FrameReceiver/FrameReceiver.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameReceiver.h"
+#include <map>
+#include <vector>
+#include <yarp/os/LogStream.h>
+
+using namespace std;
+using namespace yarp::dev;
+using namespace yarp::os;
+using namespace yarp::sig;
+using namespace yarp::math;
+using namespace yarp::rosmsg::tf2_msgs;
+void PortCallback::onRead(TFMessage& msg)
+{
+    int i = 0;
+    Bottle* submsg{ nullptr };
+
+    FrameTransform ft;
+    owner->cacheValid = false;
+    fvecguard.lock();
+    for(const auto& submsg : msg.transforms)
+    {
+        ft.frameId        = submsg.child_frame_id;
+        ft.parentFrame    = submsg.header.frame_id;
+        ft.translation.tX = submsg.transform.translation.x;
+        ft.translation.tY = submsg.transform.translation.y;
+        ft.translation.tZ = submsg.transform.translation.z;
+        ft.rotation.w()   = submsg.transform.rotation.w;
+        ft.rotation.x()   = submsg.transform.rotation.x;
+        ft.rotation.y()   = submsg.transform.rotation.y;
+        ft.rotation.z()   = submsg.transform.rotation.z;
+        ft.timestamp      = submsg.header.stamp.sec + submsg.header.stamp.nsec/1'000'000'000;
+        fvec[ft.frameId] = ft;
+        i++;
+    }
+    fvecguard.unlock();
+
+    owner->callAllCallbacks();
+}
+
+bool FrameReceiver::callbackPrepare()
+{
+    return true;
+}
+
+bool FrameReceiver::callbackDismiss()
+{
+    return true;
+}
+
+void FrameReceiver::updateFrameContainer(FrameEditor& fs)
+{
+    portCallback.fvecguard.lock();
+    for (auto& f : portCallback.fvec)
+    {
+        fs.insertUpdate(f.second);
+    }
+    cacheValid = true;
+    portCallback.fvecguard.unlock();
+}
+
+bool FrameReceiver::open(yarp::os::Searchable& params)
+{
+    static int id = 0;
+    n = std::make_unique<yarp::os::Node>("/frameReceiver" + std::to_string(id));
+    id++;
+    if(params.check("help"))
+    {
+        yInfo() << "parameters:\n\n" <<
+            "topic               - Topic name\n";
+        return false;
+    }
+
+    m_name = params.check("topic",Value("/"), "starting '/' if needed.").asString();
+
+    if (!params.check("topic", "name of the topic to subscribe to."))
+    {
+        yError() << "FrameReceiver: missing 'topic' parameter. Check you configuration file; it must be like:";
+        yError() << "   topic:         name of the topic to subscribe to, e.g. /tfOVR";
+        return false;
+    }
+
+    m_name = params.find("topic").asString();
+
+    if (!port.topic(m_name))
+    //if (!port.open(m_name + "receiver"))
+    {
+        yError("FrameReceiver: error while subscribing\n");
+        return false;
+    }
+
+    //auto b = yarp::os::Network::connect("/testframetransform", m_name + "receiver");
+    portCallback.owner = this;
+    port.useCallback(portCallback);
+    cacheValid = true;
+    return true;
+}
+
+bool FrameReceiver::close()
+{
+    port.close();
+    return true;
+}

--- a/src/devices/FrameReceiver/FrameReceiver.h
+++ b/src/devices/FrameReceiver/FrameReceiver.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_JOYPADCONTROLSERVER_FRAMERECEIVER_H
+#define YARP_DEV_JOYPADCONTROLSERVER_FRAMERECEIVER_H
+#define DEFAULT_THREAD_PERIOD   0.010 //s
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IFrameSource.h>
+#include <yarp/rosmsg/tf2_msgs/TFMessage.h>
+#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/PolyDriverList.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Subscriber.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Node.h>
+#include <map>
+#include <mutex>
+#include <memory>
+namespace yarp
+{
+    namespace dev
+    {
+        class FrameReceiver;
+        class PortCallback;
+    }
+}
+
+class yarp::dev::PortCallback : public yarp::os::TypedReaderCallback<yarp::rosmsg::tf2_msgs::TFMessage>
+{
+public:
+    FrameReceiver* owner{nullptr};
+    std::map<std::string, yarp::math::FrameTransform> fvec;
+    std::mutex fvecguard;
+    void onRead(yarp::rosmsg::tf2_msgs::TFMessage& msg) override;
+};
+
+class yarp::dev::FrameReceiver : public yarp::dev::DeviceDriver,
+                                 public yarp::dev::ImplementIFrameSource
+{
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    friend class PortCallback; //<-- ugly.. the reason is that we miss a way to give to a buffered port a lambda as a callback.. sorry
+    std::string  m_name;
+    std::string  m_remote;
+    PortCallback portCallback;
+    yarp::os::Subscriber<yarp::rosmsg::tf2_msgs::TFMessage> port;
+    //yarp::os::BufferedPort<yarp::rosmsg::tf2_msgs::TFMessage> port;
+
+    std::unique_ptr<yarp::os::Node> n;
+
+#endif //DOXYGEN_SHOULD_SKIP_THIS
+protected:
+    virtual void updateFrameContainer(FrameEditor& frameContainer) override;
+    virtual bool callbackPrepare() override;
+    virtual bool callbackDismiss() override;
+public:
+    bool open(yarp::os::Searchable& params) override;
+    bool close() override;
+};
+
+#endif //YARP_DEV_JOYPADCONTROLSERVER_FRAMERECEIVER_H
+
+

--- a/src/devices/FrameReceiver/FrameReceiver.h
+++ b/src/devices/FrameReceiver/FrameReceiver.h
@@ -8,7 +8,6 @@
 
 #ifndef YARP_DEV_JOYPADCONTROLSERVER_FRAMERECEIVER_H
 #define YARP_DEV_JOYPADCONTROLSERVER_FRAMERECEIVER_H
-#define DEFAULT_THREAD_PERIOD   0.010 //s
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IFrameSource.h>
@@ -56,7 +55,7 @@ class yarp::dev::FrameReceiver : public yarp::dev::DeviceDriver,
 
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 protected:
-    virtual void updateFrameContainer(FrameEditor& frameContainer) override;
+    virtual void updateFrameContainer(FrameEditor& fs) override;
     virtual bool callbackPrepare() override;
     virtual bool callbackDismiss() override;
 public:

--- a/src/devices/ovrheadset/OVRHeadset.h
+++ b/src/devices/ovrheadset/OVRHeadset.h
@@ -94,18 +94,18 @@ public:
     virtual ~OVRHeadset();
 
     // yarp::dev::DeviceDriver methods
-    virtual bool open(yarp::os::Searchable& cfg);
-    virtual bool close();
+    bool open(yarp::os::Searchable& cfg) override;
+    bool close() override;
 
     // yarp::os::RateThread methods
-    virtual bool threadInit();
-    virtual void threadRelease();
-    virtual void run();
+    bool threadInit() override;
+    void threadRelease() override;
+    void run() override;
 
     //  yarp::dev::IService methods
-    virtual bool startService();
-    virtual bool updateService();
-    virtual bool stopService();
+    bool startService() override;
+    bool updateService() override;
+    bool stopService() override;
 
     // yarp::dev::IJoypadController methods
     bool getAxisCount(unsigned int& axis_count) override;
@@ -142,7 +142,6 @@ private:
     void fillHatStorage();
     void resetInput();
 
-    FlexImagePort* gui_ports{ nullptr };
     std::vector<guiParam> huds;
     InputCallback* displayPorts[2]{ nullptr, nullptr };
     ovrEyeRenderDesc EyeRenderDesc[2];
@@ -169,7 +168,7 @@ private:
         {&rightFrame, &ts.HandPoses[ovrHand_Right]},
         {&leftFrame, &ts.HandPoses[ovrHand_Left]  },
         {&headFrame, &headpose },
-        {&(headFrame + "_predicted"), &predicted_headpose }
+        {&headFramePredicted, &predicted_headpose }
     };
 
     yarp::os::Mutex                  inputStateMutex;
@@ -185,6 +184,7 @@ private:
     std::string rightFrame;
     std::string rootFrame;
     std::string headFrame;
+    std::string headFramePredicted;
 
     bool closed{ false };
     long long distortionFrameIndex{ 0 };

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -105,7 +105,9 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/Wrapper.h)
 
 if(TARGET YARP::YARP_math)
-  list(APPEND YARP_dev_HDRS include/yarp/dev/IFrameTransform.h
+  list(APPEND YARP_dev_HDRS include/yarp/dev/IFrameSet.h
+                            include/yarp/dev/IFrameSource.h
+                            include/yarp/dev/IFrameTransform.h
                             include/yarp/dev/ILocalization2D.h
                             include/yarp/dev/IMap2D.h
                             include/yarp/dev/INavigation2D.h
@@ -163,6 +165,7 @@ set(YARP_dev_SRCS src/CanBusInterface.cpp
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_SRCS src/IFrameTransform.cpp
                             src/IMap2D.cpp
+                            src/ImplementIFrameSource.cpp
                             src/INavigation2D.cpp
                             src/MapGrid2D.cpp
                             src/Map2DArea.cpp)

--- a/src/libYARP_dev/include/yarp/dev/IFrameSet.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameSet.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_DEV_IFRAMESET_H
+#define YARP_DEV_IFRAMESET_H
+
+#include "api.h"
+#include <yarp/math/FrameTransform.h>
+#include <string>
+#include <vector>
+
+namespace yarp
+{
+    namespace dev
+    {
+        class IFrameSet;
+    }
+}
+
+class YARP_dev_API yarp::dev::IFrameSet
+{
+public:
+    /**
+     Removes all the registered transforms.
+    * @return true if there where some frame, false otherwise
+    */
+    virtual bool clear () = 0;
+
+    /**
+     Register a FrameTransform.
+    * @param frame the FrameTransform to set.
+    * @return false if the frame existed, true otherwise.
+    */
+    virtual bool setTransform (const yarp::math::FrameTransform& frame) = 0;
+
+    /**
+     Register multiple FrameTransforms.
+    * @param frames the FrameTransform vector
+    * @param append set it to true to append frames to previously created frames. WARNING no concistency check will be performed in this case.
+    */
+    virtual void setTransforms (const std::vector<yarp::math::FrameTransform>& frames, bool append = false) = 0;
+
+    /**
+     Deletes a transform between a frame and his parent.
+    * @param frame_id the name of the frame
+    * @return true if the frame existed, false otherwise
+    */
+    virtual bool deleteTransform (const std::string &frame_id) = 0;
+};
+#endif //YARP_DEV_IFRAMESET_H

--- a/src/libYARP_dev/include/yarp/dev/IFrameSource.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameSource.h
@@ -220,18 +220,18 @@ protected:
      this should be set to true and false in the derived class to to flag the frames present in the container as obsolete and request a new update.
      tipically the implementer will set it to false when before getting/receiving new transforms and set it to true at the end of updateFrameContainer()
     */
-    std::atomic_bool cacheValid;
+    std::atomic_bool cacheValid{false};
     
     /**
      the method to be called from the derived classes to call the callbacks.
     */
     bool callAllCallbacks()
     {
-        if (!callbacks.size())
+        if (callbacks.empty())
             return false;
 
         updateFrameContainer(frameContainer);
-        for (auto callback : callbacks)
+        for (const auto& callback : callbacks)
             if (callback.second)
                 callback.second((IFrameSource*)this);
         return true;

--- a/src/libYARP_dev/include/yarp/dev/IFrameSource.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameSource.h
@@ -34,8 +34,13 @@ public:
     class Result
     {
     public:
-        bool        valid{ false };
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+        bool        valid;
+#else
+        bool        valid{false};
+#endif
         int         error;
+
         T           value;
         //adding a operator bool(){return valid;} is a very bad idea as it can cause confusion between the result of bool functions and their success
     };
@@ -186,10 +191,15 @@ protected:
         yarp::math::FrameTransform nullframe;
 
     public:
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+        const std::map<std::string, yarp::math::FrameTransform>::const_iterator begin() const { return storage.begin(); }
+        const std::map<std::string, yarp::math::FrameTransform>::const_iterator end() const { return storage.end(); }
+        const size_t erase(const std::string& k) { return storage.erase(k); }
+#else
         const auto begin() const { return storage.begin(); }
         const auto end() const { return storage.end(); }
         const auto erase(const std::string& k) { return storage.erase(k); }
-    
+#endif
         bool insertUpdate(const yarp::math::FrameTransform& frame)
         {
             storage[frame.frameId] = frame;
@@ -224,6 +234,7 @@ protected:
         for (auto callback : callbacks)
             if (callback.second)
                 callback.second((IFrameSource*)this);
+        return true;
     }
     
     /**
@@ -265,8 +276,8 @@ public:
     virtual bool unsetCallback(const int& id) override;
     virtual Result<int> setCallback(std::function<bool(IFrameSource*)> cb) override;
     virtual std::string allFramesAsString() override;
-    virtual bool clearOlderFrames(const std::chrono::milliseconds& lifeMax);
-    virtual bool clearStaticFrames();
+    virtual bool clearOlderFrames(const std::chrono::milliseconds& lifeMax) override;
+    virtual bool clearStaticFrames() override;
     virtual Result<bool> canTransform(const std::string &target_frame, const std::string &source_frame) override;
     virtual bool frameExists(const std::string &frame_id) override;
     virtual std::unordered_set<std::string> getAllFrameIds() override;

--- a/src/libYARP_dev/include/yarp/dev/IFrameSource.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameSource.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IFRAMESOURCE_H
+#define YARP_DEV_IFRAMESOURCE_H
+
+#include <unordered_set>
+#include <map>
+#include <vector>
+#include <functional>
+#include <yarp/dev/api.h>
+#include <yarp/dev/IFrameSet.h> // <---useless include.. but without it IFrameSet doesn't export his symbol. to investigate
+#include <yarp/math/Quaternion.h>
+#include <yarp/math/FrameTransform.h>
+#include <thread>
+#include <atomic>
+
+namespace yarp {
+namespace dev {
+class IFrameSource;
+class ImplementIFrameSource;
+}
+}
+
+class YARP_dev_API yarp::dev::IFrameSource
+{
+public:
+    template <typename T>
+    class Result
+    {
+    public:
+        bool        valid{ false };
+        int         error;
+        T           value;
+        //adding a operator bool(){return valid;} is a very bad idea as it can cause confusion between the result of bool functions and their success
+    };
+
+    enum errors
+    {
+        OK = 0,
+        FRAME_NOT_FOUND,
+        TARGET_NOT_FOUND,
+        SOURCE_NOT_FOUND,
+        FRAMES_NOT_CONNECTED,
+        WRONG_INPUT_FORMAT,
+        TIMEOUT,
+        CALLBACK_ACTIVE,
+        UNDEFINED
+    };
+
+    /**
+    Disable a specific callback
+    * @param id the ID of the callback to be removed. received with setCallback()
+    * @return true if succeded false otherwise
+    */
+    virtual bool unsetCallback(const int& id) = 0;
+
+    /**
+    enable a callback system. the data producer will call all the callback at every data update
+    * @param cb the callback to be set
+    * @return Result<int> the ID of the callback (useful to unset it) wrapped by a result object containing the operation success or failure
+    */
+    virtual Result<int> setCallback(std::function<bool(IFrameSource*)> cb) = 0;
+    
+    /**
+    Creates a debug string containing the list of all registered frames.
+    * @return std::string
+    */
+    virtual std::string allFramesAsString() = 0;
+
+    /**
+    Removes all frames older than lifeMax. frame with timestamp 0.0 are considered static and will not be removed
+    * @return true if any frame has been removed, otherwise
+    */
+    virtual bool clearOlderFrames(const std::chrono::milliseconds& lifeMax) = 0;
+
+    /**
+    Removes all static frames.
+    * @return true if any frame has been removed, otherwise
+    */
+    virtual bool clearStaticFrames() = 0;
+
+    /**
+    Test if a transform exists.
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of source reference frame
+    * @return Result<bool>. if the target or the source frame are not present the result will be negative and the value inside should be ignored. if both the frame are correct but not connected 
+    *the result will be positive and the value negative. otherwise both positive
+    */
+    virtual Result<bool> canTransform(const std::string &target_frame, const std::string &source_frame) = 0;
+
+    /**
+    Check if a frame exists.
+    * @param frame_id the frame to be searched
+    * @return true if it exists, false otherwise
+    */
+    virtual bool frameExists(const std::string &frame_id) = 0;
+
+    /**
+    Gets a set containing all the frame_id.
+    * @return the set of frame ids
+    */
+    virtual std::unordered_set<std::string> getAllFrameIds() = 0;
+
+    /**
+    Gets a vector containing all the registered frames.
+    * @return the vector
+    */
+    virtual std::vector<yarp::math::FrameTransform> getAllFrames() = 0;
+
+    /**
+     Get the parent of a frame.
+    * @param frame_id the name of target reference frame
+    * @return a valid outcome will contain the parent frame. if the frame_id doesn't exist an invalid outcome should be returned
+    */
+    virtual Result<std::string> getParent(const std::string& frame_id) = 0;
+
+    /**
+     Get the transform between two frames.
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of source reference frame
+    * @param time point in which retrieve the data (if minor than 0 the last data will be used)
+    * @return a valid outcome will contain the frameTransform. if a frame doesn't exist or the frame are not connected an invalid outcome should be returned
+    */
+    virtual Result<yarp::math::FrameTransform> getTransform(const std::string &target_frame_id, const std::string &source_frame_id, double timestamp = -1) = 0;
+
+    /**
+    Transform a point into the target frame.
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of frame in which input_point is expressed
+    * @param input_point the input point (x y z)
+    * @param time point in which retrieve the data (if minor than 0 the last data will be used)
+    * @return the point transformed
+    */
+    virtual Result<yarp::sig::Vector> transformPoint(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, double timestamp = -1) = 0;
+
+    /**
+     Transform a Stamped Pose into the target frame.
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of frame in which input_pose is expressed
+    * @param input_pose the input quaternion (x y z r p y)
+    * @param time point in which retrieve the data (if minor than 0 the last data will be used)
+    * @return the pose transformed
+    */
+    virtual Result<yarp::sig::Vector> transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, double timestamp = -1) = 0;
+
+    /**
+     Transform a quaternion into the target frame.
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of frame in which input_quaternion is expressed
+    * @param input_quaternion the input quaternion (x y z w)
+    * @param time point in which retrieve the data (if minor than 0 the last data will be used)
+    * @return the quaternion transformed
+    */
+    virtual Result<yarp::math::Quaternion> transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, double timestamp = -1) = 0;
+
+    /**
+     Block until a transform from source_frame_id to target_frame_id is possible or it times out. returns the frame transform requested
+    * @param target_frame_id the name of target reference frame
+    * @param source_frame_id the name of source reference frame
+    * @param timeout (in seconds) to wait for
+    * @return the frameTransform
+    */
+    virtual Result<yarp::math::FrameTransform> waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) = 0;
+
+};
+
+/**
+ the ImplementIFrameSource class provides a default implementation of all the method of IFrameSource interface wich can be reused by the derived classes, 
+ requiring them to only implement some protected method and filling up a container with their frames.
+*/
+class YARP_dev_API yarp::dev::ImplementIFrameSource : public yarp::dev::IFrameSource
+{
+private:
+    std::map<int, std::function<bool(IFrameSource*)>> callbacks;
+protected:
+    
+    class FrameEditor
+    {
+        std::map<std::string, yarp::math::FrameTransform> storage;
+        yarp::math::FrameTransform nullframe;
+
+    public:
+        const auto begin() const { return storage.begin(); }
+        const auto end() const { return storage.end(); }
+        const auto erase(const std::string& k) { return storage.erase(k); }
+    
+        bool insertUpdate(const yarp::math::FrameTransform& frame)
+        {
+            storage[frame.frameId] = frame;
+            return true;
+        }
+
+        Result<yarp::math::FrameTransform> get(const std::string& frameid)
+        {
+            if (storage.find(frameid) == storage.end())
+            {
+                return { false, 0, nullframe };
+            }
+            return { true, 0, storage[frameid] };
+        }
+    };
+
+    /**
+     this should be set to true and false in the derived class to to flag the frames present in the container as obsolete and request a new update.
+     tipically the implementer will set it to false when before getting/receiving new transforms and set it to true at the end of updateFrameContainer()
+    */
+    std::atomic_bool cacheValid;
+    
+    /**
+     the method to be called from the derived classes to call the callbacks.
+    */
+    bool callAllCallbacks()
+    {
+        if (!callbacks.size())
+            return false;
+
+        updateFrameContainer(frameContainer);
+        for (auto callback : callbacks)
+            if (callback.second)
+                callback.second((IFrameSource*)this);
+    }
+    
+    /**
+     the method that will be called from this class in order to get the frames from the derived classes.
+     this is called if cacheValid is false (and so the frames in the container should be updated).
+     THREAD CONCURRENCY WARNING: can be called by both the user thread and the implementer thread (if any) when calling callAllCallbacks().
+    */
+    virtual void updateFrameContainer(FrameEditor& frameContainer) = 0;
+    
+    /**
+     the method for the subclasses to allow or forbid the callback system
+    */
+    virtual bool callbackPrepare() = 0;
+    
+    /**
+     the method for signaling the subclasses the dismount of a callback
+    */
+    virtual bool callbackDismiss() = 0;
+
+private:
+    enum ConnectionType
+    {
+        DIRECT,
+        INVERSE,
+        UNDIRECT,
+        DISCONNECTED
+    };
+    
+    //is pimpl pattern suitable for this case? we have protected member that should be accessed from the private methods.
+    FrameEditor         frameContainer;
+    ConnectionType      getConnectionType(const std::string& target_frame, const std::string& source_frame, std::string* commonAncestor = nullptr);
+    bool                frameExistsRaw(const std::string &frame_id);
+    Result<std::string> getParentRaw(const std::string& frame_id);
+
+    Result<yarp::math::FrameTransform> getChainedTransform(const std::string& target_frame_id, const std::string& source_frame_id);
+
+public:
+    virtual ~ImplementIFrameSource();
+    virtual bool unsetCallback(const int& id) override;
+    virtual Result<int> setCallback(std::function<bool(IFrameSource*)> cb) override;
+    virtual std::string allFramesAsString() override;
+    virtual bool clearOlderFrames(const std::chrono::milliseconds& lifeMax);
+    virtual bool clearStaticFrames();
+    virtual Result<bool> canTransform(const std::string &target_frame, const std::string &source_frame) override;
+    virtual bool frameExists(const std::string &frame_id) override;
+    virtual std::unordered_set<std::string> getAllFrameIds() override;
+    virtual std::vector<yarp::math::FrameTransform> getAllFrames() override;
+    virtual Result<std::string> getParent(const std::string& frame_id) override;
+    virtual Result<yarp::math::FrameTransform> getTransform(const std::string &target_frame_id, const std::string &source_frame_id, double timestamp = -1) override;
+    virtual Result<yarp::sig::Vector> transformPoint(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, double timestamp = -1) override;
+    virtual Result<yarp::sig::Vector> transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, double timestamp = -1) override;
+    virtual Result<yarp::math::Quaternion> transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, double timestamp = -1) override;
+    virtual Result<yarp::math::FrameTransform> waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) override;
+};
+
+#endif //YARP_DEV_IFRAMESOURCE_H

--- a/src/libYARP_dev/src/ImplementIFrameSource.cpp
+++ b/src/libYARP_dev/src/ImplementIFrameSource.cpp
@@ -16,7 +16,6 @@ using namespace yarp::sig;
 using namespace std;
 
 #define FULL_RANGE(c) (c).begin(), (c).end()
-
 FrameTransform operator*(const FrameTransform& l, const FrameTransform& r)
 {
     FrameTransform ret;
@@ -35,9 +34,9 @@ ImplementIFrameSource::~ImplementIFrameSource() = default;
 
 IFrameSource::Result<int> ImplementIFrameSource::setCallback(function<bool(IFrameSource*)> cb)
 {
-    static int callbackId = 0;
     if (callbackPrepare())
     {
+        static int callbackId = 0;
         callbacks[callbackId] = cb;
         callbackId++;
         return {true, 0, callbackId -1};
@@ -131,7 +130,7 @@ bool ImplementIFrameSource::clearOlderFrames(const std::chrono::milliseconds& li
     for (const auto& f : toErase)
         frameContainer.erase(f);
 
-    return toErase.size();
+    return !toErase.empty();
 }
 
 bool yarp::dev::ImplementIFrameSource::clearStaticFrames()
@@ -145,7 +144,7 @@ bool yarp::dev::ImplementIFrameSource::clearStaticFrames()
     for (const auto& f : toErase)
         frameContainer.erase(f);
 
-    return toErase.size();
+    return !toErase.empty();
 }
 
 IFrameSource::Result<bool> ImplementIFrameSource::canTransform(const string &target_frame, const string &source_frame)

--- a/src/libYARP_dev/src/ImplementIFrameSource.cpp
+++ b/src/libYARP_dev/src/ImplementIFrameSource.cpp
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IFrameSource.h>
+#include <algorithm>
+#include<thread>
+using namespace yarp::dev;
+using namespace yarp::math;
+using namespace yarp::sig;
+using namespace std;
+
+#define FULL_RANGE(c) (c).begin(), (c).end()
+
+FrameTransform operator*(const FrameTransform& l, const FrameTransform& r)
+{
+    FrameTransform ret;
+    ret.dst_frame_id = l.dst_frame_id;
+    ret.src_frame_id = r.src_frame_id;
+    ret.fromMatrix(l.toMatrix() * r.toMatrix());
+    return ret;
+}
+
+void invert(FrameTransform& frame)
+{
+    frame.fromMatrix(yarp::math::SE3inv(frame.toMatrix()));
+}
+
+ImplementIFrameSource::~ImplementIFrameSource() = default;
+
+IFrameSource::Result<int> ImplementIFrameSource::setCallback(function<bool(IFrameSource*)> cb)
+{
+    static int callbackId = 0;
+    if (callbackPrepare())
+    {
+        callbacks[callbackId] = cb;
+        callbackId++;
+        return {true, 0, callbackId -1};
+    }
+    else
+        return { false, -1, -1 };
+}
+
+bool ImplementIFrameSource::unsetCallback(const int& id)
+{
+    if (id == -1)
+        return false;
+    callbackDismiss();
+    callbacks.erase(id);
+    return true;
+}
+
+ImplementIFrameSource::ConnectionType ImplementIFrameSource::getConnectionType(const string& target_frame, const string& source_frame, std::string* commonAncestor)
+{
+    std::vector<std::string> tar2root_vec;
+    std::vector<std::string> src2root_vec;
+    std::string              child;
+    child = source_frame;
+
+    auto par = getParentRaw(child);
+    while (par.valid)
+    {
+        if (par.value == target_frame)
+        {
+            return DIRECT;
+        }
+
+        tar2root_vec.push_back(par.value);
+        child = par.value;
+        par = getParentRaw(child);
+    }
+    child    = target_frame;
+    par      = getParentRaw(child);
+    while (par.valid)
+    {
+        if (par.value == source_frame)
+        {
+            return INVERSE;
+        }
+
+        src2root_vec.push_back(par.value);
+        child = par.value;
+        par = getParentRaw(child);
+    }
+
+    for (const auto& i : tar2root_vec)
+    {
+        for (const auto& j : src2root_vec)
+        {
+            if (i == j)
+            {
+                if (commonAncestor)
+                {
+                    *commonAncestor = i;
+                }
+                return UNDIRECT;
+            }
+        }
+    }
+
+    return DISCONNECTED;
+}
+
+std::string ImplementIFrameSource::allFramesAsString()
+{
+    if(!cacheValid)
+        updateFrameContainer(frameContainer);
+
+    std::string ret;
+    for (const auto& frame : frameContainer)
+    {
+        ret += frame.second.toString() + " ";
+    }
+    return ret;
+}
+
+bool ImplementIFrameSource::clearOlderFrames(const std::chrono::milliseconds& lifeMax)
+{
+    vector<decltype(FrameTransform::frameId)> toErase;
+    double t = yarp::os::Time::now() - double(lifeMax.count())/1000.0;
+    
+    for (const auto& frame : frameContainer)
+        if (frame.second.timestamp != 0.0 && frame.second.timestamp < t)
+            toErase.emplace_back(frame.second.frameId);
+
+    for (const auto& f : toErase)
+        frameContainer.erase(f);
+
+    return toErase.size();
+}
+
+bool yarp::dev::ImplementIFrameSource::clearStaticFrames()
+{
+    vector<decltype(FrameTransform::frameId)> toErase;
+
+    for (const auto& frame : frameContainer)
+        if (frame.second.timestamp == 0.0)
+            toErase.emplace_back(frame.second.frameId);
+
+    for (const auto& f : toErase)
+        frameContainer.erase(f);
+
+    return toErase.size();
+}
+
+IFrameSource::Result<bool> ImplementIFrameSource::canTransform(const string &target_frame, const string &source_frame)
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+
+    if (!frameExistsRaw(target_frame))
+    {
+        return{ false, IFrameSource::TARGET_NOT_FOUND, false };
+    }
+    if (!frameExistsRaw(source_frame))
+    {
+        return{ false, IFrameSource::SOURCE_NOT_FOUND, false };
+    }
+    return { true, IFrameSource::OK, getConnectionType(target_frame, source_frame) != DISCONNECTED };
+}
+
+bool ImplementIFrameSource::frameExists(const string &frame_id)
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+    return frameExistsRaw(frame_id);
+}
+
+bool ImplementIFrameSource::frameExistsRaw(const string &frame_id)
+{
+    for (const auto& frame : frameContainer)
+    {
+        if (frame.second.frameId == frame_id)
+            return true;
+        if (frame.second.parentFrame == frame_id)
+            return true;
+    }
+    return false;
+}
+
+unordered_set<string> ImplementIFrameSource::getAllFrameIds()
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+
+    unordered_set<string> ret;
+    for (const auto& frame : frameContainer)
+    {
+        ret.insert(frame.second.frameId);
+        ret.insert(frame.second.parentFrame);
+    }
+    return ret;
+}
+
+std::vector<FrameTransform> ImplementIFrameSource::getAllFrames()
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+    std::vector<FrameTransform> v;
+    std::transform(frameContainer.begin(), frameContainer.end(), std::back_inserter(v), [](auto &kv) { return kv.second; });
+    return v;
+}
+
+IFrameSource::Result<std::string> ImplementIFrameSource::getParent(const std::string& frame_id)
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+
+    return getParentRaw(frame_id);
+}
+
+IFrameSource::Result<std::string> ImplementIFrameSource::getParentRaw(const std::string& frame_id)
+{
+    auto it = std::find_if(FULL_RANGE(frameContainer), [&frame_id](const auto& frame) { return frame.second.frameId == frame_id; });
+    if (it == frameContainer.end())
+    {
+        return { false, IFrameSource::FRAME_NOT_FOUND, ""};
+    }
+
+    return { true, IFrameSource::OK, it->second.parentFrame };
+}
+
+IFrameSource::Result<FrameTransform> ImplementIFrameSource::getChainedTransform(const std::string& target_frame_id, const std::string& source_frame_id)
+{
+    const auto& tfVec = frameContainer;
+    size_t i;
+
+    for (const auto& i : frameContainer)
+    {
+        if (i.second.frameId == source_frame_id)
+        {
+            if (i.second.parentFrame == target_frame_id)
+            {
+                return { true, IFrameSource::OK, i.second };
+            }
+            else
+            {
+                auto tf = getChainedTransform(target_frame_id, i.second.parentFrame);
+                if (tf.valid)
+                {
+                    return { true, IFrameSource::OK, tf.value * i.second };
+                }
+            }
+        }
+    }
+
+    return { false, IFrameSource::FRAMES_NOT_CONNECTED, FrameTransform() };
+}
+
+IFrameSource::Result<FrameTransform> ImplementIFrameSource::getTransform(const std::string &target_frame_id, const std::string &source_frame_id, double timestamp)
+{
+    if (!cacheValid)
+        updateFrameContainer(frameContainer);
+    ConnectionType ct;
+    std::string    ancestor;
+    ct = getConnectionType(target_frame_id, source_frame_id, &ancestor);
+    if (ct == DIRECT)
+    {
+        return getChainedTransform(target_frame_id, source_frame_id);
+    }
+    else if (ct == UNDIRECT)
+    {
+        auto root2src = getChainedTransform(ancestor, source_frame_id);
+        auto root2tar = getChainedTransform(ancestor, target_frame_id);
+        invert(root2src.value);
+        return { root2src.valid && root2tar.valid, IFrameSource::UNDEFINED, root2src.value * root2tar.value };
+    }
+    else if (ct == INVERSE)
+    {
+        auto ret = getChainedTransform(source_frame_id, target_frame_id);
+        invert(ret.value);
+        return ret;
+    }
+
+
+
+    return { false, IFrameSource::FRAMES_NOT_CONNECTED, FrameTransform() };
+}
+
+IFrameSource::Result<Vector> ImplementIFrameSource::transformPoint(const string &target_frame_id, const string &source_frame_id, const Vector &input_point, double timestamp)
+{
+    if (input_point.size() != 3)
+    {
+        return { false, IFrameSource::WRONG_INPUT_FORMAT, yarp::sig::Vector() };
+    }
+
+    auto ret = getTransform(target_frame_id, source_frame_id);
+    if (!ret.valid)
+    {
+        return { ret.valid, ret.error, yarp::sig::Vector() };
+    }
+    yarp::sig::Vector in = input_point;
+    in.push_back(1);
+    auto transformed_point = ret.value.toMatrix() * in;
+    transformed_point.pop_back();
+    return { true, IFrameSource::OK, transformed_point };
+}
+
+IFrameSource::Result<Vector> ImplementIFrameSource::transformPose(const string &target_frame_id, const string &source_frame_id, const Vector &input_pose, double timestamp)
+{
+    auto transformed_pose = yarp::sig::Vector(6);
+    if (input_pose.size() != 6)
+    {
+        return { false, IFrameSource::WRONG_INPUT_FORMAT, yarp::sig::Vector() };;
+    }
+
+    auto ret = getTransform(target_frame_id, source_frame_id);
+    if (!ret.valid)
+    {
+        return { ret.valid, ret.error, yarp::sig::Vector() };
+    }
+    FrameTransform t;
+    t.transFromVec(input_pose[0], input_pose[1], input_pose[2]);
+    t.rotFromRPY(input_pose[3], input_pose[4], input_pose[5]);
+    t.fromMatrix(ret.value.toMatrix() * t.toMatrix());
+    transformed_pose[0] = t.translation.tX;
+    transformed_pose[1] = t.translation.tY;
+    transformed_pose[2] = t.translation.tZ;
+
+    yarp::sig::Vector rot;
+    rot = t.getRPYRot();
+    transformed_pose[3] = rot[0];
+    transformed_pose[4] = rot[1];
+    transformed_pose[5] = rot[2];
+    return { true, IFrameSource::OK, transformed_pose };
+}
+
+IFrameSource::Result<Quaternion> ImplementIFrameSource::transformQuaternion(const string &target_frame_id, const string &source_frame_id, const Quaternion &input_quaternion, double timestamp)
+{
+    yarp::math::Quaternion transformed_quaternion;
+    auto ret = getTransform(target_frame_id, source_frame_id);
+    if (!ret.valid)
+    {
+        return { ret.valid, ret.error, yarp::math::Quaternion() };
+    }
+    FrameTransform t;
+    t.rotation = input_quaternion;
+    transformed_quaternion.fromRotationMatrix(ret.value.toMatrix() * t.toMatrix());
+    return { true, IFrameSource::OK, transformed_quaternion };
+}
+
+IFrameSource::Result<FrameTransform> ImplementIFrameSource::waitForTransform(const string &target_frame_id, const string &source_frame_id, const double &timeout)
+{
+    //loop until canTransform == true or timeout expires
+    double start = yarp::os::SystemClock::nowSystem();
+    auto ret = canTransform(target_frame_id, source_frame_id);
+    while (!ret.valid)
+    {
+        if (yarp::os::SystemClock::nowSystem() - start > timeout)
+        {
+            return { false, IFrameSource::TIMEOUT, FrameTransform() };
+        }
+        yarp::os::SystemClock::delaySystem(0.001);
+        ret = canTransform(target_frame_id, source_frame_id);
+    }
+    return getTransform(target_frame_id, source_frame_id);
+}

--- a/src/libYARP_math/include/yarp/math/FrameTransform.h
+++ b/src/libYARP_math/include/yarp/math/FrameTransform.h
@@ -17,119 +17,133 @@
 
 namespace yarp
 {
-    namespace math
+namespace math
+{
+
+class YARP_math_API FrameTransform
+{
+public:
+
+    std::string parentFrame;
+    std::string frameId;
+    YARP_DEPRECATED_MSG("use parentFrame and frameId instead") std::string src_frame_id;
+    YARP_DEPRECATED_MSG("use parentFrame and frameId instead") std::string dst_frame_id;
+    double      timestamp{ 0 };
+
+    struct Translation_t
     {
-        class YARP_math_API FrameTransform
+        double tX;
+        double tY;
+        double tZ;
+
+        void set(double x, double y, double z)
         {
-            public:
-            YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::string) src_frame_id;
-            YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::string) dst_frame_id;
-            double      timestamp;
+            tX = x;
+            tY = y;
+            tZ = z;
+        }
+    } translation;
 
-            struct Translation_t
-            {
-                double tX;
-                double tY;
-                double tZ;
+    Quaternion rotation;
 
-                void set(double x, double y, double z)
-                {
-                    tX = x;
-                    tY = y;
-                    tZ = z;
-                }
-            } translation;
-
-            Quaternion rotation;
-
-            FrameTransform()
-            {
-                timestamp = 0;
-                translation.set(0, 0, 0);
-            }
-
-            FrameTransform
-                (
-                const std::string& parent,
-                const std::string& child,
-                double             inTX,
-                double             inTY,
-                double             inTZ,
-                double             inRX,
-                double             inRY,
-                double             inRZ,
-                double             inRW
-                )
-            {
-                src_frame_id = parent;
-                dst_frame_id = child;
-                translation.set(inTX, inTY, inTZ);
-                rotation.w() = inRW;
-                rotation.x() = inRX;
-                rotation.y() = inRY;
-                rotation.z() = inRZ;
-            }
-
-            ~FrameTransform(){};
-
-            void transFromVec(double X, double Y, double Z)
-            {
-                translation.set(X, Y, Z);
-            }
-
-            void rotFromRPY(double R, double P, double Y)
-            {
-                double               rot[3] = { R, P, Y };
-                size_t               i = 3;
-                yarp::sig::Vector    rotV;
-                yarp::sig::Matrix    rotM;
-                rotV = yarp::sig::Vector(i, rot);
-                rotM = rpy2dcm(rotV);
-                rotation.fromRotationMatrix(rotM);
-            }
-
-            yarp::sig::Vector getRPYRot() const
-            {
-                yarp::sig::Vector rotV;
-                yarp::sig::Matrix rotM;
-                rotM = rotation.toRotationMatrix4x4();
-                rotV = dcm2rpy(rotM);
-                return rotV;
-            }
-
-            yarp::sig::Matrix toMatrix() const
-            {
-                yarp::sig::Vector rotV;
-                yarp::sig::Matrix t_mat(4,4);
-                t_mat = rotation.toRotationMatrix4x4();
-                t_mat[0][3] = translation.tX;
-                t_mat[1][3] = translation.tY;
-                t_mat[2][3] = translation.tZ;
-                return t_mat;
-            }
-
-            bool fromMatrix(const yarp::sig::Matrix& mat)
-            {
-                if (mat.cols() != 4 || mat.rows() != 4)
-                {
-                    yError("FrameTransform::fromMatrix() failed, matrix should be = 4x4");
-                    yAssert(mat.cols() == 4 && mat.rows() == 4);
-                    return false;
-                }
-
-                yarp::sig::Vector q;
-
-                translation.tX = mat[0][3];
-                translation.tY = mat[1][3];
-                translation.tZ = mat[2][3];
-                rotation.fromRotationMatrix(mat);
-                return true;
-            }
-
-            std::string toString() const;
-        };
+    FrameTransform()
+    {
+        timestamp = 0;
+        translation.set(0, 0, 0);
     }
-}
 
+    FrameTransform(const std::string& parent, const std::string& child, yarp::sig::Matrix m, bool staticTf = false) : parentFrame(parent), frameId(child)
+    {
+        fromMatrix(m);
+        if (!staticTf)
+        {
+            timestamp = yarp::os::Time::now();
+        }
+    }
+
+    FrameTransform
+        (
+        const std::string& parent,
+        const std::string& child,
+        double             inTX,
+        double             inTY,
+        double             inTZ,
+        double             inRX,
+        double             inRY,
+        double             inRZ,
+        double             inRW
+        ) : parentFrame(parent),
+            frameId(child)
+    {
+        src_frame_id = parent;
+        dst_frame_id = child;
+        translation.set(inTX, inTY, inTZ);
+        rotation.w() = inRW;
+        rotation.x() = inRX;
+        rotation.y() = inRY;
+        rotation.z() = inRZ;
+    }
+
+    ~FrameTransform(){};
+
+    void transFromVec(double X, double Y, double Z)
+    {
+        translation.set(X, Y, Z);
+    }
+
+    void rotFromRPY(double R, double P, double Y)
+    {
+        double               rot[3] = { R, P, Y };
+        size_t               i = 3;
+        yarp::sig::Vector    rotV;
+        yarp::sig::Matrix    rotM;
+        rotV = yarp::sig::Vector(i, rot);
+        rotM = rpy2dcm(rotV);
+        rotation.fromRotationMatrix(rotM);
+    }
+
+    yarp::sig::Vector getRPYRot() const
+    {
+        yarp::sig::Vector rotV;
+        yarp::sig::Matrix rotM;
+        rotM = rotation.toRotationMatrix4x4();
+        rotV = dcm2rpy(rotM);
+        return rotV;
+    }
+
+    yarp::sig::Matrix toMatrix() const
+    {
+        yarp::sig::Vector rotV;
+        yarp::sig::Matrix t_mat(4,4);
+        t_mat = rotation.toRotationMatrix4x4();
+        t_mat[0][3] = translation.tX;
+        t_mat[1][3] = translation.tY;
+        t_mat[2][3] = translation.tZ;
+        return t_mat;
+    }
+
+    bool fromMatrix(const yarp::sig::Matrix& mat)
+    {
+        if (mat.cols() != 4 || mat.rows() != 4)
+        {
+            yError("FrameTransform::fromMatrix() failed, matrix should be = 4x4");
+            yAssert(mat.cols() == 4 && mat.rows() == 4);
+            return false;
+        }
+
+        yarp::sig::Vector q;
+
+        translation.tX = mat[0][3];
+        translation.tY = mat[1][3];
+        translation.tZ = mat[2][3];
+        rotation.fromRotationMatrix(mat);
+        return true;
+    }
+
+    std::string toString() const;
+};
+
+}
+}
 #endif
 

--- a/src/libYARP_math/src/FrameTransform.cpp
+++ b/src/libYARP_math/src/FrameTransform.cpp
@@ -13,15 +13,16 @@
 std::string yarp::math::FrameTransform::toString() const
 {
     char buff[1024];
-    sprintf(buff, "%s -> %s \n tran: %f %f %f \n rot: %f %f %f %f \n\n",
-                  src_frame_id.c_str(),
-                  dst_frame_id.c_str(),
+    sprintf(buff, "%s -> %s \n tran: %f %f %f \n rot: %f %f %f %f %f \n\n",
+                  parentFrame.c_str(),
+                  frameId.c_str(),
                   translation.tX,
                   translation.tY,
                   translation.tZ,
                   rotation.x(),
                   rotation.y(),
                   rotation.z(),
-                  rotation.w());
+                  rotation.w(),
+                  timestamp);
     return std::string(buff);
 }

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -17,7 +17,7 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/Time.h>
 #include <yarp/math/Math.h>
-
+#include <chrono>
 #include <cmath>
 #include <vector>
 
@@ -27,7 +27,9 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 using namespace yarp::math;
+#if (defined _WIN32 && _MSC_VER > 1910) || (!defined _WIN32 && __cplusplus > 201402L)
 using namespace std::chrono_literals;
+#endif
 
 static bool isEqual(const yarp::sig::Vector& v1, const yarp::sig::Vector& v2, double precision)
 {
@@ -282,7 +284,11 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
             yarp::os::Time::delay(1);
             bool del_bool = itfR->frameExists("frame_test");
             yarp::os::Time::delay(1);
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+            itfR->clearOlderFrames(std::chrono::milliseconds(10));
+#else
             itfR->clearOlderFrames(10ms);
+#endif
             del_bool &= (!itfR->frameExists("frame_test"));
             CHECK(del_bool); // deleteTransform ok
         }
@@ -290,7 +296,11 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
         //test 9
         {
             itfB->clear();
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+            itfR->clearOlderFrames(std::chrono::milliseconds(0));
+#else
             itfR->clearOlderFrames(0ms);
+#endif
             itfR->clearStaticFrames();
             auto cids = itfR->getAllFrameIds();
             CHECK(cids.size() == 0); // clear ok
@@ -301,14 +311,22 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
             itfB->setTransform({"frame10", "frame2", m1});
             yarp::os::Time::delay(0.050);
             CHECK(itfR->canTransform("frame10", "frame2").value); // itf->setTransform ok
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+            itfR->clearOlderFrames(std::chrono::milliseconds(40));
+#else
             itfR->clearOlderFrames(40ms);
+#endif
             CHECK_FALSE(itfR->canTransform("frame10", "frame2").value); // itf->setTransform successfully expired after 0.6s
         }
 
         //test 11
         {
             itfB->clear();
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+            itfR->clearOlderFrames(std::chrono::milliseconds(0));
+#else
             itfR->clearOlderFrames(0ms);
+#endif
             itfR->clearStaticFrames();
             bool set_b1 = itfB->setTransform({ "frame10", "frame2", m1 });
             yarp::os::Time::delay(0.050);
@@ -348,7 +366,11 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
         //test 12
         {
             itfB->clear();
+#if (defined _WIN32 && _MSC_VER < 1910) || (!defined _WIN32 && __cplusplus < 201402L)
+            itfR->clearOlderFrames(std::chrono::milliseconds(0));
+#else
             itfR->clearOlderFrames(0ms);
+#endif
             itfR->clearStaticFrames();
             CHECK(itfB->setTransform({ "frame1", "frame2", m1 }));
             yarp::os::Time::delay(0.050);


### PR DESCRIPTION
~~This pr do a **lot** of different things. unfortunately all of them are strictly related so it cannot be splitted in different pr (or it's very painful doing it). also, splitting it in different pr makes very unclear the sense of some modifications.~~

the necessity of this pr emerged with the urge to treat devices that produces frames (poses in the 3D space), like ovrdevice and vicon device, in the standard yarp way (with the interface + wrapper + client combo, P2P paradigm).
Until now, a device that produces frames had to open a `frameTransformClient` inside and comunicate via the `frameTransformServer` to other clients via a **Client-Server-Client** architecture, different from the usual **P2P** comunication pattern.
while this has some advantages it also forces a network comunication via yarp ports even when **it is not needed** (so it is **not** possible to open the device locally and get his data via c++ calls). In order to solve this i developed two new interfaces that can be adapted to **both** paradigm.

`IFrameSource`: this particular interface can seems unusual cause it does not have any pubblic pure virtual method. This is because all the beaviour and the math involved in chaining the Frames toghether can be **reused** among all the devices and it is already implemented. instead it have a sort of **protected intra-class interface**, to allow a correct comunication between the parent class and the derived calsses, **enforcing** a lot of stuff and robustifying the architecture. in particular this is useful to build up a **callback mechanism** that allow the user to trigger a function call on every update of the device (even remotely).

pr modification list:

~~- introduces a dependency in yarp to a **new** library of robotology called `RobotologyTemplateLibrary`, which contains some utilities that should not stay in yarp but since the library is still an **unstable stub**, the dependency is coordinated by the new flag `YARP_ENABLE_UNSTABLE`. we cannot wait for the library to be stable, cause the development of this new library is strictly related to his possible usage. and it is only used in this pr at the moment, and it will likely used fisrt in yarp. with @traversaro we agreed to flag the new library as **stable** within **max 2 releases** of yarp and from then continue to develop the library with the usual deprecation policies. moving the dependency outside the `YARP_ENABLE_UNSTABLE` flag.~~ 
_the work on this became **way too** time expensive and some minor importance elements have been reduced_

~~- definition of a new global flag `YARP_EXPERIMENTAL`. useful to confine part of the code that uses the new library or that are in a **experimental** state.~~

- ~~with a tool offered by the new library,~~ two new interfaces has been developed. Actually they come from the IFrameTransform interface, splitted in two parts. one for devices which **only** produces frames, **IFrameSource**, ~~and one that rappresent the version 2 of the `IFrameTransform`~~, _and one for set some tf via function call from the user application (IFrameSet.. i know the name i ugly and misleading. go on, propose a new one!)._

- yarp::math::FrameTransform name issue. two new name to identify the frame structure has been added: `frameId `and `parentFrame`. this should substitute the old `dst_frame_id` and `src_frame_id` _which have been deprecated_. the new implementation solve the #1775 

- `ovrdevice `has been adapted to the new paradigm, deriving from `iFrameSource`, eliminating both the inclusion of the FrameTransformClient and the yarp port to publish the headset pose. ~~the new implementation is confined by `YARP_EXPERIMENTAL`, otherwise the old implementation is active~~. this allows to use it without the transform server, taking the data directly from him via c++ code or remotely in a p2p via the **network wrappers**

- `FrameReceiver `the client side network wrapper.

- `FrameBroadcaster `the produces side network wrapper.

these last three devices support the new **callback** system. so it is possible to have a user application triggered and **syncronized** with the `ovrdevice `thread.

26/03/2019 _the network wrappers comunication is made via **publisher** and **subscriber** so the distribution over multiple subscriber of the tf data is guaranteed by the topic mechanism. also the ros comunication can be archieved via topics because the message used by the network wrapper is `yarp::rosmsg::tf2_msgs::TFMessage`._

notes:
- everithing is still to be tested
~~- i think in the future, the FrameTransformClient should implement the new `IFrameManager `interface, which is Client-Server-client compliant. @randaz81 told me it is used a lot outside yarp so i leaved it untouched.~~ _at this point the FrameTransform client and server can be dismissed.._
~~- **no ROS** compatibility have been added in the `FrameBroadcaster `for now. it can be done in a future pr as it to be quick and easy.~~ _ROS compatibility added_
~~- a lot of interoperations with the other paradigm (FrameTransformClient/Server) are possible, though none of them have been developed at the moment. ~~ 
_no interoperation with the old paradigm is needed anymore._
~~- since there are probably **762** different ways to do the cmake parts, i probably picked the **wrong** one and i presume it have to be corrected. so if you have suggestions regarding the _"cmake-shining-compliant"_  way to accomplish what i've done don't be afraid of fullfill my lack of experience with cmake.~~ the cmake part is very small right now
~~- if it isn't clear the relation between all the element of the pr is the following: _RobotologyTemplateLibrary_ `Result `type is used in the ----> new interfaces to manage Frames which have been developed to change the comunication paradigm of the -----> `ovrdevice `and Others. viceversa the ovrdevice stands as an example of the new implementation.~~ _the pr is much more simpler_
- fixes the dic-iit/element_retargeting_from_human#72 and it is a preparation for the 73 and 74.
- there will be, for sure, someone who don't like the names of the new flags/interfaces/something and has better alternative. not a problem for me. Just decide  the names you like and i will change it.
- the changelog and ~~the method documentation~~ will be added/updated after the review process (i expect it to be **long**)
- sorry for possible english mistake


@GiulioRomualdi @DanielePucci @drdanz @Nicogene @randaz81 @traversaro @barbalberto 