### PR TITLE
Add const counterpart of CanBuffer::getPointer()

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -96,6 +96,7 @@ New Features
   load/save of Map2DLocation and Map2DArea.
 * Updated `AnalogWrapper` to open multiple ros topics for `wrenchStamped`
     ros msg type.
+* Added `const` counterpart of `yarp::dev::CanBuffer::getPointer()`.
 
 #### `YARP_sig`
 

--- a/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
+++ b/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
@@ -87,6 +87,11 @@ public:
         return data;
     }
 
+    const CanMessage *const *getPointer() const
+    {
+        return data;
+    }
+
     CanMessage &operator[](int k)
     {
         return *data[k];


### PR DESCRIPTION
Users were forced to `const_cast<>` a `const yarp::dev::CanBuffer` instance in order to call `getPointer()`.