### PR TITLE
YARP_sig: add std::vector under the hood of yarp::sig::Vector

### DIFF
--- a/tests/libYARP_sig/VectorOfTest.cpp
+++ b/tests/libYARP_sig/VectorOfTest.cpp
@@ -203,21 +203,21 @@ TEST_CASE("sig::VectorOfTest", "[yarp::sig]")
         v.reserve(10);
         CHECK(v[0] == 1); // Checking data consistency
         CHECK(v.size() == (size_t) 1); // The memory has been allocated but the vector is empty
-        CHECK(v.capacity() == (size_t) 10); // Checking memory allocated
+        CHECK(v.capacity() >= (size_t) 10); // Checking memory allocated
         v.push_back(2);
         CHECK(v[0] == 1); // Checking data consistency
         CHECK(v[1] == 2); // Checking data consistency
         CHECK(v.size() == (size_t) 2); // Checking size() after push_back
-        CHECK(v.capacity() == (size_t) 10); // Checking capacity() after push_back
+        CHECK(v.capacity() >= (size_t) 10); // Checking capacity() after push_back
         v.resize(11);
         CHECK(v[0] == 1); // Checking data consistency
         CHECK(v[1] == 2); // Checking data consistency
         CHECK(v.size() == (size_t) 11); // Checking size() after resize()
-        CHECK(v.capacity() == (size_t) 11); // Checking size() after resize()
+        CHECK(v.capacity() >= (size_t) 11); // Checking size() after resize()
         v.resize(1);
         CHECK(v[0] == 1); // Checking data consistency
         CHECK(v.size() == (size_t) 1); // Checking size() after push_back
-        CHECK(v.capacity() == (size_t) 11); // Checking capacity() after push_back
+        CHECK(v.capacity() >= (size_t) 11); // Checking capacity() after push_back
     }
 
     NetworkBase::setLocalMode(false);


### PR DESCRIPTION
This PR get rid of `yarp::os::ManagedBytes` in `yarp::sig::Vector`.

It is just a draft for starting a discussion
It compiles and the tests passes.
And it fixes #2192 . (hopefully, it has to be tested).
Please review code.