### PR TITLE
Synchronize "Append" and "Expect" methods for strings

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -38,6 +38,9 @@ New Features
     * `InputStream::readLine()`
 * Added `YarpPluginSelector::checkPlugin()` static method.
 * `ConnectionWriter::appendString()` is deprecated in favour of `appendText()`.
+* `ConnectionWriter::appendRawString()` is deprecated in favour of
+  `appendString()`.
+* Added `ConnectionReader::expectString()`.
 
 #### `YARP_dev`
 

--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -37,6 +37,7 @@ New Features
     * `ConnectionWriter::appendString()`
     * `InputStream::readLine()`
 * Added `YarpPluginSelector::checkPlugin()` static method.
+* `ConnectionWriter::appendString()` is deprecated in favour of `appendText()`.
 
 #### `YARP_dev`
 

--- a/example/game/game_server/main.cpp
+++ b/example/game/game_server/main.cpp
@@ -98,7 +98,7 @@ public:
         if (result.length()>0 && loggedOn) {
             //if (reply.size()>0) {
             if (writer->isTextMode()) {
-                writer->appendString(result.c_str());
+                writer->appendText(result.c_str());
             } else {
                 Bottle reply;
                 reply.fromString(result.c_str());

--- a/src/libYARP_OS/include/yarp/os/ConnectionReader.h
+++ b/src/libYARP_OS/include/yarp/os/ConnectionReader.h
@@ -61,6 +61,22 @@ public:
     virtual std::string expectText(const char terminatingChar = '\n') = 0;
 
     /**
+     * Read a string from the network connection.
+     * The string should be serialized as "length" + "block".
+     * @return the string read from the connection
+     */
+    virtual std::string expectString()
+    {
+        std::string ret;
+        std::int32_t len = expectInt32();
+        if (!isError()) {
+            ret.resize(static_cast<size_t>(len));
+            expectBlock(const_cast<char*>(ret.data()), len);
+        }
+        return ret;
+    }
+
+    /**
      * Read an integer from the network connection.
      * @return the integer read from the connection
      * @warning Unsafe, sizeof(int) is platform dependent. Use expectInt32 instead.

--- a/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
@@ -120,12 +120,23 @@ public:
      */
     virtual void appendFloat64(yarp::conf::float64_t data) = 0;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2
     /**
      * Send a character sequence to the network connection.
      * @param str the character sequence to send
      * @param terminate the terminating character to use
+     * @deprecated since YARP 3.2
      */
-    virtual void appendString(const char* str, const char terminate = '\n') = 0;
+    YARP_DEPRECATED_MSG("Use appendText() instead")
+    virtual void appendString(const char* str, const char terminate = '\n') final { appendText({str}, terminate); }
+#endif
+
+    /**
+     * Send a character sequence to the network connection.
+     * @param str the string to send
+     * @param terminate the terminating character to use
+     */
+    virtual void appendText(const std::string& str, const char terminate = '\n') = 0;
 
     /**
      * Send a block of data to the network connection, without making a copy.

--- a/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/ConnectionWriter.h
@@ -132,11 +132,35 @@ public:
 #endif
 
     /**
-     * Send a character sequence to the network connection.
+     * Send a terminated string to the network connection.
+     *
+     * The lenght of string is not specified in advance, therefore the
+     * reader should read until the terminating character is found.
+     *
      * @param str the string to send
      * @param terminate the terminating character to use
      */
     virtual void appendText(const std::string& str, const char terminate = '\n') = 0;
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2
+    YARP_DEPRECATED_MSG("Use appendString() instead")
+    virtual void appendRawString(const std::string& str) final { appendString(str); }
+#endif
+
+    /**
+     * Send a string to the network connection.
+     *
+     * The lenght of string is not specified in advance, therefore the
+     * reader should read the number of bytes specified by the first integer.
+     * The string terminating character (normally '\0') is not transmitted.
+     *
+     * @param str the string to send
+     */
+    void appendString(const std::string& str)
+    {
+        appendInt32(static_cast<std::int32_t>(str.length()));
+        appendBlock((char*)str.c_str(), str.length());
+    }
 
     /**
      * Send a block of data to the network connection, without making a copy.
@@ -240,13 +264,6 @@ public:
      *
      */
     virtual SizedWriter* getBuffer() const = 0;
-
-
-    virtual void appendRawString(const std::string& str)
-    {
-        appendInt32(static_cast<std::int32_t>(str.length()));
-        appendBlock((char*)str.c_str(), str.length());
-    }
 
     /**
      *

--- a/src/libYARP_OS/include/yarp/os/NullConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/NullConnectionWriter.h
@@ -31,7 +31,7 @@ public:
     void appendInt64(std::int64_t data) override;
     void appendFloat32(yarp::conf::float32_t data) override;
     void appendFloat64(yarp::conf::float64_t data) override;
-    void appendString(const char* str, const char terminate = '\n') override;
+    void appendText(const std::string& str, const char terminate = '\n') override;
     void appendExternalBlock(const char* data, size_t len) override;
     bool isTextMode() const override;
     bool isBareMode() const override;

--- a/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/BufferedConnectionWriter.h
@@ -133,7 +133,7 @@ public:
     void appendFloat32(yarp::conf::float32_t data) override;
     void appendFloat64(yarp::conf::float64_t data) override;
     void appendBlock(const char* data, size_t len) override;
-    void appendString(const char* str, const char terminate = '\n') override;
+    void appendText(const std::string& str, const char terminate = '\n') override;
     void appendExternalBlock(const char* data, size_t len) override;
 
     /**
@@ -151,8 +151,6 @@ public:
      * @param data the buffer to add
      */
     virtual void appendBlockCopy(const Bytes& data);
-
-    virtual void appendStringBase(const std::string& data);
 
     /**
      * Send a string along with a carriage-return-line-feed sequence.

--- a/src/libYARP_OS/include/yarp/os/impl/ConnectionRecorder.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ConnectionRecorder.h
@@ -83,7 +83,7 @@ public:
     void appendInt64(std::int64_t data) override;
     void appendFloat32(yarp::conf::float32_t data) override;
     void appendFloat64(yarp::conf::float64_t data) override;
-    void appendString(const char* str, const char terminate) override;
+    void appendText(const std::string& str, const char terminate) override;
     void appendExternalBlock(const char* data, size_t len) override;
     void declareSizes(int argc, int* argv) override;
     void setReplyHandler(yarp::os::PortReader& reader) override;

--- a/src/libYARP_OS/include/yarp/os/impl/StreamConnectionReader.h
+++ b/src/libYARP_OS/include/yarp/os/impl/StreamConnectionReader.h
@@ -55,7 +55,10 @@ public:
     bool dropRequested();
 
     virtual bool expectBlock(yarp::os::Bytes& b);
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2
+    using ConnectionReader::expectString;
     virtual std::string expectString(int len);
+#endif
     virtual std::string expectLine();
     virtual void flushWriter();
     virtual void setReference(yarp::os::Portable *obj);

--- a/src/libYARP_OS/src/BottleImpl.cpp
+++ b/src/libYARP_OS/src/BottleImpl.cpp
@@ -422,8 +422,7 @@ bool BottleImpl::write(ConnectionWriter& writer) const
 {
     // could simplify this if knew lengths of blocks up front
     if (writer.isTextMode()) {
-        // writer.appendLine(toString());
-        writer.appendString(toString().c_str(), '\n');
+        writer.appendText(toString());
     } else {
         synch();
         /*

--- a/src/libYARP_OS/src/BufferedConnectionWriter.cpp
+++ b/src/libYARP_OS/src/BufferedConnectionWriter.cpp
@@ -269,12 +269,13 @@ void BufferedConnectionWriter::appendBlock(const char* data, size_t len)
     appendBlockCopy(yarp::os::Bytes((char*)data, len));
 }
 
-void BufferedConnectionWriter::appendString(const char* str, const char terminate)
+void BufferedConnectionWriter::appendText(const std::string& str, const char terminate)
 {
     if (terminate == '\n') {
         appendLine(str);
     } else if (terminate == 0) {
-        appendStringBase(str);
+        yarp::os::Bytes b(const_cast<char*>(str.data()), str.length() + 1);
+        push(b, true);
     } else {
         std::string s = str;
         s += terminate;
@@ -296,12 +297,6 @@ void BufferedConnectionWriter::appendBlock(const yarp::os::Bytes& data)
 void BufferedConnectionWriter::appendBlockCopy(const Bytes& data)
 {
     push(data, true);
-}
-
-void BufferedConnectionWriter::appendStringBase(const std::string& data)
-{
-    yarp::os::Bytes b((char*)(data.c_str()), data.length() + 1);
-    push(b, true);
 }
 
 void BufferedConnectionWriter::appendLine(const std::string& data)

--- a/src/libYARP_OS/src/ConnectionRecorder.cpp
+++ b/src/libYARP_OS/src/ConnectionRecorder.cpp
@@ -66,7 +66,7 @@ bool yarp::os::impl::ConnectionRecorder::expectBlock(char* data, size_t len)
 std::string yarp::os::impl::ConnectionRecorder::expectText(const char terminatingChar)
 {
     std::string str = reader->expectText(terminatingChar);
-    readerStore.appendString(str.c_str(), terminatingChar);
+    readerStore.appendText(str.c_str(), terminatingChar);
     return str;
 }
 
@@ -235,10 +235,10 @@ void yarp::os::impl::ConnectionRecorder::appendFloat64(yarp::conf::float64_t dat
     writerStore.appendFloat64(data);
 }
 
-void yarp::os::impl::ConnectionRecorder::appendString(const char* str, const char terminate)
+void yarp::os::impl::ConnectionRecorder::appendText(const std::string& str, const char terminate)
 {
-    writer->appendString(str, terminate);
-    writerStore.appendString(str, terminate);
+    writer->appendText(str, terminate);
+    writerStore.appendText(str, terminate);
 }
 
 void yarp::os::impl::ConnectionRecorder::appendExternalBlock(const char* data, size_t len)

--- a/src/libYARP_OS/src/NameServer.cpp
+++ b/src/libYARP_OS/src/NameServer.cpp
@@ -783,7 +783,7 @@ public:
                         tmp += i;
                     }
                     tmp += '\r';
-                    os->appendString(tmp.c_str(), '\n');
+                    os->appendText(tmp.c_str());
 
                     YARP_DEBUG(Logger::get(),
                                std::string("name server reply is ") + result);

--- a/src/libYARP_OS/src/NullConnectionWriter.cpp
+++ b/src/libYARP_OS/src/NullConnectionWriter.cpp
@@ -45,7 +45,7 @@ void yarp::os::NullConnectionWriter::appendFloat64(yarp::conf::float64_t data)
     YARP_UNUSED(data);
 }
 
-void yarp::os::NullConnectionWriter::appendString(const char *str, const char terminate)
+void yarp::os::NullConnectionWriter::appendText(const std::string& str, const char terminate)
 {
     YARP_UNUSED(str);
     YARP_UNUSED(terminate);

--- a/src/libYARP_OS/src/PortCommand.cpp
+++ b/src/libYARP_OS/src/PortCommand.cpp
@@ -69,9 +69,9 @@ bool PortCommand::write(ConnectionWriter& writer) const {
         if (ch!='\0') {
             char buf[] = "X";
             buf[0] = ch;
-            writer.appendString(std::string(buf).c_str(), '\n');
+            writer.appendText(buf);
         } else {
-            writer.appendString(str.c_str(), '\n');
+            writer.appendText(str);
         }
     }
     return !writer.isError();

--- a/src/libYARP_OS/src/Stamp.cpp
+++ b/src/libYARP_OS/src/Stamp.cpp
@@ -91,7 +91,7 @@ bool yarp::os::Stamp::write(ConnectionWriter& connection) const
     if (connection.isTextMode()) {
         char buf[512];
         std::snprintf(buf, 512, "%d %.*g", sequenceNumber, DBL_DIG, timeStamp);
-        connection.appendString(buf);
+        connection.appendText(buf);
     } else {
         connection.appendInt32(BOTTLE_TAG_LIST); // nested structure
         connection.appendInt32(2);               // with two elements

--- a/src/libYARP_OS/src/StreamConnectionReader.cpp
+++ b/src/libYARP_OS/src/StreamConnectionReader.cpp
@@ -103,6 +103,7 @@ bool StreamConnectionReader::expectBlock(Bytes &b)
     return false;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2
 std::string StreamConnectionReader::expectString(int len)
 {
     if (!isGood()) {
@@ -122,6 +123,7 @@ std::string StreamConnectionReader::expectString(int len)
     delete[] buf;
     return s;
 }
+#endif // YARP_NO_DEPRECATED
 
 std::string StreamConnectionReader::expectLine()
 {

--- a/src/libYARP_OS/src/SystemInfoSerializer.cpp
+++ b/src/libYARP_OS/src/SystemInfoSerializer.cpp
@@ -112,14 +112,14 @@ bool SystemInfoSerializer::write(yarp::os::ConnectionWriter& connection) const
     connection.appendInt32(storage.freeSpace);
 
     // serializing network
-    //connection.appendString(network.mac.c_str());
-    //connection.appendString(network.ip4.c_str());
-    //connection.appendString(network.ip6.c_str());
+    //connection.appendText(network.mac);
+    //connection.appendText(network.ip4);
+    //connection.appendText(network.ip6);
 
     // serializing processor
-    connection.appendString(processor.architecture.c_str());
-    connection.appendString(processor.model.c_str());
-    connection.appendString(processor.vendor.c_str());
+    connection.appendText(processor.architecture);
+    connection.appendText(processor.model);
+    connection.appendText(processor.vendor);
     connection.appendInt32(processor.family);
     connection.appendInt32(processor.modelNumber);
     connection.appendInt32(processor.cores);
@@ -133,17 +133,17 @@ bool SystemInfoSerializer::write(yarp::os::ConnectionWriter& connection) const
     connection.appendInt32(load.cpuLoadInstant);
 
     // serializing platform
-    connection.appendString(platform.name.c_str());
-    connection.appendString(platform.distribution.c_str());
-    connection.appendString(platform.release.c_str());
-    connection.appendString(platform.codename.c_str());
-    connection.appendString(platform.kernel.c_str());
-    connection.appendString(platform.environmentVars.toString().c_str());
+    connection.appendText(platform.name);
+    connection.appendText(platform.distribution);
+    connection.appendText(platform.release);
+    connection.appendText(platform.codename);
+    connection.appendText(platform.kernel);
+    connection.appendText(platform.environmentVars.toString());
 
     // serializing user
-    connection.appendString(user.userName.c_str());
-    connection.appendString(user.realName.c_str());
-    connection.appendString(user.homeDir.c_str());
+    connection.appendText(user.userName);
+    connection.appendText(user.realName);
+    connection.appendText(user.homeDir);
     connection.appendInt32(user.userID);
 
     return !connection.isError();

--- a/src/libYARP_OS/src/WireWriter.cpp
+++ b/src/libYARP_OS/src/WireWriter.cpp
@@ -145,8 +145,7 @@ bool WireWriter::writeTag(const char *tag, int split, int len) const {
 bool WireWriter::writeString(const std::string& tag) const {
     writer.appendInt32(BOTTLE_TAG_STRING);
     // WARNING tag.length() value is not checked here
-    writer.appendInt32((int)tag.length());
-    writer.appendBlock(tag.c_str(), tag.length());
+    writer.appendString(tag);
     return !writer.isError();
 }
 

--- a/src/libYARP_dev/src/Map2DArea.cpp
+++ b/src/libYARP_dev/src/Map2DArea.cpp
@@ -101,7 +101,7 @@ bool Map2DArea::write(yarp::os::ConnectionWriter& connection) const
     connection.appendInt32(2+siz*2);
 
     connection.appendInt32(BOTTLE_TAG_STRING);
-    connection.appendRawString(map_id);
+    connection.appendString(map_id);
 
     connection.appendInt32(BOTTLE_TAG_INT32);
     connection.appendInt32(siz);

--- a/src/libYARP_dev/src/MapGrid2D.cpp
+++ b/src/libYARP_dev/src/MapGrid2D.cpp
@@ -792,7 +792,7 @@ bool MapGrid2D::write(yarp::os::ConnectionWriter& connection) const
     connection.appendInt32(BOTTLE_TAG_FLOAT64);
     connection.appendFloat64(m_resolution);
     connection.appendInt32(BOTTLE_TAG_STRING);
-    connection.appendRawString(m_map_name);
+    connection.appendString(m_map_name);
 
     unsigned char *mem = nullptr;
     int            memsize = 0;

--- a/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
+++ b/src/libYARP_name/include/yarp/name/NameServerConnectionHandler.h
@@ -81,11 +81,11 @@ public:
                         std::string si = v.asList()->toString();
                         si.erase(std::remove(si.begin(), si.end(), '\"'), si.end());
                         if (si.length()>0) {
-                            writer->appendString(si.c_str());
+                            writer->appendText(si.c_str());
                         }
                     } else {
                         if (v.isString()) {
-                            writer->appendString(v.asString().c_str());
+                            writer->appendText(v.asString().c_str());
                         } else {
                             yarp::os::Bottle b;
                             b.add(v);
@@ -93,7 +93,7 @@ public:
                         }
                     }
                 }
-                writer->appendString("*** end of message");
+                writer->appendText("*** end of message");
             } else {
                 reply.write(*writer);
             }

--- a/src/libYARP_name/src/BootstrapServer.cpp
+++ b/src/libYARP_name/src/BootstrapServer.cpp
@@ -50,7 +50,7 @@ public:
         DummyConnector con, con2;
         con.setTextMode(true);
         ConnectionWriter& writer = con.getWriter();
-        writer.appendString(txt.c_str());
+        writer.appendText(txt.c_str());
         bool ok = handler.apply(con.getReader(),&(con2.getWriter()));
         std::string result;
         if (ok) {

--- a/src/libYARP_wire_rep_utils/WireImage.h
+++ b/src/libYARP_wire_rep_utils/WireImage.h
@@ -95,10 +95,10 @@ public:
             encoding = "32FC1";
             break;
         }
-        buf.appendRawString(frame);
+        buf.appendString(frame);
         buf.appendInt32(image->height());
         buf.appendInt32(image->width());
-        buf.appendRawString(encoding);
+        buf.appendString(encoding);
         char is_bigendian = 0;
         buf.appendBlock(&is_bigendian,1);
         buf.appendInt32((image->width()*image->getPixelSize())+image->getPadding());


### PR DESCRIPTION
* `ConnectionWriter::appendString()` is deprecated in favour of `appendText()`.
* `ConnectionWriter::appendRawString()` is deprecated in favour of  `appendString()`.
* Added `ConnectionReader::expectString()`.

Fixes #1953
