### PR TITLE
os: Add gethostname overload to return a std::string

### DIFF
--- a/doc/release/master/gethostname_string.md
+++ b/doc/release/master/gethostname_string.md
@@ -1,0 +1,8 @@
+gethostname_string {#master}
+------------------
+
+### Libraries
+
+#### `os`
+
+* Add `gethostname()` overload to return a `std::string`

--- a/src/libYARP_os/src/yarp/os/Os.cpp
+++ b/src/libYARP_os/src/yarp/os/Os.cpp
@@ -9,10 +9,11 @@
 
 #include <yarp/os/Os.h>
 #include <yarp/os/impl/NameConfig.h>
+#include <yarp/os/impl/PlatformLimits.h>
 #include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformSysStat.h>
 #include <yarp/os/impl/PlatformUnistd.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -101,6 +102,13 @@ void yarp::os::gethostname(char* hostname, size_t size)
     if (std::strlen(hostname) == 0) {
         std::strncpy(hostname, "no_hostname", size);
     }
+}
+
+std::string yarp::os::gethostname()
+{
+    char hostname[HOST_NAME_MAX];
+    yarp::os::gethostname(hostname, HOST_NAME_MAX);
+    return {hostname};
 }
 
 char* yarp::os::getcwd(char* buf, size_t size)

--- a/src/libYARP_os/src/yarp/os/Os.h
+++ b/src/libYARP_os/src/yarp/os/Os.h
@@ -13,6 +13,7 @@
 #include <yarp/os/api.h>
 
 #include <cstddef>
+#include <string>
 
 
 namespace yarp {
@@ -47,6 +48,15 @@ YARP_os_API int getpid();
  * @param size The size of the @c hostname array
  */
 YARP_os_API void gethostname(char* hostname, size_t size);
+
+/**
+ * @brief Portable wrapper for the gethostname() function.
+ *
+ * Returns the hostname as string
+ *
+ * @return hostname the system hostname
+ */
+YARP_os_API std::string gethostname();
 
 /**
  * @brief Portable wrapper for the mkdir() function.


### PR DESCRIPTION
### Libraries

#### `os`

* Add `gethostname()` overload to return a `std::string`