### PR TITLE
os/{ConnectionState,impl/Protocol}: Port to the new logging system

### DIFF
--- a/doc/release/master/log_refactor_Protocol.md
+++ b/doc/release/master/log_refactor_Protocol.md
@@ -1,0 +1,10 @@
+log_refactor_Protocol {#master}
+---------------------
+
+### Libraries
+
+#### `os`
+
+##### `ConnectionState`
+
+* The `getLog()` method was removed.

--- a/src/libYARP_os/src/yarp/os/ConnectionState.h
+++ b/src/libYARP_os/src/yarp/os/ConnectionState.h
@@ -22,7 +22,6 @@ class OutputStream;
 class Portable;
 class Route;
 class TwoWayStream;
-class Log;
 class Contactable;
 
 /**
@@ -68,11 +67,6 @@ public:
      * when there is no low-level way to know this.
      */
     virtual void setRemainingLength(int len) = 0;
-
-    /**
-     * Access a connection-specific logging object.
-     */
-    virtual Log& getLog() const = 0;
 
     /**
      * Extract a name for the sender, if the connection

--- a/src/libYARP_os/src/yarp/os/impl/Protocol.h
+++ b/src/libYARP_os/src/yarp/os/impl/Protocol.h
@@ -16,7 +16,6 @@
 #include <yarp/os/NullConnection.h>
 #include <yarp/os/OutputProtocol.h>
 #include <yarp/os/ShiftStream.h>
-#include <yarp/os/impl/Logger.h>
 #include <yarp/os/impl/StreamConnectionReader.h>
 
 namespace yarp {
@@ -55,7 +54,6 @@ public:
     void setReference(yarp::os::Portable* ref) override;
     std::string getSenderSpecifier() const override;
     const std::string& getEnvelope() const override;
-    Log& getLog() const override;
     void setRemainingLength(int len) override;
     Connection& getConnection() override;
     Contactable* getContactable() const override;
@@ -187,7 +185,6 @@ private:
 
     int messageLen;                ///< length remaining in current message (if known)
     bool pendingAck;               ///< is an acknowledgement due
-    Logger& log;                   ///< connection-specific logger
     ShiftStream shift;             ///< input and output streams
     bool active;                   ///< is the connection up and running
     Carrier* delegate;             ///< main carrier specifying behavior of connection


### PR DESCRIPTION
### Libraries

#### `os`

##### `ConnectionState`

* The methods `getLog()` method was removed.


Depends on #2266