### PR TITLE
Add missing header for deprecation warning macro

### DIFF
--- a/doc/release/yarp_3_3/missing-depr-header.md
+++ b/doc/release/yarp_3_3/missing-depr-header.md
@@ -1,0 +1,8 @@
+missing-depr-header {#yarp_3_3}
+-----------
+
+### Libraries
+
+#### YARP_dev
+
+* Fixed missing header for deprecation warning macro.

--- a/src/libYARP_dev/src/yarp/dev/GenericSensorInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/GenericSensorInterfaces.h
@@ -9,6 +9,8 @@
 #ifndef YARP_DEV_GENERICSENSORINTERFACES_H
 #define YARP_DEV_GENERICSENSORINTERFACES_H
 
+#include <yarp/conf/system.h>
+
 YARP_COMPILER_WARNING("<yarp/dev/GenericSensorInterfaces.h> file is deprecated. Use <yarp/dev/IGenericSensor.h> instead")
 #include <yarp/dev/IGenericSensor.h>
 

--- a/src/libYARP_dev/src/yarp/dev/PreciselyTimed.h
+++ b/src/libYARP_dev/src/yarp/dev/PreciselyTimed.h
@@ -9,6 +9,8 @@
 #ifndef YARP_DEV_PRECISELYTIMED_H
 #define YARP_DEV_PRECISELYTIMED_H
 
+#include <yarp/conf/system.h>
+
 YARP_COMPILER_WARNING("<yarp/dev/PreciselyTimed.h> file is deprecated. Use <yarp/dev/IPreciselyTimed.h> instead")
 #include <yarp/dev/IPreciselyTimed.h>
 

--- a/src/libYARP_dev/src/yarp/dev/SerialInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/SerialInterfaces.h
@@ -9,6 +9,8 @@
 #ifndef YARP_DEV_SERIALINTERFACES_H
 #define YARP_DEV_SERIALINTERFACES_H
 
+#include <yarp/conf/system.h>
+
 YARP_COMPILER_WARNING("<yarp/dev/SerialInterfaces.h> file is deprecated. Use <yarp/dev/ISerialDevice.h> instead")
 #include <yarp/dev/ISerialDevice.h>
 


### PR DESCRIPTION
Follows up https://github.com/robotology/yarp/pull/2096.