### PR TITLE
[WIP] Yarp types names

### DIFF
--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -1840,6 +1840,16 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
         yarp_api_keyword = annotations.at("yarp.api.keyword");
     }
 
+    std::string yarp_type_name{};
+    if (annotations.find("yarp.type.name") != annotations.end()) {
+        yarp_api_keyword = annotations.at("yarp.type.name");
+    }
+
+    std::string yarp_type_version{};
+    if (annotations.find("yarp.type.version") != annotations.end()) {
+        yarp_api_keyword = annotations.at("yarp.type.version");
+    }
+
     // Open header file
     std::string f_header_name = get_out_dir() + get_include_prefix(program_) + name + ".h";
     ofstream_with_content_based_conditional_update f_h_;

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -1847,7 +1847,7 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
         yarp_type_name = annotations.at("yarp.type.name");
     }
     else {
-        yarp_type_name = "yarp/"+name;
+        yarp_type_name = "";
     }
 
     std::string yarp_type_version{};
@@ -1855,7 +1855,7 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
         yarp_type_version = annotations.at("yarp.type.version");
     }
     else {
-        yarp_type_version = "1.0";
+        yarp_type_version = "";
     }
 
     // Open header file
@@ -2247,7 +2247,7 @@ void t_yarp_generator::generate_struct_typeconstexpr(t_struct* tstruct, std::ost
 
     f_h_ << indent_h() << "//The name and the version for this message\n";
     f_h_ << indent_h() << "static constexpr const char* typeName = \"" << yarp_type_name << "\";\n";
-    f_h_ << indent_h() << "static constexpr const char* typeVersion = \"" << "1.0" << "\";\n";
+    f_h_ << indent_h() << "static constexpr const char* typeVersion = \"" << yarp_type_version << "\";\n";
     f_h_ << '\n';
 
     assert(indent_count_h() == 1);
@@ -2264,14 +2264,14 @@ void t_yarp_generator::generate_struct_gettype(t_struct* tstruct, std::ostringst
     f_h_ << indent_h() << "yarp::os::Type getType() const;\n";
     f_h_ << '\n';
 
-    f_cpp_ << indent_cpp() << "// Convert to a printable string\n";
+    f_cpp_ << indent_cpp() << "// Get the message type\n";
     f_cpp_ << indent_cpp() << "yarp::os::Type " << name << "::getType() const\n";
     f_cpp_ << indent_cpp() << "{\n";
     indent_up_cpp();
     {
-        f_cpp_ << indent_cpp() << " yarp::os::Type typ = yarp::os::Type::byNameOnWire(typeName);\n";
+        f_cpp_ << indent_cpp() << "yarp::os::Type typ = yarp::os::Type::byNameOnWire(typeName);\n";
         f_cpp_ << indent_cpp() << "typ.setVersion(typeVersion);\n";
-        f_cpp_ << indent_cpp() << " return typ;\n";
+        f_cpp_ << indent_cpp() << "return typ;\n";
     }
     indent_down_cpp();
     f_cpp_ << indent_cpp() << "}\n";

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -316,7 +316,9 @@ public:
     void generate_struct_read_connectionreader(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
     void generate_struct_write_wirereader(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
     void generate_struct_write_connectionreader(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
+    void generate_struct_typeconstexpr(t_struct* tstruct, std::ostringstream& f_h_, const std::string& type, const std::string& version);
     void generate_struct_tostring(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
+    void generate_struct_gettype(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
     void generate_struct_unwrapped_helper(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
     void generate_struct_editor(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
     void generate_struct_editor_default_constructor(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_);
@@ -1842,12 +1844,18 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
 
     std::string yarp_type_name{};
     if (annotations.find("yarp.type.name") != annotations.end()) {
-        yarp_api_keyword = annotations.at("yarp.type.name");
+        yarp_type_name = annotations.at("yarp.type.name");
+    }
+    else {
+        yarp_type_name = "yarp/"+name;
     }
 
     std::string yarp_type_version{};
     if (annotations.find("yarp.type.version") != annotations.end()) {
-        yarp_api_keyword = annotations.at("yarp.type.version");
+        yarp_type_version = annotations.at("yarp.type.version");
+    }
+    else {
+        yarp_type_version = "1.0";
     }
 
     // Open header file
@@ -1884,6 +1892,7 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
 
     f_h_ << "#include <yarp/os/Wire.h>\n";
     f_h_ << "#include <yarp/os/idl/WireTypes.h>\n";
+    f_h_ << "#include <yarp/os/Type.h>\n";
     if (need_common_) {
         f_h_ << '\n';
         f_h_ << "#include <" << get_include_prefix(program_) << program_->get_name() << "_common.h>" << '\n';
@@ -1925,7 +1934,9 @@ void t_yarp_generator::generate_struct(t_struct* tstruct)
     generate_struct_read_connectionreader(tstruct, f_h_, f_cpp_);
     generate_struct_write_wirereader(tstruct, f_h_, f_cpp_);
     generate_struct_write_connectionreader(tstruct, f_h_, f_cpp_);
+    generate_struct_typeconstexpr(tstruct, f_h_, yarp_type_name, yarp_type_version);
     generate_struct_tostring(tstruct, f_h_, f_cpp_);
+    generate_struct_gettype(tstruct, f_h_, f_cpp_);
     generate_struct_unwrapped_helper(tstruct, f_h_, f_cpp_);
 
     // Add editor class, if not disabled
@@ -2219,6 +2230,48 @@ void t_yarp_generator::generate_struct_tostring(t_struct* tstruct, std::ostrings
         f_cpp_ << indent_cpp() << "yarp::os::Bottle b;\n";
         f_cpp_ << indent_cpp() << "b.read(*this);\n";
         f_cpp_ << indent_cpp() << "return b.toString();\n";
+    }
+    indent_down_cpp();
+    f_cpp_ << indent_cpp() << "}\n";
+    f_cpp_ << '\n';
+
+    assert(indent_count_h() == 1);
+    assert(indent_count_cpp() == 0);
+}
+
+void t_yarp_generator::generate_struct_typeconstexpr(t_struct* tstruct, std::ostringstream& f_h_, const std::string& yarp_type_name, const std::string& yarp_type_version)
+{
+    THRIFT_DEBUG_COMMENT(f_h_);
+
+    const auto& name = tstruct->get_name();
+
+    f_h_ << indent_h() << "//The name and the version for this message\n";
+    f_h_ << indent_h() << "static constexpr const char* typeName = \"" << yarp_type_name << "\";\n";
+    f_h_ << indent_h() << "static constexpr const char* typeVersion = \"" << "1.0" << "\";\n";
+    f_h_ << '\n';
+
+    assert(indent_count_h() == 1);
+}
+
+void t_yarp_generator::generate_struct_gettype(t_struct* tstruct, std::ostringstream& f_h_, std::ostringstream& f_cpp_)
+{
+    THRIFT_DEBUG_COMMENT(f_h_);
+    THRIFT_DEBUG_COMMENT(f_cpp_);
+
+    const auto& name = tstruct->get_name();
+
+    f_h_ << indent_h() << "// Get the message type\n";
+    f_h_ << indent_h() << "yarp::os::Type getType() const;\n";
+    f_h_ << '\n';
+
+    f_cpp_ << indent_cpp() << "// Convert to a printable string\n";
+    f_cpp_ << indent_cpp() << "yarp::os::Type " << name << "::getType() const\n";
+    f_cpp_ << indent_cpp() << "{\n";
+    indent_up_cpp();
+    {
+        f_cpp_ << indent_cpp() << " yarp::os::Type typ = yarp::os::Type::byNameOnWire(typeName);\n";
+        f_cpp_ << indent_cpp() << "typ.setVersion(typeVersion);\n";
+        f_cpp_ << indent_cpp() << " return typ;\n";
     }
     indent_down_cpp();
     f_cpp_ << indent_cpp() << "}\n";

--- a/src/libYARP_dev/src/idl/LaserScan2D.thrift
+++ b/src/libYARP_dev/src/idl/LaserScan2D.thrift
@@ -37,4 +37,6 @@ struct LaserScan2D
 (
     yarp.api.include = "yarp/dev/api.h"
     yarp.api.keyword = "YARP_dev_API"
+    yarp.type.name = "yarp/LaserScan2D"
+    yarp.type.version = "1.0"
 )

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.cpp
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.cpp
@@ -82,6 +82,8 @@ bool LaserScan2D::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool LaserScan2D::write(const yarp::os::idl::WireWriter& writer) const
 {
+    write_type();
+
     if (!write_angle_min(writer)) {
         return false;
     }
@@ -119,6 +121,13 @@ std::string LaserScan2D::toString() const
     yarp::os::Bottle b;
     b.read(*this);
     return b.toString();
+}
+
+yarp::os::Type LaserScan2D::getType() const
+{
+    yarp::os::Type typ = yarp::os::Type::byNameOnWire(typeName);
+    type.setVersion(typeVersion);
+    return typ;
 }
 
 // Editor: default constructor

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.cpp
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.cpp
@@ -82,7 +82,7 @@ bool LaserScan2D::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool LaserScan2D::write(const yarp::os::idl::WireWriter& writer) const
 {
-    write_type();
+    //write_type();
 
     if (!write_angle_min(writer)) {
         return false;
@@ -126,7 +126,7 @@ std::string LaserScan2D::toString() const
 yarp::os::Type LaserScan2D::getType() const
 {
     yarp::os::Type typ = yarp::os::Type::byNameOnWire(typeName);
-    type.setVersion(typeVersion);
+    typ.setVersion(typeVersion);
     return typ;
 }
 

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.h
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/LaserScan2D.h
@@ -79,6 +79,13 @@ public:
     // If you want to serialize this class without nesting, use this helper
     typedef yarp::os::idl::Unwrapped<LaserScan2D> unwrapped;
 
+
+    // The name for this message, ROS will need this
+    static constexpr const char* typeName = "yarp/LaserScan2D";
+    static constexpr const char* typeVersion = "1.0";
+
+    yarp::os::Type getType() const override;
+
     class Editor :
             public yarp::os::Wire,
             public yarp::os::PortWriter

--- a/src/libYARP_os/src/yarp/os/Type.cpp
+++ b/src/libYARP_os/src/yarp/os/Type.cpp
@@ -84,6 +84,7 @@ public:
     Property* prop{nullptr};
     std::string name;
     std::string name_on_wire;
+    std::string version;
 };
 
 
@@ -106,6 +107,21 @@ Type::Type(Type&& rhs) noexcept :
 Type::~Type()
 {
     delete mPriv;
+}
+
+std::string Type::getVersion() const
+{
+    return mPriv->version;
+}
+
+size_t Type::getMajorVersion() const
+{
+    return 1;
+}
+
+size_t Type::getMinorVersion() const
+{
+    return 1;
 }
 
 Type& Type::operator=(const Type& rhs)
@@ -154,9 +170,14 @@ bool Type::hasName() const
     return !mPriv->name.empty();
 }
 
+bool Type::hasVersion() const
+{
+    return !mPriv->version.empty();
+}
+
 bool Type::isValid() const
 {
-    return hasName();
+    return hasName() && hasVersion();
 }
 
 std::string Type::toString() const
@@ -170,6 +191,11 @@ std::string Type::toString() const
     return "null";
 }
 
+Type& Type::setVersion(const std::string& version)
+{
+    mPriv->version = version;
+    return *this;
+}
 
 Type Type::byName(const char* name)
 {

--- a/src/libYARP_os/src/yarp/os/Type.cpp
+++ b/src/libYARP_os/src/yarp/os/Type.cpp
@@ -116,12 +116,18 @@ std::string Type::getVersion() const
 
 size_t Type::getMajorVersion() const
 {
-    return 1;
+    unsigned int major = 0;
+    unsigned int minor = 0;
+    int ret = sscanf(mPriv->version.c_str(),"%u.%u", &major, &minor);
+    return major;
 }
 
 size_t Type::getMinorVersion() const
 {
-    return 1;
+    unsigned int major = 0;
+    unsigned int minor = 0;
+    int ret = sscanf(mPriv->version.c_str(), "%u.%u", &major, &minor);
+    return minor;
 }
 
 Type& Type::operator=(const Type& rhs)
@@ -177,7 +183,11 @@ bool Type::hasVersion() const
 
 bool Type::isValid() const
 {
+#if 0
+    //this should be tested carefully, it could be a breaking change!
     return hasName() && hasVersion();
+#endif
+    return hasName();
 }
 
 std::string Type::toString() const

--- a/src/libYARP_os/src/yarp/os/Type.h
+++ b/src/libYARP_os/src/yarp/os/Type.h
@@ -72,7 +72,15 @@ public:
 
     std::string getNameOnWire() const;
 
+    std::string getVersion() const;
+    
+    size_t getMajorVersion() const;
+    
+    size_t getMinorVersion() const;
+
     bool hasName() const;
+
+    bool hasVersion() const;
 
     bool isValid() const;
 
@@ -83,6 +91,8 @@ public:
     Property& writeProperties();
 
     Type& addProperty(const char* key, const Value& val);
+
+    Type& setVersion(const std::string& vesion);
 
     /** @} */
     /** @{ */


### PR DESCRIPTION
This PR is not yet complete and its intended for discussion only. 
 
I modified the yarp thrift generator to add additional stuff in the generated code of the yarp data types. This will allow a yarp data type to know the name (string) of its own type, and the message type version.  