### PR TITLE
os: Fix negative infinity writing and reading

### DIFF
--- a/doc/release/yarp_3_3/fix_fromString_neg_inf.md
+++ b/doc/release/yarp_3_3/fix_fromString_neg_inf.md
@@ -1,0 +1,10 @@
+fix_fromString_neg_inf {yarp-3.3}
+----------------------
+
+## Libraries
+
+### `os`
+
+#### `Bottle`
+
+* Fixed toString and fromString when writing or reading negative infinity.

--- a/src/libYARP_os/src/yarp/os/impl/BottleImpl.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/BottleImpl.cpp
@@ -93,7 +93,7 @@ void BottleImpl::smartAdd(const std::string& str)
         int signCount = 0;
         bool hasPeriodOrE = false;
         for (size_t i = 0; i < str.length(); i++) {
-            if (str == "inf" || str == "nan") {
+            if (str == "inf" || str == "-inf" || str == "nan") {
                 hasPeriodOrE = true;
                 break;
             }

--- a/src/libYARP_os/src/yarp/os/impl/Storable.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/Storable.cpp
@@ -91,7 +91,7 @@ inline std::string fp_to_string(T x)
     size_t offset = str.find(lc->decimal_point);
     if (offset != std::string::npos) {
         str[offset] = '.';
-    } else if (str.find('e') == std::string::npos && str != "inf" && str != "nan") {
+    } else if (str.find('e') == std::string::npos && str != "inf" && str != "-inf" && str != "nan") {
         str += ".0";
     }
     return str;
@@ -105,6 +105,9 @@ inline T fp_from_string(std::string src)
 {
     if (src == "inf") {
         return std::numeric_limits<T>::infinity();
+    }
+    if (src == "-inf") {
+        return -std::numeric_limits<T>::infinity();
     }
     if (src == "nan") {
         return std::numeric_limits<T>::quiet_NaN();


### PR DESCRIPTION
## Libraries

### `os`

#### `Bottle`

* Fixed toString and fromString when writing or reading negative infinity.