### PR TITLE
include what you use fix on Types.h

### DIFF
--- a/src/yarprobotinterface/Types.h
+++ b/src/yarprobotinterface/Types.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <iosfwd>
 #include <list>
+#include <string>
 
 namespace yarp { namespace os { class Thread; } }
 namespace yarp { namespace os { class LogStream; } }


### PR DESCRIPTION
simple as the title said. at the moment the bug is blocking the compilation on visual studio 2019