### PR TITLE
fakeBattery more improvements

### DIFF
--- a/doc/release/master/fakeBatteryImprovements2.md
+++ b/doc/release/master/fakeBatteryImprovements2.md
@@ -1,0 +1,11 @@
+fakeBatteryImprovements2 {master}
+------------------------
+
+## New Features
+
+### Devices
+
+#### `fakeBattery`
+
+* The default values for voltage and current are now more realistic.
+* It is now possible to change the values as device options.

--- a/src/devices/fakeBattery/CMakeLists.txt
+++ b/src/devices/fakeBattery/CMakeLists.txt
@@ -12,7 +12,7 @@ yarp_prepare_plugin(fakeBattery
 
 if(NOT SKIP_fakeBattery)
   yarp_add_plugin(yarp_fakeBattery)
-  yarp_add_idl(IDL_GEN_FILES fakeBatteryService.thrift)
+  yarp_add_idl(IDL_GEN_FILES FakeBatteryService.thrift)
 
   target_sources(yarp_fakeBattery PRIVATE fakeBattery.cpp
                                           fakeBattery.h

--- a/src/devices/fakeBattery/FakeBatteryService.thrift
+++ b/src/devices/fakeBattery/FakeBatteryService.thrift
@@ -6,23 +6,11 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-enum fakeBatteryStatus
-{
-    BATTERY_OK_STANBY        = 0,
-    BATTERY_OK_IN_CHARGE     = 1,
-    BATTERY_OK_IN_USE        = 2,
-    BATTERY_GENERAL_ERROR    = 3,
-    BATTERY_TIMEOUT          = 4,
-    BATTERY_LOW_WARNING      = 5,
-    BATTERY_CRITICAL_WARNING = 6
-}
-
-service fakeBatteryService
+service FakeBatteryService
 {
     oneway void setBatteryVoltage(1: double voltage);
     oneway void setBatteryCurrent(1: double current);
     oneway void setBatteryCharge(1: double charge);
-    oneway void setBatteryStatus(1: fakeBatteryStatus status);
     oneway void setBatteryInfo(1: string info);
     oneway void setBatteryTemperature(1: double temperature);
 }

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -28,9 +28,23 @@ FakeBattery::FakeBattery() :
 
 bool FakeBattery::open(yarp::os::Searchable& config)
 {
-    double period = config.check("thread_period", Value(0.02), "thread period (smaller implies faster charge/discharge)").asFloat64();
+    double period = config.check("thread_period", Value(0.02), "Thread period (smaller implies faster charge/discharge)").asFloat64();
     setPeriod(period);
 
+    double charge = config.check("charge", Value(50.0), "Initial charge (%)").asFloat64();
+    double voltage = config.check("voltage", Value(30.0), "Initial voltage (V)").asFloat64();
+    double current = config.check("current", Value(3.0), "Initial current (A)").asFloat64();
+    double temperature = config.check("temperature", Value(20.0), "Initial temperature (°C)").asFloat64();
+    std::string info = config.check("info", Value("Fake battery system v2.0"), "Initial battery information").asString();
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        battery_charge = charge;
+        battery_voltage = voltage;
+        battery_current = current;
+        battery_temperature = temperature;
+        battery_info = std::move(info);
+        updateStatus();
+    }
     Bottle& group_general = config.findGroup("GENERAL");
     if (group_general.isNull()) {
         yWarning() << "GENERAL group parameters missing, assuming default";

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -137,13 +137,6 @@ void FakeBattery::setBatteryCharge(const double charge)
     updateStatus();
 }
 
-void FakeBattery::setBatteryStatus(const fakeBatteryStatus status)
-{
-    std::lock_guard<std::mutex> lock(m_mutex);
-    battery_status = static_cast<yarp::dev::IBattery::Battery_status>(status);
-    updateStatus();
-}
-
 void FakeBattery::setBatteryInfo(const std::string& info)
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/devices/fakeBattery/fakeBattery.h
+++ b/src/devices/fakeBattery/fakeBattery.h
@@ -27,11 +27,11 @@ class FakeBattery :
 {
 protected:
     std::mutex m_mutex;
-    double battery_charge {52.0};
-    double battery_voltage {50.0};
-    double battery_current {51.0};
+    double battery_charge {50.0};
+    double battery_voltage {30.0};
+    double battery_current {3.0};
     double battery_temperature {20.0};
-    std::string battery_info {"fake battery system v2.0"};
+    std::string battery_info {"Fake battery system v2.0"};
     Battery_status battery_status {BATTERY_OK_IN_USE};
 
     bool debugEnable {false};

--- a/src/devices/fakeBattery/fakeBattery.h
+++ b/src/devices/fakeBattery/fakeBattery.h
@@ -17,13 +17,13 @@
 
 #include <mutex>
 
-#include "fakeBatteryService.h"
+#include "FakeBatteryService.h"
 
 class FakeBattery :
         public yarp::os::PeriodicThread,
         public yarp::dev::IBattery,
         public yarp::dev::DeviceDriver,
-        public fakeBatteryService
+        public FakeBatteryService
 {
 protected:
     std::mutex m_mutex;
@@ -61,7 +61,6 @@ public:
     void setBatteryVoltage(const double voltage) override;
     void setBatteryCurrent(const double current) override;
     void setBatteryCharge(const double charge) override;
-    void setBatteryStatus(const fakeBatteryStatus status) override;
     void setBatteryInfo(const std::string& info) override;
     void setBatteryTemperature(const double temperature) override;
 


### PR DESCRIPTION
### Devices

#### `fakeBattery`

* Rename service and remove `setBatteryStatus`
* The default values for voltage and current are now more realistic.
* It is now possible to change the values as device options.