### PR TITLE
os/YarpPlugin: Port to the new logging system

### DIFF
--- a/doc/release/master/log_refactor_YarpPlugin.md
+++ b/doc/release/master/log_refactor_YarpPlugin.md
@@ -1,0 +1,10 @@
+log_refactor_YarpPlugin {#master}
+-----------------------
+
+### Libraries
+
+#### `os`
+
+##### `YarpPluginSettings`
+
+* The method `setVerboseMode()` is now deprecated in favour of Log Components.

--- a/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.cpp
+++ b/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.cpp
@@ -29,7 +29,6 @@ class MonitorSelector : public YarpPluginSelector {
  */
 MonitorSharedLib::MonitorSharedLib()
 {
-    settings.setVerboseMode(true);
 }
 
 MonitorSharedLib::~MonitorSharedLib()
@@ -45,7 +44,6 @@ bool MonitorSharedLib::load(const yarp::os::Property& options)
     selector.scan();
 
     settings.setPluginName(options.find("filename").asString());
-    settings.setVerboseMode(true);
     if (!settings.setSelector(selector)) {
         return false;
     }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -2132,6 +2132,7 @@ static void plugin_usage()
     printf("Print information about installed plugins\n");
     printf("\n");
     printf("Usage:\n");
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     printf(" * Test a specific plugin:\n");
     printf("     yarp plugin [--verbose] <pluginname>\n");
     printf("     yarp plugin [--verbose] /path/to/plugin/<libraryname>.(so|dll|dylib) <pluginpart>\n");
@@ -2141,6 +2142,17 @@ static void plugin_usage()
     printf("     yarp plugin [--verbose] --list\n");
     printf(" * Print plugin search path:\n");
     printf("     yarp plugin [--verbose] --search-path\n");
+#else
+    printf(" * Test a specific plugin:\n");
+    printf("     yarp plugin <pluginname>\n");
+    printf("     yarp plugin /path/to/plugin/<libraryname>.(so|dll|dylib) <pluginpart>\n");
+    printf(" * Test all the plugins:\n");
+    printf("     yarp plugin --all\n");
+    printf(" * Print a list of plugins:\n");
+    printf("     yarp plugin --list\n");
+    printf(" * Print plugin search path:\n");
+    printf("     yarp plugin --search-path\n");
+#endif // YARP_NO_DEPRECATED
     printf(" * Print this help and exit:\n");
     printf("     yarp plugin --help\n");
     printf("\n");
@@ -2158,6 +2170,7 @@ int Companion::cmdPlugin(int argc, char *argv[]) {
         return 0;
     }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     bool verbose = false;
     if (arg=="--verbose") {
         verbose = true;
@@ -2165,6 +2178,7 @@ int Companion::cmdPlugin(int argc, char *argv[]) {
         argv++;
         arg = argv[0];
     }
+#endif // YARP_NO_DEPRECATED
 
     YarpPluginSelector selector;
     selector.scan();
@@ -2215,7 +2229,12 @@ int Companion::cmdPlugin(int argc, char *argv[]) {
             options.asList()->pop();
             printf("  * config:         %s\n", options.toString().c_str());
             YarpPluginSettings settings;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
             settings.setVerboseMode(verbose);
+YARP_WARNING_POP
+#endif // YARP_NO_DEPRECATED
             settings.setSelector(selector);
             settings.readFromSearchable(options, name);
             ok &= plugin_test(settings);
@@ -2224,7 +2243,12 @@ int Companion::cmdPlugin(int argc, char *argv[]) {
     } else {
         Property p;
         YarpPluginSettings settings;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+YARP_WARNING_PUSH
+YARP_DISABLE_DEPRECATED_WARNING
         settings.setVerboseMode(verbose);
+YARP_WARNING_POP
+#endif
         if (argc>=2) {
             settings.setLibraryMethodName(argv[0], argv[1]);
         } else {

--- a/src/libYARP_dev/src/yarp/dev/Drivers.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Drivers.cpp
@@ -162,13 +162,11 @@ private:
 public:
     StubDriver(const char *dll_name, const char *fn_name, bool verbose = true) {
         settings.setLibraryMethodName(dll_name,fn_name);
-        settings.setVerboseMode(verbose);
         init();
     }
 
     StubDriver(const char *name, bool verbose = true) {
         settings.setPluginName(name);
-        settings.setVerboseMode(verbose);
         YarpPluginSelector selector;
         selector.scan();
         if (!settings.setSelector(selector)) {

--- a/src/libYARP_os/src/yarp/os/RFPlugin.cpp
+++ b/src/libYARP_os/src/yarp/os/RFPlugin.cpp
@@ -134,7 +134,6 @@ bool RFPlugin::open(const string& inCommand)
     mPriv->shared->selector.scan();
 
     settings.setPluginName(mPriv->name);
-    settings.setVerboseMode(true);
 
     if (!settings.setSelector(mPriv->shared->selector)) {
         return false;

--- a/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
+++ b/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
@@ -12,7 +12,7 @@
 #include <yarp/os/Property.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/SystemClock.h>
-#include <yarp/os/impl/Logger.h>
+#include <yarp/os/impl/LogComponent.h>
 #include <yarp/os/impl/NameClient.h>
 
 #include <cstdio>
@@ -20,6 +20,22 @@
 
 using namespace yarp::os;
 using namespace yarp::os::impl;
+
+namespace {
+#ifndef YARP_NO_DEPRECATED // since YARP 3.4
+// The log component cannot be const because we still support setVerboseMode
+YARP_OS_NON_CONST_LOG_COMPONENT(YARPPLUGINSETTINGS, "yarp.os.YarpPluginSettings")
+#else
+YARP_OS_LOG_COMPONENT(YARPPLUGINSETTINGS, "yarp.os.YarpPluginSettings")
+#endif
+} // namespace
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.4
+void YarpPluginSettings::setVerboseMode(bool verbose)
+{
+    YARPPLUGINSETTINGS().setMinimumPrintLevel(verbose ? yarp::os::Log::DebugType : yarp::os::Log::InfoType);
+}
+#endif // YARP_NO_DEPRECATED
 
 bool YarpPluginSettings::open(SharedLibraryFactory& factory,
                               const std::string& dll_name,
@@ -32,24 +48,45 @@ bool YarpPluginSettings::subopen(SharedLibraryFactory& factory,
                                  const std::string& dll_name,
                                  const std::string& fn_name)
 {
-    YARP_SPRINTF2(impl::Logger::get(), debug, "Trying plugin [dll: %s] [fn: %s]", dll_name.c_str(), fn_name.c_str());
+    yCDebug(YARPPLUGINSETTINGS,
+            "Trying plugin [dll: %s] [fn: %s]",
+            dll_name.c_str(),
+            fn_name.c_str());
     bool ok = factory.open(dll_name.c_str(), fn_name.c_str());
-    if (verbose) {
-        fprintf(stderr, "Trying to find library '%s' containing function '%s' -- %s\n", dll_name.c_str(), fn_name.c_str(), ok ? "found" : "fail");
-    }
+    yCDebug(YARPPLUGINSETTINGS,
+            "Trying to find library '%s' containing function '%s' -- %s",
+            dll_name.c_str(),
+            fn_name.c_str(), ok ? "found" : "fail");
     if (ok) {
-        YARP_SPRINTF2(impl::Logger::get(), debug, "Found plugin [dll: %s] [fn: %s]", dll_name.c_str(), fn_name.c_str());
+        yCDebug(YARPPLUGINSETTINGS,
+                "Found plugin [dll: %s] [fn: %s]",
+                dll_name.c_str(),
+                fn_name.c_str());
         this->dll_name = dll_name;
         this->fn_name = fn_name;
-    } else if (verbose || (factory.getStatus() != SharedLibraryFactory::STATUS_LIBRARY_NOT_FOUND)) {
-        fprintf(stderr, "error while opening %s:\n  %s\n", dll_name.c_str(), factory.getError().c_str());
+    } else {
+        if (factory.getStatus() != SharedLibraryFactory::STATUS_LIBRARY_NOT_FOUND) {
+            yCError(YARPPLUGINSETTINGS,
+                    "Error while opening %s:\n  %s",
+                    dll_name.c_str(),
+                    factory.getError().c_str());
+        } else {
+            yCDebug(YARPPLUGINSETTINGS,
+                    "Error while opening %s:\n  %s",
+                    dll_name.c_str(),
+                    factory.getError().c_str());
+        }
     }
     return ok;
 }
 
 bool YarpPluginSettings::open(SharedLibraryFactory& factory)
 {
-    YARP_SPRINTF3(impl::Logger::get(), debug, "Plugin [name: %s] [dll: %s] [fn: %s]", name.c_str(), dll_name.c_str(), fn_name.c_str());
+    yCDebug(YARPPLUGINSETTINGS,
+            "Plugin [name: %s] [dll: %s] [fn: %s]",
+            name.c_str(),
+            dll_name.c_str(),
+            fn_name.c_str());
     if (selector != nullptr && !name.empty()) {
         // we may have a YARP-specific search path available,
         // and a proper name for the DLL
@@ -125,36 +162,52 @@ void YarpPluginSettings::reportStatus(SharedLibraryFactory& factory) const
     }
     switch (problem) {
     case SharedLibraryFactory::STATUS_LIBRARY_NOT_LOADED:
-        if (verbose) {
-            fprintf(stderr, "Cannot load plugin from shared library (%s)\n", dll_name.c_str());
-            fprintf(stderr, "(%s)\n", factory.getError().c_str());
-        }
+        yCDebug(YARPPLUGINSETTINGS, "Cannot load plugin from shared library (%s)", dll_name.c_str());
+        yCDebug(YARPPLUGINSETTINGS, "(%s)", factory.getError().c_str());
         break;
     case SharedLibraryFactory::STATUS_LIBRARY_NOT_FOUND:
-        fprintf(stderr, "Cannot load plugin from shared library (%s)\n", dll_name.c_str());
-        fprintf(stderr, "(%s)\n", factory.getError().c_str());
+        yCWarning(YARPPLUGINSETTINGS, "Cannot load plugin from shared library (%s)", dll_name.c_str());
+        yCWarning(YARPPLUGINSETTINGS, "(%s)", factory.getError().c_str());
         break;
     case SharedLibraryFactory::STATUS_FACTORY_NOT_FOUND:
-        fprintf(stderr, "cannot find YARP hook in shared library (%s:%s)\n", dll_name.c_str(), fn_name.c_str());
-        fprintf(stderr, "(%s)\n", factory.getError().c_str());
+        yCWarning(YARPPLUGINSETTINGS, "Cannot find YARP hook in shared library (%s:%s)", dll_name.c_str(), fn_name.c_str());
+        yCWarning(YARPPLUGINSETTINGS, "(%s)", factory.getError().c_str());
         break;
     case SharedLibraryFactory::STATUS_FACTORY_NOT_FUNCTIONAL:
-        fprintf(stderr, "YARP hook in shared library misbehaved (%s:%s)\n", dll_name.c_str(), fn_name.c_str());
-        fprintf(stderr, "(the library may be too old/new and need to be recompiled to match YARP version)\n");
-        fprintf(stderr, "(%s)\n", factory.getError().c_str());
+        yCWarning(YARPPLUGINSETTINGS, "YARP hook in shared library misbehaved (%s:%s)", dll_name.c_str(), fn_name.c_str());
+        yCWarning(YARPPLUGINSETTINGS, "(the library may be too old/new and need to be recompiled to match YARP version)");
+        yCWarning(YARPPLUGINSETTINGS, "(%s)", factory.getError().c_str());
         break;
     default:
-        fprintf(stderr, "Unknown error (%s:%s)\n", dll_name.c_str(), fn_name.c_str());
-        fprintf(stderr, "(%s)\n", factory.getError().c_str());
+        yCWarning(YARPPLUGINSETTINGS, "Unknown error (%s:%s)", dll_name.c_str(), fn_name.c_str());
+        yCWarning(YARPPLUGINSETTINGS, "(%s)", factory.getError().c_str());
         break;
     }
 }
 
 void YarpPluginSettings::reportFailure() const
 {
-    fprintf(stderr, "Failed to create %s from shared library %s\n", fn_name.c_str(), dll_name.c_str());
+    yCError(YARPPLUGINSETTINGS, "Failed to create %s from shared library %s", fn_name.c_str(), dll_name.c_str());
 }
 
+bool YarpPluginSettings::readFromSelector(const std::string& name)
+{
+    if (!selector)
+        return false;
+    Bottle plugins = selector->getSelectedPlugins();
+    Bottle group = plugins.findGroup(name.c_str()).tail();
+    if (group.isNull()) {
+        yCError(YARPPLUGINSETTINGS,
+                "Cannot find \"%s\" plugin (not built in, and no .ini file found for it)"
+                "Check that YARP_DATA_DIRS leads to at least one directory with plugins/%s.ini "
+                "or share/yarp/plugins/%s.ini in it",
+                name.c_str(),
+                name.c_str(),
+                name.c_str());
+        return false;
+    }
+    return readFromSearchable(group, name);
+}
 
 void YarpPluginSelector::scan()
 {
@@ -172,9 +225,7 @@ void YarpPluginSelector::scan()
         return;
     }
 
-    YARP_SPRINTF0(Logger::get(),
-                  debug,
-                  "Scanning. I'm scanning. I hope you like scanning too.");
+    yCDebug(YARPPLUGINSETTINGS, "Scanning. I'm scanning. I hope you like scanning too.");
 
     // Search plugins directories
     ResourceFinder& rf = ResourceFinder::getResourceFinderSingleton();
@@ -191,16 +242,12 @@ void YarpPluginSelector::scan()
     if (plugin_paths.size() > 0) {
         for (size_t i = 0; i < plugin_paths.size(); i++) {
             std::string target = plugin_paths.get(i).asString();
-            YARP_SPRINTF1(Logger::get(),
-                          debug,
-                          "Loading configuration files related to plugins from %s.",
-                          target.c_str());
+            yCDebug(YARPPLUGINSETTINGS, "Loading configuration files related to plugins from %s.",
+                       target.c_str());
             config.fromConfigDir(target, "inifile", false);
         }
     } else {
-        YARP_SPRINTF0(Logger::get(),
-                      debug,
-                      "Plugin directory not found");
+        yCDebug(YARPPLUGINSETTINGS, "Plugin directory not found");
     }
 
     // Read the .ini files and populate the lists

--- a/src/libYARP_os/src/yarp/os/YarpPluginSettings.h
+++ b/src/libYARP_os/src/yarp/os/YarpPluginSettings.h
@@ -30,7 +30,6 @@ public:
     YarpPluginSettings() :
             wrapper_name("unknown")
     {
-        verbose = false;
         selector = nullptr;
     }
 
@@ -97,15 +96,16 @@ public:
         return false;
     }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
      * Should messages be printed showing what searches YARP is trying out?
      *
      * @param verbose verbosity flag
+     * @deprecated since YARP 3.4
      */
-    void setVerboseMode(bool verbose)
-    {
-        this->verbose = verbose;
-    }
+    YARP_DEPRECATED_MSG("Use log components instead")
+    void setVerboseMode(bool verbose);
+#endif // YARP_NO_DEPRECATED
 
     /**
      * Configure settings from a configuration file or other searchable
@@ -220,7 +220,6 @@ private:
     YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::string) class_name;
     YARP_SUPPRESS_DLL_INTERFACE_WARNING_ARG(std::string) baseclass_name;
     YarpPluginSelector* selector;
-    bool verbose;
 
     bool subopen(SharedLibraryFactory& factory,
                  const std::string& dll_name,
@@ -230,23 +229,7 @@ private:
               const std::string& dll_name,
               const std::string& fn_name);
 
-    bool readFromSelector(const std::string& name)
-    {
-        if (!selector)
-            return false;
-        Bottle plugins = selector->getSelectedPlugins();
-        Bottle group = plugins.findGroup(name.c_str()).tail();
-        if (group.isNull()) {
-            yError("Cannot find \"%s\" plugin (not built in, and no .ini file found for it)\n"
-                   "Check that YARP_DATA_DIRS leads to at least one directory with plugins/%s.ini "
-                   "or share/yarp/plugins/%s.ini in it",
-                   name.c_str(),
-                   name.c_str(),
-                   name.c_str());
-            return false;
-        }
-        return readFromSearchable(group, name);
-    }
+    bool readFromSelector(const std::string& name);
 };
 
 } // namespace os


### PR DESCRIPTION
### Libraries

#### `os`

##### `YarpPluginSettings`

* The method `setVerboseMode()` is now deprecated in favour of Log Components.
