### PR TITLE
Add the possibility to align the frames of the realsense camera also to the depth frame

### DIFF
--- a/doc/release/devel/alignRGBD.md
+++ b/doc/release/devel/alignRGBD.md
@@ -1,0 +1,10 @@
+alignRGBD {#devel}
+---------
+
+### devices
+
+#### realsense2
+
+* Deprecated the `needAlignment` parameter in favour of `alignmentFrame`.
+  The default behaviour has been maintaned, if not specified `alignmentFrame`
+  is `RGB`. The allowed values are `RGB`, `Depth` and `None`.

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -409,10 +409,8 @@ bool realsense2Driver::pipelineRestart()
     if (!pipelineShutdown())
         return false;
 
-    if (!pipelineStartup())
-        return false;
+    return pipelineStartup();
 
-    return true;
 }
 
 bool realsense2Driver::setFramerate(const int _fps)
@@ -696,12 +694,8 @@ bool realsense2Driver::open(Searchable& config)
     }
 
     // setting Parameters
-    if (!setParams())
-    {
-        return false;
-    }
+    return setParams();
 
-    return true;
 }
 
 bool realsense2Driver::close()
@@ -1076,14 +1070,7 @@ bool realsense2Driver::hasFeature(int feature, bool* hasFeature)
         return false;
     }
 
-    if (std::find(m_supportedFeatures.begin(), m_supportedFeatures.end(), f) != m_supportedFeatures.end())
-    {
-        *hasFeature = true;
-    }
-    else
-    {
-        *hasFeature = false;
-    }
+    *hasFeature = std::find(m_supportedFeatures.begin(), m_supportedFeatures.end(), f) != m_supportedFeatures.end();
 
     return true;
 }

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -354,18 +354,15 @@ static YarpDistortion rsDistToYarpDist(const rs2_distortion dist)
 }
 
 realsense2Driver::realsense2Driver() : m_depth_sensor(nullptr), m_color_sensor(nullptr),
-                                       m_paramParser(nullptr), m_verbose(false),
+                                       m_paramParser(), m_verbose(false),
                                        m_initialized(false), m_stereoMode(false),
                                        m_needAlignment(true), m_fps(0),
                                        m_scale(0.0)
 {
-
-    m_paramParser = new RGBDSensorParamParser();
-
     // realsense SDK already provides them
-    m_paramParser->depthIntrinsic.isOptional = true;
-    m_paramParser->rgbIntrinsic.isOptional   = true;
-    m_paramParser->isOptionalExtrinsic       = true;
+    m_paramParser.depthIntrinsic.isOptional = true;
+    m_paramParser.rgbIntrinsic.isOptional   = true;
+    m_paramParser.isOptionalExtrinsic       = true;
 
     m_supportedFeatures.push_back(YARP_FEATURE_EXPOSURE);
     m_supportedFeatures.push_back(YARP_FEATURE_WHITE_BALANCE);
@@ -374,15 +371,6 @@ realsense2Driver::realsense2Driver() : m_depth_sensor(nullptr), m_color_sensor(n
     m_supportedFeatures.push_back(YARP_FEATURE_SHARPNESS);
     m_supportedFeatures.push_back(YARP_FEATURE_HUE);
     m_supportedFeatures.push_back(YARP_FEATURE_SATURATION);
-}
-
-realsense2Driver::~realsense2Driver()
-{
-    if (m_paramParser)
-    {
-        delete m_paramParser;
-        m_paramParser = nullptr;
-    }
 }
 
 bool realsense2Driver::pipelineStartup()
@@ -695,7 +683,7 @@ bool realsense2Driver::open(Searchable& config)
         m_stereoMode = config.find("stereoMode").asBool();
     }
 
-    if (!m_paramParser->parseParam(config, params))
+    if (!m_paramParser.parseParam(config, params))
     {
         yError()<<"realsense2Driver: failed to parse the parameters";
         return false;

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -51,7 +51,7 @@ static std::string get_device_information(const rs2::device& dev)
 
     for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++)
     {
-        rs2_camera_info info_type = static_cast<rs2_camera_info>(i);
+        auto info_type = static_cast<rs2_camera_info>(i);
         ss << "  " << std::left << std::setw(20) << info_type << " : ";
 
         if (dev.supports(info_type))
@@ -79,7 +79,7 @@ static void print_supported_options(const rs2::sensor& sensor)
     // Starting from 0 until RS2_OPTION_COUNT (exclusive)
     for (int i = 0; i < static_cast<int>(RS2_OPTION_COUNT); i++)
     {
-        rs2_option option_type = static_cast<rs2_option>(i);
+        auto option_type = static_cast<rs2_option>(i);
         //SDK enum types can be streamed to get a string that represents them
 
         // To control an option, use the following api:
@@ -684,6 +684,7 @@ bool realsense2Driver::setParams()
 bool realsense2Driver::open(Searchable& config)
 {
     std::vector<RGBDSensorParamParser::RGBDParam*> params;
+    params.reserve(params_map.size());
     for (auto& p:params_map)
     {
         params.push_back(&(p.second));
@@ -1037,7 +1038,7 @@ bool realsense2Driver::getImage(depthImage& Frame, Stamp *timeStamp, const rs2::
     Frame.resize(w, h);
 
     float* rawImage = &Frame.pixel(0,0);
-    const uint16_t * rawImageRs =(const uint16_t *) depth_frm.get_data();
+    const auto * rawImageRs =(const uint16_t *) depth_frm.get_data();
 
     for(int i = 0; i < w * h; i++)
     {
@@ -1110,7 +1111,7 @@ bool realsense2Driver::setFeature(int feature, double value)
 
     float valToSet = 0.0;
     b = false;
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     switch(f)
     {
     case YARP_FEATURE_EXPOSURE:
@@ -1188,7 +1189,7 @@ bool realsense2Driver::getFeature(int feature, double *value)
     float valToGet = 0.0;
     b = false;
 
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     switch(f)
     {
     case YARP_FEATURE_EXPOSURE:
@@ -1258,7 +1259,7 @@ bool realsense2Driver::hasOnOff(  int feature, bool *HasOnOff)
         return false;
     }
 
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     if (f == YARP_FEATURE_WHITE_BALANCE || f == YARP_FEATURE_MIRROR || f == YARP_FEATURE_EXPOSURE)
     {
         *HasOnOff = true;
@@ -1339,7 +1340,7 @@ bool realsense2Driver::hasAuto(int feature, bool *hasAuto)
         return false;
     }
 
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     if (f == YARP_FEATURE_EXPOSURE || f == YARP_FEATURE_WHITE_BALANCE)
     {
         *hasAuto = true;
@@ -1358,7 +1359,7 @@ bool realsense2Driver::hasManual( int feature, bool* hasManual)
         return false;
     }
 
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     if (f == YARP_FEATURE_EXPOSURE || f == YARP_FEATURE_FRAME_RATE || f == YARP_FEATURE_GAIN ||
         f == YARP_FEATURE_HUE || f == YARP_FEATURE_SATURATION || f == YARP_FEATURE_SHARPNESS)
     {
@@ -1392,7 +1393,7 @@ bool realsense2Driver::setMode(int feature, FeatureMode mode)
     float one = 1.0;
     float zero = 0.0;
 
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     if (f == YARP_FEATURE_WHITE_BALANCE)
     {
         switch(mode)
@@ -1440,7 +1441,7 @@ bool realsense2Driver::getMode(int feature, FeatureMode* mode)
     }
     float res = 0.0;
     bool ret = true;
-    cameraFeature_id_t f = static_cast<cameraFeature_id_t>(feature);
+    auto f = static_cast<cameraFeature_id_t>(feature);
     if (f == YARP_FEATURE_WHITE_BALANCE)
     {
         ret &= getOption(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, m_color_sensor, res);

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -129,7 +129,7 @@ static bool isSupportedFormat(const rs2::sensor &sensor, const int width, const 
     //Next, we go over all the stream profiles and print the details of each one
 
     int profile_num = 0;
-    for (rs2::stream_profile stream_profile : stream_profiles)
+    for (const rs2::stream_profile& stream_profile : stream_profiles)
     {
         if (verbose)
         {
@@ -505,25 +505,25 @@ bool realsense2Driver::initializeRealsenseDevice()
     yInfo()<< "realsense2Driver: Device consists of" << m_sensors.size()<<"sensors";
     if (m_verbose)
     {
-        for (size_t i=0; i < m_sensors.size(); i++)
+        for (const auto & m_sensor : m_sensors)
         {
-            print_supported_options(m_sensors[i]);
+            print_supported_options(m_sensor);
         }
     }
 
-    for (size_t i=0; i < m_sensors.size(); i++)
+    for (auto & m_sensor : m_sensors)
     {
-        if (m_sensors[i].is<rs2::depth_sensor>())
+        if (m_sensor.is<rs2::depth_sensor>())
         {
-            m_depth_sensor =  &m_sensors[i];
+            m_depth_sensor =  &m_sensor;
             if (!getOption(RS2_OPTION_DEPTH_UNITS, m_depth_sensor, m_scale))
             {
                 yError()<<"relsense2Driver: failed to retrieve scale";
                 return false;
             }
         }
-        else if (m_sensors[i].get_stream_profiles()[0].stream_type() == RS2_STREAM_COLOR)
-            m_color_sensor = &m_sensors[i];
+        else if (m_sensor.get_stream_profiles()[0].stream_type() == RS2_STREAM_COLOR)
+            m_color_sensor = &m_sensor;
     }
 
     // Get stream intrinsics & extrinsics

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -200,9 +200,6 @@ private:
 
     bool        getImage(FlexImage& Frame, Stamp* timeStamp, rs2::frameset& sourceFrame);
     bool        getImage(depthImage& Frame, Stamp* timeStamp, const rs2::frameset& sourceFrame);
-    bool        setIntrinsic(yarp::os::Property& intrinsic, const rs2_intrinsics& values);
-    bool        setExtrinsicParam(yarp::sig::Matrix& extrinsic, const rs2_extrinsics& values);
-    void        settingErrorMsg(const std::string& error, bool& ret);
     void        updateTransformations();
     bool        pipelineStartup();
     bool        pipelineShutdown();

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -219,8 +219,8 @@ private:
     std::vector<rs2::sensor> m_sensors;
     rs2::sensor* m_depth_sensor;
     rs2::sensor* m_color_sensor;
-    rs2_intrinsics m_depth_intrin, m_color_intrin, m_infrared_intrin;
-    rs2_extrinsics m_depth_to_color, m_color_to_depth;
+    rs2_intrinsics m_depth_intrin{}, m_color_intrin{}, m_infrared_intrin{};
+    rs2_extrinsics m_depth_to_color{}, m_color_to_depth{};
     rs2_stream  m_alignment_stream{RS2_STREAM_COLOR};
 
 

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -131,7 +131,7 @@ private:
 
 public:
     realsense2Driver();
-    ~realsense2Driver();
+    ~realsense2Driver() override = default;
 
     // DeviceDriver
     bool open(yarp::os::Searchable& config) override;
@@ -228,7 +228,7 @@ private:
     yarp::os::Stamp m_rgb_stamp;
     yarp::os::Stamp m_depth_stamp;
     std::string m_lastError;
-    yarp::dev::RGBDSensorParamParser* m_paramParser;
+    yarp::dev::RGBDSensorParamParser m_paramParser;
     bool m_verbose;
     bool m_initialized;
     bool m_stereoMode;

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -72,7 +72,8 @@
  * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
  * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
  * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
- * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This operation could be heavy, set it to false to increase the fps   |
+ * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This option is deprecated, please use alignmentFrame instead.        |
+ * |                              |  alignmentFrame     | string              |  Read / Write   | -              |   RGB         |  No                              | This parameter specifies the frame to which the frames RGB and Depth will be aligned.  |  The accepted values are RGB, Depth, None. This operation could be heavy, set it to None to increase the fps.|
  * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
  * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minimum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
  *
@@ -89,7 +90,7 @@ depthResolution (640 480)    #Note the parentheses
 rgbResolution   (640 480)
 framerate       30
 enableEmitter   true
-needAlignment   true
+alignmentFrame  RGB
 
 [HW_DESCRIPTION]
 clipPlanes (0.2 10.0)
@@ -220,6 +221,7 @@ private:
     rs2::sensor* m_color_sensor;
     rs2_intrinsics m_depth_intrin, m_color_intrin, m_infrared_intrin;
     rs2_extrinsics m_depth_to_color, m_color_to_depth;
+    rs2_stream  m_alignment_stream{RS2_STREAM_COLOR};
 
 
     yarp::os::Stamp m_rgb_stamp;

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -190,7 +190,8 @@ set(YARP_dev_SRCS src/AudioBufferSize.cpp
                   src/MultipleAnalogSensorsInterfaces.cpp
                   src/PolyDriver.cpp
                   src/PolyDriverDescriptor.cpp
-                  src/PolyDriverList.cpp)
+                  src/PolyDriverList.cpp
+                  src/RGBDSensorParamParser.cpp)
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_SRCS src/IFrameTransform.cpp

--- a/src/libYARP_dev/src/RGBDSensorParamParser.cpp
+++ b/src/libYARP_dev/src/RGBDSensorParamParser.cpp
@@ -181,7 +181,7 @@ bool RGBDSensorParamParser::parseParam(const Searchable &config, std::vector<RGB
 
     if (!ret)
     {
-        yError() << "depthCamera driver input file not correct, please fix it!";
+        yError() << "RGBDSensorParamParser: driver input file not correct, please fix it!";
         return false;
     }
 


### PR DESCRIPTION
This PR add the possibility to align the frames of the realsense camera to the depth frame.
Before it was only possible to align the depth image over the rgb frame.

For doing so I add a new parameter called `alignmentFrame` and deprecated the old `needAlignment`.

The default behaviour has been maintaned, if not specified `alignmentFrame` is `RGB`.
The allowed values are `RGB`, `Depth` and `None`.

To be tested.

Please review code.