### PR TITLE
Add IVisualServoing destructor implementation in cpp file

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -100,6 +100,7 @@ New Features
 * `yarp::dev::IMap2D` Added method `yarp::dev::IMap2D::renameLocation()`
 * `yarp::dev::IMap2D` Added method `yarp::dev::IMap2D::renameArea()`
 
+
 #### `YARP_sig`
 
 * Added `ImageUtils.h`, an header containing the following image utilities:
@@ -143,7 +144,7 @@ New Features
   By default the  port is called `<client_name>/user_commands/rpc`.
 * `rpLidar2` device now uses rplidar sdk 1.9.0.
 * `fakeLaser` device: added configuration parameters to set the range and the
-  resolution of the device. 
+  resolution of the device.
 * `ovrheadset`: LibOVR 1.17 or later is now required.
 * Imported `usbCamera` device from iCub repository.
 * `analogServer` has learned to forward return codes to `analogSensorClient`

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -149,6 +149,7 @@ set(YARP_dev_SRCS src/CanBusInterface.cpp
                   src/ImplementVirtualAnalogSensor.cpp
                   src/IRangefinder2D.cpp
                   src/IVisualParamsImpl.cpp
+                  src/IVisualServoing.cpp
                   src/LaserMeasurementData.cpp
                   src/MultipleAnalogSensorsInterfaces.cpp
                   src/PolyDriver.cpp

--- a/src/libYARP_dev/include/yarp/dev/IVisualServoing.h
+++ b/src/libYARP_dev/include/yarp/dev/IVisualServoing.h
@@ -37,7 +37,7 @@ public:
     /*!
      * Destructor.
      */
-    virtual ~IVisualServoing() { }
+    virtual ~IVisualServoing();
 
     /*!
      * Initialize support classes, modules and connections to perform visual

--- a/src/libYARP_dev/src/IVisualServoing.cpp
+++ b/src/libYARP_dev/src/IVisualServoing.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IVisualServoing.h>
+
+yarp::dev::IVisualServoing::~IVisualServoing() = default;


### PR DESCRIPTION
After https://github.com/robotology/yarp/pull/2011#pullrequestreview-232263751 this PR has been changed to provide an `IVisualServoing.cpp` file with an explicit call to the compiler default destructor implementation.

---
_Initial post_

This PR partially reverts https://github.com/robotology/yarp/commit/864c3f851d36ad28b5d5dded442ef857477ffcb6.
In particular, it removes `YARP_dev_API` from `IVisualServoing` interface header because, under Windows, nothing is exported into a dll and the keyword triggers a linker error when using `IVisualServoing` for implementing derived classes.

Out of sheer curiosity, why wasn't I automatically call in during #2006 review for this particular file?