### PR TITLE
conf: Add yarp::conf::clamp

### DIFF
--- a/doc/release/master/clamp.md
+++ b/doc/release/master/clamp.md
@@ -1,0 +1,9 @@
+clamp {master}
+-----
+
+## Libraries
+
+### `conf`
+
+* Added `yarp::conf::clamp`. Will be replaced by `std::clamp` as soon as c++17
+  is required in YARP.

--- a/src/libYARP_conf/src/yarp/conf/numeric.h.in
+++ b/src/libYARP_conf/src/yarp/conf/numeric.h.in
@@ -60,6 +60,21 @@ typedef ::SSIZE_T ssize_t;
 typedef ::ssize_t ssize_t;
 #endif
 
+// Define `clamp` algorithm, available in c++17
+template<class T>
+constexpr const T& clamp( const T& v, const T& lo, const T& hi )
+{
+    // assert( !(hi < lo) );
+    return (v < lo) ? lo : (hi < v) ? hi : v;
+}
+
+template<class T, class Compare>
+constexpr const T& clamp( const T& v, const T& lo, const T& hi, Compare comp )
+{
+    // assert( !comp(hi, lo) );
+    return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
+}
+
 } // namespace conf
 } // namespace yarp
 


### PR DESCRIPTION
This is a small utility available in c++17, that could make lots of code a lot easier to read in many different places.

## Libraries

### `conf`

* Added `yarp::conf::clamp`. Will be replaced by `std::clamp` as soon as c++17
  is required in YARP.

