### PR TITLE
Deprecate yarp::os::Mutex in favour of std::mutex

### DIFF
--- a/doc/release/devel/TimerMutex.md
+++ b/doc/release/devel/TimerMutex.md
@@ -1,0 +1,8 @@
+setCallBackLock {#devel}
+---------------
+
+### os
+
+#### `Timer`
+
+* Added constructors that accept `std::mutex` instead of `yarp::os::Mutex`

--- a/doc/release/devel/deprecate_Mutex.md
+++ b/doc/release/devel/deprecate_Mutex.md
@@ -1,0 +1,19 @@
+deprecate_Mutex {devel}
+---------------
+
+### os
+
+* All `yarp::os::Mutex` related classes and methods are now deprecated in favour
+  of `std::mutex`:
+  * Classes:
+    * `yarp::os::Mutex`
+    * `yarp::os::RecursiveMutex`
+    * `yarp::os::AbstractLockGuard`
+    * `yarp::os::LockGuard`
+    * `yarp::os::RecursiveLockGuard`
+  * Methods:
+    * `yarp::os::Contactable::setCallbackLock(yarp::os::Mutex*)`
+    * `yarp::os::AbstractContactable::setCallbackLock(yarp::os::Mutex*)`
+    * `yarp::os::Port::setCallbackLock(yarp::os::Mutex*)`
+    * `yarp::os::Buffered::setCallbackLock(yarp::os::Mutex*)`
+    * `yarp::os::Timer::Timer(..., yarp::os::Mutex*)`

--- a/doc/release/devel/setCallBackLock.md
+++ b/doc/release/devel/setCallBackLock.md
@@ -1,0 +1,9 @@
+setCallBackLock {#devel}
+---------------
+
+### os
+
+#### `Contactable`, `AbstractContactable` `Port`, `BufferedPort`
+
+* Added `setCallbackLock` overrides to pass a `std::mutex` instead of a
+`yarp::os::Mutex`

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -37,7 +37,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/InputProtocol.h
                  include/yarp/os/InputStream.h
                  include/yarp/os/LocalReader.h
-                 include/yarp/os/LockGuard.h
                  include/yarp/os/Log.h
                  include/yarp/os/LogStream.h
                  include/yarp/os/ManagedBytes.h
@@ -45,7 +44,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/ModifyingCarrier.h
                  include/yarp/os/MonitorObject.h
                  include/yarp/os/MultiNameSpace.h
-                 include/yarp/os/Mutex.h
                  include/yarp/os/Name.h
                  include/yarp/os/NameSpace.h
                  include/yarp/os/NameStore.h
@@ -90,7 +88,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Property.h
                  include/yarp/os/Publisher.h
                  include/yarp/os/Random.h
-                 include/yarp/os/RecursiveMutex.h
                  include/yarp/os/ResourceFinder.h
                  include/yarp/os/ResourceFinderOptions.h
                  include/yarp/os/RFModule.h
@@ -343,15 +340,18 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/WireWriter.cpp
                  src/QosStyle.cpp)
 
-if(NOT YARP_NO_DEPRECATED) # Since YARP 3.0.0
-  list(APPEND YARP_OS_HDRS include/yarp/os/ConstString.h
-                           include/yarp/os/RateThread.h
-                           include/yarp/os/Runnable.h)
+if(NOT YARP_NO_DEPRECATED)
+  list(APPEND YARP_OS_HDRS include/yarp/os/ConstString.h      # DEPRECATED since YARP 3.0.0
+                           include/yarp/os/LockGuard.h        # DEPRECATED since YARP 3.3.0
+                           include/yarp/os/Mutex.h            # DEPRECATED since YARP 3.3.0
+                           include/yarp/os/RateThread.h       # DEPRECATED since YARP 3.3.0
+                           include/yarp/os/RecursiveMutex.h   # DEPRECATED since YARP 3.3.0
+                           include/yarp/os/Runnable.h)        # DEPRECATED since YARP 3.3.0
 
-  list(APPEND YARP_OS_SRCS src/Mutex.cpp
-                           src/RateThread.cpp
-                           src/RecursiveMutex.cpp
-                           src/Runnable.cpp)
+  list(APPEND YARP_OS_SRCS src/Mutex.cpp                      # DEPRECATED since YARP 3.3.0
+                           src/RateThread.cpp                 # DEPRECATED since YARP 3.3.0
+                           src/RecursiveMutex.cpp             # DEPRECATED since YARP 3.3.0
+                           src/Runnable.cpp)                  # DEPRECATED since YARP 3.3.0
 endif()
 
 

--- a/src/libYARP_OS/include/yarp/os/AbstractContactable.h
+++ b/src/libYARP_OS/include/yarp/os/AbstractContactable.h
@@ -140,8 +140,14 @@ public:
     // Documented in Contactable
     void includeNodeInName(bool flag) override;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
+    YARP_DEPRECATED_MSG("Use setCallbackLock with std::mutex instead")
     bool setCallbackLock(yarp::os::Mutex* mutex) override;
+YARP_WARNING_POP
+#endif
 
     // Documented in Contactable
     bool setCallbackLock(std::mutex* mutex = nullptr) override;

--- a/src/libYARP_OS/include/yarp/os/AbstractContactable.h
+++ b/src/libYARP_OS/include/yarp/os/AbstractContactable.h
@@ -141,7 +141,10 @@ public:
     void includeNodeInName(bool flag) override;
 
     // Documented in Contactable
-    bool setCallbackLock(yarp::os::Mutex* mutex = nullptr) override;
+    bool setCallbackLock(yarp::os::Mutex* mutex) override;
+
+    // Documented in Contactable
+    bool setCallbackLock(std::mutex* mutex = nullptr) override;
 
     // Documented in Contactable
     bool removeCallbackLock() override;

--- a/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
@@ -345,11 +345,16 @@ void yarp::os::BufferedPort<T>::includeNodeInName(bool flag)
     return port.includeNodeInName(flag);
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 template <typename T>
 bool yarp::os::BufferedPort<T>::setCallbackLock(yarp::os::Mutex* mutex)
 {
     return port.setCallbackLock(mutex);
 }
+YARP_WARNING_POP
+#endif
 
 template <typename T>
 bool yarp::os::BufferedPort<T>::setCallbackLock(std::mutex* mutex)

--- a/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort-inl.h
@@ -352,6 +352,12 @@ bool yarp::os::BufferedPort<T>::setCallbackLock(yarp::os::Mutex* mutex)
 }
 
 template <typename T>
+bool yarp::os::BufferedPort<T>::setCallbackLock(std::mutex* mutex)
+{
+    return port.setCallbackLock(mutex);
+}
+
+template <typename T>
 bool yarp::os::BufferedPort<T>::removeCallbackLock()
 {
     return port.removeCallbackLock();

--- a/src/libYARP_OS/include/yarp/os/BufferedPort.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort.h
@@ -286,6 +286,9 @@ public:
     bool setCallbackLock(yarp::os::Mutex* mutex) override;
 
     // documented in Contactable
+    bool setCallbackLock(std::mutex* mutex) override;
+
+    // documented in Contactable
     bool removeCallbackLock() override;
 
     // documented in Contactable

--- a/src/libYARP_OS/include/yarp/os/BufferedPort.h
+++ b/src/libYARP_OS/include/yarp/os/BufferedPort.h
@@ -282,8 +282,14 @@ public:
     // documented in Contactable
     void includeNodeInName(bool flag) override;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // documented in Contactable
+    YARP_DEPRECATED_MSG("Use setCallbackLock with std::mutex instead")
     bool setCallbackLock(yarp::os::Mutex* mutex) override;
+YARP_WARNING_POP
+#endif
 
     // documented in Contactable
     bool setCallbackLock(std::mutex* mutex) override;

--- a/src/libYARP_OS/include/yarp/os/Contactable.h
+++ b/src/libYARP_OS/include/yarp/os/Contactable.h
@@ -11,10 +11,15 @@
 #define YARP_OS_CONTACTABLE_H
 
 #include <yarp/os/Contact.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/PortReport.h>
 #include <yarp/os/PortWriter.h>
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#  include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif
 
 #include <mutex>
 
@@ -313,6 +318,9 @@ public:
      */
     void setRpcClient();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     /**
      * Add a lock to use when invoking callbacks.
      *
@@ -323,8 +331,13 @@ public:
      *
      * @param mutex the lock to use. If nullptr, a mutex will be allocated
      * internally by the port, and destroyed with the port.
+     *
+     * @deprecated since YARP 3.3
      */
+    YARP_DEPRECATED_MSG("Use setCallbackLock with std::mutex instead")
     virtual bool setCallbackLock(yarp::os::Mutex* mutex) = 0;
+YARP_WARNING_POP
+#endif
 
     /**
      * Add a lock to use when invoking callbacks.

--- a/src/libYARP_OS/include/yarp/os/Contactable.h
+++ b/src/libYARP_OS/include/yarp/os/Contactable.h
@@ -16,6 +16,8 @@
 #include <yarp/os/PortReport.h>
 #include <yarp/os/PortWriter.h>
 
+#include <mutex>
+
 // Forward declarations:
 namespace yarp {
 namespace os {
@@ -322,7 +324,20 @@ public:
      * @param mutex the lock to use. If nullptr, a mutex will be allocated
      * internally by the port, and destroyed with the port.
      */
-    virtual bool setCallbackLock(yarp::os::Mutex* mutex = nullptr) = 0;
+    virtual bool setCallbackLock(yarp::os::Mutex* mutex) = 0;
+
+    /**
+     * Add a lock to use when invoking callbacks.
+     *
+     * mutex.lock() will be called before and mutex.unlock() will be called
+     * after the callback.
+     * This applies at least to callbacks set by setReader and setAdminReader,
+     * and in future may apply to other callbacks.
+     *
+     * @param mutex the lock to use. If nullptr, a mutex will be allocated
+     * internally by the port, and destroyed with the port.
+     */
+    virtual bool setCallbackLock(std::mutex* mutex = nullptr) = 0;
 
     /**
      * Remove a lock on callbacks added with setCallbackLock()

--- a/src/libYARP_OS/include/yarp/os/LockGuard.h
+++ b/src/libYARP_OS/include/yarp/os/LockGuard.h
@@ -9,14 +9,22 @@
 #ifndef YARP_OS_LOCKGUARD_H
 #define YARP_OS_LOCKGUARD_H
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-#    include <yarp/os/api.h>
-#else // YARP_NO_DEPRECATED
-#    include <mutex>
-#endif // YARP_NO_DEPRECATED
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/os/LockGuard.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+
+#include <yarp/os/api.h>
+#include <mutex>
 
 namespace yarp {
 namespace os {
+
+class Mutex;
+class RecursiveMutex;
 
 /**
  * This class is a mutex wrapper that provides a convenient RAII-style mechanism for owning
@@ -25,9 +33,11 @@ namespace os {
  * When control leaves the scope in which the LockGuard object was created,
  * the LockGuard is destructed and the mutex is released.
  * The lock_guard class is non-copyable.
+ *
+ * @deprecated since YARP 3.3
  */
 template <typename Lockable>
-class AbstractLockGuard
+class YARP_DEPRECATED_MSG("Use std::lock_guard or std::scoped_lock instead") AbstractLockGuard
 {
 public:
     /**
@@ -52,8 +62,11 @@ private:
     Lockable& lock; /*!< underlining mutex */
 };
 
-
 // Implementation
+
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+
 template <typename Lockable>
 yarp::os::AbstractLockGuard<Lockable>::AbstractLockGuard(Lockable& _lock) :
         lock(_lock)
@@ -79,20 +92,14 @@ yarp::os::AbstractLockGuard<Lockable>& yarp::os::AbstractLockGuard<Lockable>::op
     return *this;
 }
 
+YARP_DEPRECATED_TYPEDEF_MSG("use std::lock_guard or std::scoped_lock instead") AbstractLockGuard<Mutex> LockGuard;
+YARP_DEPRECATED_TYPEDEF_MSG("use std::lock_guard or std::scoped_lock instead") AbstractLockGuard<RecursiveMutex> RecursiveLockGuard;
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-class Mutex;
-class RecursiveMutex;
-#else
-using Mutex = std::mutex;
-using RecursiveMutex = std::recursive_mutex;
-#endif
-
-typedef AbstractLockGuard<Mutex> LockGuard;
-typedef AbstractLockGuard<RecursiveMutex> RecursiveLockGuard;
-
+YARP_WARNING_POP
 
 } // namespace os
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_LOCKGUARD_H

--- a/src/libYARP_OS/include/yarp/os/Mutex.h
+++ b/src/libYARP_OS/include/yarp/os/Mutex.h
@@ -9,23 +9,29 @@
 #ifndef YARP_OS_MUTEX_H
 #define YARP_OS_MUTEX_H
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-#    include <yarp/os/api.h>
-#else // YARP_NO_DEPRECATED
-#    include <mutex>
-#endif // YARP_NO_DEPRECATED
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/os/Mutex.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+
+#include <yarp/os/api.h>
+#include <mutex>
 
 namespace yarp {
 namespace os {
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 /**
  * Basic wrapper for mutual exclusion.
  *
  * Intended to match std::mutex in C++11, for eventual replacement by that
  * class.
+ *
+ * @deprecated since YARP 3.3. Use \c std::mutex instead.
  */
-class YARP_OS_API Mutex
+class YARP_OS_DEPRECATED_API_MSG("Use std::mutex instead") Mutex
 {
 public:
     /**
@@ -80,13 +86,9 @@ private:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
-#else
-
-using Mutex = std::mutex;
-
-#endif // YARP_NO_DEPRECATED
-
 } // namespace os
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_MUTEX_H

--- a/src/libYARP_OS/include/yarp/os/Port.h
+++ b/src/libYARP_OS/include/yarp/os/Port.h
@@ -240,8 +240,14 @@ public:
      */
     bool isOpen() const;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     // Documented in Contactable
+    YARP_DEPRECATED_MSG("Use setCallbackLock with std::mutex instead")
     bool setCallbackLock(yarp::os::Mutex* mutex) override;
+YARP_WARNING_POP
+#endif
 
     // Documented in Contactable
     bool setCallbackLock(std::mutex* mutex = nullptr) override;

--- a/src/libYARP_OS/include/yarp/os/Port.h
+++ b/src/libYARP_OS/include/yarp/os/Port.h
@@ -241,7 +241,10 @@ public:
     bool isOpen() const;
 
     // Documented in Contactable
-    bool setCallbackLock(yarp::os::Mutex* mutex = nullptr) override;
+    bool setCallbackLock(yarp::os::Mutex* mutex) override;
+
+    // Documented in Contactable
+    bool setCallbackLock(std::mutex* mutex = nullptr) override;
 
     // Documented in Contactable
     bool removeCallbackLock() override;

--- a/src/libYARP_OS/include/yarp/os/RecursiveMutex.h
+++ b/src/libYARP_OS/include/yarp/os/RecursiveMutex.h
@@ -9,16 +9,20 @@
 #ifndef YARP_OS_RECURSIVELOCK_H
 #define YARP_OS_RECURSIVELOCK_H
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-#    include <yarp/os/api.h>
-#else // YARP_NO_DEPRECATED
-#    include <mutex>
-#endif // YARP_NO_DEPRECATED
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/os/RecursiveMutex.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+
+#include <yarp/os/api.h>
+#include <mutex>
 
 namespace yarp {
 namespace os {
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 /**
  * RecursiveMutex offers exclusive, recursive ownership semantics:
  *   - A calling thread owns a RecursiveMutex for a period of time that starts
@@ -33,8 +37,10 @@ namespace os {
  * still owned by some thread.
  * The behavior of a program is undefined if a RecursiveMutex is unlocked by a
  * thread which is not currently owning the RecursiveMutex
+ *
+ * @deprecated since YARP 3.3. Use \c std::recursive_mutex instead.
  */
-class YARP_OS_API RecursiveMutex
+class YARP_OS_DEPRECATED_API_MSG("Use std::recursive_mutex instead") RecursiveMutex
 {
 public:
     /**
@@ -81,7 +87,7 @@ public:
      * @return true if the associated resource was successfully locked. False
      *         otherwise
      *
-     * @deprecated since YARP 3.0.0. Use try_lock() instead.
+     * @deprecated since YARP 3.0.0. Use \c try_lock() instead.
      */
     YARP_DEPRECATED_MSG("Use try_lock() instead")
     bool tryLock();
@@ -93,13 +99,9 @@ private:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
-#else // YARP_NO_DEPRECATED
-
-using RecursiveMutex = std::recursive_mutex;
-
-#endif // YARP_NO_DEPRECATED
-
 } // namespace os
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_RECURSIVELOCK_H

--- a/src/libYARP_OS/include/yarp/os/Timer.h
+++ b/src/libYARP_OS/include/yarp/os/Timer.h
@@ -11,7 +11,11 @@
 
 #include <yarp/os/api.h>
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif
 
 #include <functional>
 #include <mutex>
@@ -106,6 +110,9 @@ public:
     Timer(const Timer&) = delete;
     Timer operator=(const Timer&) = delete;
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     /**
      * @brief Timer constructor
      * @param settings the timer settings. see TimerSettings documentation
@@ -117,6 +124,7 @@ public:
      * @param newThread whether the timer should be executed in a dedicated thread
      *        or with all the timers with newThread == false (in any case they
      *        will not run in the main thread)
+     * @deprecated since YARP 3.3
      */
     Timer(const yarp::os::TimerSettings& settings,
           const TimerCallback& callback,
@@ -133,6 +141,7 @@ public:
      * @param newThread whether the timer should be executed in a his own thread
      *        or with all the timers with newThread == false (in any case they
      *        will not run in the main thread)
+     * @deprecated since YARP 3.3
      */
     template <class T>
     Timer(const yarp::os::TimerSettings& settings,
@@ -147,6 +156,7 @@ public:
 
     /**
      * const version.
+     * @deprecated since YARP 3.3
      */
     template <class T>
     Timer(const yarp::os::TimerSettings& settings,
@@ -158,6 +168,8 @@ public:
             Timer(settings, std::bind(callback, object, std::placeholders::_1), newThread, mutex)
     {
     }
+YARP_WARNING_POP
+#endif
 
     /**
      * @brief Timer constructor

--- a/src/libYARP_OS/include/yarp/os/all.h
+++ b/src/libYARP_OS/include/yarp/os/all.h
@@ -22,11 +22,9 @@
 #include <yarp/os/Contactable.h>
 #include <yarp/os/DummyConnector.h>
 #include <yarp/os/Event.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/MessageStack.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/os/NetFloat32.h>
 #include <yarp/os/NetFloat64.h>
 #include <yarp/os/NetInt16.h>
@@ -55,7 +53,6 @@
 #include <yarp/os/Publisher.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Random.h>
-#include <yarp/os/RecursiveMutex.h>
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/Searchable.h>
@@ -73,10 +70,15 @@
 #include <yarp/os/Wire.h>
 #include <yarp/os/WireLink.h>
 
-#ifndef YARP_NO_DEPRECATED // since YARP 3.0.0
+#ifndef YARP_NO_DEPRECATED
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+     // since YARP 3.0.0
 #    include <yarp/os/ConstString.h>
 #    include <yarp/os/RateThread.h>
+     // since YARP 3.3
+#    include <yarp/os/LockGuard.h>
+#    include <yarp/os/Mutex.h>
+#    include <yarp/os/RecursiveMutex.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif // YARP_NO_DEPRECATED
 

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -483,7 +483,9 @@ public:
     Property* acquireProperties(bool readOnly);
     void releaseProperties(Property* prop);
 
-    bool setCallbackLock(yarp::os::Mutex* mutex = nullptr);
+    bool setCallbackLock(yarp::os::Mutex* mutex);
+
+    bool setCallbackLock(std::mutex* mutex = nullptr);
 
     bool removeCallbackLock();
 
@@ -541,7 +543,8 @@ private:
     int m_counter;    ///< port-unique ids for connections
     yarp::os::Property *m_prop;  ///< optional unstructured properties associated with port
     yarp::os::Contactable *m_contactable;  ///< user-facing object that contains this PortCore
-    yarp::os::Mutex *m_mutex; ///< callback optional access control lock
+    std::mutex* m_mutex;        ///< callback optional access control lock
+    yarp::os::Mutex* m_old_mutex;
     bool m_mutexOwned;        ///< do we own the optional callback lock
     BufferedConnectionWriter m_envelopeWriter; ///< storage area for envelope, if present
 

--- a/src/libYARP_OS/include/yarp/os/impl/PortCore.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCore.h
@@ -14,7 +14,6 @@
 #include <yarp/os/Contact.h>
 #include <yarp/os/Contactable.h>
 #include <yarp/os/ModifyingCarrier.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/PortReaderCreator.h>
 #include <yarp/os/PortReport.h>
@@ -26,6 +25,12 @@
 #include <yarp/os/impl/BufferedConnectionWriter.h>
 #include <yarp/os/impl/PortCorePackets.h>
 #include <yarp/os/impl/ThreadImpl.h>
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif
 
 #include <mutex>
 #include <vector>
@@ -483,7 +488,12 @@ public:
     Property* acquireProperties(bool readOnly);
     void releaseProperties(Property* prop);
 
-    bool setCallbackLock(yarp::os::Mutex* mutex);
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+    bool YARP_DEPRECATED setCallbackLock(yarp::os::Mutex* mutex);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     bool setCallbackLock(std::mutex* mutex = nullptr);
 
@@ -544,7 +554,12 @@ private:
     yarp::os::Property *m_prop;  ///< optional unstructured properties associated with port
     yarp::os::Contactable *m_contactable;  ///< user-facing object that contains this PortCore
     std::mutex* m_mutex;        ///< callback optional access control lock
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     yarp::os::Mutex* m_old_mutex;
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
     bool m_mutexOwned;        ///< do we own the optional callback lock
     BufferedConnectionWriter m_envelopeWriter; ///< storage area for envelope, if present
 

--- a/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
@@ -10,10 +10,15 @@
 #ifndef YARP_OS_IMPL_PORTCOREADAPTER_H
 #define YARP_OS_IMPL_PORTCOREADAPTER_H
 
-#include <yarp/os/Mutex.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/impl/PortCore.h>
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
 
 #include <mutex>
 
@@ -55,7 +60,12 @@ public:
     bool commitToRpc;
     bool active;
     std::mutex* recCallbackLock;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     yarp::os::Mutex* old_recCallbackLock;
+YARP_WARNING_POP
+#endif
     bool haveCallbackLock;
 
     PortCoreAdapter(Port& owner);
@@ -76,7 +86,12 @@ public:
     void configAdminReader(PortReader& reader);
     void configReadCreator(PortReaderCreator& creator);
     void configWaitAfterSend(bool waitAfterSend);
-    bool configCallbackLock(Mutex* lock);
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+    bool YARP_DEPRECATED configCallbackLock(Mutex* lock);
+YARP_WARNING_POP
+#endif
     bool configCallbackLock(std::mutex* lock);
     bool unconfigCallbackLock();
     PortReader* checkPortReader();

--- a/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
+++ b/src/libYARP_OS/include/yarp/os/impl/PortCoreAdapter.h
@@ -54,7 +54,8 @@ public:
     bool commitToWrite;
     bool commitToRpc;
     bool active;
-    Mutex* recCallbackLock;
+    std::mutex* recCallbackLock;
+    yarp::os::Mutex* old_recCallbackLock;
     bool haveCallbackLock;
 
     PortCoreAdapter(Port& owner);
@@ -76,6 +77,7 @@ public:
     void configReadCreator(PortReaderCreator& creator);
     void configWaitAfterSend(bool waitAfterSend);
     bool configCallbackLock(Mutex* lock);
+    bool configCallbackLock(std::mutex* lock);
     bool unconfigCallbackLock();
     PortReader* checkPortReader();
     PortReader* checkAdminPortReader();

--- a/src/libYARP_OS/src/AbstractContactable.cpp
+++ b/src/libYARP_OS/src/AbstractContactable.cpp
@@ -185,6 +185,11 @@ bool yarp::os::AbstractContactable::setCallbackLock(yarp::os::Mutex* mutex)
     return asPort().setCallbackLock(mutex);
 }
 
+bool yarp::os::AbstractContactable::setCallbackLock(std::mutex* mutex)
+{
+    return asPort().setCallbackLock(mutex);
+}
+
 bool yarp::os::AbstractContactable::removeCallbackLock()
 {
     return asPort().removeCallbackLock();

--- a/src/libYARP_OS/src/AbstractContactable.cpp
+++ b/src/libYARP_OS/src/AbstractContactable.cpp
@@ -180,10 +180,15 @@ void yarp::os::AbstractContactable::includeNodeInName(bool flag)
     asPort().includeNodeInName(flag);
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool yarp::os::AbstractContactable::setCallbackLock(yarp::os::Mutex* mutex)
 {
     return asPort().setCallbackLock(mutex);
 }
+YARP_WARNING_POP
+#endif
 
 bool yarp::os::AbstractContactable::setCallbackLock(std::mutex* mutex)
 {

--- a/src/libYARP_OS/src/Mutex.cpp
+++ b/src/libYARP_OS/src/Mutex.cpp
@@ -6,7 +6,12 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/Mutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 
 #include <mutex>
 
@@ -41,9 +46,9 @@ void Mutex::unlock()
     mPriv->unlock();
 }
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 bool Mutex::tryLock()
 {
     return mPriv->try_lock();
 }
-#endif // YARP_NO_DEPRECATED
+
+YARP_WARNING_POP

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -673,6 +673,11 @@ bool Port::setCallbackLock(yarp::os::Mutex* mutex)
     return IMPL().configCallbackLock(mutex);
 }
 
+bool Port::setCallbackLock(std::mutex* mutex)
+{
+    return IMPL().configCallbackLock(mutex);
+}
+
 bool Port::removeCallbackLock()
 {
     return IMPL().unconfigCallbackLock();

--- a/src/libYARP_OS/src/Port.cpp
+++ b/src/libYARP_OS/src/Port.cpp
@@ -668,10 +668,15 @@ bool Port::isOpen() const
     return IMPL().active;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool Port::setCallbackLock(yarp::os::Mutex* mutex)
 {
     return IMPL().configCallbackLock(mutex);
 }
+YARP_WARNING_POP
+#endif
 
 bool Port::setCallbackLock(std::mutex* mutex)
 {

--- a/src/libYARP_OS/src/PortCore.cpp
+++ b/src/libYARP_OS/src/PortCore.cpp
@@ -91,7 +91,9 @@ PortCore::PortCore() :
         m_prop(nullptr),
         m_contactable(nullptr),
         m_mutex(nullptr),
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
         m_old_mutex(nullptr),
+#endif // YARP_NO_DEPRECATED
         m_mutexOwned(false),
         m_envelopeWriter(true),
         m_typeMutex(),
@@ -2897,6 +2899,9 @@ int PortCore::getVerbosity()
     return m_verbosity;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool PortCore::setCallbackLock(yarp::os::Mutex* mutex)
 {
     removeCallbackLock();
@@ -2909,6 +2914,8 @@ bool PortCore::setCallbackLock(yarp::os::Mutex* mutex)
     }
     return true;
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 bool PortCore::setCallbackLock(std::mutex* mutex)
 {
@@ -2929,7 +2936,9 @@ bool PortCore::removeCallbackLock()
         delete m_mutex;
     }
     m_mutex = nullptr;
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
     m_old_mutex = nullptr;
+#endif // YARP_NO_DEPRECATED
     m_mutexOwned = false;
     return true;
 }
@@ -2937,11 +2946,15 @@ bool PortCore::removeCallbackLock()
 bool PortCore::lockCallback()
 {
     if (m_mutex == nullptr) {
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
         if (m_old_mutex == nullptr) {
             return false;
         }
         m_old_mutex->lock();
         return true;
+#else // YARP_NO_DEPRECATED
+        return false;
+#endif // YARP_NO_DEPRECATED
     }
     m_mutex->lock();
     return true;
@@ -2950,10 +2963,14 @@ bool PortCore::lockCallback()
 bool PortCore::tryLockCallback()
 {
     if (m_mutex == nullptr) {
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
         if (m_old_mutex == nullptr) {
             return true;
         }
         return m_old_mutex->try_lock();
+#else // YARP_NO_DEPRECATED
+        return true;
+#endif // YARP_NO_DEPRECATED
     }
     return m_mutex->try_lock();
 }
@@ -2961,10 +2978,14 @@ bool PortCore::tryLockCallback()
 void PortCore::unlockCallback()
 {
     if (m_mutex == nullptr) {
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
         if (m_old_mutex == nullptr) {
             return;
         }
         return m_old_mutex->unlock();
+#else // YARP_NO_DEPRECATED
+        return;
+#endif // YARP_NO_DEPRECATED
     }
     m_mutex->unlock();
 }

--- a/src/libYARP_OS/src/PortCoreAdapter.cpp
+++ b/src/libYARP_OS/src/PortCoreAdapter.cpp
@@ -38,6 +38,7 @@ yarp::os::impl::PortCoreAdapter::PortCoreAdapter(Port& owner) :
         commitToRpc(false),
         active(false),
         recCallbackLock(nullptr),
+        old_recCallbackLock(nullptr),
         haveCallbackLock(false)
 {
     setContactable(&owner);
@@ -290,7 +291,16 @@ void yarp::os::impl::PortCoreAdapter::configWaitAfterSend(bool waitAfterSend)
 
 bool yarp::os::impl::PortCoreAdapter::configCallbackLock(Mutex* lock)
 {
+    recCallbackLock = nullptr;
+    old_recCallbackLock = lock;
+    haveCallbackLock = true;
+    return setCallbackLock(lock);
+}
+
+bool yarp::os::impl::PortCoreAdapter::configCallbackLock(std::mutex* lock)
+{
     recCallbackLock = lock;
+    old_recCallbackLock = nullptr;
     haveCallbackLock = true;
     return setCallbackLock(lock);
 }
@@ -298,6 +308,7 @@ bool yarp::os::impl::PortCoreAdapter::configCallbackLock(Mutex* lock)
 bool yarp::os::impl::PortCoreAdapter::unconfigCallbackLock()
 {
     recCallbackLock = nullptr;
+    old_recCallbackLock = nullptr;
     haveCallbackLock = false;
     return removeCallbackLock();
 }

--- a/src/libYARP_OS/src/PortCoreAdapter.cpp
+++ b/src/libYARP_OS/src/PortCoreAdapter.cpp
@@ -38,7 +38,9 @@ yarp::os::impl::PortCoreAdapter::PortCoreAdapter(Port& owner) :
         commitToRpc(false),
         active(false),
         recCallbackLock(nullptr),
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5
         old_recCallbackLock(nullptr),
+#endif // YARP_NO_DEPRECATED
         haveCallbackLock(false)
 {
     setContactable(&owner);
@@ -289,6 +291,9 @@ void yarp::os::impl::PortCoreAdapter::configWaitAfterSend(bool waitAfterSend)
     setWaitAfterSend(waitAfterSend);
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 bool yarp::os::impl::PortCoreAdapter::configCallbackLock(Mutex* lock)
 {
     recCallbackLock = nullptr;
@@ -296,11 +301,15 @@ bool yarp::os::impl::PortCoreAdapter::configCallbackLock(Mutex* lock)
     haveCallbackLock = true;
     return setCallbackLock(lock);
 }
+YARP_WARNING_POP
+#endif
 
 bool yarp::os::impl::PortCoreAdapter::configCallbackLock(std::mutex* lock)
 {
     recCallbackLock = lock;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
     old_recCallbackLock = nullptr;
+#endif
     haveCallbackLock = true;
     return setCallbackLock(lock);
 }
@@ -308,7 +317,9 @@ bool yarp::os::impl::PortCoreAdapter::configCallbackLock(std::mutex* lock)
 bool yarp::os::impl::PortCoreAdapter::unconfigCallbackLock()
 {
     recCallbackLock = nullptr;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
     old_recCallbackLock = nullptr;
+#endif
     haveCallbackLock = false;
     return removeCallbackLock();
 }

--- a/src/libYARP_OS/src/RecursiveMutex.cpp
+++ b/src/libYARP_OS/src/RecursiveMutex.cpp
@@ -6,7 +6,9 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/RecursiveMutex.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
 #include <mutex>
 
@@ -43,9 +45,7 @@ void RecursiveMutex::unlock()
     mPriv->mutex.unlock();
 }
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 bool RecursiveMutex::tryLock()
 {
     return mPriv->mutex.try_lock();
 }
-#endif // YARP_NO_DEPRECATED

--- a/src/libYARP_OS/src/Timer.cpp
+++ b/src/libYARP_OS/src/Timer.cpp
@@ -31,6 +31,9 @@ protected:
 public:
     using TimerCallback = yarp::os::Timer::TimerCallback;
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     PrivateImpl(const TimerSettings& sett,
                 TimerCallback call,
                 yarp::os::Mutex* mutex) :
@@ -39,6 +42,8 @@ public:
             m_old_mutex(mutex)
     {
     }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     PrivateImpl(const TimerSettings& sett,
                 TimerCallback call,
@@ -65,16 +70,26 @@ public:
     double m_startStamp{0.0};
     double m_lastReal{0.0};
     std::mutex* m_mutex{nullptr};
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     yarp::os::Mutex* m_old_mutex{nullptr};
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 };
 
 class MonoThreadTimer : public yarp::os::Timer::PrivateImpl
 {
 public:
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     MonoThreadTimer(const TimerSettings& sett,
                     const TimerCallback& call,
                     yarp::os::Mutex* mutex);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     MonoThreadTimer(const TimerSettings& sett,
                     const TimerCallback& call,
@@ -167,6 +182,9 @@ public:
     }
 };
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 MonoThreadTimer::MonoThreadTimer(const TimerSettings& sett,
                                  const TimerCallback& call,
                                  yarp::os::Mutex* mutex) :
@@ -178,6 +196,8 @@ MonoThreadTimer::MonoThreadTimer(const TimerSettings& sett,
         singlInstance.start();
     }
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 MonoThreadTimer::MonoThreadTimer(const TimerSettings& sett,
                                  const TimerCallback& call,
@@ -224,6 +244,9 @@ class ThreadedTimer :
     bool singleStep{false};
 
 public:
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     ThreadedTimer(const TimerSettings& sett,
                   const TimerCallback& call,
                   yarp::os::Mutex* mutex) :
@@ -231,6 +254,8 @@ public:
             PeriodicThread(sett.period)
     {
     }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
     ThreadedTimer(const TimerSettings& sett,
                   const TimerCallback& call,
@@ -275,6 +300,9 @@ bool ThreadedTimer::threadInit()
     return true;
 }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 //the newThread parameter is not in the settings for it to be unmutable and only checked by the constructor
 Timer::Timer(const TimerSettings& settings, const TimerCallback& callback, bool newThread, Mutex* mutex) :
         //added cast for incompatible operand error
@@ -282,6 +310,8 @@ Timer::Timer(const TimerSettings& settings, const TimerCallback& callback, bool 
                        : dynamic_cast<PrivateImpl*>(new MonoThreadTimer(settings, callback, mutex)))
 {
 }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 //the newThread parameter is not in the settings for it to be unmutable and only checked by the constructor
 Timer::Timer(const TimerSettings& settings, const TimerCallback& callback, bool newThread, std::mutex* mutex) :
@@ -326,15 +356,19 @@ bool yarp::os::Timer::PrivateImpl::runTimer(unsigned int iteration, YarpTimerEve
         m_mutex->lock();
     }
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
     if (m_old_mutex != nullptr) {
         m_old_mutex->lock();
     }
+#endif // YARP_NO_DEPRECATED
 
     bool ret = m_callback(event);
 
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
     if (m_old_mutex != nullptr) {
         m_old_mutex->unlock();
     }
+#endif // YARP_NO_DEPRECATED
 
     if (m_mutex != nullptr) {
         m_mutex->unlock();


### PR DESCRIPTION
I'll just leave this here, waiting for a discussion in september, the patch is not just a lot more than just deprecating `yarp::os::Mutex` but the title should be able to catch some people eyes :laughing: 

The first part of the patch aims at supporting `std::mutex` in YARP classes. I see no reason not to have this

* `Contactable`, `AbstractContactable` `Port`, `BufferedPort`: Added `setCallbackLock` overrides to pass a `std::mutex` instead of a `yarp::os::Mutex`
* `Timer`: Added constructors that accept `std::mutex` instead of `yarp::os::Mutex`

The last part deprecates `yarp::os::Mutex` in favour of `std::mutex`. Since the yarp class adds nothing and `std::mutex` is in the standard since 2011, I see no reason to keep having a duplicated YARP class.

* All `yarp::os::Mutex` related classes and methods are now deprecated in favour
  of `std::mutex`:
  * Classes:
    * `yarp::os::Mutex`
    * `yarp::os::RecursiveMutex`
    * `yarp::os::AbstractLockGuard`
    * `yarp::os::LockGuard`
    * `yarp::os::RecursiveLockGuard`
  * Methods:
    * `yarp::os::Contactable::setCallbackLock(yarp::os::Mutex*)`
    * `yarp::os::AbstractContactable::setCallbackLock(yarp::os::Mutex*)`
    * `yarp::os::Port::setCallbackLock(yarp::os::Mutex*)`
    * `yarp::os::Buffered::setCallbackLock(yarp::os::Mutex*)`
    * `yarp::os::Timer::Timer(..., yarp::os::Mutex*)`