### PR TITLE
Allow MAS to wrap subdevice via open() method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 # Main project
 project(YARP
-        VERSION 3.3.102
+        VERSION 3.3.103
         LANGUAGES C CXX)
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")
 

--- a/doc/release/master/mas-wrap-subdevice.md
+++ b/doc/release/master/mas-wrap-subdevice.md
@@ -1,0 +1,9 @@
+mas-wrap-subdevice {#master}
+-----------
+
+### devices
+
+#### multipleanalogsensorsserver
+
+* Added support for wrapped subdevices, i.e. those explicitly instantiated via
+  `--subdevice` option on initial device configuration. (#2154)

--- a/src/devices/multipleanalogsensorsserver/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsserver/CMakeLists.txt
@@ -8,6 +8,7 @@ yarp_prepare_plugin(multipleanalogsensorsserver
                     CATEGORY device
                     TYPE MultipleAnalogSensorsServer
                     INCLUDE MultipleAnalogSensorsServer.h
+                    EXTRA_CONFIG WRAPPER=multipleanalogsensorsserver
                     DEFAULT ON)
 
 if(ENABLE_multipleanalogsensorsserver)

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -12,6 +12,7 @@
 
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
@@ -48,6 +49,10 @@ class MultipleAnalogSensorsServer :
     yarp::os::Port m_rpcPort;
     // Generic vector buffer
     yarp::sig::Vector m_buffer;
+
+    // Wrapped subdevices, if any
+    yarp::dev::PolyDriver m_subdevice;
+    bool m_isDeviceOwned{false};
 
     // Interface of the wrapped device
     yarp::dev::IThreeAxisGyroscopes* m_iThreeAxisGyroscopes{nullptr};


### PR DESCRIPTION
Besides the `attachAll` mechanism (also referred to as "deferred attach" in some other places across YARP's codebase), this patch enables the `multipleanalogsensorsserver` device to wrap a subdevice on initial configuration, i.e. via `DeviceDriver::open`. This implementation mirrors https://github.com/robotology/yarp/pull/1018.

Closes https://github.com/robotology/yarp/issues/2154.