### PR TITLE
PortCore refactor

### DIFF
--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -569,7 +569,7 @@ private:
     bool dettachPortMonitor(bool isOutput);
 
     // set the parameter for the portmonitor of the port (if any)
-    bool setParamPortMonitor(yarp::os::Property& param, bool isOutput, std::string& errMsg);
+    bool setParamPortMonitor(const yarp::os::Property& param, bool isOutput, std::string& errMsg);
 
     // get the parameters from the portmonitor of the port (if any)
     bool getParamPortMonitor(yarp::os::Property& param, bool isOutput, std::string& errMsg);

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -22,6 +22,7 @@
 #include <yarp/os/Property.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Type.h>
+#include <yarp/os/Vocab.h>
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/PortCorePackets.h>
 #include <yarp/os/impl/ThreadImpl.h>

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -233,11 +233,9 @@ public:
      * Process an administrative message.
      * @param reader source of data
      * @param id opaque identifier of connection providing data
-     * @param os stream to write error messages on
      */
     bool adminBlock(ConnectionReader& reader,
-                    void* id,
-                    yarp::os::OutputStream* os);
+                    void* id);
 
     /**
      * Set the name of this port.

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -288,7 +288,7 @@ public:
     /**
      * Configure the port to meet certain restrictions in behavior.
      */
-    void setFlags(int flags)
+    void setFlags(unsigned int flags)
     {
         this->m_flags = flags;
     }
@@ -301,7 +301,7 @@ public:
     /**
      * Check current configuration of port.
      */
-    int getFlags()
+    unsigned int getFlags()
     {
         return m_flags;
     }
@@ -533,7 +533,7 @@ private:
     int m_inputCount; ///< how many input connections do we have
     int m_outputCount;///< how many output connections do we have
     int m_dataOutputCount; ///< how many regular data output connections do we have
-    int m_flags;      ///< binary flags encoding restrictions on port
+    unsigned int m_flags;      ///< binary flags encoding restrictions on port
     int m_verbosity;  ///< threshold on what warnings or debug messages are shown
     bool m_logNeeded; ///< port needs to monitor message content
     PortCorePackets m_packets; ///< a pool for tracking messages currently being sent

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -682,8 +682,8 @@ void PortCore::cleanUnits(bool blocking)
         // Now we do some awkward shuffling (list class may be from ACE
         // or STL, if ACE it is quite limited).  We move the nulls to
         // the end of the list ...
-        unsigned int rem = 0;
-        for (unsigned int i2 = 0; i2 < m_units.size(); i2++) {
+        size_t rem = 0;
+        for (size_t i2 = 0; i2 < m_units.size(); i2++) {
             if (m_units[i2] != nullptr) {
                 if (rem < i2) {
                     m_units[rem] = m_units[i2];
@@ -694,7 +694,7 @@ void PortCore::cleanUnits(bool blocking)
         }
 
         // ... Now we get rid of the null entries
-        for (unsigned int i3 = 0; i3 < m_units.size() - rem; i3++) {
+        for (size_t i3 = 0; i3 < m_units.size() - rem; i3++) {
             m_units.pop_back();
         }
     }
@@ -1507,7 +1507,7 @@ bool PortCore::setEnvelope(PortWriter& envelope)
 void PortCore::setEnvelope(const std::string& envelope)
 {
     m_envelope = envelope;
-    for (unsigned int i = 0; i < m_envelope.length(); i++) {
+    for (size_t i = 0; i < m_envelope.length(); i++) {
         // It looks like envelopes are constrained to be printable ASCII?
         // I'm not sure why this would be.  TODO check.
         if (m_envelope[i] < 32) {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2179,6 +2179,20 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         return result;
     };
 
+    auto handleAdminRosRequestTopicCmd = [this]() {
+        // ROS-style query for topics.
+        Bottle result;
+        result.addInt32(1);
+        NestedContact nc(getName());
+        result.addString(nc.getNodeName());
+        Bottle& lst = result.addList();
+        Contact addr = getAddress();
+        lst.addString("TCPROS");
+        lst.addString(addr.getHost());
+        lst.addInt32(addr.getPort());
+        return result;
+    };
+
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
@@ -2250,19 +2264,14 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         result = handleAdminRosPublisherUpdateCmd(topic, pubs);
         reader.requestDrop(); // ROS needs us to close down.
         } break;
-    case PortCoreCommand::RosRequestTopic: {
-        // ROS-style query for topics.
+    case PortCoreCommand::RosRequestTopic:
         YARP_SPRINTF1(m_log, debug, "requestTopic! --> %s", cmd.toString().c_str());
-        result.addInt32(1);
-        NestedContact nc(getName());
-        result.addString(nc.getNodeName());
-        Bottle& lst = result.addList();
-        Contact addr = getAddress();
-        lst.addString("TCPROS");
-        lst.addString(addr.getHost());
-        lst.addInt32(addr.getPort());
+        // std::string caller_id = cmd.get(1).asString(); // Currently unused
+        // std::string topic = RosNameSpace::fromRosName(cmd.get(2).asString()); // Currently unused
+        // Bottle protocols = cmd.get(3).asList(); // Currently unused
+        result = handleAdminRosRequestTopicCmd();
         reader.requestDrop(); // ROS likes to close down.
-    } break;
+        break;
     case PortCoreCommand::RosGetPid: {
         // ROS-style query for PID.
         result.addInt32(1);

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2240,9 +2240,10 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         reader.requestDrop(); // ROS likes to close down.
     } break;
     case PortCoreCommand::Prop: {
+        PortCorePropertyAction action = parsePropertyAction(cmd.get(1).asVocab());
         // Set/get arbitrary properties on a port.
-        switch (cmd.get(1).asVocab()) {
-        case yarp::os::createVocab('g', 'e', 't'): {
+        switch (action) {
+        case PortCorePropertyAction::Get: {
             Property* p = acquireProperties(false);
             if (p != nullptr) {
                 if (!cmd.get(2).isNull()) {
@@ -2333,7 +2334,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             }
             releaseProperties(p);
         } break;
-        case yarp::os::createVocab('s', 'e', 't'): {
+        case PortCorePropertyAction::Set: {
             Property* p = acquireProperties(false);
             bool bOk = true;
             if (p != nullptr) {
@@ -2468,7 +2469,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             releaseProperties(p);
             result.addVocab((bOk) ? Vocab::encode("ok") : Vocab::encode("fail"));
         } break;
-        default:
+        case PortCorePropertyAction::Error:
             result.addVocab(Vocab::encode("fail"));
             result.addString("property action not known");
             break;

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2154,7 +2154,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                             Bottle& sched = result.addList();
                             sched.addString("sched");
                             Property& sched_prop = sched.addDict();
-                            sched_prop.put("tid", (int)this->getTid());
+                            sched_prop.put("tid", static_cast<int>(this->getTid()));
                             sched_prop.put("priority", this->getPriority());
                             sched_prop.put("policy", this->getPolicy());
 
@@ -2196,7 +2196,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                                         int priority = unit->getPriority();
                                         int policy = unit->getPolicy();
                                         int tos = getTypeOfService(unit);
-                                        int tid = (int)unit->getTid();
+                                        int tid = static_cast<int>(unit->getTid());
                                         result.clear();
                                         Bottle& sched = result.addList();
                                         sched.addString("sched");
@@ -2619,19 +2619,19 @@ bool PortCore::setProcessSchedulingParam(int priority, int policy)
 
     struct dirent* d;
     char* end;
-    int tid = 0;
+    long tid = 0;
     bool ret = true;
     while ((d = readdir(dir)) != nullptr) {
         if (isdigit((unsigned char)*d->d_name) == 0) {
             continue;
         }
 
-        tid = (pid_t)strtol(d->d_name, &end, 10);
+        tid = strtol(d->d_name, &end, 10);
         if (d->d_name == end || ((end != nullptr) && (*end != 0))) {
             closedir(dir);
             return false;
         }
-        ret &= (sched_setscheduler(tid, policy, &sch_param) == 0);
+        ret &= (sched_setscheduler(static_cast<pid_t>(tid), policy, &sch_param) == 0);
     }
     closedir(dir);
     return ret;

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1709,9 +1709,8 @@ bool PortCore::adminBlock(ConnectionReader& reader,
 
     YARP_SPRINTF2(m_log, debug, "Port %s received command %s", getName().c_str(), cmd.toString().c_str());
 
-    const PortCoreCommand command = parseCommand(cmd.get(0));
-    switch (command) {
-    case PortCoreCommand::Help:
+    auto handleAdminHelpCmd = []() {
+        Bottle result;
         // We give a list of the most useful administrative commands.
         result.addVocab(yarp::os::createVocab('m', 'a', 'n', 'y'));
         result.addString("[help]                  # give this help");
@@ -1736,6 +1735,13 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         result.addString("[dtch] [in]             # detach portmonitor plug-in from the port's input");
         //result.addString("[atch] $portname $prop  # attach a portmonitor plug-in to the connection to/from $portname");
         //result.addString("[dtch] $portname        # detach any portmonitor plug-in from the connection to/from $portname");
+        return result;
+    };
+
+    const PortCoreCommand command = parseCommand(cmd.get(0));
+    switch (command) {
+    case PortCoreCommand::Help:
+        result = handleAdminHelpCmd();
         break;
     case PortCoreCommand::Ver:
         // Gives a version number for the administrative commands.

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2626,7 +2626,7 @@ bool PortCore::dettachPortMonitor(bool isOutput)
     return true;
 }
 
-bool PortCore::setParamPortMonitor(yarp::os::Property& param,
+bool PortCore::setParamPortMonitor(const yarp::os::Property& param,
                                    bool isOutput,
                                    std::string& errMsg)
 {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -948,7 +948,7 @@ bool PortCore::addOutput(const std::string& dest,
     bool allowed = true;
     std::string err;
     std::string append;
-    int f = getFlags();
+    unsigned int f = getFlags();
     bool allow_output = (f & PORTCORE_IS_OUTPUT) != 0;
     bool rpc = (f & PORTCORE_IS_RPC) != 0;
     Name name(r.getCarrierName() + std::string("://test"));
@@ -2175,7 +2175,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                             platform_prop.put("os", pinfo.name);
                             platform_prop.put("hostname", m_address.getHost());
 
-                            int f = getFlags();
+                            unsigned int f = getFlags();
                             bool is_input = (f & PORTCORE_IS_INPUT) != 0;
                             bool is_output = (f & PORTCORE_IS_OUTPUT) != 0;
                             bool is_rpc = (f & PORTCORE_IS_RPC) != 0;

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1711,8 +1711,6 @@ bool PortCore::adminBlock(ConnectionReader& reader,
 
     YARP_SPRINTF2(m_log, debug, "Port %s received command %s", getName().c_str(), cmd.toString().c_str());
 
-    StringOutputStream cache;
-
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
@@ -1753,6 +1751,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         std::string output = cmd.get(1).asString();
         std::string carrier = cmd.get(2).asString();
         // Add an output to the port.
+        StringOutputStream cache;
         if (!carrier.empty()) {
             output = carrier + ":/" + output;
         }
@@ -1820,6 +1819,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
     case PortCoreCommand::Del: {
         const std::string dest = cmd.get(1).asString();
         // Delete any inputs or outputs involving the named port.
+        StringOutputStream cache;
         removeOutput(dest, id, &cache);
         std::string r1 = cache.toString();
         cache.reset();

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2396,16 +2396,6 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         result.write(*writer);
     }
 
-    /**
-     * @brief We introduce a nonsense arbitrary delay in the calls to the port administrator
-     * for debugging purpose. This is indeed a temporary feature and will be removed soon.
-     * The delay is applied if the "NONSENSE_ADMIN_DELAY" environment variable is set.
-     */
-    std::string nonsense_delay = NetworkBase::getEnvironment("NONSENSE_ADMIN_DELAY");
-    if (!nonsense_delay.empty()) {
-        yarp::os::SystemClock::delaySystem(atof(nonsense_delay.c_str()));
-    }
-
     return true;
 }
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2079,8 +2079,8 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                 result.fromString(p->toString());
             } else {
                 // request: "prop get /portname"
-                bool bFound = false;
                 if (key[0] == '/') {
+                    bool bFound = false;
                     // check for their own name
                     if (key == getName()) {
                         bFound = true;

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1749,6 +1749,22 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         return result;
     };
 
+    auto handleAdminAddCmd = [this, id](std::string output,
+                                        const std::string& carrier) {
+        // Add an output to the port.
+        Bottle result;
+        StringOutputStream cache;
+        if (!carrier.empty()) {
+            output = carrier + ":/" + output;
+        }
+        addOutput(output, id, &cache, false);
+        std::string r = cache.toString();
+        int v = (r[0] == 'A') ? 0 : -1;
+        result.addInt32(v);
+        result.addString(r);
+        return result;
+    };
+
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
@@ -1760,18 +1776,9 @@ bool PortCore::adminBlock(ConnectionReader& reader,
     case PortCoreCommand::Add: {
         std::string output = cmd.get(1).asString();
         std::string carrier = cmd.get(2).asString();
-        // Add an output to the port.
-        StringOutputStream cache;
-        if (!carrier.empty()) {
-            output = carrier + ":/" + output;
-        }
-        addOutput(output, id, &cache, false);
-        std::string r = cache.toString();
-        int v = (r[0] == 'A') ? 0 : -1;
-        result.addInt32(v);
-        result.addString(r);
-    } break;
-    case PortCoreCommand::Atch: {
+        result = handleAdminAddCmd(std::move(output), carrier);
+        } break;
+   case PortCoreCommand::Atch: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab());
         Property prop(cmd.get(2).asString().c_str());
         switch (direction) {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1712,7 +1712,6 @@ bool PortCore::adminBlock(ConnectionReader& reader,
     YARP_SPRINTF2(m_log, debug, "Port %s received command %s", getName().c_str(), cmd.toString().c_str());
 
     StringOutputStream cache;
-    std::string infoMsg;
 
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1696,10 +1696,8 @@ PortCorePropertyAction parsePropertyAction(yarp::conf::vocab32_t v)
 } // namespace
 
 bool PortCore::adminBlock(ConnectionReader& reader,
-                          void* id,
-                          OutputStream* os)
+                          void* id)
 {
-    YARP_UNUSED(os);
     Bottle cmd;
     Bottle result;
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1738,18 +1738,24 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         return result;
     };
 
+    auto handleAdminVerCmd = []() {
+        // Gives a version number for the administrative commands.
+        // It is distinct from YARP library versioning.
+        Bottle result;
+        result.addVocab(Vocab::encode("ver"));
+        result.addInt32(1);
+        result.addInt32(2);
+        result.addInt32(3);
+        return result;
+    };
+
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
         result = handleAdminHelpCmd();
         break;
     case PortCoreCommand::Ver:
-        // Gives a version number for the administrative commands.
-        // It is distinct from YARP library versioning.
-        result.addVocab(Vocab::encode("ver"));
-        result.addInt32(1);
-        result.addInt32(2);
-        result.addInt32(3);
+        result = handleAdminVerCmd();
         break;
     case PortCoreCommand::Add: {
         std::string output = cmd.get(1).asString();

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -435,7 +435,7 @@ void PortCore::closeMain()
         std::string removeName;
         m_stateSemaphore.wait();
         for (auto unit : m_units) {
-            if ((unit != nullptr) && unit->isInput() &&!unit->isDoomed()) {
+            if ((unit != nullptr) && unit->isInput() && !unit->isDoomed()) {
                 Route r = unit->getRoute();
                 std::string s = r.getFromName();
                 if (s.length() >= 1 && s[0] == '/' && s != getName() && s != prevName) {
@@ -1877,7 +1877,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                 }
             }
             m_stateSemaphore.post();
-            } break;
+        } break;
         case PortCoreConnectionDirection::Out: {
             // Return a list of all output connections.
             m_stateSemaphore.wait();
@@ -1892,7 +1892,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
                 }
             }
             m_stateSemaphore.post();
-            } break;
+        } break;
         case PortCoreConnectionDirection::Error:
             // Should never happen
             yAssert(false);
@@ -2028,12 +2028,12 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             }
         }
         m_stateSemaphore.post();
-    return result;
+        return result;
     };
 
     auto handleAdminGetOutCmd = [this](const std::string& target) {
         Bottle result;
-         // Get carrier parameters for a given output connection.
+        // Get carrier parameters for a given output connection.
         m_stateSemaphore.wait();
         if (target.empty()) {
             result.addInt32(-1);
@@ -2469,25 +2469,25 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         std::string output = cmd.get(1).asString();
         std::string carrier = cmd.get(2).asString();
         result = handleAdminAddCmd(std::move(output), carrier);
-        } break;
+    } break;
     case PortCoreCommand::Del: {
         const std::string dest = cmd.get(1).asString();
         result = handleAdminDelCmd(dest);
-        } break;
+    } break;
     case PortCoreCommand::Atch: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab());
         Property prop(cmd.get(2).asString().c_str());
         result = handleAdminAtchCmd(direction, std::move(prop));
-        } break;
+    } break;
     case PortCoreCommand::Dtch: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab());
         result = handleAdminDtchCmd(direction);
-        } break;
+    } break;
     case PortCoreCommand::List: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab(), true);
         const std::string target = cmd.get(2).asString();
         result = handleAdminListCmd(direction, target);
-        } break;
+    } break;
     case PortCoreCommand::Set: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab(), true);
         const std::string target = cmd.get(2).asString();
@@ -2504,7 +2504,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             yAssert(false); // Should never happen (error is out)
             break;
         }
-        } break;
+    } break;
     case PortCoreCommand::Get: {
         const PortCoreConnectionDirection direction = parseConnectionDirection(cmd.get(1).asVocab(), true);
         const std::string target = cmd.get(2).asString();
@@ -2519,7 +2519,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             yAssert(false); // Should never happen (error is out)
             break;
         }
-        } break;
+    } break;
     case PortCoreCommand::Prop: {
         PortCorePropertyAction action = parsePropertyAction(cmd.get(1).asVocab());
         const std::string key = cmd.get(2).asString();
@@ -2534,13 +2534,13 @@ bool PortCore::adminBlock(ConnectionReader& reader,
             const Bottle& sched = cmd.findGroup("sched");
             const Bottle& qos = cmd.findGroup("qos");
             result = handleAdminPropSetCmd(key, value, process, sched, qos);
-            } break;
+        } break;
         case PortCorePropertyAction::Error:
             result.addVocab(Vocab::encode("fail"));
             result.addString("property action not known");
             break;
         }
-        } break;
+    } break;
     case PortCoreCommand::RosPublisherUpdate: {
         YARP_SPRINTF1(m_log, debug, "publisherUpdate! --> %s", cmd.toString().c_str());
         // std::string caller_id = cmd.get(1).asString(); // Currently unused
@@ -2548,7 +2548,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         Bottle* pubs = cmd.get(3).asList();
         result = handleAdminRosPublisherUpdateCmd(topic, pubs);
         reader.requestDrop(); // ROS needs us to close down.
-        } break;
+    } break;
     case PortCoreCommand::RosRequestTopic:
         YARP_SPRINTF1(m_log, debug, "requestTopic! --> %s", cmd.toString().c_str());
         // std::string caller_id = cmd.get(1).asString(); // Currently unused

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2202,6 +2202,16 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         return result;
     };
 
+    auto handleAdminRosGetBusInfoCmd = []() {
+        // ROS-style query for bus information - we support this
+        // in yarp::os::Node but not otherwise.
+        Bottle result;
+        result.addInt32(1);
+        result.addString("");
+        result.addList().addList();
+        return result;
+    };
+
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
@@ -2286,14 +2296,11 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         result = handleAdminRosGetPidCmd();
         reader.requestDrop(); // ROS likes to close down.
         break;
-    case PortCoreCommand::RosGetBusInfo: {
-        // ROS-style query for bus information - we support this
-        // in yarp::os::Node but not otherwise.
-        result.addInt32(1);
-        result.addString("");
-        result.addList().addList();
+    case PortCoreCommand::RosGetBusInfo:
+        // std::string caller_id = cmd.get(1).asString(); // Currently unused
+        result = handleAdminRosGetBusInfoCmd();
         reader.requestDrop(); // ROS likes to close down.
-    } break;
+        break;
     case PortCoreCommand::Prop: {
         PortCorePropertyAction action = parsePropertyAction(cmd.get(1).asVocab());
         // Set/get arbitrary properties on a port.

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -237,8 +237,7 @@ void PortCore::run()
     while (!shouldStop) {
 
         // Block and wait for a connection
-        InputProtocol* ip = nullptr;
-        ip = m_face->read();
+        InputProtocol* ip = m_face->read();
 
         m_stateSemaphore.wait();
 

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -2193,6 +2193,15 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         return result;
     };
 
+    auto handleAdminRosGetPidCmd = []() {
+        // ROS-style query for PID.
+        Bottle result;
+        result.addInt32(1);
+        result.addString("");
+        result.addInt32(yarp::os::impl::getpid());
+        return result;
+    };
+
     const PortCoreCommand command = parseCommand(cmd.get(0));
     switch (command) {
     case PortCoreCommand::Help:
@@ -2272,13 +2281,11 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         result = handleAdminRosRequestTopicCmd();
         reader.requestDrop(); // ROS likes to close down.
         break;
-    case PortCoreCommand::RosGetPid: {
-        // ROS-style query for PID.
-        result.addInt32(1);
-        result.addString("");
-        result.addInt32(yarp::os::impl::getpid());
+    case PortCoreCommand::RosGetPid:
+        // std::string caller_id = cmd.get(1).asString(); // Currently unused
+        result = handleAdminRosGetPidCmd();
         reader.requestDrop(); // ROS likes to close down.
-    } break;
+        break;
     case PortCoreCommand::RosGetBusInfo: {
         // ROS-style query for bus information - we support this
         // in yarp::os::Node but not otherwise.

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -1534,16 +1534,6 @@ bool PortCore::getEnvelope(PortReader& envelope)
     return envelope.read(sbr);
 }
 
-// Shorthand to create a nested (tag, val) pair to add to a message.
-#define STANZA(name, tag, val) \
-    Bottle name;               \
-    (name).addString(tag);     \
-    (name).addString(val);
-#define STANZA_INT(name, tag, val) \
-    Bottle name;                   \
-    (name).addString(tag);         \
-    (name).addInt32(val);
-
 // Make an RPC connection to talk to a ROS API, send a message, get reply.
 // NOTE: ROS support can now be moved out of here, once all documentation
 // of older ways to interoperate with it are purged and people stop
@@ -1695,20 +1685,28 @@ PortCorePropertyAction parsePropertyAction(yarp::conf::vocab32_t v)
 
 void describeRoute(const Route& route, Bottle& result)
 {
-    STANZA(bfrom, "from", route.getFromName());
-    STANZA(bto, "to", route.getToName());
-    STANZA(bcarrier, "carrier", route.getCarrierName());
-    result.addList() = bfrom;
-    result.addList() = bto;
-    result.addList() = bcarrier;
+    Bottle& bfrom = result.addList();
+    bfrom.addString("from");
+    bfrom.addString(route.getFromName());
+
+    Bottle& bto = result.addList();
+    bto.addString("to");
+    bto.addString(route.getToName());
+
+    Bottle& bcarrier = result.addList();
+    bcarrier.addString("carrier");
+    bcarrier.addString(route.getCarrierName());
+
     Carrier* carrier = Carriers::chooseCarrier(route.getCarrierName());
     if (carrier->isConnectionless()) {
-        STANZA_INT(bconnectionless, "connectionless", 1);
-        result.addList() = bconnectionless;
+        Bottle& bconnectionless = result.addList();
+        bconnectionless.addString("connectionless");
+        bconnectionless.addInt32(1);
     }
     if (!carrier->isPush()) {
-        STANZA_INT(breverse, "push", 0);
-        result.addList() = breverse;
+        Bottle& breverse = result.addList();
+        breverse.addString("push");
+        breverse.addInt32(0);
     }
     delete carrier;
 }

--- a/src/libYARP_OS/src/PortCoreInputUnit.cpp
+++ b/src/libYARP_OS/src/PortCoreInputUnit.cpp
@@ -329,7 +329,7 @@ void PortCoreInputUnit::run()
             }
         } break;
         case 'a': {
-            man.adminBlock(br, id, os);
+            man.adminBlock(br, id);
         } break;
         case 'r':
             /*


### PR DESCRIPTION
Split into tiny commits, since touching this part is very dangerous, and this will allow to debug it in case something goes wrong.

Also unrelated (maybe I'll move it in a separate PR before merging),  the `yarp::os::Property` constructor using 'hash_size' was deprecated (it was already unused since the internal structure was ported to use std::map).