### PR TITLE
Transform client improvements

### DIFF
--- a/doc/release/devel/TransformClient.md
+++ b/doc/release/devel/TransformClient.md
@@ -1,0 +1,11 @@
+TransformClient {#devel}
+--------------
+
+### dev
+
+* Added new interface `yarp::dev::IFrameTranformClientControl`
+* `yarp::dev::TransformClient` implements the new interface `yarp::dev::IFrameTranformClientControl`.
+*  The rpc port of the `yarp::dev::TransformClient` allows to reconnect to the server.
+* `yarp::dev::TransformServer` allows the use of wildcard to erase all the transforms between a specified source and *;
+  or  between * and a specified destination.
+* The rpc port of the `yarp::dev::TransformServer` allows to delete a given tranform.

--- a/src/devices/transformClient/FrameTransformClient.h
+++ b/src/devices/transformClient/FrameTransformClient.h
@@ -16,14 +16,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef YARP_DEV_FRAMETRANSFORMCLIENT_FRAMETRANSFORMCLIENT_H
-#define YARP_DEV_FRAMETRANSFORMCLIENT_FRAMETRANSFORMCLIENT_H
+#ifndef YARP_DEV_FRAMETRANSFORMCLIENT_H
+#define YARP_DEV_FRAMETRANSFORMCLIENT_H
 
 
 #include <yarp/os/Network.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/dev/IFrameTransform.h>
+#include <yarp/dev/IFrameTransformClientControl.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ControlBoardHelpers.h>
 #include <yarp/sig/Vector.h>
@@ -87,6 +88,7 @@ public:
 class FrameTransformClient :
         public yarp::dev::DeviceDriver,
         public yarp::dev::IFrameTransform,
+        public yarp::dev::IFrameTransformClientControl,
         public yarp::os::PortReader,
         public yarp::os::PeriodicThread
 {
@@ -104,6 +106,14 @@ protected:
     yarp::os::Port                m_rpc_InterfaceToUser;
     std::string         m_local_name;
     std::string         m_remote_name;
+
+    std::string         m_local_rpcServer;
+    std::string         m_local_rpcUser;
+    std::string         m_remote_rpc;
+    std::string         m_remote_streaming_name;
+    std::string         m_local_streaming_name;
+
+    std::string         m_streaming_connection_type;
     Transforms_client_storage*    m_transform_storage;
     double                        m_period;
     std::mutex               m_rpc_mutex;
@@ -145,6 +155,9 @@ public:
      bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) override;
      bool     waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) override;
 
+     bool     isConnectedWithServer() override;
+     bool     reconnectWithServer() override;
+
      FrameTransformClient();
     ~FrameTransformClient();
      bool     threadInit() override;
@@ -152,4 +165,4 @@ public:
      void     run() override;
 };
 
-#endif // YARP_DEV_FRAMETRANSFORMCLIENT_FRAMETRANSFORMCLIENT_H
+#endif // YARP_DEV_FRAMETRANSFORMCLIENT_H

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -117,6 +117,7 @@ set(YARP_dev_HDRS yarp/dev/all.h
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_HDRS yarp/dev/IFrameTransform.h
+                            yarp/dev/IFrameTransformClientControl.h
                             yarp/dev/ILocalization2D.h
                             yarp/dev/IMap2D.h
                             yarp/dev/INavigation2D.h
@@ -195,6 +196,7 @@ set(YARP_dev_SRCS yarp/dev/AudioBufferSize.cpp
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_SRCS yarp/dev/IFrameTransform.cpp
+                            yarp/dev/IFrameTransformClientControl.cpp
                             yarp/dev/IMap2D.cpp
                             yarp/dev/INavigation2D.cpp
                             yarp/dev/MapGrid2D.cpp

--- a/src/libYARP_dev/src/yarp/dev/IFrameTransformClientControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IFrameTransformClientControl.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/IFrameTransformClientControl.h>
+
+yarp::dev::IFrameTransformClientControl::~IFrameTransformClientControl() = default;

--- a/src/libYARP_dev/src/yarp/dev/IFrameTransformClientControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameTransformClientControl.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_IFRAMETRANSFORM_CLIENTCONTROL_H
+#define YARP_DEV_IFRAMETRANSFORM_CLIENTCONTROL_H
+
+#include <string>
+#include <vector>
+#include <yarp/dev/api.h>
+#include <yarp/os/Vocab.h>
+
+namespace yarp {
+    namespace dev {
+        class IFrameTransformClientControl;
+      }
+}
+
+/**
+ * @ingroup dev_iface_transform
+ *
+ * IFrameTransformClientControl Interface.
+ */
+class YARP_dev_API yarp::dev::IFrameTransformClientControl
+{
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~IFrameTransformClientControl();
+
+    /**
+    * Returns true if the client is connected with the server, false otherwise.
+    * @return true/false
+    */
+    virtual bool isConnectedWithServer() = 0;
+    
+    /**
+    * Attempts to reconnect the client with the server. Returns true if the operation
+    * is succesful, false otherwise.
+    * @return true/false
+    */
+    virtual bool reconnectWithServer() = 0;
+};
+
+
+#endif // YARP_DEV_IFRAMETRANSFORM_CLIENTCONTROL_H


### PR DESCRIPTION
* Added new interface `yarp::dev::IFrameTranformClientControl`
* `yarp::dev::TransformClient` implements the new interface `yarp::dev::IFrameTranformClientControl`.
*  The rpc port of the `yarp::dev::TransformClient` allows to reconnect to the server.
* `yarp::dev::TransformServer` allows the use of wildcard to erase all the transforms between a specified source and *;
  or between * and a specified destination.
* The rpc port of the `yarp::dev::TransformServer` allows to delete a given transform.