### PR TITLE
YARP_sig: fix move operator of Image

### DIFF
--- a/src/libYARP_sig/src/Image.cpp
+++ b/src/libYARP_sig/src/Image.cpp
@@ -811,6 +811,7 @@ Image& Image::operator=(Image&& other) noexcept
 {
     Image moved(std::move(other));
     std::swap(moved.implementation, implementation);
+    moved.implementation = nullptr;
     synchronize();
     return *this;
 }


### PR DESCRIPTION
It fixes #1979 

The best should be add a test to reproduce the bug fixed, but til now I was not able to reproduce it without opencv.

Please review code.