### PR TITLE
PortReport deprecated in favor of modern callbacks

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -320,7 +320,6 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %include <yarp/os/NetInt16.h>
 %include <yarp/os/NetInt32.h>
 %include <yarp/os/NetInt64.h>
-%include <yarp/os/PortReport.h>
 %include <yarp/os/Contact.h>
 %include <yarp/os/ConnectionReader.h>
 %include <yarp/os/ConnectionWriter.h>

--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -89,7 +89,6 @@ set(YARP_os_HDRS yarp/os/AbstractCarrier.h
                  yarp/os/PortReaderBufferBaseCreator.h
                  yarp/os/PortReaderCreator.h
                  yarp/os/PortReader.h
-                 yarp/os/PortReport.h
                  yarp/os/PortWriterBuffer.h
                  yarp/os/PortWriterBufferBase.h
                  yarp/os/PortWriter.h
@@ -202,7 +201,6 @@ set(YARP_os_SRCS yarp/os/AbstractCarrier.cpp
                  yarp/os/PortReaderBufferBaseCreator.cpp
                  yarp/os/PortReader.cpp
                  yarp/os/PortReaderCreator.cpp
-                 yarp/os/PortReport.cpp
                  yarp/os/PortWriterBufferBase.cpp
                  yarp/os/PortWriter.cpp
                  yarp/os/Property.cpp
@@ -245,11 +243,14 @@ if(NOT YARP_NO_DEPRECATED)
                            yarp/os/Mutex.h            # DEPRECATED since YARP 3.3.0
                            yarp/os/RateThread.h       # DEPRECATED since YARP 3.3.0
                            yarp/os/RecursiveMutex.h   # DEPRECATED since YARP 3.3.0
-                           yarp/os/Runnable.h)        # DEPRECATED since YARP 3.3.0
+                           yarp/os/Runnable.h         # DEPRECATED since YARP 3.3.0
+                           yarp/os/PortReport.h)      # DEPRECATED since YARP 3.4.0
+
   list(APPEND YARP_os_SRCS yarp/os/Mutex.cpp          # DEPRECATED since YARP 3.3.0
                            yarp/os/RateThread.cpp     # DEPRECATED since YARP 3.3.0
                            yarp/os/RecursiveMutex.cpp # DEPRECATED since YARP 3.3.0
-                           yarp/os/Runnable.cpp)      # DEPRECATED since YARP 3.3.0
+                           yarp/os/Runnable.cpp       # DEPRECATED since YARP 3.3.0
+                           yarp/os/PortReport.cpp)    # DEPRECATED since YARP 3.4.0
 endif()
 
 set(YARP_os_IDL_HDRS yarp/os/idl/BareStyle.h

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
@@ -85,13 +85,12 @@ int yarp::os::AbstractContactable::getOutputCount()
 #ifndef YARP_NO_DEPRECATED
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
-YARP_DEPRECATED void yarp::os::AbstractContactable::getReport(PortReport& reporter)
+void yarp::os::AbstractContactable::getReport(PortReport& reporter)
 {
     asPort().getReport(reporter);
 }
 
-
-YARP_DEPRECATED void yarp::os::AbstractContactable::setReporter(PortReport& reporter)
+void yarp::os::AbstractContactable::setReporter(PortReport& reporter)
 {
     asPort().setReporter(reporter);
 }

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
@@ -82,21 +82,6 @@ int yarp::os::AbstractContactable::getOutputCount()
     return asPort().getOutputCount();
 }
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
-void yarp::os::AbstractContactable::getReport(PortReport& reporter)
-{
-    asPort().getReport(reporter);
-}
-
-void yarp::os::AbstractContactable::setReporter(PortReport& reporter)
-{
-    asPort().setReporter(reporter);
-}
-YARP_WARNING_POP
-#endif
-
 void yarp::os::AbstractContactable::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
 {
     asPort().getReport(reporter);

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
@@ -8,6 +8,7 @@
 
 #include <yarp/os/AbstractContactable.h>
 #include <yarp/os/Type.h>
+#include <functional>
 
 bool yarp::os::AbstractContactable::open(const std::string& name)
 {
@@ -81,12 +82,25 @@ int yarp::os::AbstractContactable::getOutputCount()
     return asPort().getOutputCount();
 }
 
-void yarp::os::AbstractContactable::getReport(PortReport& reporter)
+#ifndef YARP_NO_DEPRECATED
+YARP_DEPRECATED void yarp::os::AbstractContactable::getReport(PortReport& reporter)
 {
     asPort().getReport(reporter);
 }
 
-void yarp::os::AbstractContactable::setReporter(PortReport& reporter)
+
+YARP_DEPRECATED void yarp::os::AbstractContactable::setReporter(PortReport& reporter)
+{
+    asPort().setReporter(reporter);
+}
+#endif
+
+void yarp::os::AbstractContactable::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
+{
+    asPort().getReport(reporter);
+}
+
+void yarp::os::AbstractContactable::setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter)
 {
     asPort().setReporter(reporter);
 }

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
@@ -8,6 +8,7 @@
 
 #include <yarp/os/AbstractContactable.h>
 #include <yarp/os/Type.h>
+
 #include <functional>
 
 bool yarp::os::AbstractContactable::open(const std::string& name)

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.cpp
@@ -83,6 +83,8 @@ int yarp::os::AbstractContactable::getOutputCount()
 }
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 YARP_DEPRECATED void yarp::os::AbstractContactable::getReport(PortReport& reporter)
 {
     asPort().getReport(reporter);
@@ -93,6 +95,7 @@ YARP_DEPRECATED void yarp::os::AbstractContactable::setReporter(PortReport& repo
 {
     asPort().setReporter(reporter);
 }
+YARP_WARNING_POP
 #endif
 
 void yarp::os::AbstractContactable::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.h
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.h
@@ -82,11 +82,14 @@ public:
     int getOutputCount() override;
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
     YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // Documented in Contactable
     YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+YARP_WARNING_POP
 #endif
 
     // Documented in Contactable

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.h
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.h
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Port.h>
 #include <yarp/os/UnbufferedContactable.h>
+#include <functional>
 
 namespace yarp {
 namespace os {
@@ -80,11 +81,19 @@ public:
     // Documented in Contactable
     int getOutputCount() override;
 
+#ifndef YARP_NO_DEPRECATED
     // Documented in Contactable
-    void getReport(PortReport& reporter) override;
+    YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // Documented in Contactable
-    void setReporter(PortReport& reporter) override;
+    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+#endif
+
+    // Documented in Contactable
+    void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
+
+    // Documented in Contactable
+    void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable
     void resetReporter() override;

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.h
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.h
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Port.h>
 #include <yarp/os/UnbufferedContactable.h>
+
 #include <functional>
 
 namespace yarp {

--- a/src/libYARP_os/src/yarp/os/AbstractContactable.h
+++ b/src/libYARP_os/src/yarp/os/AbstractContactable.h
@@ -81,21 +81,16 @@ public:
     // Documented in Contactable
     int getOutputCount() override;
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
-    YARP_DEPRECATED void getReport(PortReport& reporter) override;
-
-    // Documented in Contactable
-    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
-YARP_WARNING_POP
-#endif
-
-    // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::getReport;
+#endif // YARP_NO_DEPRECATED
     void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::setReporter;
+#endif // YARP_NO_DEPRECATED
     void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable

--- a/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
@@ -260,6 +260,8 @@ bool yarp::os::BufferedPort<T>::isWriting()
 }
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 template <typename T>
 YARP_DEPRECATED void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
 {
@@ -271,6 +273,7 @@ YARP_DEPRECATED void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter
 {
     port.setReporter(reporter);
 }
+YARP_WARNING_POP
 #endif
 
 template <typename T>

--- a/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
@@ -259,17 +259,32 @@ bool yarp::os::BufferedPort<T>::isWriting()
     return port.isWriting();
 }
 
+#ifndef YARP_NO_DEPRECATED
 template <typename T>
-void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
+YARP_DEPRECATED void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
 {
     port.getReport(reporter);
 }
 
 template <typename T>
-void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter)
+YARP_DEPRECATED void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter)
 {
     port.setReporter(reporter);
 }
+#endif
+
+template <typename T>
+void yarp::os::BufferedPort<T>::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
+{
+    port.getReport(reporter);
+}
+
+template <typename T>
+void yarp::os::BufferedPort<T>::setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter)
+{
+    port.setReporter(reporter);
+}
+
 
 template <typename T>
 void yarp::os::BufferedPort<T>::resetReporter()

--- a/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
@@ -263,13 +263,13 @@ bool yarp::os::BufferedPort<T>::isWriting()
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
 template <typename T>
-YARP_DEPRECATED void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
+void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
 {
     port.getReport(reporter);
 }
 
 template <typename T>
-YARP_DEPRECATED void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter)
+void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter)
 {
     port.setReporter(reporter);
 }

--- a/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort-inl.h
@@ -259,23 +259,6 @@ bool yarp::os::BufferedPort<T>::isWriting()
     return port.isWriting();
 }
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
-template <typename T>
-void yarp::os::BufferedPort<T>::getReport(PortReport& reporter)
-{
-    port.getReport(reporter);
-}
-
-template <typename T>
-void yarp::os::BufferedPort<T>::setReporter(PortReport& reporter)
-{
-    port.setReporter(reporter);
-}
-YARP_WARNING_POP
-#endif
-
 template <typename T>
 void yarp::os::BufferedPort<T>::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
 {

--- a/src/libYARP_os/src/yarp/os/BufferedPort.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort.h
@@ -241,11 +241,14 @@ public:
     bool isWriting() override;
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // documented in Contactable
     YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // documented in Contactable
     YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+YARP_WARNING_POP
 #endif
 
     // Documented in Contactable

--- a/src/libYARP_os/src/yarp/os/BufferedPort.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort.h
@@ -240,21 +240,16 @@ public:
     // documented in Contactable
     bool isWriting() override;
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
-    // documented in Contactable
-    YARP_DEPRECATED void getReport(PortReport& reporter) override;
-
-    // documented in Contactable
-    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
-YARP_WARNING_POP
-#endif
-
     // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::getReport;
+#endif // YARP_NO_DEPRECATED
     void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::setReporter;
+#endif // YARP_NO_DEPRECATED
     void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // documented in Contactable

--- a/src/libYARP_os/src/yarp/os/BufferedPort.h
+++ b/src/libYARP_os/src/yarp/os/BufferedPort.h
@@ -240,11 +240,19 @@ public:
     // documented in Contactable
     bool isWriting() override;
 
+#ifndef YARP_NO_DEPRECATED
     // documented in Contactable
-    void getReport(PortReport& reporter) override;
+    YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // documented in Contactable
-    void setReporter(PortReport& reporter) override;
+    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+#endif
+
+    // Documented in Contactable
+    void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
+
+    // Documented in Contactable
+    void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // documented in Contactable
     void resetReporter() override;

--- a/src/libYARP_os/src/yarp/os/Contactable.cpp
+++ b/src/libYARP_os/src/yarp/os/Contactable.cpp
@@ -60,12 +60,12 @@ YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
 void yarp::os::Contactable::getReport(PortReport& reporter)
 {
-    getReport([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
+    getReport([&reporter](const yarp::os::PortInfo& info) { reporter.report(info); });
 }
 
 void yarp::os::Contactable::setReporter(PortReport& reporter)
 {
-    setReporter([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
+    setReporter([&reporter](const yarp::os::PortInfo& info) { reporter.report(info); });
 }
 YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED

--- a/src/libYARP_os/src/yarp/os/Contactable.cpp
+++ b/src/libYARP_os/src/yarp/os/Contactable.cpp
@@ -11,6 +11,14 @@
 
 #include <yarp/os/AbstractContactable.h>
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#include <yarp/os/PortReport.h>
+YARP_WARNING_POP
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
 
 yarp::os::Contactable::~Contactable() = default;
 
@@ -46,3 +54,18 @@ void yarp::os::Contactable::setRpcClient()
     setOutputMode(true);
     setRpcMode(true);
 }
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+void yarp::os::Contactable::getReport(PortReport& reporter)
+{
+    getReport([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
+}
+
+void yarp::os::Contactable::setReporter(PortReport& reporter)
+{
+    setReporter([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
+}
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED

--- a/src/libYARP_os/src/yarp/os/Contactable.h
+++ b/src/libYARP_os/src/yarp/os/Contactable.h
@@ -21,15 +21,6 @@
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
-#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
-#   include <yarp/os/PortReport.h>
-YARP_WARNING_POP
-#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
-#endif
-
 #include <mutex>
 
 // Forward declarations:
@@ -37,6 +28,11 @@ namespace yarp {
 namespace os {
 
 class Property;
+class PortInfo;
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+class PortReport;
+#endif
 
 /**
  * @brief An abstract port.
@@ -190,7 +186,7 @@ public:
      */
     virtual int getOutputCount() = 0;
 
-#ifndef YARP_NO_DEPRECATED
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
     /**
@@ -201,9 +197,9 @@ YARP_DISABLE_DEPRECATED_WARNING
      * method instead.
      *
      * @param reporter callback for port event/state information
-     * @deprecated since yarp 4
+     * @deprecated since YARP 3.4
      */
-    YARP_DEPRECATED virtual void getReport(PortReport& reporter) = 0;
+    YARP_DEPRECATED virtual void getReport(PortReport& reporter) final;
 
 
     /**
@@ -213,9 +209,9 @@ YARP_DISABLE_DEPRECATED_WARNING
      * instead.
      *
      * @param reporter callback for port event/state information
-     * @deprecated since yarp 4
+     * @deprecated since YARP 3.4
      */
-    YARP_DEPRECATED virtual void setReporter(PortReport& reporter) = 0;
+    YARP_DEPRECATED virtual void setReporter(PortReport& reporter) final;
 YARP_WARNING_POP
 #endif
 

--- a/src/libYARP_os/src/yarp/os/Contactable.h
+++ b/src/libYARP_os/src/yarp/os/Contactable.h
@@ -14,6 +14,7 @@
 #include <yarp/os/PortReader.h>
 #include <yarp/os/PortReport.h>
 #include <yarp/os/PortWriter.h>
+#include <functional>
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
@@ -181,6 +182,7 @@ public:
      */
     virtual int getOutputCount() = 0;
 
+#ifndef YARP_NO_DEPRECATED
     /**
      * Get information on the state of the port - connections etc.
      * PortReport::report will be called once for each connection to
@@ -189,8 +191,9 @@ public:
      * method instead.
      *
      * @param reporter callback for port event/state information
+     * @deprecated since yarp 4
      */
-    virtual void getReport(PortReport& reporter) = 0;
+    YARP_DEPRECATED virtual void getReport(PortReport& reporter) = 0;
 
 
     /**
@@ -200,8 +203,31 @@ public:
      * instead.
      *
      * @param reporter callback for port event/state information
+     * @deprecated since yarp 4
      */
-    virtual void setReporter(PortReport& reporter) = 0;
+    YARP_DEPRECATED virtual void setReporter(PortReport& reporter) = 0;
+#endif
+
+    /**
+     * Get information on the state of the port - connections etc.
+     * PortReport::report will be called once for each connection to
+     * the port that exists right now.  To request callbacks for
+     * any future connections/disconnections, use the setReporter
+     * method instead.
+     *
+     * @param reporter callback for port event/state information
+     */
+    virtual void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) = 0;
+
+    /**
+     * Set a callback to be called upon any future connections and
+     * disconnections to/from the port.  To get information on
+     * the current connections that exist, use the getReport method
+     * instead.
+     *
+     * @param reporter callback for port event/state information
+     */
+    virtual void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) = 0;
 
     /**
      * Remove the callback which is called upon any future connections and

--- a/src/libYARP_os/src/yarp/os/Contactable.h
+++ b/src/libYARP_os/src/yarp/os/Contactable.h
@@ -12,13 +12,21 @@
 
 #include <yarp/os/Contact.h>
 #include <yarp/os/PortReader.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/PortWriter.h>
 #include <functional>
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #  include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#   include <yarp/os/PortReport.h>
+YARP_WARNING_POP
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif
 
@@ -183,6 +191,8 @@ public:
     virtual int getOutputCount() = 0;
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     /**
      * Get information on the state of the port - connections etc.
      * PortReport::report will be called once for each connection to
@@ -206,11 +216,12 @@ public:
      * @deprecated since yarp 4
      */
     YARP_DEPRECATED virtual void setReporter(PortReport& reporter) = 0;
+YARP_WARNING_POP
 #endif
 
     /**
      * Get information on the state of the port - connections etc.
-     * PortReport::report will be called once for each connection to
+     * `reporter()` will be called once for each connection to
      * the port that exists right now.  To request callbacks for
      * any future connections/disconnections, use the setReporter
      * method instead.

--- a/src/libYARP_os/src/yarp/os/Node.cpp
+++ b/src/libYARP_os/src/yarp/os/Node.cpp
@@ -25,8 +25,8 @@
 #include <cstdlib>
 #include <list>
 #include <map>
-#include <vector>
 #include <mutex>
+#include <vector>
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
@@ -248,8 +248,7 @@ public:
                     if (info.incoming) {
                         c = RosNameSpace::rosify(nic.queryName(info.sourceName));
                         incomingURIs.insert(std::make_pair(info.portName, c.toURI()));
-                    }
-                    else {
+                    } else {
                         c = RosNameSpace::rosify(nic.queryName(info.targetName));
                         outgoingURIs.insert(std::make_pair(info.portName, c.toURI()));
                     }

--- a/src/libYARP_os/src/yarp/os/Node.cpp
+++ b/src/libYARP_os/src/yarp/os/Node.cpp
@@ -16,7 +16,6 @@
 #include <yarp/os/Os.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/PortInfo.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/RosNameSpace.h>
 #include <yarp/os/Type.h>
 #include <yarp/os/impl/LogComponent.h>

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -571,13 +571,13 @@ YARP_DISABLE_DEPRECATED_WARNING
 void Port::getReport(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
-    core.describe(reporter);
+    core.describe([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
 }
 
 void Port::setReporter(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
-    core.setReportCallback(&reporter);
+    core.setReportCallback([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
 }
 YARP_WARNING_POP
 #endif

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -565,17 +565,32 @@ int Port::getOutputCount()
     return core.getOutputCount();
 }
 
-void Port::getReport(PortReport& reporter)
+#ifndef YARP_NO_DEPRECATED
+YARP_DEPRECATED void Port::getReport(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
     core.describe(reporter);
 }
 
 
-void Port::setReporter(PortReport& reporter)
+YARP_DEPRECATED void Port::setReporter(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
     core.setReportCallback(&reporter);
+}
+#endif
+
+void Port::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
+{
+    PortCoreAdapter& core = IMPL();
+    core.describe(reporter);
+}
+
+
+void Port::setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter)
+{
+    PortCoreAdapter& core = IMPL();
+    core.setReportCallback(reporter);
 }
 
 

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -568,14 +568,13 @@ int Port::getOutputCount()
 #ifndef YARP_NO_DEPRECATED
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
-YARP_DEPRECATED void Port::getReport(PortReport& reporter)
+void Port::getReport(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
     core.describe(reporter);
 }
 
-
-YARP_DEPRECATED void Port::setReporter(PortReport& reporter)
+void Port::setReporter(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
     core.setReportCallback(&reporter);

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -566,6 +566,8 @@ int Port::getOutputCount()
 }
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 YARP_DEPRECATED void Port::getReport(PortReport& reporter)
 {
     PortCoreAdapter& core = IMPL();
@@ -578,6 +580,7 @@ YARP_DEPRECATED void Port::setReporter(PortReport& reporter)
     PortCoreAdapter& core = IMPL();
     core.setReportCallback(&reporter);
 }
+YARP_WARNING_POP
 #endif
 
 void Port::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -565,23 +565,6 @@ int Port::getOutputCount()
     return core.getOutputCount();
 }
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
-void Port::getReport(PortReport& reporter)
-{
-    PortCoreAdapter& core = IMPL();
-    core.describe([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
-}
-
-void Port::setReporter(PortReport& reporter)
-{
-    PortCoreAdapter& core = IMPL();
-    core.setReportCallback([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
-}
-YARP_WARNING_POP
-#endif
-
 void Port::getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter)
 {
     PortCoreAdapter& core = IMPL();

--- a/src/libYARP_os/src/yarp/os/Port.h
+++ b/src/libYARP_os/src/yarp/os/Port.h
@@ -165,11 +165,19 @@ public:
     // Documented in Contactable
     int getOutputCount() override;
 
+#ifndef YARP_NO_DEPRECATED
     // Documented in Contactable
-    void getReport(PortReport& reporter) override;
+    YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // Documented in Contactable
-    void setReporter(PortReport& reporter) override;
+    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+#endif
+
+    // Documented in Contactable
+    void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
+
+    // Documented in Contactable
+    void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable
     void resetReporter() override;

--- a/src/libYARP_os/src/yarp/os/Port.h
+++ b/src/libYARP_os/src/yarp/os/Port.h
@@ -166,11 +166,14 @@ public:
     int getOutputCount() override;
 
 #ifndef YARP_NO_DEPRECATED
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
     YARP_DEPRECATED void getReport(PortReport& reporter) override;
 
     // Documented in Contactable
     YARP_DEPRECATED void setReporter(PortReport& reporter) override;
+YARP_WARNING_POP
 #endif
 
     // Documented in Contactable

--- a/src/libYARP_os/src/yarp/os/Port.h
+++ b/src/libYARP_os/src/yarp/os/Port.h
@@ -165,21 +165,16 @@ public:
     // Documented in Contactable
     int getOutputCount() override;
 
-#ifndef YARP_NO_DEPRECATED
-YARP_WARNING_PUSH
-YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
-    YARP_DEPRECATED void getReport(PortReport& reporter) override;
-
-    // Documented in Contactable
-    YARP_DEPRECATED void setReporter(PortReport& reporter) override;
-YARP_WARNING_POP
-#endif
-
-    // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::getReport;
+#endif // YARP_NO_DEPRECATED
     void getReport(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    using yarp::os::Contactable::setReporter;
+#endif // YARP_NO_DEPRECATED
     void setReporter(const std::function<void(const yarp::os::PortInfo&)>& reporter) override;
 
     // Documented in Contactable

--- a/src/libYARP_os/src/yarp/os/PortReport.cpp
+++ b/src/libYARP_os/src/yarp/os/PortReport.cpp
@@ -7,7 +7,16 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/os/PortReport.h>
+#include <yarp/conf/system.h>
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+#   include <yarp/os/PortReport.h>
+YARP_WARNING_POP
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif
 
 
 yarp::os::PortReport::~PortReport() = default;

--- a/src/libYARP_os/src/yarp/os/PortReport.h
+++ b/src/libYARP_os/src/yarp/os/PortReport.h
@@ -7,28 +7,38 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/os/PortReport.h> file is deprecated")
+#endif
+
 #ifndef YARP_OS_PORTREPORT_H
 #define YARP_OS_PORTREPORT_H
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+
 #include <yarp/os/api.h>
-
 namespace yarp {
 namespace os {
+
 class PortInfo;
-} // namespace os
-} // namespace yarp
-
-namespace yarp {
-namespace os {
 
 /**
  * \ingroup comm_class
  *
  * A base class for objects that want information about port status
  * changes.
+ *
+ * @deprecated since YARP 3.4
  */
-class YARP_os_API PortReport
+class YARP_os_DEPRECATED_API PortReport
 {
+    // HACK Issue a deprecated warning in classes derived from yarp::os::PortReport
+    class YARP_DEPRECATED yarp__os__PortReport_is_deprecated {};
+    yarp__os__PortReport_is_deprecated issue_warning;
+
 public:
     /**
      * Destructor.
@@ -50,5 +60,7 @@ public:
 
 } // namespace os
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_PORTREPORT_H

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
@@ -1107,12 +1107,12 @@ void PortCore::describe(void* id, OutputStream* os)
 
 
 #ifndef YARP_NO_DEPRECATED
-YARP_DEPRECATED void PortCore::describe(PortReport& reporter)
+void PortCore::describe(PortReport& reporter)
 {
     this->describe([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
 }
 
-YARP_DEPRECATED void PortCore::setReportCallback(yarp::os::PortReport *reporter)
+void PortCore::setReportCallback(yarp::os::PortReport *reporter)
 {
     setReportCallback([&reporter](const yarp::os::PortInfo & info) { reporter->report(info); });
 }

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
@@ -1105,19 +1105,6 @@ void PortCore::describe(void* id, OutputStream* os)
     }
 }
 
-
-#ifndef YARP_NO_DEPRECATED
-void PortCore::describe(PortReport& reporter)
-{
-    this->describe([&reporter](const yarp::os::PortInfo & info) { reporter.report(info); });
-}
-
-void PortCore::setReportCallback(yarp::os::PortReport *reporter)
-{
-    setReportCallback([&reporter](const yarp::os::PortInfo & info) { reporter->report(info); });
-}
-#endif
-
 void PortCore::describe(const std::function<void(const yarp::os::PortInfo&)>& reporter)
 {
     cleanUnits();

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.h
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.h
@@ -219,16 +219,6 @@ public:
      */
     void describe(void* id, yarp::os::OutputStream* os);
 
-
-#ifndef YARP_NO_DEPRECATED
-    /**
-     * Generate a description of the connections associated with the
-     * port.
-     * @deprecated since yarp 4.0
-     */
-    YARP_DEPRECATED void describe(yarp::os::PortReport& reporter);
-#endif
-
     /**
      * Generate a description of the connections associated with the
      * port.
@@ -463,14 +453,6 @@ public:
      * Undo an interrupt()
      */
     void resume();
-
-#ifndef YARP_NO_DEPRECATED
-    /**
-     * Set a callback to be notified of changes in port status.
-     * @deprecated since yarp 4
-     */
-    YARP_DEPRECATED void setReportCallback(yarp::os::PortReport *reporter);
-#endif
 
     /**
      * Set a callback to be notified of changes in port status.

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.h
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.h
@@ -32,9 +32,9 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <vector>
-#include <functional>
 
 namespace yarp {
 namespace os {

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.h
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.h
@@ -35,6 +35,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <vector>
+#include <functional>
 
 namespace yarp {
 namespace os {
@@ -218,11 +219,21 @@ public:
      */
     void describe(void* id, yarp::os::OutputStream* os);
 
+
+#ifndef YARP_NO_DEPRECATED
+    /**
+     * Generate a description of the connections associated with the
+     * port.
+     * @deprecated since yarp 4.0
+     */
+    YARP_DEPRECATED void describe(yarp::os::PortReport& reporter);
+#endif
+
     /**
      * Generate a description of the connections associated with the
      * port.
      */
-    void describe(yarp::os::PortReport& reporter);
+    void describe(const std::function<void(const yarp::os::PortInfo&)>& reporter);
 
     /**
      * Read a block of regular payload data.
@@ -453,10 +464,18 @@ public:
      */
     void resume();
 
+#ifndef YARP_NO_DEPRECATED
+    /**
+     * Set a callback to be notified of changes in port status.
+     * @deprecated since yarp 4
+     */
+    YARP_DEPRECATED void setReportCallback(yarp::os::PortReport *reporter);
+#endif
+
     /**
      * Set a callback to be notified of changes in port status.
      */
-    void setReportCallback(yarp::os::PortReport* reporter);
+    void setReportCallback(const std::function<void(const yarp::os::PortInfo&)>& reporter);
 
     /**
      * Reset the callback to be notified of changes in port status.
@@ -531,7 +550,7 @@ private:
     yarp::os::PortReader *m_reader {nullptr}; ///< where to send read events
     yarp::os::PortReader *m_adminReader {nullptr}; ///< where to send admin read events
     yarp::os::PortReaderCreator *m_readableCreator {nullptr}; ///< factory for readers
-    yarp::os::PortReport *m_eventReporter {nullptr}; ///< where to send general events
+    std::function<void(const yarp::os::PortInfo&)> m_eventReporter; ///< where to send general events
     std::atomic<bool> m_listening {false}; ///< is the port server listening on the network?
     std::atomic<bool> m_running {false};   ///< is the port server thread running?
     std::atomic<bool> m_starting {false};  ///< is the port in its startup phase?

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.h
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.h
@@ -16,7 +16,6 @@
 #include <yarp/os/ModifyingCarrier.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/PortReaderCreator.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/PortWriter.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/Type.h>

--- a/src/libYARP_os/src/yarp/os/impl/PortCoreInputUnit.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCoreInputUnit.cpp
@@ -12,7 +12,6 @@
 #include <yarp/os/Name.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/PortInfo.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/LogComponent.h>

--- a/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp
@@ -11,7 +11,6 @@
 
 #include <yarp/os/Name.h>
 #include <yarp/os/PortInfo.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/Portable.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -590,22 +590,6 @@ public:
 };
 
 
-/**************************************************************************/
-class DumpReporter : public PortReport
-{
-private:
-    DumpThread *thread{nullptr};
-
-public:
-    DumpReporter() = default;
-    void setThread(DumpThread *thread) { this->thread=thread; }
-    void report(const PortInfo &info) override
-    {
-        if ((thread!=nullptr) && info.incoming)
-            thread->writeSource(info.sourceName,info.created);
-    }
-};
-
 
 /**************************************************************************/
 class DumpModule: public RFModule
@@ -615,7 +599,6 @@ private:
     DumpPort<Bottle> *p_bottle{nullptr};
     DumpPort<Image>  *p_image{nullptr};
     DumpThread       *t{nullptr};
-    DumpReporter      reporter;
     Port              rpcPort;
     DumpFormat        dumptype{ DumpFormat::bottle};
     bool              rxTime{false};
@@ -750,7 +733,11 @@ public:
             return false;
         }
 
-        reporter.setThread(t);
+        auto reporter = [this](const PortInfo& info)
+        {
+            if ((t != nullptr) && info.incoming)
+                t->writeSource(info.sourceName, info.created);
+        };
 
         if (dumptype == DumpFormat::bottle)
         {

--- a/tests/libYARP_os/PortTest.cpp
+++ b/tests/libYARP_os/PortTest.cpp
@@ -23,7 +23,6 @@
 #include <yarp/os/NetType.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/PortReport.h>
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/PortInfo.h>

--- a/tests/libYARP_os/PortTest.cpp
+++ b/tests/libYARP_os/PortTest.cpp
@@ -274,16 +274,14 @@ public:
 };
 
 
-class MyReport :
-        public PortReport
+class MyReport
 {
 public:
     int ct {0};
     int oct {0};
     int ict {0};
 
-    void report(const PortInfo& info) override
-    {
+    void operator()(const PortInfo& info) {
         if (info.tag == PortInfo::PORTINFO_CONNECTION) {
             if (info.incoming == false) {
                 oct++;
@@ -1205,7 +1203,7 @@ TEST_CASE("os::PortTest", "[yarp::os]")
         Network::sync("/foo");
         Network::sync("/bar");
         MyReport report;
-        p1.getReport(report);
+        p1.getReport(std::ref(report));
         CHECK(report.ct>0); // got some report
         CHECK(report.oct == 1); // exactly one output
         p1.close();
@@ -1218,8 +1216,8 @@ TEST_CASE("os::PortTest", "[yarp::os]")
         Port p2;
         MyReport report1;
         MyReport report2;
-        p1.setReporter(report1);
-        p2.setReporter(report2);
+        p1.setReporter(std::ref(report1));
+        p2.setReporter(std::ref(report2));
         p1.open("/foo");
         p2.open("/bar");
         Network::connect("/foo", "/bar");
@@ -1245,7 +1243,7 @@ TEST_CASE("os::PortTest", "[yarp::os]")
         Network::sync("/foo");
         Network::sync("/bar");
         MyReport report;
-        p1.getReport(report);
+        p1.getReport(std::ref(report));
         CHECK(report.ct>0); // got some report
         CHECK(report.oct == 1); // exactly one output
         p1.close();
@@ -1258,8 +1256,8 @@ TEST_CASE("os::PortTest", "[yarp::os]")
         RpcServer p2;
         MyReport report1;
         MyReport report2;
-        p1.setReporter(report1);
-        p2.setReporter(report2);
+        p1.setReporter(std::ref(report1));
+        p2.setReporter(std::ref(report2));
         p1.open("/foo");
         p2.open("/bar");
         Network::connect("/foo", "/bar");


### PR DESCRIPTION
the pr makes possible to pass a callable to everywhere the PortReport was used.

example 
`port.setReportCallback([ ](const yarp::os::PortInfo & info) { //do things });`
the major difference when passing a functor that has member variables that changes inside the operator() is that its required to wrapping it with std::ref()