### PR TITLE
Improvements to Yarp .map files

### DIFF
--- a/doc/release/master/featureMapGrid2DOrigin.md
+++ b/doc/release/master/featureMapGrid2DOrigin.md
@@ -1,0 +1,11 @@
+MapGrid2DOrigin {#master}
+-----------------
+
+### Libraries
+
+#### `dev`
+
+* The format of .map file loaded by `MapGrid2D` has been changed. It can now include the parameters `resolution <double>` and 
+  `orientation <bottle>` to adjust the map reference frame.
+  
+* `MapGrid2DOrigin` can now handle a generic orientation. Previously only the trasnslational part was handled by methods `world2Cell` and `cell2World`

--- a/src/libYARP_dev/src/yarp/dev/MapGrid2D.h
+++ b/src/libYARP_dev/src/yarp/dev/MapGrid2D.h
@@ -68,6 +68,7 @@ namespace yarp
                 bool loadMapROSOnly(std::string ros_yaml_filename);
                 bool loadROSParams(std::string ros_yaml_filename, std::string& pgm_occ_filename, double& resolution, double& orig_x, double& orig_y, double& orig_t);
                 bool loadMapYarpAndRos(std::string yarp_img_filename, std::string ros_yaml_filename);
+                bool parseMapParameters(const yarp::os::Property& mapfile);
 
             public:
                 MapGrid2D();

--- a/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.cpp
+++ b/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.cpp
@@ -6,6 +6,9 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define _USE_MATH_DEFINES
+
+#include <cmath>
 #include <yarp/dev/MapGrid2DInfo.h>
 
 using namespace yarp::dev;
@@ -15,6 +18,10 @@ using namespace yarp::os;
 using namespace yarp::math;
 using namespace std;
 
+#ifndef DEG2RAD
+#define DEG2RAD M_PI/180.0
+#endif
+
 MapGrid2DOrigin::MapGrid2DOrigin()
 {
     x = 0;
@@ -22,12 +29,29 @@ MapGrid2DOrigin::MapGrid2DOrigin()
     theta = 0;
 }
 
-MapGrid2DOrigin::MapGrid2DOrigin(double x_init, double y_init, double t_init)
+void MapGrid2DOrigin::setOrigin(double x_init, double y_init, double t_init)
 {
     x = x_init;
     y = y_init;
-    theta = t_init;
+    theta = fmod(t_init, 360.0);
+    sa = sin (theta * DEG2RAD);
+    ca = cos (theta * DEG2RAD);
 }
+
+MapGrid2DOrigin::MapGrid2DOrigin(double x_init, double y_init, double t_init)
+{
+    setOrigin(x_init,  y_init,  t_init);
+}
+
+bool MapGrid2DOrigin::operator != (const MapGrid2DOrigin& other) const
+{
+    if (x != other.x) return true;
+    if (y != other.y) return true;
+    if (theta != other.theta) return true; //should I check for 360 wrap?
+    return false;
+}
+
+//--------------------------------------------------------------------
 
 MapGrid2DInfo::MapGrid2DInfo()
 {
@@ -42,21 +66,30 @@ XYWorld MapGrid2DInfo::cell2World(XYCell cell) const
 {
     //convert a cell (from the upper-left corner) to the map reference frame (located in m_origin, measured in meters)
     //beware: the location of m_origin is referred to the lower-left corner (ROS convention)
-    XYWorld v;
-    v.x = double(cell.x) * this->m_resolution;
-    v.y = double(cell.y) * this->m_resolution;
-    v.x = +v.x + m_origin.x + 0 * this->m_resolution;
-    v.y = -v.y + m_origin.y + (m_height - 1) * this->m_resolution;
-    return v;
+    XYWorld v1;
+    XYWorld v2;
+    v1.x = double(cell.x) * this->m_resolution;
+    v1.y = double(cell.y) * this->m_resolution;
+    v1.x = +v1.x + m_origin.get_x() + 0 * this->m_resolution;
+    v1.y = -v1.y + m_origin.get_y() + (m_height - 1) * this->m_resolution;
+    //note that in the following operation, we are using -get_sa()
+    //this is an optimization, since sin(-a)=-sin(a) and cos(-a)=cos(a)
+    //we need -a instead of a because of we are using the inverse tranformation respect to world2cell
+    v2.x = v1.x *  m_origin.get_ca() - v1.y * -m_origin.get_sa();
+    v2.y = v1.x * -m_origin.get_sa() + v1.y *  m_origin.get_ca();
+    return v2;
 }
 
 XYCell MapGrid2DInfo::world2Cell(XYWorld world) const
 {
     //convert a world location (wrt the map reference frame located in m_origin, measured in meters), to a cell from the upper-left corner.
     //beware: the location of m_origin is referred to the lower-left corner (ROS convention)
+    XYWorld world2;
+    world2.x = world.x * m_origin.get_ca() - world.y * m_origin.get_sa();
+    world2.y = world.x * m_origin.get_sa() + world.y * m_origin.get_ca();
+    int x = int((+world2.x - this->m_origin.get_x()) / this->m_resolution) + 0;
+    int y = int((-world2.y + this->m_origin.get_y()) / this->m_resolution) + m_height - 1;
     XYCell c;
-    int x = int((+world.x - this->m_origin.x) / this->m_resolution) + 0;
-    int y = int((-world.y + this->m_origin.y) / this->m_resolution) + m_height - 1;
     c.x = (x < 0) ? 0 : x;
     c.y = (y < 0) ? 0 : y;
     c.x = (c.x >= m_width) ? m_width-1 : c.x;
@@ -68,9 +101,12 @@ XYCell MapGrid2DInfo::world2Cell_unsafeFast(XYWorld world) const
 {
     //convert a world location (wrt the map reference frame located in m_origin, measured in meters), to a cell from the upper-left corner.
     //beware: the location of m_origin is referred to the lower-left corner (ROS convention)
+    XYWorld world2;
+    world2.x = world.x * m_origin.get_ca() - world.y * m_origin.get_sa();
+    world2.y = world.x * m_origin.get_sa() + world.y * m_origin.get_ca();
     XYCell c;
-    c.x = int((+world.x - this->m_origin.x) / this->m_resolution) + 0;
-    c.y = int((-world.y + this->m_origin.y) / this->m_resolution) + m_height - 1;
+    c.x = int((+world2.x - this->m_origin.get_x()) / this->m_resolution) + 0;
+    c.y = int((-world2.y + this->m_origin.get_y()) / this->m_resolution) + m_height - 1;
     return c;
 }
 

--- a/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.h
+++ b/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.h
@@ -30,12 +30,24 @@ namespace yarp
         {
             class YARP_dev_API MapGrid2DOrigin
             {
+            private:
+                double sa;
+                double ca;
+            private:
+                double x;     ///< in meters
+                double y;     ///< in meters
+                double theta; ///< in degrees
             public:
                 MapGrid2DOrigin();
                 MapGrid2DOrigin(double x_init, double y_init, double t_init);
-                double x;     ///< in meters
-                double y;     ///< in meters
-                double theta; ///< in radians
+                inline double get_x() const     { return x; }
+                inline double get_y() const     { return y; }
+                inline double get_theta() const { return theta; }
+                void   setOrigin(double x_init, double y_init, double t_init);
+                bool operator != (const MapGrid2DOrigin& other) const;
+            public:
+                inline double get_ca() const { return ca; }
+                inline double get_sa() const { return sa; }
             };
 
             class YARP_dev_API MapGrid2DInfo


### PR DESCRIPTION
* The format of .map file loaded by `MapGrid2D` has been changed. It can now include the parameters `resolution <double>` and 
  `orientation <bottle>` to adjust the map reference frame.
  
* `MapGrid2DOrigin` can now handle a generic orientation. Previously only the trasnslational part was handled by methods `world2Cell` and `cell2World`