### PR TITLE
Conditionally enable colored logger output in runtime check (WIN10)

### DIFF
--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -51,18 +51,24 @@
 #ifdef YARP_HAS_WIN_VT_SUPPORT
 #include <windows.h>
 
-static bool yarp_logger_vt_colors_enabled = false;
-extern "C" static void yarp_logger_enable_vt_colors()
+namespace
 {
-    DWORD handleMode = 0;
-    HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+    bool yarp_logger_vt_colors_enabled = false;
 
-    if (hStdout != INVALID_HANDLE_VALUE && GetConsoleMode(hStdout, &handleMode)) {
-        handleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        SetConsoleMode(hStdout, handleMode);
+    bool yarp_logger_enable_vt_colors()
+    {
+        DWORD handleMode = 0;
+        HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+        bool success = false;
+
+        if (hStdout != INVALID_HANDLE_VALUE && GetConsoleMode(hStdout, &handleMode)) {
+            handleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            success = SetConsoleMode(hStdout, handleMode);
+        }
+
+        yarp_logger_vt_colors_enabled = true;
+        return success;
     }
-
-    yarp_logger_vt_colors_enabled = true;
 }
 #endif
 
@@ -226,7 +232,7 @@ yarp::os::Log::Log(const char* file,
 {
 #ifdef YARP_HAS_WIN_VT_SUPPORT
     if (!yarp_logger_vt_colors_enabled) {
-        yarp_logger_enable_vt_colors();
+        mPriv->colored_output &= yarp_logger_enable_vt_colors();
     }
 #endif
 }
@@ -236,7 +242,7 @@ yarp::os::Log::Log() :
 {
 #ifdef YARP_HAS_WIN_VT_SUPPORT
     if (!yarp_logger_vt_colors_enabled) {
-        yarp_logger_enable_vt_colors();
+        mPriv->colored_output &= yarp_logger_enable_vt_colors();
     }
 #endif
 }


### PR DESCRIPTION
Follow-up of https://github.com/robotology/yarp/pull/2076 and https://github.com/robotology/yarp/pull/2137. This patch performs a runtime check so that Windows systems that do not support colors do not attempt to add color markers (i.e. print `[DEBUG]test` instead of `[DEBUG]\033[01;32mtest\033[00m`). Also, I moved this Windows-specific code into an anonymous namespace (the C++ way of declaring variables and functions with internal static linkage).