### PR TITLE
Add filesystem utilities

### DIFF
--- a/doc/release/devel/addFilesystem.md
+++ b/doc/release/devel/addFilesystem.md
@@ -1,0 +1,14 @@
+addFilesystem  {#devel}
+-------------
+
+#### YARP_conf
+
+* Added `yarp::conf::filesystem` utilities(#1855).
+
+#### YARP_os
+
+* Deprecated filesystem utilities of `Network`.
+  `getDirectorySeparator` and `getPathSeparator` have been deprecated in
+  favour of `yarp::conf::filesystem::preferred_separator`
+  and `yarp::conf::filesystem::path_separator`respectively.
+

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -12,6 +12,7 @@
 
 #include <yarp/conf/system.h>
 #include <yarp/conf/version.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Carriers.h>
@@ -1827,7 +1828,7 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
     if (yarp::os::impl::isatty(yarp::os::impl::fileno(stdin))) //if interactive mode
     {
         hist_file=yarp::os::ResourceFinder::getDataHome();
-        std::string slash=NetworkBase::getDirectorySeparator();
+        std::string slash{yarp::conf::filesystem::preferred_separator};
         hist_file += slash;
         hist_file += "yarp_write";
         if (yarp::os::mkdir_p(hist_file.c_str(), 1) != 0)

--- a/src/libYARP_conf/src/CMakeLists.txt
+++ b/src/libYARP_conf/src/CMakeLists.txt
@@ -102,7 +102,8 @@ endforeach()
 add_library(YARP_conf INTERFACE)
 add_library(YARP::YARP_conf ALIAS YARP_conf)
 
-target_include_directories(YARP_conf INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+target_include_directories(YARP_conf INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+                                               $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_features(YARP_conf INTERFACE cxx_std_14)
 
@@ -115,6 +116,10 @@ install(TARGETS YARP_conf
 
 # INTERFACE libraries do not support the PUBLIC_HEADER property
 # https://gitlab.kitware.com/cmake/cmake/issues/20056
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/yarp/conf"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/yarp
+        COMPONENT YARP_conf-dev
+        FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/yarp/conf"
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/yarp
         COMPONENT YARP_conf-dev

--- a/src/libYARP_conf/src/yarp/conf/filesystem.h
+++ b/src/libYARP_conf/src/yarp/conf/filesystem.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_OS_FILESYSTEM_H
+#define YARP_OS_FILESYSTEM_H
+
+namespace yarp {
+namespace conf {
+namespace filesystem {
+#if (defined _WIN32)
+#  if (_MSC_VER >= 1920)
+typedef wchar_t             value_type;
+static constexpr value_type preferred_separator = L'\\';
+static constexpr value_type path_separator = L';';
+#  else
+typedef char                value_type;
+static constexpr value_type preferred_separator = '\\';
+static constexpr value_type path_separator = ';';
+#  endif
+#else
+typedef char                value_type;
+static constexpr value_type preferred_separator = '/';
+static constexpr value_type path_separator = ':';
+#endif
+} // namespace filesystem
+} // namespace conf
+} // namespace yarp
+
+
+#endif // YARP_OS_FILESYSTEM_H

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
@@ -8,6 +8,7 @@
 
 #include <yarp/manager/scriptbroker.h>
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Bottle.h>
 #include <string>
@@ -18,13 +19,13 @@
 using namespace yarp::os;
 using namespace yarp::manager;
 using namespace std;
+namespace fs = yarp::conf::filesystem;
 
-static char slash = NetworkBase::getDirectorySeparator()[0];
+constexpr fs::value_type slash = fs::preferred_separator;
+constexpr fs::value_type sep   = fs::path_separator;
 
 ////// adapted from YARP_os: ResourceFinder.cpp
 static Bottle parsePaths(const std::string& txt) {
-    char slash = NetworkBase::getDirectorySeparator()[0];
-    char sep = NetworkBase::getPathSeparator()[0];
     Bottle result;
     const char *at = txt.c_str();
     int slash_tweak = 0;
@@ -71,7 +72,8 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
         yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
         for (size_t i=0; i<possiblePaths.size(); ++i)
         {
-            std::string guessString=possiblePaths.get(i).asString() + slash + szcmd;
+            std::string guessString=possiblePaths.get(i).asString() +
+            std::string{slash} + szcmd;
             const char* guess=guessString.c_str();
             if (fileExists (guess))
             {

--- a/src/libYARP_manager/src/yarp/manager/xmlapploader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlapploader.cpp
@@ -8,6 +8,7 @@
 
 #include <yarp/manager/xmlapploader.h>
 #include <yarp/manager/utility.h>
+#include <yarp/conf/filesystem.h>
 #include <dirent.h>
 #include <tinyxml.h>
 #include <yarp/os/Value.h>
@@ -19,7 +20,6 @@
 #include <cctype>
 #include <string>
 #include <fstream>
-#include <yarp/os/Network.h>
 #include <yarp/manager/impl/textparser.h>
 
 
@@ -42,7 +42,7 @@ XmlAppLoader::XmlAppLoader(const char* szPath, const char* szAppName)
 
     if(strlen(szPath))
     {
-        const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+        const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
         if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/libYARP_manager/src/yarp/manager/xmlmodloader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlmodloader.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <yarp/manager/xmlmodloader.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/manager/utility.h>
 #include <dirent.h>
 #include <yarp/manager/physicresource.h>
@@ -33,7 +34,7 @@ XmlModLoader::XmlModLoader(const char* szPath, const char* szName)
 
     if(strlen(szPath))
     {
-        const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+        const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
         if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/libYARP_manager/src/yarp/manager/xmlresloader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlresloader.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <yarp/manager/xmlresloader.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/manager/utility.h>
 #include <dirent.h>
 #include <yarp/manager/physicresource.h>
@@ -29,7 +30,7 @@ XmlResLoader::XmlResLoader(const char* szPath, const char* szName)
     parser = new(TextParser);
     if(strlen(szPath))
     {
-        const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+        const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
         if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/libYARP_manager/src/yarp/manager/xmltemploader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmltemploader.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <yarp/manager/xmltemploader.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/manager/utility.h>
 #include <dirent.h>
 
@@ -34,7 +35,7 @@ XmlTempLoader::XmlTempLoader(const char* szPath, const char* szAppName)
 
     if(strlen(szPath))
     {
-        const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+        const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
         if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -9,6 +9,7 @@
 
 #include <yarp/os/Network.h>
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Carriers.h>
 #include <yarp/os/Face.h>
@@ -1374,27 +1375,19 @@ void NetworkBase::unsetEnvironment(const std::string& key)
     yarp::os::impl::unsetenv(key.c_str());
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3.0
+
 std::string NetworkBase::getDirectorySeparator()
 {
-#if defined(_WIN32)
-    // note this may be wrong under cygwin
-    // should be ok for mingw
-    return "\\";
-#else
-    return "/";
-#endif
+    return std::string{yarp::conf::filesystem::preferred_separator};
 }
 
 std::string NetworkBase::getPathSeparator()
 {
-#if defined(_WIN32)
-    // note this may be wrong under cygwin
-    // should be ok for mingw
-    return ";";
-#else
-    return ":";
-#endif
+    return std::string{yarp::conf::filesystem::path_separator};
 }
+
+#endif // YARP_NO_DEPRECATED
 
 namespace {
 std::mutex& getNetworkMutex()

--- a/src/libYARP_os/src/yarp/os/Network.h
+++ b/src/libYARP_os/src/yarp/os/Network.h
@@ -559,19 +559,26 @@ public:
     static void unsetEnvironment(const std::string& key);
 
 
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.2.0
     /**
      *
-     * Get an OS-appropriate directory separator (e.g. "/" on linux)
+     *  Get an OS-appropriate directory separator (e.g. "/" on linux)
+     *  @deprecated since YARP 3.2.0
      *
      */
+    YARP_DEPRECATED_MSG("Use yarp::conf::filesystem::preferred_separator instead")
     static std::string getDirectorySeparator();
 
     /**
      *
      * Get an OS-appropriate path separator (e.g. ":" on linux)
-     *
+     * @deprecated since YARP 3.2.0
      */
+    YARP_DEPRECATED_MSG("Use yarp::conf::filesystem::path_separator instead")
     static std::string getPathSeparator();
+
+#endif // YARP_NO_DEPRECATED
 
     /**
      *

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
@@ -9,6 +9,7 @@
 
 #include <yarp/os/ResourceFinder.h>
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
@@ -26,6 +27,7 @@
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
+namespace fs = yarp::conf::filesystem;
 
 #define RTARGET stderr
 #define RESOURCE_FINDER_CACHE_TIME 10
@@ -63,8 +65,8 @@ static Bottle parsePaths(const std::string& txt)
     if (txt.empty()) {
         return Bottle();
     }
-    char slash = NetworkBase::getDirectorySeparator()[0];
-    char sep = NetworkBase::getPathSeparator()[0];
+    constexpr fs::value_type slash = fs::preferred_separator;
+    constexpr fs::value_type sep   = fs::path_separator;
     Bottle result;
     const char* at = txt.c_str();
     int slash_tweak = 0;
@@ -93,10 +95,10 @@ static void appendResourceType(std::string& path,
     if (resourceType.empty()) {
         return;
     }
-    std::string slash = NetworkBase::getDirectorySeparator();
+    std::string slash{fs::preferred_separator};
     if (path.length() > 0) {
         if (path[path.length() - 1] != slash[0]) {
-            path += NetworkBase::getDirectorySeparator();
+            path +=slash;
         }
     }
     path += resourceType;
@@ -108,8 +110,8 @@ static void prependResourceType(std::string& path,
     if (resourceType.empty()) {
         return;
     }
-    std::string slash = NetworkBase::getDirectorySeparator();
-    path = resourceType + NetworkBase::getDirectorySeparator() + path;
+    std::string slash{fs::preferred_separator};
+    path = resourceType + slash + path;
 }
 
 static void appendResourceType(Bottle& paths,
@@ -266,7 +268,7 @@ public:
         }
 
         std::string s;
-        std::string slash = NetworkBase::getDirectorySeparator();
+        std::string slash{fs::preferred_separator};
 
         if (!base1.empty()) {
             s = base1;
@@ -484,7 +486,7 @@ public:
         }
 
         if ((locs & ResourceFinderOptions::Robot) != 0) {
-            std::string slash = NetworkBase::getDirectorySeparator();
+            std::string slash{fs::preferred_separator};
             bool found = false;
             std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
             if (!found) {
@@ -714,7 +716,7 @@ public:
         }
         std::string path = getPath(ResourceFinder::getDataHome(), "contexts", context, "");
 
-        std::string slash = NetworkBase::getDirectorySeparator();
+        std::string slash{fs::preferred_separator};
         if (path.length() > 1) {
             if (path[path.length() - 1] == slash[0]) {
                 path = path.substr(0, path.length() - slash.size());
@@ -744,7 +746,7 @@ public:
         }
         std::string path = getPath(ResourceFinder::getDataHome(), "robots", robot, "");
 
-        std::string slash = NetworkBase::getDirectorySeparator();
+        std::string slash{fs::preferred_separator};
         if (path.length() > 1) {
             if (path[path.length() - 1] == slash[0]) {
                 path = path.substr(0, path.length() - slash.size());
@@ -1021,7 +1023,7 @@ ResourceFinder& ResourceFinder::getResourceFinderSingleton()
 
 std::string ResourceFinder::getDataHomeWithPossibleCreation(bool mayCreate)
 {
-    std::string slash = NetworkBase::getDirectorySeparator();
+    std::string slash{fs::preferred_separator};
     bool found = false;
     std::string yarp_version = NetworkBase::getEnvironment("YARP_DATA_HOME",
                                                            &found);
@@ -1062,7 +1064,7 @@ std::string ResourceFinder::getDataHomeWithPossibleCreation(bool mayCreate)
 
 std::string ResourceFinder::getConfigHomeWithPossibleCreation(bool mayCreate)
 {
-    std::string slash = NetworkBase::getDirectorySeparator();
+    std::string slash{fs::preferred_separator};
     bool found = false;
     std::string yarp_version = NetworkBase::getEnvironment("YARP_CONFIG_HOME",
                                                            &found);
@@ -1112,7 +1114,7 @@ std::string ResourceFinder::createIfAbsent(bool mayCreate,
 
 Bottle ResourceFinder::getDataDirs()
 {
-    std::string slash = NetworkBase::getDirectorySeparator();
+    std::string slash{fs::preferred_separator};
     bool found = false;
     Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_DATA_DIRS",
                                                                  &found));
@@ -1144,7 +1146,6 @@ Bottle ResourceFinder::getDataDirs()
 
 Bottle ResourceFinder::getConfigDirs()
 {
-    std::string slash = NetworkBase::getDirectorySeparator();
     bool found = false;
     Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_CONFIG_DIRS",
                                                                  &found));

--- a/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
@@ -11,6 +11,7 @@
 #include <yarp/os/impl/NameConfig.h>
 
 #include <yarp/conf/system.h>
+#include <yarp/conf/filesystem.h>
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetType.h>
@@ -90,7 +91,7 @@ std::string NameConfig::expandFilename(const char* fname)
     std::string root = ResourceFinder::getConfigHome();
     std::string conf;
     if (!root.empty()) {
-        conf = root + NetworkBase::getDirectorySeparator() + fname;
+        conf = root + std::string{yarp::conf::filesystem::preferred_separator} + fname;
     } else {
         conf = fname;
     }

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -14,6 +14,7 @@
 #include <yarp/run/impl/PlatformUnistd.h>
 #include <yarp/run/impl/PlatformSysPrctl.h>
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/LogStream.h>
@@ -77,6 +78,8 @@ bool yarp::run::Run::mStresstest=false;
 bool yarp::run::Run::mLogged=false;
 std::string yarp::run::Run::mLoggerPort("/yarplogger");
 
+namespace fs = yarp::conf::filesystem;
+
 ////////////////////////////////////
 
 static RunTerminator *pTerminator = nullptr;
@@ -93,11 +96,10 @@ void sigstdio_handler(int sig)
 
 ////////////////////////////////////
 
-static char slash = yarp::os::NetworkBase::getDirectorySeparator()[0];
-////// adapted from YARP_os: ResourceFinder.cpp
+constexpr fs::value_type slash = fs::preferred_separator;
+constexpr fs::value_type sep   = fs::path_separator;
+////// adapted from libYARP_OS: ResourceFinder.cpp
 static yarp::os::Bottle parsePaths(const std::string& txt) {
-    char slash = yarp::os::NetworkBase::getDirectorySeparator()[0];
-    char sep = yarp::os::NetworkBase::getPathSeparator()[0];
     yarp::os::Bottle result;
     const char *at = txt.c_str();
     int slash_tweak = 0;
@@ -721,7 +723,8 @@ int yarp::run::Run::server()
                 yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
                 for (int i=0; i<possiblePaths.size(); ++i)
                 {
-                    std::string guessString=possiblePaths.get(i).asString() + slash + fileName;
+                    std::string guessString=possiblePaths.get(i).asString() +
+                    std::string{slash} + fileName;
                     const char* guess=guessString.c_str();
                     if (fileExists (guess))
                     {

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -21,6 +21,7 @@
 #include <yarp/manager/xmlapploader.h>
 #include <yarp/manager/application.h>
 #include <dirent.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/ResourceFinder.h>
 
 /*
@@ -788,7 +789,7 @@ bool YConsoleManager::process(const vector<string> &cmdList)
         return true;
     }
 
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
 
     /**
      *  list available modules
@@ -1163,7 +1164,7 @@ void YConsoleManager::onCnnFailed(void* which)
 
 bool YConsoleManager::loadRecursiveApplications(const char* szPath)
 {
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     string strPath = szPath;
     if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "entitiestreewidget.h"
+#include <yarp/conf/filesystem.h>
 #include <dirent.h>
 #include <QProcess>
 #include <QHeaderView>
@@ -119,7 +120,7 @@ void EntitiesTreeWidget::addApplication(yarp::manager::Application *app)
 
     string fname;
     string fpath = app->getXmlFile();
-    size_t pos = fpath.rfind(yarp::os::NetworkBase::getDirectorySeparator());
+    size_t pos = fpath.rfind(yarp::conf::filesystem::preferred_separator);
     if (pos!=string::npos) {
         fname = fpath.substr(pos+1);
     } else {
@@ -145,7 +146,7 @@ void EntitiesTreeWidget::addComputer(yarp::manager::Computer* comp)
 
     string fname;
     string fpath = comp->getXmlFile();
-    size_t pos = fpath.rfind(yarp::os::NetworkBase::getDirectorySeparator());
+    size_t pos = fpath.rfind(yarp::conf::filesystem::preferred_separator);
     if (pos!=string::npos) {
         fname = fpath.substr(pos+1);
     } else {
@@ -170,7 +171,7 @@ void EntitiesTreeWidget::addModule(yarp::manager::Module* mod)
 
     string fname;
     string fpath = mod->getXmlFile();
-    size_t pos = fpath.rfind(yarp::os::NetworkBase::getDirectorySeparator());
+    size_t pos = fpath.rfind(yarp::conf::filesystem::preferred_separator);
     if (pos!=string::npos) {
         fname = fpath.substr(pos+1);
     } else {

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include "ui_mainwindow.h"
 
 #include <yarp/conf/version.h>
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/ResourceFinder.h>
 #include <dirent.h>
@@ -223,7 +224,7 @@ void MainWindow::onWizardError(QString err)
 void MainWindow::init(yarp::os::Property config)
 {
     this->config = config;
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
 
     string basepath=config.check("ymanagerini_dir", yarp::os::Value("")).asString();
 
@@ -437,7 +438,7 @@ void MainWindow::syncApplicationList(QString selectNodeForEditing, bool open)
  */
 bool MainWindow::loadRecursiveTemplates(const char* szPath)
 {
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     string strPath = szPath;
     if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1)) {
@@ -479,7 +480,7 @@ bool MainWindow::loadRecursiveTemplates(const char* szPath)
  */
 bool MainWindow::loadRecursiveApplications(const char* szPath)
 {
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     string strPath = szPath;
     if((strPath.rfind(directorySeparator)==string::npos) ||
             (strPath.rfind(directorySeparator)!=strPath.size()-1))

--- a/src/yarpmanager/src-manager/newapplicationwizard.cpp
+++ b/src/yarpmanager/src-manager/newapplicationwizard.cpp
@@ -23,7 +23,7 @@
 #include <QMessageBox>
 
 #include <dirent.h>
-#include <yarp/os/Network.h>
+#include <yarp/conf/filesystem.h>
 
 using namespace std;
 using namespace yarp::manager;
@@ -121,7 +121,7 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
 
 
 
-    const std::string directorySeparator = yarp::os::NetworkBase::getDirectorySeparator();
+    const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     if(m_config->check("apppath")){
         string basepath=m_config->check("ymanagerini_dir", yarp::os::Value("")).asString();
         string appPaths(m_config->find("apppath").asString());
@@ -219,7 +219,7 @@ void NewApplicationWizard::buildFileName(){
     //checking if the path terminate with / or not
     if (folderCombo->currentText().at(folderCombo->currentText().size()-1) != '/')
     {
-        sep = yarp::os::Network::getDirectorySeparator().c_str();
+        sep = QString{yarp::conf::filesystem::preferred_separator};
     }
     this->fileName = QString("%1"+sep+"%2").arg(folderCombo->currentText().toLatin1().data()).arg(fileEdit->text().toLatin1().data());
 }

--- a/src/yarprobotinterface/XMLReaderVx.cpp
+++ b/src/yarprobotinterface/XMLReaderVx.cpp
@@ -24,8 +24,8 @@
 #include "Types.h"
 #include "RobotInterfaceDTD.h"
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
 
 #include <tinyxml.h>
@@ -77,7 +77,7 @@ RobotInterface::Robot& RobotInterface::XMLReader::getRobot(const std::string& fi
     std::replace(filename.begin(), filename.end(), '/', '\\');
 #endif
     std::string curr_filename = fileName;
-    std::string path = filename.substr(0, filename.rfind(yarp::os::Network::getDirectorySeparator()));
+    std::string path = filename.substr(0, filename.rfind(yarp::conf::filesystem::preferred_separator));
 
     yDebug() << "Reading file" << filename.c_str();
     auto* doc = new TiXmlDocument(filename.c_str());

--- a/tests/devices/harness_devices.cpp
+++ b/tests/devices/harness_devices.cpp
@@ -9,6 +9,7 @@
 
 #include "YarpBuildLocation.h"
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
 #include <yarp/dev/PolyDriver.h>
@@ -100,23 +101,23 @@ static void setup_Environment()
     // and YARP_DATA_HOME is set to a non existent directory
     std::string yarp_data_dirs =
             CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "share" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp" +
-            yarp::os::NetworkBase::getPathSeparator() +
+            std::string{yarp::conf::filesystem::path_separator} +
             TEST_DATA_DIR;
     yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "home" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "user" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             ".local" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
@@ -124,20 +125,20 @@ static void setup_Environment()
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
     // YARP_CONFIG_HOME are set to a non existent directory
     std::string yarp_config_dirs = CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "etc" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "home" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "user" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             ".config" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 

--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -10,6 +10,7 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/NameStore.h>
@@ -35,23 +36,23 @@ static void setup_Environment()
     // and YARP_DATA_HOME is set to a non existent directory
     std::string yarp_data_dirs =
             CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "share" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp" +
-            yarp::os::NetworkBase::getPathSeparator() +
+            std::string{yarp::conf::filesystem::path_separator}  +
             TEST_DATA_DIR;
     yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "home" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "user" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             ".local" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
@@ -59,20 +60,20 @@ static void setup_Environment()
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
     // YARP_CONFIG_HOME are set to a non existent directory
     std::string yarp_config_dirs = CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "etc" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "home" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "user" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             ".config" +
-            yarp::os::NetworkBase::getDirectorySeparator() +
+            std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
     yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -7,6 +7,7 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include <yarp/conf/filesystem.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
@@ -66,7 +67,7 @@ static std::string pathify(const Bottle& dirs)
     if (!result) {
         REQUIRE(result!=nullptr); // cwd/pwd not too long
     }
-    std::string slash = Network::getDirectorySeparator();
+    std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
     std::string dir = buf;
     for (size_t i=0; i<dirs.size(); i++) {
         dir += slash;
@@ -77,7 +78,7 @@ static std::string pathify(const Bottle& dirs)
 
 static void mkdir(const Bottle& dirs)
 {
-    std::string slash = Network::getDirectorySeparator();
+    std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
     std::string dir = "";
     for (size_t i=0; i<dirs.size(); i++) {
         if (i>0) dir += slash;
@@ -88,8 +89,8 @@ static void mkdir(const Bottle& dirs)
 
 static void setUpTestArea(bool etc_pathd)
 {
-    std::string colon = Network::getPathSeparator();
-    std::string slash = Network::getDirectorySeparator();
+    std::string colon = std::string{yarp::conf::filesystem::path_separator};
+    std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
     FILE *fout;
 
     std::string base = etc_pathd ? "__test_dir_rf_a1" : "__test_dir_rf_a2";
@@ -517,7 +518,7 @@ TEST_CASE("OS::ResourceFinderTest", "[yarp::os]")
         CHECK(ResourceFinder::getDataHome() == "/foo"); // YARP_DATA_HOME noticed
         Network::unsetEnvironment("YARP_DATA_HOME");
         Network::setEnvironment("XDG_DATA_HOME", "/foo");
-        std::string slash = Network::getDirectorySeparator();
+        std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getDataHome() == (std::string("/foo") + slash + "yarp")); // XDG_DATA_HOME noticed
         Network::unsetEnvironment("XDG_DATA_HOME");
 #ifdef __linux__
@@ -536,7 +537,7 @@ TEST_CASE("OS::ResourceFinderTest", "[yarp::os]")
         CHECK(ResourceFinder::getConfigHome() == "/foo"); // YARP_CONFIG_HOME noticed
         Network::unsetEnvironment("YARP_CONFIG_HOME");
         Network::setEnvironment("XDG_CONFIG_HOME", "/foo");
-        std::string slash = Network::getDirectorySeparator();
+        std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getConfigHome() == (std::string("/foo") + slash + "yarp")); // XDG_CONFIG_HOME noticed
         Network::unsetEnvironment("XDG_CONFIG_HOME");
 #ifdef __linux__
@@ -550,8 +551,8 @@ TEST_CASE("OS::ResourceFinderTest", "[yarp::os]")
     {
         saveEnvironment("YARP_DATA_DIRS");
         saveEnvironment("XDG_DATA_DIRS");
-        std::string slash = Network::getDirectorySeparator();
-        std::string colon = Network::getPathSeparator();
+        std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
+        std::string colon = std::string{yarp::conf::filesystem::path_separator};
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
@@ -588,8 +589,8 @@ TEST_CASE("OS::ResourceFinderTest", "[yarp::os]")
     {
         saveEnvironment("YARP_CONFIG_DIRS");
         saveEnvironment("XDG_CONFIG_DIRS");
-        std::string slash = Network::getDirectorySeparator();
-        std::string colon = Network::getPathSeparator();
+        std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
+        std::string colon = std::string{yarp::conf::filesystem::path_separator};
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
@@ -737,7 +738,7 @@ TEST_CASE("OS::ResourceFinderTest", "[yarp::os]")
 
     SECTION("test get 'home' dirs for writing")
     {
-        std::string slash = Network::getDirectorySeparator();
+        std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         setUpTestArea(false);
 
         {


### PR DESCRIPTION
It fixes #1855 .

The main feature brought by this PR is that it has been possible to remove the inclusion of `Network.h` in several places where the actual network or communication wasn't involved.

It is a draft since @drdanz has some plan to create a separate library and get rid of other stuff not concerning the network in `Network.h`  