### PR TITLE
os/Log: Make trace generated code disappear when building in release mode

### DIFF
--- a/doc/release/master/log_remove_trace.md
+++ b/doc/release/master/log_remove_trace.md
@@ -1,0 +1,12 @@
+log_remove_trace {#master}
+----------------
+
+### Libraries
+
+#### `os`
+
+##### `Log`
+
+* Trace should no longer generate code when building in release mode.
+  When building with `-DYARP_NO_DEBUG_OUTPUT` debug should not generate any code
+  as well. See https://godbolt.org/z/hSAC56

--- a/src/libYARP_os/src/yarp/os/Log.h
+++ b/src/libYARP_os/src/yarp/os/Log.h
@@ -115,8 +115,20 @@ public:
     static LogCallback forwardCallback();        //!< Get current forward callback (or nullptr if forwarding is not enabled)
     static LogCallback defaultForwardCallback(); //!< Get default forward callback (or nullptr if forwarding is not enabled)
 
-private:
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
+    static void nolog(const char* msg, ...) {}
+    struct NoLog
+    {
+        template <typename T>
+        NoLog& operator<<(const T&)
+        {
+            return *this;
+        }
+    };
+    static NoLog nolog() { return NoLog(); }
+
+private:
     yarp::os::impl::LogPrivate* const mPriv;
 
     friend class yarp::os::LogStream;
@@ -143,8 +155,19 @@ private:
 } // namespace yarp
 
 
-#define yTrace(...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).trace(__VA_ARGS__)
-#define yDebug(...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).debug(__VA_ARGS__)
+
+#ifndef NDEBUG
+#  define yTrace(...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).trace(__VA_ARGS__)
+#else
+#  define yTrace(...)   yarp::os::Log::nolog(__VA_ARGS__)
+#endif
+
+#ifndef YARP_NO_DEBUG_OUTPUT
+#  define yDebug(...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).debug(__VA_ARGS__)
+#else
+#  define yDebug(...)   yarp::os::Log::nolog(__VA_ARGS__)
+#endif
+
 #define yInfo(...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).info(__VA_ARGS__)
 #define yWarning(...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).warning(__VA_ARGS__)
 #define yError(...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).error(__VA_ARGS__)

--- a/src/libYARP_os/src/yarp/os/LogComponent.h
+++ b/src/libYARP_os/src/yarp/os/LogComponent.h
@@ -84,8 +84,18 @@ private:
         return component; \
     }
 
-#define yCTrace(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).trace(__VA_ARGS__)
-#define yCDebug(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).debug(__VA_ARGS__)
+#ifndef NDEBUG
+#  define yCTrace(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).trace(__VA_ARGS__)
+#else
+#  define yCTrace(component, ...)   yarp::os::Log::nolog(__VA_ARGS__)
+#endif
+
+#ifndef YARP_NO_DEBUG_OUTPUT
+#  define yCDebug(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).debug(__VA_ARGS__)
+#else
+#  define yCDebug(component, ...)   yarp::os::Log::nolog(__VA_ARGS__)
+#endif
+
 #define yCInfo(component, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).info(__VA_ARGS__)
 #define yCWarning(component, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).warning(__VA_ARGS__)
 #define yCError(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).error(__VA_ARGS__)


### PR DESCRIPTION
### Libraries

#### `os`

##### `Log`

* Trace should no longer generate code when building in release mode. When building with `-DYARP_NO_DEBUG_OUTPUT` debug should not generate any code as well. See https://godbolt.org/z/hSAC56
