### PR TITLE
[yarpdataplayer] add rpc method to get slider percentage

### DIFF
--- a/doc/release/master/featureYarpdataplayerGetSliderPercentage.md
+++ b/doc/release/master/featureYarpdataplayerGetSliderPercentage.md
@@ -1,0 +1,9 @@
+featureYarpdataplayerGetSliderPercentage {master}
+----------------------
+
+### Tools
+
+#### yarpdataplayer
+
+* Added getSliderPercentage method to the rpc port of yarpdataplayer. (#2148)
+  This method returns the progress percentage of the seek bar while playing a dataset.

--- a/doc/release/v3_3_0.md
+++ b/doc/release/v3_3_0.md
@@ -166,6 +166,8 @@ New Features
 #### `yarpdataplayer`
 
 * `info.log` files containing timestamp info are now handled.
+* Added getSliderPercentage method to the rpc port of yarpdataplayer.
+  This method returns the progress percentage of the seek bar while playing a dataset.
 
 
 ### devices

--- a/doc/release/v3_3_0.md
+++ b/doc/release/v3_3_0.md
@@ -166,8 +166,6 @@ New Features
 #### `yarpdataplayer`
 
 * `info.log` files containing timestamp info are now handled.
-* Added getSliderPercentage method to the rpc port of yarpdataplayer.
-  This method returns the progress percentage of the seek bar while playing a dataset.
 
 
 ### devices

--- a/src/yarpdataplayer/idl_generated_code/include/yarpdataplayer_IDL.h
+++ b/src/yarpdataplayer/idl_generated_code/include/yarpdataplayer_IDL.h
@@ -59,6 +59,12 @@ public:
     virtual bool load(const std::string& path);
 
     /**
+     * Get slider percentage
+     * @return i32 percentage
+     */
+    virtual std::int32_t getSliderPercentage();
+
+    /**
      * Plays the dataSets
      * @return true/false on success/failure
      */

--- a/src/yarpdataplayer/idl_generated_code/src/yarpdataplayer_IDL.cpp
+++ b/src/yarpdataplayer/idl_generated_code/src/yarpdataplayer_IDL.cpp
@@ -210,6 +210,49 @@ bool yarpdataplayer_IDL_load_helper::read(yarp::os::ConnectionReader& connection
     return true;
 }
 
+class yarpdataplayer_IDL_getSliderPercentage_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit yarpdataplayer_IDL_getSliderPercentage_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static std::int32_t s_return_helper;
+};
+
+thread_local std::int32_t yarpdataplayer_IDL_getSliderPercentage_helper::s_return_helper = {};
+
+yarpdataplayer_IDL_getSliderPercentage_helper::yarpdataplayer_IDL_getSliderPercentage_helper()
+{
+    s_return_helper = {};
+}
+
+bool yarpdataplayer_IDL_getSliderPercentage_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getSliderPercentage", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool yarpdataplayer_IDL_getSliderPercentage_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readI32(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
 class yarpdataplayer_IDL_play_helper :
         public yarp::os::Portable
 {
@@ -428,6 +471,16 @@ bool yarpdataplayer_IDL::load(const std::string& path)
     return ok ? yarpdataplayer_IDL_load_helper::s_return_helper : bool{};
 }
 
+std::int32_t yarpdataplayer_IDL::getSliderPercentage()
+{
+    yarpdataplayer_IDL_getSliderPercentage_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "std::int32_t yarpdataplayer_IDL::getSliderPercentage()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? yarpdataplayer_IDL_getSliderPercentage_helper::s_return_helper : std::int32_t{};
+}
+
 bool yarpdataplayer_IDL::play()
 {
     yarpdataplayer_IDL_play_helper helper{};
@@ -479,6 +532,7 @@ std::vector<std::string> yarpdataplayer_IDL::help(const std::string& functionNam
         helpString.emplace_back("setFrame");
         helpString.emplace_back("getFrame");
         helpString.emplace_back("load");
+        helpString.emplace_back("getSliderPercentage");
         helpString.emplace_back("play");
         helpString.emplace_back("pause");
         helpString.emplace_back("stop");
@@ -510,6 +564,11 @@ std::vector<std::string> yarpdataplayer_IDL::help(const std::string& functionNam
             helpString.emplace_back("bool load(const std::string& path) ");
             helpString.emplace_back("Loads a dataset from a path ");
             helpString.emplace_back("@return true/false on success/failure ");
+        }
+        if (functionName == "getSliderPercentage") {
+            helpString.emplace_back("std::int32_t getSliderPercentage() ");
+            helpString.emplace_back("Get slider percentage ");
+            helpString.emplace_back("@return i32 percentage ");
         }
         if (functionName == "play") {
             helpString.emplace_back("bool play() ");
@@ -630,6 +689,20 @@ bool yarpdataplayer_IDL::read(yarp::os::ConnectionReader& connection)
                     return false;
                 }
                 if (!writer.writeBool(yarpdataplayer_IDL_load_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getSliderPercentage") {
+            yarpdataplayer_IDL_getSliderPercentage_helper::s_return_helper = getSliderPercentage();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeI32(yarpdataplayer_IDL_getSliderPercentage_helper::s_return_helper)) {
                     return false;
                 }
             }

--- a/src/yarpdataplayer/include/mainwindow.h
+++ b/src/yarpdataplayer/include/mainwindow.h
@@ -107,6 +107,10 @@ public:
      */
     bool load(const std::string &path) override;
     /**
+     * function that returns slider percentage
+     */
+    int  getSliderPercentage() override;
+    /**
      * function that handles an IDL message - play
      */
     bool play() override;
@@ -225,7 +229,7 @@ signals:
     void internalStep(yarp::os::Bottle *reply);
     void internalSetFrame(const std::string &name, const int frameNum);
     void internalGetFrame(const std::string &name, int *frame);
-
+    void internalGetSliderPercentage(int * percentage);
 
 private slots:
     void onInternalQuit();
@@ -258,6 +262,7 @@ private slots:
     void onInternalStep(yarp::os::Bottle *reply);
     void onInternalSetFrame(const std::string &name, const int frameNum);
     void onInternalGetFrame(const std::string &name, int *frame);
+    void onInternalGetSliderPercentage(int *frame);
 
 };
 

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -116,6 +116,7 @@ MainWindow::MainWindow(yarp::os::ResourceFinder &rf, QWidget *parent) :
     connect(this,SIGNAL(internalSetFrame(std::string,int)),this,SLOT(onInternalSetFrame(std::string,int)),Qt::BlockingQueuedConnection);
     connect(this,SIGNAL(internalGetFrame(std::string, int*)),this,SLOT(onInternalGetFrame(std::string,int*)),Qt::BlockingQueuedConnection);
     connect(this,SIGNAL(internalQuit()),this,SLOT(onInternalQuit()),Qt::QueuedConnection);
+    connect(this,SIGNAL(internalGetSliderPercentage(int*)),this,SLOT(onInternalGetSliderPercentage(int*)),Qt::BlockingQueuedConnection);
 
     QShortcut *openShortcut = new QShortcut(QKeySequence("Ctrl+O"), parent);
     QObject::connect(openShortcut, SIGNAL(activated()), this, SLOT(onInternalLoad(QString)));
@@ -202,6 +203,24 @@ int MainWindow::getFrame(const string &name)
 void MainWindow::onInternalGetFrame(const string &name, int *frame)
 {
     getFrameCmd(name.c_str(),frame);
+}
+
+/**********************************************************/
+int MainWindow::getSliderPercentage()
+{
+    int percentage = 0;
+    emit internalGetSliderPercentage(&percentage);
+    if (percentage < 1){
+        return -1;
+    } else {
+        return percentage;
+    }
+}
+
+/**********************************************************/
+void MainWindow::onInternalGetSliderPercentage(int *percentage)
+{
+    *percentage = ui->playSlider->value();
 }
 
 /**********************************************************/

--- a/src/yarpdataplayer/yarpdataplayer.thrift
+++ b/src/yarpdataplayer/yarpdataplayer.thrift
@@ -54,6 +54,13 @@ service yarpdataplayer_IDL
   */
   bool load(1:string path);
 
+
+  /**
+   * Get slider percentage
+   * @return i32 percentage
+   */
+  i32 getSliderPercentage();
+
   /**
   * Plays the dataSets
   * @return true/false on success/failure


### PR DESCRIPTION
This PR adds `getSliderPercentage()` method to yarpdataplayer rpc.

cc @Nicogene @vtikha 
Could you please confirm that committing the IDL generated code is also required?

