### PR TITLE
RealsenseWithImu device driver

### DIFF
--- a/doc/release/master/featureRealsenseWithIMU.md
+++ b/doc/release/master/featureRealsenseWithIMU.md
@@ -1,0 +1,17 @@
+featureRealsenseWithIMU {master}
+----------------------
+
+
+### devices
+
+* added the following new EXPERIMENTAL devices. 
+* Experimental means that the software is under development, provided with uncomplete documentation and it may be modified/renamed/removed without any notice.
+
+#### Realsense2WithIMU
+
+* `Realsense2WithIMU` Experimental driver for Realsense D435i
+
+#### Relasense2Tracking
+
+* `Relasense2Tracking` Experimental driver for Realsense T265
+

--- a/src/devices/realsense2/CMakeLists.txt
+++ b/src/devices/realsense2/CMakeLists.txt
@@ -38,3 +38,41 @@ if(ENABLE_realsense2)
 
   set_property(TARGET yarp_realsense2 PROPERTY FOLDER "Plugins/Device")
 endif()
+
+yarp_prepare_plugin(realsense2withIMU
+                    CATEGORY device
+                    TYPE realsense2withIMUDriver
+                    INCLUDE realsense2withIMUDriver.h
+                    EXTRA_CONFIG WRAPPER=RGBDSensorWrapper
+                    DEPENDS "YARP_HAS_realsense2")
+
+if(ENABLE_realsense2withIMU)
+  yarp_add_plugin(yarp_realsense2withIMU)
+
+  target_sources(yarp_realsense2withIMU PRIVATE realsense2Driver.cpp
+                                         realsense2withIMUDriver.cpp
+                                         realsense2withIMUDriver.h)
+
+  target_link_libraries(yarp_realsense2withIMU PRIVATE YARP::YARP_os
+                                                YARP::YARP_sig
+                                                YARP::YARP_dev
+                                                YARP::YARP_math)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_math)
+
+  target_link_libraries(yarp_realsense2withIMU PRIVATE realsense2::realsense2)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS realsense2)
+
+  yarp_install(TARGETS yarp_realsense2withIMU
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_realsense2withIMU PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/realsense2/CMakeLists.txt
+++ b/src/devices/realsense2/CMakeLists.txt
@@ -76,3 +76,40 @@ if(ENABLE_realsense2withIMU)
 
   set_property(TARGET yarp_realsense2withIMU PROPERTY FOLDER "Plugins/Device")
 endif()
+
+yarp_prepare_plugin(realsense2Tracking
+                    CATEGORY device
+                    TYPE realsense2Tracking
+                    INCLUDE realsense2Tracking.h
+                    DEPENDS "YARP_HAS_realsense2")
+
+if(ENABLE_realsense2Tracking)
+  yarp_add_plugin(yarp_realsense2Tracking)
+
+  target_sources(yarp_realsense2Tracking PRIVATE realsense2Tracking.cpp
+                                                 realsense2Tracking.h)
+
+  target_link_libraries(yarp_realsense2Tracking PRIVATE YARP::YARP_os
+                                                YARP::YARP_sig
+                                                YARP::YARP_dev
+                                                YARP::YARP_math)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_math)
+
+  target_link_libraries(yarp_realsense2Tracking PRIVATE realsense2::realsense2)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS realsense2)
+
+  yarp_install(TARGETS yarp_realsense2Tracking
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_realsense2Tracking PROPERTY FOLDER "Plugins/Device")
+endif()
+

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -562,7 +562,7 @@ bool realsense2Driver::initializeRealsenseDevice()
     // Given a device, we can query its sensors using:
     m_sensors = m_device.query_sensors();
 
-    yInfo()<< "realsense2Driver: Device consists of" << m_sensors.size()<<"sensors";
+    yInfo()<< "realsense2Driver: Device consists of" << m_sensors.size()<<"sensors. More infos using --verbose option";
     if (m_verbose)
     {
         for (const auto & m_sensor : m_sensors)

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -194,7 +194,7 @@ public:
     int height() const override;
     int width() const override;
 
-private:
+protected:
     //method
     inline bool initializeRealsenseDevice();
     inline bool setParams();
@@ -210,7 +210,7 @@ private:
 
 
     // realsense classes
-    std::mutex   m_mutex;
+    mutable std::mutex m_mutex;
     rs2::context m_ctx;
     rs2::config m_cfg;
     rs2::pipeline m_pipeline;

--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -1,0 +1,435 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "realsense2Tracking.h"
+
+#include <yarp/os/Value.h>
+
+#include <yarp/sig/ImageUtils.h>
+
+#include <yarp/math/quaternion.h>
+#include <yarp/math/math.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <librealsense2/rsutil.h>
+#include <librealsense2/rs.hpp>
+#include <mutex>
+
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::os;
+
+using namespace std;
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct float3 {
+    float x, y, z;
+    float3 operator*(float t)
+    {
+        return { x * t, y * t, z * t };
+    }
+
+    float3 operator-(float t)
+    {
+        return { x - t, y - t, z - t };
+    }
+
+    void operator*=(float t)
+    {
+        x = x * t;
+        y = y * t;
+        z = z * t;
+    }
+
+    void operator=(float3 other)
+    {
+        x = other.x;
+        y = other.y;
+        z = other.z;
+    }
+
+    void add(float t1, float t2, float t3)
+    {
+        x += t1;
+        y += t2;
+        z += t3;
+    }
+};
+
+//---------------------------------------------------------------
+
+static std::string get_device_information(const rs2::device& dev)
+{
+
+    std::stringstream ss;
+    ss << "Device information: " << std::endl;
+
+    for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++) {
+        auto info_type = static_cast<rs2_camera_info>(i);
+        ss << "  " << std::left << std::setw(20) << info_type << " : ";
+
+        if (dev.supports(info_type))
+            ss << dev.get_info(info_type) << std::endl;
+        else
+            ss << "N/A" << std::endl;
+    }
+    return ss.str();
+}
+
+static bool setOption(rs2_option option, const rs2::sensor* sensor, float value)
+{
+
+    if (!sensor) {
+        return false;
+    }
+
+    // First, verify that the sensor actually supports this option
+    if (!sensor->supports(option)) {
+        yError() << "realsense2Driver: The option" << rs2_option_to_string(option) << "is not supported by this sensor";
+        return false;
+    }
+
+    // To set an option to a different value, we can call set_option with a new value
+    try {
+        sensor->set_option(option, value);
+    } catch (const rs2::error& e) {
+        // Some options can only be set while the camera is streaming,
+        // and generally the hardware might fail so it is good practice to catch exceptions from set_option
+        yError() << "realsense2Driver: Failed to set option " << rs2_option_to_string(option) << ". (" << e.what() << ")";
+        return false;
+    }
+    return true;
+}
+
+static bool getOption(rs2_option option, const rs2::sensor* sensor, float& value)
+{
+    if (!sensor) {
+        return false;
+    }
+
+    // First, verify that the sensor actually supports this option
+    if (!sensor->supports(option)) {
+        yError() << "realsense2Driver: The option" << rs2_option_to_string(option) << "is not supported by this sensor";
+        return false;
+    }
+
+    // To set an option to a different value, we can call set_option with a new value
+    try {
+        value = sensor->get_option(option);
+    } catch (const rs2::error& e) {
+        // Some options can only be set while the camera is streaming,
+        // and generally the hardware might fail so it is good practice to catch exceptions from set_option
+        yError() << "realsense2Driver: Failed to get option " << rs2_option_to_string(option) << ". (" << e.what() << ")";
+        return false;
+    }
+    return true;
+}
+
+static void settingErrorMsg(const string& error, bool& ret)
+{
+    yError() << "realsense2Driver:" << error.c_str();
+    ret = false;
+}
+
+realsense2Tracking::realsense2Tracking()
+{
+}
+
+bool realsense2Tracking::pipelineStartup()
+{
+    try {
+        m_profile = m_pipeline.start(m_cfg);
+    } catch (const rs2::error& e) {
+        yError() << "realsense2Driver: failed to start the pipeline:"
+                 << "(" << e.what() << ")";
+        m_lastError = e.what();
+        return false;
+    }
+    return true;
+}
+
+bool realsense2Tracking::pipelineShutdown()
+{
+    try {
+        m_pipeline.stop();
+    } catch (const rs2::error& e) {
+        yError() << "realsense2Driver: failed to stop the pipeline:"
+                 << "(" << e.what() << ")";
+        m_lastError = e.what();
+        return false;
+    }
+    return true;
+}
+
+bool realsense2Tracking::pipelineRestart()
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (!pipelineShutdown())
+        return false;
+
+    return pipelineStartup();
+}
+
+bool realsense2Tracking::open(Searchable& config)
+{
+    string sensor_is = "t265";
+    bool b= true;
+
+    m_cfg.enable_stream(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    m_cfg.enable_stream(RS2_STREAM_GYRO, RS2_FORMAT_MOTION_XYZ32F);
+    m_cfg.enable_stream(RS2_STREAM_POSE, RS2_FORMAT_6DOF);
+    b &= pipelineStartup();
+    if (b==false)
+    {
+        yError() << "Pipeline initialization failed";
+        return false;
+    }
+
+    return true;
+}
+
+bool realsense2Tracking::close()
+{
+    pipelineShutdown();
+    return true;
+}
+
+//---------------------------------------------------------------------------------------------------------------
+/* IThreeAxisGyroscopes methods */
+size_t realsense2Tracking::getNrOfThreeAxisGyroscopes() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2Tracking::getThreeAxisGyroscopeStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2Tracking::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_gyro_sensor_tag;
+    return true;
+}
+
+bool realsense2Tracking::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_gyroFrameName;
+    return true;
+}
+
+bool realsense2Tracking::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    if (sens_index != 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fg = dataframe.first(RS2_STREAM_GYRO, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::motion_frame gyro = fg.as<rs2::motion_frame>();
+    m_last_gyro = gyro.get_motion_data();
+    out.resize(3);
+    out[0] = m_last_gyro.x;
+    out[1] = m_last_gyro.y;
+    out[2] = m_last_gyro.z;
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IThreeAxisLinearAccelerometers methods */
+size_t realsense2Tracking::getNrOfThreeAxisLinearAccelerometers() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2Tracking::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2Tracking::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_accel_sensor_tag;
+    return true;
+}
+
+bool realsense2Tracking::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_accelFrameName;
+    return true;
+}
+
+bool realsense2Tracking::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::motion_frame accel = fa.as<rs2::motion_frame>();
+    m_last_accel = accel.get_motion_data();
+    out.resize(3);
+    out[0] = m_last_accel.x;
+    out[1] = m_last_accel.y;
+    out[2] = m_last_accel.z;
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IOrientationSensors methods */
+size_t realsense2Tracking::getNrOfOrientationSensors() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2Tracking::getOrientationSensorStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2Tracking::getOrientationSensorName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_orientation_sensor_tag;
+    return true;
+}
+
+bool realsense2Tracking::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_orientationFrameName;
+    return true;
+}
+
+
+bool realsense2Tracking::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const
+{
+    if (sens_index != 0) { return false; }
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        rs2::frameset dataframe = m_pipeline.wait_for_frames();
+        auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+        rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+        m_last_pose = pose.get_pose_data();
+        yarp::math::Quaternion q(m_last_pose.rotation.x, m_last_pose.rotation.y, m_last_pose.rotation.z, m_last_pose.rotation.w);
+        yarp::sig::Matrix mat = q.toRotationMatrix3x3();
+        yarp::sig::Vector rpy_temp = yarp::math::dcm2rpy(mat);
+        rpy[0] = 0 + rpy_temp[0] * 180 / M_PI; //here we can eventually adjust the sign and/or sum an offset
+        rpy[1] = 0 + rpy_temp[1] * 180 / M_PI;
+        rpy[2] = 0 + rpy_temp[2] * 180 / M_PI;
+       return true;
+    }
+    return false;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IPositionSensors methods */
+size_t realsense2Tracking::getNrOfPositionSensors() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2Tracking::getPositionSensorStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2Tracking::getPositionSensorName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_pose_sensor_tag;
+    return true;
+}
+
+bool realsense2Tracking::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_poseFrameName;
+    return true;
+}
+
+
+bool realsense2Tracking::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+    m_last_pose = pose.get_pose_data();
+    xyz.resize(3);
+    xyz[0] = m_last_pose.translation.x;
+    xyz[1] = m_last_pose.translation.y;
+    xyz[2] = m_last_pose.translation.z;
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+#if 0
+/* IPoseSensors methods */
+size_t realsense2Tracking::getNrOfPoseSensors() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2Tracking::getPoseSensorStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2Tracking::getPoseSensorName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_pose_sensor_tag;
+    return true;
+}
+
+bool realsense2Tracking::getPoseSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_poseFrameName;
+    return true;
+}
+
+bool realsense2Tracking::getPoseSensorMeasureAsXYZRPY(size_t sens_index, yarp::sig::Vector& xyzrpy, double& timestamp) const
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+    m_last_pose = pose.get_pose_data();
+    xyzrpy.resize(6);
+    xyzrpy[0] = m_last_pose.translation.x;
+    xyzrpy[1] = m_last_pose.translation.y;
+    xyzrpy[2] = m_last_pose.translation.z;
+    yarp::math::Quaternion q(m_last_pose.rotation.x, m_last_pose.rotation.y, m_last_pose.rotation.z, m_last_pose.rotation.w);
+    yarp::sig::Matrix mat = q.toRotationMatrix3x3();
+    yarp::sig::Vector rpy = yarp::math::dcm2rpy(mat);
+    xyzrpy[3] = 0 + rpy[0] * 180 / M_PI;
+    xyzrpy[4] = 0 + rpy[1] * 180 / M_PI;
+    xyzrpy[5] = 0 + rpy[2] * 180 / M_PI;
+    return true;
+}
+#endif
+//-----------------------------------------------------------------------------

--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms of the
@@ -22,6 +22,11 @@
 #include <librealsense2/rsutil.h>
 #include <librealsense2/rs.hpp>
 #include <mutex>
+
+ /**********************************************************************************************************/
+ // This software module is experimental.
+ // It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.
+ /**********************************************************************************************************/
 
 using namespace yarp::dev;
 using namespace yarp::sig;
@@ -183,6 +188,9 @@ bool realsense2Tracking::pipelineRestart()
 
 bool realsense2Tracking::open(Searchable& config)
 {
+    yWarning() << "This software module is experimental.";
+    yWarning() << "It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.";
+
     string sensor_is = "t265";
     bool b= true;
 

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef REALSENSE2TRACKING_H
+#define REALSENSE2TRACKING_H
+
+#include <yarp/os/PeriodicThread.h>
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+
+#include "realsense2Driver.h"
+#include <cstring>
+#include <iostream>
+#include <librealsense2/rs.hpp>
+#include <map>
+#include <mutex>
+
+
+/**
+ *  @ingroup dev_impl_media
+ *
+ * @brief `realsense2` : driver for realsense2 compatible devices.
+ *
+ * This device driver exposes the IRGBDSensor and IFrameGrabberControls
+ * interfaces to read the images and operate on the available settings.
+ * See the documentation for more details about each interface.
+ *
+ * This device is paired with its server called RGBDSensorWrapper to stream the images and perform remote operations.
+ *
+ * The configuration file is subdivided into 2 major sections called "SETTINGS" and "HW_DESCRIPTION".
+ *
+ * The "SETTINGS" section is meant for read/write parameters, meaning parameters which can be get and set by the device.
+ * A common case of setting is the image resolution in pixel. This setting will be read by the device and it'll be applied
+ * in the startup phase. If the setting fails, the device will terminate the execution with a error message.
+ *
+ * The "HW_DESCRIPTION" section is meant for read only parameters which describe the hardware property of the device and
+ * cannot be provided by the device through software API.
+ * A common case is the 'Field Of View' property, which may or may not be supported by the physical device.
+ * When a property is present in the HW_DESCRIPTION group, the YARP RGBDSensorClient will report this value when asked for
+ * and setting will be disabled.
+ * This group can also be used to by-pass realsense2 API in case some functionality is not correctly working with the current
+ * device. For example the 'clipPlanes' property may return incorrect values or values using non-standard measurement unit.
+ * In this case using the HW_DESCRIPTION, a user can override the value got from OpenNI2 API with a custom value.
+ *
+ * \note Parameters inside the HW_DESCRIPTION are read only, so the relative set functionality will be disabled.
+ * \note For parameters which are neither in SETTINGS nor in HW_DESCRIPTION groups, read / write functionality is assumed
+ *  but not initial setting will be performed. Device will start with manufacturer default values.
+ * \warning A single parameter cannot be present into both SETTINGS and HW_DESCRIPTION groups.
+ * \warning whenever more then one value is required by the setting, the values must be in parentheses!
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `realsense2` |
+ *
+ *   Parameters used by this device are:
+ * | Parameter name               | SubParameter        | Type                |  Read / write   | Units          | Default Value | Required                         | Description                                                                            | Notes                                                                 |
+ * |:----------------------------:|:-------------------:|:-------------------:|:---------------:|:--------------:|:-------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|:---------------------------------------------------------------------:|
+ * |  stereoMode                  |      -              | bool                |  Read / write   |                |   false       |  No(see notes)                   | Flag for using the realsense as stereo camera                                          |  This option is to use it with yarp::dev::ServerGrabber as network wrapper. The stereo images provided are raw images(yarp::sig::PixelMono) and note that not all the realsense devices have the stereo streams. |
+ * |  verbose                     |      -              | bool                |  Read / write   |                |   false       |  No                              | Flag for enabling debug prints                                                         |                                                                       |
+ * |  SETTINGS                    |      -              | group               |  Read / write   | -              |   -           |  Yes                             | Initial setting of the device.                                                         |  Properties must be read/writable in order for setting to work        |
+ * |                              |  rgbResolution      | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of rgb image in pixels                                                            |  2 values expected as height, width                                   |
+ * |                              |  depthResolution    | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of depth image in pixels                                                          |  Values are height, width                                             |
+ * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
+ * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
+ * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
+ * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This option is deprecated, please use alignmentFrame instead.        |
+ * |                              |  alignmentFrame     | string              |  Read / Write   | -              |   RGB         |  No                              | This parameter specifies the frame to which the frames RGB and Depth will be aligned.  |  The accepted values are RGB, Depth, None. This operation could be heavy, set it to None to increase the fps.|
+ * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
+ * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minimum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
+ *
+ * Configuration file using .ini format, for using as RGBD device:
+ *
+ * \code{.unparsed}
+
+device       RGBDSensorWrapper
+subdevice    realsense2
+name         /depthCamerac
+
+[SETTINGS]
+depthResolution (640 480)    #Note the parentheses
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)
+ *
+ * \endcode
+ *
+ * Configuration file using .ini format, for using as stereo camera:
+ * \code{.unparsed}
+device       grabberDual
+subdevice    realsense2
+name         /stereoCamera
+capabilities RAW
+stereoMode   true
+
+[SETTINGS]
+rgbResolution   (640 480)
+depthResolution   (640 480)
+framerate       30
+enableEmitter   false
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)
+ * \endcode
+ */
+
+
+class realsense2Tracking :
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IThreeAxisGyroscopes,
+        public yarp::dev::IThreeAxisLinearAccelerometers,
+        public yarp::dev::IOrientationSensors,
+        public yarp::dev::IPositionSensors
+{
+private:
+    typedef yarp::os::Stamp Stamp;
+    typedef yarp::os::Property Property;
+
+public:
+    realsense2Tracking();
+    ~realsense2Tracking() override = default;
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+private:
+    //method
+    inline bool initializeRealsenseDevice();
+    inline bool setParams();
+
+    bool pipelineStartup();
+    bool pipelineShutdown();
+    bool pipelineRestart();
+
+public:
+    /* IThreeAxisGyroscopes methods */
+    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
+    bool getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const override;
+    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IThreeAxisLinearAccelerometers methods */
+    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
+    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const override;
+    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IOrientationSensors methods */
+    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
+    bool getOrientationSensorName(size_t sens_index, std::string& name) const override;
+    bool getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+
+    /* IPositionSensors methods */
+    size_t getNrOfPositionSensors() const override;
+    yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
+    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
+    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+
+#if 0
+    /* IPoseSensors methods */
+    size_t getNrOfPoseSensors() const ;
+    yarp::dev::MAS_status getPoseSensorStatus(size_t sens_index) const;
+    bool getPoseSensorName(size_t sens_index, std::string& name) const;
+    bool getPoseSensorFrameName(size_t sens_index, std::string& frameName) const;
+    bool getPoseSensorMeasureAsXYZRPY(size_t sens_index, yarp::sig::Vector& xyzrpy, double& timestamp) const;
+#endif
+
+protected:
+    // realsense classes
+    mutable rs2_vector m_last_gyro;
+    mutable rs2_vector m_last_accel;
+    mutable rs2_pose   m_last_pose;
+
+    //strings
+    std::string       m_inertial_sensor_name_prefix;
+    const std::string m_accel_sensor_tag       = "accelerations_sensor";
+    const std::string m_gyro_sensor_tag        = "gyro_sensor";
+    const std::string m_orientation_sensor_tag = "orientation_sensor";
+    const std::string m_position_sensor_tag    = "position_sensor";
+    const std::string m_pose_sensor_tag        = "pose_sensor";
+    std::string       m_gyroFrameName;
+    std::string       m_accelFrameName;
+    std::string       m_orientationFrameName;
+    std::string       m_positionFrameName;
+    std::string       m_poseFrameName;
+
+    rs2::config   m_cfg;
+    mutable std::mutex    m_mutex;
+    rs2::pipeline m_pipeline;
+    rs2::pipeline_profile m_profile;
+    std::string m_lastError;
+
+    /*
+    rs2::context m_ctx;
+
+    rs2::device  m_device;
+    std::vector<rs2::sensor> m_sensors;
+
+    bool m_verbose;
+    bool m_initialized;
+    std::vector<cameraFeature_id_t> m_supportedFeatures;*/
+};
+#endif

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms of the
@@ -21,99 +21,11 @@
 #include <map>
 #include <mutex>
 
-
-/**
- *  @ingroup dev_impl_media
- *
- * @brief `realsense2` : driver for realsense2 compatible devices.
- *
- * This device driver exposes the IRGBDSensor and IFrameGrabberControls
- * interfaces to read the images and operate on the available settings.
- * See the documentation for more details about each interface.
- *
- * This device is paired with its server called RGBDSensorWrapper to stream the images and perform remote operations.
- *
- * The configuration file is subdivided into 2 major sections called "SETTINGS" and "HW_DESCRIPTION".
- *
- * The "SETTINGS" section is meant for read/write parameters, meaning parameters which can be get and set by the device.
- * A common case of setting is the image resolution in pixel. This setting will be read by the device and it'll be applied
- * in the startup phase. If the setting fails, the device will terminate the execution with a error message.
- *
- * The "HW_DESCRIPTION" section is meant for read only parameters which describe the hardware property of the device and
- * cannot be provided by the device through software API.
- * A common case is the 'Field Of View' property, which may or may not be supported by the physical device.
- * When a property is present in the HW_DESCRIPTION group, the YARP RGBDSensorClient will report this value when asked for
- * and setting will be disabled.
- * This group can also be used to by-pass realsense2 API in case some functionality is not correctly working with the current
- * device. For example the 'clipPlanes' property may return incorrect values or values using non-standard measurement unit.
- * In this case using the HW_DESCRIPTION, a user can override the value got from OpenNI2 API with a custom value.
- *
- * \note Parameters inside the HW_DESCRIPTION are read only, so the relative set functionality will be disabled.
- * \note For parameters which are neither in SETTINGS nor in HW_DESCRIPTION groups, read / write functionality is assumed
- *  but not initial setting will be performed. Device will start with manufacturer default values.
- * \warning A single parameter cannot be present into both SETTINGS and HW_DESCRIPTION groups.
- * \warning whenever more then one value is required by the setting, the values must be in parentheses!
- *
- * | YARP device name |
- * |:-----------------:|
- * | `realsense2` |
- *
- *   Parameters used by this device are:
- * | Parameter name               | SubParameter        | Type                |  Read / write   | Units          | Default Value | Required                         | Description                                                                            | Notes                                                                 |
- * |:----------------------------:|:-------------------:|:-------------------:|:---------------:|:--------------:|:-------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|:---------------------------------------------------------------------:|
- * |  stereoMode                  |      -              | bool                |  Read / write   |                |   false       |  No(see notes)                   | Flag for using the realsense as stereo camera                                          |  This option is to use it with yarp::dev::ServerGrabber as network wrapper. The stereo images provided are raw images(yarp::sig::PixelMono) and note that not all the realsense devices have the stereo streams. |
- * |  verbose                     |      -              | bool                |  Read / write   |                |   false       |  No                              | Flag for enabling debug prints                                                         |                                                                       |
- * |  SETTINGS                    |      -              | group               |  Read / write   | -              |   -           |  Yes                             | Initial setting of the device.                                                         |  Properties must be read/writable in order for setting to work        |
- * |                              |  rgbResolution      | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of rgb image in pixels                                                            |  2 values expected as height, width                                   |
- * |                              |  depthResolution    | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of depth image in pixels                                                          |  Values are height, width                                             |
- * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
- * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
- * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
- * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This option is deprecated, please use alignmentFrame instead.        |
- * |                              |  alignmentFrame     | string              |  Read / Write   | -              |   RGB         |  No                              | This parameter specifies the frame to which the frames RGB and Depth will be aligned.  |  The accepted values are RGB, Depth, None. This operation could be heavy, set it to None to increase the fps.|
- * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
- * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minimum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
- *
- * Configuration file using .ini format, for using as RGBD device:
- *
- * \code{.unparsed}
-
-device       RGBDSensorWrapper
-subdevice    realsense2
-name         /depthCamerac
-
-[SETTINGS]
-depthResolution (640 480)    #Note the parentheses
-rgbResolution   (640 480)
-framerate       30
-enableEmitter   true
-alignmentFrame  RGB
-
-[HW_DESCRIPTION]
-clipPlanes (0.2 10.0)
- *
- * \endcode
- *
- * Configuration file using .ini format, for using as stereo camera:
- * \code{.unparsed}
-device       grabberDual
-subdevice    realsense2
-name         /stereoCamera
-capabilities RAW
-stereoMode   true
-
-[SETTINGS]
-rgbResolution   (640 480)
-depthResolution   (640 480)
-framerate       30
-enableEmitter   false
-
-[HW_DESCRIPTION]
-clipPlanes (0.2 10.0)
- * \endcode
- */
-
-
+ /**********************************************************************************************************/
+ // This software module is experimental.
+ // It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.
+ /**********************************************************************************************************/
+ 
 class realsense2Tracking :
         public yarp::dev::DeviceDriver,
         public yarp::dev::IThreeAxisGyroscopes,

--- a/src/devices/realsense2/realsense2withIMUDriver.cpp
+++ b/src/devices/realsense2/realsense2withIMUDriver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms of the
@@ -23,6 +23,11 @@
 #include <librealsense2/rs.hpp>
 #include <mutex>
 
+ /**********************************************************************************************************/
+ // This software module is experimental.
+ // It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.
+ /**********************************************************************************************************/
+ 
 using namespace yarp::dev;
 using namespace yarp::sig;
 using namespace yarp::os;
@@ -115,6 +120,7 @@ public:
         // Calculate rotation angle from accelerometer data
         accel_angle.z = atan2(accel_data.y, accel_data.z);
         accel_angle.x = atan2(accel_data.x, sqrt(accel_data.y * accel_data.y + accel_data.z * accel_data.z));
+        accel_angle.y = 0; //ADDED by randaz81
 
         // If it is the first iteration, set initial pose of camera according to accelerometer data (note the different handling for Y axis)
         std::lock_guard<std::mutex> lock(theta_mtx);
@@ -276,6 +282,9 @@ void realsense2Driver::fallback()
 
 bool realsense2withIMUDriver::open(Searchable& config)
 {
+    yWarning() << "This software module is experimental.";
+    yWarning() << "It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.";
+
     string sensor_is = "d435i";
     bool b = true;
 

--- a/src/devices/realsense2/realsense2withIMUDriver.cpp
+++ b/src/devices/realsense2/realsense2withIMUDriver.cpp
@@ -1,0 +1,399 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "realsense2withIMUdriver.h"
+
+#include <yarp/os/Value.h>
+
+#include <yarp/sig/ImageUtils.h>
+
+#include <yarp/math/quaternion.h>
+#include <yarp/math/math.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <librealsense2/rsutil.h>
+#include <mutex>
+
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::os;
+
+using namespace std;
+
+static std::string get_device_information(const rs2::device& dev)
+{
+
+    std::stringstream ss;
+    ss << "Device information: " << std::endl;
+
+    for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++) {
+        auto info_type = static_cast<rs2_camera_info>(i);
+        ss << "  " << std::left << std::setw(20) << info_type << " : ";
+
+        if (dev.supports(info_type))
+            ss << dev.get_info(info_type) << std::endl;
+        else
+            ss << "N/A" << std::endl;
+    }
+    return ss.str();
+}
+
+static bool setOption(rs2_option option, const rs2::sensor* sensor, float value)
+{
+
+    if (!sensor) {
+        return false;
+    }
+
+    // First, verify that the sensor actually supports this option
+    if (!sensor->supports(option)) {
+        yError() << "realsense2Driver: The option" << rs2_option_to_string(option) << "is not supported by this sensor";
+        return false;
+    }
+
+    // To set an option to a different value, we can call set_option with a new value
+    try {
+        sensor->set_option(option, value);
+    } catch (const rs2::error& e) {
+        // Some options can only be set while the camera is streaming,
+        // and generally the hardware might fail so it is good practice to catch exceptions from set_option
+        yError() << "realsense2Driver: Failed to set option " << rs2_option_to_string(option) << ". (" << e.what() << ")";
+        return false;
+    }
+    return true;
+}
+
+static bool getOption(rs2_option option, const rs2::sensor* sensor, float& value)
+{
+    if (!sensor) {
+        return false;
+    }
+
+    // First, verify that the sensor actually supports this option
+    if (!sensor->supports(option)) {
+        yError() << "realsense2Driver: The option" << rs2_option_to_string(option) << "is not supported by this sensor";
+        return false;
+    }
+
+    // To set an option to a different value, we can call set_option with a new value
+    try {
+        value = sensor->get_option(option);
+    } catch (const rs2::error& e) {
+        // Some options can only be set while the camera is streaming,
+        // and generally the hardware might fail so it is good practice to catch exceptions from set_option
+        yError() << "realsense2Driver: Failed to get option " << rs2_option_to_string(option) << ". (" << e.what() << ")";
+        return false;
+    }
+    return true;
+}
+
+static void settingErrorMsg(const string& error, bool& ret)
+{
+    yError() << "realsense2Driver:" << error.c_str();
+    ret = false;
+}
+
+realsense2withIMUDriver::realsense2withIMUDriver() :
+        realsense2Driver()
+{
+}
+
+#if 0
+bool realsense2withIMUDriver::pipelineStartup()
+{
+    try {
+        m_profile = m_pipeline.start(m_cfg);
+    } catch (const rs2::error& e) {
+        yError() << "realsense2Driver: failed to start the pipeline:"
+                 << "(" << e.what() << ")";
+        m_lastError = e.what();
+        return false;
+    }
+    return true;
+}
+
+bool realsense2withIMUDriver::pipelineShutdown()
+{
+    try {
+        m_pipeline.stop();
+    } catch (const rs2::error& e) {
+        yError() << "realsense2Driver: failed to stop the pipeline:"
+                 << "(" << e.what() << ")";
+        m_lastError = e.what();
+        return false;
+    }
+    return true;
+}
+
+bool realsense2withIMUDriver::pipelineRestart()
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (!pipelineShutdown())
+        return false;
+
+    return pipelineStartup();
+}
+
+
+void realsense2Driver::fallback()
+{
+    m_cfg.enable_stream(RS2_STREAM_COLOR, m_color_intrin.width, m_color_intrin.height, RS2_FORMAT_RGB8, m_fps);
+    m_cfg.enable_stream(RS2_STREAM_DEPTH, m_depth_intrin.width, m_depth_intrin.height, RS2_FORMAT_Z16, m_fps);
+    yWarning() << "realsense2Driver: format not supported, use --verbose for more details. Setting the fallback format";
+    std::cout << "COLOR: " << m_color_intrin.width << "x" << m_color_intrin.height << " fps: " << m_fps << std::endl;
+    std::cout << "DEPTH: " << m_depth_intrin.width << "x" << m_depth_intrin.height << " fps: " << m_fps << std::endl;
+}
+#endif
+
+bool realsense2withIMUDriver::open(Searchable& config)
+{
+    realsense2Driver::open(config);
+    m_cfg.enable_stream(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    m_cfg.enable_stream(RS2_STREAM_GYRO, RS2_FORMAT_MOTION_XYZ32F);
+    m_sensor_has_pose_capabilities = false;
+    if (m_sensor_has_pose_capabilities)
+    {
+        m_cfg.enable_stream(RS2_STREAM_POSE, RS2_FORMAT_6DOF);
+    }
+    bool b = pipelineRestart();
+    return b;
+}
+
+bool realsense2withIMUDriver::close()
+{
+    pipelineShutdown();
+    return true;
+}
+
+//---------------------------------------------------------------------------------------------------------------
+/* IThreeAxisGyroscopes methods */
+size_t realsense2withIMUDriver::getNrOfThreeAxisGyroscopes() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2withIMUDriver::getThreeAxisGyroscopeStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2withIMUDriver::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_gyro_sensor_tag;
+    return true;
+}
+
+bool realsense2withIMUDriver::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_gyroFrameName;
+    return true;
+}
+
+bool realsense2withIMUDriver::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    if (sens_index != 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(realsense2Driver::m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fg = dataframe.first(RS2_STREAM_GYRO, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::motion_frame gyro = fg.as<rs2::motion_frame>();
+    m_last_gyro = gyro.get_motion_data();
+    out.resize(3);
+    out[0] = m_last_gyro.x;
+    out[1] = m_last_gyro.y;
+    out[2] = m_last_gyro.z;
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IThreeAxisLinearAccelerometers methods */
+size_t realsense2withIMUDriver::getNrOfThreeAxisLinearAccelerometers() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2withIMUDriver::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
+{
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2withIMUDriver::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
+{
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_accel_sensor_tag;
+    return true;
+}
+
+bool realsense2withIMUDriver::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (sens_index != 0) { return false; }
+    frameName = m_accelFrameName;
+    return true;
+}
+
+bool realsense2withIMUDriver::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::motion_frame accel = fa.as<rs2::motion_frame>();
+    m_last_accel = accel.get_motion_data();
+    out.resize(3);
+    out[0] = m_last_accel.x;
+    out[1] = m_last_accel.y;
+    out[2] = m_last_accel.z;
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IOrientationSensors methods */
+size_t realsense2withIMUDriver::getNrOfOrientationSensors() const
+{
+    if (m_sensor_has_pose_capabilities) { return 1; }
+    if (m_sensor_has_orientation_estimator) { return 1; }
+    return 0;
+}
+
+yarp::dev::MAS_status realsense2withIMUDriver::getOrientationSensorStatus(size_t sens_index) const
+{
+    if (m_sensor_has_pose_capabilities == false || m_sensor_has_orientation_estimator == false) {return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2withIMUDriver::getOrientationSensorName(size_t sens_index, std::string& name) const
+{
+    if (m_sensor_has_pose_capabilities ==false || m_sensor_has_orientation_estimator==false)
+    {
+        return false;
+    }
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_orientation_sensor_tag;
+    return true;
+}
+
+bool realsense2withIMUDriver::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (m_sensor_has_pose_capabilities == false || m_sensor_has_orientation_estimator == false)
+    {
+        return false;
+    }
+    if (sens_index != 0) { return false; }
+    frameName = m_orientationFrameName;
+    return true;
+}
+
+
+bool realsense2withIMUDriver::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const
+{
+    if (m_sensor_has_pose_capabilities == false || m_sensor_has_orientation_estimator == false)
+    {
+        return false;
+    }
+    if (sens_index != 0) { return false; }
+    return true;
+}
+
+//-------------------------------------------------------------------------------------------------------
+
+/* IPoseSensors methods */
+size_t realsense2withIMUDriver::getNrOfPoseSensors() const
+{
+    if (m_sensor_has_pose_capabilities == false) { return 0; }
+    return 1;
+}
+
+yarp::dev::MAS_status realsense2withIMUDriver::getPoseSensorStatus(size_t sens_index) const
+{
+    if (m_sensor_has_pose_capabilities == false) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    if (sens_index != 0) { return yarp::dev::MAS_status::MAS_UNKNOWN; }
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool realsense2withIMUDriver::getPoseSensorName(size_t sens_index, std::string& name) const
+{
+    if (m_sensor_has_pose_capabilities == false) { return false; }
+    if (sens_index != 0) { return false; }
+    name = m_inertial_sensor_name_prefix + "/" + m_pose_sensor_tag;
+    return true;
+}
+
+bool realsense2withIMUDriver::getPoseSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    if (m_sensor_has_pose_capabilities == false) { return false; }
+    if (sens_index != 0) { return false; }
+    frameName = m_poseFrameName;
+    return true;
+}
+
+
+bool realsense2withIMUDriver::getPoseSensorMeasureAsXYZRPY(size_t sens_index, yarp::sig::Vector& xyzrpy, double& timestamp) const
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first(RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F);
+    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+    m_last_pose = pose.get_pose_data();
+    xyzrpy.resize(6);
+    xyzrpy[0] = m_last_pose.translation.x;
+    xyzrpy[1] = m_last_pose.translation.y;
+    xyzrpy[2] = m_last_pose.translation.z;
+    yarp::math::Quaternion q(m_last_pose.rotation.x, m_last_pose.rotation.y,m_last_pose.rotation.z,m_last_pose.rotation.w);
+    yarp::sig::Matrix mat = q.toRotationMatrix3x3();
+    yarp::sig::Vector rpy = yarp::math::dcm2rpy(mat);
+    xyzrpy[3] = rpy[0];
+    xyzrpy[4] = rpy[1];
+    xyzrpy[5] = rpy[2];
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+
+#ifdef FORCE_MISSING_MAGNETOMETERS_ON
+/* IThreeAxisMagnetometers methods */
+size_t realsense2withIMUDriver::getNrOfThreeAxisMagnetometers() const
+{
+    return 0;
+}
+
+yarp::dev::MAS_status realsense2withIMUDriver::getThreeAxisMagnetometerStatus(size_t sens_index) const
+{
+    return yarp::dev::MAS_status::MAS_UNKNOWN;
+}
+
+bool realsense2withIMUDriver::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
+{
+    name = "invalid";
+    return false;
+}
+
+bool realsense2withIMUDriver::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const
+{
+    frameName = "invalid";
+    return false;
+}
+
+bool realsense2withIMUDriver::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    out.resize(3);
+    out[0] = out[1] = out[2] = std::nan("");
+    timestamp = yarp::os::Time::now();
+    return false;
+}
+#endif

--- a/src/devices/realsense2/realsense2withIMUDriver.h
+++ b/src/devices/realsense2/realsense2withIMUDriver.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef REALSENSE2IMU_DRIVER_H
+#define REALSENSE2IMU_DRIVER_H
+
+#include <yarp/os/PeriodicThread.h>
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+
+#include "realsense2Driver.h"
+#include <cstring>
+#include <iostream>
+#include <librealsense2/rs.hpp>
+#include <map>
+#include <mutex>
+
+
+/**
+ *  @ingroup dev_impl_media
+ *
+ * @brief `realsense2` : driver for realsense2 compatible devices.
+ *
+ * This device driver exposes the IRGBDSensor and IFrameGrabberControls
+ * interfaces to read the images and operate on the available settings.
+ * See the documentation for more details about each interface.
+ *
+ * This device is paired with its server called RGBDSensorWrapper to stream the images and perform remote operations.
+ *
+ * The configuration file is subdivided into 2 major sections called "SETTINGS" and "HW_DESCRIPTION".
+ *
+ * The "SETTINGS" section is meant for read/write parameters, meaning parameters which can be get and set by the device.
+ * A common case of setting is the image resolution in pixel. This setting will be read by the device and it'll be applied
+ * in the startup phase. If the setting fails, the device will terminate the execution with a error message.
+ *
+ * The "HW_DESCRIPTION" section is meant for read only parameters which describe the hardware property of the device and
+ * cannot be provided by the device through software API.
+ * A common case is the 'Field Of View' property, which may or may not be supported by the physical device.
+ * When a property is present in the HW_DESCRIPTION group, the YARP RGBDSensorClient will report this value when asked for
+ * and setting will be disabled.
+ * This group can also be used to by-pass realsense2 API in case some functionality is not correctly working with the current
+ * device. For example the 'clipPlanes' property may return incorrect values or values using non-standard measurement unit.
+ * In this case using the HW_DESCRIPTION, a user can override the value got from OpenNI2 API with a custom value.
+ *
+ * \note Parameters inside the HW_DESCRIPTION are read only, so the relative set functionality will be disabled.
+ * \note For parameters which are neither in SETTINGS nor in HW_DESCRIPTION groups, read / write functionality is assumed
+ *  but not initial setting will be performed. Device will start with manufacturer default values.
+ * \warning A single parameter cannot be present into both SETTINGS and HW_DESCRIPTION groups.
+ * \warning whenever more then one value is required by the setting, the values must be in parentheses!
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `realsense2` |
+ *
+ *   Parameters used by this device are:
+ * | Parameter name               | SubParameter        | Type                |  Read / write   | Units          | Default Value | Required                         | Description                                                                            | Notes                                                                 |
+ * |:----------------------------:|:-------------------:|:-------------------:|:---------------:|:--------------:|:-------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|:---------------------------------------------------------------------:|
+ * |  stereoMode                  |      -              | bool                |  Read / write   |                |   false       |  No(see notes)                   | Flag for using the realsense as stereo camera                                          |  This option is to use it with yarp::dev::ServerGrabber as network wrapper. The stereo images provided are raw images(yarp::sig::PixelMono) and note that not all the realsense devices have the stereo streams. |
+ * |  verbose                     |      -              | bool                |  Read / write   |                |   false       |  No                              | Flag for enabling debug prints                                                         |                                                                       |
+ * |  SETTINGS                    |      -              | group               |  Read / write   | -              |   -           |  Yes                             | Initial setting of the device.                                                         |  Properties must be read/writable in order for setting to work        |
+ * |                              |  rgbResolution      | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of rgb image in pixels                                                            |  2 values expected as height, width                                   |
+ * |                              |  depthResolution    | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of depth image in pixels                                                          |  Values are height, width                                             |
+ * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
+ * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
+ * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
+ * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This option is deprecated, please use alignmentFrame instead.        |
+ * |                              |  alignmentFrame     | string              |  Read / Write   | -              |   RGB         |  No                              | This parameter specifies the frame to which the frames RGB and Depth will be aligned.  |  The accepted values are RGB, Depth, None. This operation could be heavy, set it to None to increase the fps.|
+ * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
+ * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minimum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
+ *
+ * Configuration file using .ini format, for using as RGBD device:
+ *
+ * \code{.unparsed}
+
+device       RGBDSensorWrapper
+subdevice    realsense2
+name         /depthCamerac
+
+[SETTINGS]
+depthResolution (640 480)    #Note the parentheses
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)
+ *
+ * \endcode
+ *
+ * Configuration file using .ini format, for using as stereo camera:
+ * \code{.unparsed}
+device       grabberDual
+subdevice    realsense2
+name         /stereoCamera
+capabilities RAW
+stereoMode   true
+
+[SETTINGS]
+rgbResolution   (640 480)
+depthResolution   (640 480)
+framerate       30
+enableEmitter   false
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)
+ * \endcode
+ */
+
+class realsense2withIMUDriver :
+        public realsense2Driver,
+        public yarp::dev::IThreeAxisGyroscopes,
+        public yarp::dev::IThreeAxisLinearAccelerometers,
+#ifdef FORCE_MISSING_MAGNETOMETERS_ON
+        public yarp::dev::IThreeAxisMagnetometers,
+#endif
+        public yarp::dev::IOrientationSensors
+{
+private:
+    typedef yarp::os::Stamp Stamp;
+    typedef yarp::os::Property Property;
+
+public:
+    realsense2withIMUDriver();
+    ~realsense2withIMUDriver() override = default;
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+private:
+    //method
+    inline bool initializeRealsenseDevice();
+    inline bool setParams();
+
+    void updateTransformations();
+#if 0
+    bool pipelineStartup(); //inherited
+    bool pipelineShutdown(); //inherited
+    bool pipelineRestart(); //inherited
+    void fallback(); //inherited
+#endif
+    bool setFramerate(const int _fps);
+
+
+public:
+    /* IThreeAxisGyroscopes methods */
+    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
+    bool getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const override;
+    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IThreeAxisLinearAccelerometers methods */
+    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
+    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const override;
+    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+#ifdef FORCE_MISSING_MAGNETOMETERS_ON
+    /* IThreeAxisMagnetometers methods */
+    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
+    bool getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const override;
+    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+#endif
+
+    /* IOrientationSensors methods */
+    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
+    bool getOrientationSensorName(size_t sens_index, std::string& name) const override;
+    bool getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+
+        /* IPoseSensors methods */
+    size_t getNrOfPoseSensors() const ;
+    yarp::dev::MAS_status getPoseSensorStatus(size_t sens_index) const;
+    bool getPoseSensorName(size_t sens_index, std::string& name) const;
+    bool getPoseSensorFrameName(size_t sens_index, std::string& frameName) const;
+    bool getPoseSensorMeasureAsXYZRPY(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const;
+
+protected:
+    // realsense classes
+    mutable rs2_vector m_last_gyro;
+    mutable rs2_vector m_last_accel;
+    mutable rs2_pose   m_last_pose;
+
+    bool m_sensor_has_pose_capabilities;
+    bool m_sensor_has_orientation_estimator;
+
+    //strings
+    std::string m_inertial_sensor_name_prefix;
+    const std::string m_accel_sensor_tag = "accelerations_sensor";
+    const std::string m_gyro_sensor_tag = "gyro_sensor";
+    const std::string m_orientation_sensor_tag = "orientation_sensor";
+    const std::string m_pose_sensor_tag = "pose_sensor";
+    const std::string m_magnetic_sensor_tag = "magnetic_field_sensor";
+    std::string m_gyroFrameName;
+    std::string m_accelFrameName;
+    std::string m_orientationFrameName;
+    std::string m_poseFrameName;
+    std::string m_magneticFrameName;
+
+    /*std::mutex   m_mutex;
+    rs2::context m_ctx;
+    rs2::config m_cfg;
+    rs2::pipeline m_pipeline;
+    rs2::pipeline_profile m_profile;
+    rs2::device  m_device;
+    std::vector<rs2::sensor> m_sensors;
+    rs2::sensor* m_depth_sensor;
+    rs2::sensor* m_color_sensor;
+    rs2_intrinsics m_depth_intrin{}, m_color_intrin{}, m_infrared_intrin{};
+    rs2_extrinsics m_depth_to_color{}, m_color_to_depth{};
+    rs2_stream  m_alignment_stream{RS2_STREAM_COLOR};
+
+
+    yarp::os::Stamp m_rgb_stamp;
+    yarp::os::Stamp m_depth_stamp;
+    std::string m_lastError;
+    yarp::dev::RGBDSensorParamParser m_paramParser;
+    bool m_verbose;
+    bool m_initialized;
+    bool m_stereoMode;
+    bool m_needAlignment;
+    int m_fps;
+    float m_scale;
+    std::vector<cameraFeature_id_t> m_supportedFeatures;*/
+};
+#endif

--- a/src/devices/realsense2/realsense2withIMUDriver.h
+++ b/src/devices/realsense2/realsense2withIMUDriver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms of the
@@ -21,98 +21,11 @@
 #include <map>
 #include <mutex>
 
-
-/**
- *  @ingroup dev_impl_media
- *
- * @brief `realsense2` : driver for realsense2 compatible devices.
- *
- * This device driver exposes the IRGBDSensor and IFrameGrabberControls
- * interfaces to read the images and operate on the available settings.
- * See the documentation for more details about each interface.
- *
- * This device is paired with its server called RGBDSensorWrapper to stream the images and perform remote operations.
- *
- * The configuration file is subdivided into 2 major sections called "SETTINGS" and "HW_DESCRIPTION".
- *
- * The "SETTINGS" section is meant for read/write parameters, meaning parameters which can be get and set by the device.
- * A common case of setting is the image resolution in pixel. This setting will be read by the device and it'll be applied
- * in the startup phase. If the setting fails, the device will terminate the execution with a error message.
- *
- * The "HW_DESCRIPTION" section is meant for read only parameters which describe the hardware property of the device and
- * cannot be provided by the device through software API.
- * A common case is the 'Field Of View' property, which may or may not be supported by the physical device.
- * When a property is present in the HW_DESCRIPTION group, the YARP RGBDSensorClient will report this value when asked for
- * and setting will be disabled.
- * This group can also be used to by-pass realsense2 API in case some functionality is not correctly working with the current
- * device. For example the 'clipPlanes' property may return incorrect values or values using non-standard measurement unit.
- * In this case using the HW_DESCRIPTION, a user can override the value got from OpenNI2 API with a custom value.
- *
- * \note Parameters inside the HW_DESCRIPTION are read only, so the relative set functionality will be disabled.
- * \note For parameters which are neither in SETTINGS nor in HW_DESCRIPTION groups, read / write functionality is assumed
- *  but not initial setting will be performed. Device will start with manufacturer default values.
- * \warning A single parameter cannot be present into both SETTINGS and HW_DESCRIPTION groups.
- * \warning whenever more then one value is required by the setting, the values must be in parentheses!
- *
- * | YARP device name |
- * |:-----------------:|
- * | `realsense2` |
- *
- *   Parameters used by this device are:
- * | Parameter name               | SubParameter        | Type                |  Read / write   | Units          | Default Value | Required                         | Description                                                                            | Notes                                                                 |
- * |:----------------------------:|:-------------------:|:-------------------:|:---------------:|:--------------:|:-------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|:---------------------------------------------------------------------:|
- * |  stereoMode                  |      -              | bool                |  Read / write   |                |   false       |  No(see notes)                   | Flag for using the realsense as stereo camera                                          |  This option is to use it with yarp::dev::ServerGrabber as network wrapper. The stereo images provided are raw images(yarp::sig::PixelMono) and note that not all the realsense devices have the stereo streams. |
- * |  verbose                     |      -              | bool                |  Read / write   |                |   false       |  No                              | Flag for enabling debug prints                                                         |                                                                       |
- * |  SETTINGS                    |      -              | group               |  Read / write   | -              |   -           |  Yes                             | Initial setting of the device.                                                         |  Properties must be read/writable in order for setting to work        |
- * |                              |  rgbResolution      | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of rgb image in pixels                                                            |  2 values expected as height, width                                   |
- * |                              |  depthResolution    | int, int            |  Read / write   | pixels         |   -           |  Yes                             | Size of depth image in pixels                                                          |  Values are height, width                                             |
- * |                              |  accuracy           | double              |  Read / write   | meters         |   -           |  No                              | Accuracy of the device, as the depth measurement error at 1 meter distance             |  Note that only few realsense devices allows to set it                |
- * |                              |  framerate          | int                 |  Read / Write   | fps            |   30          |  No                              | Framerate of the sensor                                                                |                                                                       |
- * |                              |  enableEmitter      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the IR emitter(if supported by the sensor)                           |                                                                       |
- * |                              |  needAlignment      | bool                |  Read / Write   | -              |   true        |  No                              | Flag for enabling the alignment of the depth frame over the rgb frame                  |  This option is deprecated, please use alignmentFrame instead.        |
- * |                              |  alignmentFrame     | string              |  Read / Write   | -              |   RGB         |  No                              | This parameter specifies the frame to which the frames RGB and Depth will be aligned.  |  The accepted values are RGB, Depth, None. This operation could be heavy, set it to None to increase the fps.|
- * |  HW_DESCRIPTION              |      -              |  group              |                 | -              |   -           |  Yes                             | Hardware description of device property.                                               |  Read only property. Setting will be disabled                         |
- * |                              |  clipPlanes         | double, double      |  Read / write   | meters         |   -           |  No                              | Minimum and maximum distance at which an object is seen by the depth sensor            |  parameter introduced mainly for simulated sensors, it can be used to set the clip planes if Openni gives wrong values |
- *
- * Configuration file using .ini format, for using as RGBD device:
- *
- * \code{.unparsed}
-
-device       RGBDSensorWrapper
-subdevice    realsense2
-name         /depthCamerac
-
-[SETTINGS]
-depthResolution (640 480)    #Note the parentheses
-rgbResolution   (640 480)
-framerate       30
-enableEmitter   true
-alignmentFrame  RGB
-
-[HW_DESCRIPTION]
-clipPlanes (0.2 10.0)
- *
- * \endcode
- *
- * Configuration file using .ini format, for using as stereo camera:
- * \code{.unparsed}
-device       grabberDual
-subdevice    realsense2
-name         /stereoCamera
-capabilities RAW
-stereoMode   true
-
-[SETTINGS]
-rgbResolution   (640 480)
-depthResolution   (640 480)
-framerate       30
-enableEmitter   false
-
-[HW_DESCRIPTION]
-clipPlanes (0.2 10.0)
- * \endcode
- */
-
+ /**********************************************************************************************************/
+ // This software module is experimental.
+ // It is provided with uncomplete documentation and it may be modified/renamed/removed without any notice.
+ /**********************************************************************************************************/
+ 
 class rotation_estimator;
 
 class realsense2withIMUDriver :

--- a/src/devices/realsense2/realsense2withIMUDriver.h
+++ b/src/devices/realsense2/realsense2withIMUDriver.h
@@ -113,13 +113,12 @@ clipPlanes (0.2 10.0)
  * \endcode
  */
 
+class rotation_estimator;
+
 class realsense2withIMUDriver :
         public realsense2Driver,
         public yarp::dev::IThreeAxisGyroscopes,
         public yarp::dev::IThreeAxisLinearAccelerometers,
-#ifdef FORCE_MISSING_MAGNETOMETERS_ON
-        public yarp::dev::IThreeAxisMagnetometers,
-#endif
         public yarp::dev::IOrientationSensors
 {
 private:
@@ -139,15 +138,12 @@ private:
     inline bool initializeRealsenseDevice();
     inline bool setParams();
 
-    void updateTransformations();
 #if 0
     bool pipelineStartup(); //inherited
     bool pipelineShutdown(); //inherited
     bool pipelineRestart(); //inherited
     void fallback(); //inherited
 #endif
-    bool setFramerate(const int _fps);
-
 
 public:
     /* IThreeAxisGyroscopes methods */
@@ -164,15 +160,6 @@ public:
     bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const override;
     bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
-#ifdef FORCE_MISSING_MAGNETOMETERS_ON
-    /* IThreeAxisMagnetometers methods */
-    size_t getNrOfThreeAxisMagnetometers() const override;
-    yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    bool getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const override;
-    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
-#endif
-
     /* IOrientationSensors methods */
     size_t getNrOfOrientationSensors() const override;
     yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
@@ -180,34 +167,25 @@ public:
     bool getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
     bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
-        /* IPoseSensors methods */
-    size_t getNrOfPoseSensors() const ;
-    yarp::dev::MAS_status getPoseSensorStatus(size_t sens_index) const;
-    bool getPoseSensorName(size_t sens_index, std::string& name) const;
-    bool getPoseSensorFrameName(size_t sens_index, std::string& frameName) const;
-    bool getPoseSensorMeasureAsXYZRPY(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const;
-
 protected:
     // realsense classes
     mutable rs2_vector m_last_gyro;
     mutable rs2_vector m_last_accel;
     mutable rs2_pose   m_last_pose;
+    mutable rotation_estimator* m_rotation_estimator;
 
-    bool m_sensor_has_pose_capabilities;
     bool m_sensor_has_orientation_estimator;
 
     //strings
-    std::string m_inertial_sensor_name_prefix;
-    const std::string m_accel_sensor_tag = "accelerations_sensor";
-    const std::string m_gyro_sensor_tag = "gyro_sensor";
+    std::string       m_inertial_sensor_name_prefix;
+    const std::string m_accel_sensor_tag       = "accelerations_sensor";
+    const std::string m_gyro_sensor_tag        = "gyro_sensor";
     const std::string m_orientation_sensor_tag = "orientation_sensor";
-    const std::string m_pose_sensor_tag = "pose_sensor";
-    const std::string m_magnetic_sensor_tag = "magnetic_field_sensor";
+    const std::string m_position_sensor_tag    = "position_sensor";
     std::string m_gyroFrameName;
     std::string m_accelFrameName;
     std::string m_orientationFrameName;
-    std::string m_poseFrameName;
-    std::string m_magneticFrameName;
+    std::string m_positionFrameName;
 
     /*std::mutex   m_mutex;
     rs2::context m_ctx;
@@ -236,3 +214,4 @@ protected:
     std::vector<cameraFeature_id_t> m_supportedFeatures;*/
 };
 #endif
+

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -214,7 +214,7 @@ include(YarpIDL)
 set(YARP_dev_IDL idl/stateExt.thrift
                  idl/audioBufferSizeData.thrift
                  idl/OdometryData.thrift
-				 idl/OdometryData6D.thrift)
+                 idl/OdometryData6D.thrift)
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_IDL idl/Map2DLocationData.thrift


### PR DESCRIPTION
realsense2withIMUDriver extends class realsense2Driver, using realsense SDK to add **support for d435i and t265 devices**. 
These two devices are equipped with an **IMU sensor**, whose data are obtained through the interfaces included in **MultipleAnalogSensorsInterfaces.h**