### PR TITLE
dev: Fix dependency from YARP_math that should be PUBLIC at CMake package level

### DIFF
--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -280,7 +280,7 @@ list(APPEND YARP_dev_PRIVATE_DEPS YARP_rosmsg)
 
 if(TARGET YARP::YARP_math)
   target_link_libraries(YARP_dev PUBLIC YARP::YARP_math)
-  list(APPEND YARP_dev_PRIVATE_DEPS YARP_math)
+  list(APPEND YARP_dev_PUBLIC_DEPS YARP_math)
 endif()
 
 set_property(TARGET YARP_dev PROPERTY PUBLIC_HEADER ${YARP_dev_HDRS}


### PR DESCRIPTION
This fix the regression introduced in https://github.com/robotology/yarp/pull/2216, where `YARP::YARP_math` was made a public dependency of `YARP::YARP_dev`, but this was not propagated at the CMake level.

Fix https://github.com/robotology/yarp/issues/2217 .

fyi @drdanz 