### PR TITLE
Correctly handle return codes in IAnalogSensor server/client device pair

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -145,6 +145,8 @@ New Features
 * Imported `usbCamera` device from iCub repository.
 * `analogServer` has learned to forward return codes to `analogSensorClient`
   (#1981).
+* `analogServer` now forwards `calibrateSensor(const yarp::sig::Vector& value)`
+  calls to wrapped subdevices.
 
 ### extern
 

--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -143,6 +143,8 @@ New Features
   resolution of the device. 
 * `ovrheadset`: LibOVR 1.17 or later is now required.
 * Imported `usbCamera` device from iCub repository.
+* `analogServer` has learned to forward return codes to `analogSensorClient`
+  (#1981).
 
 ### extern
 

--- a/src/libYARP_dev/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
+++ b/src/libYARP_dev/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
@@ -10,6 +10,7 @@
 #include "AnalogSensorClient.h"
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+#include <yarp/os/Value.h>
 
 /*! \file AnalogSensorClient.cpp implementation of an analog sensor client class*/
 
@@ -17,6 +18,14 @@ using namespace yarp::dev;
 using namespace yarp::os;
 using namespace yarp::sig;
 
+namespace
+{
+    inline int checkResponse(bool ok, yarp::os::Bottle& response)
+    {
+        const yarp::os::Value & v = response.get(0);
+        return ok && v.isInt32() ? v.asInt32() : IAnalogSensor::AS_ERROR;
+    }
+}
 
 inline void InputPortProcessor::resetStat()
 {
@@ -258,7 +267,7 @@ int yarp::dev::AnalogSensorClient::calibrateSensor()
     cmd.addVocab(VOCAB_IANALOG);
     cmd.addVocab(VOCAB_CALIBRATE);
     bool ok = rpcPort.write(cmd, response);
-    return CHECK_FAIL(ok, response);
+    return checkResponse(ok, response);
 }
 
 int yarp::dev::AnalogSensorClient::calibrateSensor(const yarp::sig::Vector& value)
@@ -270,7 +279,7 @@ int yarp::dev::AnalogSensorClient::calibrateSensor(const yarp::sig::Vector& valu
     for (int i = 0; i < this->getChannels(); i++)
          l.addFloat64(value[i]);
     bool ok = rpcPort.write(cmd, response);
-    return CHECK_FAIL(ok, response);
+    return checkResponse(ok, response);
 }
 
 int yarp::dev::AnalogSensorClient::calibrateChannel(int ch)
@@ -280,7 +289,7 @@ int yarp::dev::AnalogSensorClient::calibrateChannel(int ch)
     cmd.addVocab(VOCAB_CALIBRATE_CHANNEL);
     cmd.addInt32(ch);
     bool ok = rpcPort.write(cmd, response);
-    return CHECK_FAIL(ok, response);
+    return checkResponse(ok, response);
 }
 
 int yarp::dev::AnalogSensorClient::calibrateChannel(int ch, double value)
@@ -291,7 +300,7 @@ int yarp::dev::AnalogSensorClient::calibrateChannel(int ch, double value)
     cmd.addInt32(ch);
     cmd.addFloat64(value);
     bool ok = rpcPort.write(cmd, response);
-    return CHECK_FAIL(ok, response);
+    return checkResponse(ok, response);
 }
 
 Stamp yarp::dev::AnalogSensorClient::getLastInputStamp()

--- a/src/libYARP_dev/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
+++ b/src/libYARP_dev/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
@@ -20,7 +20,7 @@ using namespace yarp::sig;
 
 namespace
 {
-    inline int checkResponse(bool ok, yarp::os::Bottle& response)
+    inline int checkResponse(bool ok, const yarp::os::Bottle& response)
     {
         const yarp::os::Value & v = response.get(0);
         return ok && v.isInt32() ? v.asInt32() : IAnalogSensor::AS_ERROR;

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -55,35 +55,36 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
       return false;
 
     const size_t msgsize=cmd.size();
-    int ret = IAnalogSensor::AS_ERROR;
+    int ret=IAnalogSensor::AS_ERROR;
 
     int code=cmd.get(1).asVocab();
     switch (code)
     {
     case VOCAB_CALIBRATE:
       if (msgsize==2)
-        ret = is->calibrateSensor();
+        ret=is->calibrateSensor();
       else if (msgsize>2)
       {
-        Vector v(msgsize - 2);
-        for (unsigned int i = 0; i < v.size(); i++)
+        size_t offset=2;
+        Vector v(msgsize-offset);
+        for (unsigned int i=0; i<v.size(); i++)
         {
-          v[i] = cmd.get(i + 2).asFloat64();
+          v[i]=cmd.get(i+offset).asFloat64();
         }
-        ret = is->calibrateSensor(v);
+        ret=is->calibrateSensor(v);
       }
       break;
     case VOCAB_CALIBRATE_CHANNEL:
       if (msgsize==3)
       {
         int ch=cmd.get(2).asInt32();
-        ret = is->calibrateChannel(ch);
+        ret=is->calibrateChannel(ch);
       }
       else if (msgsize==4)
       {
         int ch=cmd.get(2).asInt32();
         double v=cmd.get(3).asFloat64();
-        ret = is->calibrateChannel(ch, v);
+        ret=is->calibrateChannel(ch, v);
       }
       break;
     default:

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -54,7 +54,7 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
     if (is==nullptr)
       return false;
 
-    const int msgsize=cmd.size();
+    const size_t msgsize=cmd.size();
     int ret = IAnalogSensor::AS_ERROR;
 
     int code=cmd.get(1).asVocab();
@@ -63,7 +63,7 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
     case VOCAB_CALIBRATE:
       if (msgsize==2)
         ret = is->calibrateSensor();
-      else
+      else if (msgsize>2)
       {
         Vector v(msgsize - 2);
         for (unsigned int i = 0; i < v.size(); i++)
@@ -79,7 +79,7 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
         int ch=cmd.get(2).asInt32();
         ret = is->calibrateChannel(ch);
       }
-      if (msgsize==4)
+      else if (msgsize==4)
       {
         int ch=cmd.get(2).asInt32();
         double v=cmd.get(3).asFloat64();

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -54,7 +54,7 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
     if (is==nullptr)
       return false;
 
-    int msgsize=cmd.size();
+    const int msgsize=cmd.size();
     int ret = IAnalogSensor::AS_ERROR;
 
     int code=cmd.get(1).asVocab();
@@ -65,7 +65,13 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
         ret = is->calibrateSensor();
       else
       {
-        //read Vector of values and pass to is->calibrate();
+        int length = msgsize - 2;
+        Vector v(length);
+        for (int i = 0; i < length; i++)
+        {
+          v[i] = cmd.get(i).asFloat64();
+        }
+        ret = is->calibrateSensor(v);
       }
       break;
     case VOCAB_CALIBRATE_CHANNEL:

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -65,11 +65,10 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
         ret = is->calibrateSensor();
       else
       {
-        int length = msgsize - 2;
-        Vector v(length);
-        for (int i = 0; i < length; i++)
+        Vector v(msgsize - 2);
+        for (unsigned int i = 0; i < v.size(); i++)
         {
-          v[i] = cmd.get(i).asFloat64();
+          v[i] = cmd.get(i + 2).asFloat64();
         }
         ret = is->calibrateSensor(v);
       }

--- a/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/libYARP_dev/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -55,37 +55,38 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
       return false;
 
     int msgsize=cmd.size();
+    int ret = IAnalogSensor::AS_ERROR;
 
     int code=cmd.get(1).asVocab();
     switch (code)
     {
     case VOCAB_CALIBRATE:
       if (msgsize==2)
-        is->calibrateSensor();
+        ret = is->calibrateSensor();
       else
       {
         //read Vector of values and pass to is->calibrate();
       }
-      return true;
       break;
     case VOCAB_CALIBRATE_CHANNEL:
       if (msgsize==3)
       {
         int ch=cmd.get(2).asInt32();
-        is->calibrateChannel(ch);
+        ret = is->calibrateChannel(ch);
       }
       if (msgsize==4)
       {
         int ch=cmd.get(2).asInt32();
         double v=cmd.get(3).asFloat64();
-        is->calibrateChannel(ch, v);
+        ret = is->calibrateChannel(ch, v);
       }
-
-      return true;
       break;
     default:
       return false;
     }
+
+    reply.addInt32(ret);
+    return true;
 }
 
 bool AnalogServerHandler::read(yarp::os::ConnectionReader& connection)


### PR DESCRIPTION
Closes #1981. Also, remote calls to `calibrateSensor(const yarp::sig::Vector& value)` are now handled by the server device.