### PR TITLE
Fix checkMotionDone

### DIFF
--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
@@ -449,10 +449,14 @@ bool DynamixelAX12FtdiDriver::checkMotionDone(int j, bool *flag) {
 
 bool DynamixelAX12FtdiDriver::checkMotionDone(bool *flag) {
     bool t = true;
-    for (int k = 0; k < numOfAxes; k++) {
-        if (!this->checkMotionDone(k, &flag[k]))
+    bool tmp_done(false), all_done(true);
+    for (int k = 0; k < numOfAxes; k++)
+    {
+        if (!this->checkMotionDone(k, &tmp_done))
             t = false;
+        all_done &= tmp_done;
     }
+    *flag = all_done;
     return t;
 }
 
@@ -889,4 +893,88 @@ bool DynamixelAX12FtdiDriver::initMotorIndex(yarp::os::Bottle *sensorIndex) {
     }
     return true;
 }
+
+bool DynamixelAX12FtdiDriver::positionMove(const int n_joint, const int *joints, const double *refs)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= positionMove(joints[j], refs[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::relativeMove(const int n_joint, const int *joints, const double *deltas)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= relativeMove(joints[j], deltas[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::checkMotionDone(const int n_joint, const int *joints, bool *flag)
+{
+    bool ret = true;
+    bool tmp_joint(false), tmp_device(true);
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= checkMotionDone(joints[j], &tmp_joint);
+        tmp_device &= tmp_joint;
+    }
+    *flag = tmp_device;
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::setRefSpeeds(const int n_joint, const int *joints, const double *spds)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= setRefSpeed(joints[j], spds[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::setRefAccelerations(const int n_joint, const int *joints, const double *accs)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= setRefAcceleration(joints[j], accs[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::getRefSpeeds(const int n_joint, const int *joints, double *spds)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= getRefSpeed(joints[j], &spds[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::getRefAccelerations(const int n_joint, const int *joints, double *accs)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= getRefSpeed(joints[j], &accs[j]);
+    }
+    return ret;
+}
+
+bool DynamixelAX12FtdiDriver::stop(const int n_joint, const int *joints)
+{
+    bool ret = true;
+    for(int j=0; j<n_joint; j++)
+    {
+        ret &= stop(joints[j]);
+    }
+    return ret;
+}
+
 

--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
@@ -279,6 +279,17 @@ public:
     bool setRefTorque(int j, double t) override;
     bool getTorqueRange(int j, double* min, double* max) override;
     bool getTorqueRanges(double* min, double* max) override;
+
+    // multiple joint version
+    bool positionMove(const int n_joint, const int *joints, const double *refs) override;
+    bool relativeMove(const int n_joint, const int *joints, const double *deltas) override;
+    bool checkMotionDone(const int n_joint, const int *joints, bool *flag) override;
+    bool setRefSpeeds(const int n_joint, const int *joints, const double *spds) override;
+    bool setRefAccelerations(const int n_joint, const int *joints, const double *accs) override;
+    bool getRefSpeeds(const int n_joint, const int *joints, double *spds) override;
+    bool getRefAccelerations(const int n_joint, const int *joints, double *accs) override;
+    bool stop(const int n_joint, const int *joints) override;
+
 private:
 
     double *positions;

--- a/src/libYARP_dev/include/yarp/dev/IPositionControl.h
+++ b/src/libYARP_dev/include/yarp/dev/IPositionControl.h
@@ -397,10 +397,10 @@ public:
 
     /** Check if the current trajectory is terminated. Non blocking.
      * @param joints pointer to the array of joint numbers
-     * @param flags  pointer to return value (logical "and" of all set of joints)
+     * @param flag  pointer to return value (logical "and" of all set of joints)
      * @return true/false if network communication went well.
      */
-    virtual bool checkMotionDone(const int n_joint, const int *joints, bool *flags)=0;
+    virtual bool checkMotionDone(const int n_joint, const int *joints, bool *flag)=0;
 
     /** Set reference speed on all joints. These values are used during the
      * interpolation of the trajectory.

--- a/src/libYARP_dev/src/ImplementPositionControl.cpp
+++ b/src/libYARP_dev/src/ImplementPositionControl.cpp
@@ -160,14 +160,7 @@ bool ImplementPositionControl::checkMotionDone(const int n_joint, const int *joi
 
 bool ImplementPositionControl::checkMotionDone(bool *flag)
 {
-    bool *flags_tmp = new bool[nj];
-    bool ret = iPosition->checkMotionDoneRaw(flags_tmp);
-    for(int i=0; i<nj; i++)
-    {
-        flag[i] = flags_tmp[castToMapper(helper)->toHw(i)];
-    }
-    delete []flags_tmp;
-    return ret;
+    return iPosition->checkMotionDoneRaw(flag);
 }
 
 bool ImplementPositionControl::setRefSpeed(int j, double sp)


### PR DESCRIPTION
This PR fixes issues reported in issue #2027 for files

 * DynamixelAX12FtdiDriver.cpp
 * ControlBoardWrapper.cpp
 * ImplementPositionControl.cpp

The device `DynamixelAX12FtdiDriver.cpp` has been updated with multiple-joint version of functions, e.g.
`    bool positionMove(const int n_joint, const int *joints, const double *refs) override;`
They now are mandatory for a device driver.

_**Before merging this PR**_, we need to merge the PR fixing the implementation in iCub's `embobjMotionControl`
