### PR TITLE
yarpidl_thrift/YarpIDL more refactor

### DIFF
--- a/cmake/YarpIDL.cmake
+++ b/cmake/YarpIDL.cmake
@@ -11,9 +11,16 @@
 # optionally storing the list of source/header files in the supplied
 # variables. Call as:
 #
-#   yarp_idl_to_dir(foo.thrift foo)
-#   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS)
-#   yarp_idl_to_dir(foo.thrift foo SOURCES HEADERS INCLUDE_PATHS)
+#   yarp_idl_to_dir([SOURCES_VAR <var>]
+#                   [HEADERS_VAR <var>]
+#                   [INCLUDE_DIRS_VAR <var>]
+#                   [CMAKE_SCRIPTS_VAR <var>]
+#                   [THRIFT_INCLUDE_PREFIX]
+#                   [THRIFT_NO_NAMESPACE_PREFIX]
+#                   [THRIFT_NO_COPYRIGHT}
+#                   [THRIFT_NO_EDITOR]
+#                   [THRIFT_NO_DOC]
+#                   [VERBOSE])
 #
 # yarp_add_idl
 # ------------
@@ -38,181 +45,270 @@ if(COMMAND _yarp_idl_rosmsg_to_file_list)
   return()
 endif()
 
-function(YARP_IDL_TO_DIR yarpidl_file_base output_dir)
-  # Store optional output variable(s).
-  set(out_vars ${ARGN})
+function(YARP_IDL_TO_DIR)
 
-  # Make sure output_dir variable is visible when expanding templates.
-  set(output_dir ${output_dir})
+  set(_options VERBOSE
+               THRIFT_INCLUDE_PREFIX
+               THRIFT_NO_NAMESPACE_PREFIX
+               THRIFT_NO_COPYRIGHT
+               THRIFT_NO_EDITOR
+               THRIFT_NO_DOC)
+  set(_oneValueArgs OUTPUT_DIR
+                    SOURCES_VAR
+                    HEADERS_VAR
+                    INCLUDE_DIRS_VAR
+                    CMAKE_SCRIPTS_VAR)
+  set(_multiValueArgs INPUT_FILES)
+  cmake_parse_arguments(_YITD "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN} )
 
-  # Extract a name and extension.
-  if(IS_ABSOLUTE ${yarpidl_file_base})
-    file(RELATIVE_PATH yarpidl_file ${CMAKE_CURRENT_SOURCE_DIR} ${yarpidl_file_base})
-  else()
-    set(yarpidl_file ${yarpidl_file_base})
-  endif()
-  get_filename_component(include_prefix ${yarpidl_file} PATH)
-  get_filename_component(yarpidlName ${yarpidl_file} NAME_WE)
-  get_filename_component(yarpidlExt ${yarpidl_file} EXT)
-  string(TOLOWER "${yarpidlExt}" yarpidlExt)
-  string(TOLOWER "${yarpidlName}" yarpidlNameLower)
-  set(dir_add "")
-
-  # Figure out format we are working with.
-  set(yarpidl_native 0)
-  if(yarpidlExt STREQUAL ".thrift")
-    set(family thrift)
-    set(dir_add "/${yarpidlNameLower}")
-  elseif("${yarpidlExt}" MATCHES "\\.(msg|srv)" OR
-         "${yarpidl_file}" MATCHES "^(time|duration)$")
-    set(family rosmsg)
-    if("${yarpidl_file}" STREQUAL "time")
-      set(yarpidlName TickTime)
-      set(yarpidl_native 1)
-    elseif("${yarpidl_file}" STREQUAL "duration")
-      set(yarpidlName TickDuration)
-      set(yarpidl_native 1)
-    endif()
-  else()
-    message(FATAL_ERROR "yarp_idl_to_dir does not know what to do with \"${yarpidl_file}\", unrecognized extension \"${yarpidlExt}\"")
-  endif()
-
-  if("${family}" STREQUAL "thrift")
-    set(yarpidl_target_name "${yarpidl_file}")
-  else()
-    get_filename_component(rospkg_name "${include_prefix}" NAME)
-    get_filename_component(include_prefix "${include_prefix}" PATH)
-    if(rospkg_name MATCHES "(msg|srv)")
-      get_filename_component(rospkg_name "${include_prefix}" NAME)
-      get_filename_component(include_prefix "${include_prefix}" PATH)
-    endif()
-    if(NOT "${rospkg_name}" STREQUAL "")
-      set(yarpidl_target_name "${rospkg_name}_${yarpidlName}${yarpidlExt}")
-    else()
-      set(yarpidl_target_name "${yarpidlName}${yarpidlExt}")
-    endif()
-  endif()
-  string(REGEX REPLACE "[^a-zA-Z0-9]" "_" yarpidl_target_name ${yarpidl_target_name})
-
-  string(LENGTH "${include_prefix}" include_prefix_len)
-  if(include_prefix_len GREATER 0)
-    set(include_prefix "/${include_prefix}")
-  endif()
-
-  # Set intermediate output directory.
-  set(dir ${CMAKE_CURRENT_BINARY_DIR}/_yarp_idl_${include_prefix}${dir_add})
-
-  # Ensure that the intermediate output directory is deleted on make clean
-  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${dir})
-
-  set(settings_file ${output_dir}/${yarpidl_target_name}.cmake)
-
-  # Check if generation has never happened.
-  set(files_missing TRUE)
-  if(EXISTS ${settings_file})
-    set(files_missing FALSE)
-  endif()
-
-  # Flag to control whether IDL generation is allowed.
-  option(ALLOW_IDL_GENERATION "Allow YARP to (re)build IDL files as needed" ${files_missing})
-
-  set(full_headers)
-  set(full_sources)
-  if(ALLOW_IDL_GENERATION)
-    # Say what we are doing.
-    message(STATUS "${family} code for ${yarpidl_file} => ${output_dir}")
-    # Generate code at configuration time, so we know filenames.
-    find_program(YARPIDL_${family}_LOCATION
-                 NAMES yarpidl_${family}
-                 HINTS ${YARP_IDL_BINARY_HINT} # This is a list of directories defined
-                                               # in YarpOptions.cmake (for YARP) or in
-                                               # YARPConfig.cmake for dependencies
-                 NO_DEFAULT_PATH)
-    # Make sure intermediate output directory exists.
-    make_directory(${dir})
-    # Generate a script controlling final layout of files.
-    configure_file(${YARP_MODULE_DIR}/template/placeGeneratedYarpIdlFiles.cmake.in ${dir}/place${yarpidlName}.cmake @ONLY)
-
-    if("${family}" STREQUAL "thrift")
-      set(cmd "${YARPIDL_thrift_LOCATION}" --gen yarp:include_prefix --I "${CMAKE_CURRENT_SOURCE_DIR}" --out "${dir}" "${yarpidl_file}")
-    else()
-      set(_verbose )
-      set(_output_quiet OUTPUT_QUIET)
-      if(YARPIDL_rosmsg_VERBOSE)
-        set(_verbose --verbose)
-        set(_output_quiet )
+  if(NOT YARP_NO_DEPRECATED) # Since YARP 3.2
+    # Support old way to pass SOURCES_VAR, HEADERS_VAR and INCLUDE_DIRS_VAR
+    # (i.e. using ARGN)
+    list(LENGTH _YITD_UNPARSED_ARGUMENTS _len)
+    if(_len GREATER 0)
+      message(DEPRECATION "Passing variables without name argument to YARP_IDL_TO_DIR is deprecated. Use SOURCES_VAR, HEADERS_VAR and INCLUDE_DIRS_VAR")
+      if(NOT _YITD_INPUT_FILES)
+        list(GET _YITD_UNPARSED_ARGUMENTS 0 _YITD_INPUT_FILES)
       endif()
-      set(cmd "${YARPIDL_rosmsg_LOCATION}" --no-ros true --no-cache ${_verbose} --out "${dir}" "${yarpidl_file}")
+      if(NOT _YITD_OUTPUT_DIR)
+        list(GET _YITD_UNPARSED_ARGUMENTS 1 _YITD_OUTPUT_DIR)
+      endif()
+      # include_prefix was always enabled in the old version
+      if(NOT _YITD_THRIFT_INCLUDE_PREFIX)
+        set(_YITD_THRIFT_INCLUDE_PREFIX 1)
+      endif()
+      if(NOT _YITD_THRIFT_NO_NAMESPACE_PREFIX)
+        set(_YITD_THRIFT_NO_NAMESPACE_PREFIX 1)
+      endif()
     endif()
-
-    # Go ahead and generate files.
-    execute_process(COMMAND ${cmd}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE res
-                    ${_output_quiet})
-    # Failure is bad news, let user know.
-    if(NOT "${res}" STREQUAL "0")
-      message(FATAL_ERROR "yarpidl_${family} (${YARPIDL_${family}_LOCATION}) failed, aborting.")
+    if(_len GREATER 3)
+      if(NOT DEFINED _YITD_SOURCES_VAR)
+        list(GET _YITD_UNPARSED_ARGUMENTS 2 _YITD_SOURCES_VAR)
+      endif()
+      if(NOT DEFINED _YITD_HEADERS_VAR)
+        list(GET _YITD_UNPARSED_ARGUMENTS 3 _YITD_HEADERS_VAR)
+      endif()
     endif()
-    # Place the files in their final location.
-    execute_process(COMMAND ${CMAKE_COMMAND} -P ${dir}/place${yarpidlName}.cmake)
-    set(files_missing FALSE)
+    if(_len GREATER 4)
+      if(NOT DEFINED _YITD_INCLUDE_DIRS_VAR)
+        list(GET _YITD_UNPARSED_ARGUMENTS 4 _YITD_INCLUDE_DIRS_VAR)
+      endif()
+    endif()
   endif()
 
-  # Prepare list of generated files.
-  if(NOT files_missing)
-    include(${settings_file})
-    set(DEST_FILES)
-    foreach(generatedFile ${headers})
-      list(APPEND DEST_FILES ${output_dir}/${generatedFile})
-      list(APPEND full_headers ${output_dir}/${generatedFile})
-    endforeach(generatedFile)
-    foreach(generatedFile ${sources})
-      list(APPEND DEST_FILES ${output_dir}/${generatedFile})
-      list(APPEND full_sources ${output_dir}/${generatedFile})
-    endforeach(generatedFile)
-  endif()
+  unset(_full_headers)
+  unset(_full_sources)
+  unset(_full_paths)
+  unset(_cmake_scripts)
 
-  if(ALLOW_IDL_GENERATION)
-    # Add a command/target to regenerate the files if the IDL file changes.
-    set(yarpidl_depends ${yarpidl_file})
-    if(yarpidl_native)
-      unset(yarpidl_depends)
-    endif()
-    add_custom_command(OUTPUT ${output_dir}/${yarpidl_target_name}.cmake ${DEST_FILES}
-                       COMMAND ${YARPIDL_${family}_LOCATION} --out ${dir} --gen yarp:include_prefix --I ${CMAKE_CURRENT_SOURCE_DIR} ${yarpidl_file}
-                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                       COMMAND ${CMAKE_COMMAND} -P ${dir}/place${yarpidlName}.cmake
-                       DEPENDS ${yarpidl_depends} ${YARPIDL_LOCATION})
-    add_custom_target(${yarpidl_target_name} DEPENDS ${output_dir}/${yarpidl_target_name}.cmake)
+  foreach(_file ${_YITD_INPUT_FILES})
 
-    # Put the target in the right folder if defined
-    get_property(autogen_source_group_set GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER SET)
-    if(autogen_source_group_set)
-      get_property(autogen_targets_folder GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER)
-      set_property(TARGET ${yarpidl_target_name} PROPERTY FOLDER "${autogen_targets_folder}")
-    endif()
-  else()
-    if(files_missing)
-      message(FATAL_ERROR "Generated IDL files for ${yarpidl_file} not found and cannot make them because ALLOW_IDL_GENERATION=${ALLOW_IDL_GENERATION} (maybe this should be turned on?)")
-    endif()
-  endif(ALLOW_IDL_GENERATION)
-
-  list(LENGTH out_vars len)
-  if(len GREATER 1)
-    list(GET out_vars 0 target_src)
-    list(GET out_vars 1 target_hdr)
-    set(${target_src} ${full_sources} PARENT_SCOPE)
-    set(${target_hdr} ${full_headers} PARENT_SCOPE)
-  endif()
-  if(len GREATER 2)
-    list(GET out_vars 2 target_paths)
-    if("${family}" STREQUAL "thrift")
-      set(${target_paths} ${output_dir} ${output_dir}/include PARENT_SCOPE)
+    # Extract a name and extension.
+    if(IS_ABSOLUTE ${_file})
+      file(RELATIVE_PATH _file ${CMAKE_CURRENT_SOURCE_DIR} ${_file})
     else()
-      set(${target_paths} ${output_dir}/include PARENT_SCOPE)
+      set(_file ${_file})
     endif()
+    get_filename_component(_include_prefix ${_file} PATH)
+    string(REPLACE "../" "" _include_prefix "${_include_prefix}")
+    get_filename_component(_name ${_file} NAME_WE)
+    get_filename_component(_ext ${_file} EXT)
+    string(TOLOWER "${_ext}" _ext)
+    string(TOLOWER "${_name}" _name_lower)
+    set(_dir_add "")
+
+    # Figure out format we are working with.
+    set(_yarpidl_native 0)
+    if(_ext STREQUAL ".thrift")
+      set(_family thrift)
+      set(_dir_add "/${_name_lower}")
+    elseif("${_ext}" MATCHES "\\.(msg|srv)" OR
+           "${_file}" MATCHES "^(time|duration)$")
+      set(_family rosmsg)
+      if("${_file}" STREQUAL "time")
+        set(_name TickTime)
+        set(_yarpidl_native 1)
+      elseif("${_file}" STREQUAL "duration")
+        set(_name TickDuration)
+        set(_yarpidl_native 1)
+      endif()
+    else()
+      message(FATAL_ERROR "yarp_idl_to_dir does not know what to do with \"${_file}\", unrecognized extension \"${_ext}\"")
+    endif()
+
+    if("${_family}" STREQUAL "thrift")
+      set(_target_name "${_file}")
+    else()
+      get_filename_component(_rospkg_name "${_include_prefix}" NAME)
+      get_filename_component(_include_prefix "${_include_prefix}" PATH)
+      if(_rospkg_name MATCHES "(msg|srv)")
+        get_filename_component(_rospkg_name "${_include_prefix}" NAME)
+        get_filename_component(_include_prefix "${_include_prefix}" PATH)
+      endif()
+      if(NOT "${_rospkg_name}" STREQUAL "")
+        set(_target_name "${_rospkg_name}_${_name}${_ext}")
+      else()
+        set(_target_name "${_name}${_ext}")
+      endif()
+    endif()
+    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" _target_name ${_target_name})
+
+    string(LENGTH "${_include_prefix}" _include_prefix_len)
+    if(_include_prefix_len GREATER 0)
+      set(_include_prefix "/${_include_prefix}")
+    endif()
+
+    # Set intermediate output directory.
+    set(_dir ${CMAKE_CURRENT_BINARY_DIR}/_yarp_idl_${_include_prefix}${_dir_add})
+
+    # Set cmake script file name
+    set(_cmake_script "${_YITD_OUTPUT_DIR}/${_target_name}.cmake")
+    list(APPEND _cmake_scripts "${_cmake_script}")
+
+    # Ensure that the intermediate output directory is deleted on make clean
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${_dir})
+
+    set(settings_file ${_YITD_OUTPUT_DIR}/${_target_name}.cmake)
+
+    # Check if generation has never happened.
+    set(files_missing TRUE)
+    if(EXISTS ${settings_file})
+      set(files_missing FALSE)
+    endif()
+
+    # Flag to control whether IDL generation is allowed.
+    option(ALLOW_IDL_GENERATION "Allow YARP to (re)build IDL files as needed" ${files_missing})
+
+    if(ALLOW_IDL_GENERATION)
+      # Say what we are doing.
+      message(STATUS "${_family} code for ${_file} => ${_YITD_OUTPUT_DIR}")
+      # Generate code at configuration time, so we know filenames.
+      find_program(YARPIDL_${_family}_LOCATION
+                   NAMES yarpidl_${_family}
+                   HINTS ${YARP_IDL_BINARY_HINT} # This is a list of directories defined
+                                                 # in YarpOptions.cmake (for YARP) or in
+                                                 # YARPConfig.cmake for dependencies
+                   NO_DEFAULT_PATH)
+      # Make sure intermediate output directory exists.
+      make_directory(${_dir})
+      # Generate a script controlling final layout of files.
+      # Make sure that variables are visible when expanding templates.
+      set(_output_dir ${_YITD_OUTPUT_DIR})
+      configure_file("${YARP_MODULE_DIR}/template/placeGeneratedYarpIdlFiles.cmake.in"
+                     "${_dir}/place${_name}.cmake"
+                     @ONLY)
+      unset(_args)
+      if("${_family}" STREQUAL "thrift")
+        unset(_extra_args)
+        foreach(_ARG INCLUDE_PREFIX
+                     NO_NAMESPACE_PREFIX
+                     NO_COPYRIGHT
+                     NO_EDITOR
+                     NO_DOC)
+          if(_YITD_THRIFT_${_ARG})
+            string(TOLOWER "${_ARG}" _arg)
+            list(APPEND _extra_args ${_arg})
+          endif()
+        endforeach()
+        if (NOT "${_extra_args}" STREQUAL "")
+          string(REPLACE ";" "," _extra_args "${_extra_args}")
+          set(_extra_args ":${_extra_args}")
+        endif()
+        list(APPEND _args --gen yarp${_extra_args})
+        list(APPEND _args --I "${CMAKE_CURRENT_SOURCE_DIR}")
+      else()
+        list(APPEND _args --no-ros true)
+        list(APPEND _args --no-cache)
+        if(_YITD_VERBOSE)
+          list(APPEND _args --verbose)
+        endif()
+      endif()
+      list(APPEND _args --out "${_dir}")
+
+      set(_output_quiet OUTPUT_QUIET)
+      if(_YITD_VERBOSE)
+        set(_output_quiet)
+      endif()
+
+      set(_cmd "${YARPIDL_${_family}_LOCATION}" ${_args} "${_file}")
+
+      if(_YITD_VERBOSE)
+        string(REPLACE ";" " " _cmd_str "${_cmd}")
+        message(STATUS "    WORKING_DIRECTORY = [${CMAKE_CURRENT_SOURCE_DIR}]")
+        message(STATUS "    COMMAND = [${_cmd_str}]")
+      endif()
+
+      # Go ahead and generate files.
+      execute_process(COMMAND ${_cmd}
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                      RESULT_VARIABLE res
+                      ${_output_quiet})
+      # Failure is bad news, let user know.
+      if(NOT "${res}" STREQUAL "0")
+        message(FATAL_ERROR "yarpidl_${_family} (${YARPIDL_${_family}_LOCATION}) failed, aborting.")
+      endif()
+      # Place the files in their final location.
+      execute_process(COMMAND ${CMAKE_COMMAND} -P "${_dir}/place${_name}.cmake")
+      set(files_missing FALSE)
+    endif()
+
+    # Prepare list of generated files.
+    if(NOT files_missing)
+      include(${settings_file})
+      set(DEST_FILES)
+      foreach(generatedFile ${headers})
+        list(APPEND DEST_FILES ${_YITD_OUTPUT_DIR}/${generatedFile})
+        list(APPEND _full_headers ${_YITD_OUTPUT_DIR}/${generatedFile})
+      endforeach(generatedFile)
+      foreach(generatedFile ${sources})
+        list(APPEND DEST_FILES ${_YITD_OUTPUT_DIR}/${generatedFile})
+        list(APPEND _full_sources ${_YITD_OUTPUT_DIR}/${generatedFile})
+      endforeach(generatedFile)
+    endif()
+
+    if(ALLOW_IDL_GENERATION)
+      # Add a command/target to regenerate the files if the IDL file changes.
+      set(yarpidl_depends ${_file})
+      if(_yarpidl_native)
+        unset(yarpidl_depends)
+      endif()
+      add_custom_command(OUTPUT ${_YITD_OUTPUT_DIR}/${_target_name}.cmake ${DEST_FILES}
+                         COMMAND ${YARPIDL_${_family}_LOCATION} --out ${_dir} --gen yarp:include_prefix --I ${CMAKE_CURRENT_SOURCE_DIR} ${_file}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                         COMMAND ${CMAKE_COMMAND} -P ${_dir}/place${_name}.cmake
+                         DEPENDS ${yarpidl_depends} ${YARPIDL_LOCATION})
+      add_custom_target(${_target_name} DEPENDS ${_YITD_OUTPUT_DIR}/${_target_name}.cmake)
+
+      # Put the target in the right folder if defined
+      get_property(autogen_source_group_set GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER SET)
+      if(autogen_source_group_set)
+        get_property(autogen_targets_folder GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER)
+        set_property(TARGET ${_target_name} PROPERTY FOLDER "${autogen_targets_folder}")
+      endif()
+    else()
+      if(files_missing)
+        message(FATAL_ERROR "Generated IDL files for ${_file} not found and cannot make them because ALLOW_IDL_GENERATION=${ALLOW_IDL_GENERATION} (maybe this should be turned on?)")
+      endif()
+    endif(ALLOW_IDL_GENERATION)
+
+    list(APPEND _full_paths "${_YITD_OUTPUT_DIR}/include")
+    list(REMOVE_DUPLICATES _full_paths)
+  endforeach()
+
+  # Set requested variables in parent scope
+  if(DEFINED _YITD_SOURCES_VAR)
+    set(${_YITD_SOURCES_VAR} ${_full_sources} PARENT_SCOPE)
   endif()
+  if(DEFINED _YITD_HEADERS_VAR)
+    set(${_YITD_HEADERS_VAR} ${_full_headers} PARENT_SCOPE)
+  endif()
+  if(DEFINED _YITD_INCLUDE_DIRS_VAR)
+    set(${_YITD_INCLUDE_DIRS_VAR} ${_full_paths} PARENT_SCOPE)
+  endif()
+  if(DEFINED _YITD_CMAKE_SCRIPTS_VAR)
+    set(${_YITD_CMAKE_SCRIPTS_VAR} "${_cmake_scripts}" PARENT_SCOPE)
+  endif()
+
 endfunction()
 
 

--- a/cmake/template/placeGeneratedYarpIdlFiles.cmake.in
+++ b/cmake/template/placeGeneratedYarpIdlFiles.cmake.in
@@ -4,53 +4,57 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-set(headers)
-set(sources)
+# Configured with the following variables:
+#
+#  - family = @_family@
+#  - dir = @_dir@
+#  - name = @_name@
+#  - output_dir = @_output_dir@
+#  - target_name = @_target_name@
+#  - cmake_script = @_cmake_script@
 
-set(prefix)
-if ("@family@" STREQUAL "thrift")
-  string(REGEX REPLACE "^/*([^/].+[^/])/*$" "\\1/" prefix "@include_prefix@")
-endif()
+set(_headers)
+set(_sources)
 
-file(STRINGS "@dir@/@yarpidlName@_indexALL.txt" index)
-foreach(genFile ${index})
-  get_filename_component(type ${genFile} EXT)
-  get_filename_component(main ${genFile} NAME_WE)
-  if(${type} STREQUAL ".h")
-    if(EXISTS "@dir@/${genFile}")
-      configure_file("@dir@/${genFile}"
-                     "@output_dir@/include/${prefix}${genFile}"
+file(STRINGS "@_dir@/@_name@_indexALL.txt" _index)
+foreach(_gen_file ${_index})
+  get_filename_component(_type ${_gen_file} EXT)
+  get_filename_component(_main ${_gen_file} NAME_WE)
+  if(${_type} STREQUAL ".h")
+    if(EXISTS "@_dir@/${_gen_file}")
+      configure_file("@_dir@/${_gen_file}"
+                     "@_output_dir@/include/${_gen_file}"
                      COPYONLY)
-      list(APPEND headers "include/${prefix}${genFile}")
-      list(REMOVE_DUPLICATES headers)
+      list(APPEND _headers "include/${_gen_file}")
+      list(REMOVE_DUPLICATES _headers)
     else()
-      message(WARNING "${genFile} not found in @yarpidlName@ dir!")
+      message(WARNING "${_gen_file} not found in @_dir@ dir!")
     endif()
-    if(EXISTS "@dir@/${main}Reply${type}")
-      configure_file("@dir@/${main}Reply${type}"
-                     "@output_dir@/include/${prefix}${main}Reply${type}"
+    if(EXISTS "@_dir@/${_main}Reply${_type}")
+      configure_file("@_dir@/${_main}Reply${_type}"
+                     "@_output_dir@/include/${_prefix}${_main}Reply${_type}"
                      COPYONLY)
-      list(APPEND headers "include/${prefix}${main}Reply${type}")
-      list(REMOVE_DUPLICATES headers)
+      list(APPEND _headers "include/${_main}Reply${_type}")
+      list(REMOVE_DUPLICATES _headers)
     endif()
-  elseif(${type} STREQUAL ".cpp")
-    if(EXISTS "@dir@/${genFile}")
-      configure_file("@dir@/${genFile}"
-                     "@output_dir@/src/${genFile}"
+  elseif(${_type} STREQUAL ".cpp")
+    if(EXISTS "@_dir@/${_gen_file}")
+      configure_file("@_dir@/${_gen_file}"
+                     "@_output_dir@/src/${_gen_file}"
                      COPYONLY)
-      list(APPEND sources "src/${genFile}")
-      list(REMOVE_DUPLICATES sources)
+      list(APPEND _sources "src/${_gen_file}")
+      list(REMOVE_DUPLICATES _sources)
     else()
-      message(WARNING "${genFile} not found in @yarpidlName@ dir!")
+      message(WARNING "${_gen_file} not found in @_name@ dir!")
     endif()
 
   else()
-    message(WARNING "Filename extension of ${genFile} is neither .h nor .cpp")
+    message(WARNING "Filename extension of ${_gen_file} is neither .h nor .cpp")
   endif()
-endforeach(genFile)
+endforeach(_gen_file)
 
 
-file(WRITE "@output_dir@/@yarpidl_target_name@.cmake"
+file(WRITE "@_cmake_script@"
 "# Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
 # All rights reserved.
 #
@@ -60,6 +64,6 @@ file(WRITE "@output_dir@/@yarpidl_target_name@.cmake"
 ## This is an automatically-generated file.
 ## It could get re-generated if the ALLOW_IDL_GENERATION flag is on
 
-set(headers ${headers})
-set(sources ${sources})
+set(headers ${_headers})
+set(sources ${_sources})
 ")

--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -3,7 +3,7 @@ YARP 3.2.0 (UNRELEASED)                                                {#v3_2_0}
 
 [TOC]
 
-YARP 3.1.1 Release Notes
+YARP 3.2.0 Release Notes
 ========================
 
 
@@ -47,6 +47,21 @@ New Features
 * All the internal CMake variables related to packages now use the same case
   as the relative CMake module (i.e. `YARP_HAS_OpenCV` instead of
   `YARP_HAS_OPENCV`)
+* `yarp_idl_to_dir` signature changed, and now supports passing optional
+  parameters:
+  ```
+     yarp_idl_to_dir([SOURCES_VAR <var>]
+                     [HEADERS_VAR <var>]
+                     [INCLUDE_DIRS_VAR <var>]
+                     [CMAKE_SCRIPTS_VAR <var>]
+                     [THRIFT_INCLUDE_PREFIX]
+                     [THRIFT_NO_NAMESPACE_PREFIX]
+                     [THRIFT_NO_COPYRIGHT}
+                     [THRIFT_NO_EDITOR]
+                     [THRIFT_NO_DOC]
+                     [VERBOSE])
+  ```
+  The old behaviour is still supported, but deprecated.
 
 
 ### Libraries
@@ -178,6 +193,8 @@ New Features
   `yarp.api.keyword` annotations.
 * Portables serialized using `appendExternalBlock` (i.e. `yarp::sig::Vector`)
   can now be safely returned by thrift methods.
+* Files are now generating using namespace as subdirectory (this can be
+  disabled using the no_namespace_prefix option.
 
 
 ### GUIs

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -223,16 +223,17 @@ set(YARP_dev_devices_HDRS src/devices/AnalogSensorClient/AnalogSensorClient.h
                           src/devices/TestMotor/TestMotor.h
                           src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h)
 
-# handle the yarp thrift messages
+# Handle the YARP thrift messages
 include(YarpIDL)
-yarp_idl_to_dir("${CMAKE_CURRENT_SOURCE_DIR}/stateExt.thrift"
-                "${CMAKE_CURRENT_SOURCE_DIR}/src/devices/msgs/yarp"
-                YARP_dev_idl_SRCS
-                YARP_dev_idl_HDRS
-                YARP_dev_idl_INCLUDE_DIRS)
-include("${CMAKE_CURRENT_SOURCE_DIR}/src/devices/msgs/yarp/stateExt_thrift.cmake")
-
-
+yarp_idl_to_dir(INPUT_FILES stateExt.thrift
+                OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/devices/msgs/yarp"
+                SOURCES_VAR YARP_dev_idl_SRCS
+                HEADERS_VAR YARP_dev_idl_HDRS
+                INCLUDE_DIRS_VAR YARP_dev_idl_INCLUDE_DIRS
+                CMAKE_SCRIPTS_VAR YARP_dev_idl_CMAKE_SCRIPTS)
+foreach(_script ${YARP_dev_idl_CMAKE_SCRIPTS})
+  include("${_script}")
+endforeach()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/devices/AnalogSensorClient
                     ${CMAKE_CURRENT_SOURCE_DIR}/src/devices/JoypadControlServer)

--- a/src/libYARP_rosmsg/CMakeLists.txt
+++ b/src/libYARP_rosmsg/CMakeLists.txt
@@ -27,11 +27,11 @@ macro(_yarp_choose_idl _prefix)
       set(${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
     else()
       foreach(_msg ${ARGN})
-        yarp_idl_to_dir(${_msg}
-                        "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
-                        ${_prefix}_GEN_SRCS
-                        ${_prefix}_GEN_HDRS
-                        ${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS)
+        yarp_idl_to_dir(INPUT_FILES ${_msg}
+                        OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
+                        SOURCES_VAR ${_prefix}_GEN_SRCS
+                        HEADERS_VAR ${_prefix}_GEN_HDRS
+                        INCLUDE_DIRS_VAR ${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS)
         set(${_prefix}_GEN_FILES ${${_prefix}_GEN_SRCS} ${${_prefix}_GEN_HDRS})
       endforeach()
     endif()

--- a/src/yarpdataplayer/CMakeLists.txt
+++ b/src/yarpdataplayer/CMakeLists.txt
@@ -54,11 +54,11 @@ if(YARP_COMPILE_yarpdataplayer)
   qt5_wrap_ui(yarpdataplayer_UI_GEN_SRCS ${yarpdataplayer_UI_FILES})
 
   include(YarpIDL)
-  yarp_idl_to_dir(${yarpdataplayer_THRIFT_FILES}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code
-                  yarpdataplayer_THRIFT_GEN_SRCS
-                  yarpdataplayer_THRIFT_GEN_HDRS
-                  yarpdataplayer_THRIFT_INCLUDE_DIRS)
+  yarp_idl_to_dir(INPUT_FILES ${yarpdataplayer_THRIFT_FILES}
+                  OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
+                  SOURCES_VAR yarpdataplayer_THRIFT_GEN_SRCS
+                  HEADERS_VAR yarpdataplayer_THRIFT_GEN_HDRS
+                  INCLUDE_DIRS_VAR yarpdataplayer_THRIFT_INCLUDE_DIRS)
 
   include_directories(${yarpdataplayer_THRIFT_INCLUDE_DIRS})
 

--- a/src/yarprobotinterface/CMakeLists.txt
+++ b/src/yarprobotinterface/CMakeLists.txt
@@ -37,12 +37,12 @@ if(YARP_COMPILE_yarprobotinterface)
       yarprobotinterface.thrift)
 
   include(YarpIDL)
-  yarp_idl_to_dir(${yarprobotinterface_IDLS}
-                  "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
-                  yarprobotinterface_IDLS_SRCS
-                  yarprobotinterface_IDLS_HDRS
-                  yarprobotinterface_IDLS_INCLUDE_DIRS)
-  include_directories("${yarprobotinterface_IDLS_INCLUDE_DIRS}")
+  yarp_idl_to_dir(INPUT_FILES ${yarprobotinterface_IDLS}
+                  OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"
+                  SOURCES_VAR yarprobotinterface_IDLS_SRCS
+                  HEADERS_VAR yarprobotinterface_IDLS_HDRS
+                  INCLUDE_DIRS_VAR yarprobotinterface_IDLS_INCLUDE_DIRS)
+  include_directories(${yarprobotinterface_IDLS_INCLUDE_DIRS})
 
   add_executable(yarprobotinterface ${yarprobotinterface_SRCS}
                                     ${yarprobotinterface_HDRS}

--- a/tests/yarpidl_rosmsg/demo/CMakeLists.txt
+++ b/tests/yarpidl_rosmsg/demo/CMakeLists.txt
@@ -15,7 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS 1)
 set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER "Autogen Targets")
 set_property(GLOBAL PROPERTY AUTOGEN_SOURCE_GROUP "Generated Files")
 
-find_package(YARP REQUIRED)
+find_package(YARP COMPONENTS OS sig idl_tools REQUIRED)
 
 include(ParseAndAddCatchTests)
 set(PARSE_CATCH_TESTS_VERBOSE OFF CACHE INTERNAL "")
@@ -27,31 +27,38 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/catch2)
 set(AdditionalCatchParameters "-s" "--use-colour" "yes")
 set(OptionalCatchTestLauncher ${YARP_TEST_LAUNCHER})
 
-# Test using yarp_idl_to_dir
-set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}/bits")
-yarp_idl_to_dir(SharedData.msg ${generated_libs_dir} S1 H1)
-yarp_idl_to_dir(Demo.msg ${generated_libs_dir} S2 H2)
-yarp_idl_to_dir(Tennis.srv ${generated_libs_dir} S3 H3)
-yarp_idl_to_dir(Rpc.srv ${generated_libs_dir} S4 H4)
-yarp_idl_to_dir(HeaderTest.msg ${generated_libs_dir} S5 H5)
-yarp_idl_to_dir(HeaderTest2.srv ${generated_libs_dir} S6 H6)
-
-include_directories(${generated_libs_dir}/include)
-add_executable(demo_yarp_idl_to_dir main.cpp ${S1} ${S2} ${S3} ${S4} ${H1} ${H2} ${H3} ${H4} ${S5} ${H5} ${S6} ${H6})
-target_link_libraries(demo_yarp_idl_to_dir ${YARP_LIBRARIES})
-
-ParseAndAddCatchTests(demo_yarp_idl_to_dir)
-
-# Test using yarp_add_idl
 set(IDL_FILES SharedData.msg
               Demo.msg
               Tennis.srv
               Rpc.srv
               HeaderTest.msg
               HeaderTest2.srv)
+
+# Test using yarp_idl_to_dir
+set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}/bits")
+yarp_idl_to_dir(INPUT_FILES ${IDL_FILES}
+                OUTPUT_DIR "${generated_libs_dir}"
+                SOURCES_VAR IDL_GEN_SRCS
+                HEADERS_VAR IDL_GEN_HDRS
+                INCLUDE_DIRS_VAR IDL_INCLUDE_DIRS
+                THRIFT_INCLUDE_PREFIX
+                THRIFT_NO_NAMESPACE_PREFIX)
+
+include_directories(${generated_libs_dir}/include)
+add_executable(demo_yarp_idl_to_dir main.cpp ${IDL_GEN_SRCS} ${IDL_GEN_HDRS})
+target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_OS
+                                                   YARP::YARP_init
+                                                   YARP::YARP_sig)
+
+ParseAndAddCatchTests(demo_yarp_idl_to_dir)
+
+
+# Test using yarp_add_idl
 yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
 
 add_executable(demo_yarp_add_idl main.cpp ${IDL_GEN_FILES})
-target_link_libraries(demo_yarp_add_idl ${YARP_LIBRARIES})
+target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_OS
+                                                YARP::YARP_init
+                                                YARP::YARP_sig)
 
 ParseAndAddCatchTests(demo_yarp_add_idl)

--- a/tests/yarpidl_thrift/demo/CMakeLists.txt
+++ b/tests/yarpidl_thrift/demo/CMakeLists.txt
@@ -15,7 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS 1)
 set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER "Autogen Targets")
 set_property(GLOBAL PROPERTY AUTOGEN_SOURCE_GROUP "Generated Files")
 
-find_package(YARP REQUIRED)
+find_package(YARP COMPONENTS OS sig idl_tools REQUIRED)
 
 include(ParseAndAddCatchTests)
 set(PARSE_CATCH_TESTS_VERBOSE OFF CACHE INTERNAL "")
@@ -27,31 +27,37 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/catch2)
 set(AdditionalCatchParameters "-s" "--use-colour" "yes")
 set(OptionalCatchTestLauncher ${YARP_TEST_LAUNCHER})
 
-# Test using yarp_idl_to_dir
-set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}")
-yarp_idl_to_dir(demo.thrift ${generated_libs_dir} S1 H1 I1)
-yarp_idl_to_dir(namespaced.thrift ${generated_libs_dir} S2 H2 I2)
-yarp_idl_to_dir(objects3D.thrift ${generated_libs_dir} S3 H3 I3)
-yarp_idl_to_dir(wrapping.thrift ${generated_libs_dir} S4 H4 I4)
-yarp_idl_to_dir(sub/directory/clock_rpc.thrift ${generated_libs_dir} S5 H5 I5)
-yarp_idl_to_dir(settings.thrift ${generated_libs_dir} S6 H6 I6)
-
-include_directories(${generated_libs_dir}/include)
-add_executable(demo_yarp_idl_to_dir main.cpp ${S1} ${S2} ${S3} ${S4} ${S5} ${S6} ${H1} ${H2} ${H3} ${H4} ${H5} ${H6})
-target_link_libraries(demo_yarp_idl_to_dir ${YARP_LIBRARIES})
-
-ParseAndAddCatchTests(demo_yarp_idl_to_dir)
-
-
-# Test using yarp_add_idl
 set(IDL_FILES demo.thrift
               namespaced.thrift
               objects3D.thrift
               wrapping.thrift
               sub/directory/clock_rpc.thrift
               settings.thrift)
+
+# Test using yarp_idl_to_dir
+set(generated_libs_dir "${CMAKE_CURRENT_BINARY_DIR}")
+yarp_idl_to_dir(INPUT_FILES ${IDL_FILES}
+                OUTPUT_DIR "${generated_libs_dir}"
+                SOURCES_VAR IDL_GEN_SRCS
+                HEADERS_VAR IDL_GEN_HDRS
+                INCLUDE_DIRS_VAR IDL_INCLUDE_DIRS
+                THRIFT_INCLUDE_PREFIX
+                THRIFT_NO_NAMESPACE_PREFIX)
+
+include_directories(${generated_libs_dir}/include)
+add_executable(demo_yarp_idl_to_dir main.cpp ${IDL_GEN_SRCS} ${IDL_GEN_HDRS})
+target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_OS
+                                                   YARP::YARP_init
+                                                   YARP::YARP_sig)
+
+ParseAndAddCatchTests(demo_yarp_idl_to_dir)
+
+
+# Test using yarp_add_idl
 yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
 add_executable(demo_yarp_add_idl main.cpp ${IDL_GEN_FILES})
-target_link_libraries(demo_yarp_add_idl ${YARP_LIBRARIES})
+target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_OS
+                                                YARP::YARP_init
+                                                YARP::YARP_sig)
 
 ParseAndAddCatchTests(demo_yarp_add_idl)


### PR DESCRIPTION
* Support passing multiple files to `yarp_idl_to_dir`
* Add optional parameters to `yarp_idl_to_dir`
* Use the namespace as subdirectory (can be disabled using the no_namespace_prefix option. For compatibility, this is disabled by default when using `yarp_idl_to_dir` with the old syntax)
* Cleanup
