### PR TITLE
yarpdatadumper to save PNG images

### DIFF
--- a/doc/cmd_yarpdatadumper.dox
+++ b/doc/cmd_yarpdatadumper.dox
@@ -29,11 +29,13 @@ for the user through --rxTime option.
 
 Moreover, a file called 'info.log' is produced containing
 information about the data type stored within the 'data.log'
-file as well as the name of the yarp ports connected or
-disconnected to the dumper, as in the following:
+file as well as the logged time stamps and the name of the
+yarp ports connected or disconnected to the dumper,
+as in the following:
 
 \code
 Type: [Bottle; | Image; | Image; Video:ext(huffyuv);]
+Stamp: [rx; | tx; | tx+rx;]
 [local-timestamp] /yarp-port-name [connected]
 [local-timestamp] /yarp-port-name [disconnected]
 \endcode
@@ -108,9 +110,9 @@ by the \ref yarpdatadumper.
 
 --type \e datatype
 - The parameter \e datatype selects the type of items to be
-  stored. It can be \e bottle, \e image, \e image_jpg or \e video; if not
-  specified \e bottle is assumed. Note that images are stored
-  using the corresponding file formats. The data type \e video
+  stored. It can be \e bottle, \e image, \e image_jpg, \e image_png or
+  \e video; if not specified \e bottle is assumed. Note that images are
+  stored using the corresponding file formats. The data type \e video
   is available if OpenCV is found and the codec \e huffyuv is installed.
 
 --addVideo

--- a/doc/release/devel.md
+++ b/doc/release/devel.md
@@ -1,0 +1,36 @@
+Important Changes
+-----------------
+
+New Features
+------------
+
+### Build System
+
+### Libraries
+
+#### `YARP_OS`
+
+#### `YARP_sig`
+
+#### `YARP_dev`
+
+#### `YARP_cv`
+
+
+### Devices
+
+### Tools
+
+#### `yarpdatadumper`
+* Allow to dump PNG images
+* Provide stamp info within `info.log`
+* Refactor + cleanup
+
+
+### GUIs
+
+#### `yarpdataplayer`
+* Handle `info.log` containing stamp info
+
+Bug Fixes
+---------

--- a/src/yarpdatadumper/CMakeLists.txt
+++ b/src/yarpdatadumper/CMakeLists.txt
@@ -8,7 +8,6 @@
 if(YARP_COMPILE_yarpdatadumper)
   if(YARP_HAS_OpenCV)
     add_definitions(-DADD_VIDEO)
-    include_directories(${OpenCV_INCLUDE_DIRS})
   else()
     message(STATUS "yarpdatadumper: OpenCV not selected, keep on building...")
   endif()
@@ -21,10 +20,10 @@ if(YARP_COMPILE_yarpdatadumper)
     target_link_libraries(yarpdatadumper ${OpenCV_LIBRARIES})
   endif()
 
-  target_link_libraries(yarpdatadumper YARP::YARP_OS
-                                       YARP::YARP_init
-                                       YARP::YARP_sig
-                                       YARP::YARP_cv)
+  target_link_libraries(yarpdatadumper YARP::YARP_OS YARP::YARP_init YARP::YARP_sig)
+  if(YARP_HAS_OpenCV)
+    target_link_libraries(yarpdatadumper YARP::YARP_cv)
+  endif()
 
   install(TARGETS yarpdatadumper
           COMPONENT utilities

--- a/src/yarpdatadumper/CMakeLists.txt
+++ b/src/yarpdatadumper/CMakeLists.txt
@@ -23,7 +23,8 @@ if(YARP_COMPILE_yarpdatadumper)
 
   target_link_libraries(yarpdatadumper YARP::YARP_OS
                                        YARP::YARP_init
-                                       YARP::YARP_sig)
+                                       YARP::YARP_sig
+                                       YARP::YARP_cv)
 
   install(TARGETS yarpdatadumper
           COMPONENT utilities

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -15,7 +15,6 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/all.h>
-#include <yarp/cv/Cv.h>
 
 #include <iostream>
 #include <iomanip>
@@ -27,13 +26,17 @@
 
 #ifdef ADD_VIDEO
     #include <opencv2/opencv.hpp>
+    #include <yarp/cv/Cv.h>
 #endif
 
 
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;
-using namespace yarp::cv;
+
+#ifdef ADD_VIDEO
+    using namespace yarp::cv;
+#endif
 
 /**************************************************************************/
 enum class DumpType { bottle, image };
@@ -138,6 +141,7 @@ public:
         return (fName.str()+" ["+Vocab::decode(code)+"]");
     }
 
+#ifdef ADD_VIDEO
     const cv::Mat &getImage()
     {
         int code=p->getPixelCode();
@@ -155,6 +159,7 @@ public:
         }
         return img;
     }
+#endif
 };
 
 

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -14,8 +14,8 @@
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Stamp.h>
-
 #include <yarp/sig/all.h>
+#include <yarp/cv/Cv.h>
 
 #include <iostream>
 #include <iomanip>
@@ -33,19 +33,23 @@
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;
+using namespace yarp::cv;
 
 /**************************************************************************/
-enum DumpType { bottle, image };
-bool save_jpeg = false;
+enum class DumpType { bottle, image };
+enum class DumpFormat { plain, image_jpg, image_png } dump_format;
 
 // Abstract object definition for queueing
 /**************************************************************************/
 class DumpObj
 {
+protected: 
+    DumpFormat dump_format{DumpFormat::plain};
+
 public:
     virtual ~DumpObj() = default;
     virtual const string toFile(const string&, unsigned int) = 0;
-    virtual void *getPtr() = 0;
+    virtual void attachFormat(const DumpFormat &format) { dump_format=format; }
 };
 
 
@@ -68,8 +72,6 @@ public:
         string ret=p->toString();
         return ret;
     }
-
-    void *getPtr() override { return nullptr; }
 };
 
 
@@ -88,6 +90,7 @@ class DumpImage : public DumpObj
 {
 private:
     Image *p;
+    cv::Mat img;
 
 public:
     DumpImage() { p=new Image(); }
@@ -112,10 +115,15 @@ public:
             format=file::FORMAT_PGM;
             ext=".pgm";
         }
-        else if (save_jpeg)
+        else if (dump_format==DumpFormat::image_jpg)
         {
             format=file::FORMAT_JPG;
             ext=".jpg";
+        }
+        else if (dump_format==DumpFormat::image_png)
+        {
+            format=file::FORMAT_PNG;
+            ext=".png";
         }
         else
         {
@@ -130,7 +138,23 @@ public:
         return (fName.str()+" ["+Vocab::decode(code)+"]");
     }
 
-    void *getPtr() override { return p->getRawImage(); }
+    const cv::Mat &getImage()
+    {
+        int code=p->getPixelCode();
+        if (code==VOCAB_PIXEL_MONO_FLOAT)
+        {
+            img=toCvMat(*dynamic_cast<ImageOf<PixelFloat>*>(p));
+        }
+        else if (code==VOCAB_PIXEL_MONO)
+        {
+            img=toCvMat(*dynamic_cast<ImageOf<PixelMono>*>(p));
+        }
+        else
+        {
+            img=toCvMat(*dynamic_cast<ImageOf<PixelRgb>*>(p));
+        }
+        return img;
+    }
 };
 
 
@@ -258,6 +282,7 @@ private:
                 item.timeStamp.setRxStamp(Time::now());
 
             item.obj=factory(obj);
+            item.obj->attachFormat(dump_format);
 
             buf.lock();
             buf.push_back(item);
@@ -288,6 +313,8 @@ private:
     bool            saveData;
     bool            videoOn;
     string          videoType;
+    bool            rxTime;
+    bool            txTime;
     bool            closing;
 
 #ifdef ADD_VIDEO
@@ -301,8 +328,9 @@ private:
 #endif
 
 public:
-    DumpThread(DumpType _type, DumpQueue &Q, string _dirName, int szToWrite,
-               bool _saveData, bool _videoOn, string _videoType) :
+    DumpThread(DumpType _type, DumpQueue &Q, const string &_dirName, const int szToWrite,
+               const bool _saveData, const bool _videoOn, const string &_videoType,
+               const bool _rxTime, const bool _txTime) :
         PeriodicThread(0.05),
         buf(Q),
         type(_type),
@@ -314,6 +342,8 @@ public:
         saveData(_saveData),
         videoOn(_videoOn),
         videoType(std::move(_videoType)),
+        rxTime(_rxTime),
+        txTime(_txTime),
         closing(false)
     {
         infoFile=dirName;
@@ -363,14 +393,23 @@ public:
         }
 
         finfo<<"Type: ";
-        if (type==bottle)
+        if (type==DumpType::bottle)
             finfo<<"Bottle;";
-        else if (type==image)
+        else if (type==DumpType::image)
         {
             finfo<<"Image;";
             if (videoOn)
                 finfo<<" Video:"<<videoType<<"(huffyuv);";
         }
+        finfo<<endl;
+
+        finfo<<"Stamp: ";
+        if (txTime && rxTime)
+            finfo<<"tx+rx;";
+        else if (txTime)
+            finfo<<"tx;";
+        else
+            finfo<<"rx;";
         finfo<<endl;
 
         fdata.open(dataFile.c_str());
@@ -398,8 +437,9 @@ public:
 
     void run() override
     {
+        //!!! access to size must be protected: problem spotted with Linux stl
         buf.lock();
-        unsigned int sz=buf.size(); //!!! access to size must be protected: problem spotted with Linux stl
+        unsigned int sz=(unsigned int)buf.size();
         buf.unlock();
 
         // each 10 seconds it issues a writeToDisk command straightaway
@@ -425,8 +465,9 @@ public:
                 buf.unlock();
 
                 int fps;
-                int frameW=((IplImage*)itemEnd.obj->getPtr())->width;
-                int frameH=((IplImage*)itemEnd.obj->getPtr())->height;
+                const cv::Mat &img=dynamic_cast<DumpImage*>(itemEnd.obj)->getImage();
+                int frameW=img.size().width;
+                int frameH=img.size().height;
 
                 t0=itemFront.timeStamp.getStamp();
                 double dt=itemEnd.timeStamp.getStamp()-t0;
@@ -464,8 +505,7 @@ public:
             #ifdef ADD_VIDEO
                 if (doSaveFrame)
                 {
-                    cv::Mat img=cv::cvarrToMat((IplImage*)item.obj->getPtr());
-                    videoWriter<<img;
+                    videoWriter << dynamic_cast<DumpImage*>(item.obj)->getImage();
 
                     // write the timecode of the frame
                     int dt=(int)(1000.0*(item.timeStamp.getStamp()-t0));
@@ -525,7 +565,7 @@ private:
     DumpThread       *t{nullptr};
     DumpReporter      reporter;
     Port              rpcPort;
-    DumpType          type{bottle};
+    DumpType          type{DumpType::bottle};
     bool              rxTime{false};
     bool              txTime{false};
     unsigned int      dwnsample{0};
@@ -540,6 +580,7 @@ public:
         if (portName[0]!='/')
             portName="/"+portName;
 
+        dump_format=DumpFormat::plain;
         bool saveData=true;
         bool videoOn=false;
         string videoType=rf.check("videoType",Value("mkv")).asString();
@@ -548,24 +589,23 @@ public:
         {
             string optTypeName=rf.find("type").asString();
             if (optTypeName=="bottle")
-                type=bottle;
-            else if (optTypeName=="image")
+                type=DumpType::bottle;
+            else if ((optTypeName=="image") || (optTypeName=="image_jpg") || (optTypeName=="image_png"))
             {
-                type=image;
+                type=DumpType::image;
+                if (optTypeName=="image_jpg")
+                    dump_format=DumpFormat::image_jpg;
+                else if (optTypeName=="image_png")
+                    dump_format=DumpFormat::image_png;
             #ifdef ADD_VIDEO
                 if (rf.check("addVideo"))
                     videoOn=true;
             #endif
             }
-            else if (optTypeName == "image_jpg")
-            {
-                type=image;
-                save_jpeg = true;
-            }
         #ifdef ADD_VIDEO
             else if (optTypeName=="video")
             {
-                type=image;
+                type=DumpType::image;
                 videoOn=true;
                 saveData=false;
             }
@@ -577,7 +617,7 @@ public:
             }
         }
         else
-            type=bottle;
+            type=DumpType::bottle;
 
         dwnsample=rf.check("downsample",Value(1)).asInt32();
         rxTime=rf.check("rxTime");
@@ -609,7 +649,7 @@ public:
         yarp::os::mkdir_p(dirName.c_str());
 
         q=new DumpQueue();
-        t=new DumpThread(type,*q,dirName,100,saveData,videoOn,videoType);
+        t=new DumpThread(type,*q,dirName,100,saveData,videoOn,videoType,rxTime,txTime);
 
         if (!t->start())
         {
@@ -621,7 +661,7 @@ public:
 
         reporter.setThread(t);
 
-        if (type==bottle)
+        if (type==DumpType::bottle)
         {
             p_bottle=new DumpPort<Bottle>(*q,dwnsample,rxTime,txTime);
             p_bottle->useCallback();
@@ -642,7 +682,7 @@ public:
         {
             string srcPort=rf.find("connect").asString();
             bool ok=Network::connect(srcPort.c_str(),
-                                     (type==bottle)?p_bottle->getName().c_str():
+                                     (type==DumpType::bottle)?p_bottle->getName().c_str():
                                      p_image->getName().c_str(),"tcp");
 
             ostringstream msg;
@@ -668,7 +708,7 @@ public:
     {
         t->stop();
 
-        if (type==bottle)
+        if (type==DumpType::bottle)
         {
             p_bottle->interrupt();
             p_bottle->close();
@@ -712,11 +752,11 @@ int main(int argc, char *argv[])
         yInfo() << "\t--dir        name: provide explicit name of storage directory";
         yInfo() << "\t--overwrite      : overwrite pre-existing storage directory";
     #ifdef ADD_VIDEO
-        yInfo() << "\t--type       type: type of the data to be dumped [bottle(default), image, image_jpg, video]";
-        yInfo() << "\t--addVideo       : produce video as well (if image is selected)";
+        yInfo() << "\t--type       type: type of the data to be dumped [bottle(default), image, image_jpg, image_png, video]";
+        yInfo() << "\t--addVideo       : produce video as well (if image* is selected)";
         yInfo() << "\t--videoType   ext: produce video of specified container type [mkv(default), avi]";
     #else
-        yInfo() << "\t--type       type: type of the data to be dumped [bottle(default), image, image_jpg]";
+        yInfo() << "\t--type       type: type of the data to be dumped [bottle(default), image, image_jpg, image_png]";
     #endif
         yInfo() << "\t--downsample    n: downsample rate (default: 1 => downsample disabled)";
         yInfo() << "\t--rxTime         : dump the receiver time instead of the sender time";

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -93,7 +93,9 @@ class DumpImage : public DumpObj
 {
 private:
     Image *p;
+#ifdef ADD_VIDEO
     cv::Mat img;
+#endif
 
 public:
     DumpImage() { p=new Image(); }

--- a/src/yarpdataplayer/src/utils.cpp
+++ b/src/yarpdataplayer/src/utils.cpp
@@ -257,15 +257,19 @@ bool Utilities::setupDataFromParts(partsData &part)
     if (str.is_open()){
         string line;
         int itr = 0;
-        while( getline( str, line ) && (itr <= 2) ){
+        while( getline( str, line ) && (itr < 3) ){
             Bottle b( line );
             if (itr == 0){
                 part.type = b.get(1).toString();
-                part.type.erase(part.type.size() -1 );      // remove the ";" character
+                part.type.erase(part.type.size() -1 );          // remove the ";" character
             }
-            if (itr == 2){
-                part.portName = b.get(1).toString();
-                LOG( "the name of the port is %s\n",part.portName.c_str());
+            else{
+                string stamp_tag = b.get(0).toString();
+                if (stamp_tag.find("Stamp") == string::npos){   // skip stamp information
+                    part.portName = b.get(1).toString();
+                    LOG( "the name of the port is %s\n",part.portName.c_str());
+                    break;
+                }
             }
             itr++;
         }

--- a/src/yarpdataplayer/src/utils.cpp
+++ b/src/yarpdataplayer/src/utils.cpp
@@ -225,7 +225,7 @@ int Utilities::getRecSubDirList(string dir, vector<string> &names, vector<string
 /**********************************************************/
 bool Utilities::checkLogValidity(const char *filename)
 {
-    bool check = false;
+    bool check = true;
     fstream str;
     str.open (filename, ios_base::in);//, ios::binary);
 
@@ -234,17 +234,14 @@ bool Utilities::checkLogValidity(const char *filename)
         int itr = 0;
         while( getline( str, line ) && itr < 3){
             Bottle b( line );
-            if (itr >= 0){
-                if ( b.size() < 1){
-                    check = false;
-                } else {
-                    check = true;
-                }
+            if ( b.size() == 0){
+                check = false;
+                break;
             }
             itr++;
         }
         str.close();
-        fprintf (stdout, "The size of the file is %d \n",itr );
+        fprintf (stdout, "The file contains at least %d non-empty lines\n",itr );
     }
     return check;
 }
@@ -260,13 +257,13 @@ bool Utilities::setupDataFromParts(partsData &part)
     if (str.is_open()){
         string line;
         int itr = 0;
-        while( getline( str, line ) && (itr <= 1) ){
+        while( getline( str, line ) && (itr <= 2) ){
             Bottle b( line );
             if (itr == 0){
                 part.type = b.get(1).toString();
                 part.type.erase(part.type.size() -1 );      // remove the ";" character
             }
-            if (itr == 1){
+            if (itr == 2){
                 part.portName = b.get(1).toString();
                 LOG( "the name of the port is %s\n",part.portName.c_str());
             }


### PR DESCRIPTION
This PR aims to extend `yarpdatadumper` so that:
- Images can be saved also in the PNG format; for that, just use the option `--type image_png`
- The format of the time stamps is provided from within the `info.log` file as in the following example:
    ```
    Type: Bottle;
    Stamp: [rx; | tx; | tx+rx;]
    [local-timestamp] /yarp-port-name [connected]
    [local-timestamp] /yarp-port-name [disconnected]
    ```

Preliminary tests show that the low-level YARP services devoted to deal with storing the PNG images are correctly called, even though I'm getting some PNG header errors on my machine. This behavior might be linked to my installation though, hence further verifications are required.

@vtikha I've modified the `yarpdataplayer` to let it read the new format of `info.log`. Please, have a look at it. Moreover, the new information on which stamps are logged could be employed later on to get rid of the command line option `withExtraTimeCol`.

@drdanz which is the release file I'm supposed to edit to keep track of these additions?