### PR TITLE
yarpdatadumper can handle dir name w/ special chars

### DIFF
--- a/doc/release/devel/yarpdatadumper_dirname.md
+++ b/doc/release/devel/yarpdatadumper_dirname.md
@@ -1,0 +1,5 @@
+fix/dumper-dirname {#devel}
+--------------
+
+#### `yarpdatadumper`
+* Fixed creating directories whose name contains not allowed characters (e.g. ':', '*'...)

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <array>
 #include <deque>
 #include <utility>
 #include <mutex>
@@ -578,6 +579,15 @@ private:
     unsigned int      dwnsample{0};
     string            portName;
 
+    void polish_filename(string &fname)
+    {
+        array<char,6> notallowed={':','*','?','|','>','<'};
+        for (auto &c:notallowed)
+        {
+            replace(fname.begin(),fname.end(),c,'_');
+        }
+    }
+
 public:
     DumpModule() = default;
 
@@ -630,6 +640,7 @@ public:
         rxTime=rf.check("rxTime");
         txTime=rf.check("txTime");
         string templateDirName=rf.check("dir")?rf.find("dir").asString():portName;
+        polish_filename(templateDirName);
         if (templateDirName[0]!='/')
             templateDirName="/"+templateDirName;
 


### PR DESCRIPTION
This PR addresses #2116 so that special chars (`:`, `*`, `|`...) in the name of the dirs created by `yarpdatadumper` get replaced with the underscore. The chars `/`, '\' can be still used as it will allow for creating nested dirs.