### PR TITLE
batteryClient: Fix PeriodicThread using 100% CPU

### DIFF
--- a/doc/release/yarp_3_3/fix_batteryClient2.md
+++ b/doc/release/yarp_3_3/fix_batteryClient2.md
@@ -1,0 +1,8 @@
+fix_batteryClient2 {yarp-3.3}
+------------------
+
+### Devices
+
+#### `batteryClient`
+
+* Fixed `PeriodicThread` using 100% CPU

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -31,8 +31,10 @@ bool FakeBattery::open(yarp::os::Searchable& config)
 {
     Bottle& group_general = config.findGroup("GENERAL");
 
-    int period = config.find("thread_period").asInt32();
-    setPeriod((double)period / 1000.0);
+    if (config.check("thread_period")) {
+        int period = config.find("thread_period").asInt32();
+        setPeriod((double)period / 1000.0);
+    }
 
     if (group_general.isNull())
     {


### PR DESCRIPTION
### Devices

#### `batteryClient`

* Fixed `PeriodicThread` using 100% CPU