### PR TITLE
Added method to rename areas and locations

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -97,6 +97,8 @@ New Features
 * Updated `AnalogWrapper` to open multiple ros topics for `wrenchStamped`
     ros msg type.
 * Added `const` counterpart of `yarp::dev::CanBuffer::getPointer()`.
+* `yarp::dev::IMap2D` Added method `yarp::dev::IMap2D::renameLocation()`
+* `yarp::dev::IMap2D` Added method `yarp::dev::IMap2D::renameArea()`
 
 #### `YARP_sig`
 

--- a/src/devices/map2DClient/Map2DClient.cpp
+++ b/src/devices/map2DClient/Map2DClient.cpp
@@ -482,6 +482,34 @@ bool   yarp::dev::Map2DClient::deleteLocation(std::string location_name)
     return true;
 }
 
+bool   yarp::dev::Map2DClient::renameLocation(std::string original_name, std::string new_name)
+{
+    yarp::os::Bottle b;
+    yarp::os::Bottle resp;
+
+    b.addVocab(VOCAB_INAVIGATION);
+    b.addVocab(VOCAB_NAV_RENAME_X);
+    b.addVocab(VOCAB_NAV_LOCATION);
+    b.addString(original_name);
+    b.addString(new_name);
+
+    bool ret = m_rpcPort_to_Map2DServer.write(b, resp);
+    if (ret)
+    {
+        if (resp.get(0).asVocab() != VOCAB_OK)
+        {
+            yError() << "Navigation2DClient::renameLocation() received error from locations server";
+            return false;
+        }
+    }
+    else
+    {
+        yError() << "Navigation2DClient::renameLocation() error on writing on rpc port";
+        return false;
+    }
+    return true;
+}
+
 bool   yarp::dev::Map2DClient::deleteArea(std::string location_name)
 {
     yarp::os::Bottle b;
@@ -504,6 +532,34 @@ bool   yarp::dev::Map2DClient::deleteArea(std::string location_name)
     else
     {
         yError() << "Navigation2DClient::deleteArea() error on writing on rpc port";
+        return false;
+    }
+    return true;
+}
+
+bool   yarp::dev::Map2DClient::renameArea(std::string original_name, std::string new_name)
+{
+    yarp::os::Bottle b;
+    yarp::os::Bottle resp;
+
+    b.addVocab(VOCAB_INAVIGATION);
+    b.addVocab(VOCAB_NAV_RENAME_X);
+    b.addVocab(VOCAB_NAV_AREA);
+    b.addString(original_name);
+    b.addString(new_name);
+
+    bool ret = m_rpcPort_to_Map2DServer.write(b, resp);
+    if (ret)
+    {
+        if (resp.get(0).asVocab() != VOCAB_OK)
+        {
+            yError() << "Navigation2DClient::renameArea() received error from locations server";
+            return false;
+        }
+    }
+    else
+    {
+        yError() << "Navigation2DClient::renameArea() error on writing on rpc port";
         return false;
     }
     return true;

--- a/src/devices/map2DClient/Map2DClient.h
+++ b/src/devices/map2DClient/Map2DClient.h
@@ -81,7 +81,9 @@ public:
     bool     storeArea(std::string location_name, Map2DArea area) override;
     bool     getLocation(std::string location_name, Map2DLocation& loc) override;
     bool     getArea(std::string location_name, Map2DArea& area) override;
+    bool     renameLocation(std::string original_name, std::string new_name) override;
     bool     deleteLocation(std::string location_name) override;
+    bool     renameArea(std::string original_name, std::string new_name) override;
     bool     deleteArea(std::string location_name) override;
     bool     getLocationsList(std::vector<std::string>& locations) override;
     bool     getAreasList(std::vector<std::string>& locations) override;

--- a/src/devices/map2DServer/Map2DServer.cpp
+++ b/src/devices/map2DServer/Map2DServer.cpp
@@ -244,25 +244,77 @@ void Map2DServer::parse_vocab_command(yarp::os::Bottle& in, yarp::os::Bottle& ou
 
 //             ret = true;
         }
-        else if (cmd == VOCAB_NAV_DELETE_X && in.get(2).asVocab() == VOCAB_NAV_AREA)
+        else if (cmd == VOCAB_NAV_RENAME_X && in.get(2).asVocab() == VOCAB_NAV_LOCATION)
         {
-            std::string name = in.get(3).asString();
+            std::string orig_name = in.get(3).asString();
+            std::string new_name = in.get(4).asString();
 
-            std::map<std::string, Map2DArea>::iterator it;
-            it = m_areas_storage.find(name);
-            if (it != m_areas_storage.end())
+            std::map<std::string, Map2DLocation>::iterator orig_it;
+            orig_it = m_locations_storage.find(orig_name);
+            std::map<std::string, Map2DLocation>::iterator new_it;
+            new_it = m_locations_storage.find(new_name);
+
+            if (orig_it != m_locations_storage.end() &&
+                new_it  == m_locations_storage.end())
             {
-                yInfo() << "Deleted area " << name;
-                m_areas_storage.erase(it);
+                yInfo() << "location: " << orig_name << " renamed to: " << new_name;
+                auto loc = orig_it->second;
+                m_locations_storage.erase(orig_it);
+                m_locations_storage.insert(std::pair<std::string, Map2DLocation>(new_name, loc));
                 out.addVocab(VOCAB_OK);
             }
             else
             {
-                yError("User requested an invalid area name");
+                yError("User requested an invalid rename operation");
                 out.addVocab(VOCAB_ERR);
             }
+            //             ret = true;
+        }
+        else if (cmd == VOCAB_NAV_RENAME_X && in.get(2).asVocab() == VOCAB_NAV_AREA)
+        {
+            std::string orig_name = in.get(3).asString();
+            std::string new_name = in.get(4).asString();
 
+            std::map<std::string, Map2DArea>::iterator orig_it;
+            orig_it = m_areas_storage.find(orig_name);
+            std::map<std::string, Map2DArea>::iterator new_it;
+            new_it = m_areas_storage.find(new_name);
+
+            if (orig_it != m_areas_storage.end() &&
+                new_it == m_areas_storage.end())
+            {
+                yInfo() << "area: " << orig_name << " renamed to: " << new_name;
+                auto area = orig_it->second;
+                m_areas_storage.erase(orig_it);
+                m_areas_storage.insert(std::pair<std::string, Map2DArea>(new_name,area));
+                out.addVocab(VOCAB_OK);
+            }
+            else
+            {
+                yError("User requested an invalid rename operation");
+                out.addVocab(VOCAB_ERR);
+            }
 //             ret = true;
+        }
+        else if (cmd == VOCAB_NAV_DELETE_X && in.get(2).asVocab() == VOCAB_NAV_AREA)
+        {
+        std::string name = in.get(3).asString();
+
+        std::map<std::string, Map2DArea>::iterator it;
+        it = m_areas_storage.find(name);
+        if (it != m_areas_storage.end())
+        {
+            yInfo() << "Deleted area " << name;
+            m_areas_storage.erase(it);
+            out.addVocab(VOCAB_OK);
+        }
+        else
+        {
+            yError("User requested an invalid area name");
+            out.addVocab(VOCAB_ERR);
+        }
+
+        //             ret = true;
         }
         else if (cmd == VOCAB_NAV_GET_X && in.get(2).asVocab() == VOCAB_NAV_LOCATION)
         {

--- a/src/libYARP_dev/include/yarp/dev/ILocalization2D.h
+++ b/src/libYARP_dev/include/yarp/dev/ILocalization2D.h
@@ -85,6 +85,7 @@ constexpr yarp::conf::vocab32_t VOCAB_NAV_GET_LOCALIZER_STATUS  = yarp::os::crea
 constexpr yarp::conf::vocab32_t VOCAB_NAV_GET_LOCALIZER_POSES   = yarp::os::createVocab('l','p','s','s');
 constexpr yarp::conf::vocab32_t VOCAB_NAV_CLEAR_X               = yarp::os::createVocab('c','l','r');
 constexpr yarp::conf::vocab32_t VOCAB_NAV_DELETE_X              = yarp::os::createVocab('d','e','l');
+constexpr yarp::conf::vocab32_t VOCAB_NAV_RENAME_X              = yarp::os::createVocab('r','e','n','m');
 constexpr yarp::conf::vocab32_t VOCAB_NAV_STORE_X               = yarp::os::createVocab('s','t','o','r');
 constexpr yarp::conf::vocab32_t VOCAB_NAV_AREA                  = yarp::os::createVocab('a','r','e','a');
 constexpr yarp::conf::vocab32_t VOCAB_NAV_LOCATION              = yarp::os::createVocab('l','o','c');

--- a/src/libYARP_dev/include/yarp/dev/IMap2D.h
+++ b/src/libYARP_dev/include/yarp/dev/IMap2D.h
@@ -116,11 +116,27 @@ public:
     virtual bool getAreasList(std::vector<std::string>& areas) = 0;
 
     /**
+    * Searches for a location and renames it
+    * @param original_name the name of the area
+    * @param new_name the new name of the area
+    * @return true/false
+    */
+    virtual bool renameLocation(std::string original_name, std::string new_name) = 0;
+
+    /**
     * Delete a location
     * @param location_name the name of the location
     * @return true/false
     */
     virtual bool deleteLocation(std::string location_name) = 0;
+
+    /**
+    * Searches for an area and renames it
+    * @param original_name the name of the area
+    * @param new_name the new name of the area
+    * @return true/false
+    */
+    virtual bool renameArea(std::string original_name, std::string new_name) = 0;
 
     /**
     * Delete an area

--- a/tests/libYARP_dev/MapGrid2DTest.cpp
+++ b/tests/libYARP_dev/MapGrid2DTest.cpp
@@ -305,6 +305,21 @@ TEST_CASE("dev::MapGrid2DTest", "[yarp::dev]")
             imap->getLocationsList(loc_names);
             b1 = (loc_names.size() == 0);
             CHECK(b1);
+
+            ret = imap->storeArea("area", Map2DArea("map1", vec1));  CHECK(ret);
+            ret = imap->storeLocation("loc", Map2DLocation("map2", 4, 5, 6));  CHECK(ret);
+            ret = imap->renameArea("area_fail", "area_new");  CHECK(ret == false);
+            ret = imap->renameLocation("loc_fail", "loc_new");  CHECK(ret == false);
+            ret = imap->renameArea("area", "area_new");  CHECK(ret);
+            ret = imap->renameLocation("loc", "loc_new");  CHECK(ret);
+            ret = imap->getArea("area", area);         CHECK(ret==false);
+            ret = imap->getArea("area_new", area);      CHECK(ret); 
+            ret = imap->getLocation("loc", loc);       CHECK(ret==false);
+            ret = imap->getLocation("loc_new", loc);    CHECK(ret);
+            
+            //final cleanup, already tested        
+            ret = imap->clearAllLocations();  CHECK(ret);
+            ret = imap->clearAllAreas();  CHECK(ret);
         }
 
         //////////"Checking IMap2D methods which involve usage of classes MapGrid2D"


### PR DESCRIPTION
Added the following methods:
yarp::dev::IMap2D::renameLocation(std::string original_name, std::string new_name);
yarp::dev::IMap2D::renameArea(std::string original_name, std::string new_name);