### PR TITLE
Include what you use in YARP_dev interfaces

### DIFF
--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
@@ -14,7 +14,9 @@
 #include "MultipleAnalogSensorsMetadata.h"
 #include "SensorStreamingData.h"
 
+#include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
+#include <yarp/dev/DeviceDriver.h>
 
 #include <mutex>
 

--- a/src/devices/navigation2DServer/navigation2DServer.cpp
+++ b/src/devices/navigation2DServer/navigation2DServer.cpp
@@ -22,6 +22,7 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Port.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/INavigation2D.h>
 #include <yarp/dev/MapGrid2D.h>

--- a/src/devices/test_grabber/TestFrameGrabber.h
+++ b/src/devices/test_grabber/TestFrameGrabber.h
@@ -13,6 +13,7 @@
 #include <cstdio>
 
 #include <yarp/sig/ImageFile.h>
+#include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/PreciselyTimed.h>

--- a/src/devices/usbCamera/common/USBcamera.h
+++ b/src/devices/usbCamera/common/USBcamera.h
@@ -25,6 +25,7 @@
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 
+#include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IVisualParams.h>
 #include <yarp/dev/PreciselyTimed.h>

--- a/src/devices/usbCamera/linux/V4L_camera.h
+++ b/src/devices/usbCamera/linux/V4L_camera.h
@@ -23,6 +23,7 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 
+#include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IVisualParams.h>
 #include <yarp/dev/PreciselyTimed.h>

--- a/src/libYARP_dev/include/yarp/dev/AudioVisualInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/AudioVisualInterfaces.h
@@ -13,6 +13,8 @@
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/os/PortablePair.h>
+#include <yarp/sig/Image.h>
+#include <yarp/sig/Sound.h>
 
 namespace yarp{
     namespace dev {

--- a/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
+++ b/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
@@ -12,7 +12,7 @@
 
 #include <cstring> // for std::memset
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/os/Log.h>
 
 /*! \file CanBusInterface.h define interface for can bus devices*/
@@ -29,7 +29,7 @@ namespace yarp {
     }
 }
 
-class yarp::dev::CanErrors
+class YARP_dev_API yarp::dev::CanErrors
 {
 public:
     CanErrors()
@@ -52,7 +52,7 @@ public:
     unsigned int rxBufferOvr;    // rx buffer overflow
 };
 
-class yarp::dev::CanMessage
+class YARP_dev_API yarp::dev::CanMessage
 {
  public:
     virtual ~CanMessage(){}
@@ -68,7 +68,7 @@ class yarp::dev::CanMessage
     virtual void setBuffer(unsigned char *)=0;
 };
 
-class yarp::dev::CanBuffer
+class YARP_dev_API yarp::dev::CanBuffer
 {
     yarp::dev::CanMessage **data;
     int size;
@@ -97,7 +97,7 @@ class yarp::dev::CanBuffer
         }
 };
 
-class yarp::dev::ICanBufferFactory
+class YARP_dev_API yarp::dev::ICanBufferFactory
 {
 public:
     virtual ~ICanBufferFactory(){}
@@ -111,7 +111,7 @@ public:
  * IMPL is the internal representation of the can message.
  */
 template<class M, class IMPL>
-class yarp::dev::ImplementCanBufferFactory: public ICanBufferFactory
+class YARP_dev_API yarp::dev::ImplementCanBufferFactory: public ICanBufferFactory
 {
 public:
     virtual ~ImplementCanBufferFactory(){}
@@ -165,7 +165,7 @@ public:
 /**
  * Interface for a can bus device
  */
-class yarp::dev::ICanBus
+class YARP_dev_API yarp::dev::ICanBus
 {
  public:
     virtual ~ICanBus(){}

--- a/src/libYARP_dev/include/yarp/dev/CartesianControl.h
+++ b/src/libYARP_dev/include/yarp/dev/CartesianControl.h
@@ -12,7 +12,7 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 /*!
@@ -34,7 +34,7 @@ namespace yarp {
  *
  * \brief Structure for configuring a cartesian event.
  */
-struct yarp::dev::CartesianEventParameters
+struct YARP_dev_API yarp::dev::CartesianEventParameters
 {
     /*!
      * The signature of the event as specified by the user.
@@ -62,7 +62,7 @@ struct yarp::dev::CartesianEventParameters
  *
  * \brief Structure for configuring a cartesian event.
  */
-struct yarp::dev::CartesianEventVariables
+struct YARP_dev_API yarp::dev::CartesianEventVariables
 {
     /*!
      * The signature of the received event as filled by the event
@@ -90,7 +90,7 @@ struct yarp::dev::CartesianEventVariables
  * \brief Interface for a event notified by the cartesian
  *              controller.
  */
-class yarp::dev::CartesianEvent
+class YARP_dev_API yarp::dev::CartesianEvent
 {
 public:
     /*!
@@ -125,7 +125,7 @@ public:
  * Please read carefully the <a
  * href="http://wiki.icub.org/iCub/main/dox/html/icub_cartesian_interface.html">documentation</a>.
  */
-class yarp::dev::ICartesianControl
+class YARP_dev_API yarp::dev::ICartesianControl
 {
 public:
     /*!

--- a/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ControlBoardInterfaces.h
@@ -10,6 +10,8 @@
 #ifndef YARP_DEV_CONTROLBOARDINTERFACES_H
 #define YARP_DEV_CONTROLBOARDINTERFACES_H
 
+#include <yarp/os/Vocab.h>
+
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/ControlBoardPid.h>
 #include <yarp/dev/CalibratorInterfaces.h>

--- a/src/libYARP_dev/include/yarp/dev/FrameGrabberControl2.h
+++ b/src/libYARP_dev/include/yarp/dev/FrameGrabberControl2.h
@@ -9,7 +9,6 @@
 #ifndef YARP_DEV_FRAMEGRABBERCONTROL2_H
 #define YARP_DEV_FRAMEGRABBERCONTROL2_H
 
-#include <string>
 #include <yarp/dev/FrameGrabberInterfaces.h>        // to include VOCAB definitions
 
 /*! \file FrameGrabberControl2.h define common interfaces to discover

--- a/src/libYARP_dev/include/yarp/dev/FrameGrabberControlImpl.h
+++ b/src/libYARP_dev/include/yarp/dev/FrameGrabberControlImpl.h
@@ -10,6 +10,8 @@
 #define YARP_DEV_FRAMEGRABBERCONTROLIMPL_H
 
 #include <string>
+#include <yarp/os/Port.h>
+#include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>        // to include VOCAB definitions
 
 /*! \file FrameGrabberInterfaces.h define common interfaces to discover

--- a/src/libYARP_dev/include/yarp/dev/FrameGrabberInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/FrameGrabberInterfaces.h
@@ -10,7 +10,10 @@
 #ifndef YARP_FRAMEGRABBERINTERFACES_H
 #define YARP_FRAMEGRABBERINTERFACES_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <string>
+
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Vector.h>
 

--- a/src/libYARP_dev/include/yarp/dev/GPUInterface.h
+++ b/src/libYARP_dev/include/yarp/dev/GPUInterface.h
@@ -10,7 +10,7 @@
 #ifndef YARPGPUINTERFACES
 #define YARPGPUINTERFACES
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Image.h>
 
 /*! \file GPUInterface.h define interfaces for a generic GPU*/

--- a/src/libYARP_dev/include/yarp/dev/GazeControl.h
+++ b/src/libYARP_dev/include/yarp/dev/GazeControl.h
@@ -10,9 +10,11 @@
 #ifndef YARP_DEV_GAZECONTROL_H
 #define YARP_DEV_GAZECONTROL_H
 
+#include <string>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 /*!
@@ -34,7 +36,7 @@ namespace yarp {
  *
  * \brief Structure for configuring a gaze event.
  */
-struct yarp::dev::GazeEventParameters
+struct YARP_dev_API yarp::dev::GazeEventParameters
 {
     /*!
      * The signature of the event as specified by the user.
@@ -70,7 +72,7 @@ struct yarp::dev::GazeEventParameters
  *
  * \brief Structure for retrieving information from a gaze event.
  */
-struct yarp::dev::GazeEventVariables
+struct YARP_dev_API yarp::dev::GazeEventVariables
 {
     /*!
      * The signature of the received event as filled by the event
@@ -97,7 +99,7 @@ struct yarp::dev::GazeEventVariables
  *
  * \brief Interface for a event notified by the gaze controller.
  */
-class yarp::dev::GazeEvent
+class YARP_dev_API yarp::dev::GazeEvent
 {
 public:
     /*!
@@ -132,7 +134,7 @@ public:
  * Please read carefully the
  * <a href="http://wiki.icub.org/iCub/main/dox/html/icub_gaze_interface.html">documentation</a>.
  */
-class yarp::dev::IGazeControl
+class YARP_dev_API yarp::dev::IGazeControl
 {
 public:
     /*!

--- a/src/libYARP_dev/include/yarp/dev/GenericSensorInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/GenericSensorInterfaces.h
@@ -10,7 +10,7 @@
 #ifndef YARP_DEV_GENERICSENSORINTERFACES_H
 #define YARP_DEV_GENERICSENSORINTERFACES_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 /*! \file GenericSensorInterfaces.h define interfaces for a generic sensor*/

--- a/src/libYARP_dev/include/yarp/dev/IAmplifierControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IAmplifierControl.h
@@ -10,7 +10,8 @@
 #ifndef YARP_DEV_IAMPLIFIERCONTROL_H
 #define YARP_DEV_IAMPLIFIERCONTROL_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 /*! \file IAmplifierControl.h define control board standard interfaces*/
 

--- a/src/libYARP_dev/include/yarp/dev/IAnalogSensor.h
+++ b/src/libYARP_dev/include/yarp/dev/IAnalogSensor.h
@@ -11,7 +11,7 @@
 #define YARP_DEV_IANALOGSENSOR_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 constexpr yarp::conf::vocab32_t VOCAB_IANALOG           = yarp::os::createVocab('i','a','n','a');

--- a/src/libYARP_dev/include/yarp/dev/IAxisInfo.h
+++ b/src/libYARP_dev/include/yarp/dev/IAxisInfo.h
@@ -10,7 +10,11 @@
 #ifndef YARP_DEV_IAXISINFO_H
 #define YARP_DEV_IAXISINFO_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <string>
+
+#include <yarp/os/Log.h>
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 /*! \file IAxisInfo.h define control board standard interfaces*/
 

--- a/src/libYARP_dev/include/yarp/dev/IBattery.h
+++ b/src/libYARP_dev/include/yarp/dev/IBattery.h
@@ -9,9 +9,10 @@
 #ifndef YARP_DEV_IBATTERY_H
 #define YARP_DEV_IBATTERY_H
 
-#include <yarp/dev/DeviceDriver.h>
-#include <yarp/sig/Vector.h>
+#include <string>
+
 #include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 constexpr yarp::conf::vocab32_t VOCAB_IBATTERY     = yarp::os::createVocab('i','b','a','t');
 constexpr yarp::conf::vocab32_t VOCAB_BATTERY_INFO = yarp::os::createVocab('b','t','n','f');

--- a/src/libYARP_dev/include/yarp/dev/IControlCalibration.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlCalibration.h
@@ -10,9 +10,9 @@
 #ifndef YARP_DEV_ICONTROLCALIBRATION_H
 #define YARP_DEV_ICONTROLCALIBRATION_H
 
-#include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/ControlBoardPid.h>
-#include <yarp/dev/CalibratorInterfaces.h>
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
+#include <yarp/dev/CalibratorInterfaces.h> // ICalibrator
 
 namespace yarp {
     namespace dev {

--- a/src/libYARP_dev/include/yarp/dev/IControlDebug.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlDebug.h
@@ -10,7 +10,7 @@
 #ifndef YARP_DEV_ICONTROLDEBUG_H
 #define YARP_DEV_ICONTROLDEBUG_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 
 /*! \file ControlDebug.h define control board standard interfaces*/
 

--- a/src/libYARP_dev/include/yarp/dev/IControlLimits.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlLimits.h
@@ -11,7 +11,7 @@
 #define YARP_DEV_ICONTROLLIMITS_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 
 /*! \file IControlLimits.h define control board standard interfaces*/
 

--- a/src/libYARP_dev/include/yarp/dev/IControlLimits2.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlLimits2.h
@@ -9,7 +9,7 @@
 #ifndef YARP_DEV_ICONTROLLIMITS2_H
 #define YARP_DEV_ICONTROLLIMITS2_H
 
-#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IControlLimits.h>
 
 namespace yarp {
     namespace dev {

--- a/src/libYARP_dev/include/yarp/dev/IControlMode.h
+++ b/src/libYARP_dev/include/yarp/dev/IControlMode.h
@@ -100,7 +100,7 @@ public:
  * Interface for setting control mode in control board. See IControlMode for
  * more documentation.
  */
-class yarp::dev::IControlModeRaw
+class YARP_dev_API yarp::dev::IControlModeRaw
 {
 public:
     virtual ~IControlModeRaw(){}

--- a/src/libYARP_dev/include/yarp/dev/ICurrentControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ICurrentControl.h
@@ -10,7 +10,7 @@
 #define YARP_DEV_ICURRENTCONTROL_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/ControlBoardPid.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -110,7 +110,7 @@ public:
  *
  * Interface for control boards implementing current control.
  */
-class yarp::dev::ICurrentControlRaw
+class YARP_dev_API yarp::dev::ICurrentControlRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IFrameTransform.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameTransform.h
@@ -9,11 +9,14 @@
 #ifndef YARP_DEV_IFRAMETRANSFORM_H
 #define YARP_DEV_IFRAMETRANSFORM_H
 
+#include <string>
+#include <vector>
+
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/sig/Matrix.h>
+#include <yarp/sig/Vector.h>
 #include <yarp/math/Quaternion.h>
-#include <vector>
 
 namespace yarp {
     namespace dev {

--- a/src/libYARP_dev/include/yarp/dev/IHapticDevice.h
+++ b/src/libYARP_dev/include/yarp/dev/IHapticDevice.h
@@ -26,7 +26,7 @@ namespace yarp {
 /**
  * A generic interface for an haptic device.
  */
-class yarp::dev::IHapticDevice
+class YARP_dev_API yarp::dev::IHapticDevice
 {
 public:
     virtual ~IHapticDevice() { }

--- a/src/libYARP_dev/include/yarp/dev/IImpedanceControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IImpedanceControl.h
@@ -24,7 +24,7 @@ namespace yarp{
  *
  * Interface for control boards implementing impedance control.
  */
-class yarp::dev::IImpedanceControlRaw
+class YARP_dev_API yarp::dev::IImpedanceControlRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IInteractionMode.h
+++ b/src/libYARP_dev/include/yarp/dev/IInteractionMode.h
@@ -9,8 +9,8 @@
 #ifndef YARP_DEV_IINTERACTIONMODE_H
 #define YARP_DEV_IINTERACTIONMODE_H
 
-#include <yarp/dev/ControlBoardInterfaces.h>
-
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -118,7 +118,7 @@ public:
  * Interface settings the way the robot interacts with the environment: basic interaction types are Stiff and Compliant.
  * This setting is intended to work in conjunction with other settings like position or velocity control.
  */
-class yarp::dev::IInteractionModeRaw
+class YARP_dev_API yarp::dev::IInteractionModeRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/include/yarp/dev/IJoypadController.h
@@ -13,9 +13,11 @@
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Searchable.h>
 #include <yarp/dev/GenericVocabs.h>
 #include <map>
 #include <vector>
+#include <string>
 
 #define HAT_ACTIONS_ID_SHIFT 100
 

--- a/src/libYARP_dev/include/yarp/dev/ILocalization2D.h
+++ b/src/libYARP_dev/include/yarp/dev/ILocalization2D.h
@@ -10,7 +10,7 @@
 #define YARP_DEV_ILOCALIZATION2D_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/os/Log.h>
+#include <yarp/dev/api.h>
 #include <yarp/dev/Map2DLocation.h>
 #include <vector>
 
@@ -32,7 +32,7 @@ namespace yarp {
  *
  * ILocalization2D interface. Provides methods to obtain the pose of the robot in a known map.
  */
-class yarp::dev::ILocalization2D
+class YARP_dev_API yarp::dev::ILocalization2D
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IMap2D.h
+++ b/src/libYARP_dev/include/yarp/dev/IMap2D.h
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Vocab.h>
 #include <yarp/sig/Image.h>
+#include <yarp/dev/api.h>
 #include <yarp/dev/MapGrid2D.h>
 #include <yarp/dev/Map2DLocation.h>
 #include <yarp/dev/Map2DArea.h>

--- a/src/libYARP_dev/include/yarp/dev/IMotor.h
+++ b/src/libYARP_dev/include/yarp/dev/IMotor.h
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Log.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -24,7 +25,7 @@ namespace yarp {
  *
  * Control board, encoder interface.
  */
-class yarp::dev::IMotorRaw
+class YARP_dev_API yarp::dev::IMotorRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IMotorEncoders.h
+++ b/src/libYARP_dev/include/yarp/dev/IMotorEncoders.h
@@ -10,6 +10,7 @@
 #define YARP_DEV_IMOTORENCODERS_H
 
 #include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -23,7 +24,7 @@ namespace yarp {
  *
  * Control board, encoder interface.
  */
-class yarp::dev::IMotorEncodersRaw
+class YARP_dev_API yarp::dev::IMotorEncodersRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/INavigation2D.h
+++ b/src/libYARP_dev/include/yarp/dev/INavigation2D.h
@@ -10,13 +10,14 @@
 #define YARP_DEV_INAVIGATION2D_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/os/Log.h>
+#include <yarp/dev/api.h>
 #include <yarp/dev/ILocalization2D.h>
 #include <yarp/dev/Map2DLocation.h>
 #include <yarp/dev/Map2DArea.h>
 #include <yarp/dev/MapGrid2D.h>
 #include <vector>
 #include <limits>
+#include <string>
 
 namespace yarp {
     namespace dev {
@@ -56,7 +57,7 @@ namespace yarp {
     }
 }
 
-class yarp::dev::INavigation2DTargetActions
+class YARP_dev_API yarp::dev::INavigation2DTargetActions
 {
 public:
     /**
@@ -105,7 +106,7 @@ public:
     virtual bool getRelativeLocationOfCurrentTarget(double& x, double& y, double& theta) = 0;
 };
 
-class yarp::dev::INavigation2DControlActions
+class YARP_dev_API yarp::dev::INavigation2DControlActions
 {
 public:
     /**
@@ -173,9 +174,9 @@ public:
  *
  * An interface to control the navigation of a mobile robot in a 2D environment.
  */
-class yarp::dev::INavigation2D :  public yarp::dev::INavigation2DTargetActions,
-                                  public yarp::dev::INavigation2DControlActions,
-                                  public yarp::dev::ILocalization2D
+class YARP_dev_API yarp::dev::INavigation2D :  public yarp::dev::INavigation2DTargetActions,
+                                               public yarp::dev::INavigation2DControlActions,
+                                               public yarp::dev::ILocalization2D
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IPWMControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPWMControl.h
@@ -84,7 +84,7 @@ public:
 *
 * Interface for controlling an axis, by sending directly a PWM reference signal to a motor.
 */
-class yarp::dev::IPWMControlRaw
+class YARP_dev_API yarp::dev::IPWMControlRaw
 {
 public:
     virtual ~IPWMControlRaw(){}

--- a/src/libYARP_dev/include/yarp/dev/IPidControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPidControl.h
@@ -9,7 +9,8 @@
 #ifndef YARP_DEV_PIDCONTROL_H
 #define YARP_DEV_PIDCONTROL_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 #include <yarp/dev/GenericVocabs.h>
 #include <yarp/dev/PidEnums.h>
 #include <yarp/dev/ControlBoardPid.h>

--- a/src/libYARP_dev/include/yarp/dev/IPositionDirect.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionDirect.h
@@ -10,6 +10,7 @@
 #ifndef YARP_IPOSITIONDIRECT_H
 #define YARP_IPOSITIONDIRECT_H
 
+#include <yarp/os/Vocab.h>
 #include <yarp/dev/api.h>
 
 namespace yarp {
@@ -113,7 +114,7 @@ public:
  * This interface is used to send high frequency streaming commands to the boards, the aim
  * is to reach low level control in firmware bypassing the trajetory generator, raw functions.
  */
-class yarp::dev::IPositionDirectRaw
+class YARP_dev_API yarp::dev::IPositionDirectRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IRGBDSensor.h
+++ b/src/libYARP_dev/include/yarp/dev/IRGBDSensor.h
@@ -9,10 +9,12 @@
 #ifndef YARP_DEV_IRGBDSENSOR_H
 #define YARP_DEV_IRGBDSENSOR_H
 
+#include <yarp/os/Vocab.h>
 #include <yarp/os/Stamp.h>
+#include <yarp/os/Property.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Matrix.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/dev/IVisualParams.h>
 
 namespace yarp {

--- a/src/libYARP_dev/include/yarp/dev/IRangefinder2D.h
+++ b/src/libYARP_dev/include/yarp/dev/IRangefinder2D.h
@@ -10,10 +10,11 @@
 #define YARP_DEV_IRANGEFINDER2D_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/LaserMeasurementData.h>
 #include <vector>
+#include <string>
 
 constexpr yarp::conf::vocab32_t VOCAB_ILASER2D             = yarp::os::createVocab('i','l','a','s');
 constexpr yarp::conf::vocab32_t VOCAB_DEVICE_INFO          = yarp::os::createVocab('l','s','n','f');

--- a/src/libYARP_dev/include/yarp/dev/IRemoteVariables.h
+++ b/src/libYARP_dev/include/yarp/dev/IRemoteVariables.h
@@ -9,7 +9,11 @@
 #ifndef YARP_DEV_IREMOTEVARIABLES_H
 #define YARP_DEV_IREMOTEVARIABLES_H
 
+#include <string>
+
+#include <yarp/os/Bottle.h>
 #include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -21,9 +25,9 @@ namespace yarp {
 /**
  * @ingroup dev_iface_motor
  *
- * IRemoteVariables interface.
+ * IRemoteVariablesRaw interface.
  */
-class yarp::dev::IRemoteVariablesRaw
+class YARP_dev_API yarp::dev::IRemoteVariablesRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IRobotDescription.h
+++ b/src/libYARP_dev/include/yarp/dev/IRobotDescription.h
@@ -11,7 +11,6 @@
 
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
-#include <yarp/os/Log.h>
 #include <vector>
 #include <string>
 

--- a/src/libYARP_dev/include/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/include/yarp/dev/ITorqueControl.h
@@ -10,11 +10,7 @@
 #define YARP_DEV_ITORQUECONTROL_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/ControlBoardPid.h>
-
-//TO PROVIDE BACKWARD COMPATIBILITY FOR DEPRECATED METHODS: TO BE REMOVED LATER!
-#include <yarp/dev/IPidControl.h>
-#include <yarp/os/LogStream.h>
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {
@@ -139,7 +135,7 @@ public:
  *
  * Interface for control boards implementing torque control.
  */
-class yarp::dev::ITorqueControlRaw
+class YARP_dev_API yarp::dev::ITorqueControlRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IVelocityControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IVelocityControl.h
@@ -10,12 +10,9 @@
 #ifndef YARP_DEV_IVELOCITYCONTROL_H
 #define YARP_DEV_IVELOCITYCONTROL_H
 
+#include <yarp/os/Vocab.h>
 #include <yarp/dev/api.h>
-#include <yarp/dev/ControlBoardPid.h>
 
-//TO PROVIDE BACKWARD COMPATIBILITY FOR DEPRECATED METHODS: TO BE REMOVED LATER!
-#include <yarp/dev/IPidControl.h>
-#include <yarp/os/LogStream.h>
 namespace yarp {
     namespace dev {
         class IVelocityControl;
@@ -28,7 +25,7 @@ namespace yarp {
  *
  * Interface for control boards implementig velocity control in encoder coordinates.
  */
-class yarp::dev::IVelocityControlRaw
+class YARP_dev_API yarp::dev::IVelocityControlRaw
 {
 public:
     /**

--- a/src/libYARP_dev/include/yarp/dev/IVirtualAnalogSensor.h
+++ b/src/libYARP_dev/include/yarp/dev/IVirtualAnalogSensor.h
@@ -10,7 +10,7 @@
 #define YARP_DEV_IVIRTUALANALOGSENSOR_H
 
 #include <yarp/os/Vocab.h>
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 constexpr yarp::conf::vocab32_t VOCAB_IVIRTUAL_ANALOG   = yarp::os::createVocab('i','v','a','n');

--- a/src/libYARP_dev/include/yarp/dev/IVisualServoing.h
+++ b/src/libYARP_dev/include/yarp/dev/IVisualServoing.h
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include <yarp/os/Bottle.h>
-#include <string>
 #include <yarp/sig/Vector.h>
+#include <yarp/dev/api.h>
 
 namespace yarp{
     namespace dev {
@@ -26,7 +26,7 @@ namespace yarp{
 /*!
  * \brief Interface for visual servoing controllers.
  */
-class yarp::dev::IVisualServoing
+class YARP_dev_API yarp::dev::IVisualServoing
 {
 public:
     /*!

--- a/src/libYARP_dev/include/yarp/dev/LaserMeasurementData.h
+++ b/src/libYARP_dev/include/yarp/dev/LaserMeasurementData.h
@@ -6,10 +6,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/dev/api.h>
-
 #ifndef YARP_DEV_LASERMEASURMENTDATA_H
 #define YARP_DEV_LASERMEASURMENTDATA_H
+
+#include <yarp/dev/api.h>
 
 /*!
  * \file LaserMeasurementData.h

--- a/src/libYARP_dev/include/yarp/dev/Map2DLocation.h
+++ b/src/libYARP_dev/include/yarp/dev/Map2DLocation.h
@@ -9,11 +9,10 @@
 #ifndef YARP_DEV_MAP2DLOCATION_H
 #define YARP_DEV_MAP2DLOCATION_H
 
-#include <yarp/os/Portable.h>
-#include <yarp/math/Vec2D.h>
-#include <yarp/dev/api.h>
 #include <sstream>
 #include <string>
+
+#include <yarp/dev/api.h>
 
 /**
 * \file Map2DLocation.h contains the definition of a Map2DLocation type
@@ -22,7 +21,7 @@ namespace yarp
 {
     namespace dev
     {
-        struct Map2DLocation
+        struct YARP_dev_API Map2DLocation
         {
             /**
             * Constructor

--- a/src/libYARP_dev/include/yarp/dev/MapGrid2D.h
+++ b/src/libYARP_dev/include/yarp/dev/MapGrid2D.h
@@ -9,9 +9,11 @@
 #ifndef YARP_DEV_MAPGRID2D_H
 #define YARP_DEV_MAPGRID2D_H
 
+#include <string>
+
 #include <yarp/os/Portable.h>
+#include <yarp/os/ConnectionReader.h>
 #include <yarp/sig/Image.h>
-#include <yarp/sig/Vector.h>
 #include <yarp/math/Vec2D.h>
 #include <yarp/dev/api.h>
 

--- a/src/libYARP_dev/include/yarp/dev/MultipleAnalogSensorsInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/MultipleAnalogSensorsInterfaces.h
@@ -10,9 +10,9 @@
 #define YARP_DEV_MULTIPLEANALOGSENSORSINTERFACES_H
 
 #include <cassert>
+#include <string>
 
-#include <yarp/dev/DeviceDriver.h>
-#include <yarp/sig/Matrix.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 namespace yarp

--- a/src/libYARP_dev/include/yarp/dev/PidEnums.h
+++ b/src/libYARP_dev/include/yarp/dev/PidEnums.h
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Vocab.h>
 #include <yarp/conf/system.h>
+#include <yarp/dev/api.h>
 
 namespace yarp
 {

--- a/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
+++ b/src/libYARP_dev/include/yarp/dev/RGBDSensorParamParser.h
@@ -6,13 +6,13 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/os/Searchable.h>
-#include <yarp/sig/Matrix.h>
-#include <yarp/dev/api.h>
-
-#include <yarp/sig/IntrinsicParams.h>
-
 #include <vector>
+
+#include <yarp/os/Searchable.h>
+#include <yarp/os/Value.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/IntrinsicParams.h>
+#include <yarp/dev/api.h>
 
 #ifndef YARP_DEV_RGBDSENSORPARAMPARSER_H
 #define YARP_DEV_RGBDSENSORPARAMPARSER_H

--- a/src/libYARP_dev/include/yarp/dev/SerialInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/SerialInterfaces.h
@@ -11,7 +11,8 @@
 #ifndef YARP_DEV_SERIALINTERFACES_H
 #define YARP_DEV_SERIALINTERFACES_H
 
-#include <yarp/dev/DeviceDriver.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
 /*! \file SerialInterfaces.h define interfaces for a generic serial device (I/O)*/

--- a/src/libYARP_dev/include/yarp/dev/ServiceInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/ServiceInterfaces.h
@@ -10,8 +10,7 @@
 #ifndef YARP_DEV_SERVICEINTERFACES_H
 #define YARP_DEV_SERVICEINTERFACES_H
 
-#include <yarp/dev/DeviceDriver.h>
-
+#include <yarp/dev/api.h>
 
 namespace yarp {
     namespace dev {

--- a/src/libYARP_dev/include/yarp/dev/Wrapper.h
+++ b/src/libYARP_dev/include/yarp/dev/Wrapper.h
@@ -10,6 +10,7 @@
 #ifndef YARP_DEV_WRAPPER_H
 #define YARP_DEV_WRAPPER_H
 
+#include <yarp/dev/api.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -20,6 +20,7 @@
 #include "partitem.h"
 #include "log.h"
 
+#include <yarp/os/LogStream.h>
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
 


### PR DESCRIPTION
I had noticed a few missing `YARP_dev_API` macros, so I decided to review and update all libYARP_dev's interface headers accordingly. Since this required to add a `#include <yarp/dev/api.h>` in some places, I also focused on header inclusions. As a result, some `#include`s have been added (for the sake of being explicit and avoiding transitive dependencies), others have been removed (["include what you use"](https://include-what-you-use.org/), i.e. avoid unnecessary inclusions) or "downgraded", i.e. `<yarp/dev/DeviceDriver.h>` has become a `<yarp/dev/api.h>`. Some YARP tools reported undeclared symbols, therefore a few .cpp had to be updated, too. For that reason, this can be considered a breaking change for projects that depend(ed) on transitively included YARP_dev headers.