### PR TITLE
yarpdev: Try to find a better name for terminator port

### DIFF
--- a/doc/release/master/yarpdev_quit.md
+++ b/doc/release/master/yarpdev_quit.md
@@ -1,0 +1,11 @@
+yarpdev_quit {#master}
+------------
+
+### Tools
+
+#### `yarpdev`
+
+* The terminator port now tries to use the default value for `--name` accepted
+  by the device.
+  For example `yarpdev --device test_grabber` will open the port `/grabber/quit`
+  instead of `/test_grabber/quit`.


### PR DESCRIPTION
### Tools

#### `yarpdev`

* The terminator port now tries to use the default value for `--name` accepted
  by the device.
  For example `yarpdev --device test_grabber` will open the port `/grabber/quit`
  instead of `/test_grabber/quit`.
----

:warning: This is a very small breaking change

At the moment when yarpdev is started without passing the `--name` parameter, the terminator port is opened as `/<device>/quit`

For example `yarpdev --device test_grabber` opens the following ports:
* `/grabber`
* `/grabber/rpc`
* `/test_grabber/quit`

If instead a `--name /foo` option is passed, it opens the following ports:
* `/foo`
* `/foo/rpc`
* `/foo/quit`

With this change, if the name was not passed, the name used by default is searched inside the options searched by the device. Therefore in the first case the ports opened are:
* `/grabber`
* `/grabber/rpc`
* `/grabber/quit`


