### PR TITLE
Remove YARP_dev_API attribute from yarp::dev::ImplementCanBufferFactory

### DIFF
--- a/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
+++ b/src/libYARP_dev/include/yarp/dev/CanBusInterface.h
@@ -116,7 +116,7 @@ public:
  * IMPL is the internal representation of the can message.
  */
 template<class M, class IMPL>
-class YARP_dev_API yarp::dev::ImplementCanBufferFactory: public ICanBufferFactory
+class yarp::dev::ImplementCanBufferFactory: public ICanBufferFactory
 {
 public:
     virtual ~ImplementCanBufferFactory(){}


### PR DESCRIPTION
Pure template classes do not need any symbol-visibility attributes, as they define no symbols in the `libYARP_dev`  library. 
If there was  an explicit template instantiation in the library, then `YARP_dev_API` should be added to the template instantiation (see https://anteru.net/blog/2008/c-tricks-6-explicit-template-instantiation/).

Fix https://github.com/robotology/icub-main/issues/577 .