### PR TITLE
positionSensors added to MultipleAnalogSensorsInterfaces

### DIFF
--- a/doc/release/master/featureIPositionSensors.md
+++ b/doc/release/master/featureIPositionSensors.md
@@ -1,0 +1,24 @@
+featureIPositionSensors {master}
+----------------------
+
+### YARP_dev
+
+* Added new interface `yarp::dev::IPositionSensors`.
+
+### devices
+
+#### multipleAnalogSensorsMsgs
+
+* `multipleAnalogSensorsSerializations.thrift` have been extended to handle position sensors.
+
+#### multipleanalogsensorsserver
+
+* Added handlers for `IPositionSensors` interface.
+
+#### multipleanalogsensorsclient
+
+* Added handlers for `IPositionSensors` interface.
+
+#### multipleanalogsensorsremapper
+
+* Added handlers for `IPositionSensors` interface.

--- a/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/include/SensorRPCData.h
+++ b/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/include/SensorRPCData.h
@@ -32,6 +32,7 @@ public:
     std::vector<SensorMetadata> ContactLoadCellArrays;
     std::vector<SensorMetadata> EncoderArrays;
     std::vector<SensorMetadata> SkinPatches;
+    std::vector<SensorMetadata> PositionSensors;
 
     // Default constructor
     SensorRPCData();
@@ -45,7 +46,8 @@ public:
                   const std::vector<SensorMetadata>& SixAxisForceTorqueSensors,
                   const std::vector<SensorMetadata>& ContactLoadCellArrays,
                   const std::vector<SensorMetadata>& EncoderArrays,
-                  const std::vector<SensorMetadata>& SkinPatches);
+                  const std::vector<SensorMetadata>& SkinPatches,
+                  const std::vector<SensorMetadata>& PositionSensors);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;
@@ -179,6 +181,13 @@ public:
         virtual bool will_set_SkinPatches();
         virtual bool did_set_SkinPatches();
 
+        // Editor: PositionSensors field
+        void set_PositionSensors(const std::vector<SensorMetadata>& PositionSensors);
+        void set_PositionSensors(size_t index, const SensorMetadata& elem);
+        const std::vector<SensorMetadata>& get_PositionSensors() const;
+        virtual bool will_set_PositionSensors();
+        virtual bool did_set_PositionSensors();
+
         // Editor: clean
         void clean();
 
@@ -205,6 +214,7 @@ public:
         bool is_dirty_ContactLoadCellArrays;
         bool is_dirty_EncoderArrays;
         bool is_dirty_SkinPatches;
+        bool is_dirty_PositionSensors;
         int dirty_count;
 
         // Editor: send if possible
@@ -223,6 +233,7 @@ public:
         void mark_dirty_ContactLoadCellArrays();
         void mark_dirty_EncoderArrays();
         void mark_dirty_SkinPatches();
+        void mark_dirty_PositionSensors();
 
         // Editor: dirty_flags
         void dirty_flags(bool flag);
@@ -282,6 +293,12 @@ private:
     bool write_SkinPatches(const yarp::os::idl::WireWriter& writer) const;
     bool nested_read_SkinPatches(yarp::os::idl::WireReader& reader);
     bool nested_write_SkinPatches(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write PositionSensors field
+    bool read_PositionSensors(yarp::os::idl::WireReader& reader);
+    bool write_PositionSensors(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_PositionSensors(yarp::os::idl::WireReader& reader);
+    bool nested_write_PositionSensors(const yarp::os::idl::WireWriter& writer) const;
 };
 
 #endif // YARP_THRIFT_GENERATOR_STRUCT_SENSORRPCDATA_H

--- a/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/include/SensorStreamingData.h
+++ b/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/include/SensorStreamingData.h
@@ -32,6 +32,7 @@ public:
     SensorMeasurements ContactLoadCellArrays;
     SensorMeasurements EncoderArrays;
     SensorMeasurements SkinPatches;
+    SensorMeasurements PositionSensors;
 
     // Default constructor
     SensorStreamingData();
@@ -45,7 +46,8 @@ public:
                         const SensorMeasurements& SixAxisForceTorqueSensors,
                         const SensorMeasurements& ContactLoadCellArrays,
                         const SensorMeasurements& EncoderArrays,
-                        const SensorMeasurements& SkinPatches);
+                        const SensorMeasurements& SkinPatches,
+                        const SensorMeasurements& PositionSensors);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;
@@ -170,6 +172,12 @@ public:
         virtual bool will_set_SkinPatches();
         virtual bool did_set_SkinPatches();
 
+        // Editor: PositionSensors field
+        void set_PositionSensors(const SensorMeasurements& PositionSensors);
+        const SensorMeasurements& get_PositionSensors() const;
+        virtual bool will_set_PositionSensors();
+        virtual bool did_set_PositionSensors();
+
         // Editor: clean
         void clean();
 
@@ -196,6 +204,7 @@ public:
         bool is_dirty_ContactLoadCellArrays;
         bool is_dirty_EncoderArrays;
         bool is_dirty_SkinPatches;
+        bool is_dirty_PositionSensors;
         int dirty_count;
 
         // Editor: send if possible
@@ -214,6 +223,7 @@ public:
         void mark_dirty_ContactLoadCellArrays();
         void mark_dirty_EncoderArrays();
         void mark_dirty_SkinPatches();
+        void mark_dirty_PositionSensors();
 
         // Editor: dirty_flags
         void dirty_flags(bool flag);
@@ -273,6 +283,12 @@ private:
     bool write_SkinPatches(const yarp::os::idl::WireWriter& writer) const;
     bool nested_read_SkinPatches(yarp::os::idl::WireReader& reader);
     bool nested_write_SkinPatches(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write PositionSensors field
+    bool read_PositionSensors(yarp::os::idl::WireReader& reader);
+    bool write_PositionSensors(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_PositionSensors(yarp::os::idl::WireReader& reader);
+    bool nested_write_PositionSensors(const yarp::os::idl::WireWriter& writer) const;
 };
 
 #endif // YARP_THRIFT_GENERATOR_STRUCT_SENSORSTREAMINGDATA_H

--- a/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/MultipleAnalogSensorsMetadata.cpp
+++ b/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/MultipleAnalogSensorsMetadata.cpp
@@ -120,7 +120,7 @@ bool MultipleAnalogSensorsMetadata::read(yarp::os::ConnectionReader& connection)
             MultipleAnalogSensorsMetadata_getMetadata_helper::s_return_helper = getMetadata();
             yarp::os::idl::WireWriter writer(reader);
             if (!writer.isNull()) {
-                if (!writer.writeListHeader(9)) {
+                if (!writer.writeListHeader(10)) {
                     return false;
                 }
                 if (!writer.write(MultipleAnalogSensorsMetadata_getMetadata_helper::s_return_helper)) {

--- a/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/SensorRPCData.cpp
+++ b/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/SensorRPCData.cpp
@@ -24,7 +24,8 @@ SensorRPCData::SensorRPCData() :
         SixAxisForceTorqueSensors(),
         ContactLoadCellArrays(),
         EncoderArrays(),
-        SkinPatches()
+        SkinPatches(),
+        PositionSensors()
 {
 }
 
@@ -37,7 +38,8 @@ SensorRPCData::SensorRPCData(const std::vector<SensorMetadata>& ThreeAxisGyrosco
                              const std::vector<SensorMetadata>& SixAxisForceTorqueSensors,
                              const std::vector<SensorMetadata>& ContactLoadCellArrays,
                              const std::vector<SensorMetadata>& EncoderArrays,
-                             const std::vector<SensorMetadata>& SkinPatches) :
+                             const std::vector<SensorMetadata>& SkinPatches,
+                             const std::vector<SensorMetadata>& PositionSensors) :
         WirePortable(),
         ThreeAxisGyroscopes(ThreeAxisGyroscopes),
         ThreeAxisLinearAccelerometers(ThreeAxisLinearAccelerometers),
@@ -47,7 +49,8 @@ SensorRPCData::SensorRPCData(const std::vector<SensorMetadata>& ThreeAxisGyrosco
         SixAxisForceTorqueSensors(SixAxisForceTorqueSensors),
         ContactLoadCellArrays(ContactLoadCellArrays),
         EncoderArrays(EncoderArrays),
-        SkinPatches(SkinPatches)
+        SkinPatches(SkinPatches),
+        PositionSensors(PositionSensors)
 {
 }
 
@@ -81,6 +84,9 @@ bool SensorRPCData::read(yarp::os::idl::WireReader& reader)
     if (!read_SkinPatches(reader)) {
         return false;
     }
+    if (!read_PositionSensors(reader)) {
+        return false;
+    }
     return !reader.isError();
 }
 
@@ -88,7 +94,7 @@ bool SensorRPCData::read(yarp::os::idl::WireReader& reader)
 bool SensorRPCData::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(9)) {
+    if (!reader.readListHeader(10)) {
         return false;
     }
     return read(reader);
@@ -124,6 +130,9 @@ bool SensorRPCData::write(const yarp::os::idl::WireWriter& writer) const
     if (!write_SkinPatches(writer)) {
         return false;
     }
+    if (!write_PositionSensors(writer)) {
+        return false;
+    }
     return !writer.isError();
 }
 
@@ -131,7 +140,7 @@ bool SensorRPCData::write(const yarp::os::idl::WireWriter& writer) const
 bool SensorRPCData::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(9)) {
+    if (!writer.writeListHeader(10)) {
         return false;
     }
     return write(writer);
@@ -552,6 +561,44 @@ bool SensorRPCData::Editor::did_set_SkinPatches()
     return true;
 }
 
+// Editor: PositionSensors setter
+void SensorRPCData::Editor::set_PositionSensors(const std::vector<SensorMetadata>& PositionSensors)
+{
+    will_set_PositionSensors();
+    obj->PositionSensors = PositionSensors;
+    mark_dirty_PositionSensors();
+    communicate();
+    did_set_PositionSensors();
+}
+
+// Editor: PositionSensors setter (list)
+void SensorRPCData::Editor::set_PositionSensors(size_t index, const SensorMetadata& elem)
+{
+    will_set_PositionSensors();
+    obj->PositionSensors[index] = elem;
+    mark_dirty_PositionSensors();
+    communicate();
+    did_set_PositionSensors();
+}
+
+// Editor: PositionSensors getter
+const std::vector<SensorMetadata>& SensorRPCData::Editor::get_PositionSensors() const
+{
+    return obj->PositionSensors;
+}
+
+// Editor: PositionSensors will_set
+bool SensorRPCData::Editor::will_set_PositionSensors()
+{
+    return true;
+}
+
+// Editor: PositionSensors did_set
+bool SensorRPCData::Editor::did_set_PositionSensors()
+{
+    return true;
+}
+
 // Editor: clean
 void SensorRPCData::Editor::clean()
 {
@@ -673,8 +720,16 @@ bool SensorRPCData::Editor::read(yarp::os::ConnectionReader& connection)
                     return false;
                 }
             }
+            if (field == "PositionSensors") {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeString("std::vector<SensorMetadata> PositionSensors")) {
+                    return false;
+                }
+            }
         }
-        if (!writer.writeListHeader(10)) {
+        if (!writer.writeListHeader(11)) {
             return false;
         }
         writer.writeString("*** Available fields:");
@@ -687,6 +742,7 @@ bool SensorRPCData::Editor::read(yarp::os::ConnectionReader& connection)
         writer.writeString("ContactLoadCellArrays");
         writer.writeString("EncoderArrays");
         writer.writeString("SkinPatches");
+        writer.writeString("PositionSensors");
         return true;
     }
     bool nested = true;
@@ -767,6 +823,12 @@ bool SensorRPCData::Editor::read(yarp::os::ConnectionReader& connection)
                 return false;
             }
             did_set_SkinPatches();
+        } else if (key == "PositionSensors") {
+            will_set_PositionSensors();
+            if (!obj->nested_read_PositionSensors(reader)) {
+                return false;
+            }
+            did_set_PositionSensors();
         } else {
             // would be useful to have a fallback here
         }
@@ -920,6 +982,20 @@ bool SensorRPCData::Editor::write(yarp::os::ConnectionWriter& connection) const
             return false;
         }
     }
+    if (is_dirty_PositionSensors) {
+        if (!writer.writeListHeader(3)) {
+            return false;
+        }
+        if (!writer.writeString("set")) {
+            return false;
+        }
+        if (!writer.writeString("PositionSensors")) {
+            return false;
+        }
+        if (!obj->nested_write_PositionSensors(writer)) {
+            return false;
+        }
+    }
     return !writer.isError();
 }
 
@@ -1040,6 +1116,17 @@ void SensorRPCData::Editor::mark_dirty_SkinPatches()
     mark_dirty();
 }
 
+// Editor: PositionSensors mark_dirty
+void SensorRPCData::Editor::mark_dirty_PositionSensors()
+{
+    if (is_dirty_PositionSensors) {
+        return;
+    }
+    dirty_count++;
+    is_dirty_PositionSensors = true;
+    mark_dirty();
+}
+
 // Editor: dirty_flags
 void SensorRPCData::Editor::dirty_flags(bool flag)
 {
@@ -1053,7 +1140,8 @@ void SensorRPCData::Editor::dirty_flags(bool flag)
     is_dirty_ContactLoadCellArrays = flag;
     is_dirty_EncoderArrays = flag;
     is_dirty_SkinPatches = flag;
-    dirty_count = flag ? 9 : 0;
+    is_dirty_PositionSensors = flag;
+    dirty_count = flag ? 10 : 0;
 }
 
 // read ThreeAxisGyroscopes field
@@ -1677,6 +1765,76 @@ bool SensorRPCData::nested_write_SkinPatches(const yarp::os::idl::WireWriter& wr
     }
     for (const auto& _item119 : SkinPatches) {
         if (!writer.writeNested(_item119)) {
+            return false;
+        }
+    }
+    if (!writer.writeListEnd()) {
+        return false;
+    }
+    return true;
+}
+
+// read PositionSensors field
+bool SensorRPCData::read_PositionSensors(yarp::os::idl::WireReader& reader)
+{
+    PositionSensors.clear();
+    uint32_t _size120;
+    yarp::os::idl::WireState _etype123;
+    reader.readListBegin(_etype123, _size120);
+    PositionSensors.resize(_size120);
+    for (size_t _i124 = 0; _i124 < _size120; ++_i124) {
+        if (!reader.readNested(PositionSensors[_i124])) {
+            reader.fail();
+            return false;
+        }
+    }
+    reader.readListEnd();
+    return true;
+}
+
+// write PositionSensors field
+bool SensorRPCData::write_PositionSensors(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(PositionSensors.size()))) {
+        return false;
+    }
+    for (const auto& _item125 : PositionSensors) {
+        if (!writer.writeNested(_item125)) {
+            return false;
+        }
+    }
+    if (!writer.writeListEnd()) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) PositionSensors field
+bool SensorRPCData::nested_read_PositionSensors(yarp::os::idl::WireReader& reader)
+{
+    PositionSensors.clear();
+    uint32_t _size126;
+    yarp::os::idl::WireState _etype129;
+    reader.readListBegin(_etype129, _size126);
+    PositionSensors.resize(_size126);
+    for (size_t _i130 = 0; _i130 < _size126; ++_i130) {
+        if (!reader.readNested(PositionSensors[_i130])) {
+            reader.fail();
+            return false;
+        }
+    }
+    reader.readListEnd();
+    return true;
+}
+
+// write (nested) PositionSensors field
+bool SensorRPCData::nested_write_PositionSensors(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(PositionSensors.size()))) {
+        return false;
+    }
+    for (const auto& _item131 : PositionSensors) {
+        if (!writer.writeNested(_item131)) {
             return false;
         }
     }

--- a/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/SensorStreamingData.cpp
+++ b/src/devices/multipleAnalogSensorsMsgs/idl_generated_code/src/SensorStreamingData.cpp
@@ -24,7 +24,8 @@ SensorStreamingData::SensorStreamingData() :
         SixAxisForceTorqueSensors(),
         ContactLoadCellArrays(),
         EncoderArrays(),
-        SkinPatches()
+        SkinPatches(),
+        PositionSensors()
 {
 }
 
@@ -37,7 +38,8 @@ SensorStreamingData::SensorStreamingData(const SensorMeasurements& ThreeAxisGyro
                                          const SensorMeasurements& SixAxisForceTorqueSensors,
                                          const SensorMeasurements& ContactLoadCellArrays,
                                          const SensorMeasurements& EncoderArrays,
-                                         const SensorMeasurements& SkinPatches) :
+                                         const SensorMeasurements& SkinPatches,
+                                         const SensorMeasurements& PositionSensors) :
         WirePortable(),
         ThreeAxisGyroscopes(ThreeAxisGyroscopes),
         ThreeAxisLinearAccelerometers(ThreeAxisLinearAccelerometers),
@@ -47,7 +49,8 @@ SensorStreamingData::SensorStreamingData(const SensorMeasurements& ThreeAxisGyro
         SixAxisForceTorqueSensors(SixAxisForceTorqueSensors),
         ContactLoadCellArrays(ContactLoadCellArrays),
         EncoderArrays(EncoderArrays),
-        SkinPatches(SkinPatches)
+        SkinPatches(SkinPatches),
+        PositionSensors(PositionSensors)
 {
 }
 
@@ -81,6 +84,9 @@ bool SensorStreamingData::read(yarp::os::idl::WireReader& reader)
     if (!read_SkinPatches(reader)) {
         return false;
     }
+    if (!read_PositionSensors(reader)) {
+        return false;
+    }
     return !reader.isError();
 }
 
@@ -88,7 +94,7 @@ bool SensorStreamingData::read(yarp::os::idl::WireReader& reader)
 bool SensorStreamingData::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(9)) {
+    if (!reader.readListHeader(10)) {
         return false;
     }
     return read(reader);
@@ -124,6 +130,9 @@ bool SensorStreamingData::write(const yarp::os::idl::WireWriter& writer) const
     if (!write_SkinPatches(writer)) {
         return false;
     }
+    if (!write_PositionSensors(writer)) {
+        return false;
+    }
     return !writer.isError();
 }
 
@@ -131,7 +140,7 @@ bool SensorStreamingData::write(const yarp::os::idl::WireWriter& writer) const
 bool SensorStreamingData::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(9)) {
+    if (!writer.writeListHeader(10)) {
         return false;
     }
     return write(writer);
@@ -462,6 +471,34 @@ bool SensorStreamingData::Editor::did_set_SkinPatches()
     return true;
 }
 
+// Editor: PositionSensors setter
+void SensorStreamingData::Editor::set_PositionSensors(const SensorMeasurements& PositionSensors)
+{
+    will_set_PositionSensors();
+    obj->PositionSensors = PositionSensors;
+    mark_dirty_PositionSensors();
+    communicate();
+    did_set_PositionSensors();
+}
+
+// Editor: PositionSensors getter
+const SensorMeasurements& SensorStreamingData::Editor::get_PositionSensors() const
+{
+    return obj->PositionSensors;
+}
+
+// Editor: PositionSensors will_set
+bool SensorStreamingData::Editor::will_set_PositionSensors()
+{
+    return true;
+}
+
+// Editor: PositionSensors did_set
+bool SensorStreamingData::Editor::did_set_PositionSensors()
+{
+    return true;
+}
+
 // Editor: clean
 void SensorStreamingData::Editor::clean()
 {
@@ -583,8 +620,16 @@ bool SensorStreamingData::Editor::read(yarp::os::ConnectionReader& connection)
                     return false;
                 }
             }
+            if (field == "PositionSensors") {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeString("SensorMeasurements PositionSensors")) {
+                    return false;
+                }
+            }
         }
-        if (!writer.writeListHeader(10)) {
+        if (!writer.writeListHeader(11)) {
             return false;
         }
         writer.writeString("*** Available fields:");
@@ -597,6 +642,7 @@ bool SensorStreamingData::Editor::read(yarp::os::ConnectionReader& connection)
         writer.writeString("ContactLoadCellArrays");
         writer.writeString("EncoderArrays");
         writer.writeString("SkinPatches");
+        writer.writeString("PositionSensors");
         return true;
     }
     bool nested = true;
@@ -677,6 +723,12 @@ bool SensorStreamingData::Editor::read(yarp::os::ConnectionReader& connection)
                 return false;
             }
             did_set_SkinPatches();
+        } else if (key == "PositionSensors") {
+            will_set_PositionSensors();
+            if (!obj->nested_read_PositionSensors(reader)) {
+                return false;
+            }
+            did_set_PositionSensors();
         } else {
             // would be useful to have a fallback here
         }
@@ -830,6 +882,20 @@ bool SensorStreamingData::Editor::write(yarp::os::ConnectionWriter& connection) 
             return false;
         }
     }
+    if (is_dirty_PositionSensors) {
+        if (!writer.writeListHeader(3)) {
+            return false;
+        }
+        if (!writer.writeString("set")) {
+            return false;
+        }
+        if (!writer.writeString("PositionSensors")) {
+            return false;
+        }
+        if (!obj->nested_write_PositionSensors(writer)) {
+            return false;
+        }
+    }
     return !writer.isError();
 }
 
@@ -950,6 +1016,17 @@ void SensorStreamingData::Editor::mark_dirty_SkinPatches()
     mark_dirty();
 }
 
+// Editor: PositionSensors mark_dirty
+void SensorStreamingData::Editor::mark_dirty_PositionSensors()
+{
+    if (is_dirty_PositionSensors) {
+        return;
+    }
+    dirty_count++;
+    is_dirty_PositionSensors = true;
+    mark_dirty();
+}
+
 // Editor: dirty_flags
 void SensorStreamingData::Editor::dirty_flags(bool flag)
 {
@@ -963,7 +1040,8 @@ void SensorStreamingData::Editor::dirty_flags(bool flag)
     is_dirty_ContactLoadCellArrays = flag;
     is_dirty_EncoderArrays = flag;
     is_dirty_SkinPatches = flag;
-    dirty_count = flag ? 9 : 0;
+    is_dirty_PositionSensors = flag;
+    dirty_count = flag ? 10 : 0;
 }
 
 // read ThreeAxisGyroscopes field
@@ -1303,6 +1381,44 @@ bool SensorStreamingData::nested_read_SkinPatches(yarp::os::idl::WireReader& rea
 bool SensorStreamingData::nested_write_SkinPatches(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeNested(SkinPatches)) {
+        return false;
+    }
+    return true;
+}
+
+// read PositionSensors field
+bool SensorStreamingData::read_PositionSensors(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.read(PositionSensors)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write PositionSensors field
+bool SensorStreamingData::write_PositionSensors(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.write(PositionSensors)) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) PositionSensors field
+bool SensorStreamingData::nested_read_PositionSensors(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readNested(PositionSensors)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write (nested) PositionSensors field
+bool SensorStreamingData::nested_write_PositionSensors(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeNested(PositionSensors)) {
         return false;
     }
     return true;

--- a/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift
+++ b/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift
@@ -33,6 +33,7 @@ struct SensorStreamingData
   7: SensorMeasurements ContactLoadCellArrays;
   8: SensorMeasurements EncoderArrays;
   9: SensorMeasurements SkinPatches;
+  10: SensorMeasurements PositionSensors;
 }
 
 struct SensorMetadata {
@@ -52,6 +53,7 @@ struct SensorRPCData
   7: list<SensorMetadata> ContactLoadCellArrays;
   8: list<SensorMetadata> EncoderArrays;
   9: list<SensorMetadata> SkinPatches;
+  10: list<SensorMetadata> PositionSensors;
 }
 
 service MultipleAnalogSensorsMetadata

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -399,6 +399,32 @@ bool MultipleAnalogSensorsClient::getOrientationSensorMeasureAsRollPitchYaw(size
                              m_streamingPort.receivedData.OrientationSensors, sens_index, out, timestamp);
 }
 
+size_t MultipleAnalogSensorsClient::getNrOfPositionSensors() const
+{
+    return genericGetNrOfSensors(m_sensorsMetadata.PositionSensors,
+                                 m_streamingPort.receivedData.PositionSensors);
+}
+
+yarp::dev::MAS_status MultipleAnalogSensorsClient::getPositionSensorStatus(size_t sens_index) const
+{
+    return genericGetStatus();
+}
+
+bool MultipleAnalogSensorsClient::getPositionSensorName(size_t sens_index, std::string& name) const
+{
+    return genericGetName(m_sensorsMetadata.PositionSensors, "PositionSensors", sens_index, name);
+}
+
+bool MultipleAnalogSensorsClient::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    return genericGetFrameName(m_sensorsMetadata.PositionSensors, "PositionSensors", sens_index, frameName);
+}
+
+bool MultipleAnalogSensorsClient::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    return genericGetMeasure(m_sensorsMetadata.PositionSensors, "PositionSensors", m_streamingPort.receivedData.PositionSensors, sens_index, out, timestamp);
+}
+
 size_t MultipleAnalogSensorsClient::getNrOfTemperatureSensors() const
 {
     return genericGetNrOfSensors(m_sensorsMetadata.TemperatureSensors,

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
@@ -59,6 +59,7 @@ class MultipleAnalogSensorsClient :
         public yarp::dev::IThreeAxisGyroscopes,
         public yarp::dev::IThreeAxisLinearAccelerometers,
         public yarp::dev::IThreeAxisMagnetometers,
+        public yarp::dev::IPositionSensors,
         public yarp::dev::IOrientationSensors,
         public yarp::dev::ITemperatureSensors,
         public yarp::dev::ISixAxisForceTorqueSensors,
@@ -118,6 +119,13 @@ public:
     bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
     bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
     bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IPositionSensors methods */
+    size_t getNrOfPositionSensors() const override;
+    yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
+    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
+    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
     /* IOrientationSensors methods */
     size_t getNrOfOrientationSensors() const override;

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -54,6 +54,9 @@ inline std::string MAS_getTagFromEnum(const MAS_SensorType type)
         case SkinPatches:
             return "SkinPatches";
             break;
+        case PositionSensors:
+            return "PositionSensors";
+            break;
         default:
             assert(false);
             return "MAS_getTagFromEnum_notExpectedEnum";
@@ -213,6 +216,8 @@ bool MultipleAnalogSensorsRemapper::attachAll(const PolyDriverList &polylist)
                                 &IThreeAxisLinearAccelerometers::getThreeAxisLinearAccelerometerName, &IThreeAxisLinearAccelerometers::getNrOfThreeAxisLinearAccelerometers);
     ok = ok && genericAttachAll(ThreeAxisMagnetometers, m_iThreeAxisMagnetometers, polylist,
                                 &IThreeAxisMagnetometers::getThreeAxisMagnetometerName, &IThreeAxisMagnetometers::getNrOfThreeAxisMagnetometers);
+    ok = ok && genericAttachAll(PositionSensors, m_iPositionSensors, polylist,
+                                &IPositionSensors::getPositionSensorName, &IPositionSensors::getNrOfPositionSensors);
     ok = ok && genericAttachAll(OrientationSensors, m_iOrientationSensors, polylist,
                                 &IOrientationSensors::getOrientationSensorName, &IOrientationSensors::getNrOfOrientationSensors);
     ok = ok && genericAttachAll(TemperatureSensors, m_iTemperatureSensors, polylist,
@@ -234,6 +239,7 @@ bool MultipleAnalogSensorsRemapper::detachAll()
     m_iThreeAxisGyroscopes.resize(0);
     m_iThreeAxisLinearAccelerometers.resize(0);
     m_iThreeAxisMagnetometers.resize(0);
+    m_iPositionSensors.resize(0);
     m_iOrientationSensors.resize(0);
     m_iTemperatureSensors.resize(0);
     m_iSixAxisForceTorqueSensors.resize(0);
@@ -450,6 +456,31 @@ bool MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerFrameName(size_t sen
 bool MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ThreeAxisMagnetometers, sens_index, out, timestamp, m_iThreeAxisMagnetometers, &IThreeAxisMagnetometers::getThreeAxisMagnetometerMeasure);
+}
+
+size_t MultipleAnalogSensorsRemapper::getNrOfPositionSensors() const
+{
+    return m_indicesMap[PositionSensors].size();
+}
+
+MAS_status MultipleAnalogSensorsRemapper::getPositionSensorStatus(size_t sens_index) const
+{
+    return genericGetStatus(PositionSensors, sens_index, m_iPositionSensors, &IPositionSensors::getPositionSensorStatus);
+}
+
+bool MultipleAnalogSensorsRemapper::getPositionSensorName(size_t sens_index, std::string& name) const
+{
+    return genericGetName(PositionSensors, sens_index, name, m_iPositionSensors, &IPositionSensors::getPositionSensorName);
+}
+
+bool MultipleAnalogSensorsRemapper::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    return genericGetFrameName(PositionSensors, sens_index, frameName, m_iPositionSensors, &IPositionSensors::getPositionSensorFrameName);
+}
+
+bool MultipleAnalogSensorsRemapper::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    return genericGetMeasure(PositionSensors, sens_index, out, timestamp, m_iPositionSensors, &IPositionSensors::getPositionSensorMeasure);
 }
 
 size_t MultipleAnalogSensorsRemapper::getNrOfOrientationSensors() const

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
@@ -30,7 +30,8 @@ enum MAS_SensorType
     SixAxisForceTorqueSensors=5,
     ContactLoadCellArrays=6,
     EncoderArrays=7,
-    SkinPatches=8
+    SkinPatches=8,
+    PositionSensors=9
 };
 
 /**
@@ -94,7 +95,8 @@ class MultipleAnalogSensorsRemapper :
         public yarp::dev::ISixAxisForceTorqueSensors,
         public yarp::dev::IContactLoadCellArrays,
         public yarp::dev::IEncoderArrays,
-        public yarp::dev::ISkinPatches
+        public yarp::dev::ISkinPatches,
+        public yarp::dev::IPositionSensors
 {
 private:
     bool m_verbose{false};
@@ -126,6 +128,8 @@ private:
     std::vector<yarp::dev::IContactLoadCellArrays*> m_iContactLoadCellArrays;
     std::vector<yarp::dev::IEncoderArrays*> m_iEncoderArrays;
     std::vector<yarp::dev::ISkinPatches*> m_iSkinPatches;
+    std::vector<yarp::dev::IPositionSensors*> m_iPositionSensors;
+
 
     // Templated methods to streamline of the function implementation for all the different sensors
     // This part is complicated, but is useful to avoid a huge code duplication
@@ -237,6 +241,13 @@ public:
     bool getSkinPatchName(size_t sens_index, std::string &name) const override;
     bool getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getSkinPatchSize(size_t sens_index) const override;
+
+    /* IPositionSensors methods */
+    size_t getNrOfPositionSensors() const override;
+    yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
+    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
+    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 };
 
 

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -168,6 +168,10 @@ bool MultipleAnalogSensorsServer::populateAllSensorsMetadata()
                                        &yarp::dev::IThreeAxisMagnetometers::getNrOfThreeAxisMagnetometers,
                                        &yarp::dev::IThreeAxisMagnetometers::getThreeAxisMagnetometerName,
                                        &yarp::dev::IThreeAxisMagnetometers::getThreeAxisMagnetometerFrameName);
+    ok = ok && populateSensorsMetadata(m_iPositionSensors, m_sensorMetadata.PositionSensors, "PositionSensors",
+                                       &yarp::dev::IPositionSensors::getNrOfPositionSensors,
+                                       &yarp::dev::IPositionSensors::getPositionSensorName,
+                                       &yarp::dev::IPositionSensors::getPositionSensorFrameName);
     ok = ok && populateSensorsMetadata(m_iOrientationSensors, m_sensorMetadata.OrientationSensors, "OrientationSensors",
                                        &yarp::dev::IOrientationSensors::getNrOfOrientationSensors,
                                        &yarp::dev::IOrientationSensors::getOrientationSensorName,
@@ -223,6 +227,7 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
     poly->view(m_iThreeAxisGyroscopes);
     poly->view(m_iThreeAxisLinearAccelerometers);
     poly->view(m_iThreeAxisMagnetometers);
+    poly->view(m_iPositionSensors);
     poly->view(m_iOrientationSensors);
     poly->view(m_iTemperatureSensors);
     poly->view(m_iSixAxisForceTorqueSensors);
@@ -342,6 +347,11 @@ void MultipleAnalogSensorsServer::run()
                                  streamingData.ThreeAxisMagnetometers.measurements,
                                  &yarp::dev::IThreeAxisMagnetometers::getThreeAxisMagnetometerStatus,
                                  &yarp::dev::IThreeAxisMagnetometers::getThreeAxisMagnetometerMeasure);
+
+    ok = ok && genericStreamData(m_iPositionSensors, m_sensorMetadata.PositionSensors,
+                                 streamingData.PositionSensors.measurements,
+                                 &yarp::dev::IPositionSensors::getPositionSensorStatus,
+                                 &yarp::dev::IPositionSensors::getPositionSensorMeasure);
 
     ok = ok && genericStreamData(m_iOrientationSensors, m_sensorMetadata.OrientationSensors,
                                  streamingData.OrientationSensors.measurements,

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -53,6 +53,7 @@ class MultipleAnalogSensorsServer :
     yarp::dev::IThreeAxisGyroscopes* m_iThreeAxisGyroscopes{nullptr};
     yarp::dev::IThreeAxisLinearAccelerometers* m_iThreeAxisLinearAccelerometers{nullptr};
     yarp::dev::IThreeAxisMagnetometers* m_iThreeAxisMagnetometers{nullptr};
+    yarp::dev::IPositionSensors* m_iPositionSensors{nullptr};
     yarp::dev::IOrientationSensors* m_iOrientationSensors{nullptr};
     yarp::dev::ITemperatureSensors* m_iTemperatureSensors{nullptr};
     yarp::dev::ISixAxisForceTorqueSensors* m_iSixAxisForceTorqueSensors{nullptr};

--- a/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
@@ -22,6 +22,7 @@ namespace yarp
         class IThreeAxisGyroscopes;
         class IThreeAxisLinearAccelerometers;
         class IThreeAxisMagnetometers;
+        class IPositionSensors;
         class IOrientationSensors;
         class ITemperatureSensors;
         class ISixAxisForceTorqueSensors;
@@ -196,6 +197,63 @@ public:
     virtual bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~IThreeAxisMagnetometers(){}
+};
+
+/**
+ * @ingroup dev_iface_multiple_analog
+ *
+ * \brief Device interface to one or multiple position sensors, such as UWB localization sensors.
+ * The device returns the relative position between a lab or surface-fixed frame and
+ * a frame rigidly attached to the sensor.
+ *
+ * The definition of the lab or surface-fixed frame is sensor-specific.
+ *
+ * | Sensor Tag  |
+ * |:-----------------:|
+ * | `PositionSensors` |
+ */
+class YARP_dev_API yarp::dev::IPositionSensors
+{
+public:
+    /**
+     * Get the number of position sensors exposed by this device.
+     */
+    virtual size_t getNrOfPositionSensors() const = 0;
+
+    /**
+     * Get the status of the specified sensor.
+     */
+    virtual yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const = 0;
+
+    /**
+     * Get the name of the specified sensor.
+     * @return false if an error occurred, true otherwise.
+     */
+    virtual bool getPositionSensorName(size_t sens_index, std::string& name) const = 0;
+
+    /**
+     * Get the name of the frame of the specified sensor.
+     *
+     * @note This is an implementation specific method, that may return the name of the sensor
+     *       frame in a scenegraph
+     *
+     * @return false if an error occurred, true otherwise.
+     */
+    virtual bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const = 0;
+
+    /**
+     * Get the last reading of the position sensor as x y z.
+     *
+     * @param[in] sens_index The index of the specified sensor (should be between 0 and getNrOfPositionSensors()-1).
+     * @param[out] out The requested measure. The vector should be 3-dimensional. The measure is expressed in meters.
+     * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
+     * @return false if an error occurred, true otherwise.
+     */
+    virtual bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const = 0;
+
+    virtual ~IPositionSensors()
+    {
+    }
 };
 
 /**


### PR DESCRIPTION
Added a new interface `yarp::dev::IPositionSensors`, which can be used with localization sensors (e.g. UWB localization sensor) to broadcast a XYZ measurement of the device w.r.t. a fixed frame.
`MultipleAnalogSensorsServer` and `MultipleAnalogSensorsClient` have been modified accordingly.