### PR TITLE
batteryWrapper: Fix parameters accepted by subdevice not printed with --verbose

### DIFF
--- a/doc/release/yarp_3_3/fix_batteryWrapper.md
+++ b/doc/release/yarp_3_3/fix_batteryWrapper.md
@@ -1,0 +1,8 @@
+fix_batteryWrapper {yarp-3.3}
+------------------
+
+### Devices
+
+#### `batteryWraper`
+
+* Fixed parameters accepted by subdevice not printed with --verbose.

--- a/src/devices/batteryWrapper/BatteryWrapper.cpp
+++ b/src/devices/batteryWrapper/BatteryWrapper.cpp
@@ -200,12 +200,13 @@ bool BatteryWrapper::open(yarp::os::Searchable &config)
 
     if (config.check("subdevice"))
     {
-        Property       p;
         PolyDriverList driverlist;
-
-        p.fromString(config.toString(), false);
-        p.put("device", config.find("subdevice").asString());
+        Property p;
+        p.fromString(config.toString());
+        p.unput("device");
         p.unput("subdevice");
+        p.put("device", config.find("subdevice").asString());
+        p.setMonitor(config.getMonitor(), "subdevice"); // pass on any monitoring
 
         if (!m_driver.open(p) || !m_driver.isValid())
         {


### PR DESCRIPTION
### Devices

#### `batteryWraper`

* Fixed parameters accepted by subdevice not printed with --verbose.