### PR TITLE
Add upowerBattery device

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -311,7 +311,7 @@ buildandset_dependency(hmac)
 find_package(Eigen3 QUIET)
 checkandset_dependency(Eigen3)
 
-find_package(Qt5 COMPONENTS Core Widgets Gui Quick Qml Multimedia Xml PrintSupport QUIET)
+find_package(Qt5 COMPONENTS Core Widgets Gui Quick Qml Multimedia Xml PrintSupport OPTIONAL_COMPONENTS DBus QUIET)
 checkandset_dependency(Qt5)
 
 find_package(QCustomPlot QUIET)

--- a/doc/release/master/upowerBattery.md
+++ b/doc/release/master/upowerBattery.md
@@ -1,0 +1,9 @@
+upowerBattery {master}
+-------------
+
+## New Features
+
+### Devices
+
+* New device `upowerBattery` to view the battery of a linux laptop in YARP using
+  the `yarp::dev::IBattery` interface.

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -41,6 +41,7 @@ yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
   add_subdirectory(SDLJoypad)
   add_subdirectory(batteryClient)
   add_subdirectory(batteryWrapper)
+  add_subdirectory(upowerBattery)
   add_subdirectory(Rangefinder2DWrapper)
   add_subdirectory(realsense2)
   add_subdirectory(multipleAnalogSensorsMsgs)

--- a/src/devices/upowerBattery/CMakeLists.txt
+++ b/src/devices/upowerBattery/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+find_package(Qt5 COMPONENTS DBus QUIET)
+
+yarp_prepare_plugin(upowerBattery
+                    CATEGORY device
+                    TYPE UpowerBattery
+                    INCLUDE upowerBattery.h
+                    EXTRA_CONFIG WRAPPER=batteryWrapper
+                    DEPENDS "UNIX; NOT APPLE; YARP_HAS_Qt5; Qt5DBus_FOUND")
+
+if(NOT SKIP_upowerBattery)
+  yarp_add_plugin(yarp_upowerBattery)
+
+  target_sources(yarp_upowerBattery PRIVATE upowerBattery.cpp
+                                            upowerBattery.h
+                                            ${DBUS_STCS})
+
+  target_link_libraries(yarp_upowerBattery PRIVATE YARP::YARP_os
+                                                   YARP::YARP_sig
+                                                   YARP::YARP_dev
+                                                   Qt5::DBus)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig
+                                                      YARP_dev)
+
+  yarp_install(TARGETS yarp_upowerBattery
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_upowerBattery PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/upowerBattery/upowerBattery.cpp
+++ b/src/devices/upowerBattery/upowerBattery.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "upowerBattery.h"
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Time.h>
+
+#include <iostream>
+#include <cstring>
+
+#include <QString>
+#include <QDBusInterface>
+#include <QDBusReply>
+
+using namespace std;
+using namespace yarp::os;
+using namespace yarp::dev;
+
+const QString UPOWER_SERVICE = QStringLiteral("org.freedesktop.UPower");
+const QString UPOWER_OBJECT = QStringLiteral("org.freedesktop.UPower.Device");
+
+bool UpowerBattery::open(yarp::os::Searchable& config)
+{
+    std::string device_path = config.check("device_path", Value("/org/freedesktop/UPower/devices/battery_BAT0"), "Battery device path (as returned by 'upower -e', for example '/org/freedesktop/UPower/devices/battery_BAT0')").asString();
+
+    m_interface = new QDBusInterface(UPOWER_SERVICE, QString(device_path.c_str()), UPOWER_OBJECT, QDBusConnection::systemBus());
+    if (!m_interface->isValid()) {
+        yError() << "Interface not found";
+        delete m_interface;
+        return false;
+    }
+
+    return true;
+}
+
+bool UpowerBattery::close()
+{
+    delete m_interface;
+    return true;
+}
+
+bool UpowerBattery::getBatteryVoltage(double& voltage)
+{
+    voltage = m_interface->property("Voltage").toDouble();
+    return true;
+}
+
+bool UpowerBattery::getBatteryCurrent(double& current)
+{
+    auto energyrate = m_interface->property("EnergyRate").toDouble();
+    auto voltage = m_interface->property("Voltage").toDouble();
+    auto state = m_interface->property("State").toUInt();
+    current = energyrate / voltage;
+    if (current > 0 && state == 1 /* Charging */) {
+        current = -current;
+    }
+    return true;
+}
+
+bool UpowerBattery::getBatteryCharge(double& charge)
+{
+    charge = m_interface->property("Percentage").toInt();
+    return true;
+}
+
+bool UpowerBattery::getBatteryStatus(Battery_status& status)
+{
+    status = yarp::dev::IBattery::BATTERY_OK_STANBY;
+    auto st = m_interface->property("State").toUInt();
+    auto wl = m_interface->property("WarningLevel").toUInt();
+
+    switch (st) {
+    case 1 /* Charging */: [[fallthrough]];
+    case 5 /* Pending charge */:
+        status = yarp::dev::IBattery::BATTERY_OK_IN_CHARGE;
+        break;
+    case 2 /* Discharging */:
+    case 6 /* Pending discharge */:
+        switch (wl) {
+            case 1 /* None */: [[fallthrough]];
+            case 2 /* Discharging (only for UPSes) */:
+                status = yarp::dev::IBattery::BATTERY_OK_IN_USE;
+                break;
+            case 3 /* Low */:
+                status = yarp::dev::IBattery::BATTERY_LOW_WARNING;
+                break;
+            case 4 /* Critical */: [[fallthrough]];
+            case 5 /* Action */:
+                status = yarp::dev::IBattery::BATTERY_CRITICAL_WARNING;
+                break;
+            case 0 /* Unknown */: [[fallthrough]];
+            default:
+                status = yarp::dev::IBattery::BATTERY_GENERAL_ERROR;
+        }
+        break;
+    case 3 /* Empty */:
+        status = yarp::dev::IBattery::BATTERY_CRITICAL_WARNING;
+        break;
+    case 4 /* Fully charged */:
+        status = yarp::dev::IBattery::BATTERY_OK_STANBY;
+        break;
+    case 0 /* Unknown */: [[fallthrough]];
+    default:
+        status = yarp::dev::IBattery::BATTERY_GENERAL_ERROR;
+        break;
+    }
+
+    return true;
+}
+
+bool UpowerBattery::getBatteryTemperature(double& temperature)
+{
+    temperature = m_interface->property("Temperature").toDouble();
+    return true;
+}
+
+bool UpowerBattery::getBatteryInfo(string& info)
+{
+    info = QStringLiteral("Vendor: %1, Model: %2, Serial: %3")
+                .arg(m_interface->property("Vendor").toString())
+                .arg(m_interface->property("Model").toString())
+                .arg(m_interface->property("Serial").toString())
+                .toStdString();
+    yDebug() << info;
+    return true;
+}

--- a/src/devices/upowerBattery/upowerBattery.h
+++ b/src/devices/upowerBattery/upowerBattery.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_UPOWERBATTERY_H
+#define YARP_UPOWERBATTERY_H
+
+#include <yarp/dev/IBattery.h>
+#include <yarp/dev/PolyDriver.h>
+
+#include <QDBusInterface>
+
+
+class UpowerBattery :
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IBattery
+{
+public:
+    UpowerBattery() = default;
+    UpowerBattery(const UpowerBattery&) = delete;
+    UpowerBattery(UpowerBattery&&) = delete;
+    UpowerBattery& operator=(const UpowerBattery&) = delete;
+    UpowerBattery& operator=(UpowerBattery&&) = delete;
+
+    ~UpowerBattery() override = default;
+
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+    bool getBatteryVoltage(double& voltage) override;
+    bool getBatteryCurrent(double& current) override;
+    bool getBatteryCharge(double& charge) override;
+    bool getBatteryStatus(Battery_status& status) override;
+    bool getBatteryInfo(std::string& info) override;
+    bool getBatteryTemperature(double& temperature) override;
+
+private:
+    QDBusInterface *m_interface { nullptr };
+};
+
+#endif


### PR DESCRIPTION
## New Features

### Devices

* New device `upowerBattery` to view the battery of a linux laptop in YARP using
  the `yarp::dev::IBattery` interface.