### PR TITLE
Lidar devices from template

### DIFF
--- a/doc/release/master/laserDevicesRefactored.md
+++ b/doc/release/master/laserDevicesRefactored.md
@@ -1,0 +1,16 @@
+laserDevicesRefactored {master}
+----------------------
+
+### devices
+
+#### fakeLaser
+* the device is now derived from `Lidar2DDeviceBase`
+
+#### laserFromExternalPort
+* the device is now derived from `Lidar2DDeviceBase`
+
+#### laserFromPointCloud
+* the device is now derived from `Lidar2DDeviceBase`
+
+#### laserFromDepth
+* the device is now derived from `Lidar2DDeviceBase`

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -38,6 +38,7 @@ using namespace std;
 #define DEG2RAD M_PI/180.0
 #endif
 
+YARP_LOG_COMPONENT(LASER_FROM_DEPTH, "yarp.devices.laserFromDepth")
 
 //-------------------------------------------------------------------------------------
 
@@ -48,61 +49,22 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     m_device_status = DEVICE_OK_STANBY;
 
 #ifdef LASER_DEBUG
-    yDebug("%s\n", config.toString().c_str());
+    yCDebug(LASER_FROM_DEPTH) << "%s\n", config.toString().c_str();
 #endif
 
     m_min_distance = 0.1; //m
     m_max_distance = 2.5;  //m
-    bool br = config.check("SENSOR");
-    if (br != false)
-    {
-        yarp::os::Searchable& general_config = config.findGroup("SENSOR");
-        m_clip_max_enable = general_config.check("clip_max");
-        m_clip_min_enable = general_config.check("clip_min");
-        if (m_clip_max_enable) { m_max_distance = general_config.find("clip_max").asFloat64(); }
-        if (m_clip_min_enable) { m_min_distance = general_config.find("clip_min").asFloat64(); }
-        m_do_not_clip_infinity_enable = (general_config.find("allow_infinity").asInt32()!=0);
-    }
-    else
-    {
-        yError() << "Missing SENSOR section";
-        return false;
-    }
-    bool bs = config.check("SKIP");
-    if (bs != false)
-    {
-        yarp::os::Searchable& skip_config = config.findGroup("SKIP");
-        Bottle mins = skip_config.findGroup("min");
-        Bottle maxs = skip_config.findGroup("max");
-        size_t s_mins = mins.size();
-        size_t s_maxs = mins.size();
-        if (s_mins == s_maxs && s_maxs > 1 )
-        {
-            for (size_t s = 1; s < s_maxs; s++)
-            {
-                Range_t range;
-                range.max = maxs.get(s).asFloat64();
-                range.min = mins.get(s).asFloat64();
-                if (range.max >= 0 && range.max <= 360 &&
-                    range.min >= 0 && range.min <= 360 &&
-                    range.max > range.min)
-                {
-                    m_range_skip_vector.push_back(range);
-                }
-                else
-                {
-                    yError() << "Invalid range in SKIP section";
-                    return false;
-                }
-            }
-        }
 
+    if (this->parseConfiguration(config) == false)
+    {
+        yCError(LASER_FROM_DEPTH) << "error parsing parameters";
+        return false;
     }
 
     Property prop;
     if(!config.check("RGBD_SENSOR_CLIENT"))
     {
-        yError() << "missing RGBD_SENSOR_CLIENT section in configuration file!";
+        yCError(LASER_FROM_DEPTH) << "missing RGBD_SENSOR_CLIENT section in configuration file!";
         return false;
     }
     prop.fromString(config.findGroup("RGBD_SENSOR_CLIENT").toString());
@@ -111,13 +73,13 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     driver.open(prop);
     if (!driver.isValid())
     {
-        yError("Error opening PolyDriver check parameters");
+        yCError(LASER_FROM_DEPTH) << "Error opening PolyDriver check parameters";
         return false;
     }
     driver.view(iRGBD);
     if (!iRGBD)
     {
-        yError("Error opening iRGBD interface. Device not available");
+        yCError(LASER_FROM_DEPTH) << "Error opening iRGBD interface. Device not available";
         return false;
     }
 
@@ -133,7 +95,7 @@ bool LaserFromDepth::open(yarp::os::Searchable& config)
     m_min_angle = -hfov / 2;
     PeriodicThread::start();
 
-    yInfo("Sensor ready");
+    yCInfo(LASER_FROM_DEPTH) << "Sensor ready";
     return true;
 }
 
@@ -144,15 +106,7 @@ bool LaserFromDepth::close()
     if(driver.isValid())
         driver.close();
 
-    yInfo() << "LaserFromDepth closed";
-    return true;
-}
-
-bool LaserFromDepth::getDistanceRange(double& min, double& max)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    min = m_min_distance;
-    max = m_max_distance;
+    yCInfo(LASER_FROM_DEPTH) << "closed";
     return true;
 }
 
@@ -164,88 +118,32 @@ bool LaserFromDepth::setDistanceRange(double min, double max)
     return true;
 }
 
-bool LaserFromDepth::getScanLimits(double& min, double& max)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    min = m_min_angle;
-    max = m_max_angle;
-    return true;
-}
-
 bool LaserFromDepth::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
-    yWarning("setScanLimits not yet implemented");
-    return true;
-}
-
-bool LaserFromDepth::getHorizontalResolution(double& step)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    step = m_resolution;
+    yCWarning(LASER_FROM_DEPTH) << "setScanLimits not yet implemented";
     return true;
 }
 
 bool LaserFromDepth::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
-    yWarning("setHorizontalResolution not yet implemented");
-    return true;
-}
-
-bool LaserFromDepth::getScanRate(double& rate)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    yWarning("getScanRate not yet implemented");
+    yCWarning(LASER_FROM_DEPTH) << "setHorizontalResolution not yet implemented";
     return true;
 }
 
 bool LaserFromDepth::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
-    yWarning("setScanRate not yet implemented");
+    yCWarning(LASER_FROM_DEPTH) << "setScanRate not yet implemented";
     return false;
-}
-
-
-bool LaserFromDepth::getRawData(yarp::sig::Vector &out)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    out = m_laser_data;
-    m_device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-    return true;
-}
-
-bool LaserFromDepth::getLaserMeasurement(std::vector<LaserMeasurementData> &data)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-#ifdef LASER_DEBUG
-        //yDebug("data: %s\n", laser_data.toString().c_str());
-#endif
-    size_t size = m_laser_data.size();
-    data.resize(size);
-    if (m_max_angle < m_min_angle) { yError() << "getLaserMeasurement failed"; return false; }
-    double laser_angle_of_view = m_max_angle - m_min_angle;
-    for (size_t i = 0; i < size; i++)
-    {
-        double angle = (i / double(size)*laser_angle_of_view + m_min_angle)* DEG2RAD;
-        data[i].set_polar(m_laser_data[i], angle);
-    }
-    m_device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-    return true;
-}
-bool LaserFromDepth::getDeviceStatus(Device_status &status)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    status = m_device_status;
-    return true;
 }
 
 bool LaserFromDepth::threadInit()
 {
 #ifdef LASER_DEBUG
-    yDebug("LaserFromDepth:: thread initialising...\n");
-    yDebug("... done!\n");
+    yCDebug(LASER_FROM_DEPTH) << "thread initialising...\n";
+    yCDebug(LASER_FROM_DEPTH) << "... done!\n";
 #endif
 
     return true;
@@ -261,57 +159,32 @@ void LaserFromDepth::run()
     iRGBD->getDepthImage(m_depth_image);
     if (m_depth_image.getRawImage()==nullptr)
     {
-        yDebug()<<"invalid image received";
+        yCDebug(LASER_FROM_DEPTH)<<"invalid image received";
         return;
     }
 
     if (m_depth_image.width()!=m_depth_width ||
         m_depth_image.height()!=m_depth_height)
     {
-        yDebug()<<"invalid image size";
+        yCDebug(LASER_FROM_DEPTH)<<"invalid image size";
         return;
     }
 
 
     auto* pointer = (float*)m_depth_image.getPixelAddress(0, m_depth_height / 2);
-    double angle, distance, infinity, angleShift;
-    size_t i;
+    double angle, distance, angleShift;
 
-    infinity   = std::numeric_limits<double>::infinity();
     angleShift = m_sensorsNum * m_resolution / 2;
 
-    for (int elem = 0; elem < m_sensorsNum; elem++)
+    for (size_t elem = 0; elem < m_sensorsNum; elem++)
     {
-
         angle    = elem * m_resolution;    //deg
-
         //the 1 / cos(blabla) distortion simulate the way RGBD devices calculate the distance..
         distance = *(pointer + elem);
         distance /= cos((angle - angleShift) * DEG2RAD); //m
-
-        if (m_clip_min_enable && distance < m_min_distance)
-        {
-            distance = m_max_distance;
-        }
-
-        if (m_clip_max_enable              &&
-            distance > m_max_distance      &&
-            !m_do_not_clip_infinity_enable &&
-            distance <= infinity)
-        {
-            distance = m_max_distance;
-        }
-
-        for (i = 0; i < m_range_skip_vector.size(); i++)
-        {
-            if (angle > m_range_skip_vector[i].min && angle < m_range_skip_vector[i].max)
-            {
-                distance = infinity;
-            }
-        }
-
         m_laser_data[m_sensorsNum - 1 - elem] = distance;
     }
+    applyLimitsOnLaserData();
 
     return;
 }
@@ -319,16 +192,9 @@ void LaserFromDepth::run()
 void LaserFromDepth::threadRelease()
 {
 #ifdef LASER_DEBUG
-    yDebug("LaserFromDepth Thread releasing...");
-    yDebug("... done.");
+    yCDebug(LASER_FROM_DEPTH)<<"LaserFromDepth Thread releasing...";
+    yCDebug(LASER_FROM_DEPTH) <<"... done.";
 #endif
 
     return;
-}
-
-bool LaserFromDepth::getDeviceInfo(std::string &device_info)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    device_info = m_info;
-    return true;
 }

--- a/src/devices/laserFromDepth/laserFromDepth.h
+++ b/src/devices/laserFromDepth/laserFromDepth.h
@@ -26,6 +26,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/IRGBDSensor.h>
+#include <yarp/dev/Lidar2DDeviceBase.h>
 
 #include <mutex>
 #include <string>
@@ -37,56 +38,20 @@ using namespace yarp::dev;
 typedef unsigned char byte;
 
 //---------------------------------------------------------------------------------------------------------------
-struct Range_t
-{
-    double min;
-    double max;
-};
 
-//---------------------------------------------------------------------------------------------------------------
-
-class LaserFromDepth : public PeriodicThread, public yarp::dev::IRangefinder2D, public DeviceDriver
+class LaserFromDepth : public PeriodicThread, public yarp::dev::Lidar2DDeviceBase, public DeviceDriver
 {
 protected:
     PolyDriver driver;
-    IRGBDSensor* iRGBD;
-    std::mutex m_mutex;
+    IRGBDSensor* iRGBD = nullptr;
 
-    int m_depth_width;
-    int m_depth_height;
+    size_t m_depth_width = 0;
+    size_t m_depth_height = 0;
     yarp::sig::ImageOf<float> m_depth_image;
-
-    int m_sensorsNum;
-    double m_min_angle;
-    double m_max_angle;
-    double m_min_distance;
-    double m_max_distance;
-    double m_resolution;
-    bool m_clip_max_enable;
-    bool m_clip_min_enable;
-    bool m_do_not_clip_infinity_enable;
-    std::vector <Range_t> m_range_skip_vector;
-
-    std::string m_info;
-    Device_status m_device_status;
-
-    yarp::sig::Vector m_laser_data;
 
 public:
     LaserFromDepth(double period = 0.01) : PeriodicThread(period),
-        iRGBD(nullptr),
-        m_depth_width(0),
-        m_depth_height(0),
-        m_sensorsNum(0),
-        m_min_angle(0.0),
-        m_max_angle(0.0),
-        m_min_distance(0.0),
-        m_max_distance(0.0),
-        m_resolution(0.0),
-        m_clip_max_enable(false),
-        m_clip_min_enable(false),
-        m_do_not_clip_infinity_enable(false),
-        m_device_status(Device_status::DEVICE_OK_STANBY)
+        Lidar2DDeviceBase()
     {}
 
     ~LaserFromDepth()
@@ -101,17 +66,9 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector &data) override;
-    bool getLaserMeasurement(std::vector<LaserMeasurementData> &data) override;
-    bool getDeviceStatus     (Device_status &status) override;
-    bool getDeviceInfo       (std::string &device_info) override;
-    bool getDistanceRange    (double& min, double& max) override;
     bool setDistanceRange    (double min, double max) override;
-    bool getScanLimits        (double& min, double& max) override;
     bool setScanLimits        (double min, double max) override;
-    bool getHorizontalResolution      (double& step) override;
     bool setHorizontalResolution      (double step) override;
-    bool getScanRate         (double& rate) override;
     bool setScanRate         (double rate) override;
 };
 

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.h
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.h
@@ -45,9 +45,9 @@ typedef unsigned char byte;
 class InputPortProcessor :
     public yarp::os::BufferedPort<yarp::dev::LaserScan2D>
 {
-    std::mutex             mutex;
-    yarp::dev::LaserScan2D lastScan;
-    yarp::os::Stamp        lastStamp;
+    std::mutex             m_port_mutex;
+    yarp::dev::LaserScan2D m_lastScan;
+    yarp::os::Stamp        m_lastStamp;
 
 public:
 
@@ -70,7 +70,7 @@ protected:
 
 
 public:
-    LaserFromExternalPort(double period = 0.01) : PeriodicThread(period), Lidar2DDeviceBase()
+    LaserFromExternalPort(double period = 0.01) : Lidar2DDeviceBase(), PeriodicThread(period)
     {}
 
     ~LaserFromExternalPort()

--- a/src/devices/laserFromPointCloud/laserFromPointCloud.h
+++ b/src/devices/laserFromPointCloud/laserFromPointCloud.h
@@ -48,20 +48,20 @@ class LaserFromPointCloud : public PeriodicThread, public yarp::dev::Lidar2DDevi
 {
 protected:
     PolyDriver m_rgbd_driver;
-    IRGBDSensor* m_iRGBD;
+    IRGBDSensor* m_iRGBD = nullptr;
 
     PolyDriver m_tc_driver;
-    IFrameTransform* m_iTc;
+    IFrameTransform* m_iTc = nullptr;
 
-    int m_depth_width;
-    int m_depth_height;
+    int m_depth_width = 0;
+    int m_depth_height = 0;
     yarp::os::Property m_propIntrinsics;
     yarp::sig::IntrinsicParams m_intrinsics;
     yarp::sig::ImageOf<float> m_depth_image;
 
     //point cloud
-    size_t m_pc_stepx;
-    size_t m_pc_stepy;
+    size_t m_pc_stepx = 0;
+    size_t m_pc_stepy = 0;
     yarp::sig::utils::PCL_ROI m_pc_roi;
 
     //frames and point cloud clipping planes
@@ -73,10 +73,6 @@ protected:
 
 public:
     LaserFromPointCloud(double period = 0.01) : PeriodicThread(period),
-        m_iRGBD(nullptr),
-        m_iTc(nullptr),
-        m_depth_width(0),
-        m_depth_height(0),
         Lidar2DDeviceBase()
     {}
 

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
@@ -22,6 +22,8 @@ using namespace std;
 #define DEG2RAD M_PI/180.0
 #endif
 
+YARP_LOG_COMPONENT(LASER_BASE, "yarp.devices.Lidar2DDeviceBase")
+
 bool Lidar2DDeviceBase::getScanLimits(double& min, double& max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
@@ -56,7 +58,6 @@ bool Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     out = m_laser_data;
-    m_device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
     return true;
 }
 
@@ -82,19 +83,18 @@ bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& d
 #endif
     size_t size = m_laser_data.size();
     data.resize(size);
-    if (m_max_angle < m_min_angle) { yError() << "getLaserMeasurement failed"; return false; }
+    if (m_max_angle < m_min_angle) { yCError(LASER_BASE) << "getLaserMeasurement failed"; return false; }
     double laser_angle_of_view = m_max_angle - m_min_angle;
     for (size_t i = 0; i < size; i++)
     {
         double angle = (i / double(size) * laser_angle_of_view + m_min_angle) * DEG2RAD;
         data[i].set_polar(m_laser_data[i], angle);
     }
-    m_device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
     return true;
 }
 
 Lidar2DDeviceBase::Lidar2DDeviceBase() :
-    m_device_status(yarp::dev::IRangefinder2D::Device_status::DEVICE_OK_STANBY),
+    m_device_status(yarp::dev::IRangefinder2D::Device_status::DEVICE_GENERAL_ERROR),
     m_scan_rate(0.0),
     m_sensorsNum(0),
     m_min_angle(0.0),
@@ -104,59 +104,153 @@ Lidar2DDeviceBase::Lidar2DDeviceBase() :
     m_resolution(0.0),
     m_clip_max_enable(false),
     m_clip_min_enable(false),
-    m_do_not_clip_infinity_enable(false)
+    m_do_not_clip_and_allow_infinity_enable(true)
 {}
 
-bool Lidar2DDeviceBase::parse(yarp::os::Searchable& config)
+bool Lidar2DDeviceBase::parseConfiguration(yarp::os::Searchable& config)
 {
-    bool br = config.check("SENSOR");
-    if (br != false)
+    //sensor options (should be mandatory? TBD)
     {
-        yarp::os::Searchable& general_config = config.findGroup("SENSOR");
-        m_clip_max_enable = general_config.check("clip_max");
-        m_clip_min_enable = general_config.check("clip_min");
-        if (m_clip_max_enable) { m_max_distance = general_config.find("clip_max").asFloat64(); }
-        if (m_clip_min_enable) { m_min_distance = general_config.find("clip_min").asFloat64(); }
-        m_do_not_clip_infinity_enable = (general_config.find("allow_infinity").asInt32() != 0);
+        bool br = config.check("SENSOR");
+        if (br != false)
+        {
+            yarp::os::Searchable& general_config = config.findGroup("SENSOR");
+            if (general_config.check("max_angle")) { m_max_angle = general_config.find("max_angle").asFloat64(); }
+            if (general_config.check("min_angle")) { m_min_angle = general_config.find("min_angle").asFloat64(); }
+            if (general_config.check("resolution")) { m_resolution = general_config.find("resolution").asFloat64(); }
+            m_clip_max_enable = general_config.check("max_distance");
+            m_clip_min_enable = general_config.check("min_distance");
+            if (m_clip_max_enable) { m_max_distance = general_config.find("max_distance").asFloat64(); }
+            if (m_clip_min_enable) { m_min_distance = general_config.find("min_distance").asFloat64(); }
+            m_do_not_clip_and_allow_infinity_enable = (general_config.find("allow_infinity").asInt32() == 1);
+        }
+        else
+        {
+            //yCError(LASER_BASE) << "Missing SENSOR section";
+            //return false;
+        }
     }
-    else
+
+    //skip options (optional)
     {
-        yError() << "Missing SENSOR section";
+        bool bs = config.check("SKIP");
+        if (bs == true)
+        {
+            yarp::os::Searchable& skip_config = config.findGroup("SKIP");
+            Bottle mins = skip_config.findGroup("min");
+            Bottle maxs = skip_config.findGroup("max");
+            size_t s_mins = mins.size();
+            size_t s_maxs = mins.size();
+            if (s_mins == s_maxs && s_maxs > 1)
+            {
+                for (size_t s = 1; s < s_maxs; s++)
+                {
+                    Range_t range;
+                    range.max = maxs.get(s).asFloat64();
+                    range.min = mins.get(s).asFloat64();
+                    if (range.max >= 0 && range.max <= 360 &&
+                        range.min >= 0 && range.min <= 360 &&
+                        range.max > range.min)
+                    {
+                        m_range_skip_vector.push_back(range);
+                    }
+                    else
+                    {
+                        yCError(LASER_BASE) << "Invalid range in SKIP section";
+                        return false;
+                    }
+                }
+            }
+            //yCDebug(LASER_BASE) << "Skip section set successfully";
+        }
+        else
+        {
+            //yCDebug(LASER_BASE) << "No Skip section required";
+        }
+    }
+
+    //checks and allocation
+    if (m_max_distance - m_min_distance <= 0)
+    {
+        yCError(LASER_BASE) << "invalid parameters: max_distance/min_distance";
         return false;
     }
-    bool bs = config.check("SKIP");
-    if (bs == true)
+    double fov = (m_max_angle - m_min_angle);
+    if (fov <= 0)
     {
-        yarp::os::Searchable& skip_config = config.findGroup("SKIP");
-        Bottle mins = skip_config.findGroup("min");
-        Bottle maxs = skip_config.findGroup("max");
-        size_t s_mins = mins.size();
-        size_t s_maxs = mins.size();
-        if (s_mins == s_maxs && s_maxs > 1)
+        yCError(LASER_BASE) << "invalid parameters: max_angle should be > min_angle";
+        return false;
+    }
+    if (fov > 360)
+    {
+        yCError(LASER_BASE) << "invalid parameters: max_angle - min_angle <= 360";
+        return false;
+    }
+    if (m_resolution <= 0)
+    {
+        yCError(LASER_BASE) << "invalid parameters resolution";
+        return false;
+    }
+    m_sensorsNum = (int)(fov / m_resolution);
+    m_laser_data.resize(m_sensorsNum, 0.0);
+
+    yCInfo(LASER_BASE) << "Using the following parameters:";
+    yCInfo(LASER_BASE) << "max_dist:" << m_max_distance << " min_dist:" << m_min_distance;
+    yCInfo(LASER_BASE) << "max_angle:" << m_max_angle << " min_angle:" << m_min_angle;
+    yCInfo(LASER_BASE) << "resolution:" << m_resolution;
+    yCInfo(LASER_BASE) << "sensors:" << m_sensorsNum;
+    yCInfo(LASER_BASE) << "allow_infinity:" << (m_do_not_clip_and_allow_infinity_enable ==true);
+    return true;
+}
+
+//this function checks if the angle is inside the allowed limits
+//if not, distance value is set to NaN
+bool Lidar2DDeviceBase::checkSkipAngle(const double& angle, double& distance)
+{
+    for (auto& it_skip : m_range_skip_vector)
+    {
+        if (angle > it_skip.min&& angle < it_skip.max)
         {
-            for (size_t s = 1; s < s_maxs; s++)
+            distance = std::nan("");
+            return true;
+        }
+    }
+    return false;
+}
+
+void Lidar2DDeviceBase::applyLimitsOnLaserData()
+{
+    for (size_t i = 0; i < m_sensorsNum; i++)
+    {
+        double& distance = m_laser_data[i];
+        double  angle = i * m_resolution;
+
+        if (std::isnan(distance)) continue;
+        if (checkSkipAngle(angle, distance)) continue;
+
+        if (m_clip_min_enable)
+        {
+            if (distance < m_min_distance)
             {
-                Range_t range;
-                range.max = maxs.get(s).asFloat64();
-                range.min = mins.get(s).asFloat64();
-                if (range.max >= 0 && range.max <= 360 &&
-                    range.min >= 0 && range.min <= 360 &&
-                    range.max > range.min)
+                distance = std::numeric_limits<double>::infinity();
+                //the following means: if we want to clip infinity...
+                if (m_do_not_clip_and_allow_infinity_enable == false)
                 {
-                    m_range_skip_vector.push_back(range);
-                }
-                else
-                {
-                    yError() << "Invalid range in SKIP section";
-                    return false;
+                    distance = m_min_distance;
                 }
             }
         }
-        //yDebug() << "Skip section set sucesfully";
+        if (m_clip_max_enable)
+        {
+            if (distance > m_max_distance)
+            {
+                distance = std::numeric_limits<double>::infinity();
+                //the following means: if we want to clip infinity...
+                if (m_do_not_clip_and_allow_infinity_enable ==false)
+                {
+                    distance = m_max_distance;
+                }
+            }
+        }
     }
-    else
-    {
-        //yDebug() << "No Skip section required";
-    }
-    return true;
 }

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
@@ -50,12 +50,12 @@ protected:
     double         m_resolution;
     bool           m_clip_max_enable;
     bool           m_clip_min_enable;
-    bool           m_do_not_clip_infinity_enable;
+    bool           m_do_not_clip_and_allow_infinity_enable;
     std::vector <Range_t> m_range_skip_vector;
 
 public:
     // the main parse function
-    bool parse (yarp::os::Searchable& config);
+    bool parseConfiguration(yarp::os::Searchable& config);
 
 public:
     //constructor
@@ -71,6 +71,14 @@ public:
     bool getScanLimits(double& min, double& max) override;
     bool getHorizontalResolution(double& step) override;
     bool getScanRate(double& rate) override;
+
+protected:
+    //utility methods called by laser devices
+    void applyLimitsOnLaserData();
+
+private:
+    //utility methods called internally by Lidar2DDeviceBase
+    bool checkSkipAngle(const double& angle, double& distance);
 };
 
 } // dev


### PR DESCRIPTION
- This PR  should be merged after https://github.com/robotology/yarp/pull/2199

* the following lidar devices in Yarp are now derived from Lidar2DDeviceTemplate. Marked items have been tested.
- [x] fakeLaser
- [ ] laserFromDepth
- [ ] laserFromPointCloud
- [ ] laserFromExternalPort


