### PR TITLE
os/ResourceFinder: Port to the new logging system

### DIFF
--- a/bindings/lua/examples/example.lua
+++ b/bindings/lua/examples/example.lua
@@ -14,7 +14,6 @@ require("yarp")
 yarp.Network()
 
 local rf = yarp.ResourceFinder()
-rf:setVerbose(true)
 rf:setDefaultContext("myContext")
 rf:setDefaultConfigFile("default.ini")
 rf:configure(arg)

--- a/bindings/lua/tests/test_resource_finder.lua
+++ b/bindings/lua/tests/test_resource_finder.lua
@@ -13,7 +13,6 @@ function test_resource_finder()
   yarp.Network()
 
   local rf = yarp.ResourceFinder()
-  rf:setVerbose(true)
   rf:setDefaultContext("myContext")
   rf:setDefaultConfigFile("default.ini")
   rf:configure(arg)

--- a/bindings/python/examples/example.py
+++ b/bindings/python/examples/example.py
@@ -12,7 +12,6 @@ import yarp
 yarp.Network.init()
 
 rf = yarp.ResourceFinder()
-rf.setVerbose(True);
 rf.setDefaultContext("myContext");
 rf.setDefaultConfigFile("default.ini");
 

--- a/doc/release/master/log_refactor_ResourceFinder.md
+++ b/doc/release/master/log_refactor_ResourceFinder.md
@@ -1,0 +1,11 @@
+log_refactor_ResourceFinder {#master}
+---------------------------
+
+### Libraries
+
+#### `os`
+
+##### `ResourceFinder`
+
+* The methods `setVerbose()` and `setQuiet()` are now deprecated in favour of
+  Log Components

--- a/doc/resource_finder_advanced.dox
+++ b/doc/resource_finder_advanced.dox
@@ -34,7 +34,6 @@ The main function will be something like:
 
 \code
 ResourceFinder rf;
-rf.setVerbose();
 rf.setDefaultConfigFile("or.ini");
 rf.configure(argc, argv);
 \endcode

--- a/doc/resource_finder_basic.dox
+++ b/doc/resource_finder_basic.dox
@@ -89,7 +89,6 @@ But first let's provide the ResourceFinder with a default configuration file so 
 
 ~~~{.cpp}
 ResourceFinder rf;
-rf.setVerbose(); //logs searched directories
 rf.setDefaultConfigFile("config.ini"); //specifies a default configuration file
 rf.configure(argc, argv);
 ~~~

--- a/doc/resource_finder_installation.dox
+++ b/doc/resource_finder_installation.dox
@@ -24,7 +24,6 @@ We defined a default initialization context, i.e., "randomMotion", for the modul
 
 ~~~{.cpp}
 ResourceFinder rf;
-rf.setVerbose();
 rf.setDefaultConfigFile("config.ini");
 rf.setDefaultContext("randomMotion");
 rf.configure(argc, argv);

--- a/doc/thrift_tutorial.dox
+++ b/doc/thrift_tutorial.dox
@@ -434,7 +434,6 @@ int main(int argc, char *argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc, argv);
 
     DemoServerModule demoMod;

--- a/doc/thrift_tutorial_simple.dox
+++ b/doc/thrift_tutorial_simple.dox
@@ -299,7 +299,6 @@ int main(int argc, char *argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc, argv);
 
     DemoServerModule demoMod;

--- a/example/idl/thrift/userImpl/DemoServerModule.cpp
+++ b/example/idl/thrift/userImpl/DemoServerModule.cpp
@@ -99,7 +99,6 @@ int main(int argc, char* argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc, argv);
 
     DemoServerModule demoMod;

--- a/example/idl/thriftSimple/DemoServerModule.cpp
+++ b/example/idl/thriftSimple/DemoServerModule.cpp
@@ -147,7 +147,6 @@ int main(int argc, char* argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc, argv);
 
     DemoServerModule demoMod;

--- a/example/os/image_process_module.cpp
+++ b/example/os/image_process_module.cpp
@@ -83,7 +83,6 @@ int main(int argc, char *argv[]) {
     /* prepare and configure the resource finder */
     ResourceFinder rf;
     rf.configure(argc, argv);
-    rf.setVerbose(true);
 
     // Create and run our module
     ImageProcessModule module;

--- a/example/resourceFinder/tutorial_rf_advanced.cpp
+++ b/example/resourceFinder/tutorial_rf_advanced.cpp
@@ -21,7 +21,6 @@ int main(int argc, char *argv[])
     Network yarp;
 
     ResourceFinder rf;
-    rf.setVerbose();
     rf.setDefaultConfigFile("or.ini");
     rf.setDefaultContext("orBottle");
     rf.configure(argc, argv);

--- a/example/resourceFinder/tutorial_rf_basic.cpp
+++ b/example/resourceFinder/tutorial_rf_basic.cpp
@@ -21,7 +21,6 @@ int main(int argc, char *argv[])
     Network yarp;
 
     ResourceFinder rf;
-    rf.setVerbose();
     rf.setDefaultConfigFile("config.ini");
     rf.setDefaultContext("randomMotion");
     rf.configure(argc, argv);

--- a/example/rfmodule/main.cpp
+++ b/example/rfmodule/main.cpp
@@ -82,7 +82,6 @@ int main(int argc, char * argv[])
     // prepare and configure the resource finder
     yarp::os::ResourceFinder rf;
     rf.configure(argc, argv);
-    rf.setVerbose(true);
 
     std::cout << "Configuring and starting module.\n";
     // This calls configure(rf) and, upon success, the module execution begins with a call to updateModule()

--- a/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
+++ b/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
@@ -42,7 +42,6 @@ bool fakeNavigation :: open(yarp::os::Searchable& config)
     if (config.check("from")) file_name    = config.find("from").asString();
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.setDefaultContext(context_name.c_str());
     rf.setDefaultConfigFile(file_name.c_str());
 

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -145,7 +145,6 @@ bool RpLidar::open(yarp::os::Searchable& config)
 
     Property prop;
     ResourceFinder rf;
-    rf.setVerbose();
     std::string serial_completefilename= rf.findFileByName(serial_filename);
 
     prop.put("device", "serialport");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -1399,7 +1399,12 @@ int Companion::cmdResource(int argc, char *argv[]) {
         return 0;
     }
     ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose();
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
     Property p;
     p.fromCommand(argc, argv, false);
     if (p.check("find")) {

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.h
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.h
@@ -40,9 +40,8 @@ public:
 
     const ResourceFinder& operator=(const ResourceFinder& alt);
 
-
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
-     *
      * Request that information be printed to the console on how
      * resources are being found.  This is especially useful to
      * understand why resources are *not* found or the wrong resource
@@ -51,12 +50,11 @@ public:
      * @param verbose set/suppress printing of information
      *
      * @return true iff information will be printed
-     *
+     * @deprecated since YARP 3.4
      */
     bool setVerbose(bool verbose = true);
 
     /**
-     *
      * Request that information be suppressed from the console.  By
      * default ResourceFinder will print messages if it fails to find
      * files, for example.
@@ -64,9 +62,10 @@ public:
      * @param quiet suppress printing of information
      *
      * @return true iff information will be suppressed
-     *
+     * @deprecated since YARP 3.4
      */
     bool setQuiet(bool quiet = true);
+#endif // YARP_NO_DEPRECATED
 
     /**
      * Sets up the ResourceFinder.

--- a/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
+++ b/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
@@ -181,7 +181,6 @@ void YarpPluginSelector::scan()
     if (!rf.isConfigured()) {
         rf.configure(0, nullptr);
     }
-    rf.setQuiet(true);
     Bottle plugin_paths = rf.findPaths("plugins");
     if (plugin_paths.size() == 0) {
         plugin_paths = rf.findPaths("share/yarp/plugins");

--- a/src/libYARP_robottestingframework/src/yarp/robottestingframework/TestCase.cpp
+++ b/src/libYARP_robottestingframework/src/yarp/robottestingframework/TestCase.cpp
@@ -54,7 +54,6 @@ bool yarp::robottestingframework::TestCase::setup(int argc, char** argv)
     // load the config file and update the environment if available
     // E.g., "--from mytest.ini"
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(false);
     if(useSuiteContext) {
         rf.setDefaultContext(envprop.find("context").asString().c_str());
     } else {

--- a/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -42,7 +42,6 @@ bool YarpFixManager::setup(int argc, char** argv) {
         // load the config file and update the environment if available
         // E.g., "--application myapp.xml"
         yarp::os::ResourceFinder rf;
-        rf.setVerbose(false);
         rf.setDefaultContext("RobotTesting");
         rf.configure(argc, argv, false);
 

--- a/src/yarp-config/yarpcontext.cpp
+++ b/src/yarp-config/yarpcontext.cpp
@@ -46,8 +46,14 @@ int yarp_context_main(int argc, char *argv[]) {
     }
     if (options.check("list")) {
         yarp::os::ResourceFinder rf;
-        if (options.check("verbose"))
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+        if (options.check("verbose")) {
             rf.setVerbose(true);
+        }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
         if(options.check("user") || options.check("sysadm") || options.check("installed"))
         {
             if (options.check("user"))
@@ -69,18 +75,31 @@ int yarp_context_main(int argc, char *argv[]) {
     if(options.check("import"))
     {
         Bottle importArg=options.findGroup("import");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return import(importArg, CONTEXTS, options.check("verbose"));
+#else
+        return import(importArg, CONTEXTS);
+#endif
     }
 
     if(options.check("import-all"))
     {
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return importAll(CONTEXTS, options.check("verbose"));
+#else
+        return importAll(CONTEXTS);
+#endif
     }
 
     if(options.check("remove"))
     {
         Bottle removeArg=options.findGroup("remove");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return remove(removeArg, CONTEXTS, options.check("verbose"));
+#else
+        return remove(removeArg, CONTEXTS);
+#endif
+
     }
 
     if(options.check("where"))
@@ -103,8 +122,14 @@ int yarp_context_main(int argc, char *argv[]) {
                 opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Installed);
         }
         yarp::os::ResourceFinder rf;
-        if (options.check("verbose"))
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+        if (options.check("verbose")) {
             rf.setVerbose(true);
+        }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
         yarp::os::Bottle paths=rf.findPaths(std::string("contexts") + PATH_SEPARATOR +contextName, opts);
         for (size_t curCont=0; curCont<paths.size(); ++curCont)
             printf("%s\n", paths.get(curCont).asString().c_str());
@@ -141,16 +166,28 @@ int yarp_context_main(int argc, char *argv[]) {
             printf("No context name provided\n");
             return 0;
         }
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return diff(contextName, CONTEXTS, options.check("verbose"));
+#else
+        return diff(contextName, CONTEXTS);
+#endif
     }
     if(options.check("diff-list"))
     {
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return diffList(CONTEXTS, options.check("verbose"));
+#else
+        return diffList(CONTEXTS);
+#endif
     }
     if(options.check("merge"))
     {
         Bottle mergeArg=options.findGroup("merge");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return merge(mergeArg, CONTEXTS, options.check("verbose"));
+#else
+        return merge(mergeArg, CONTEXTS);
+#endif
     }
     yarp_context_help();
     return 1;

--- a/src/yarp-config/yarpcontextutils.cpp
+++ b/src/yarp-config/yarpcontextutils.cpp
@@ -595,8 +595,11 @@ int recursiveMerge(std::string srcDirName, std::string destDirName, std::string 
     return (ok ? 0 : 1);//tbm
 }
 
-
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int import(yarp::os::Bottle& importArg, folderType fType, bool verbose)
+#else
+int import(yarp::os::Bottle& importArg, folderType fType)
+#endif
 {
     std::string contextName;
     if (importArg.size() >1)
@@ -607,7 +610,12 @@ int import(yarp::os::Bottle& importArg, folderType fType, bool verbose)
         return 0;
     }
     yarp::os::ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose(verbose);
+YARP_WARNING_POP
+#endif
     ResourceFinderOptions opts;
     opts.searchLocations = ResourceFinderOptions::Installed;
     std::string originalpath = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(contextName), opts);
@@ -670,10 +678,19 @@ int import(yarp::os::Bottle& importArg, folderType fType, bool verbose)
     }
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int importAll(folderType fType, bool verbose)
+#else
+int importAll(folderType fType)
+#endif
 {
     yarp::os::ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose(verbose);
+YARP_WARNING_POP
+#endif
 
     prepareHomeFolder(rf, fType);
     ResourceFinderOptions opts;
@@ -716,7 +733,11 @@ int importAll(folderType fType, bool verbose)
     return 0;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int remove(yarp::os::Bottle& removeArg, folderType fType, bool verbose)
+#else
+int remove(yarp::os::Bottle& removeArg, folderType fType)
+#endif
 {
     std::string contextName;
     if (removeArg.size() >1)
@@ -727,7 +748,12 @@ int remove(yarp::os::Bottle& removeArg, folderType fType, bool verbose)
         return 0;
     }
     yarp::os::ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose(verbose);
+YARP_WARNING_POP
+#endif
     ResourceFinderOptions opts;
     opts.searchLocations = ResourceFinderOptions::User;
     std::string targetPath = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(contextName), opts);
@@ -813,10 +839,19 @@ int remove(yarp::os::Bottle& removeArg, folderType fType, bool verbose)
     }
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int diff(std::string contextName, folderType fType, bool verbose)
+#else
+int diff(std::string contextName, folderType fType)
+#endif
 {
     yarp::os::ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose(verbose);
+YARP_WARNING_POP
+#endif
 
     ResourceFinderOptions opts;
     opts.searchLocations = ResourceFinderOptions::User;
@@ -844,7 +879,11 @@ int diff(std::string contextName, folderType fType, bool verbose)
 #endif
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int diffList(folderType fType, bool verbose)
+#else
+int diffList(folderType fType)
+#endif
 {
     yarp::os::ResourceFinder rf;
     ResourceFinderOptions opts;
@@ -858,7 +897,12 @@ int diffList(folderType fType, bool verbose)
         {
             ostream tmp(nullptr);
             opts.searchLocations = ResourceFinderOptions::User;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
             rf.setQuiet();
+YARP_WARNING_POP
+#endif
             std::string userPath = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(subDir), opts);
             if (userPath == "")
                 continue;
@@ -877,7 +921,11 @@ int diffList(folderType fType, bool verbose)
     return 0;
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
 int merge(yarp::os::Bottle& mergeArg, folderType fType, bool verbose)
+#else
+int merge(yarp::os::Bottle& mergeArg, folderType fType)
+#endif
 {
     std::string contextName;
     if (mergeArg.size() >1)
@@ -888,7 +936,12 @@ int merge(yarp::os::Bottle& mergeArg, folderType fType, bool verbose)
         return 0;
     }
     yarp::os::ResourceFinder rf;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
     rf.setVerbose(verbose);
+YARP_WARNING_POP
+#endif
 
     if (mergeArg.size() >2)
     {

--- a/src/yarp-config/yarpcontextutils.h
+++ b/src/yarp-config/yarpcontextutils.h
@@ -41,11 +41,20 @@ int fileMerge(std::string srcFileName, std::string destFileName, std::string com
 int recursiveMerge(std::string srcDirName, std::string destDirName, std::string commonParentName, std::ostream &output=std::cout);
 
 //actual commands:
+#ifndef YARP_NO_DEPRECATED
 int import(yarp::os::Bottle& importArg, folderType fType, bool verbose=false);
 int importAll(folderType fType, bool verbose=false);
 int remove(yarp::os::Bottle& removeArg, folderType fType, bool verbose=false);
 int diff(std::string contextName, folderType fType, bool verbose=false);
 int diffList(folderType fType, bool verbose=false);
 int merge(yarp::os::Bottle& mergeArg, folderType fType, bool verbose=false);
+#else
+int import(yarp::os::Bottle& importArg, folderType fType);
+int importAll(folderType fType);
+int remove(yarp::os::Bottle& removeArg, folderType fType);
+int diff(std::string contextName, folderType fType);
+int diffList(folderType fType);
+int merge(yarp::os::Bottle& mergeArg, folderType fType);
+#endif
 
 #endif // YARPCONTEXTUTILS_H

--- a/src/yarp-config/yarprobot.cpp
+++ b/src/yarp-config/yarprobot.cpp
@@ -44,8 +44,14 @@ int yarp_robot_main(int argc, char *argv[]) {
     }
     if (options.check("list")) {
         yarp::os::ResourceFinder rf;
-        if (options.check("verbose"))
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+        if (options.check("verbose")) {
             rf.setVerbose(true);
+        }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
         if(options.check("user") || options.check("sysadm") || options.check("installed"))
         {
             if (options.check("user"))
@@ -67,20 +73,31 @@ int yarp_robot_main(int argc, char *argv[]) {
     if(options.check("import"))
     {
         Bottle importArg=options.findGroup("import");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return import(importArg, ROBOTS, options.check("verbose"));
+#else
+        return import(importArg, ROBOTS);
+#endif
     }
 
     if(options.check("import-all-robots"))
     {
-
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return importAll(ROBOTS, options.check("verbose"));
+#else
+        return importAll(ROBOTS);
+#endif
     }
 
     if(options.check("remove"))
     {
 
         Bottle removeArg=options.findGroup("remove");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return remove(removeArg, ROBOTS, options.check("verbose"));
+#else
+        return remove(removeArg, ROBOTS);
+#endif
     }
 
     if(options.check("where"))
@@ -103,8 +120,15 @@ int yarp_robot_main(int argc, char *argv[]) {
                 opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Installed);
         }
         yarp::os::ResourceFinder rf;
-        if (options.check("verbose"))
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
+        if (options.check("verbose")) {
             rf.setVerbose(true);
+        }
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
+
         yarp::os::Bottle paths=rf.findPaths(std::string("robots") + PATH_SEPARATOR +contextName, opts);
         for (size_t curCont=0; curCont<paths.size(); ++curCont)
             printf("%s\n", paths.get(curCont).asString().c_str());
@@ -151,16 +175,28 @@ int yarp_robot_main(int argc, char *argv[]) {
             printf("No robot name provided\n");
             return 0;
         }
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return diff(contextName, ROBOTS, options.check("verbose"));
+#else
+        return diff(contextName, ROBOTS);
+#endif
     }
     if(options.check("diff-list"))
     {
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return diffList(ROBOTS, options.check("verbose"));
+#else
+        return diffList(ROBOTS);
+#endif
     }
     if(options.check("merge"))
     {
         Bottle mergeArg=options.findGroup("merge");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
         return merge(mergeArg, ROBOTS, options.check("verbose"));
+#else
+        return merge(mergeArg, ROBOTS);
+#endif
     }
     yarp_robot_help();
     return 1;

--- a/src/yarpbatterygui/main.cpp
+++ b/src/yarpbatterygui/main.cpp
@@ -54,7 +54,6 @@ int main(int argc, char *argv[])
     }
 
     ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc,argv);
 
     QApplication a(argc, argv);

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -770,7 +770,6 @@ int main(int argc, char *argv[])
     Network yarp;
 
     ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc,argv);
 
     if (rf.check("help"))

--- a/src/yarpdataplayer/src/main.cpp
+++ b/src/yarpdataplayer/src/main.cpp
@@ -60,7 +60,6 @@ int main(int argc, char *argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose( true );
     rf.setDefaultConfigFile( "config.ini" );        //overridden by --from parameter
     rf.setDefaultContext( "yarpdataplayer" );        //overridden by --context parameter
     rf.configure( argc, argv );

--- a/src/yarplaserscannergui/main.cpp
+++ b/src/yarplaserscannergui/main.cpp
@@ -293,7 +293,6 @@ int main(int argc, char *argv[])
     ResourceFinder rf;
 
     //retrieve information for the list of parts
-    rf.setVerbose();
     rf.setDefaultConfigFile("yarplaserscannergui.ini");
     rf.configure(argc, argv);
     if (rf.check("help"))

--- a/src/yarplogger-console/main.cpp
+++ b/src/yarplogger-console/main.cpp
@@ -180,7 +180,6 @@ int main(int argc, char *argv[])
     }
 
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(true);
     rf.setDefaultConfigFile("yarprunLogger.ini");           //overridden by --from parameter
     rf.setDefaultContext("yarprunLogger");                  //overridden by --context parameter
     rf.configure(argc,argv);

--- a/src/yarplogger/main.cpp
+++ b/src/yarplogger/main.cpp
@@ -39,7 +39,6 @@ int main(int argc, char *argv[])
     }
 
     yarp::os::ResourceFinder &rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
-    rf.setVerbose(true);
     rf.setDefaultConfigFile("yarprunLogger.ini");           //overridden by --from parameter
     rf.setDefaultContext("yarprunLogger");                  //overridden by --context parameter
     rf.configure(argc,argv);

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -147,7 +147,6 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
 
     // Setup resource finder
     yarp::os::ResourceFinder rf;
-    rf.setVerbose(false);
     rf.setDefaultContext("yarpmanager");
     rf.setDefaultConfigFile(DEF_CONFIG_FILE);
     rf.configure(argc, argv);

--- a/src/yarpmanager/src-manager/main.cpp
+++ b/src/yarpmanager/src-manager/main.cpp
@@ -83,7 +83,6 @@ int main(int argc, char *argv[])
     // Setup resource finder
 
     yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
-    rf.setVerbose(false);
     rf.setDefaultContext("yarpmanager");
     rf.setDefaultConfigFile(DEF_CONFIG_FILE);
     rf.configure(argc, argv);

--- a/src/yarpmobilebasegui/main.cpp
+++ b/src/yarpmobilebasegui/main.cpp
@@ -55,7 +55,6 @@ int main(int argc, char *argv[])
     }
 
     ResourceFinder rf;
-    rf.setVerbose(true);
     rf.configure(argc,argv);
 
     QApplication a(argc, argv);

--- a/src/yarpmotorgui/main.cpp
+++ b/src/yarpmotorgui/main.cpp
@@ -80,7 +80,6 @@ int main(int argc, char *argv[])
     QApplication   a(argc, argv);
     ResourceFinder &finder = ResourceFinder::getResourceFinderSingleton();
     //retrieve information for the list of parts
-    finder.setVerbose();
     finder.setDefaultConfigFile("yarpmotorgui.ini");
     finder.configure(argc, argv);
 

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -555,7 +555,6 @@ bool MainWindow::init(QStringList enabledParts,
     QScrollArea *scroll = nullptr;
     PartItem *part = nullptr;
     m_finder = finder;
-    //m_finder.setVerbose(true);
     m_user_script1 = m_finder.find("script1").asString();
     m_user_script2 = m_finder.find("script2").asString();
 

--- a/src/yarprobotinterface/main.cpp
+++ b/src/yarprobotinterface/main.cpp
@@ -33,7 +33,6 @@ int main(int argc, char* argv[])
     }
 
     yarp::os::ResourceFinder& rf(yarp::os::ResourceFinder::getResourceFinderSingleton());
-    rf.setVerbose();
     rf.setDefaultConfigFile("yarprobotinterface.ini");
     rf.configure(argc, argv);
 

--- a/src/yarpscope/plugin/qtyarpscope.cpp
+++ b/src/yarpscope/plugin/qtyarpscope.cpp
@@ -85,7 +85,6 @@ bool QtYARPScope::parseParameters(QStringList params)
     }
     // Setup resource finder
     yarp::os::ResourceFinder rf;
-    rf.setVerbose();
     // TODO Read default values from yarpscope.ini
     rf.setDefaultConfigFile("yarpscope.ini");
     rf.setDefaultContext("yarpscope");

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -639,7 +639,6 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
             CHECK_FALSE(p.check("data_dir0")); // data_dirs not found
             CHECK_FALSE(p.check("project1")); // project1 not found
             p.clear();
-            //rf.setVerbose(true);
             rf.readConfig(p, "data.ini",
                           ResourceFinderOptions::findAllMatch());
             CHECK(p.find("magic_number").asInt32() == 42); // right priority


### PR DESCRIPTION
### Libraries

#### `os`

##### `ResourceFinder`

* The methods `setVerbose()` and `setQuiet()` are now deprecated in favour of
  Log Components