### PR TITLE
Fix sig::image assignment operators

### DIFF
--- a/src/libYARP_sig/src/Image.cpp
+++ b/src/libYARP_sig/src/Image.cpp
@@ -809,50 +809,57 @@ Image::Image(Image&& other) noexcept
 
 Image& Image::operator=(Image&& other) noexcept
 {
-    Image moved(std::move(other));
-    std::swap(moved.implementation, implementation);
-    moved.implementation = nullptr;
+    if (implementation!=nullptr) {
+        delete (ImageStorage*)implementation;
+        implementation = nullptr;
+    }
+    std::swap(other.implementation, implementation);
     synchronize();
     return *this;
 }
 
 
-const Image& Image::operator=(const Image& alt) {
-    copy(alt);
+const Image& Image::operator=(const Image& alt)
+{
+    if (&alt != this) {
+        copy(alt);
+    }
     return *this;
 }
 
 
-bool Image::copy(const Image& alt) {
-
-    int myCode = getPixelCode();
-    if (myCode==0) {
-        setPixelCode(alt.getPixelCode());
-        setQuantum(alt.getQuantum());
-    }
-    resize(alt.width(),alt.height());
-    int q1 = alt.getQuantum();
-    int q2 = getQuantum();
-    if (q1==0) { q1 = YARP_IMAGE_ALIGN; }
-    if (q2==0) { q2 = YARP_IMAGE_ALIGN; }
-
-    bool o1 = alt.topIsLowIndex();
-    bool o2 = topIsLowIndex();
-
-    yAssert(width()==alt.width());
-    yAssert(height()==alt.height());
-    if (getPixelCode()==alt.getPixelCode()) {
-        if (getQuantum()==alt.getQuantum()) {
-            yAssert(getRawImageSize()==alt.getRawImageSize());
-            yAssert(q1==q2);
+bool Image::copy(const Image& alt)
+{
+    if (&alt != this)
+    {
+        int myCode = getPixelCode();
+        if (myCode==0) {
+            setPixelCode(alt.getPixelCode());
+            setQuantum(alt.getQuantum());
         }
+        resize(alt.width(),alt.height());
+        int q1 = alt.getQuantum();
+        int q2 = getQuantum();
+        if (q1==0) { q1 = YARP_IMAGE_ALIGN; }
+        if (q2==0) { q2 = YARP_IMAGE_ALIGN; }
+
+        bool o1 = alt.topIsLowIndex();
+        bool o2 = topIsLowIndex();
+
+        yAssert(width()==alt.width());
+        yAssert(height()==alt.height());
+        if (getPixelCode()==alt.getPixelCode()) {
+            if (getQuantum()==alt.getQuantum()) {
+                yAssert(getRawImageSize()==alt.getRawImageSize());
+                yAssert(q1==q2);
+            }
+        }
+
+        copyPixels(alt.getRawImage(),alt.getPixelCode(),
+                   getRawImage(),getPixelCode(),
+                   width(),height(),
+                   getRawImageSize(),q1,q2,o1,o2);
     }
-
-    copyPixels(alt.getRawImage(),alt.getPixelCode(),
-               getRawImage(),getPixelCode(),
-               width(),height(),
-               getRawImageSize(),q1,q2,o1,o2);
-
     return true;
 }
 


### PR DESCRIPTION
The move assignment operator causes a memory leak after #1980, moreover the extra move constructor is redundant.

The copy operator does not check for `this`. Same for the `copy()` method.