### PR TITLE
os/Port: Port to the new logging system

### DIFF
--- a/doc/release/master/log_refactor_Port.md
+++ b/doc/release/master/log_refactor_Port.md
@@ -1,0 +1,11 @@
+log_refactor_Port {#master}
+-----------------
+
+### Libraries
+
+#### `os`
+
+##### `Port`
+
+* The methods `setVerbosity` and `getVerbosity` are deprecated in favour
+  of Log Components.

--- a/src/carriers/tcpros_carrier/RosSlave.h
+++ b/src/carriers/tcpros_carrier/RosSlave.h
@@ -36,7 +36,6 @@ public:
     void start(const char *hostname, int portnum) {
         this->hostname = hostname;
         this->portnum = portnum;
-        slave.setVerbosity(-1);
         slave.setReader(*this);
         slave.open("...");
     }

--- a/src/libYARP_os/src/yarp/os/Port.h
+++ b/src/libYARP_os/src/yarp/os/Port.h
@@ -206,19 +206,25 @@ public:
      */
     bool setTimeout(float timeout);
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
      * Set whether the port should issue messages about its operations.
      *
      * @param level verbosity level, -1 to inhibit messages.
+     * @deprecated since YARP 3.4
      */
+    YARP_DEPRECATED_MSG("Use LogComponent instead")
     void setVerbosity(int level);
 
     /**
      * Get port verbosity level.
      *
      * @return port verbosity level.
+     * @deprecated since YARP 3.4
      */
+    YARP_DEPRECATED
     int getVerbosity();
+#endif
 
     // Documented in Contactable
     Type getType() override;


### PR DESCRIPTION
### Libraries

#### `os`

##### `Port`

* The methods `setVerbosity` and `getVerbosity` are deprecated in favour of Log Components.
