### PR TITLE
Fix interface checks in CBW prior to forwarding a method call

### DIFF
--- a/doc/release/v3_1_1.md
+++ b/doc/release/v3_1_1.md
@@ -49,6 +49,7 @@ Bug Fixes
 * Made optional the view of `IFrameGrabberControls` in `RGBDSensorWrapper`
   (#1875).
 * Fixed header inclusion in `ImplementControlLimits2.h`.
+* Fixed interface pointer checks in ControlBoardWrapper.
 
 #### `YARP_companion`
 

--- a/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/libYARP_dev/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -4559,7 +4559,7 @@ bool ControlBoardWrapper::getRefVelocities(const int n_joints, const int* joints
 
     for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
     {
-        if(rpcData.subdevices_p[subIndex]->posDir)
+        if(rpcData.subdevices_p[subIndex]->vel)
         {
             ret= ret && rpcData.subdevices_p[subIndex]->vel->getRefVelocities( rpcData.subdev_jointsVectorLen[subIndex],
                                                                                 rpcData.jointNumbers[subIndex],
@@ -4733,7 +4733,7 @@ bool ControlBoardWrapper::setInteractionModes(int n_joints, int *joints, yarp::d
 
     for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
     {
-        if(rpcData.subdevices_p[subIndex]->vel)
+        if(rpcData.subdevices_p[subIndex]->iInteract)
         {
             ret= ret && rpcData.subdevices_p[subIndex]->iInteract->setInteractionModes( rpcData.subdev_jointsVectorLen[subIndex],
                                                                                         rpcData.jointNumbers[subIndex],


### PR DESCRIPTION
Might have led to buggy behavior in case some subdevice did not implement an unrelated interface.