### PR TITLE
os: Fix reading 64 bits integer

### DIFF
--- a/doc/release/yarp_3_3/fix_fromString_int64.md
+++ b/doc/release/yarp_3_3/fix_fromString_int64.md
@@ -1,0 +1,10 @@
+fix_fronString_int64 {yarp-3.3}
+--------------------
+
+## Libraries
+
+### `os`
+
+#### `Bottle`
+
+* Fixed fromString when reading a 64 bit integer.


### PR DESCRIPTION
## Libraries

### `os`

#### `Bottle`

* Fixed fromString when reading a 64 bit integer.