### PR TITLE
ovrheadset bugfixes and enhancements

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -354,7 +354,7 @@ checkandset_dependency(PNG)
 find_package(MPI QUIET)
 checkandset_dependency(MPI)
 
-set(LibOVR_REQUIRED_VERSION 1.17)
+set(LibOVR_REQUIRED_VERSION 1.19)
 find_package(LibOVR ${LibOVR_REQUIRED_VERSION} QUIET)
 checkandset_dependency(LibOVR)
 

--- a/doc/release/master/oculusUpdate.md
+++ b/doc/release/master/oculusUpdate.md
@@ -1,0 +1,14 @@
+oculusUpdate {master}
+----------------------
+
+### Devices
+
+#### `ovrheadset`
+
+* Port to the new rendering API and make it focus aware (SDK 1.19 is required).
+* Fixed race condition causing randomly frame drops.
+* Fixed behaviour of the `CTRL` button. Both `CTRL` buttons can now be pressed,
+  only `SHIFT` will decide which eye offsets should be modified.
+* Add `P` command to print current settings.
+* Fixed `--no-logo` option.
+* Fixed `--userpose` option.

--- a/src/devices/ovrheadset/InputCallback.cpp
+++ b/src/devices/ovrheadset/InputCallback.cpp
@@ -54,8 +54,12 @@ InputCallback::~InputCallback()
 void InputCallback::onRead(ImageType &img)
 {
     int delaycnt = 0;
+
+    eyeRenderTexture->mutex.lock();
     while (eyeRenderTexture->dataReady && delaycnt <= 3) {
+        eyeRenderTexture->mutex.unlock();
         yarp::os::SystemClock::delaySystem(0.001);
+        eyeRenderTexture->mutex.lock();
         ++delaycnt;
     }
 
@@ -92,8 +96,6 @@ void InputCallback::onRead(ImageType &img)
     }
     expected = (found + 1) % 10;
 #endif // DEBUG_SQUARES
-
-    eyeRenderTexture->mutex.lock();
 
     if(eyeRenderTexture->ptr) {
         size_t w = img.width();

--- a/src/devices/ovrheadset/InputCallback.cpp
+++ b/src/devices/ovrheadset/InputCallback.cpp
@@ -127,13 +127,6 @@ void InputCallback::onRead(ImageType &img)
             }
         }
 
-//        float roll = OVR::DegreeToRad(static_cast<float>(-img.roll)) + rollOffset;
-//        float pitch = OVR::DegreeToRad(static_cast<float>(img.pitch)) + rollOffset;
-//        float yaw = OVR::DegreeToRad(static_cast<float>(img.yaw)) + rollOffset;
-//        float x = static_cast<float>(img.x);
-//        float y = static_cast<float>(img.y);
-//        float z = static_cast<float>(img.z);
-
         float x = 0.0f;
         float y = 0.0f;
         float z = 0.0f;
@@ -151,12 +144,7 @@ void InputCallback::onRead(ImageType &img)
             roll += OVR::DegreeToRad(static_cast<float>(r));
             pitch += OVR::DegreeToRad(static_cast<float>(p));
             yaw += OVR::DegreeToRad(static_cast<float>(yy));
-//        if (b.size() == 3) {
-//            roll += OVR::DegreeToRad(static_cast<float>(b.get(0).asFloat64()));
-//            pitch += OVR::DegreeToRad(static_cast<float>(b.get(1).asFloat64()));
-//            yaw += OVR::DegreeToRad(static_cast<float>(b.get(2).asFloat64()));
         }
-        yDebug() << b.size() << b.toString() << "-------------------" << roll << pitch << yaw;
 
         eyeRenderTexture->eyePose.Orientation.w = (float)(- cos(roll/2) * cos(pitch/2) * cos(yaw/2) - sin(roll/2) * sin(pitch/2) * sin(yaw/2));
         eyeRenderTexture->eyePose.Orientation.x = (float)(- cos(roll/2) * sin(pitch/2) * cos(yaw/2) - sin(roll/2) * cos(pitch/2) * sin(yaw/2));
@@ -166,7 +154,6 @@ void InputCallback::onRead(ImageType &img)
         eyeRenderTexture->eyePose.Position.x = x;
         eyeRenderTexture->eyePose.Position.y = y;
         eyeRenderTexture->eyePose.Position.z = z;
-
 
         eyeRenderTexture->imageWidth = img.width();
         eyeRenderTexture->imageHeight = img.height();

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -606,7 +606,7 @@ bool yarp::dev::OVRHeadset::threadInit()
     OVR::System::Init();
 
     // Initializes LibOVR, and the Rift
-    ovrInitParams initParams = { ovrInit_RequestVersion, OVR_MINOR_VERSION, ovrDebugCallback, reinterpret_cast<uintptr_t>(this), 0 };
+    ovrInitParams initParams = { ovrInit_RequestVersion | ovrInit_FocusAware, OVR_MINOR_VERSION, ovrDebugCallback, reinterpret_cast<uintptr_t>(this), 0 };
     ovrResult r = ovr_Initialize(&initParams);
 //    VALIDATE(OVR_SUCCESS(r), "Failed to initialize libOVR.");
     if (!OVR_SUCCESS(r)) {
@@ -909,6 +909,10 @@ void yarp::dev::OVRHeadset::run()
     if (!sessionStatus.IsVisible) {
         resetInput();
         return;
+    }
+
+    if (!sessionStatus.HasInputFocus) {
+      //  return;
     }
 
     // Begin frame

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -1225,6 +1225,11 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
     bool rightShiftPressed = (glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS);
     bool leftCtrlPressed = (glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS);
     bool rightCtrlPressed = (glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS);
+    bool leftAltPressed = (glfwGetKey(window, GLFW_KEY_LEFT_ALT) == GLFW_PRESS);
+    bool rightAltPressed = (glfwGetKey(window, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS);
+    bool shiftPressed = leftShiftPressed || rightShiftPressed;
+    bool ctrlPressed = leftCtrlPressed || rightCtrlPressed;
+    bool altPressed = leftAltPressed || rightAltPressed;
 
     switch (key) {
     case GLFW_KEY_R:
@@ -1259,9 +1264,11 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
     case GLFW_KEY_I:
         imagePoseEnabled = !imagePoseEnabled;
         yDebug() << "Image pose" << (imagePoseEnabled ? "ON" : "OFF");
+        yDebug() << "User pose" << (userPoseEnabled ? "ON" : "OFF");
         break;
     case GLFW_KEY_U:
         userPoseEnabled = !userPoseEnabled;
+        yDebug() << "Image pose" << (imagePoseEnabled ? "ON" : "OFF");
         yDebug() << "User pose" << (userPoseEnabled ? "ON" : "OFF");
         break;
     case GLFW_KEY_L:
@@ -1269,14 +1276,16 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
         yDebug() << "Overlays:" <<
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
-            "Battery" << (batteryEnabled ? "ON" : "OFF");
+            "Battery" << (batteryEnabled ? "ON" : "OFF") <<
+            "Gui" << (enableGui ? "ON" : "OFF");
         break;
     case GLFW_KEY_C:
         crosshairsEnabled = !crosshairsEnabled;
         yDebug() << "Overlays:" <<
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
-            "Battery" << (batteryEnabled ? "ON" : "OFF");
+            "Battery" << (batteryEnabled ? "ON" : "OFF") <<
+            "Gui" << (enableGui ? "ON" : "OFF");
         break;
     case GLFW_KEY_B:
         batteryEnabled = !batteryEnabled;
@@ -1288,7 +1297,16 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
         yDebug() << "Overlays:" <<
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
-            "Battery" << (batteryEnabled ? "ON" : "OFF");
+            "Battery" << (batteryEnabled ? "ON" : "OFF") <<
+            "Gui" << (enableGui ? "ON" : "OFF");
+        break;
+    case GLFW_KEY_G:
+        enableGui = !enableGui;
+        yDebug() << "Overlays:" <<
+            "Logo" << (logoEnabled ? "ON" : "OFF") <<
+            "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
+            "Battery" << (batteryEnabled ? "ON" : "OFF") <<
+            "Gui" << (enableGui ? "ON" : "OFF");
         break;
     case GLFW_KEY_ESCAPE:
         this->close();
@@ -1319,61 +1337,61 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
         break;
     case GLFW_KEY_UP:
         if (!rightShiftPressed) {
-            displayPorts[0]->pitchOffset += rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->pitchOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye pitch offset =" << displayPorts[0]->pitchOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->pitchOffset += leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->pitchOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye pitch offset =" << displayPorts[1]->pitchOffset;
         }
         break;
     case GLFW_KEY_DOWN:
         if (!rightShiftPressed) {
-            displayPorts[0]->pitchOffset -= rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->pitchOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye pitch offset =" << displayPorts[0]->pitchOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->pitchOffset -= leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->pitchOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye pitch offset =" << displayPorts[1]->pitchOffset;
         }
         break;
     case GLFW_KEY_LEFT:
         if (!rightShiftPressed) {
-            displayPorts[0]->yawOffset += rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->yawOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye yaw offset =" << displayPorts[0]->yawOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->yawOffset += leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->yawOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye yaw offset =" << displayPorts[1]->yawOffset;
         }
         break;
     case GLFW_KEY_RIGHT:
         if (!rightShiftPressed) {
-            displayPorts[0]->yawOffset -= rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->yawOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye yaw offset =" << displayPorts[0]->yawOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->yawOffset -= leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->yawOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye yaw offset =" << displayPorts[1]->yawOffset;
         }
         break;
     case GLFW_KEY_PAGE_UP:
         if (!rightShiftPressed) {
-            displayPorts[0]->rollOffset += rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->rollOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye roll offset =" << displayPorts[0]->rollOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->rollOffset += leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->rollOffset += ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye roll offset =" << displayPorts[1]->rollOffset;
         }
         break;
     case GLFW_KEY_PAGE_DOWN:
         if (!rightShiftPressed) {
-            displayPorts[0]->rollOffset -= rightCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[0]->rollOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Left eye roll offset =" << displayPorts[0]->rollOffset;
         }
         if (!leftShiftPressed) {
-            displayPorts[1]->rollOffset -= leftCtrlPressed ? 0.05f : 0.0025f;
+            displayPorts[1]->rollOffset -= ctrlPressed ? 0.05f : 0.0025f;
             yDebug() << "Right eye roll offset =" << displayPorts[1]->rollOffset;
         }
         break;
@@ -1384,11 +1402,6 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
             ovr_SetInt(session, OVR_PERF_HUD_MODE, PerfHudMode);
         }
         break;
-    case GLFW_KEY_G:
-    {
-        enableGui = !enableGui;
-    }
-    break;
     default:
         break;
     }

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -1175,7 +1175,10 @@ void yarp::dev::OVRHeadset::run()
 
         ovrLayerHeader** layers = new ovrLayerHeader*[layerList.size()];
         std::copy(layerList.begin(), layerList.end(), layers);
-        ovrResult result = ovr_SubmitFrame(session, distortionFrameIndex, nullptr, layers, layerList.size());
+
+        ovr_WaitToBeginFrame(session, distortionFrameIndex);
+        ovr_BeginFrame(session, distortionFrameIndex);
+        ovr_EndFrame(session, distortionFrameIndex, nullptr, layers, layerList.size());
         delete[] layers;
 
         // Blit mirror texture to back buffer

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -1412,6 +1412,29 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
             ovr_SetInt(session, OVR_PERF_HUD_MODE, PerfHudMode);
         }
         break;
+    case GLFW_KEY_P:
+        yDebug() << "--------------------------------------------";
+        yDebug() << "Current settings:";
+        yDebug() << "  Flip input" << (flipInputEnabled ? "ON" : "OFF");
+        yDebug() << "  Image pose" << (imagePoseEnabled ? "ON" : "OFF");
+        yDebug() << "  User pose" << (userPoseEnabled ? "ON" : "OFF");
+        yDebug() << "  Overlays:";
+        yDebug() << "    Logo" << (logoEnabled ? "ON" : "OFF");
+        yDebug() << "    Crosshairs" << (crosshairsEnabled ? "ON" : "OFF");
+        yDebug() << "    Battery" << (batteryEnabled ? "ON" : "OFF");
+        yDebug() << "    Gui" << ((guiCount != 0) ? (guiEnabled ? "ON" : "OFF") : "DISABLED");
+        yDebug() << "  Left eye:";
+        yDebug() << "    HFOV = " << camHFOV[0];
+        yDebug() << "    pitch offset =" << displayPorts[0]->pitchOffset;
+        yDebug() << "    yaw offset =" << displayPorts[0]->yawOffset;
+        yDebug() << "    roll offset =" << displayPorts[0]->rollOffset;
+        yDebug() << "  Right eye:";
+        yDebug() << "    HFOV =" << camHFOV[1];
+        yDebug() << "    pitch offset =" << displayPorts[1]->pitchOffset;
+        yDebug() << "    yaw offset =" << displayPorts[1]->yawOffset;
+        yDebug() << "    roll offset =" << displayPorts[1]->rollOffset;
+        yDebug() << "--------------------------------------------";
+        break;
     default:
         break;
     }

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -835,7 +835,7 @@ bool yarp::dev::OVRHeadset::updateService()
         return false;
     }
 
-    const double delay = 5.0;
+    constexpr double delay = 60.0;
     yDebug("Thread ran %d times, est period %lf[ms], used %lf[ms]",
            getIterations(),
            getEstimatedPeriod()*1000,

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -467,6 +467,10 @@ bool yarp::dev::OVRHeadset::open(yarp::os::Searchable& cfg)
                 huds.push_back(hud);
             }
         }
+        else
+        {
+            guiEnabled = false;
+        }
 
     }
 
@@ -1146,7 +1150,7 @@ void yarp::dev::OVRHeadset::run()
         }
 
         //setting up dynamic hud
-        if (enableGui)
+        if (guiEnabled)
         {
             for (auto& hud : huds)
             {
@@ -1281,7 +1285,7 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
             "Battery" << (batteryEnabled ? "ON" : "OFF") <<
-            "Gui" << (enableGui ? "ON" : "OFF");
+            "Gui" << ((guiCount != 0) ? (guiEnabled ? "ON" : "OFF") : "DISABLED");
         break;
     case GLFW_KEY_C:
         crosshairsEnabled = !crosshairsEnabled;
@@ -1289,7 +1293,7 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
             "Battery" << (batteryEnabled ? "ON" : "OFF") <<
-            "Gui" << (enableGui ? "ON" : "OFF");
+            "Gui" << ((guiCount != 0) ? (guiEnabled ? "ON" : "OFF") : "DISABLED");
         break;
     case GLFW_KEY_B:
         batteryEnabled = !batteryEnabled;
@@ -1302,15 +1306,17 @@ void yarp::dev::OVRHeadset::onKey(int key, int scancode, int action, int mods)
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
             "Battery" << (batteryEnabled ? "ON" : "OFF") <<
-            "Gui" << (enableGui ? "ON" : "OFF");
+            "Gui" << ((guiCount != 0) ? (guiEnabled ? "ON" : "OFF") : "DISABLED");
         break;
     case GLFW_KEY_G:
-        enableGui = !enableGui;
+        if (guiCount != 0) {
+            guiEnabled = !guiEnabled;
+        }
         yDebug() << "Overlays:" <<
             "Logo" << (logoEnabled ? "ON" : "OFF") <<
             "Crosshairs" << (crosshairsEnabled ? "ON" : "OFF") <<
             "Battery" << (batteryEnabled ? "ON" : "OFF") <<
-            "Gui" << (enableGui ? "ON" : "OFF");
+            "Gui" << ((guiCount != 0) ? (guiEnabled ? "ON" : "OFF") : "DISABLED") ;
         break;
     case GLFW_KEY_ESCAPE:
         this->close();

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -566,7 +566,7 @@ bool yarp::dev::OVRHeadset::open(yarp::os::Searchable& cfg)
     {
         { "flipinput",     "[F] Enable input flipping",                &flipInputEnabled,  true },
         { "no-imagepose",  "[I] Disable image pose",                   &imagePoseEnabled,  false },
-        { "userpose",      "[U] Use user pose instead of camera pose", &imagePoseEnabled,  true  },
+        { "userpose",      "[U] Use user pose instead of camera pose", &userPoseEnabled,   true  },
         { "no-logo",       "[L] Disable logo",                         &logoEnabled,       false },
         { "no-crosshairs", "[C] Disable crosshairs",                   &crosshairsEnabled, false },
         { "no-battery",    "[B] Disable battery",                      &batteryEnabled,    false }

--- a/src/devices/ovrheadset/OVRHeadset.cpp
+++ b/src/devices/ovrheadset/OVRHeadset.cpp
@@ -567,7 +567,7 @@ bool yarp::dev::OVRHeadset::open(yarp::os::Searchable& cfg)
         { "flipinput",     "[F] Enable input flipping",                &flipInputEnabled,  true },
         { "no-imagepose",  "[I] Disable image pose",                   &imagePoseEnabled,  false },
         { "userpose",      "[U] Use user pose instead of camera pose", &imagePoseEnabled,  true  },
-        { "no-logo",       "[L] Disable logo",                         &imagePoseEnabled,  false },
+        { "no-logo",       "[L] Disable logo",                         &logoEnabled,       false },
         { "no-crosshairs", "[C] Disable crosshairs",                   &crosshairsEnabled, false },
         { "no-battery",    "[B] Disable battery",                      &batteryEnabled,    false }
     };

--- a/src/devices/ovrheadset/OVRHeadset.h
+++ b/src/devices/ovrheadset/OVRHeadset.h
@@ -167,7 +167,7 @@ private:
     ovrPoseStatef headpose;
     ovrPoseStatef predicted_headpose;
     unsigned int guiCount;
-    bool         enableGui{ true };
+    bool         guiEnabled{ true };
     std::mutex                       inputStateMutex;
     ovrInputState                    inputState;
     bool                             inputStateError{ false };


### PR DESCRIPTION
### Devices

#### `ovrheadset`

* Port to the new rendering API and make it focus aware (SDK 1.19 is required).
* Fixed race condition causing randomly frame drops.
* Fixed behaviour of the `CTRL` button. Both `CTRL` buttons can now be pressed,
  only `SHIFT` will decide which eye offsets should be modified.
* Add `P` command to print current settings.
* Fixed `--no-logo` option.
* Fixed `--userpose` option.