### PR TITLE
fix MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure 

### DIFF
--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -506,7 +506,7 @@ bool MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure(size_t sens_inde
 {
     yarp::sig::Vector dummy(1);
     bool ok = genericGetMeasure(TemperatureSensors, sens_index, dummy, timestamp, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorMeasure);
-    out = dummy[1];
+    out = dummy[0];
     return ok;
 }
 


### PR DESCRIPTION
Here
https://github.com/robotology/yarp/blob/3c157dc43783506b71fb03fe65ad9b201886aaaa/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp#L509
 
the remapper creates dummy, a auxiliary vector of 1 element only, but then accesses to dummy[1], its second element.

This pr fixes this issue #2056
