### PR TITLE
os/MessageStack: Refactor

### DIFF
--- a/doc/release/devel/refactor_MessageStack.md
+++ b/doc/release/devel/refactor_MessageStack.md
@@ -1,0 +1,9 @@
+refactor_MessageStack {#devel}
+
+### os
+
+#### `MessageStack`
+
+* Constructor now accepts the max number of thread as `size_t` instead of `int`.
+* Constructor is now explicit.
+* Copy and move constructors and operators are now explicitly deleted.

--- a/src/libYARP_os/src/yarp/os/MessageStack.h
+++ b/src/libYARP_os/src/yarp/os/MessageStack.h
@@ -23,41 +23,42 @@ class YARP_os_API MessageStack
 {
 public:
     /**
-     *
      * Constructor.
+     *
      * @param max_threads maximum number of worker threads allowed (0 means
      * unlimited)
-     *
      */
-    MessageStack(int max_threads = 0);
+    explicit MessageStack(size_t max_threads = 0);
+
+    MessageStack(const MessageStack&) = delete;
+    MessageStack(MessageStack&&) noexcept = delete;
+    MessageStack& operator=(const MessageStack&) = delete;
+    MessageStack& operator=(MessageStack&&) = delete;
 
     /**
-     *
      * Destructor.
-     *
      */
     virtual ~MessageStack();
 
     /**
-     *
      * @param owner the destination to send messages to
-     *
      */
     void attach(PortReader& owner);
 
     /**
-     *
      * Add a message to the message stack, to be sent whenever the gods
      * see fit.
+     *
      * @param msg the message to send
      * @param tag an optional string to prefix the message with
-     *
      */
     void stack(PortWriter& msg, const std::string& tag = "");
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:
-    int max_threads;
-    void* implementation;
+    class Private;
+    Private* mPriv;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
 } // namespace os


### PR DESCRIPTION
* Properly implement PIMPL.
* Use condition_variable instead of semaphore.
* Constructor now accepts the max number of thread as `size_t` instead of `int`.
* Copy and move constructors and operators are now explicitly deleted.
* Cleanup.