### PR TITLE
YarpPlugin: do not require CMAKE_INCLUDE_CURRENT_DIR

### DIFF
--- a/cmake/YarpPlugin.cmake
+++ b/cmake/YarpPlugin.cmake
@@ -277,6 +277,20 @@ macro(YARP_PREPARE_PLUGIN _plugin_name)
     endif()
   endif()
 
+  if(NOT IS_ABSOLUTE "${_YPP_INCLUDE}")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_YPP_INCLUDE}")
+      # DEPRECATED Since YARP 3.4
+      message(DEPRECATION "${CMAKE_CURRENT_SOURCE_DIR}/The file \"${_YPP_INCLUDE}\" does not exist. This will not be allowed in a future release")
+    else()
+      get_filename_component(_abs_include "${_YPP_INCLUDE}" ABSOLUTE)
+      set(_YPP_INCLUDE ${_abs_include})
+    endif()
+  else()
+    if(NOT EXISTS "${_YPP_INCLUDE}")
+      message(SEND_ERROR "The file \"${_YPP_INCLUDE}\" does not exist")
+    endif()
+  endif()
+
   # Set up a flag to enable/disable compilation of this plugin.
   if(NOT YARP_PLUGIN_MASTER STREQUAL "")
     set(_plugin_fullname "${YARP_PLUGIN_MASTER}_${_plugin_name}")

--- a/doc/release/master/YarpPlugin_absolute.md
+++ b/doc/release/master/YarpPlugin_absolute.md
@@ -1,0 +1,12 @@
+YarpPlugin_absolute {#master}
+------------------
+
+### CMake
+
+#### `yarp_prepare_plugin`
+
+* Including current directory (either explicitly, or using
+  `CMAKE_INCLUDE_CURRENT_DIR`) is no longer required by the generated files.
+* `INCLUDE` must now be an existing file, either using a path relative to
+  current directory, or an absolute path. Using a path relative to one of the
+  include directories is deprecated.

--- a/example/externaldevices/baz/bazBot/CMakeLists.txt
+++ b/example/externaldevices/baz/bazBot/CMakeLists.txt
@@ -18,8 +18,6 @@ yarp_prepare_plugin(bazbot
 if(NOT SKIP_bazbot)
   yarp_add_plugin(bazbot)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
   target_sources(bazbot PRIVATE bazbot.cpp
                                 bazbot.h)
   target_link_libraries(bazbot PRIVATE YARP::YARP_os

--- a/example/externaldevices/baz/bazDevice/CMakeLists.txt
+++ b/example/externaldevices/baz/bazDevice/CMakeLists.txt
@@ -18,8 +18,6 @@ yarp_prepare_plugin(bazdevice
 if(NOT SKIP_bazdevice)
   yarp_add_plugin(bazdevice)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
   target_sources(bazdevice PRIVATE bazdevice.cpp
                                    bazdevice.h)
   target_link_libraries(bazdevice PRIVATE YARP::YARP_os

--- a/example/externaldevices/foo/fooBot/CMakeLists.txt
+++ b/example/externaldevices/foo/fooBot/CMakeLists.txt
@@ -18,8 +18,6 @@ yarp_prepare_plugin(foobot
 if(NOT SKIP_foobot)
   yarp_add_plugin(foobot)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
   target_sources(foobot PRIVATE foobot.cpp
                                 foobot.h)
   target_link_libraries(foobot PRIVATE YARP::YARP_os

--- a/example/externaldevices/foo/fooDevice/CMakeLists.txt
+++ b/example/externaldevices/foo/fooDevice/CMakeLists.txt
@@ -18,8 +18,6 @@ yarp_prepare_plugin(foodevice
 if(NOT SKIP_foodevice)
   yarp_add_plugin(foodevice)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
   target_sources(foodevice PRIVATE foodevice.cpp
                                    foodevice.h)
   target_link_libraries(foodevice PRIVATE YARP::YARP_os

--- a/example/portmonitor/ascii_image/CMakeLists.txt
+++ b/example/portmonitor/ascii_image/CMakeLists.txt
@@ -8,8 +8,6 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(YARP COMPONENTS os sig dev REQUIRED)
 
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp_pm_asciiimage is always built with dynamic plugins")
 # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
 yarp_configure_plugins_installation(asciiimage_portmonitor)

--- a/example/portmonitor/simple_dll/CMakeLists.txt
+++ b/example/portmonitor/simple_dll/CMakeLists.txt
@@ -8,8 +8,6 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(YARP COMPONENTS os sig dev REQUIRED)
 
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp_pm_simple is always built with dynamic plugins")
 # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
 yarp_configure_plugins_installation(simplemonitor_portmonitor)

--- a/src/carriers/bayer_carrier/CMakeLists.txt
+++ b/src/carriers/bayer_carrier/CMakeLists.txt
@@ -15,8 +15,6 @@ yarp_prepare_plugin(bayer
 if(NOT SKIP_bayer)
   yarp_add_plugin(yarp_bayer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   if(NOT YARP_HAS_Libdc1394)
     set(DC1394_SRC ${libdc1394_bayer_ROOT}/libdc1394_bayer.c
                    ${libdc1394_bayer_ROOT}/conversions.h)

--- a/src/carriers/depth_image_portmonitor/CMakeLists.txt
+++ b/src/carriers/depth_image_portmonitor/CMakeLists.txt
@@ -12,8 +12,6 @@ yarp_prepare_plugin(depthimage TYPE DepthImageConverter
 if(NOT SKIP_depthimage)
   yarp_add_plugin(yarp_pm_depthimage)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_pm_depthimage PRIVATE DepthImage.cpp
                                             DepthImage.h)
   target_link_libraries(yarp_pm_depthimage PRIVATE YARP::YARP_os

--- a/src/carriers/h264_carrier/CMakeLists.txt
+++ b/src/carriers/h264_carrier/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(h264
 if(NOT SKIP_h264)
   yarp_add_plugin(yarp_h264)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_h264 PRIVATE H264Carrier.h
                                    H264Carrier.cpp
                                    H264Stream.h

--- a/src/carriers/human_carrier/CMakeLists.txt
+++ b/src/carriers/human_carrier/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(human
 if(NOT SKIP_human)
   yarp_add_plugin(yarp_human)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_human PRIVATE HumanCarrier.h
                                     HumanStream.h
                                     HumanCarrier.cpp

--- a/src/carriers/mjpeg_carrier/CMakeLists.txt
+++ b/src/carriers/mjpeg_carrier/CMakeLists.txt
@@ -21,8 +21,6 @@ yarp_renamed_option(MJPEG_AUTOCOMPRESS YARP_MJPEG_AUTOCOMPRESS) # Since YARP 3.3
 if(NOT SKIP_mjpeg)
   yarp_add_plugin(yarp_mjpeg)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_mjpeg PRIVATE MjpegCarrier.h
                                     MjpegCarrier.cpp
                                     MjpegStream.h

--- a/src/carriers/mpi_carrier/CMakeLists.txt
+++ b/src/carriers/mpi_carrier/CMakeLists.txt
@@ -21,8 +21,6 @@ yarp_renamed_option(MPI_DEBUG_MSG YARP_MPI_DEBUG_MSG) # Since YARP 3.3
 if(NOT SKIP_mpi)
   yarp_add_plugin(yarp_mpi)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_mpi PRIVATE MpiCarrier.cpp
                                   MpiComm.cpp
                                   MpiStream.cpp
@@ -66,8 +64,6 @@ yarp_prepare_plugin(mpibcast
 
 if(NOT SKIP_mpibcast)
   yarp_add_plugin(yarp_mpibcast)
-
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
   target_sources(yarp_mpibcast PRIVATE MpiCarrier.cpp
                                        MpiBcastCarrier.cpp

--- a/src/carriers/portmonitor_carrier/CMakeLists.txt
+++ b/src/carriers/portmonitor_carrier/CMakeLists.txt
@@ -15,9 +15,6 @@ yarp_prepare_plugin(portmonitor
 if (NOT SKIP_portmonitor)
   yarp_add_plugin(yarp_portmonitor)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-
   target_sources(yarp_portmonitor PRIVATE PortMonitor.h
                                           MonitorBinding.h
                                           MonitorEvent.h
@@ -30,7 +27,8 @@ if (NOT SKIP_portmonitor)
                                             lua/MonitorLua.h)
   endif()
 
-  target_include_directories(yarp_portmonitor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dll)
+  target_include_directories(yarp_portmonitor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                                      ${CMAKE_CURRENT_SOURCE_DIR}/dll)
   target_link_libraries(yarp_portmonitor PRIVATE YARP::YARP_os)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os)
 

--- a/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.h
+++ b/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.h
@@ -9,14 +9,14 @@
 #ifndef MONITOR_SHAREDLIB_INC
 #define MONITOR_SHAREDLIB_INC
 
-#include <string>
-#include <string>
+#include "MonitorBinding.h"
+
+#include <yarp/os/MonitorObject.h>
 #include <yarp/os/SharedLibraryClass.h>
 #include <yarp/os/SharedLibrary.h>
 #include <yarp/os/YarpPlugin.h>
 
-#include <yarp/os/MonitorObject.h>
-#include "MonitorBinding.h"
+#include <string>
 
 class MonitorSharedLib : public MonitorBinding
 {

--- a/src/carriers/priority_carrier/CMakeLists.txt
+++ b/src/carriers/priority_carrier/CMakeLists.txt
@@ -16,8 +16,6 @@ yarp_prepare_plugin(priority
 if(NOT SKIP_priority)
   yarp_add_plugin(yarp_priority)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_priority PRIVATE PriorityCarrier.h
                                        PriorityCarrier.cpp)
 

--- a/src/carriers/shmem_carrier/CMakeLists.txt
+++ b/src/carriers/shmem_carrier/CMakeLists.txt
@@ -15,8 +15,6 @@ yarp_prepare_plugin(shmem
 if(NOT SKIP_shmem)
   yarp_add_plugin(yarp_shmem)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_shmem PRIVATE ShmemCarrier.cpp
                                     ShmemCarrier.h
                                     ShmemHybridStream.cpp

--- a/src/carriers/tcpros_carrier/CMakeLists.txt
+++ b/src/carriers/tcpros_carrier/CMakeLists.txt
@@ -20,8 +20,6 @@ yarp_prepare_plugin(rossrv
 if(NOT SKIP_tcpros OR NOT SKIP_rossrv)
   yarp_add_plugin(yarp_tcpros)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_tcpros PRIVATE TcpRosCarrier.h
                                      TcpRosCarrier.cpp
                                      TcpRosStream.h

--- a/src/carriers/xmlrpc_carrier/CMakeLists.txt
+++ b/src/carriers/xmlrpc_carrier/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(xmlrpc
 if(NOT SKIP_xmlrpc)
   yarp_add_plugin(yarp_xmlrpc)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_xmlrpc PRIVATE XmlRpcCarrier.h
                                      XmlRpcCarrier.cpp
                                      XmlRpcStream.h

--- a/src/carriers/zfp_portmonitor/CMakeLists.txt
+++ b/src/carriers/zfp_portmonitor/CMakeLists.txt
@@ -12,8 +12,6 @@ yarp_prepare_plugin(zfp TYPE ZfpMonitorObject
 if(NOT SKIP_zfp)
   yarp_add_plugin(yarp_pm_zfp)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_pm_zfp PRIVATE zfpPortmonitor.cpp
                                      zfpPortmonitor.h)
 

--- a/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
+++ b/src/carriers/zfp_portmonitor/zfpPortmonitor.cpp
@@ -6,16 +6,18 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include "zfpPortmonitor.h"
+
 #include <cstdio>
 #include <cstring>
 #include <cmath>
 #include <algorithm>
 #include <yarp/sig/Image.h>
 #include <yarp/os/LogStream.h>
+
 extern "C" {
     #include "zfp.h"
 }
-#include "zfpPortmonitor.h"
 
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/devices/AnalogSensorClient/CMakeLists.txt
+++ b/src/devices/AnalogSensorClient/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(analogsensorclient
 if(NOT SKIP_analogsensorclient)
   yarp_add_plugin(yarp_analogsensorclient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_analogsensorclient PRIVATE AnalogSensorClient.cpp
                                                  AnalogSensorClient.h)
 

--- a/src/devices/AnalogWrapper/CMakeLists.txt
+++ b/src/devices/AnalogWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(analogServer
 if(NOT SKIP_analogServer)
   yarp_add_plugin(yarp_analogServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_analogServer PRIVATE AnalogWrapper.cpp
                                            AnalogWrapper.h)
 

--- a/src/devices/ControlBoardRemapper/CMakeLists.txt
+++ b/src/devices/ControlBoardRemapper/CMakeLists.txt
@@ -20,8 +20,6 @@ yarp_prepare_plugin(remotecontrolboardremapper
 if(NOT SKIP_controlboardremapper OR NOT SKIP_remotecontrolboardremapper)
   yarp_add_plugin(yarp_controlboardremapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_controlboardremapper PRIVATE ControlBoardRemapper.cpp
                                                    ControlBoardRemapper.h
                                                    ControlBoardRemapperHelpers.cpp

--- a/src/devices/ControlBoardWrapper/CMakeLists.txt
+++ b/src/devices/ControlBoardWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(controlboardwrapper2
 if(NOT SKIP_controlboardwrapper2)
   yarp_add_plugin(yarp_controlboardwrapper2)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_controlboardwrapper2 PRIVATE ControlBoardWrapper.cpp
                                                    ControlBoardWrapper.h
                                                    RPCMessagesParser.cpp

--- a/src/devices/DeviceGroup/CMakeLists.txt
+++ b/src/devices/DeviceGroup/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(group
 if(NOT SKIP_group)
   yarp_add_plugin(yarp_group)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_group PRIVATE DeviceGroup.cpp
                                     DeviceGroup.h)
 

--- a/src/devices/DevicePipe/CMakeLists.txt
+++ b/src/devices/DevicePipe/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(pipe
 if(NOT SKIP_pipe)
   yarp_add_plugin(yarp_pipe)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_pipe PRIVATE DevicePipe.cpp
                                    DevicePipe.h)
 

--- a/src/devices/DynamixelAX12Ftdi/CMakeLists.txt
+++ b/src/devices/DynamixelAX12Ftdi/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(dynamixelAX12Ftdi
 if(NOT SKIP_dynamixelAX12Ftdi)
   yarp_add_plugin(yarp_dynamixelAX12Ftdi)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_dynamixelAX12Ftdi PRIVATE DynamixelAX12FtdiDriver.cpp
                                                 DynamixelAX12FtdiDriver.h)
 

--- a/src/devices/JoypadControlClient/CMakeLists.txt
+++ b/src/devices/JoypadControlClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(JoypadControlClient
 if(NOT SKIP_JoypadControlClient)
   yarp_add_plugin(yarp_JoypadControlClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_JoypadControlClient PRIVATE JoypadControlClient.cpp
                                                   JoypadControlClient.h)
 

--- a/src/devices/JoypadControlServer/CMakeLists.txt
+++ b/src/devices/JoypadControlServer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(JoypadControlServer
 if(NOT SKIP_JoypadControlServer)
   yarp_add_plugin(yarp_JoypadControlServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_JoypadControlServer PRIVATE JoypadControlServer.cpp
                                                   JoypadControlServer.h)
 

--- a/src/devices/RGBDSensorClient/CMakeLists.txt
+++ b/src/devices/RGBDSensorClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(RGBDSensorClient
 if(NOT SKIP_RGBDSensorClient)
   yarp_add_plugin(yarp_RGBDSensorClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_RGBDSensorClient PRIVATE RGBDSensorClient.cpp
                                                RGBDSensorClient.h
                                                RGBDSensorClient_StreamingMsgParser.cpp

--- a/src/devices/RGBDSensorWrapper/CMakeLists.txt
+++ b/src/devices/RGBDSensorWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(RGBDSensorWrapper
 if(NOT SKIP_RGBDSensorWrapper)
   yarp_add_plugin(yarp_RGBDSensorWrapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_RGBDSensorWrapper PRIVATE RGBDSensorWrapper.cpp
                                                 RGBDSensorWrapper.h
                                                 rosPixelCode.h)

--- a/src/devices/Rangefinder2DClient/CMakeLists.txt
+++ b/src/devices/Rangefinder2DClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(Rangefinder2DClient
 if(NOT SKIP_Rangefinder2DClient)
   yarp_add_plugin(yarp_Rangefinder2DClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_Rangefinder2DClient PRIVATE Rangefinder2DClient.cpp
                                                   Rangefinder2DClient.h)
 

--- a/src/devices/Rangefinder2DWrapper/CMakeLists.txt
+++ b/src/devices/Rangefinder2DWrapper/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(Rangefinder2DWrapper
 if(NOT SKIP_Rangefinder2DWrapper)
   yarp_add_plugin(yarp_Rangefinder2DWrapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_Rangefinder2DWrapper PRIVATE Rangefinder2DWrapper.cpp
                                                    Rangefinder2DWrapper.h)
 

--- a/src/devices/RemoteControlBoard/CMakeLists.txt
+++ b/src/devices/RemoteControlBoard/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(remote_controlboard
 if(NOT SKIP_remote_controlboard)
   yarp_add_plugin(yarp_remote_controlboard)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_remote_controlboard PRIVATE RemoteControlBoard.cpp
                                                   RemoteControlBoard.h
                                                   stateExtendedReader.cpp

--- a/src/devices/RemoteFrameGrabber/CMakeLists.txt
+++ b/src/devices/RemoteFrameGrabber/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(remote_grabber
 if(NOT SKIP_remote_grabber)
   yarp_add_plugin(yarp_remote_grabber)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_remote_grabber PRIVATE RemoteFrameGrabber.cpp
                                              RemoteFrameGrabber.h)
 

--- a/src/devices/RobotDescriptionClient/CMakeLists.txt
+++ b/src/devices/RobotDescriptionClient/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(robotDescriptionClient
 if(NOT SKIP_robotDescriptionClient)
   yarp_add_plugin(yarp_robotDescriptionClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_robotDescriptionClient PRIVATE RobotDescriptionClient.cpp
                                                      RobotDescriptionClient.h)
 

--- a/src/devices/RobotDescriptionServer/CMakeLists.txt
+++ b/src/devices/RobotDescriptionServer/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(robotDescriptionServer
 if(NOT SKIP_robotDescriptionServer)
   yarp_add_plugin(yarp_robotDescriptionServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_robotDescriptionServer PRIVATE RobotDescriptionServer.cpp
                                                      RobotDescriptionServer.h)
 

--- a/src/devices/SDLJoypad/CMakeLists.txt
+++ b/src/devices/SDLJoypad/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(SDLJoypad
 if(ENABLE_SDLJoypad)
   yarp_add_plugin(yarp_SDLJoypad)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_SDLJoypad PRIVATE SDLJoypad.cpp
                                         SDLJoypad.h)
 

--- a/src/devices/SerialServoBoard/CMakeLists.txt
+++ b/src/devices/SerialServoBoard/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(SerialServoBoard
 if(NOT SKIP_SerialServoBoard)
   yarp_add_plugin(yarp_SerialServoBoard)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_SerialServoBoard PRIVATE SerialServoBoard.cpp
                                                SerialServoBoard.h)
 

--- a/src/devices/ServerFrameGrabber/CMakeLists.txt
+++ b/src/devices/ServerFrameGrabber/CMakeLists.txt
@@ -15,8 +15,6 @@ yarp_prepare_plugin(grabber
 if(NOT SKIP_grabber)
   yarp_add_plugin(yarp_grabber)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_grabber PRIVATE ServerFrameGrabber.cpp
                                       ServerFrameGrabber.h)
 

--- a/src/devices/ServerGrabber/CMakeLists.txt
+++ b/src/devices/ServerGrabber/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(grabberDual
 if(NOT SKIP_grabberDual)
   yarp_add_plugin(yarp_grabberDual)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_grabberDual PRIVATE ServerGrabber.cpp
                                           ServerGrabber.h)
 

--- a/src/devices/ServerInertial/CMakeLists.txt
+++ b/src/devices/ServerInertial/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(inertial
 if(NOT SKIP_inertial)
   yarp_add_plugin(yarp_inertial)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_inertial PRIVATE ServerInertial.cpp
                                        ServerInertial.h)
 

--- a/src/devices/ServerSerial/CMakeLists.txt
+++ b/src/devices/ServerSerial/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(serial
 if(NOT SKIP_serial)
   yarp_add_plugin(yarp_serial)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_serial PRIVATE ServerSerial.cpp
                                      ServerSerial.h)
 

--- a/src/devices/ServerSoundGrabber/CMakeLists.txt
+++ b/src/devices/ServerSoundGrabber/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(ServerSoundGrabber
 if(NOT SKIP_ServerSoundGrabber)
   yarp_add_plugin(yarp_ServerSoundGrabber)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_ServerSoundGrabber PRIVATE ServerSoundGrabber.h)
 
   target_link_libraries(yarp_ServerSoundGrabber PRIVATE YARP::YARP_os

--- a/src/devices/TestMotor/CMakeLists.txt
+++ b/src/devices/TestMotor/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(test_motor
 if(NOT SKIP_test_motor)
   yarp_add_plugin(yarp_test_motor)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_test_motor PRIVATE TestMotor.cpp
                                          TestMotor.h)
 

--- a/src/devices/VirtualAnalogWrapper/CMakeLists.txt
+++ b/src/devices/VirtualAnalogWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(virtualAnalogServer
 if(NOT SKIP_virtualAnalogServer)
   yarp_add_plugin(yarp_virtualAnalogServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_virtualAnalogServer PRIVATE VirtualAnalogWrapper.cpp
                                                   VirtualAnalogWrapper.h)
 

--- a/src/devices/audioPlayerWrapper/CMakeLists.txt
+++ b/src/devices/audioPlayerWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(AudioPlayerWrapper
 if(NOT SKIP_AudioPlayerWrapper)
   yarp_add_plugin(yarp_AudioPlayerWrapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_AudioPlayerWrapper PRIVATE AudioPlayerWrapper.cpp
                                                  AudioPlayerWrapper.h)
   target_link_libraries(yarp_AudioPlayerWrapper PRIVATE YARP::YARP_os

--- a/src/devices/audioRecorderWrapper/AudioRecorderWrapper.cpp
+++ b/src/devices/audioRecorderWrapper/AudioRecorderWrapper.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <AudioRecorderWrapper.h>
+#include "AudioRecorderWrapper.h"
 #include <yarp/os/LogStream.h>
 
 using namespace yarp::dev;

--- a/src/devices/audioRecorderWrapper/CMakeLists.txt
+++ b/src/devices/audioRecorderWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(AudioRecorderWrapper
 if(NOT SKIP_AudioRecorderWrapper)
   yarp_add_plugin(yarp_AudioRecorderWrapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_AudioRecorderWrapper PRIVATE AudioRecorderWrapper.cpp
                                                    AudioRecorderWrapper.h)
   target_link_libraries(yarp_AudioRecorderWrapper PRIVATE YARP::YARP_os

--- a/src/devices/batteryClient/CMakeLists.txt
+++ b/src/devices/batteryClient/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(batteryClient
 if(NOT SKIP_batteryClient)
   yarp_add_plugin(yarp_batteryClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_batteryClient PRIVATE BatteryClient.cpp
                                             BatteryClient.h)
 

--- a/src/devices/batteryWrapper/CMakeLists.txt
+++ b/src/devices/batteryWrapper/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(batteryWrapper
 if(NOT SKIP_batteryWrapper)
   yarp_add_plugin(yarp_batteryWrapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_batteryWrapper PRIVATE BatteryWrapper.cpp
                                              BatteryWrapper.h)
 

--- a/src/devices/depthCamera/CMakeLists.txt
+++ b/src/devices/depthCamera/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(depthCamera
 if(ENABLE_depthCamera)
   yarp_add_plugin(yarp_depthCamera)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_depthCamera PRIVATE depthCameraDriver.cpp
                                           depthCameraDriver.h)
 

--- a/src/devices/fakeAnalogSensor/CMakeLists.txt
+++ b/src/devices/fakeAnalogSensor/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeAnalogSensor
 if(ENABLE_fakeAnalogSensor)
   yarp_add_plugin(yarp_fakeAnalogSensor)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeAnalogSensor PRIVATE fakeAnalogSensor.cpp
                                                fakeAnalogSensor.h)
 

--- a/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
+++ b/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
@@ -6,11 +6,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include "fakeAnalogSensor.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/LogStream.h>
-
-#include <fakeAnalogSensor.h>
 
 using namespace std;
 using namespace yarp::dev;

--- a/src/devices/fakeBattery/CMakeLists.txt
+++ b/src/devices/fakeBattery/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeBattery
 if(NOT SKIP_fakeBattery)
   yarp_add_plugin(yarp_fakeBattery)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeBattery PRIVATE fakeBattery.cpp
                                           fakeBattery.h)
 

--- a/src/devices/fakeDepthCamera/CMakeLists.txt
+++ b/src/devices/fakeDepthCamera/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeDepthCamera
 if(ENABLE_fakeDepthCamera)
   yarp_add_plugin(yarp_fakeDepthCamera)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeDepthCamera PRIVATE fakeDepthCameraDriver.cpp
                                               fakeDepthCameraDriver.h)
 

--- a/src/devices/fakeIMU/CMakeLists.txt
+++ b/src/devices/fakeIMU/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(fakeIMU
 if(NOT SKIP_fakeIMU)
   yarp_add_plugin(yarp_fakeIMU)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeIMU PRIVATE fakeIMU.cpp
                                       fakeIMU.h)
 

--- a/src/devices/fakeIMU/fakeIMU.cpp
+++ b/src/devices/fakeIMU/fakeIMU.cpp
@@ -6,14 +6,15 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <string>
+#include "fakeIMU.h"
+
 #include <yarp/os/Thread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/LogStream.h>
 
-#include <fakeIMU.h>
+#include <string>
 
 using namespace yarp::os;
 using namespace yarp::dev;

--- a/src/devices/fakeLaser/CMakeLists.txt
+++ b/src/devices/fakeLaser/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeLaser
 if(NOT SKIP_fakeLaser)
   yarp_add_plugin(yarp_fakeLaser)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeLaser PRIVATE fakeLaser.h
                                         fakeLaser.cpp)
 

--- a/src/devices/fakeLocalizerDevice/CMakeLists.txt
+++ b/src/devices/fakeLocalizerDevice/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeLocalizer
 if(NOT SKIP_fakeLocalizer)
   yarp_add_plugin(yarp_fakeLocalizer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeLocalizer PRIVATE fakeLocalizerDev.h
                                             fakeLocalizerDev.cpp)
 

--- a/src/devices/fakeMicrophone/CMakeLists.txt
+++ b/src/devices/fakeMicrophone/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeMicrophone
 if(NOT SKIP_fakeMicrophone)
   yarp_add_plugin(yarp_fakeMicrophone)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeMicrophone PRIVATE fakeMicrophone.cpp
                                              fakeMicrophone.h)
 

--- a/src/devices/fakeMotionControl/CMakeLists.txt
+++ b/src/devices/fakeMotionControl/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(fakeMotionControl
 if(NOT SKIP_fakeMotionControl)
   yarp_add_plugin(yarp_fakeMotionControl)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeMotionControl PRIVATE fakeMotionControl.cpp
                                                 fakeMotionControl.h)
 

--- a/src/devices/fakeNavigationDevice/CMakeLists.txt
+++ b/src/devices/fakeNavigationDevice/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeNavigation
 if(NOT SKIP_fakeNavigation)
   yarp_add_plugin(yarp_fakeNavigation)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeNavigation PRIVATE fakeNavigationDev.h
                                              fakeNavigationDev.cpp)
 

--- a/src/devices/fakeSpeaker/CMakeLists.txt
+++ b/src/devices/fakeSpeaker/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakeSpeaker
 if(NOT SKIP_fakeSpeaker)
   yarp_add_plugin(yarp_fakeSpeaker)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakeSpeaker PRIVATE fakeSpeaker.cpp
                                           fakeSpeaker.h)
 

--- a/src/devices/fakeSpeaker/fakeSpeaker.cpp
+++ b/src/devices/fakeSpeaker/fakeSpeaker.cpp
@@ -6,14 +6,14 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include "fakeSpeaker.h"
+
 #include <string>
 #include <yarp/os/Thread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/LogStream.h>
-
-#include <fakeSpeaker.h>
 
 using namespace yarp::os;
 using namespace yarp::dev;

--- a/src/devices/fakebot/CMakeLists.txt
+++ b/src/devices/fakebot/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(fakebot
 if(NOT SKIP_fakebot)
   yarp_add_plugin(yarp_fakebot)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_fakebot PRIVATE FakeBot.cpp
                                       FakeBot.h)
 

--- a/src/devices/ffmpeg/CMakeLists.txt
+++ b/src/devices/ffmpeg/CMakeLists.txt
@@ -20,7 +20,6 @@ yarp_prepare_plugin(ffmpeg_writer
 if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
   yarp_add_plugin(yarp_ffmpeg)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
   target_sources(yarp_ffmpeg PRIVATE FfmpegGrabber.cpp
                                      FfmpegWriter.cpp
                                      FfmpegGrabber.h

--- a/src/devices/ffmpeg/FfmpegGrabber.h
+++ b/src/devices/ffmpeg/FfmpegGrabber.h
@@ -18,7 +18,7 @@ extern "C" {
 }
 
 /*
- * A Yarp 2 frame grabber device driver using ffmpeg to implement
+ * A YARP frame grabber device driver using ffmpeg to implement
  * image capture from AVI files.
  */
 

--- a/src/devices/imuBosch_BNO055/CMakeLists.txt
+++ b/src/devices/imuBosch_BNO055/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(imuBosch_BNO055
 if(ENABLE_imuBosch_BNO055)
   yarp_add_plugin(yarp_imuBosch_BNO055)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_imuBosch_BNO055 PRIVATE imuBosch_BNO055.cpp
                                               imuBosch_BNO055.h)
 

--- a/src/devices/laserFromDepth/CMakeLists.txt
+++ b/src/devices/laserFromDepth/CMakeLists.txt
@@ -12,8 +12,6 @@ yarp_prepare_plugin(laserFromDepth
 if(NOT SKIP_laserFromDepth)
   yarp_add_plugin(laserFromDepth)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(laserFromDepth PRIVATE laserFromDepth.h
                                         laserFromDepth.cpp)
 

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -18,19 +18,19 @@
 
 #define _USE_MATH_DEFINES
 
-#include <laserFromDepth.h>
+#include "laserFromDepth.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <mutex>
 #include <yarp/os/ResourceFinder.h>
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
-#include <limits>
 
 #include <cmath>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <mutex>
 
 using namespace std;
 

--- a/src/devices/laserHokuyo/CMakeLists.txt
+++ b/src/devices/laserHokuyo/CMakeLists.txt
@@ -12,8 +12,6 @@ yarp_prepare_plugin(laserHokuyo
 if(NOT SKIP_laserHokuyo)
   yarp_add_plugin(laserHokuyo)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(laserHokuyo PRIVATE laserHokuyo.h
                                      laserHokuyo.cpp)
 

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -18,16 +18,17 @@
 
 #define _USE_MATH_DEFINES
 
-#include <laserHokuyo.h>
+#include "laserHokuyo.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
-#include <limits>
+
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
 
 //#define LASER_DEBUG
 

--- a/src/devices/localization2DClient/CMakeLists.txt
+++ b/src/devices/localization2DClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(localization2DClient
 if(NOT SKIP_localization2DClient)
   yarp_add_plugin(yarp_localization2DClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_localization2DClient PRIVATE Localization2DClient.cpp
                                                    Localization2DClient.h)
 

--- a/src/devices/localization2DServer/CMakeLists.txt
+++ b/src/devices/localization2DServer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(localization2DServer
 if(NOT SKIP_localization2DServer)
   yarp_add_plugin(yarp_localization2DServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_localization2DServer PRIVATE Localization2DServer.h
                                                    Localization2DServer.cpp)
 

--- a/src/devices/map2DClient/CMakeLists.txt
+++ b/src/devices/map2DClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(map2DClient
 if(NOT SKIP_map2DClient)
   yarp_add_plugin(yarp_map2DClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_map2DClient PRIVATE Map2DClient.cpp
                                           Map2DClient.h)
 

--- a/src/devices/map2DServer/CMakeLists.txt
+++ b/src/devices/map2DServer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(map2DServer
 if(NOT SKIP_map2DServer)
   yarp_add_plugin(yarp_map2DServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_map2DServer PRIVATE Map2DServer.cpp
                                           Map2DServer.h)
 

--- a/src/devices/multipleanalogsensorsclient/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsclient/CMakeLists.txt
@@ -13,7 +13,6 @@ yarp_prepare_plugin(multipleanalogsensorsclient
 if(ENABLE_multipleanalogsensorsclient)
   yarp_add_plugin(yarp_multipleanalogsensorsclient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
   target_sources(yarp_multipleanalogsensorsclient PRIVATE MultipleAnalogSensorsClient.cpp
                                                           MultipleAnalogSensorsClient.h)
 

--- a/src/devices/multipleanalogsensorsremapper/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsremapper/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(multipleanalogsensorsremapper
 if(ENABLE_multipleanalogsensorsremapper)
   yarp_add_plugin(yarp_multipleanalogsensorsremapper)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_multipleanalogsensorsremapper PRIVATE MultipleAnalogSensorsRemapper.cpp
                                                             MultipleAnalogSensorsRemapper.h)
 

--- a/src/devices/multipleanalogsensorsserver/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsserver/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(multipleanalogsensorsserver
 if(ENABLE_multipleanalogsensorsserver)
   yarp_add_plugin(yarp_multipleanalogsensorsserver)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_multipleanalogsensorsserver PRIVATE MultipleAnalogSensorsServer.cpp
                                                           MultipleAnalogSensorsServer.h)
 

--- a/src/devices/navigation2DClient/CMakeLists.txt
+++ b/src/devices/navigation2DClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(navigation2DClient
 if(NOT SKIP_navigation2DClient)
   yarp_add_plugin(yarp_navigation2DClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_navigation2DClient PRIVATE Navigation2DClient.cpp
                                                  Navigation2DClient.h)
 

--- a/src/devices/navigation2DServer/CMakeLists.txt
+++ b/src/devices/navigation2DServer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(navigation2DServer
 if(NOT SKIP_navigation2DServer)
   yarp_add_plugin(yarp_navigation2DServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_navigation2DServer PRIVATE navigation2DServer.h
                                                  navigation2DServer.cpp)
 

--- a/src/devices/opencv/CMakeLists.txt
+++ b/src/devices/opencv/CMakeLists.txt
@@ -15,8 +15,6 @@ yarp_prepare_plugin(opencv_grabber
 if(NOT SKIP_opencv_grabber)
   yarp_add_plugin(yarp_opencv)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_opencv PRIVATE OpenCVGrabber.cpp
                                      OpenCVGrabber.h)
 

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -19,10 +19,11 @@
  */
 
 /*
- * A Yarp 2 frame grabber device driver using OpenCV to implement
+ * A YARP frame grabber device driver using OpenCV to implement
  * image capture from cameras and AVI files.
  */
 
+#include "OpenCVGrabber.h"
 
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
@@ -42,7 +43,6 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#include <OpenCVGrabber.h>
 
 
 using yarp::dev::DeviceDriver;

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -22,7 +22,7 @@
 #define YARP_OPENCV_GRABBER_DEVICE_OPENCVGRABBER_H
 
 /*
- * A Yarp 2 frame grabber device driver using OpenCV to implement
+ * A YARP frame grabber device driver using OpenCV to implement
  * image capture from cameras and AVI files.
  */
 
@@ -34,8 +34,6 @@
 #include <yarp/dev/IPreciselyTimed.h>
 
 #include <opencv2/highgui/highgui.hpp>
-
-#include <OpenCVGrabber.h>
 
 /**
  * @ingroup dev_impl_media

--- a/src/devices/ovrheadset/CMakeLists.txt
+++ b/src/devices/ovrheadset/CMakeLists.txt
@@ -13,8 +13,6 @@ yarp_prepare_plugin(ovrheadset
 if(NOT SKIP_ovrheadset)
   yarp_add_plugin(yarp_ovrheadset)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   set(yarp_ovrheadset_SRCS OVRHeadset.cpp
                            TextureBuffer.cpp
                            TextureStatic.cpp

--- a/src/devices/portaudio/CMakeLists.txt
+++ b/src/devices/portaudio/CMakeLists.txt
@@ -16,8 +16,6 @@ yarp_prepare_plugin(portaudio
 if(NOT SKIP_portaudio)
   yarp_add_plugin(yarp_portaudio)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_portaudio PRIVATE PortAudioBuffer.cpp
                                         PortAudioBuffer.h
                                         PortAudioDeviceDriver.cpp

--- a/src/devices/portaudio/PortAudioDeviceDriver.cpp
+++ b/src/devices/portaudio/PortAudioDeviceDriver.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <PortAudioDeviceDriver.h>
+#include "PortAudioDeviceDriver.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/devices/portaudioPlayer/CMakeLists.txt
+++ b/src/devices/portaudioPlayer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(portaudioPlayer
 if(NOT SKIP_portaudioPlayer)
   yarp_add_plugin(yarp_portaudioPlayer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_portaudioPlayer PRIVATE PortAudioPlayerDeviceDriver.cpp
                                               PortAudioPlayerDeviceDriver.h)
 

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <PortAudioPlayerDeviceDriver.h>
+#include "PortAudioPlayerDeviceDriver.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/devices/portaudioRecorder/CMakeLists.txt
+++ b/src/devices/portaudioRecorder/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(portaudioRecorder
 if(NOT SKIP_portaudioRecorder)
   yarp_add_plugin(yarp_portaudioRecorder)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_portaudioRecorder PRIVATE PortAudioRecorderDeviceDriver.cpp
                                                 PortAudioRecorderDeviceDriver.h)
 

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <PortAudioRecorderDeviceDriver.h>
+#include "PortAudioRecorderDeviceDriver.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/devices/realsense2/CMakeLists.txt
+++ b/src/devices/realsense2/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(realsense2
 if(ENABLE_realsense2)
   yarp_add_plugin(yarp_realsense2)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_realsense2 PRIVATE realsense2Driver.cpp
                                          realsense2Driver.h)
 

--- a/src/devices/rpLidar/CMakeLists.txt
+++ b/src/devices/rpLidar/CMakeLists.txt
@@ -12,8 +12,6 @@ yarp_prepare_plugin(rpLidar
 if(NOT SKIP_rpLidar)
   yarp_add_plugin(yarp_rpLidar)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_rpLidar PRIVATE rpLidar.h
                                       rpLidar.cpp)
 

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -18,19 +18,20 @@
 
 #define _USE_MATH_DEFINES
 
-#include <rpLidar.h>
+#include "rpLidar.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/ResourceFinder.h>
-#include <iostream>
-#include <cstring>
+
+#include <cmath>
 #include <cstdlib>
+#include <cstring>
+#include <iostream>
 #include <limits>
 #include <mutex>
 
-#include <cmath>
 
 //#define LASER_DEBUG
 //#define FORCE_SCAN

--- a/src/devices/rpLidar2/CMakeLists.txt
+++ b/src/devices/rpLidar2/CMakeLists.txt
@@ -37,8 +37,6 @@ if(NOT SKIP_rpLidar2)
   # Build YARP rpLidar2 device
   yarp_add_plugin(yarp_rpLidar2)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_rpLidar2 PRIVATE rpLidar2.h
                                        rpLidar2.cpp)
   target_compile_definitions(yarp_rpLidar2 PRIVATE _USE_MATH_DEFINES)

--- a/src/devices/rpLidar2/rpLidar2.cpp
+++ b/src/devices/rpLidar2/rpLidar2.cpp
@@ -16,15 +16,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <rpLidar2.h>
+#include "rpLidar2.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/ResourceFinder.h>
-#include <iostream>
-#include <cstring>
+
 #include <cstdlib>
+#include <cstring>
+#include <iostream>
 #include <limits>
 #include <mutex>
 

--- a/src/devices/serialport/CMakeLists.txt
+++ b/src/devices/serialport/CMakeLists.txt
@@ -15,8 +15,6 @@ yarp_prepare_plugin(serialport
 if(NOT SKIP_serialport)
   yarp_add_plugin(yarp_serialport)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_serialport PRIVATE SerialDeviceDriver.cpp
                                          SerialDeviceDriver.h)
 

--- a/src/devices/serialport/SerialDeviceDriver.cpp
+++ b/src/devices/serialport/SerialDeviceDriver.cpp
@@ -8,13 +8,12 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <SerialDeviceDriver.h>
+#include "SerialDeviceDriver.h"
+
+#include <yarp/os/Log.h>
 
 #include <cstdio>
 #include <cstdlib>
-
-///#include <yarp/os/Time.h>
-#include <yarp/os/Log.h>
 
 using namespace yarp::os;
 using namespace yarp::dev;

--- a/src/devices/test_grabber/CMakeLists.txt
+++ b/src/devices/test_grabber/CMakeLists.txt
@@ -14,7 +14,6 @@ yarp_prepare_plugin(test_grabber
 if(ENABLE_test_grabber)
   yarp_add_plugin(yarp_test_grabber)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
   target_sources(yarp_test_grabber PRIVATE TestFrameGrabber.cpp
                                            TestFrameGrabber.h)
 

--- a/src/devices/test_grabber/TestFrameGrabber.cpp
+++ b/src/devices/test_grabber/TestFrameGrabber.cpp
@@ -7,12 +7,12 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <TestFrameGrabber.h>
-#include <yarp/dev/PolyDriver.h>
+#include "TestFrameGrabber.h"
 
-#include <yarp/sig/ImageDraw.h>
-#include <random>
 #include <yarp/os/LogStream.h>
+#include <yarp/sig/ImageDraw.h>
+
+#include <random>
 
 using namespace yarp::os;
 using namespace yarp::dev;

--- a/src/devices/test_nop/CMakeLists.txt
+++ b/src/devices/test_nop/CMakeLists.txt
@@ -17,8 +17,6 @@ yarp_prepare_plugin(test_nop
 if(NOT SKIP_test_nop)
   yarp_add_plugin(yarp_test_nop)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_test_nop PRIVATE Nop.cpp
                                        Nop.h)
 

--- a/src/devices/test_segfault/CMakeLists.txt
+++ b/src/devices/test_segfault/CMakeLists.txt
@@ -17,8 +17,6 @@ yarp_prepare_plugin(test_segfault
 if(NOT SKIP_test_segfault)
   yarp_add_plugin(yarp_test_segfault)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_test_segfault PRIVATE SegFault.cpp
                                             SegFault.h)
 

--- a/src/devices/transformClient/CMakeLists.txt
+++ b/src/devices/transformClient/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(transformClient
 if(NOT SKIP_transformClient)
   yarp_add_plugin(yarp_transformClient)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_transformClient PRIVATE FrameTransformClient.cpp
                                               FrameTransformClient.h)
 

--- a/src/devices/transformServer/CMakeLists.txt
+++ b/src/devices/transformServer/CMakeLists.txt
@@ -14,8 +14,6 @@ yarp_prepare_plugin(transformServer
 if(NOT SKIP_transformServer)
   yarp_add_plugin(yarp_transformServer)
 
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
   target_sources(yarp_transformServer PRIVATE FrameTransformServer.cpp
                                               FrameTransformServer.h)
 

--- a/src/devices/usbCamera/CMakeLists.txt
+++ b/src/devices/usbCamera/CMakeLists.txt
@@ -7,21 +7,19 @@
 yarp_prepare_plugin(usbCamera
                     CATEGORY device
                     TYPE USBCameraDriverRgb
-                    INCLUDE USBcamera.h
+                    INCLUDE common/USBcamera.h
                     EXTRA_CONFIG WRAPPER=grabberDual
                     DEPENDS "UNIX;NOT APPLE;YARP_HAS_Libv4l2;YARP_HAS_Libv4lconvert;YARP_HAS_OpenCV")
 
 yarp_prepare_plugin(usbCameraRaw
                     CATEGORY device
                     TYPE USBCameraDriverRaw
-                    INCLUDE USBcamera.h
+                    INCLUDE common/USBcamera.h
                     EXTRA_CONFIG WRAPPER=grabberDual
                     DEPENDS "UNIX;NOT APPLE;YARP_HAS_Libv4l2;YARP_HAS_Libv4lconvert;YARP_HAS_OpenCV")
 
 if(ENABLE_usbCamera OR ENABLE_usbCameraRaw)
   yarp_add_plugin(yarp_usbCamera)
-
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
   target_sources(yarp_usbCamera PRIVATE common/USBcamera.cpp
                                         common/USBcamera.h


### PR DESCRIPTION
* Including current directory (either explicitly, or using `CMAKE_INCLUDE_CURRENT_DIR`) is no longer required by the generated files.
* `INCLUDE` must now be an existing file, either using a path relative to current directory, or an absolute path. Using a path relative to one of the include directories is deprecated.