### PR TITLE
os: Fix infinity and nan writing and reading

### DIFF
--- a/doc/release/yarp_3_3/fix_fromString_inf_nan.md
+++ b/doc/release/yarp_3_3/fix_fromString_inf_nan.md
@@ -1,0 +1,10 @@
+fix_fromString_inf_nan {yarp-3.3}
+----------------------
+
+## Libraries
+
+### `os`
+
+#### `Bottle`
+
+* Fixed toString and fromString when writing or reading infinity or nan.

--- a/doc/release/yarp_3_3/fix_fromString_int64.md
+++ b/doc/release/yarp_3_3/fix_fromString_int64.md
@@ -1,4 +1,4 @@
-fix_fronString_int64 {yarp-3.3}
+fix_fromString_int64 {yarp-3.3}
 --------------------
 
 ## Libraries

--- a/src/libYARP_os/src/yarp/os/impl/BottleImpl.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/BottleImpl.cpp
@@ -93,6 +93,10 @@ void BottleImpl::smartAdd(const std::string& str)
         int signCount = 0;
         bool hasPeriodOrE = false;
         for (size_t i = 0; i < str.length(); i++) {
+            if (str == "inf" || str == "nan") {
+                hasPeriodOrE = true;
+                break;
+            }
             char ch2 = str[i];
             if (ch2 == '.') {
                 hasPeriodOrE = true;
@@ -139,7 +143,7 @@ void BottleImpl::smartAdd(const std::string& str)
         }
 
         if (numberLike &&
-            ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.') &&
+            ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.' || ch == 'i' /* inf */ || ch == 'n' /* nan */) &&
             (ch != '.' || str.length() > 1)) {
             if (!hasPeriodOrE) {
                 s = new StoreInt64(0);

--- a/src/libYARP_os/src/yarp/os/impl/Storable.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/Storable.cpp
@@ -22,6 +22,7 @@
 #include <clocale>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 using yarp::os::Bottle;
 using yarp::os::ConnectionReader;
@@ -90,10 +91,8 @@ inline std::string fp_to_string(T x)
     size_t offset = str.find(lc->decimal_point);
     if (offset != std::string::npos) {
         str[offset] = '.';
-    } else {
-        if (str.find('e') == std::string::npos) {
-            str += ".0";
-        }
+    } else if (str.find('e') == std::string::npos && str != "inf" && str != "nan") {
+        str += ".0";
     }
     return str;
 }
@@ -104,6 +103,12 @@ inline std::string fp_to_string(T x)
 template <typename T>
 inline T fp_from_string(std::string src)
 {
+    if (src == "inf") {
+        return std::numeric_limits<T>::infinity();
+    }
+    if (src == "nan") {
+        return std::numeric_limits<T>::quiet_NaN();
+    }
     // YARP Bug 2526259: Locale settings influence YARP behavior
     // Need to deal with alternate versions of the decimal point.
     size_t offset = src.find('.');
@@ -113,7 +118,8 @@ inline T fp_from_string(std::string src)
     }
     return static_cast<T>(strtod(src.c_str(), nullptr));
 }
-}
+
+} // namespace
 
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Libraries

### `os`

#### `Bottle`

* Fixed toString and fromString when writing or reading infinity or nan.