### PR TITLE
Correctly detect color sensor on D435i

### DIFF
--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -69,8 +69,10 @@ static void print_supported_options(const rs2::sensor& sensor)
 
     if (sensor.is<rs2::depth_sensor>())
         yInfo() << "Depth sensor supports the following options:\n";
-    else
+    else if (sensor.get_stream_profiles()[0].stream_type() == RS2_STREAM_COLOR)
         yInfo() << "RGB camera supports the following options:\n";
+    else
+        yInfo() << "Sensor supports the following options:\n";
 
     // The following loop shows how to iterate over all available options
     // Starting from 0 until RS2_OPTION_COUNT (exclusive)
@@ -523,7 +525,7 @@ bool realsense2Driver::initializeRealsenseDevice()
                 return false;
             }
         }
-        else
+        else if (m_sensors[i].get_stream_profiles()[0].stream_type() == RS2_STREAM_COLOR)
             m_color_sensor = &m_sensors[i];
     }
 


### PR DESCRIPTION
Fixes https://github.com/robotology/yarp/issues/2009, please test on other RealSense models (@Nicogene).

Known `rs2::sensor` subclasses include, at time of writing: `rs2::depth_sensor` (checked against in current code), `rs2::pose_sensor`, `rs2::wheel_odometer` and `rs2::roi_sensor` (see [*rs_sensor.hpp*](https://github.com/IntelRealSense/librealsense/blob/9bdbfd98440b6516f8c864fbdfd6a9778b2c5715/include/librealsense2/hpp/rs_sensor.hpp)). I noticed that the color sensor in D435i is perceived by the SDK as a `rs2::roi_sensor` (`sensor.is<rs2::roi_sensor>() == true`). Since this might not be portable to other models, the solution described in https://github.com/IntelRealSense/librealsense/issues/1163#issuecomment-364733894 has been implemented here.