### PR TITLE
yarp::os::Property: Small Refactor

### DIFF
--- a/doc/release/devel/Property_refactor.md
+++ b/doc/release/devel/Property_refactor.md
@@ -1,0 +1,9 @@
+Property_refactor {#devel}
+-----------------
+
+### os
+
+#### `Property`
+
+* The `yarp::os::Property` constructor using 'hash_size' was deprecated (it was
+  already unused since the internal structure was ported to use std::map).

--- a/doc/release/devel/Property_refactor.md
+++ b/doc/release/devel/Property_refactor.md
@@ -3,7 +3,13 @@ Property_refactor {#devel}
 
 ### os
 
+#### `Searchable`
+
+* Added move constructor and assignment operator.
+
+
 #### `Property`
 
+* Added move constructor and assignment operator.
 * The `yarp::os::Property` constructor using 'hash_size' was deprecated (it was
   already unused since the internal structure was ported to use std::map).

--- a/src/libYARP_OS/include/yarp/os/Property.h
+++ b/src/libYARP_OS/include/yarp/os/Property.h
@@ -41,13 +41,23 @@ public:
 
     /**
      * Constructor.
+     */
+    Property();
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+    /**
+     * Constructor.
      *
      * @param hash_size a scalar controlling efficiency of the
      * hash map storing the data.  Set to 0 for default size.
      * The bigger this number, the more memory used, but the
      * more efficient the map.
+     *
+     * @deprecated Since YARP 3.3
      */
-    Property(int hash_size = 0);
+    YARP_DEPRECATED_MSG("Use default constructor instead")
+    Property(int hash_size);
+#endif
 
     /**
      * Initialize from a string, using fromString().
@@ -61,6 +71,11 @@ public:
     Property(const Property& rhs);
 
     /**
+     * Move constructor
+     */
+    Property(Property&& rhs) noexcept;
+
+    /**
      * @brief Initializer list constructor.
      * @param[in] values, list of std::pair with which initialize the Property.
      */
@@ -68,12 +83,17 @@ public:
     /**
      * Destructor.
      */
-    virtual ~Property();
+    ~Property() override;
 
     /**
-     * Assignment operator.
+     * Copy assignment operator.
      */
-    const Property& operator=(const Property& prop);
+    Property& operator=(const Property& prop);
+
+    /**
+     * Move assignment operator.
+     */
+    Property& operator=(Property&& prop) noexcept;
 
     // documented in Searchable
     bool check(const std::string& key) const override;
@@ -432,12 +452,6 @@ public:
 
     // documented in Portable
     bool write(ConnectionWriter& writer) const override;
-
-private:
-    int hash_size;
-
-    void summon();
-    bool check() const;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:

--- a/src/libYARP_OS/include/yarp/os/Searchable.h
+++ b/src/libYARP_OS/include/yarp/os/Searchable.h
@@ -78,9 +78,29 @@ public:
     explicit Searchable();
 
     /**
+     * Copy constructor
+     */
+    Searchable(const Searchable& rhs) = default;
+
+    /**
+     * Move constructor
+     */
+    Searchable(Searchable&& rhs) noexcept = default;
+
+    /**
      * Destructor.
      */
     virtual ~Searchable();
+
+    /**
+     * Copy assignment operator.
+     */
+    Searchable& operator=(const Searchable& rhs) = default;
+
+    /**
+     * Move assignment operator.
+     */
+    Searchable& operator=(Searchable&& rhs) noexcept = default;
 
     /**
      * Check if there exists a property of the given name

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -173,7 +173,6 @@ public:
 
     Value& get(const std::string& key) const
     {
-        std::string out;
         PropertyItem* p = getPropNoCreate(key);
         if (p != nullptr) {
             p->flush();

--- a/src/libYARP_OS/src/Property.cpp
+++ b/src/libYARP_OS/src/Property.cpp
@@ -558,14 +558,11 @@ public:
                                 if (bot.get(0).toString() == "include") {
                                     including = true;
                                     // close an open group if an [include something] tag is found
-                                    if (bot.size() > 1) {
-                                        if (!tag.empty()) {
-                                            if (accum.size() >= 1) {
-                                                putBottleCompat(tag.c_str(),
-                                                                accum);
-                                            }
-                                            tag = "";
+                                    if (!tag.empty()) {
+                                        if (accum.size() >= 1) {
+                                            putBottleCompat(tag.c_str(), accum);
                                         }
+                                        tag = "";
                                     }
                                     if (bot.size() > 2) {
                                         std::string subName;


### PR DESCRIPTION
#### `Searchable`

* Added move constructor and assignment operator.


#### `Property`

* Minor refactor (always allocate the pimpl member, instead of calling 'summon()' everywhere). this will have a minor impact when creating an empty property that is never "summoned" (if that ever happened), but a tiny speedup (a function call and an if) whenever the property is used.
* Added move constructor and assignment operator.
* :warning: The `yarp::os::Property` constructor using `hash_size` was deprecated (it was
  already unused since the internal structure was ported to use `std::map`).