### PR TITLE
Fix mjpeg while using BGR images

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -1,0 +1,37 @@
+Important Changes
+-----------------
+
+New Features
+------------
+
+### Build System
+
+### Libraries
+
+#### `YARP_OS`
+
+#### `YARP_sig`
+
+#### `YARP_dev`
+
+#### `YARP_cv`
+
+
+### Devices
+
+### Tools
+
+#### `yarpdatadumper`
+
+### GUIs
+
+Bug Fixes
+---------
+
+### Libraries
+
+### Devices
+
+### Carriers
+
+- Fixed `mjpeg` carrier using BGR images(#2060).


### PR DESCRIPTION
This PR fixes #2060.

`MONO`, `RGB` and `BGR` have been successfully tested