### PR TITLE
yarpview: Checkable menu issue fixed

### DIFF
--- a/doc/release/yarp_3_3/fix_yarpview_save_menu_checks.md
+++ b/doc/release/yarp_3_3/fix_yarpview_save_menu_checks.md
@@ -1,0 +1,10 @@
+fix_yarpview_save_menu_checks {#yarp_3_3}
+---------------
+
+### GUIs
+
+#### `yarpview`
+
+* Now the "checked" state of the two checkable elements in the File menu of "yarpview" 
+  (i.e. "Save single image..." and "Save a set of images...") turns to false when the 
+  corresponding dialogs are closed.

--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -41,8 +41,9 @@ Rectangle {
     signal changeWindowSize(int w, int h)
     signal synchRate(bool check);
     signal autosize(bool check);
-    signal setName(string name)
-
+    signal setName(string name);
+    signal saveSetClosed(bool check);
+    signal saveSingleClosed(bool check);
 
     /*********Connections*********/
     Connections{
@@ -365,6 +366,10 @@ Rectangle {
         signal stopSavingFrameSet()
         signal setFileName(url fileName)
 
+        onClosing: {
+            saveSetClosed(false);
+        }
+
         function save(){
             saveFrameSet()
         }
@@ -450,6 +455,10 @@ Rectangle {
 
         signal saveFrame()
         signal setFileName(url fileName)
+
+        onClosing: {
+            saveSingleClosed(false);
+        }
 
         function save(){
             saveFrame()

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -48,6 +48,22 @@ MenuBar {
             autosizeItem.checked = false
         }
     }
+
+    // NB: This is not the best solution but the fastest one.
+    /*!
+      \brief Changes the "saveSingle" menu checked state
+      \param checked Bollean: Whether or not the menu item has to be checked
+      */
+    function saveSingleChecked(checked){
+        saveSingle.checked = checked;
+    }
+    /*!
+      \brief Changes the "saveSet" menu checked state
+      \param checked Bollean: Whether or not the menu item has to be checked
+      */
+    function saveSetChecked(checked){
+        saveSet.checked = checked;
+    }
     
     Menu {
 

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -85,6 +85,12 @@ ApplicationWindow {
         onSetName:{
             statusBar.setName(name)
         }
+        onSaveSetClosed:{
+            menu.saveSetChecked(check);
+        }
+        onSaveSingleClosed:{
+            menu.saveSingleChecked(check);
+        }
     }
 
     Connections{


### PR DESCRIPTION
Now the "checked" state of the two checkable elements in the File menu
of "yarpview" (i.e. "Save single image..." and "Save a set of
images...") turns to false when the corresponding dialogs are closed.