### PR TITLE
Enable colored logger output on Windows 10

### DIFF
--- a/cmake/YarpSystemCheck.cmake
+++ b/cmake/YarpSystemCheck.cmake
@@ -187,6 +187,13 @@ if(WIN32)
     add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
     add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
 
+    set(YARP_HAS_WIN_VT_SUPPORT 0)
+
+    # Check whether colored output is available on Windows console.
+    if(NOT CMAKE_SYSTEM_VERSION VERSION_LESS 10.0.10586)
+      set(YARP_HAS_WIN_VT_SUPPORT 1)
+    endif()
+
     # Traditionally, we add "d" postfix to debug libraries
     set(CMAKE_DEBUG_POSTFIX "d")
   endif()

--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -359,6 +359,8 @@ set(YARP_os_IMPL_POSIX_SRCS yarp/os/impl/posix/TcpAcceptor.cpp
 set(YARP_os_IMPL_MACOS_HDRS yarp/os/impl/macos/MacOSAPI.h)
 set(YARP_os_IMPL_MACOS_SRCS yarp/os/impl/macos/MacOSAPI.mm)
 
+set(YARP_os_IMPL_WIN32_SRCS yarp/os/impl/windows/WinConsole.c)
+
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
              PREFIX "Source Files"
              FILES ${YARP_os_SRCS}
@@ -401,6 +403,12 @@ if(APPLE)
                                  ${YARP_os_IMPL_MACOS_SRCS})
   # Required by MacOSAPI.mm
   target_link_libraries(YARP_os PRIVATE "-framework Foundation")
+endif()
+
+if(MSVC AND YARP_HAS_WIN_VT_SUPPORT)
+  target_sources(YARP_os PRIVATE ${YARP_os_IMPL_WIN32_SRCS})
+  # Used in Log.cpp
+  target_compile_definitions(YARP_os PRIVATE YARP_HAS_WIN_VT_SUPPORT)
 endif()
 
 target_include_directories(YARP_os PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -38,34 +38,25 @@
 
 #define YARP_MAX_LOG_MSG_SIZE 1024
 
-#if !defined(_WIN32)
+#define RED     (colored_output ? "\033[01;31m" : "")
+#define GREEN   (colored_output ? "\033[01;32m" : "")
+#define YELLOW  (colored_output ? "\033[01;33m" : "")
+#define BLUE    (colored_output ? "\033[01;34m" : "")
+#define MAGENTA (colored_output ? "\033[01;35m" : "")
+#define CYAN    (colored_output ? "\033[01;36m" : "")
+#define WHITE   (colored_output ? "\033[01;37m" : "")
+#define RED_BG  (colored_output ? "\033[01;41m" : "")
+#define CLEAR   (colored_output ? "\033[00m" : "")
 
-#    define RED     (colored_output ? "\033[01;31m" : "")
-#    define GREEN   (colored_output ? "\033[01;32m" : "")
-#    define YELLOW  (colored_output ? "\033[01;33m" : "")
-#    define BLUE    (colored_output ? "\033[01;34m" : "")
-#    define MAGENTA (colored_output ? "\033[01;35m" : "")
-#    define CYAN    (colored_output ? "\033[01;36m" : "")
-#    define WHITE   (colored_output ? "\033[01;37m" : "")
-#    define RED_BG  (colored_output ? "\033[01;41m" : "")
-#    define CLEAR   (colored_output ? "\033[00m" : "")
-
-#else
-
-// TODO colored and verbose_output for WIN32
-#    define RED     ""
-#    define GREEN   ""
-#    define YELLOW  ""
-#    define BLUE    ""
-#    define MAGENTA ""
-#    define CYAN    ""
-#    define WHITE   ""
-#    define RED_BG  ""
-#    define CLEAR   ""
-
+#ifdef YARP_HAS_WIN_VT_SUPPORT
+extern "C" void yarp_logger_enable_vt_colors(void);
 #endif
 
+#if defined(_WIN32) && !defined(YARP_HAS_WIN_VT_SUPPORT)
+bool yarp::os::impl::LogImpl::colored_output(false);
+#else
 bool yarp::os::impl::LogImpl::colored_output((getenv("YARP_COLORED_OUTPUT") != nullptr)     &&  (strcmp(yarp::os::getenv("YARP_COLORED_OUTPUT"), "1") == 0));
+#endif
 bool yarp::os::impl::LogImpl::verbose_output((getenv("YARP_VERBOSE_OUTPUT") != nullptr)     &&  (strcmp(yarp::os::getenv("YARP_VERBOSE_OUTPUT"), "1") == 0));
 bool yarp::os::impl::LogImpl::trace_output((getenv("YARP_TRACE_ENABLE") != nullptr)         &&  (strcmp(yarp::os::getenv("YARP_TRACE_ENABLE"), "1") == 0));
 bool yarp::os::impl::LogImpl::debug_output((getenv("YARP_DEBUG_ENABLE") == nullptr)         || !(strcmp(yarp::os::getenv("YARP_DEBUG_ENABLE"), "0") == 0));
@@ -219,11 +210,17 @@ yarp::os::Log::Log(const char* file,
                    const char* func) :
         mPriv(new yarp::os::impl::LogImpl(file, line, func))
 {
+#ifdef YARP_HAS_WIN_VT_SUPPORT
+    yarp_logger_enable_vt_colors();
+#endif
 }
 
 yarp::os::Log::Log() :
         mPriv(new yarp::os::impl::LogImpl(nullptr, 0, nullptr))
 {
+#ifdef YARP_HAS_WIN_VT_SUPPORT
+    yarp_logger_enable_vt_colors();
+#endif
 }
 
 yarp::os::Log::~Log()

--- a/src/libYARP_os/src/yarp/os/impl/windows/WinConsole.c
+++ b/src/libYARP_os/src/yarp/os/impl/windows/WinConsole.c
@@ -1,0 +1,21 @@
+#include <stdbool.h> // C99+
+#include <windows.h>
+
+void yarp_logger_enable_vt_colors(void)
+{
+    static bool enabled = false;
+
+    if (!enabled)
+    {
+        DWORD handleMode = 0;
+        HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+
+        if (hStdout != INVALID_HANDLE_VALUE && GetConsoleMode(hStdout, &handleMode))
+        {
+            handleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            SetConsoleMode(hStdout, handleMode);
+        }
+
+        enabled = true;
+    }
+}


### PR DESCRIPTION
Colored output by `yarp::os::Log`'s utilities is achieved via setting the `YARP_COLORED_OUTPUT` environment variable on UNIX systems. This patch enables said feature for the Windows 10 console.

Tested on 17134 (1803). Should work since 10586 (1511), although code authors were forced to enable colors programatically from 14393 (1607) onwards according to https://github.com/symfony/symfony/issues/19520#issuecomment-238815318.

Adapted from RL/UC3M code, see https://github.com/roboticslab-uc3m/color-debug/issues/5 for full rationale.

Sample test code:

```c++
cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
project(yarp-logger-test LANGUAGES CXX)
find_package(YARP 3.1 REQUIRED COMPONENTS OS)
file(WRITE ${CMAKE_BINARY_DIR}/main.cpp
"
	#include <yarp/os/LogStream.h>
	int main()
	{
		yTrace() << \"yTrace()\";
		yInfo() << \"yInfo()\";
		yDebug() << \"yDebug()\";
		yWarning() << \"yWarning()\";
		yError() << \"yError()\";
		return 0;
	}
")
add_executable(${PROJECT_NAME} ${CMAKE_BINARY_DIR}/main.cpp)
target_link_libraries(${PROJECT_NAME} PRIVATE YARP::YARP_OS)
```

Output:

![logger](https://user-images.githubusercontent.com/9977198/62734396-41b02880-ba29-11e9-9523-517e76e1b2dd.png)
