### PR TITLE
Add initilizer_list constructor in Property

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -56,6 +56,7 @@ New Features
 * `ConnectionWriter::appendRawString()` is deprecated in favour of
   `appendString()`.
 * Added `ConnectionReader::expectString()`.
+* Added the `initiliizer_list` constructor in `yarp::os::Property`.
 
 #### `YARP_dev`
 

--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -59,6 +59,11 @@ public:
     Property(const Property& prop);
 
     /**
+     * @brief Initializer list constructor.
+     * @param[in] values, list of std::pair with which initialize the Property.
+     */
+    Property(std::initializer_list<std::pair<std::string, yarp::os::Value>> values);
+    /**
      * Destructor.
      */
     virtual ~Property();

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -896,6 +896,15 @@ Property::Property(const Property& prop) : Searchable(), Portable() {
     fromString(prop.toString());
 }
 
+Property::Property(std::initializer_list<std::pair<std::string, yarp::os::Value>> values) {
+    hash_size = 0;
+    implementation = new PropertyHelper(*this, 0);
+    yAssert(implementation!=nullptr);
+    for (const auto& val:values) {
+        put(val.first, val.second);
+    }
+}
+
 
 void Property::summon() {
     if (check()) return;

--- a/tests/libYARP_OS/PropertyTest.cpp
+++ b/tests/libYARP_OS/PropertyTest.cpp
@@ -598,4 +598,20 @@ check $x $y\n\
         pCopy2 = p;
         CHECK(pCopy.toString() == p.toString()); // test if addGroup works fine with Property copy operator
     }
+
+    SECTION("checking initializer_list constructor")
+    {
+        Property p {{"one", Value(1)},
+                    {"two", Value(2.0)},
+                    {"string", Value("foo")}
+                    };
+
+        CHECK(p.find("one").isInt32());
+        CHECK(p.find("two").isFloat64());
+        CHECK(p.find("string").isString());
+
+        CHECK(p.find("one").asInt32() == 1);
+        CHECK(p.find("two").asFloat64() == 2.0);
+        CHECK(p.find("string").asString() == "foo");
+    }
 }


### PR DESCRIPTION
This PR add the `initializer_list` constructor for the property.

Now it is possible to easily initilialize the Property from the construction.

E.g. : 
```c++
    Property p {{"one", Value(1)},
                {"two", Value(2.0)},
                {"string", Value("foo")}
                };

```

It is an idea that came up with @aerydna 
Please review code 