### PR TITLE
`yarprobotinterface` will not run anymore deprecated DTD format v1.0

### DIFF
--- a/doc/release/v3_2_0.md
+++ b/doc/release/v3_2_0.md
@@ -298,6 +298,10 @@ New Features
 
 ### Tools
 
+#### `yarprobotinterface`
+* YARP//DTD yarprobotinterface 3.0//EN is now the default parser for robot xml configuration files. 
+  `yarprobotinterface` will not run anymore deprecated DTD format v1.0
+
 #### `yarpidl_thrift`
 
 * The thrift tool was refactored.

--- a/src/yarprobotinterface/Module.cpp
+++ b/src/yarprobotinterface/Module.cpp
@@ -73,8 +73,10 @@ bool RobotInterface::Module::configure(yarp::os::ResourceFinder &rf)
     yTrace() << "Reading robot config file" << filename;
 
     bool verbosity = rf.check("verbose");
+    bool deprecated = rf.check("allow-deprecated-dtd");
     RobotInterface::XMLReader reader;
     reader.setVerbose(verbosity);
+    reader.setEnableDeprecated(deprecated);
     mPriv->robot = reader.getRobot(filename);
     // yDebug() << mPriv->robot;
 

--- a/src/yarprobotinterface/RobotInterfaceDTD.cpp
+++ b/src/yarprobotinterface/RobotInterfaceDTD.cpp
@@ -86,8 +86,8 @@ bool RobotInterfaceDTD::valid()
 void RobotInterfaceDTD::setDefault()
 {
     type = RobotInterfaceDTD::DocTypeUnknown;
-    identifier = "-//YARP//DTD yarprobotinterface 1.0//EN";
-    uri = "http://www.yarp.it/DTD/yarprobotinterfaceV1.0.dtd";
+    identifier = "-//YARP//DTD yarprobotinterface 3.0//EN";
+    uri = "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd";
     majorVersion = 1;
     minorVersion = 0;
 }

--- a/src/yarprobotinterface/XMLReader.h
+++ b/src/yarprobotinterface/XMLReader.h
@@ -68,8 +68,10 @@ public:
 
     Robot& getRobot(const std::string &filename);
     void setVerbose(bool verbose);
+    void setEnableDeprecated(bool enab);
 private:
     bool verbose;
+    bool enable_deprecated;
     XMLReaderFileVx * mReader;
 }; // class XMLReader
 

--- a/src/yarprobotinterface/XMLReaderVx.cpp
+++ b/src/yarprobotinterface/XMLReaderVx.cpp
@@ -47,6 +47,7 @@
 RobotInterface::XMLReader::XMLReader() :
     mReader(nullptr)
 {
+    enable_deprecated = false;
     verbose = false;
 }
 
@@ -62,6 +63,11 @@ RobotInterface::XMLReader::~XMLReader()
 void RobotInterface::XMLReader::setVerbose(bool verb)
 {
     verbose = verb;
+}
+
+void RobotInterface::XMLReader::setEnableDeprecated(bool enab)
+{
+    enable_deprecated = enab;
 }
 
 RobotInterface::Robot& RobotInterface::XMLReader::getRobot(const std::string& fileName)
@@ -94,7 +100,7 @@ RobotInterface::Robot& RobotInterface::XMLReader::getRobot(const std::string& fi
     }
 
     if (!dtd.valid()) {
-        SYNTAX_WARNING(doc->Row()) << "No DTD found. Assuming version yarprobotinterfaceV1.0";
+        SYNTAX_WARNING(doc->Row()) << "No DTD found. Assuming version yarprobotinterfaceV3.0";
         dtd.setDefault();
         dtd.type = RobotInterfaceDTD::DocTypeRobot;
     }
@@ -106,9 +112,17 @@ RobotInterface::Robot& RobotInterface::XMLReader::getRobot(const std::string& fi
 
     if (dtd.majorVersion == 1)
     {
-        yDebug() << "yarprobotinterface: using xml parser for DTD v1.x";
-        mReader = new RobotInterface::XMLReaderFileV1;
-        return mReader->getRobotFile(filename,verbose);
+        yError() << "DTD V1.x has been deprecated. Please update your configuration files to DTD v3.x";
+        if (enable_deprecated)
+        {
+            yWarning() << "yarprobotinterface: using DEPRECATED xml parser for DTD v1.x";
+            mReader = new RobotInterface::XMLReaderFileV1;
+            return mReader->getRobotFile(filename, verbose);
+        }
+        else
+        {
+            yFatal("Invalid DTD version, execution stopped.");
+        }
     }
     else if (dtd.majorVersion == 3)
     {


### PR DESCRIPTION
Parser for yarprobotinterface configuration files v1.0 is now deprecated. Only v3.0 is supported.