### PR TITLE
Remove executable path from port name from LogForwarder and yarprun

### DIFF
--- a/doc/release/master/LogForwarder_path.md
+++ b/doc/release/master/LogForwarder_path.md
@@ -1,0 +1,19 @@
+LogForwarder_path {#master}
+-----------------
+
+### Libraries
+
+#### `os`
+
+##### `Log`
+
+* The name of the port used to forward the output no longer contains the full
+  path, but only the executable name.
+
+
+### Tools
+
+#### `yarprun`
+
+* The name of the port used to forward the output no longer contains the full
+  path, but only the executable name.

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
@@ -33,7 +33,7 @@ yarp::os::impl::LogForwarder::LogForwarder()
     yarp::os::SystemInfo::ProcessInfo processInfo = yarp::os::SystemInfo::getProcessInfo();
 
     outputPort.setWriteOnly();
-    std::string logPortName = "/log/" + std::string(hostname) + "/" + processInfo.name + "/" + std::to_string(processInfo.pid);
+    std::string logPortName = "/log/" + std::string(hostname) + "/" + processInfo.name.substr(processInfo.name.find_last_of("\\/") + 1) + "/" + std::to_string(processInfo.pid);
     if (!outputPort.open(logPortName)) {
         printf("LogForwarder error while opening port %s\n", logPortName.c_str());
     }

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -544,9 +544,9 @@ int yarp::run::Run::server()
                     std::string strAlias=msg.find("as").asString();
                     std::string portName="/log";
                     portName+=mPortName+"/";
-                    std::string command=msg.findGroup("cmd").get(1).asString();
-                    int space=command.find(" ");
-                    if (space!=std::string::npos) command=command.substr(0, space);
+                    std::string command = msg.findGroup("cmd").get(1).asString();
+                    command = command.substr(0, command.find(' '));
+                    command = command.substr(command.find_last_of("\\/") + 1);
                     portName+=command;
 
                     yarp::os::Bottle botFwd;
@@ -1041,9 +1041,9 @@ int yarp::run::Run::server()
                         std::string strAlias=msg.find("as").asString();
                         std::string portName="/log";
                         portName+=mPortName+"/";
-                        std::string command=msg.findGroup("cmd").get(1).asString();
-                        size_t space=command.find(' ');
-                        if (space!=std::string::npos) command=command.substr(0, space);
+                        std::string command = msg.findGroup("cmd").get(1).asString();
+                        command = command.substr(0, command.find(' '));
+                        command = command.substr(command.find_last_of("\\/") + 1);
                         portName+=command;
 
                         yarp::os::Bottle botFwd;
@@ -1929,9 +1929,9 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
     std::string strAlias=msg.find("as").asString();
     std::string portName="/log";
     portName+=mPortName+"/";
-    std::string command=msg.findGroup("cmd").get(1).asString();
-    int space=command.find(" ");
-    if (space!=std::string::npos) command=command.substr(0, space);
+    std::string command = msg.findGroup("cmd").get(1).asString();
+    command = command.substr(0, command.find(' '));
+    command = command.substr(command.find_last_of("\\/") + 1);
     portName+=command;
 
     // PIPES
@@ -2869,11 +2869,10 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
     std::string portName="/log";
     portName+=mPortName+"/";
 
-    std::string command=strCmd;
-    size_t space=command.find(' ');
-    if (space != std::string::npos) {
-        command=command.substr(0, space);
-    }
+    std::string command = strCmd;
+    command = command.substr(0, command.find(' '));
+    command = command.substr(command.find_last_of("\\/") + 1);
+
     portName+=command;
 
 


### PR DESCRIPTION

### Libraries

#### `os`

##### `Log`

* The name of the port used to forward the output no longer contains the full
  path, but only the executable name.


### Tools

#### `yarprun`

* The name of the port used to forward the output no longer contains the full
  path, but only the executable name.