### PR TITLE
companion: Add yarp env command

### DIFF
--- a/doc/release/master/companion_env.md
+++ b/doc/release/master/companion_env.md
@@ -1,0 +1,9 @@
+companion_env {#master}
+-------------
+
+### Tools
+
+#### `yarp`
+
+* Added new `env` subcommand to print one or the full list of environment
+  variables.

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -15,7 +15,9 @@ set(YARP_companion_SRCS )
 
 set(YARP_companion_IMPL_HDRS yarp/companion/impl/Companion.h)
 
-set(YARP_companion_IMPL_SRCS yarp/companion/impl/Companion.cpp yarp/companion/impl/Companion.qos.cpp)
+set(YARP_companion_IMPL_SRCS yarp/companion/impl/Companion.cpp
+                             yarp/companion/impl/Companion.env.cpp
+                             yarp/companion/impl/Companion.qos.cpp)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
              PREFIX "Source Files"

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -286,6 +286,7 @@ Companion::Companion() :
     add("connect",         &Companion::cmdConnect,        "create a connection between two ports");
     add("detect",          &Companion::cmdDetect,         "search for the yarp name server");
     add("disconnect",      &Companion::cmdDisconnect,     "remove a connection between two ports");
+    add("env",             &Companion::cmdEnv,            "print the value of environment variables");
     add("exists",          &Companion::cmdExists,         "check if a port or connection is alive");
     add("help",            &Companion::cmdHelp,           "get this list");
     add("merge",           &Companion::cmdMerge,          "concatenate input from several ports into a single unit");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.env.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.env.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/SystemClock.h>
+
+#include <yarp/companion/impl/Companion.h>
+
+using yarp::companion::impl::Companion;
+
+extern char** environ;
+
+int Companion::cmdEnv(int argc, char* argv[])
+{
+    auto cmdEnv_usage = []() {
+        yCInfo(COMPANION, "Print the value of environment variables.");
+        yCInfo(COMPANION);
+        yCInfo(COMPANION, "Usage:");
+        yCInfo(COMPANION, "yarp env [variable]");
+    };
+
+    if (argc > 1) {
+        cmdEnv_usage();
+        return EXIT_FAILURE;
+    }
+
+    std::string var;
+    if (argc == 1) {
+        var = argv[0];
+        if (var == "--help") {
+            cmdEnv_usage();
+            return EXIT_SUCCESS;
+        }
+    }
+
+    char* s = *environ;
+    for (int i = 1; s; i++) {
+        std::string tmp(s);
+        std::string key;
+        std::string value;
+        size_t equalsSign = tmp.find('=');
+        if (equalsSign != std::string::npos) {
+            key = tmp.substr(0, equalsSign);
+            value = tmp.substr(equalsSign + 1);
+        } else {
+            yCWarning(COMPANION, "Cannot parse environment variable '%s'", tmp.c_str());
+        }
+
+        if (var.empty() || var == key) {
+            yCInfo(COMPANION, "%s", s);
+            if (!var.empty()) {
+                yarp::os::SystemClock::delaySystem(2);
+                return EXIT_SUCCESS;
+            }
+        }
+
+        s = *(environ + i);
+    }
+
+    yarp::os::SystemClock::delaySystem(2);
+
+    if (!var.empty()) {
+        yCWarning(COMPANION, "Could not find environment variable '%s'", var.c_str());
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -170,6 +170,8 @@ public:
 
     int cmdClock(int argc, char *argv[]);
 
+    int cmdEnv(int argc, char *argv[]);
+
     int cmdPray(int argc, char *argv[]);
 
 private:


### PR DESCRIPTION
### Tools

#### `yarp`

* Added new `env` subcommand to print one or the full list of environment variables.

This is could be useful, for example, for debugging the values of the environment variables for programs executed remotely using yarprun.

Depends on #2273