### PR TITLE
IMU bosh: read error propagated up to YARP call - issue #1994

### DIFF
--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -19,6 +19,7 @@
 #ifndef BOSCH_IMU_DEVICE
 #define BOSCH_IMU_DEVICE
 
+#include <atomic>
 #include <yarp/sig/Vector.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
@@ -203,6 +204,7 @@ protected:
     bool sendReadCommandI2c(unsigned char register_add, int len, unsigned char* buf, std::string comment = "");
 
     int errs;
+    std::atomic<bool> dataIsValid;
 
 public:
     BoschIMU();


### PR DESCRIPTION
This commit implements requests from issue #1994, the PR is done on devel as requested.

HW read error is propagated to YARP call
While opening, a first read is done, if it fails the device is closed.

Please test the PR on a real device before merging, to verify it works as specification.