### PR TITLE
Fix yarpdataplayer play rpc

### DIFF
--- a/doc/release/yarp_3_3/fixYarpdataplayerPlayRpc.md
+++ b/doc/release/yarp_3_3/fixYarpdataplayerPlayRpc.md
@@ -1,0 +1,8 @@
+fixYarpdataplayerPlayRpc {#yarp_3_3}
+------------------------
+
+### Tools
+
+#### yarpdataplayer
+
+* Fixed the rpc request `play` while it is already running(#2144).

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -759,14 +759,14 @@ void MainWindow::onMenuPlayBackPlay()
             }
         }
 
-        if ( utilities->masterThread->isRunning() ) {
+        if ( utilities->masterThread->isSuspended() ) {
             LOG("asking the thread to resume\n");
 
             for (int i=0; i < subDirCnt; i++)
                 utilities->partDetails[i].worker->resetTime();
 
             utilities->masterThread->resume();
-        } else {
+        } else if (!utilities->masterThread->isRunning()) {
             LOG("asking the thread to start\n");
             LOG("initializing the workers...\n");
 


### PR DESCRIPTION
It fixes #2144.

What I learnt is that if you call `resume()` on a `PeriodicThread` already running, causes deadlock.

Tested successfully on my laptop.

Please review code