### PR TITLE
cleanup of the signature of several methods of yarp::os::Network

### DIFF
--- a/doc/release/devel/Network_isConnected.md
+++ b/doc/release/devel/Network_isConnected.md
@@ -1,0 +1,23 @@
+network_isConnected {#devel}
+---------------
+
+### os
+
+#### `Network`
+
+* Cleanup of the signature of the following methods of `yarp::os::Network`:
+```
+    static bool connect(const std::string& src, const std::string& dest, const ContactStyle& style);
+    static bool connect(const std::string& src, const std::string& dest, const std::string& carrier = "",  bool quiet = true);
+    static bool connect(const char* src, const char* dest, const char* carrier,  bool quiet = true);
+
+    static bool disconnect(const std::string& src, const std::string& dest, bool quiet);
+    static bool disconnect(const std::string& src, const std::string& dest, const ContactStyle& style);
+    static bool disconnect(const std::string& src, const std::string& dest, const std::string& carrier = "", bool quiet = true);
+    static bool disconnect(const char* src, const char* dest, const char* carrier, bool quiet = true);
+ 
+    static bool isConnected(const std::string& src, const std::string& dest, bool quiet);
+    static bool isConnected(const std::string& src, const std::string& dest, const ContactStyle& style);
+    static bool isConnected(const std::string& src, const std::string& dest, const std::string& carrier = "", bool quiet = true);
+    static bool isConnected(const char* src, const char* dest, const char* carrier,  bool quiet = true);
+```

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -647,12 +647,32 @@ bool NetworkBase::disconnect(const std::string& src,
     return result == 0;
 }
 
+bool NetworkBase::disconnect(const std::string& src, const std::string& dest, const std::string& carrier, bool quiet)
+{
+    ContactStyle style;
+    style.quiet = quiet;
+    if (!carrier.empty()) {
+        style.carrier = carrier;
+    }
+    return disconnect(src, dest, style);
+}
+
 bool NetworkBase::isConnected(const std::string& src,
                               const std::string& dest,
                               bool quiet)
 {
     ContactStyle style;
     style.quiet = quiet;
+    return isConnected(src, dest, style);
+}
+
+bool NetworkBase::isConnected(const std::string& src, const std::string& dest, const std::string& carrier, bool quiet)
+{
+    ContactStyle style;
+    style.quiet = quiet;
+    if (!carrier.empty()) {
+        style.carrier = carrier;
+    }
     return isConnected(src, dest, style);
 }
 

--- a/src/libYARP_os/src/yarp/os/Network.h
+++ b/src/libYARP_os/src/yarp/os/Network.h
@@ -145,7 +145,7 @@ public:
      */
     static bool disconnect(const std::string& src,
                            const std::string& dest,
-                           bool quiet = true);
+                           bool quiet);
 
     /**
      * Request that an output port disconnect from an input port.
@@ -159,6 +159,31 @@ public:
                            const ContactStyle& style);
 
     /**
+     * Request that an output port disconnect from an input port.
+     * @param src the name of an output port
+     * @param dest the name of an input port
+     * @param carrier the name of the protocol to use (tcp/udp/mcast)
+     * @param quiet suppress messages displayed upon success/failure
+     * @return true on success, false on failure
+     */
+    static bool disconnect(const std::string& src,
+                        const std::string& dest,
+                        const std::string& carrier = "",
+                        bool quiet = true);
+
+    // Catch old uses of nullptr for carrier
+    static bool disconnect(const char* src,
+                        const char* dest,
+                        const char* carrier,
+                        bool quiet = true)
+    {
+        return disconnect(std::string(src),
+                       std::string(dest),
+                       std::string((carrier == nullptr) ? "" : carrier),
+                       quiet);
+    }
+
+    /**
      * Check if a connection exists between two ports.
      * @param src the name of an output port
      * @param dest the name of an input port
@@ -167,7 +192,7 @@ public:
      */
     static bool isConnected(const std::string& src,
                             const std::string& dest,
-                            bool quiet = true);
+                            bool quiet);
 
     /**
      * Check if a connection exists between two ports.
@@ -179,6 +204,31 @@ public:
     static bool isConnected(const std::string& src,
                             const std::string& dest,
                             const ContactStyle& style);
+
+    /**
+     * Check if a connection exists between two ports.
+     * @param src the name of an output port
+     * @param dest the name of an input port
+     * @param carrier the name of the protocol to use (tcp/udp/mcast)
+     * @param quiet suppress messages displayed upon success/failure
+     * @return true if there is a connection
+     */
+    static bool isConnected(const std::string& src,
+                        const std::string& dest,
+                        const std::string& carrier = "",
+                        bool quiet = true);
+
+    // Catch old uses of nullptr for carrier
+    static bool isConnected(const char* src,
+                        const char* dest,
+                        const char* carrier,
+                        bool quiet = true)
+    {
+        return isConnected(std::string(src),
+                       std::string(dest),
+                       std::string((carrier == nullptr) ? "" : carrier),
+                       quiet);
+    }
 
     /**
      * Check for a port to be ready and responsive.


### PR DESCRIPTION
* Cleanup of the signature of the following methods of `yarp::os::Network`:
```
    static bool connect(const std::string& src, const std::string& dest, const ContactStyle& style);
    static bool connect(const std::string& src, const std::string& dest, const std::string& carrier = "",  bool quiet = true);
    static bool connect(const char* src, const char* dest, const char* carrier,  bool quiet = true);

    static bool disconnect(const std::string& src, const std::string& dest, bool quiet);
    static bool disconnect(const std::string& src, const std::string& dest, const ContactStyle& style);
    static bool disconnect(const std::string& src, const std::string& dest, const std::string& carrier = "", bool quiet = true);
    static bool disconnect(const char* src, const char* dest, const char* carrier, bool quiet = true);
 
    static bool isConnected(const std::string& src, const std::string& dest, bool quiet);
    static bool isConnected(const std::string& src, const std::string& dest, const ContactStyle& style);
    static bool isConnected(const std::string& src, const std::string& dest, const std::string& carrier = "", bool quiet = true);
    static bool isConnected(const char* src, const char* dest, const char* carrier,  bool quiet = true);
```