### PR TITLE
Make MangedBytes and VectorOf movable

### DIFF
--- a/doc/release/master/makeVectorMovable.md
+++ b/doc/release/master/makeVectorMovable.md
@@ -1,0 +1,11 @@
+makeVectorMovable {master}
+-----------------
+
+### `YARP_os`
+
+* Added move semantics in `yarp::os::ManagedBytes`.
+
+
+### `YARP_sig`
+
+* Added move semantics in `yarp::sig::VectorOf`.

--- a/src/libYARP_os/src/yarp/os/ManagedBytes.cpp
+++ b/src/libYARP_os/src/yarp/os/ManagedBytes.cpp
@@ -57,6 +57,30 @@ ManagedBytes::ManagedBytes(const ManagedBytes& alt) :
     }
 }
 
+void ManagedBytes::moveOwnership(ManagedBytes &other)
+{
+    clear();
+    b = other.b;
+    owned = other.owned;
+    use = other.use;
+    use_set = other.use_set;
+    other.owned = false;
+    other.clear();
+}
+
+ManagedBytes::ManagedBytes(ManagedBytes&& other) noexcept
+{
+    moveOwnership(other);
+}
+
+ManagedBytes& ManagedBytes::operator=(ManagedBytes&& other) noexcept
+{
+    if (&other != this) {
+        moveOwnership(other);
+    }
+    return *this;
+}
+
 const ManagedBytes& ManagedBytes::operator=(const ManagedBytes& alt)
 {
     if (&alt != this) {

--- a/src/libYARP_os/src/yarp/os/ManagedBytes.h
+++ b/src/libYARP_os/src/yarp/os/ManagedBytes.h
@@ -44,6 +44,21 @@ public:
     ManagedBytes(const Bytes& ext, bool owned = false);
 
     /**
+     * @brief Move constructor.
+     *
+     * @param other the ManagedBytes to be moved
+     */
+    ManagedBytes(ManagedBytes&& other) noexcept;
+
+    /**
+     * @brief Move assignment operator.
+     *
+     * @param other the MangedBytes to be moved
+     * @return this object
+     */
+    ManagedBytes& operator=(ManagedBytes&& other) noexcept;
+
+    /**
      * Copy constructor.
      * @param alt the data to copy.  If it is "owned" an independent copy
      * is made.
@@ -149,6 +164,8 @@ public:
     }
 
 private:
+    void moveOwnership(ManagedBytes& other);
+
     Bytes b;
     bool owned;
     size_t use;

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -184,6 +184,29 @@ public:
         memcpy(this->data(), p, sizeof(T)*s);
     }
 
+    /**
+     * @brief Move constructor.
+     *
+     * @param other the VectorOf to be moved
+     */
+    VectorOf(VectorOf<T>&& other) noexcept : bytes(std::move(other.bytes))
+    {
+        _updatePointers();
+    }
+
+    /**
+     * @brief Move assignment operator.
+     *
+     * @param other the VectorOf to be moved
+     * @return this object
+     */
+    VectorOf& operator=(VectorOf<T>&& other) noexcept
+    {
+        bytes = std::move(other.bytes);
+        _updatePointers();
+        return *this;
+    }
+
     VectorOf(const VectorOf& r) : VectorBase()
     {
         bytes = r.bytes;


### PR DESCRIPTION
This PR makes `ManagedBytes` and `VectorOf` movable.

It fixes #1965.

Please review the code.