### PR TITLE
Deprecate os/{Runnable,RateThreadWrapper}, dev/Data{Source,Writer}{,2}

### DIFF
--- a/doc/cmd_yarpdev.dox
+++ b/doc/cmd_yarpdev.dox
@@ -107,7 +107,7 @@ $ yarpdev --device test_grabber --period 0.5 --width 640 --height 480
 \endverbatim
 was automatically expanded to:
 \verbatim
-$ yarpdev --device grabber --subdevice test_grabber --period 0.5 --width 640 --height 480
+$ yarpdev --device grabberDual --subdevice test_grabber --period 0.5 --width 640 --height 480
 \endverbatim
 
 \section yarpdev_verbose yarpdev --verbose --device DEVICENAME  ...

--- a/doc/device_invocation/grabber_basic.dox
+++ b/doc/device_invocation/grabber_basic.dox
@@ -1,12 +1,12 @@
 /**
  * \ingroup dev_examples
  *
- * \defgroup grabber_basic Example for grabber (grabber_basic)
+ * \defgroup grabber_basic Example for grabberDual (grabber_basic)
 
-Instantiates \ref cmd_device_grabber "grabber" device implemented by ServerFrameGrabber.
+Instantiates \ref cmd_device_grabberDual "grabberDual" device implemented by ServerGrabber.
 \verbatim
 # start up a network wrapper around a test_grabber
-device grabber
+device grabberDual
 subdevice test_grabber
 width 640
 height 480
@@ -34,39 +34,19 @@ So this is just an example
 <table>
 <tr><td>PROPERTY</td><td>DESCRIPTION</td><td>DEFAULT</td></tr>
 <tr><td>device</td><td></td><td></td></tr>
-<tr><td>subdevice</td><td>name (or nested configuration) of device to wrap</td><td></td></tr>
-<tr><td>test_grabber.device</td><td></td><td></td></tr>
-<tr><td>test_grabber.wrapped</td><td></td><td></td></tr>
-<tr><td>test_grabber.width</td><td>desired width of test image</td><td>320</td></tr>
-<tr><td>test_grabber.height</td><td>desired height of test image</td><td>240</td></tr>
-<tr><td>test_grabber.horizontalFov</td><td>desired horizontal fov of test image</td><td>1.0</td></tr>
-<tr><td>test_grabber.verticalFov</td><td>desired vertical fov of test image</td><td>2.0</td></tr>
-<tr><td>test_grabber.mirror</td><td>mirroring disabled by default</td><td>0</td></tr>
-<tr><td>test_grabber.physFocalLength</td><td>Physical focal length of the test_grabber</td><td>3.0</td></tr>
-<tr><td>test_grabber.focalLengthX</td><td>Horizontal component of the focal length of the test_grabber</td><td>4.0</td></tr>
-<tr><td>test_grabber.focalLengthY</td><td>Vertical component of the focal length of the test_grabber</td><td>5.0</td></tr>
-<tr><td>test_grabber.principalPointX</td><td>X coordinate of the principal point of the test_grabber</td><td>6.0</td></tr>
-<tr><td>test_grabber.principalPointY</td><td>Y coordinate of the principal point of the test_grabber</td><td>7.0</td></tr>
-<tr><td>test_grabber.retificationMatrix</td><td>Matrix that describes the lens' distortion(fake)</td><td>1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0</td></tr>
-<tr><td>test_grabber.distortionModel</td><td>Reference to group of parameters describing the distortion model of the camera</td><td>FishEye</td></tr>
-<tr><td>test_grabber.k1</td><td>Radial distortion coefficient of the lens(fake)</td><td>8.0</td></tr>
-<tr><td>test_grabber.k2</td><td>Radial distortion coefficient of the lens(fake)</td><td>9.0</td></tr>
-<tr><td>test_grabber.k3</td><td>Radial distortion coefficient of the lens(fake)</td><td>10.0</td></tr>
-<tr><td>test_grabber.t1</td><td>Tangential distortion of the lens(fake)</td><td>11.0</td></tr>
-<tr><td>test_grabber.t2</td><td>Tangential distortion of the lens(fake)</td><td>12.0</td></tr>
-<tr><td>test_grabber.freq</td><td>rate of test images in Hz</td><td></td></tr>
-<tr><td>test_grabber.period</td><td>period of test images in seconds</td><td></td></tr>
-<tr><td>test_grabber.mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], none [none], time test[time]</td><td>line</td></tr>
-<tr><td>test_grabber.src</td><td></td><td></td></tr>
-<tr><td>test_grabber.bayer</td><td>should emit bayer test image?</td><td></td></tr>
-<tr><td>test_grabber.mono</td><td>should emit a monochrome image?</td><td></td></tr>
+<tr><td>period</td><td>refresh period(in ms) of the broadcasted values through yarp ports</td><td></td></tr>
+<tr><td>subdevice</td><td>name of the subdevice to use as a data source</td><td></td></tr>
+<tr><td>left_config</td><td></td><td></td></tr>
+<tr><td>right_config</td><td></td><td></td></tr>
+<tr><td>twoCameras</td><td>if true ServerGrabber will open and handle two devices, if false only one</td><td></td></tr>
+<tr><td>split</td><td>set 'true' to split the streaming on two different ports</td><td></td></tr>
+<tr><td>capabilities</td><td>two capabilities supported, COLOR and RAW respectively for rgb and raw streaming</td><td></td></tr>
 <tr><td>no_drop</td><td>if present, use strict policy for sending data</td><td></td></tr>
 <tr><td>stamp</td><td>if present, add timestamps to data</td><td></td></tr>
-<tr><td>name</td><td>name of port to send data on</td><td>/grabber</td></tr>
 <tr><td>single_threaded</td><td>if present, operate in single threaded mode</td><td></td></tr>
-<tr><td>framerate</td><td>maximum rate in Hz to read from subdevice</td><td>0</td></tr>
+<tr><td>name</td><td>name of port to send data on</td><td>/grabber</td></tr>
 </table>
 
-\sa ServerFrameGrabber
+\sa ServerGrabber
 
  */

--- a/doc/note_devices.dox
+++ b/doc/note_devices.dox
@@ -315,7 +315,7 @@ we do:
 Once we've reached this point, some fun things become possible.
 For example:
 \code
-  Property config("(device grabber) (subdevice fakey) (w 640) (h 480)");
+  Property config("(device grabberDual) (subdevice fakey) (w 640) (h 480)");
   PolyDriver dd(config);
   ...
 \endcode

--- a/doc/release/devel/deprecate_Runnable.md
+++ b/doc/release/devel/deprecate_Runnable.md
@@ -1,0 +1,6 @@
+deprecate_Runnable {#devel}
+------------------
+
+* Deprecate `os/{Runnable,RateThreadWrapper}`, `dev/Data{Source,Writer}{,2}`.
+  Note: Unfortunately `ServerFrameGrabber` still uses them, at the moment
+  deprecation warnings are disabled for this device.

--- a/example/dev/double_server.cpp
+++ b/example/dev/double_server.cpp
@@ -22,7 +22,7 @@ int main() {
     Network yarp;
 
     Property config;
-    config.fromString("(device grabber) (subdevice ffmpeg_grabber) (name /dev1/image) (name2 /dev1/sound)");
+    config.fromString("(device grabberDual) (subdevice ffmpeg_grabber) (name /dev1/image) (name2 /dev1/sound)");
 
     PolyDriver dd(config);
     if (!dd.isValid()) {
@@ -31,7 +31,7 @@ int main() {
     }
 
     Property config2;
-    config2.fromString("(device grabber) (subdevice ffmpeg_grabber) (name /dev2/image) (name2 /dev2/sound)");
+    config2.fromString("(device grabberDual) (subdevice ffmpeg_grabber) (name /dev2/image) (name2 /dev2/sound)");
 
     PolyDriver dd2(config2);
     if (!dd2.isValid()) {

--- a/example/dev/fake_grabber_net.cpp
+++ b/example/dev/fake_grabber_net.cpp
@@ -23,13 +23,13 @@ int main() {
     // give YARP a factory for creating instances of FakeFrameGrabber
     DriverCreator *fakey_factory = 
         new DriverCreatorOf<FakeFrameGrabber>("fakey",
-                                              "grabber",
+                                              "grabberDual",
                                               "FakeFrameGrabber");
     Drivers::factory().add(fakey_factory); // hand factory over to YARP
 
     // use YARP to create and configure a networked of FakeFrameGrabber
     Property config;
-    config.fromString("(device grabber) (name /fakey) (subdevice fakey) (w 200) (h 200)");
+    config.fromString("(device grabberDual) (name /fakey) (subdevice fakey) (w 200) (h 200)");
     PolyDriver dd(config);
     if (!dd.isValid()) {
         printf("Failed to create and configure a device\n");

--- a/example/dev/fake_grabber_net2.cpp
+++ b/example/dev/fake_grabber_net2.cpp
@@ -23,13 +23,13 @@ int main() {
     // give YARP a factory for creating instances of FakeFrameGrabber
     DriverCreator *fakey_factory = 
         new DriverCreatorOf<FakeFrameGrabber>("fakey",
-                                              "grabber",
+                                              "grabberDual",
                                               "FakeFrameGrabber");
     Drivers::factory().add(fakey_factory); // hand factory over to YARP
 
     // use YARP to create and configure a networked of FakeFrameGrabber
     Property config;
-    config.fromString("(device grabber) (name /fakey) (subdevice fakey) (w 200) (h 200)");
+    config.fromString("(device grabberDual) (name /fakey) (subdevice fakey) (w 200) (h 200)");
     PolyDriver dd(config);
     if (!dd.isValid()) {
         printf("Failed to create and configure a device\n");

--- a/example/dev/file_grabber_net.cpp
+++ b/example/dev/file_grabber_net.cpp
@@ -23,14 +23,14 @@ int main() {
     // give YARP a factory for creating instances of FileFrameGrabber
     DriverCreator *file_grabber_factory = 
         new DriverCreatorOf<FileFrameGrabber>("file_grabber",
-                                              "grabber",
+                                              "grabberDual",
                                               "FileFrameGrabber");
     Drivers::factory().add(file_grabber_factory); // hand factory over to YARP
 
     // use YARP to create and configure a networked of FakeFrameGrabber
     Property config;
     // You may have to tweak the "image" path to match where your executable is
-    config.fromString("(device grabber) (name /file) (subdevice file_grabber) (pattern \"image/img%04d.ppm\") (first 250)");
+    config.fromString("(device grabberDual) (name /file) (subdevice file_grabber) (pattern \"image/img%04d.ppm\") (first 250)");
     PolyDriver dd(config);
     if (!dd.isValid()) {
         printf("Failed to create and configure a device\n");

--- a/example/plugin/userlib/fake_grabber/CMakeLists.txt
+++ b/example/plugin/userlib/fake_grabber/CMakeLists.txt
@@ -17,7 +17,7 @@ yarp_prepare_plugin(fake_grabber
                     CATEGORY device
                     TYPE FakeFrameGrabber
                     INCLUDE FakeFrameGrabber.h
-                    EXTRA_CONFIG WRAPPER=grabber)
+                    EXTRA_CONFIG WRAPPER=grabberDual)
 
 if(NOT SKIP_fake_grabber)
   yarp_add_plugin(fake_grabber FakeFrameGrabber.cpp FakeFrameGrabber.h)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -62,7 +62,6 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(DevicePipe)
   add_subdirectory(ServerSerial)
   add_subdirectory(TestMotor)
-  add_subdirectory(ServerFrameGrabber)
   add_subdirectory(RemoteFrameGrabber)
   add_subdirectory(RemoteControlBoard)
   add_subdirectory(AnalogSensorClient)
@@ -82,6 +81,7 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
 
   add_subdirectory(portaudio) # DEPRECATED Since YARP 3.2
   add_subdirectory(ServerSoundGrabber) # DEPRECATED Since YARP 3.2
+  add_subdirectory(ServerFrameGrabber) # DEPRECATED Since YARP 3.3
 
   # We can also suck in other device libraries built the same way.
   # We seek an ExternalModules.cmake file either in the conf directory

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -24,9 +24,6 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(ffmpeg)
   add_subdirectory(opencv)
   add_subdirectory(serialport)
-  if(NOT YARP_NO_DEPRECATED) # since YARP 3.2.0
-    add_subdirectory(portaudio)
-  endif()
   add_subdirectory(portaudioPlayer)
   add_subdirectory(portaudioRecorder)
   add_subdirectory(imuBosch_BNO055)
@@ -45,9 +42,6 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(batteryWrapper)
   add_subdirectory(Rangefinder2DWrapper)
   add_subdirectory(realsense2)
-  if(NOT YARP_NO_DEPRECATED) # since YARP 3.2.0
-    add_subdirectory(ServerSoundGrabber)
-  endif()
   add_subdirectory(multipleAnalogSensorsMsgs)
   add_subdirectory(multipleanalogsensorsserver)
   add_subdirectory(multipleanalogsensorsclient)
@@ -86,6 +80,8 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(JoypadControlClient)
   add_subdirectory(JoypadControlServer)
 
+  add_subdirectory(portaudio) # DEPRECATED Since YARP 3.2
+  add_subdirectory(ServerSoundGrabber) # DEPRECATED Since YARP 3.2
 
   # We can also suck in other device libraries built the same way.
   # We seek an ExternalModules.cmake file either in the conf directory

--- a/src/devices/ServerFrameGrabber/CMakeLists.txt
+++ b/src/devices/ServerFrameGrabber/CMakeLists.txt
@@ -9,7 +9,8 @@ yarp_prepare_plugin(grabber
                     TYPE ServerFrameGrabber
                     INCLUDE ServerFrameGrabber.h
                     EXTRA_CONFIG WRAPPER=grabber
-                    DEFAULT ON)
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.3
 
 if(NOT SKIP_grabber)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
+++ b/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
@@ -15,6 +15,8 @@ using namespace yarp::os;
 using namespace yarp::dev;
 using namespace yarp::sig;
 
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 
 bool ServerFrameGrabber::close()
 {
@@ -493,3 +495,5 @@ bool ServerFrameGrabber::updateService()
     }
     return false;
 }
+
+YARP_WARNING_POP

--- a/src/devices/ServerFrameGrabber/ServerFrameGrabber.h
+++ b/src/devices/ServerFrameGrabber/ServerFrameGrabber.h
@@ -12,7 +12,6 @@
 
 #include <cstdio>
 
-#include <yarp/dev/DataSource.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/FrameGrabberControlImpl.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
@@ -28,8 +27,11 @@
 
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/RateThread.h>
+#include <yarp/dev/DataSource.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 
 /**
  * @ingroup dev_impl_wrapper
@@ -75,7 +77,7 @@
  *
  */
 class ServerFrameGrabber :
-        public yarp::dev::DeviceDriver,
+        public yarp::dev::DeprecatedDeviceDriver,
         public yarp::dev::DeviceResponder,
         public yarp::dev::IFrameGrabberImage,
         public yarp::dev::IAudioVisualGrabber,
@@ -90,7 +92,10 @@ private:
     yarp::dev::IRgbVisualParams* rgbVis_p{nullptr};
     yarp::os::Port p;
     yarp::os::Port *p2{nullptr};
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     yarp::os::RateThreadWrapper thread;
+YARP_WARNING_POP
     yarp::dev::PolyDriver poly;
     yarp::dev::IFrameGrabberImage *fgImage{nullptr};
     yarp::dev::IFrameGrabberImageRaw *fgImageRaw{nullptr};
@@ -158,5 +163,7 @@ public:
 
     bool updateService() override;
 };
+
+YARP_WARNING_POP
 
 #endif // YARP_DEV_SERVERFRAMEGRABBER_H

--- a/src/devices/ServerSoundGrabber/CMakeLists.txt
+++ b/src/devices/ServerSoundGrabber/CMakeLists.txt
@@ -8,7 +8,8 @@ yarp_prepare_plugin(ServerSoundGrabber
                     CATEGORY device
                     TYPE ServerSoundGrabber
                     INCLUDE ServerSoundGrabber.h
-                    DEFAULT ON)
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.2
 
 if(NOT SKIP_ServerSoundGrabber)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/devices/fakebot/fakebot.example.ini
+++ b/src/devices/fakebot/fakebot.example.ini
@@ -9,7 +9,7 @@ sx 1.0
 sy 1.0
 
 [part grab]
-device grabber
+device grabberDual
 subdevice robot
 name /fakebot/camera
 

--- a/src/devices/ffmpeg/CMakeLists.txt
+++ b/src/devices/ffmpeg/CMakeLists.txt
@@ -9,7 +9,7 @@ yarp_prepare_plugin(ffmpeg_grabber
                     CATEGORY device
                     TYPE FfmpegGrabber
                     INCLUDE FfmpegGrabber.h
-                    EXTRA_CONFIG WRAPPER=grabber
+                    EXTRA_CONFIG WRAPPER=grabberDual
                     DEPENDS "YARP_HAS_FFMPEG")
 yarp_prepare_plugin(ffmpeg_writer
                     CATEGORY device

--- a/src/devices/opencv/CMakeLists.txt
+++ b/src/devices/opencv/CMakeLists.txt
@@ -9,7 +9,7 @@ yarp_prepare_plugin(opencv_grabber
                     CATEGORY device
                     TYPE OpenCVGrabber
                     INCLUDE OpenCVGrabber.h
-                    EXTRA_CONFIG WRAPPER=grabber
+                    EXTRA_CONFIG WRAPPER=grabberDual
                     DEPENDS "YARP_HAS_OpenCV")
 
 if(NOT SKIP_opencv_grabber)

--- a/src/devices/portaudio/CMakeLists.txt
+++ b/src/devices/portaudio/CMakeLists.txt
@@ -10,7 +10,8 @@ yarp_prepare_plugin(portaudio
                     TYPE PortAudioDeviceDriver
                     INCLUDE PortAudioDeviceDriver.h
                     EXTRA_CONFIG WRAPPER=grabber
-                    DEPENDS "YARP_HAS_PortAudio")
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED;YARP_HAS_PortAudio") # DEPRECATED Since YARP 3.2
 
 if(NOT SKIP_portaudio)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/devices/test_grabber/CMakeLists.txt
+++ b/src/devices/test_grabber/CMakeLists.txt
@@ -8,7 +8,7 @@ yarp_prepare_plugin(test_grabber
                     CATEGORY device
                     TYPE TestFrameGrabber
                     INCLUDE TestFrameGrabber.h
-                    EXTRA_CONFIG WRAPPER=grabber
+                    EXTRA_CONFIG WRAPPER=grabberDual
                     DEFAULT ON)
 
 if(ENABLE_test_grabber)

--- a/src/libYARP_OS/CMakeLists.txt
+++ b/src/libYARP_OS/CMakeLists.txt
@@ -90,7 +90,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Property.h
                  include/yarp/os/Publisher.h
                  include/yarp/os/Random.h
-                 include/yarp/os/RateThread.h
                  include/yarp/os/RecursiveMutex.h
                  include/yarp/os/ResourceFinder.h
                  include/yarp/os/ResourceFinderOptions.h
@@ -100,7 +99,6 @@ set(YARP_OS_HDRS include/yarp/os/AbstractCarrier.h
                  include/yarp/os/Route.h
                  include/yarp/os/RpcClient.h
                  include/yarp/os/RpcServer.h
-                 include/yarp/os/Runnable.h
                  include/yarp/os/Searchable.h
                  include/yarp/os/Semaphore.h
                  include/yarp/os/SharedLibraryClassApi.h
@@ -298,7 +296,6 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/Property.cpp
                  src/Protocol.cpp
                  src/Random.cpp
-                 src/RateThread.cpp
                  src/ResourceFinder.cpp
                  src/ResourceFinderOptions.cpp
                  src/RFModule.cpp
@@ -308,7 +305,6 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/Route.cpp
                  src/RpcClient.cpp
                  src/RpcServer.cpp
-                 src/Runnable.cpp
                  src/Searchable.cpp
                  src/Semaphore.cpp
                  src/SharedLibrary.cpp
@@ -348,10 +344,14 @@ set(YARP_OS_SRCS src/AbstractCarrier.cpp
                  src/QosStyle.cpp)
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.0.0
-  list(APPEND YARP_OS_HDRS include/yarp/os/ConstString.h)
+  list(APPEND YARP_OS_HDRS include/yarp/os/ConstString.h
+                           include/yarp/os/RateThread.h
+                           include/yarp/os/Runnable.h)
 
   list(APPEND YARP_OS_SRCS src/Mutex.cpp
-                           src/RecursiveMutex.cpp)
+                           src/RateThread.cpp
+                           src/RecursiveMutex.cpp
+                           src/Runnable.cpp)
 endif()
 
 

--- a/src/libYARP_OS/include/yarp/os/RateThread.h
+++ b/src/libYARP_OS/include/yarp/os/RateThread.h
@@ -16,6 +16,10 @@
 YARP_COMPILER_WARNING("<yarp/os/RateThread.h> file is deprecated")
 #endif
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0 (RateThreadWrapper since YARP 3.3)
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+
 #include <yarp/os/api.h>
 
 #include <yarp/os/PeriodicThread.h>
@@ -23,8 +27,6 @@ YARP_COMPILER_WARNING("<yarp/os/RateThread.h> file is deprecated")
 
 namespace yarp {
 namespace os {
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
-
 
 /**
  * \ingroup key_class
@@ -219,7 +221,9 @@ protected:
     void afterStart(bool success) override;
 };
 
-
+/**
+ * @deprecated since YARP 3.0
+ */
 class YARP_OS_DEPRECATED_API_MSG("Use PeriodicThread(..., == ShouldUseSystemClock::Yes) instead") SystemRateThread : public PeriodicThread
 {
 public:
@@ -231,12 +235,12 @@ public:
 };
 
 
-#endif
 /**
  * This class takes a Runnable instance and wraps a thread around it.
- * This class is under development - API may change a lot.
+ *
+ * @deprecated since YARP 3.3
  */
-class YARP_OS_API RateThreadWrapper : public PeriodicThread
+class YARP_OS_DEPRECATED_API RateThreadWrapper : public PeriodicThread
 {
 private:
     yarp::os::Runnable* helper;
@@ -272,5 +276,7 @@ public:
 } // namespace os
 } // namespace yarp
 
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_OS_RATETHREAD_H

--- a/src/libYARP_OS/include/yarp/os/Runnable.h
+++ b/src/libYARP_OS/include/yarp/os/Runnable.h
@@ -7,8 +7,16 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_OS_OS_RUNNABLE_H
-#define YARP_OS_OS_RUNNABLE_H
+#ifndef YARP_OS_RUNNABLE_H
+#define YARP_OS_RUNNABLE_H
+
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/os/Runnable.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
 
 #include <yarp/os/api.h>
 
@@ -17,8 +25,10 @@ namespace os {
 
 /**
  * A class that can be managed by another thread.
+ *
+ * @deprecated since YARP 3.3
  */
-class YARP_OS_API Runnable
+class YARP_OS_DEPRECATED_API Runnable
 {
 public:
     /**
@@ -74,4 +84,6 @@ public:
 } // namespace os
 } // namespace yarp
 
-#endif // YARP_OS_OS_RUNNABLE_H
+#endif // YARP_NO_DEPRECATED
+
+#endif // YARP_OS_RUNNABLE_H

--- a/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
+++ b/src/libYARP_OS/include/yarp/os/impl/ThreadImpl.h
@@ -11,7 +11,6 @@
 #define YARP_OS_IMPL_THREADIMPL_H
 
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/Runnable.h>
 
 #include <atomic>
 #include <thread>
@@ -23,17 +22,14 @@ namespace impl {
 /**
  * An abstraction for a thread of execution.
  */
-class YARP_OS_impl_API ThreadImpl : public Runnable
+class YARP_OS_impl_API ThreadImpl
 {
 public:
-    ThreadImpl();
-    ThreadImpl(Runnable* target);
-
     virtual ~ThreadImpl();
 
     int join(double seconds = -1);
-    void run() override;
-    void close() override;
+    virtual void run();
+    virtual void close();
 
     // similar to close, but it does not call join (does not wait for thread termination)
     void askToClose();
@@ -44,11 +40,11 @@ public:
     bool isClosing();
     bool isRunning();
 
-    void beforeStart() override;
-    void afterStart(bool success) override;
+    virtual void beforeStart();
+    virtual void afterStart(bool success);
 
-    bool threadInit() override;
-    void threadRelease() override;
+    virtual bool threadInit();
+    virtual void threadRelease();
 
     static int getCount();
 
@@ -70,24 +66,23 @@ public:
     int getPolicy();
     long getTid();
 
-    long tid;
+    long tid{-1};
     YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::thread::id) id;
 
     static void yield();
 
 private:
-    int defaultPriority;
-    int defaultPolicy;
+    int defaultPriority{-1};
+    int defaultPolicy{-1};
     YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::thread) thread;
-    YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::atomic<bool>) active;
-    bool opened;
-    bool closing;
-    bool needJoin;
-    Runnable* delegate;
+    YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::atomic<bool>) active{false};
+    bool opened{false};
+    bool closing{false};
+    bool needJoin{false};
 
-    yarp::os::Semaphore synchro;
+    yarp::os::Semaphore synchro{0};
 
-    bool initWasSuccessful;
+    bool initWasSuccessful{false};
 };
 
 } // namespace impl

--- a/src/libYARP_OS/src/RateThread.cpp
+++ b/src/libYARP_OS/src/RateThread.cpp
@@ -11,11 +11,12 @@
 #include <yarp/os/RateThread.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+
 #include <yarp/os/impl/Logger.h>
 
 using namespace yarp::os;
-
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 
 RateThread::RateThread(int period) :
         PeriodicThread(period / 1000.0)
@@ -159,8 +160,6 @@ bool SystemRateThread::stepSystem()
     return true;
 }
 
-#endif
-
 RateThreadWrapper::RateThreadWrapper() :
         PeriodicThread(0)
 {
@@ -280,3 +279,5 @@ Runnable* RateThreadWrapper::getAttachment() const
 {
     return helper;
 }
+
+YARP_WARNING_POP

--- a/src/libYARP_OS/src/Runnable.cpp
+++ b/src/libYARP_OS/src/Runnable.cpp
@@ -7,8 +7,12 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/Runnable.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
 
 yarp::os::Runnable::~Runnable() = default;
 
@@ -37,3 +41,5 @@ bool yarp::os::Runnable::threadInit()
 void yarp::os::Runnable::threadRelease()
 {
 }
+
+YARP_WARNING_POP

--- a/src/libYARP_OS/src/ThreadImpl.cpp
+++ b/src/libYARP_OS/src/ThreadImpl.cpp
@@ -95,40 +95,6 @@ void theExecutiveBranch(void* args)
 }
 
 
-ThreadImpl::ThreadImpl() :
-        tid(-1),
-        id(std::thread::id()),
-        defaultPriority(-1),
-        defaultPolicy(-1),
-        thread(std::thread()),
-        active(false),
-        opened(false),
-        closing(false),
-        needJoin(false),
-        delegate(nullptr),
-        synchro(0),
-        initWasSuccessful(false)
-{
-}
-
-
-ThreadImpl::ThreadImpl(Runnable* target) :
-        tid(-1),
-        id(std::thread::id()),
-        defaultPriority(-1),
-        defaultPolicy(-1),
-        thread(std::thread()),
-        active(false),
-        opened(false),
-        closing(false),
-        needJoin(false),
-        delegate(target),
-        synchro(0),
-        initWasSuccessful(false)
-{
-}
-
-
 ThreadImpl::~ThreadImpl()
 {
     YARP_DEBUG(Logger::get(), "Thread being deleted");
@@ -187,17 +153,11 @@ int ThreadImpl::join(double seconds)
 
 void ThreadImpl::run()
 {
-    if (delegate != nullptr) {
-        delegate->run();
-    }
 }
 
 void ThreadImpl::close()
 {
     closing = true;
-    if (delegate != nullptr) {
-        delegate->close();
-    }
     join(-1);
 }
 
@@ -205,38 +165,23 @@ void ThreadImpl::close()
 void ThreadImpl::askToClose()
 {
     closing = true;
-    if (delegate != nullptr) {
-        delegate->close();
-    }
 }
 
 void ThreadImpl::beforeStart()
 {
-    if (delegate != nullptr) {
-        delegate->beforeStart();
-    }
 }
 
 void ThreadImpl::afterStart(bool success)
 {
-    if (delegate != nullptr) {
-        delegate->afterStart(success);
-    }
 }
 
 bool ThreadImpl::threadInit()
 {
-    if (delegate != nullptr) {
-        return delegate->threadInit();
-    }
     return true;
 }
 
 void ThreadImpl::threadRelease()
 {
-    if (delegate != nullptr) {
-        delegate->threadRelease();
-    }
 }
 
 bool ThreadImpl::start()

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -23,7 +23,6 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/ControlBoardInterfacesImpl.h
                   include/yarp/dev/ControlBoardPid.h
                   include/yarp/dev/ControlBoardVocabs.h
-                  include/yarp/dev/DataSource.h
                   include/yarp/dev/DeviceDriver.h
                   include/yarp/dev/DriverLinkCreator.h
                   include/yarp/dev/Drivers.h
@@ -123,7 +122,8 @@ if(TARGET YARP::YARP_math)
 endif()
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.3.0
-  list(APPEND YARP_dev_HDRS include/yarp/dev/GenericSensorInterfaces.h
+  list(APPEND YARP_dev_HDRS include/yarp/dev/DataSource.h
+                            include/yarp/dev/GenericSensorInterfaces.h
                             include/yarp/dev/PreciselyTimed.h
                             include/yarp/dev/SerialInterfaces.h
                             include/yarp/dev/Wrapper.h)

--- a/src/libYARP_dev/include/yarp/dev/DataSource.h
+++ b/src/libYARP_dev/include/yarp/dev/DataSource.h
@@ -10,6 +10,17 @@
 #ifndef YARP_DEV_DATASOURCE_H
 #define YARP_DEV_DATASOURCE_H
 
+#include <yarp/conf/system.h>
+
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/dev/DataSource.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.3
+
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+
 #include <yarp/os/Port.h>
 #include <yarp/os/Runnable.h>
 #include <yarp/os/PortWriterBuffer.h>
@@ -36,14 +47,14 @@ namespace yarp {
 }
 
 template <class T>
-class yarp::dev::DataSource {
+class YARP_DEPRECATED yarp::dev::DataSource {
 public:
     virtual ~DataSource() {}
     virtual bool getDatum(T& datum) = 0;
 };
 
 template <class T>
-class yarp::dev::DataWriter : public yarp::os::Runnable {
+class YARP_DEPRECATED yarp::dev::DataWriter : public yarp::os::Runnable {
 private:
     yarp::os::Port& port;
     yarp::os::PortWriterBuffer<T> writer;
@@ -140,7 +151,7 @@ public:
 
 
 template <class T1, class T2>
-class yarp::dev::DataSource2 {
+class YARP_DEPRECATED yarp::dev::DataSource2 {
 public:
     virtual ~DataSource2() {}
     virtual bool getDatum(T1& datum1, T2& datum2) = 0;
@@ -148,7 +159,7 @@ public:
 
 
 template <class T1, class T2>
-class yarp::dev::DataWriter2 : public yarp::os::Runnable {
+class YARP_DEPRECATED yarp::dev::DataWriter2 : public yarp::os::Runnable {
 private:
     yarp::os::Port& port1;
     yarp::os::Port& port2;
@@ -186,7 +197,10 @@ public:
 };
 
 
-#endif /*DOXYGEN_SHOULD_SKIP_THIS*/
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+YARP_WARNING_POP
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_DEV_DATASOURCE_H

--- a/src/libYARP_dev/include/yarp/dev/all.h
+++ b/src/libYARP_dev/include/yarp/dev/all.h
@@ -21,7 +21,6 @@
 #include <yarp/dev/IControlDebug.h>
 #include <yarp/dev/IControlLimits.h>
 #include <yarp/dev/ControlBoardPid.h>
-#include <yarp/dev/DataSource.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/DriverLinkCreator.h>
 #include <yarp/dev/Drivers.h>
@@ -41,5 +40,11 @@
 #include <yarp/dev/ServiceInterfaces.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.3
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#include <yarp/dev/DataSource.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_DEV_ALL_H

--- a/tests/devices/grabber_audiovisual.ini
+++ b/tests/devices/grabber_audiovisual.ini
@@ -6,3 +6,4 @@ source tiny.avi
 # (or could use shared-ports flag to put them on same port)
 name /visual
 name2 /audio
+allow-deprecated-devices

--- a/tests/devices/grabber_basic.ini
+++ b/tests/devices/grabber_basic.ini
@@ -1,5 +1,5 @@
 # start up a network wrapper around a test_grabber
-device grabber
+device grabberDual
 subdevice test_grabber
 width 640
 height 480

--- a/tests/libYARP_dev/TestFrameGrabberTest.cpp
+++ b/tests/libYARP_dev/TestFrameGrabberTest.cpp
@@ -28,7 +28,6 @@ using namespace yarp::sig;
 TEST_CASE("dev::TestFrameGrabberTest", "[yarp::dev]")
 {
     YARP_REQUIRE_PLUGIN("test_grabber", "device");
-    YARP_REQUIRE_PLUGIN("grabber", "device");
     YARP_REQUIRE_PLUGIN("remote_grabber", "device");
     YARP_REQUIRE_PLUGIN("grabberDual", "device");
 
@@ -40,8 +39,7 @@ TEST_CASE("dev::TestFrameGrabberTest", "[yarp::dev]")
         // try to take an image and check the relative port and rpc port
         PolyDriver dd;
         Property p;
-        p.put("device","grabber");
-        p.put("subdevice","test_grabber");
+        p.put("device","test_grabber");
         REQUIRE(dd.open(p)); // open reported successful
         IFrameGrabberImage *grabber = nullptr;
         REQUIRE(dd.view(grabber)); // interface reported
@@ -60,7 +58,7 @@ TEST_CASE("dev::TestFrameGrabberTest", "[yarp::dev]")
         p.put("device","remote_grabber");
         p.put("remote","/grabber");
         p.put("local","/grabber/client");
-        p2.put("device","grabber");
+        p2.put("device","grabberDual");
         p2.put("subdevice","test_grabber");
 
         REQUIRE(dd2.open(p2)); // server open reported successful
@@ -93,7 +91,7 @@ TEST_CASE("dev::TestFrameGrabberTest", "[yarp::dev]")
         p.put("local","/grabber/client");
         p.put("no_stream", 1);
 
-        p2.put("device","grabber");
+        p2.put("device","grabberDual");
         p2.put("subdevice","test_grabber");
 
         REQUIRE(dd2.open(p2)); // server open reported successful
@@ -189,14 +187,13 @@ TEST_CASE("dev::TestFrameGrabberTest", "[yarp::dev]")
         vertices.resize(2);
         vertices[0] = std::pair <int, int> (0, 0);
         vertices[1] = std::pair <int, int> ( 10, 10); // Configure a doable crop.
-        // check crop function must not work on old server (call does not hangs)
-        CHECK_FALSE(grabber->getImageCrop(YARP_CROP_RECT, vertices, crop));
+
+        CHECK(grabber->getImageCrop(YARP_CROP_RECT, vertices, crop));
 
         CHECK(dd2.close()); // server close reported successful
         CHECK(dd.close()); // client close reported successful
     }
 
-    //Testing the new ServerGrabber
     SECTION("Test the IRgbVisualParams interface")
     {
         PolyDriver dd;


### PR DESCRIPTION
This patch deprecates some parts of YARP that should be used only inside of `ServerFrameGrabber`, that is unofficially deprecated in favour of `grabberDual`.

Note: Unfortunately ServerFrameGrabber still uses them, at the moment
deprecation warnings are disabled for this device.
