### PR TITLE
fakeBattery: Add RPC port to change the values returned

### DIFF
--- a/doc/release/master/fakeBatteryImprovements.md
+++ b/doc/release/master/fakeBatteryImprovements.md
@@ -1,0 +1,12 @@
+fakeBatteryImprovements {master}
+-----------------------
+
+## New Features
+
+### Devices
+
+#### `fakeBattery`
+
+* Added a new port `<name>/control/rpc:i` to change the values reported by the
+  fake battery.
+* The battery is now charged/discharged depending on the sign of the current.

--- a/src/devices/fakeBattery/CMakeLists.txt
+++ b/src/devices/fakeBattery/CMakeLists.txt
@@ -12,9 +12,11 @@ yarp_prepare_plugin(fakeBattery
 
 if(NOT SKIP_fakeBattery)
   yarp_add_plugin(yarp_fakeBattery)
+  yarp_add_idl(IDL_GEN_FILES fakeBatteryService.thrift)
 
   target_sources(yarp_fakeBattery PRIVATE fakeBattery.cpp
-                                          fakeBattery.h)
+                                          fakeBattery.h
+                                          ${IDL_GEN_FILES})
 
   target_link_libraries(yarp_fakeBattery PRIVATE YARP::YARP_os
                                                  YARP::YARP_sig

--- a/src/devices/fakeBattery/fakeBatteryService.thrift
+++ b/src/devices/fakeBattery/fakeBatteryService.thrift
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+enum fakeBatteryStatus
+{
+    BATTERY_OK_STANBY        = 0,
+    BATTERY_OK_IN_CHARGE     = 1,
+    BATTERY_OK_IN_USE        = 2,
+    BATTERY_GENERAL_ERROR    = 3,
+    BATTERY_TIMEOUT          = 4,
+    BATTERY_LOW_WARNING      = 5,
+    BATTERY_CRITICAL_WARNING = 6
+}
+
+service fakeBatteryService
+{
+    oneway void setBatteryVoltage(1: double voltage);
+    oneway void setBatteryCurrent(1: double current);
+    oneway void setBatteryCharge(1: double charge);
+    oneway void setBatteryStatus(1: fakeBatteryStatus status);
+    oneway void setBatteryInfo(1: string info);
+    oneway void setBatteryTemperature(1: double temperature);
+}


### PR DESCRIPTION
## New Features

### Devices

#### `fakeBattery`

* Added a new port `<name>/control/rpc:i` to change the values reported by the
  fake battery.
* The battery is now charged/discharged depending on the sign of the current.
