### PR TITLE
Documentation fix on RPCServer write function

### DIFF
--- a/src/libYARP_OS/include/yarp/os/RpcServer.h
+++ b/src/libYARP_OS/include/yarp/os/RpcServer.h
@@ -36,11 +36,15 @@ public:
      */
     virtual ~RpcServer();
 
-    // documented in UnbufferedContactable
+    /**
+     * Write cannot be called by RPCServer
+     */
     virtual bool write(const PortWriter& writer,
                        const PortWriter* callback = nullptr) const override;
 
-    // documented in UnbufferedContactable
+    /**
+     * Write cannot be called by RPCServer
+     */
     virtual bool write(const PortWriter& writer,
                        PortReader& reader,
                        const PortWriter* callback = nullptr) const override;


### PR DESCRIPTION
The method write in RPCServer.h is overridden to disable it, but on the YARP documentation website it appears to be highlighted and working. The method documentation is then modified, as this can be misleading.