### PR TITLE
Add initializer_list constructor in Bottle

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -57,6 +57,7 @@ New Features
   `appendString()`.
 * Added `ConnectionReader::expectString()`.
 * Added the `initiliizer_list` constructor in `yarp::os::Property`.
+* Added the `initiliizer_list` constructor in `yarp::os::Bottle`.
 
 #### `YARP_dev`
 

--- a/src/libYARP_OS/include/yarp/os/Bottle.h
+++ b/src/libYARP_OS/include/yarp/os/Bottle.h
@@ -100,6 +100,12 @@ public:
     Bottle(const Bottle& bottle);
 
     /**
+     * @brief Initializer list constructor.
+     * @param[in] values, list of Value with which initialize the Bottle.
+     */
+    Bottle(std::initializer_list<yarp::os::Value> values);
+
+    /**
      * Assignment operator.
      *
      * @param bottle The object to copy.

--- a/src/libYARP_OS/src/Bottle.cpp
+++ b/src/libYARP_OS/src/Bottle.cpp
@@ -63,6 +63,19 @@ Bottle::Bottle(const Bottle& bottle)
     copy(bottle);
 }
 
+Bottle::Bottle(std::initializer_list<Value> values)
+        : Portable(), Searchable(), implementation(new BottleImpl(this))
+{
+    yAssert(implementation != nullptr);
+    implementation->invalid = false;
+    implementation->ro = false;
+
+    for (const auto& val:values)
+    {
+        add(val);
+    }
+}
+
 Bottle& Bottle::operator=(const Bottle& bottle)
 {
     implementation->edit();

--- a/tests/libYARP_OS/BottleTest.cpp
+++ b/tests/libYARP_OS/BottleTest.cpp
@@ -517,4 +517,25 @@ TEST_CASE("OS::BottleTest", "[yarp::os]")
         Portable::copyPortable(b1,s3);
         CHECK(s3.getCount() == 42); // "bottle-to-stamp ok"
     }
+
+    SECTION("test initializer_list constructor")
+    {
+        Bottle b { Value(1),
+                   Value(2.0),
+                   Value("foo")
+                 };
+
+        REQUIRE(b.size() == 3);
+        CHECK(b.isNull() == false);
+
+        CHECK(b.get(0).isInt32());
+        CHECK(b.get(1).isFloat64());
+        CHECK(b.get(2).isString());
+
+        CHECK(b.get(0).asInt32() == 1);
+        CHECK(b.get(1).asFloat64() == 2.0);
+        CHECK(b.get(2).asString() == "foo");
+
+
+    }
 }


### PR DESCRIPTION
This PR adds the `initializer_list` constructor in `Bottle`.

Example:

```c++
   Bottle b { Value(1),
              Value(2.0),
              Value("foo")
            };
```

Please review code.