### PR TITLE
Cleanup headers of libYARP_robotinterface

### DIFF
--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
@@ -17,41 +17,7 @@ namespace yarp {
 namespace robotinterface {
 
 class Robot;
-
-
-class YARP_robotinterface_API XMLReaderFileVx
-{
-public:
-    bool verbose;
-    virtual ~XMLReaderFileVx() {};
-    virtual  Robot& getRobotFile(const std::string &filename, bool verbose = false)=0;
-};
-
-class YARP_robotinterface_API XMLReaderFileV1 : public XMLReaderFileVx
-{
-public:
-    XMLReaderFileV1();
-    virtual ~XMLReaderFileV1();
-
-    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
-
-private:
-    class privateXMLReaderFileV1;
-    privateXMLReaderFileV1 * const mPriv;
-};
-
-class YARP_robotinterface_API XMLReaderFileV3: public XMLReaderFileVx
-{
-public:
-    XMLReaderFileV3();
-    virtual ~XMLReaderFileV3();
-
-    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
-
-private:
-    class privateXMLReaderFileV3;
-    privateXMLReaderFileV3 * const mPriv;
-};
+class XMLReaderFileVx;
 
 class YARP_robotinterface_API XMLReader
 {

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV1.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV1.cpp
@@ -6,12 +6,14 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+
 #include "XMLReader.h"
 #include "Action.h"
 #include "Device.h"
 #include "Param.h"
 #include "Robot.h"
 #include "Types.h"
+#include "impl/XMLReaderFileVx.h"
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
@@ -12,6 +12,7 @@
 #include "Param.h"
 #include "Robot.h"
 #include "Types.h"
+#include "impl/XMLReaderFileVx.h"
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
@@ -13,6 +13,8 @@
 #include "Robot.h"
 #include "Types.h"
 #include "impl/RobotInterfaceDTD.h"
+#include "impl/XMLReaderFileVx.h"
+
 
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/LogStream.h>

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/RobotInterfaceDTD.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/RobotInterfaceDTD.h
@@ -6,6 +6,8 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#ifndef YARP_ROBOTINTERFACE_IMPL_ROBOTINTERFACEDTD_H
+#define YARP_ROBOTINTERFACE_IMPL_ROBOTINTERFACEDTD_H
 
 #include <yarp/robotinterface/XMLReader.h>
 #include <yarp/robotinterface/Action.h>
@@ -33,7 +35,7 @@ namespace robotinterface {
 
 // Represent something like this in the xml file
 // <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 1.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV1.0.dtd">
-class YARP_robotinterface_API RobotInterfaceDTD
+class RobotInterfaceDTD
 {
 public:
     enum DocType {
@@ -68,7 +70,9 @@ public:
 };
 
 
-YARP_robotinterface_API std::string DocTypeToString(RobotInterfaceDTD::DocType doctype);
+std::string DocTypeToString(RobotInterfaceDTD::DocType doctype);
 
 } // namespace robotinterface
 } // namespace yarp
+
+#endif // YARP_ROBOTINTERFACE_ROBOTINTERFACEDTD_H

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_ROBOTINTERFACE_IMPL_XMLREADERFILEVX_H
+#define YARP_ROBOTINTERFACE_IMPL_XMLREADERFILEVX_H
+
+#include <yarp/robotinterface/Robot.h>
+
+#include <string>
+
+namespace yarp {
+namespace robotinterface {
+
+class XMLReaderFileVx
+{
+public:
+    bool verbose;
+    virtual ~XMLReaderFileVx() {};
+    virtual  Robot& getRobotFile(const std::string &filename, bool verbose = false)=0;
+};
+
+class XMLReaderFileV1 : public XMLReaderFileVx
+{
+public:
+    XMLReaderFileV1();
+    virtual ~XMLReaderFileV1();
+
+    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
+
+private:
+    class privateXMLReaderFileV1;
+    privateXMLReaderFileV1 * const mPriv;
+};
+
+class XMLReaderFileV3: public XMLReaderFileVx
+{
+public:
+    XMLReaderFileV3();
+    virtual ~XMLReaderFileV3();
+
+    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
+
+private:
+    class privateXMLReaderFileV3;
+    privateXMLReaderFileV3 * const mPriv;
+};
+
+} // namespace robotinterface
+} // namespace yarp
+
+#endif // YARP_ROBOTINTERFACE_XMLREADERFILEVX_H
+


### PR DESCRIPTION
* Fix include guards  of RobotInterfaceDTD
* Make XMLReaderFileVx, XMLReaderFileV1 and XMLReaderFileV3 private classes