### PR TITLE
os/Portable: Make copyPortable first argument const

### DIFF
--- a/doc/release/master/copyPortable_const.md
+++ b/doc/release/master/copyPortable_const.md
@@ -1,0 +1,13 @@
+copyPortable_const {master}
+------------------
+
+## Libraries
+
+### `os`
+
+#### `Portable`
+
+* The first argument of `copyPortable` is now `const`. The new signature is:
+  ```
+    bool copyPortable(const PortWriter& writer, PortReader& reader)
+  ```

--- a/src/libYARP_os/src/yarp/os/Portable.cpp
+++ b/src/libYARP_os/src/yarp/os/Portable.cpp
@@ -16,7 +16,7 @@ yarp::os::Type yarp::os::Portable::getType() const
     return getReadType();
 }
 
-bool yarp::os::Portable::copyPortable(yarp::os::PortWriter& writer, yarp::os::PortReader& reader)
+bool yarp::os::Portable::copyPortable(const yarp::os::PortWriter& writer, yarp::os::PortReader& reader)
 {
     yarp::os::DummyConnector con;
     if (!writer.write(con.getWriter())) {

--- a/src/libYARP_os/src/yarp/os/Portable.h
+++ b/src/libYARP_os/src/yarp/os/Portable.h
@@ -40,7 +40,7 @@ public:
      *
      * @return true iff writer.write and reader.read both succeeded.
      */
-    static bool copyPortable(PortWriter& writer, PortReader& reader);
+    static bool copyPortable(const PortWriter& writer, PortReader& reader);
 };
 
 } // namespace os


### PR DESCRIPTION
## Libraries

### `os`

#### `Portable`

* The first argument of `copyPortable` is now `const`. The new signature is:
  ```
    bool copyPortable(const PortWriter& writer, PortReader& reader)
  ```