### PR TITLE
[yarpmanager] Fix wrong text label in clusterWidget

### DIFF
--- a/src/yarpmanager/src-manager/clusterWidget.ui
+++ b/src/yarpmanager/src-manager/clusterWidget.ui
@@ -68,7 +68,7 @@
             </size>
            </property>
            <property name="text">
-            <string>Cluster Managerment Window</string>
+            <string>Cluster Management Window</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This fixes a wrong label in `yarpmanager clusterWidget` user interface

https://github.com/robotology/yarp/blob/e28da21babaace57aa55507fa8c291459a113737/src/yarpmanager/src-manager/clusterWidget.ui#L71

changing it to 

```<string>Cluster Management Window</string> ```.

fixes #2113 