### PR TITLE
os/Network: Port to the new logging system

### DIFF
--- a/doc/release/master/log_refactor_Network.md
+++ b/doc/release/master/log_refactor_Network.md
@@ -1,0 +1,10 @@
+log_refactor_Network {#master}
+--------------------
+
+### Libraries
+
+#### `os`
+
+##### `NetworkBase`
+
+* The `setVerbosity` method is now deprecated in favor of Log Components.

--- a/src/libYARP_os/src/yarp/os/Network.h
+++ b/src/libYARP_os/src/yarp/os/Network.h
@@ -515,14 +515,16 @@ public:
      */
     static bool initialized();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
-     *
      * Set level of verbosity of YARP messages.
      *
      * @param verbosity -1 inhibits messages, 0 is normal, 1 is verbose
-     *
+     * @deprecated since YARP 3.4
      */
+    YARP_DEPRECATED_MSG("Use LogComponents instead")
     static void setVerbosity(int verbosity);
+#endif // YARP_NO_DEPRECATED
 
     /**
      *

--- a/src/libYARP_robottestingframework/src/yarp/robottestingframework/TestCase.cpp
+++ b/src/libYARP_robottestingframework/src/yarp/robottestingframework/TestCase.cpp
@@ -40,7 +40,6 @@ yarp::robottestingframework::TestCase::~TestCase()
 bool yarp::robottestingframework::TestCase::setup(int argc, char** argv)
 {
     // check yarp network
-    mPriv->yarp.setVerbosity(-1);
     ROBOTTESTINGFRAMEWORK_ASSERT_ERROR_IF_FALSE(mPriv->yarp.checkNetwork(),
                                                 "YARP network does not seem to be available, is the yarp server accessible?");
 

--- a/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -35,7 +35,6 @@ bool YarpFixManager::setup(int argc, char** argv) {
     bool ret;
     if(!initialized) {
         // check yarp network
-        yarp.setVerbosity(-1);
         ROBOTTESTINGFRAMEWORK_ASSERT_ERROR_IF_FALSE(yarp.checkNetwork(),
                             "YARP network does not seem to be available, is the yarp server accessible?");
 

--- a/src/yarpmanager-console/yarpmanager.cpp
+++ b/src/yarpmanager-console/yarpmanager.cpp
@@ -22,7 +22,6 @@
 int main(int argc, char* argv[])
 {
     yarp::os::Network yarp(yarp::os::YARP_CLOCK_SYSTEM);
-    yarp.setVerbosity(-1);
 
     YConsoleManager ymanager(argc, argv);
 

--- a/src/yarpmanager/src-manager/main.cpp
+++ b/src/yarpmanager/src-manager/main.cpp
@@ -88,7 +88,6 @@ int main(int argc, char *argv[])
     rf.configure(argc, argv);
 
     yarp::os::Network yarp(yarp::os::YARP_CLOCK_SYSTEM);
-    yarp.setVerbosity(-1);
 
     yarp::os::Property config;
     config.fromString(rf.toString());

--- a/tests/devices/harness_devices.cpp
+++ b/tests/devices/harness_devices.cpp
@@ -82,9 +82,11 @@ void usage(const char* name)
 static void init_Network()
 {
     net = new yarp::os::Network;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     if (verbose) {
         yarp::os::NetworkBase::setVerbosity(1);
     }
+#endif
 }
 
 static void fini_Network()

--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -89,9 +89,11 @@ static void setup_Environment()
 static void init_Network()
 {
     net = new yarp::os::Network;
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     if (verbose) {
         yarp::os::NetworkBase::setVerbosity(1);
     }
+#endif // YARP_NO_DEPRECATED
 }
 
 static void fini_Network()


### PR DESCRIPTION
### Libraries

#### `os`

##### `NetworkBase`

* The `setVerbosity` method is now deprecated in favor of Log Components.
