### PR TITLE
quaternion members discussion/proposal

### DIFF
--- a/src/devices/map2DServer/Map2DServer.cpp
+++ b/src/devices/map2DServer/Map2DServer.cpp
@@ -1056,10 +1056,10 @@ bool Map2DServer::updateVizMarkers()
         marker.pose.position.x    = it->second.x;
         marker.pose.position.y    = it->second.y;
         marker.pose.position.z    = 0;
-        marker.pose.orientation.x = q.x();
-        marker.pose.orientation.y = q.y();
-        marker.pose.orientation.z = q.z();
-        marker.pose.orientation.w = q.w();
+        marker.pose.orientation.x = q.x;
+        marker.pose.orientation.y = q.y;
+        marker.pose.orientation.z = q.z;
+        marker.pose.orientation.w = q.w;
         marker.scale.x            = 1;
         marker.scale.y            = 0.1;
         marker.scale.z            = 0.1;

--- a/src/devices/transformClient/FrameTransformClient.cpp
+++ b/src/devices/transformClient/FrameTransformClient.cpp
@@ -95,10 +95,10 @@ void Transforms_client_storage::onRead(yarp::os::Bottle &b)
                 t.translation.tX = bt->get(3).asFloat64();
                 t.translation.tY = bt->get(4).asFloat64();
                 t.translation.tZ = bt->get(5).asFloat64();
-                t.rotation.w() = bt->get(6).asFloat64();
-                t.rotation.x() = bt->get(7).asFloat64();
-                t.rotation.y() = bt->get(8).asFloat64();
-                t.rotation.z() = bt->get(9).asFloat64();
+                t.rotation.w = bt->get(6).asFloat64();
+                t.rotation.x = bt->get(7).asFloat64();
+                t.rotation.y = bt->get(8).asFloat64();
+                t.rotation.z = bt->get(9).asFloat64();
                 m_transforms.push_back(t);
             }
         }
@@ -696,10 +696,10 @@ bool yarp::dev::FrameTransformClient::setTransform(const std::string& target_fra
     b.addFloat64(tf.translation.tX);
     b.addFloat64(tf.translation.tY);
     b.addFloat64(tf.translation.tZ);
-    b.addFloat64(tf.rotation.w());
-    b.addFloat64(tf.rotation.x());
-    b.addFloat64(tf.rotation.y());
-    b.addFloat64(tf.rotation.z());
+    b.addFloat64(tf.rotation.w);
+    b.addFloat64(tf.rotation.x);
+    b.addFloat64(tf.rotation.y);
+    b.addFloat64(tf.rotation.z);
     bool ret = m_rpc_InterfaceToServer.write(b, resp);
     if (ret)
     {
@@ -750,10 +750,10 @@ bool yarp::dev::FrameTransformClient::setTransformStatic(const std::string &targ
     b.addFloat64(tf.translation.tX);
     b.addFloat64(tf.translation.tY);
     b.addFloat64(tf.translation.tZ);
-    b.addFloat64(tf.rotation.w());
-    b.addFloat64(tf.rotation.x());
-    b.addFloat64(tf.rotation.y());
-    b.addFloat64(tf.rotation.z());
+    b.addFloat64(tf.rotation.w);
+    b.addFloat64(tf.rotation.x);
+    b.addFloat64(tf.rotation.y);
+    b.addFloat64(tf.rotation.z);
     bool ret = m_rpc_InterfaceToServer.write(b, resp);
     if (ret)
     {

--- a/src/devices/transformServer/FrameTransformServer.cpp
+++ b/src/devices/transformServer/FrameTransformServer.cpp
@@ -213,10 +213,10 @@ bool FrameTransformServer::read(yarp::os::ConnectionReader& connection)
                 t.translation.tX = in.get(5).asFloat64();
                 t.translation.tY = in.get(6).asFloat64();
                 t.translation.tZ = in.get(7).asFloat64();
-                t.rotation.w() = in.get(8).asFloat64();
-                t.rotation.x() = in.get(9).asFloat64();
-                t.rotation.y() = in.get(10).asFloat64();
-                t.rotation.z() = in.get(11).asFloat64();
+                t.rotation.w = in.get(8).asFloat64();
+                t.rotation.x = in.get(9).asFloat64();
+                t.rotation.y = in.get(10).asFloat64();
+                t.rotation.z = in.get(11).asFloat64();
                 t.timestamp = yarp::os::Time::now();
 
                 if (duration > 0)
@@ -660,10 +660,10 @@ void FrameTransformServer::run()
                         t.translation.tX = tfs[i].transform.translation.x;
                         t.translation.tY = tfs[i].transform.translation.y;
                         t.translation.tZ = tfs[i].transform.translation.z;
-                        t.rotation.x() = tfs[i].transform.rotation.x;
-                        t.rotation.y() = tfs[i].transform.rotation.y;
-                        t.rotation.z() = tfs[i].transform.rotation.z;
-                        t.rotation.w() = tfs[i].transform.rotation.w;
+                        t.rotation.x = tfs[i].transform.rotation.x;
+                        t.rotation.y = tfs[i].transform.rotation.y;
+                        t.rotation.z = tfs[i].transform.rotation.z;
+                        t.rotation.w = tfs[i].transform.rotation.w;
                         t.src_frame_id = tfs[i].header.frame_id;
                         t.dst_frame_id = tfs[i].child_frame_id;
                         //@@@ should we use yarp or ROS timestamps? 
@@ -688,10 +688,10 @@ void FrameTransformServer::run()
                         t.translation.tX = tfs[i].transform.translation.x;
                         t.translation.tY = tfs[i].transform.translation.y;
                         t.translation.tZ = tfs[i].transform.translation.z;
-                        t.rotation.x() = tfs[i].transform.rotation.x;
-                        t.rotation.y() = tfs[i].transform.rotation.y;
-                        t.rotation.z() = tfs[i].transform.rotation.z;
-                        t.rotation.w() = tfs[i].transform.rotation.w;
+                        t.rotation.x = tfs[i].transform.rotation.x;
+                        t.rotation.y = tfs[i].transform.rotation.y;
+                        t.rotation.z = tfs[i].transform.rotation.z;
+                        t.rotation.w = tfs[i].transform.rotation.w;
                         t.src_frame_id = tfs[i].header.frame_id;
                         t.dst_frame_id = tfs[i].child_frame_id;
                         //@@@ should we use yarp or ROS timestamps?
@@ -726,10 +726,10 @@ void FrameTransformServer::run()
             transform.addFloat64((*m_yarp_static_transform_storage)[i].translation.tY);
             transform.addFloat64((*m_yarp_static_transform_storage)[i].translation.tZ);
 
-            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.w());
-            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.x());
-            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.y());
-            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.z());
+            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.w);
+            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.x);
+            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.y);
+            transform.addFloat64((*m_yarp_static_transform_storage)[i].rotation.z);
         }
         for (size_t i = 0; i < tfVecSize_timed_yarp; i++)
         {
@@ -742,10 +742,10 @@ void FrameTransformServer::run()
             transform.addFloat64((*m_yarp_timed_transform_storage)[i].translation.tY);
             transform.addFloat64((*m_yarp_timed_transform_storage)[i].translation.tZ);
 
-            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.w());
-            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.x());
-            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.y());
-            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.z());
+            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.w);
+            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.x);
+            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.y);
+            transform.addFloat64((*m_yarp_timed_transform_storage)[i].rotation.z);
         }
         for (size_t i = 0; i < tfVecSize_timed_ros; i++)
         {
@@ -758,10 +758,10 @@ void FrameTransformServer::run()
             transform.addFloat64((*m_ros_timed_transform_storage)[i].translation.tY);
             transform.addFloat64((*m_ros_timed_transform_storage)[i].translation.tZ);
 
-            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.w());
-            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.x());
-            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.y());
-            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.z());
+            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.w);
+            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.x);
+            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.y);
+            transform.addFloat64((*m_ros_timed_transform_storage)[i].rotation.z);
         }
         for (size_t i = 0; i < tfVecSize_static_ros; i++)
         {
@@ -774,10 +774,10 @@ void FrameTransformServer::run()
             transform.addFloat64((*m_ros_static_transform_storage)[i].translation.tY);
             transform.addFloat64((*m_ros_static_transform_storage)[i].translation.tZ);
 
-            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.w());
-            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.x());
-            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.y());
-            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.z());
+            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.w);
+            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.x);
+            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.y);
+            transform.addFloat64((*m_ros_static_transform_storage)[i].rotation.z);
         }
 
         m_streamingPort.setEnvelope(m_lastStateStamp);
@@ -796,10 +796,10 @@ void FrameTransformServer::run()
                 transform_timed.header.frame_id = (*m_yarp_timed_transform_storage)[i].src_frame_id;
                 transform_timed.header.seq = rosMsgCounter;
                 transform_timed.header.stamp = (*m_yarp_timed_transform_storage)[i].timestamp;
-                transform_timed.transform.rotation.x = (*m_yarp_timed_transform_storage)[i].rotation.x();
-                transform_timed.transform.rotation.y = (*m_yarp_timed_transform_storage)[i].rotation.y();
-                transform_timed.transform.rotation.z = (*m_yarp_timed_transform_storage)[i].rotation.z();
-                transform_timed.transform.rotation.w = (*m_yarp_timed_transform_storage)[i].rotation.w();
+                transform_timed.transform.rotation.x = (*m_yarp_timed_transform_storage)[i].rotation.x;
+                transform_timed.transform.rotation.y = (*m_yarp_timed_transform_storage)[i].rotation.y;
+                transform_timed.transform.rotation.z = (*m_yarp_timed_transform_storage)[i].rotation.z;
+                transform_timed.transform.rotation.w = (*m_yarp_timed_transform_storage)[i].rotation.w;
                 transform_timed.transform.translation.x = (*m_yarp_timed_transform_storage)[i].translation.tX;
                 transform_timed.transform.translation.y = (*m_yarp_timed_transform_storage)[i].translation.tY;
                 transform_timed.transform.translation.z = (*m_yarp_timed_transform_storage)[i].translation.tZ;
@@ -817,10 +817,10 @@ void FrameTransformServer::run()
                 transform_static.header.frame_id = (*m_yarp_static_transform_storage)[i].src_frame_id;
                 transform_static.header.seq = rosMsgCounter;
                 transform_static.header.stamp = yarp::os::Time::now(); //@@@check timestamp of static transform?
-                transform_static.transform.rotation.x = (*m_yarp_static_transform_storage)[i].rotation.x();
-                transform_static.transform.rotation.y = (*m_yarp_static_transform_storage)[i].rotation.y();
-                transform_static.transform.rotation.z = (*m_yarp_static_transform_storage)[i].rotation.z();
-                transform_static.transform.rotation.w = (*m_yarp_static_transform_storage)[i].rotation.w();
+                transform_static.transform.rotation.x = (*m_yarp_static_transform_storage)[i].rotation.x;
+                transform_static.transform.rotation.y = (*m_yarp_static_transform_storage)[i].rotation.y;
+                transform_static.transform.rotation.z = (*m_yarp_static_transform_storage)[i].rotation.z;
+                transform_static.transform.rotation.w = (*m_yarp_static_transform_storage)[i].rotation.w;
                 transform_static.transform.translation.x = (*m_yarp_static_transform_storage)[i].translation.tX;
                 transform_static.transform.translation.y = (*m_yarp_static_transform_storage)[i].translation.tY;
                 transform_static.transform.translation.z = (*m_yarp_static_transform_storage)[i].translation.tZ;

--- a/src/libYARP_math/include/yarp/math/FrameTransform.h
+++ b/src/libYARP_math/include/yarp/math/FrameTransform.h
@@ -64,10 +64,10 @@ namespace yarp
                 src_frame_id = parent;
                 dst_frame_id = child;
                 translation.set(inTX, inTY, inTZ);
-                rotation.w() = inRW;
-                rotation.x() = inRX;
-                rotation.y() = inRY;
-                rotation.z() = inRZ;
+                rotation.w = inRW;
+                rotation.x = inRX;
+                rotation.y = inRY;
+                rotation.z = inRZ;
             }
 
             ~FrameTransform(){};

--- a/src/libYARP_math/include/yarp/math/Quaternion.h
+++ b/src/libYARP_math/include/yarp/math/Quaternion.h
@@ -25,22 +25,21 @@ namespace yarp {
 
 class YARP_math_API yarp::math::Quaternion : public yarp::os::Portable
 {
-    double internal_data[4]; // stored as [w x y z]
-
 public:
     Quaternion();
     Quaternion(const Quaternion &l);
     Quaternion(double x, double y, double z, double w);
-    double* data();
-    const double* data() const;
-    double x() const;
-    double y() const;
-    double z() const;
-    double w() const;
-    double& x() ;
-    double& y() ;
-    double& z() ;
-    double& w() ;
+    double data[4];
+    double& w{data[0]};
+    double& x{data[1]};
+    double& y{data[2]};
+    double& z{data[3]};
+
+    Quaternion& operator=(const Quaternion& other)
+    {
+        memcpy(data, other.data, 4 * sizeof(double));
+        return *this;
+    }
 
     std::string toString(int precision = -1, int width = -1) const;
 

--- a/src/libYARP_math/src/FrameTransform.cpp
+++ b/src/libYARP_math/src/FrameTransform.cpp
@@ -19,9 +19,9 @@ std::string yarp::math::FrameTransform::toString() const
                   translation.tX,
                   translation.tY,
                   translation.tZ,
-                  rotation.x(),
-                  rotation.y(),
-                  rotation.z(),
-                  rotation.w());
+                  rotation.x,
+                  rotation.y,
+                  rotation.z,
+                  rotation.w);
     return std::string(buff);
 }

--- a/src/libYARP_math/src/Quaternion.cpp
+++ b/src/libYARP_math/src/Quaternion.cpp
@@ -28,86 +28,36 @@ YARP_END_PACK
 
 Quaternion::Quaternion()
 {
-    internal_data[0] = 1;
-    internal_data[1] = 0;
-    internal_data[2] = 0;
-    internal_data[3] = 0;
+    w = 1;
+    x = 0;
+    y = 0;
+    z = 0;
 }
 
 Quaternion::Quaternion(double x, double y, double z, double w)
 {
-    internal_data[0] = w;
-    internal_data[1] = x;
-    internal_data[2] = y;
-    internal_data[3] = z;
+    w = w;
+    x = x;
+    y = y;
+    z = z;
 }
 
 Quaternion::Quaternion(const Quaternion &l)
 {
-    internal_data[0] = l.w();
-    internal_data[1] = l.x();
-    internal_data[2] = l.y();
-    internal_data[3] = l.z();
-}
-
-const double* Quaternion::data() const
-{
-    return internal_data;
-}
-
-double* Quaternion::data()
-{
-    return internal_data;
+    w = l.w;
+    x = l.x;
+    y = l.y;
+    z = l.z;
 }
 
 yarp::sig::Vector Quaternion::toVector()  const
 {
     yarp::sig::Vector v(4);
-    v[0] = internal_data[0];
-    v[1] = internal_data[1];
-    v[2] = internal_data[2];
-    v[3] = internal_data[3];
+    v[0] = w;
+    v[1] = x;
+    v[2] = y;
+    v[3] = z;
     return v;
-}
-
-double Quaternion::w() const
-{
-    return internal_data[0];
-}
-
-double Quaternion::x() const
-{
-    return internal_data[1];
-}
-
-double Quaternion::y() const
-{
-    return internal_data[2];
-}
-
-double Quaternion::z() const
-{
-    return internal_data[3];
-}
-
-double& Quaternion::w()
-{
-    return internal_data[0];
-}
-
-double& Quaternion::x()
-{
-    return internal_data[1];
-}
-
-double& Quaternion::y()
-{
-    return internal_data[2];
-}
-
-double& Quaternion::z()
-{
-    return internal_data[3];
 }
 
 bool Quaternion::read(yarp::os::ConnectionReader& connection)
@@ -120,10 +70,10 @@ bool Quaternion::read(yarp::os::ConnectionReader& connection)
 
     if (header.listLen == 4 &&  header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
     {
-        this->internal_data[0] = connection.expectFloat64();
-        this->internal_data[1] = connection.expectFloat64();
-        this->internal_data[2] = connection.expectFloat64();
-        this->internal_data[3] = connection.expectFloat64();
+        this->w = connection.expectFloat64();
+        this->x = connection.expectFloat64();
+        this->y = connection.expectFloat64();
+        this->z = connection.expectFloat64();
     }
     else
     {
@@ -142,10 +92,10 @@ bool Quaternion::write(yarp::os::ConnectionWriter& connection) const
 
     connection.appendBlock((char*)&header, sizeof(header));
 
-    connection.appendFloat64(this->internal_data[0]);
-    connection.appendFloat64(this->internal_data[1]);
-    connection.appendFloat64(this->internal_data[2]);
-    connection.appendFloat64(this->internal_data[3]);
+    connection.appendFloat64(w);
+    connection.appendFloat64(x);
+    connection.appendFloat64(y);
+    connection.appendFloat64(z);
 
     // if someone is foolish enough to connect in text mode,
     // let them see something readable.
@@ -168,46 +118,46 @@ void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
     {
         double sqtrp1 = sqrt(tr + 1.0);
         double sqtrp12 = 2.0*sqtrp1;
-        internal_data[0] = 0.5*sqtrp1;
-        internal_data[1] = (R(2, 1) - R(1, 2)) / sqtrp12;
-        internal_data[2] = (R(0, 2) - R(2, 0)) / sqtrp12;
-        internal_data[3] = (R(1, 0) - R(0, 1)) / sqtrp12;
+        w = 0.5*sqtrp1;
+        x = (R(2, 1) - R(1, 2)) / sqtrp12;
+        y = (R(0, 2) - R(2, 0)) / sqtrp12;
+        z = (R(1, 0) - R(0, 1)) / sqtrp12;
     }
     else if ((R(1, 1)>R(0, 0)) && (R(1, 1)>R(2, 2)))
     {
         double sqdip1 = sqrt(R(1, 1) - R(0, 0) - R(2, 2) + 1.0);
-        internal_data[2] = 0.5*sqdip1;
+        y = 0.5*sqdip1;
 
         if (sqdip1>0.0)
             sqdip1 = 0.5 / sqdip1;
 
-        internal_data[0] = (R(0, 2) - R(2, 0))*sqdip1;
-        internal_data[1] = (R(1, 0) + R(0, 1))*sqdip1;
-        internal_data[3] = (R(2, 1) + R(1, 2))*sqdip1;
+        w = (R(0, 2) - R(2, 0))*sqdip1;
+        x = (R(1, 0) + R(0, 1))*sqdip1;
+        z = (R(2, 1) + R(1, 2))*sqdip1;
     }
     else if (R(2, 2)>R(0, 0))
     {
         double sqdip1 = sqrt(R(2, 2) - R(0, 0) - R(1, 1) + 1.0);
-        internal_data[3] = 0.5*sqdip1;
+        z = 0.5*sqdip1;
 
         if (sqdip1>0.0)
             sqdip1 = 0.5 / sqdip1;
 
-        internal_data[0] = (R(1, 0) - R(0, 1))*sqdip1;
-        internal_data[1] = (R(0, 2) + R(2, 0))*sqdip1;
-        internal_data[2] = (R(2, 1) + R(1, 2))*sqdip1;
+        w = (R(1, 0) - R(0, 1))*sqdip1;
+        x = (R(0, 2) + R(2, 0))*sqdip1;
+        y = (R(2, 1) + R(1, 2))*sqdip1;
     }
     else
     {
         double sqdip1 = sqrt(R(0, 0) - R(1, 1) - R(2, 2) + 1.0);
-        internal_data[1] = 0.5*sqdip1;
+        x = 0.5*sqdip1;
 
         if (sqdip1>0.0)
             sqdip1 = 0.5 / sqdip1;
 
-        internal_data[0] = (R(2, 1) - R(1, 2))*sqdip1;
-        internal_data[2] = (R(1, 0) + R(0, 1))*sqdip1;
-        internal_data[3] = (R(0, 2) + R(2, 0))*sqdip1;
+        w = (R(2, 1) - R(1, 2))*sqdip1;
+        y = (R(1, 0) + R(0, 1))*sqdip1;
+        z = (R(0, 2) + R(2, 0))*sqdip1;
     }
 }
 
@@ -255,17 +205,17 @@ std::string Quaternion::toString(int precision, int width) const
     char tmp[350];
     if (width<0)
     {
-        sprintf(tmp, "w=% .*lf\t", precision, internal_data[0]);   ret += tmp;
-        sprintf(tmp, "x=% .*lf\t", precision, internal_data[1]);   ret += tmp;
-        sprintf(tmp, "y=% .*lf\t", precision, internal_data[2]);   ret += tmp;
-        sprintf(tmp, "z=% .*lf\t", precision, internal_data[3]);   ret += tmp;
+        sprintf(tmp, "w=% .*lf\t", precision, w);   ret += tmp;
+        sprintf(tmp, "x=% .*lf\t", precision, x);   ret += tmp;
+        sprintf(tmp, "y=% .*lf\t", precision, y);   ret += tmp;
+        sprintf(tmp, "z=% .*lf\t", precision, z);   ret += tmp;
     }
     else
     {
-        sprintf(tmp, "w=% *.*lf ", width, precision, internal_data[0]);    ret += tmp;
-        sprintf(tmp, "x=% *.*lf ", width, precision, internal_data[1]);    ret += tmp;
-        sprintf(tmp, "y=% *.*lf ", width, precision, internal_data[2]);    ret += tmp;
-        sprintf(tmp, "z=% *.*lf ", width, precision, internal_data[3]);    ret += tmp;
+        sprintf(tmp, "w=% *.*lf ", width, precision, w);    ret += tmp;
+        sprintf(tmp, "x=% *.*lf ", width, precision, x);    ret += tmp;
+        sprintf(tmp, "y=% *.*lf ", width, precision, y);    ret += tmp;
+        sprintf(tmp, "z=% *.*lf ", width, precision, z);    ret += tmp;
     }
 
     return ret.substr(0, ret.length() - 1);
@@ -276,10 +226,10 @@ void Quaternion::fromAxisAngle(const yarp::sig::Vector &v)
     yarp::sig::Matrix m = axis2dcm(v);
     Quaternion q;
     q.fromRotationMatrix(m);
-    this->internal_data[0] = q.internal_data[0];
-    this->internal_data[1] = q.internal_data[1];
-    this->internal_data[2] = q.internal_data[2];
-    this->internal_data[3] = q.internal_data[3];
+    this->w = q.w;
+    this->x = q.x;
+    this->y = q.y;
+    this->z = q.z;
 }
 
 void Quaternion::fromAxisAngle(const yarp::sig::Vector& axis, const double& angle)
@@ -289,10 +239,10 @@ void Quaternion::fromAxisAngle(const yarp::sig::Vector& axis, const double& angl
     yarp::sig::Matrix m = axis2dcm(v);
     Quaternion q;
     q.fromRotationMatrix(m);
-    this->internal_data[0] = q.internal_data[0];
-    this->internal_data[1] = q.internal_data[1];
-    this->internal_data[2] = q.internal_data[2];
-    this->internal_data[3] = q.internal_data[3];
+    this->w = q.w;
+    this->x = q.x;
+    this->y = q.y;
+    this->z = q.z;
 }
 
 yarp::sig::Vector Quaternion::toAxisAngle()
@@ -304,32 +254,31 @@ yarp::sig::Vector Quaternion::toAxisAngle()
 
 double Quaternion::abs()
 {
-    return sqrt(internal_data[0] * internal_data[0] +
-                internal_data[1] * internal_data[1] +
-                internal_data[2] * internal_data[2] +
-                internal_data[3] * internal_data[3]);
+    return sqrt(w * w +
+                x * x +
+                y * y +
+                z * z);
 }
 
 void Quaternion::normalize()
 {
     double length = abs();
-    internal_data[0] /= length;
-    internal_data[1] /= length;
-    internal_data[2] /= length;
-    internal_data[3] /= length;
+    w /= length;
+    x /= length;
+    y /= length;
+    z /= length;
     return;
 }
 
 double Quaternion::arg()
 {
-    return atan2(sqrt(internal_data[1] * internal_data[1] +
-                      internal_data[2] * internal_data[2] +
-                      internal_data[3] * internal_data[3]),
-                 internal_data[0]);
+    return atan2(sqrt(x * x +
+                      y * y +
+                      z * z),
+                          w);
 }
 
 Quaternion Quaternion::inverse() const
 {
-    //                     w                  x                 y                  z
-    return Quaternion(internal_data[0], -internal_data[1], -internal_data[2], -internal_data[3]);
+    return Quaternion(w, -x, -y, -z);
 }

--- a/src/libYARP_math/src/math.cpp
+++ b/src/libYARP_math/src/math.cpp
@@ -238,10 +238,10 @@ Vector& operator*=(Vector &a, const Vector &b)
 
 Quaternion operator*(const Quaternion& a, const Quaternion& b)
 {
-    return Quaternion(a.w()*b.x() + a.x()*b.w() + a.y()*b.z() - a.z()*b.y(),
-                      a.w()*b.y() + a.y()*b.w() + a.z()*b.x() - a.x()*b.z(),
-                      a.w()*b.z() + a.z()*b.w() + a.x()*b.y() - a.y()*b.x(),
-                      a.w()*b.w() - a.x()*b.x() - a.y()*b.y() - a.z()*b.z());
+    return Quaternion(a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+                      a.w*b.y + a.y*b.w + a.z*b.x - a.x*b.z,
+                      a.w*b.z + a.z*b.w + a.x*b.y - a.y*b.x,
+                      a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z);
 }
 
 Vector operator/(const Vector &a, const Vector &b)


### PR DESCRIPTION
this PR should be a issue and not a pr but since it seems not possible to open a issue posting also some changes as example, i'll go through PR (anyway the code is valid and ready to be reviewed since the modification impact is small).

I just wanted to understand if there are particular reason for our quaternion's member to be implemented as reference returning function instead of simply class reference(as in this pull request). in the code you will find the difference between the two and the reason i ask it is because i find it a little counterintuitive and peculiar (no other library that surround yarp implements it this way).

also, i would ask to @traversaro in case like this one, if someone want to fix this, if there would be a way to respect the deprecation policy considering that:
- the two cannot co-exist (the method x() and the variable x, for instance)
- it's absurd to change the class name or the variable name.
