### PR TITLE
yarpidl_thrift/YarpIDL.cmake: Allow "standard" file placements

### DIFF
--- a/doc/release/devel/YarpIDL_PLACEMENT.md
+++ b/doc/release/devel/YarpIDL_PLACEMENT.md
@@ -1,0 +1,20 @@
+YarpIDL_PLACEMENT {#devel}
+-----------------
+
+### CMake
+
+* The `yarp_idl_to_dir` command now accepts the `PLACEMENT` option:
+   * `MERGED`:        headers and sources in `<OUTPUT_DIR>/<namespace>`
+   * `SEPARATE`:      headers in `<OUTPUT_DIR>/include/<namespace>` sources in `<OUTPUT_DIR>/src/<namespace>`
+   * `SEPARATE_EVEN`: alias for `SEPARATE`
+   * `SEPARATE_ODD`:  headers in `<OUTPUT_DIR>/include/<namespace>` sources in `<OUTPUT_DIR>/src`
+  For backwards compatibility the default value is `SEPARATE_ODD`.
+
+* After calling the `yarp_add_idl` method, the `YARP_ADD_IDL_INCLUDE_DIR`
+  variable contains the include directory for using the header files
+
+### Tools
+
+#### `yarpidl_trift`
+
+* yarpidl_thrift now places the source files according to the "separate" layout.

--- a/src/devices/multipleAnalogSensorsMsgs/CMakeLists.txt
+++ b/src/devices/multipleAnalogSensorsMsgs/CMakeLists.txt
@@ -11,7 +11,7 @@ if(YARP_COMPILE_DEVICE_PLUGINS)
      NOT ALLOW_IDL_GENERATION AND
      YARP_COMPILE_EXECUTABLES)
     yarp_add_idl(MAS_THRIFT_GEN_FILES multipleAnalogSensorsSerializations.thrift)
-    set(MAS_THRIFT_INTERFACE_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
+    set(MAS_THRIFT_INTERFACE_INCLUDE_DIRS "${YARP_ADD_IDL_INCLUDE_DIR}")
   else()
     yarp_idl_to_dir(INPUT_FILES multipleAnalogSensorsSerializations.thrift
                     OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/idl_generated_code"

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -669,7 +669,7 @@ void t_yarp_generator::init_generator()
     // Each enum produces a .cpp and a .h files
     for (const auto& enum_ : program_->get_enums()) {
         f_out_index_ << get_include_prefix(program_) << enum_->get_name() << ".h\n";
-        f_out_index_ << enum_->get_name() << ".cpp\n";
+        f_out_index_ << get_include_prefix(program_) << enum_->get_name() << ".cpp\n";
     }
 
     // Each struct and exception produces a .h and a .cpp files unless
@@ -677,14 +677,14 @@ void t_yarp_generator::init_generator()
     for (const auto& obj : program_->get_objects()) {
         if (obj->annotations_.find("yarp.includefile") == obj->annotations_.end()) {
             f_out_index_ << get_include_prefix(program_) << obj->get_name() << ".h\n";
-            f_out_index_ << obj->get_name() << ".cpp\n";
+            f_out_index_ << get_include_prefix(program_) << obj->get_name() << ".cpp\n";
         }
     }
 
     // Each service produces a .h and a .cpp files
     for (const auto& service : program_->get_services()) {
         f_out_index_ << get_include_prefix(program_) << service->get_name() << ".h\n";
-        f_out_index_ << service->get_name() << ".cpp\n";
+        f_out_index_ << get_include_prefix(program_) << service->get_name() << ".cpp\n";
     }
 
     f_out_index_.close();
@@ -1622,7 +1622,7 @@ void t_yarp_generator::generate_enum(t_enum* tenum)
     THRIFT_DEBUG_COMMENT(f_h_);
 
     // Open cpp files
-    std::string f_cpp_name = get_out_dir() + name + ".cpp";
+    std::string f_cpp_name = get_out_dir() + get_include_prefix(program_) + name + ".cpp";
     ofstream_with_content_based_conditional_update f_cpp_;
     f_cpp_.open(f_cpp_name);
     THRIFT_DEBUG_COMMENT(f_cpp_);
@@ -1846,7 +1846,7 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
     f_h_.open(f_header_name);
 
     // Open cpp file
-    std::string f_cpp_name = get_out_dir() + name + ".cpp";
+    std::string f_cpp_name = get_out_dir() + get_include_prefix(program_) + name + ".cpp";
     ofstream_with_content_based_conditional_update f_cpp_;
     f_cpp_.open(f_cpp_name);
 
@@ -3230,7 +3230,7 @@ void t_yarp_generator::generate_service(t_service* tservice)
     f_h_.open(f_header_name);
 
     // Open cpp files
-    std::string f_cpp_name = get_out_dir() + service_name + ".cpp";
+    std::string f_cpp_name = get_out_dir() + get_include_prefix(program_) + service_name + ".cpp";
     ofstream_with_content_based_conditional_update f_cpp_;
     f_cpp_.open(f_cpp_name);
 

--- a/src/libYARP_rosmsg/CMakeLists.txt
+++ b/src/libYARP_rosmsg/CMakeLists.txt
@@ -24,7 +24,7 @@ macro(_yarp_choose_idl _prefix)
        YARP_COMPILE_EXECUTABLES)
       yarp_add_idl(${_prefix}_GEN_FILES
                    ${ARGN})
-      set(${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
+      set(${_prefix}_BUILD_INTERFACE_INCLUDE_DIRS "${YARP_ADD_IDL_INCLUDE_DIR}")
     else()
       foreach(_msg ${ARGN})
         yarp_idl_to_dir(INPUT_FILES ${_msg}


### PR DESCRIPTION
The `yarp_idl_to_dir` command now accepts the `PLACEMENT` option:
 * `MERGED`:        headers and sources in `<OUTPUT_DIR>/<namespace>`
 * `SEPARATE`:      headers in `<OUTPUT_DIR>/include/<namespace>` sources in
                    `<OUTPUT_DIR>/src/<namespace>`
 * `SEPARATE_EVEN`: Alias for `SEPARATE`
 * `SEPARATE_ODD`:  headers in `<OUTPUT_DIR>/include/<namespace>` sources in
                    `<OUTPUT_DIR>/src`

For backwards compatibility the default value is `SEPARATE_ODD`.

yarpidl_thrift now places the source files according to the "separate"
layout.

After calling the `yarp_add_idl` method, the `YARP_ADD_IDL_INCLUDE_DIR`
variable contains the include directory for using the header files