### PR TITLE
dev: Move files in proper .cpp/.h

### DIFF
--- a/doc/release/devel/GenericSensorInterfaces.md
+++ b/doc/release/devel/GenericSensorInterfaces.md
@@ -1,0 +1,7 @@
+GenericSensorInterfaces {#devel}
+-----------------------
+
+### dev
+
+* The `<yarp/dev/GenericSensorInterfaces.h>` include file is deprecated in favour of
+  `<yarp/dev/IGenericSensor.h>`.

--- a/doc/release/devel/SerialInterfaces.md
+++ b/doc/release/devel/SerialInterfaces.md
@@ -1,0 +1,7 @@
+SerialInterfaces {#devel}
+----------------
+
+### dev
+
+* The `<yarp/dev/SerialInterfaces.h>` include file is deprecated in favour of
+  `<yarp/dev/ISerialDevice.h>`.

--- a/doc/release/devel/Wrapper.md
+++ b/doc/release/devel/Wrapper.md
@@ -1,0 +1,7 @@
+Wrapper {#devel}
+-------
+
+### dev
+
+* The `<yarp/dev/Wrapper.h>` include file is deprecated in favour of
+  `<yarp/dev/IWrapper.h>` and `<yarp/dev/IMultipleWrapper.h>`.

--- a/example/attachable/main.cpp
+++ b/example/attachable/main.cpp
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <vector>
 
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 using namespace yarp::dev;
 

--- a/example/dev/RGBD/RGBD_test_1b_server.cpp
+++ b/example/dev/RGBD/RGBD_test_1b_server.cpp
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <yarp/os/Time.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/dev/Drivers.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/dev/PolyDriver.h>

--- a/src/devices/AnalogWrapper/AnalogWrapper.h
+++ b/src/devices/AnalogWrapper/AnalogWrapper.h
@@ -31,7 +31,7 @@
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/api.h>
 
 

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
@@ -16,7 +16,7 @@
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <string>
 #include <vector>

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -28,7 +28,7 @@
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/ControlBoardHelpers.h>
 
 #include <mutex>

--- a/src/devices/JoypadControlServer/JoypadControlServer.h
+++ b/src/devices/JoypadControlServer/JoypadControlServer.h
@@ -12,7 +12,8 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IJoypadController.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 #include <yarp/os/BufferedPort.h>

--- a/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -26,7 +26,8 @@
 
 #include <yarp/sig/Vector.h>
 
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
 #include <yarp/dev/IVisualParamsImpl.h>

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.h
@@ -41,7 +41,7 @@
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/api.h>
 #include <yarp/dev/IPreciselyTimed.h>
 

--- a/src/devices/RobotDescriptionServer/RobotDescriptionServer.h
+++ b/src/devices/RobotDescriptionServer/RobotDescriptionServer.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Time.h>
 #include <string>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/IRobotDescription.h>
 
 /**

--- a/src/devices/SerialServoBoard/SerialServoBoard.cpp
+++ b/src/devices/SerialServoBoard/SerialServoBoard.cpp
@@ -13,7 +13,7 @@
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
 
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/devices/SerialServoBoard/SerialServoBoard.h
+++ b/src/devices/SerialServoBoard/SerialServoBoard.h
@@ -11,7 +11,7 @@
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
 
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/devices/ServerGrabber/ServerGrabber.h
+++ b/src/devices/ServerGrabber/ServerGrabber.h
@@ -26,7 +26,8 @@
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/IVisualParamsImpl.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 
 class ServerGrabber;

--- a/src/devices/ServerInertial/ServerInertial.cpp
+++ b/src/devices/ServerInertial/ServerInertial.cpp
@@ -12,7 +12,7 @@
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>

--- a/src/devices/ServerInertial/ServerInertial.h
+++ b/src/devices/ServerInertial/ServerInertial.h
@@ -21,7 +21,8 @@
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/IPreciselyTimed.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 // ROS state publisher
 #include <yarp/os/Node.h>

--- a/src/devices/ServerInertial/ServerInertial.h
+++ b/src/devices/ServerInertial/ServerInertial.h
@@ -14,7 +14,7 @@
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>

--- a/src/devices/ServerSerial/ServerSerial.h
+++ b/src/devices/ServerSerial/ServerSerial.h
@@ -16,7 +16,7 @@
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>

--- a/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+++ b/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
@@ -24,7 +24,7 @@
 
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <yarp/dev/IVirtualAnalogSensor.h>
 

--- a/src/devices/audioPlayerWrapper/AudioPlayerWrapper.h
+++ b/src/devices/audioPlayerWrapper/AudioPlayerWrapper.h
@@ -42,7 +42,7 @@
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/api.h>
 #include <yarp/dev/IPreciselyTimed.h>
 

--- a/src/devices/audioRecorderWrapper/AudioRecorderWrapper.h
+++ b/src/devices/audioRecorderWrapper/AudioRecorderWrapper.h
@@ -26,7 +26,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/PeriodicThread.h>

--- a/src/devices/batteryWrapper/BatteryWrapper.h
+++ b/src/devices/batteryWrapper/BatteryWrapper.h
@@ -40,7 +40,7 @@
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/api.h>
 
  /**

--- a/src/devices/fakeIMU/fakeIMU.h
+++ b/src/devices/fakeIMU/fakeIMU.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>

--- a/src/devices/fakeMicrophone/fakeMicrophone.h
+++ b/src/devices/fakeMicrophone/fakeMicrophone.h
@@ -8,7 +8,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/CircularAudioBuffer.h>
 #include <yarp/sig/Sound.h>

--- a/src/devices/fakeSpeaker/fakeSpeaker.h
+++ b/src/devices/fakeSpeaker/fakeSpeaker.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/CircularAudioBuffer.h>
 #include <yarp/sig/Sound.h>

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -24,7 +24,7 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/math/Quaternion.h>

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -25,7 +25,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/dev/SerialInterfaces.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/math/Quaternion.h>
 #include <mutex>

--- a/src/devices/laserHokuyo/laserHokuyo.h
+++ b/src/devices/laserHokuyo/laserHokuyo.h
@@ -27,7 +27,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/sig/Vector.h>
 
 using namespace yarp::os;

--- a/src/devices/localization2DServer/Localization2DServer.h
+++ b/src/devices/localization2DServer/Localization2DServer.h
@@ -27,7 +27,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ILocalization2D.h>
 #include <math.h>

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
@@ -11,7 +11,7 @@
 #define YARP_DEV_MULTIPLEANALOGSENSORSREMAPPER_MULTIPLEANALOGSENSORSREMAPPER_H
 
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <vector>
 #include <map>

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -12,7 +12,7 @@
 
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
 // Thrift-generated classes

--- a/src/devices/navigation2DServer/navigation2DServer.h
+++ b/src/devices/navigation2DServer/navigation2DServer.h
@@ -23,7 +23,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/INavigation2D.h>
 #include <yarp/dev/ILocalization2D.h>

--- a/src/devices/rpLidar/rpLidar.h
+++ b/src/devices/rpLidar/rpLidar.h
@@ -26,7 +26,7 @@
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 
 #include <mutex>
 #include <string>

--- a/src/devices/rpLidar2/rpLidar2.h
+++ b/src/devices/rpLidar2/rpLidar2.h
@@ -26,7 +26,7 @@
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 
 #include <mutex>
 #include <string>

--- a/src/devices/serialport/SerialDeviceDriver.h
+++ b/src/devices/serialport/SerialDeviceDriver.h
@@ -13,7 +13,7 @@
 #define SerialDeviceDriverh
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/os/Bottle.h>
 
 #include <stdio.h>

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -36,6 +36,8 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/GPUInterface.h
                   include/yarp/dev/IAmplifierControl.h
                   include/yarp/dev/IAnalogSensor.h
+                  include/yarp/dev/IAudioVisualGrabber.h
+                  include/yarp/dev/IAudioVisualStream.h
                   include/yarp/dev/IAxisInfo.h
                   include/yarp/dev/IBattery.h
                   include/yarp/dev/ICalibrator.h
@@ -48,6 +50,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/ICurrentControl.h
                   include/yarp/dev/IEncoders.h
                   include/yarp/dev/IEncodersTimed.h
+                  include/yarp/dev/IFrameWriterAudioVisual.h
                   include/yarp/dev/IHapticDevice.h
                   include/yarp/dev/IImpedanceControl.h
                   include/yarp/dev/IInteractionMode.h
@@ -138,7 +141,10 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/FrameGrabberControlImpl.cpp
                   src/GazeControl.cpp
                   src/IAnalogSensor.cpp
+                  src/IAudioVisualGrabber.cpp
+                  src/IAudioVisualStream.cpp
                   src/IBattery.cpp
+                  src/IFrameWriterAudioVisual.cpp
                   src/IJoypadController.cpp
                   src/IRemoteCalibrator.cpp
                   src/ImplementAmplifierControl.cpp

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -31,7 +31,6 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/FrameGrabberControlImpl.h
                   include/yarp/dev/FrameGrabberInterfaces.h
                   include/yarp/dev/GazeControl.h
-                  include/yarp/dev/GenericSensorInterfaces.h
                   include/yarp/dev/GenericVocabs.h
                   include/yarp/dev/GPUInterface.h
                   include/yarp/dev/IAmplifierControl.h
@@ -51,6 +50,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/IEncoders.h
                   include/yarp/dev/IEncodersTimed.h
                   include/yarp/dev/IFrameWriterAudioVisual.h
+                  include/yarp/dev/IGenericSensor.h
                   include/yarp/dev/IHapticDevice.h
                   include/yarp/dev/IImpedanceControl.h
                   include/yarp/dev/IInteractionMode.h
@@ -123,7 +123,8 @@ if(TARGET YARP::YARP_math)
 endif()
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.3.0
-  list(APPEND YARP_dev_HDRS include/yarp/dev/PreciselyTimed.h
+  list(APPEND YARP_dev_HDRS include/yarp/dev/GenericSensorInterfaces.h
+                            include/yarp/dev/PreciselyTimed.h
                             include/yarp/dev/Wrapper.h)
 endif()
 
@@ -147,6 +148,7 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/IAudioVisualStream.cpp
                   src/IBattery.cpp
                   src/IFrameWriterAudioVisual.cpp
+                  src/IGenericSensor.cpp
                   src/IJoypadController.cpp
                   src/IRemoteCalibrator.cpp
                   src/IMultipleWrapper.cpp

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -57,6 +57,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/IJoypadController.h
                   include/yarp/dev/IMotorEncoders.h
                   include/yarp/dev/IMotor.h
+                  include/yarp/dev/IMultipleWrapper.h
                   include/yarp/dev/ImplementAmplifierControl.h
                   include/yarp/dev/ImplementAxisInfo.h
                   include/yarp/dev/ImplementControlBoardInterfaces.h
@@ -100,6 +101,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/IVisualParams.h
                   include/yarp/dev/IVisualParamsImpl.h
                   include/yarp/dev/IVisualServoing.h
+                  include/yarp/dev/IWrapper.h
                   include/yarp/dev/LaserMeasurementData.h
                   include/yarp/dev/MultipleAnalogSensorsInterfaces.h
                   include/yarp/dev/PidEnums.h
@@ -108,8 +110,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/PolyDriverList.h
                   include/yarp/dev/RGBDSensorParamParser.h
                   include/yarp/dev/SerialInterfaces.h
-                  include/yarp/dev/ServiceInterfaces.h
-                  include/yarp/dev/Wrapper.h)
+                  include/yarp/dev/ServiceInterfaces.h)
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_HDRS include/yarp/dev/IFrameTransform.h
@@ -122,7 +123,8 @@ if(TARGET YARP::YARP_math)
 endif()
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.3.0
-  list(APPEND YARP_dev_HDRS include/yarp/dev/PreciselyTimed.h)
+  list(APPEND YARP_dev_HDRS include/yarp/dev/PreciselyTimed.h
+                            include/yarp/dev/Wrapper.h)
 endif()
 
 
@@ -147,6 +149,7 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/IFrameWriterAudioVisual.cpp
                   src/IJoypadController.cpp
                   src/IRemoteCalibrator.cpp
+                  src/IMultipleWrapper.cpp
                   src/ImplementAmplifierControl.cpp
                   src/ImplementAxisInfo.cpp
                   src/ImplementControlCalibration.cpp
@@ -173,6 +176,7 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/IRobotDescription.cpp
                   src/IVisualParamsImpl.cpp
                   src/IVisualServoing.cpp
+                  src/IWrapper.cpp
                   src/LaserMeasurementData.cpp
                   src/MultipleAnalogSensorsInterfaces.cpp
                   src/PolyDriver.cpp

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -94,6 +94,7 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/IRemoteVariables.h
                   include/yarp/dev/IRGBDSensor.h
                   include/yarp/dev/IRobotDescription.h
+                  include/yarp/dev/ISerialDevice.h
                   include/yarp/dev/ITorqueControl.h
                   include/yarp/dev/IVelocityControl2.h
                   include/yarp/dev/IVelocityControl.h
@@ -109,7 +110,6 @@ set(YARP_dev_HDRS include/yarp/dev/all.h
                   include/yarp/dev/PolyDriver.h
                   include/yarp/dev/PolyDriverList.h
                   include/yarp/dev/RGBDSensorParamParser.h
-                  include/yarp/dev/SerialInterfaces.h
                   include/yarp/dev/ServiceInterfaces.h)
 
 if(TARGET YARP::YARP_math)
@@ -125,6 +125,7 @@ endif()
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.3.0
   list(APPEND YARP_dev_HDRS include/yarp/dev/GenericSensorInterfaces.h
                             include/yarp/dev/PreciselyTimed.h
+                            include/yarp/dev/SerialInterfaces.h
                             include/yarp/dev/Wrapper.h)
 endif()
 
@@ -173,6 +174,7 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/ImplementVelocityControl.cpp
                   src/ImplementVirtualAnalogSensor.cpp
                   src/IPreciselyTimed.cpp
+                  src/ISerialDevice.cpp
                   src/IRGBDSensor.cpp
                   src/IRangefinder2D.cpp
                   src/IRobotDescription.cpp

--- a/src/libYARP_dev/include/yarp/dev/AudioVisualInterfaces.h
+++ b/src/libYARP_dev/include/yarp/dev/AudioVisualInterfaces.h
@@ -12,91 +12,20 @@
 
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
+
+#include <yarp/dev/IAudioVisualGrabber.h>
+#include <yarp/dev/IAudioVisualStream.h>
+#include <yarp/dev/IFrameWriterAudioVisual.h>
+
 #include <yarp/os/PortablePair.h>
-#include <yarp/sig/Image.h>
-#include <yarp/sig/Sound.h>
 
-namespace yarp{
-    namespace dev {
-        class IAudioVisualGrabber;
-        class IAudioVisualStream;
-        class IFrameWriterAudioVisual;
-        typedef yarp::os::PortablePair<yarp::sig::ImageOf<yarp::sig::PixelRgb>,
-                                       yarp::sig::Sound> ImageRgbSound;
-    }
-}
+namespace yarp {
+namespace dev {
 
-/**
- * @ingroup dev_iface_media
- *
- * Read a YARP-format image and sound from a device.
- */
-class YARP_dev_API yarp::dev::IAudioVisualGrabber
-{
-public:
-    /**
-     * Destructor.
-     */
-    virtual ~IAudioVisualGrabber(){}
+typedef yarp::os::PortablePair<yarp::sig::ImageOf<yarp::sig::PixelRgb>,
+                               yarp::sig::Sound> ImageRgbSound;
 
-    /**
-     * Get an image and sound
-     *
-     * @param image the image to be filled
-     * @param sound the sound to be filled
-     * @return true/false upon success/failure
-     */
-    virtual bool getAudioVisual(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image,
-                                yarp::sig::Sound& sound) = 0;
-};
-
-
-/**
- * @ingroup dev_iface_media
- *
- * Write a YARP-format image and sound to a device.
- */
-class YARP_dev_API yarp::dev::IFrameWriterAudioVisual
-{
-public:
-    /**
-     * Destructor.
-     */
-    virtual ~IFrameWriterAudioVisual(){}
-
-    /**
-     * Write an image and sound
-     *
-     * @param image the image to be written
-     * @param sound the sound to be written
-     * @return true/false upon success/failure
-     */
-    virtual bool putAudioVisual(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image,
-                                yarp::sig::Sound& sound) = 0;
-};
-
-
-/**
- * @ingroup dev_iface_media
- *
- * For streams capable of holding different kinds of content,
- * check what they actually have.
- *
- */
-class YARP_dev_API yarp::dev::IAudioVisualStream {
-public:
-    /**
-     * Destructor.
-     */
-    virtual ~IAudioVisualStream(){}
-
-    virtual bool hasAudio() = 0;
-
-    virtual bool hasVideo() = 0;
-
-    virtual bool hasRawVideo() {
-        return hasVideo();
-    }
-};
+} // namespace dev
+} // namespace yarp
 
 #endif // YARP_DEV_AUDIOVISUALINTERFACES_H

--- a/src/libYARP_dev/include/yarp/dev/IAudioVisualGrabber.h
+++ b/src/libYARP_dev/include/yarp/dev/IAudioVisualGrabber.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IAUDIOVISUALGRABBER_H
+#define YARP_DEV_IAUDIOVISUALGRABBER_H
+
+#include <yarp/dev/api.h>
+
+#include <yarp/sig/Image.h>
+#include <yarp/sig/Sound.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_iface_media
+ *
+ * Read a YARP-format image and sound from a device.
+ */
+class YARP_dev_API IAudioVisualGrabber
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IAudioVisualGrabber();
+
+    /**
+     * Get an image and sound
+     *
+     * @param image the image to be filled
+     * @param sound the sound to be filled
+     * @return true/false upon success/failure
+     */
+    virtual bool getAudioVisual(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image,
+                                yarp::sig::Sound& sound) = 0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IAUDIOVISUALGRABBER_H

--- a/src/libYARP_dev/include/yarp/dev/IAudioVisualStream.h
+++ b/src/libYARP_dev/include/yarp/dev/IAudioVisualStream.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+/**
+ * @ingroup dev_iface_media
+ *
+ * For streams capable of holding different kinds of content,
+ * check what they actually have.
+ *
+ */
+
+#ifndef YARP_DEV_IAUDIOVISUALSTREAM_H
+#define YARP_DEV_IAUDIOVISUALSTREAM_H
+
+#include <yarp/dev/api.h>
+
+namespace yarp {
+namespace dev {
+
+class YARP_dev_API IAudioVisualStream
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IAudioVisualStream();
+
+    virtual bool hasAudio() = 0;
+
+    virtual bool hasVideo() = 0;
+
+    virtual bool hasRawVideo() {
+        return hasVideo();
+    }
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IAUDIOVISUALSTREAM_H

--- a/src/libYARP_dev/include/yarp/dev/IFrameWriterAudioVisual.h
+++ b/src/libYARP_dev/include/yarp/dev/IFrameWriterAudioVisual.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IFRAMEWRITERAUDIOVISUAL_H
+#define YARP_DEV_IFRAMEWRITERAUDIOVISUAL_H
+
+#include <yarp/dev/api.h>
+
+#include <yarp/sig/Image.h>
+#include <yarp/sig/Sound.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_iface_media
+ *
+ * Write a YARP-format image and sound to a device.
+ */
+class YARP_dev_API IFrameWriterAudioVisual
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IFrameWriterAudioVisual();
+
+    /**
+     * Write an image and sound
+     *
+     * @param image the image to be written
+     * @param sound the sound to be written
+     * @return true/false upon success/failure
+     */
+    virtual bool putAudioVisual(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image,
+                                yarp::sig::Sound& sound) = 0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IFRAMEWRITERAUDIOVISUAL_H

--- a/src/libYARP_dev/include/yarp/dev/IGenericSensor.h
+++ b/src/libYARP_dev/include/yarp/dev/IGenericSensor.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IGENERICSENSOR_H
+#define YARP_DEV_IGENERICSENSOR_H
+
+#include <yarp/dev/api.h>
+#include <yarp/sig/Vector.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_iface_other
+ *
+ * A generic interface to sensors -- gyro, a/d converters etc.
+ */
+class YARP_dev_API IGenericSensor
+{
+public:
+    virtual ~IGenericSensor();
+
+    /**
+     * Read a vector from the sensor.
+     * @param out a vector containing the sensor's last readings.
+     * @return true/false success/failure
+     */
+    virtual bool read(yarp::sig::Vector &out) = 0;
+
+    /**
+     * Get the number of channels of the sensor.
+     * @param nc pointer to storage, return value
+     * @return true/false success/failure
+     */
+    virtual bool getChannels(int *nc) = 0;
+
+    /**
+     * Calibrate the sensor, single channel.
+     * @param ch channel number
+     * @param v reset valure
+     * @return true/false success/failure
+     */
+    virtual bool calibrate(int ch, double v) = 0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IGENERICSENSOR_H

--- a/src/libYARP_dev/include/yarp/dev/IMultipleWrapper.h
+++ b/src/libYARP_dev/include/yarp/dev/IMultipleWrapper.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IMULTIPLEWRAPPER_H
+#define YARP_DEV_IMULTIPLEWRAPPER_H
+
+#include <yarp/dev/api.h>
+#include <yarp/dev/PolyDriverList.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_imultiplewrapper
+ *
+ * Interface for an object that can wrap/attach to to another. This is useful
+ * for example when an object refers internally to another device, but
+ * you want to decouple the creation of the two objects. In this case
+ * you first creates the two objects separately then you can attach one
+ * to the other. This class is similar to IWrapper, but allows attaching
+ * to more than one object by subsequent calls to attach.
+ */
+class YARP_dev_API IMultipleWrapper
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IMultipleWrapper();
+
+    /**
+     * Attach to a list of objects.
+     * @param p the polydriver list that you want to attach to.
+     * @return true/false on success failure.
+     */
+    virtual bool attachAll(const PolyDriverList &p)=0;
+
+    /**
+     * Detach the object (you must have first called attach).
+     * @return true/false on success failure.
+     */
+    virtual bool detachAll()=0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IMULTIPLEWRAPPER_H

--- a/src/libYARP_dev/include/yarp/dev/ISerialDevice.h
+++ b/src/libYARP_dev/include/yarp/dev/ISerialDevice.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006 Alexandre Bernardino
+ * Copyright (C) 2006 Carlos Beltran-Gonzalez
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_ISERIALDEVICE_H
+#define YARP_DEV_ISERIALDEVICE_H
+
+#include <yarp/os/Bottle.h>
+#include <yarp/dev/api.h>
+#include <yarp/sig/Vector.h>
+
+
+namespace yarp {
+namespace dev {
+
+/**
+ * \ingroup dev_iface_other
+ *
+ * \brief A generic interface to serial port devices.
+ */
+class YARP_dev_API ISerialDevice
+{
+public:
+    virtual ~ISerialDevice();
+
+    /**
+     * Sends a string of chars to the serial communications channel.
+     * \param msg the string to send
+     * \return true on success
+     */
+    virtual bool send(const yarp::os::Bottle& msg) = 0;
+    virtual bool send(char *msg, size_t size) = 0;
+
+    //bool putMessage(Bottle& msg, bool waitreply, double replytimeout, Bottle& reply, char *replydelimiter, int replysize );
+    /**
+     * Gets the existing chars in the receive queue.
+     * \param msg the received string
+     * \return true on success; false if no messages available
+     */
+    virtual bool receive(yarp::os::Bottle& msg) = 0;
+
+    /**
+     * Gets one single char from the receive queue.
+     * \param chr the received char.
+     * \return 0 if no chars are received; 1 if one char is received.
+     */
+    virtual int receiveChar(char& chr) = 0;
+
+    /**
+    * Gets an array of bytes (unsigned char) with size <= 'size' parameter. The array is NOT null terminated.
+    * @param bytes a previously allocated buffer where the received data is stored.
+    * @param size the size of the 'bytes' parameter.
+    * @return the number of received bytes. The function returns 0 if no bytes are received.
+    */
+    virtual int receiveBytes(unsigned char* bytes, const int size) = 0;
+
+    /**
+    * Gets one line (a sequence of chars with a ending '\\n' or '\\r') from the receive queue. The ending '\\n''\\r' chars are not removed in the returned line.
+    * \param line a previously allocated buffer where the received line is stored.
+    * \param MaxLineLength the size of the 'line' parameter.
+    * \return the number of received characters (including the '\n''\r' chars, plus the buffer terminator '\\0'). The function returns 0 if no chars are received.
+    */
+
+    virtual int receiveLine(char* line, const int MaxLineLength) = 0;
+    /**
+    * Enable/Disable DTR protocol
+    * @param enable Enable/Disable DTR protocol
+    * @return true on success
+    */
+    virtual bool setDTR(bool enable) = 0;
+    /**
+     * Flushes the internal buffer.
+     * \return the number of flushed characters.
+     */
+    virtual int flush() = 0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_ISERIALDEVICE_H

--- a/src/libYARP_dev/include/yarp/dev/IWrapper.h
+++ b/src/libYARP_dev/include/yarp/dev/IWrapper.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IWRAPPER_H
+#define YARP_DEV_IWRAPPER_H
+
+#include <yarp/dev/api.h>
+#include <yarp/dev/PolyDriver.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_iwrapper
+ *
+ * Interface for an object that can wrap/or "attach" to another. This is useful
+ * for example when an object refers internally to another device, but
+ * you want to decouple the creation of the two objects. In this case
+ * you first creates the two objects separately then you can attach one
+ * to the other.
+ */
+class YARP_dev_API IWrapper
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IWrapper();
+
+    /**
+     * Attach to another object.
+     * @param poly the polydriver that you want to attach to.
+     * @return true/false on success failure.
+     */
+    virtual bool attach(PolyDriver *poly) = 0;
+
+    /**
+     * Detach the object (you must have first called attach).
+     * @return true/false on success failure.
+     */
+    virtual bool detach() = 0;
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_IWRAPPER_H

--- a/src/libYARP_dev/include/yarp/dev/Wrapper.h
+++ b/src/libYARP_dev/include/yarp/dev/Wrapper.h
@@ -10,80 +10,8 @@
 #ifndef YARP_DEV_WRAPPER_H
 #define YARP_DEV_WRAPPER_H
 
-#include <yarp/dev/api.h>
-#include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/PolyDriverList.h>
-
-/*! \file Wrapper.h define the interface for an attachable object*/
-
-namespace yarp {
-    namespace dev {
-        class IWrapper;
-        class IMultipleWrapper;
-    }
-}
-
-/**
- * @ingroup dev_iwrapper
- *
- * Interface for an object that can wrap/or "attach" to another. This is useful
- * for example when an object refers internally to another device, but
- * you want to decouple the creation of the two objects. In this case
- * you first creates the two objects separately then you can attach one
- * to the other.
- */
-class YARP_dev_API yarp::dev::IWrapper
-{
-public:
-    /**
-     * Destructor.
-     */
-    virtual ~IWrapper() {}
-
-    /**
-     * Attach to another object.
-     * @param poly the polydriver that you want to attach to.
-     * @return true/false on success failure.
-     */
-    virtual bool attach(PolyDriver *poly)=0;
-
-    /**
-     * Detach the object (you must have first called attach).
-     * @return true/false on success failure.
-     */
-    virtual bool detach()=0;
-};
-
-/**
- * @ingroup dev_imultiplewrapper
- *
- * Interface for an object that can wrap/attach to to another. This is useful
- * for example when an object refers internally to another device, but
- * you want to decouple the creation of the two objects. In this case
- * you first creates the two objects separately then you can attach one
- * to the other. This class is similar to IWrapper, but allows attaching
- * to more than one object by subsequent calls to attach.
- */
-class YARP_dev_API yarp::dev::IMultipleWrapper
-{
-public:
-    /**
-     * Destructor.
-     */
-    virtual ~IMultipleWrapper() {}
-
-    /**
-     * Attach to a list of objects.
-     * @param p the polydriver list that you want to attach to.
-     * @return true/false on success failure.
-     */
-    virtual bool attachAll(const PolyDriverList &p)=0;
-
-    /**
-     * Detach the object (you must have first called attach).
-     * @return true/false on success failure.
-     */
-    virtual bool detachAll()=0;
-};
+YARP_COMPILER_WARNING("<yarp/dev/Wrapper.h> file is deprecated. Use <yarp/dev/IWrapper.h> and <yarp/dev/IMultipleWrapper.h> instead")
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #endif // YARP_DEV_WRAPPER_H

--- a/src/libYARP_dev/include/yarp/dev/all.h
+++ b/src/libYARP_dev/include/yarp/dev/all.h
@@ -28,7 +28,7 @@
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/FrameGrabberControl2.h>
 #include <yarp/dev/GazeControl.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/GPUInterface.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/IRGBDSensor.h>

--- a/src/libYARP_dev/include/yarp/dev/all.h
+++ b/src/libYARP_dev/include/yarp/dev/all.h
@@ -39,6 +39,7 @@
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ServiceInterfaces.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #endif // YARP_DEV_ALL_H

--- a/src/libYARP_dev/src/IAudioVisualGrabber.cpp
+++ b/src/libYARP_dev/src/IAudioVisualGrabber.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IAudioVisualGrabber.h>
+
+yarp::dev::IAudioVisualGrabber::~IAudioVisualGrabber() = default;

--- a/src/libYARP_dev/src/IAudioVisualStream.cpp
+++ b/src/libYARP_dev/src/IAudioVisualStream.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IAudioVisualStream.h>
+
+yarp::dev::IAudioVisualStream::~IAudioVisualStream() = default;

--- a/src/libYARP_dev/src/IFrameWriterAudioVisual.cpp
+++ b/src/libYARP_dev/src/IFrameWriterAudioVisual.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IFrameWriterAudioVisual.h>
+
+yarp::dev::IFrameWriterAudioVisual::~IFrameWriterAudioVisual() = default;

--- a/src/libYARP_dev/src/IGenericSensor.cpp
+++ b/src/libYARP_dev/src/IGenericSensor.cpp
@@ -6,10 +6,6 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_DEV_GENERICSENSORINTERFACES_H
-#define YARP_DEV_GENERICSENSORINTERFACES_H
-
-YARP_COMPILER_WARNING("<yarp/dev/GenericSensorInterfaces.h> file is deprecated. Use <yarp/dev/IGenericSensor.h> instead")
 #include <yarp/dev/IGenericSensor.h>
 
-#endif // YARP_DEV_GENERICSENSORINTERFACES_H
+yarp::dev::IGenericSensor::~IGenericSensor() = default;

--- a/src/libYARP_dev/src/IMultipleWrapper.cpp
+++ b/src/libYARP_dev/src/IMultipleWrapper.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IMultipleWrapper.h>
+
+yarp::dev::IMultipleWrapper::~IMultipleWrapper() = default;

--- a/src/libYARP_dev/src/ISerialDevice.cpp
+++ b/src/libYARP_dev/src/ISerialDevice.cpp
@@ -6,10 +6,6 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_DEV_SERIALINTERFACES_H
-#define YARP_DEV_SERIALINTERFACES_H
-
-YARP_COMPILER_WARNING("<yarp/dev/SerialInterfaces.h> file is deprecated. Use <yarp/dev/ISerialDevice.h> instead")
 #include <yarp/dev/ISerialDevice.h>
 
-#endif // YARP_DEV_SERIALINTERFACES_H
+yarp::dev::ISerialDevice::~ISerialDevice() = default;

--- a/src/libYARP_dev/src/IWrapper.cpp
+++ b/src/libYARP_dev/src/IWrapper.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IWrapper.h>
+
+yarp::dev::IWrapper::~IWrapper() = default;

--- a/src/yarprobotinterface/Device.cpp
+++ b/src/yarprobotinterface/Device.cpp
@@ -29,7 +29,7 @@
 #include <yarp/dev/CalibratorInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 
 #include <string>

--- a/tests/libYARP_dev/ControlBoardRemapperTest.cpp
+++ b/tests/libYARP_dev/ControlBoardRemapperTest.cpp
@@ -11,7 +11,7 @@
 #include <yarp/dev/IControlMode2.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <vector>
 

--- a/tests/libYARP_dev/ControlBoardWrapper2Test.cpp
+++ b/tests/libYARP_dev/ControlBoardWrapper2Test.cpp
@@ -12,7 +12,7 @@
 #include <yarp/os/Network.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <string>
 

--- a/tests/libYARP_dev/MultipleAnalogSensorsInterfacesTest.cpp
+++ b/tests/libYARP_dev/MultipleAnalogSensorsInterfacesTest.cpp
@@ -11,7 +11,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <cmath>
 #include <chrono>


### PR DESCRIPTION
Move a few interfaces in the `.h` file where they belong.
These interfaces need to be included at least once in the library (because they are declared `YARP_dev_API`, therefore the relative `.cpp` header is also included.

Moreover a few of these files are useless, therefore:

### dev

* The `<yarp/dev/GenericSensorInterfaces.h>` include file is deprecated in favour of
  `<yarp/dev/IGenericSensor.h>`.
* The `<yarp/dev/SerialInterfaces.h>` include file is deprecated in favour of
  `<yarp/dev/ISerialDevice.h>`.
* The `<yarp/dev/Wrapper.h>` include file is deprecated in favour of
  `<yarp/dev/IWrapper.h>` and `<yarp/dev/IMultipleWrapper.h>`.