### PR TITLE
yarpview: Pixel rgb value in status bar

### DIFF
--- a/doc/release/master/feature_yarpview_color_picker.md
+++ b/doc/release/master/feature_yarpview_color_picker.md
@@ -1,0 +1,16 @@
+fix_yarpview_color_picker {#master}
+---------------
+
+### GUIs
+
+#### `yarpview`
+
+* Added a checkable menu item that, if checked, shows an additional line in the `status bar` that displays the color value of the pixel pointed by the mouse cursor.
+  
+  The string has the following format 
+  ```
+  Pixel("x","y") = "hexstring"
+  ```
+  Where  `x` and `y` are the coordinates of the pixel and `hexstring` is the hexadecimal (in the ARGB format) string representing the pixel color
+  
+  The additional line on the `status bar` contains also a little rectangle that will turn the same color of the currently selected pixel.

--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -37,6 +37,7 @@ Rectangle {
     property int menuHeight: 0
     property string name: "yarpview"
     property string version: "2.0"
+    property bool showPixelCol: false
 
     signal changeWindowSize(int w, int h)
     signal synchRate(bool check);
@@ -136,6 +137,11 @@ Rectangle {
     /******************************/
 
     /********Functions************/
+    function enableColorPicking(flag){
+        coordsMouseArea.hoverEnabled = flag;
+        maincontainer.showPixelCol = flag;
+    }
+
     function parseParameters(params){
         var ret = yarpViewCore.parseParameters(params)
         return ret
@@ -248,23 +254,31 @@ Rectangle {
             property var currY
             property bool pressing: false
 
+            function coordsConverter(x,y){
+
+                var frameW = yarpViewCore.videoProducer.frameWidth;
+                var frameH = yarpViewCore.videoProducer.frameHeight;
+
+                var w = mainVideoOutput.width;
+                var h = mainVideoOutput.height;
+
+                var ratioW = w/frameW;
+                var ratioH = h/frameH;
+
+                var toReturn = {"x":0,"y":0};
+                toReturn["x"] = Math.round(x/ratioW);
+                toReturn["y"] = Math.round(y/ratioH);
+
+                return toReturn;
+            }
+
             onClicked: {
                 startclickX = mouse.x
                 startclickY = mouse.y
-                var x = mouse.x
-                var y = mouse.y
+                var clickCoords = coordsConverter(mouse.x,mouse.y);
 
-                var frameW = yarpViewCore.videoProducer.frameWidth;
-                var frameH = yarpViewCore.videoProducer.frameHeight
-
-                var w = mainVideoOutput.width
-                var h = mainVideoOutput.height
-
-                var ratioW = w/frameW
-                var ratioH = h/frameH
-
-                clickX = x/ratioW
-                clickY = y/ratioH
+                clickX = clickCoords["x"];
+                clickY = clickCoords["y"];
 
                 yarpViewCore.clickCoords_2(clickX,clickY)
             }
@@ -272,20 +286,12 @@ Rectangle {
             onPressed: {
                 startclickX = mouse.x
                 startclickY = mouse.y
-                var x = mouse.x
-                var y = mouse.y
+                startclickX = mouse.x
+                startclickY = mouse.y
+                var clickCoords = coordsConverter(mouse.x,mouse.y);
 
-                var frameW = yarpViewCore.videoProducer.frameWidth;
-                var frameH = yarpViewCore.videoProducer.frameHeight
-
-                var w = mainVideoOutput.width
-                var h = mainVideoOutput.height
-
-                var ratioW = w/frameW
-                var ratioH = h/frameH
-
-                clickX = x/ratioW
-                clickY = y/ratioH
+                clickX = clickCoords["x"];
+                clickY = clickCoords["y"];
             }
 
             onPressAndHold: {
@@ -297,31 +303,29 @@ Rectangle {
                 if (pressing)
                 {
                     pressing = false;
-                    var x = mouse.x
-                    var y = mouse.y
+                    var clickCoords = coordsConverter(mouse.x,mouse.y);
 
-                    var frameW = yarpViewCore.videoProducer.frameWidth;
-                    var frameH = yarpViewCore.videoProducer.frameHeight
+                    lastclickX = clickCoords["x"];
+                    lastclickY = clickCoords["y"];
 
-                    var w = mainVideoOutput.width
-                    var h = mainVideoOutput.height
-
-                    var ratioW = w/frameW
-                    var ratioH = h/frameH
-
-                    lastclickX=mouse.x/ratioW
-                    lastclickY=mouse.y/ratioH
-
-                    yarpViewCore.clickCoords_4(clickX,clickY,lastclickX,lastclickY)
+                    yarpViewCore.clickCoords_4(clickX,clickY,lastclickX,lastclickY);
                 }
-                canvasOverlay.requestPaint()
+                canvasOverlay.requestPaint();
             }
 
             onPositionChanged:
             {
-                currX=mouse.x;
-                currY=mouse.y;
-                canvasOverlay.requestPaint()
+                if(maincontainer.showPixelCol){
+                    var coords = coordsConverter(mouse.x,mouse.y);
+                    dataArea.pixelXStr = ""+coords["x"];
+                    dataArea.pixelYStr = ""+coords["y"];
+                    dataArea.pixelValStr = yarpViewCore.getPixelAsStr(coords["x"],coords["y"]);
+                }
+                if(pressed){
+                    currX=mouse.x;
+                    currY=mouse.y;
+                    canvasOverlay.requestPaint()
+                }
             }
 
             Canvas

--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -254,6 +254,11 @@ Rectangle {
             property var currY
             property bool pressing: false
 
+            /*! \brief Converts a pair of mouse XY coordinates to video frame coordinates
+             *  \param x Integer: The mouse X coordinate
+             *  \param y Integer: The mouse Y coordinate
+             *  \return toReturn Dictionary: It contains the X and Y values of the newly computed video frame coordinates
+             */
             function coordsConverter(x,y){
 
                 var frameW = yarpViewCore.videoProducer.frameWidth;
@@ -319,7 +324,7 @@ Rectangle {
                     var coords = coordsConverter(mouse.x,mouse.y);
                     dataArea.pixelXStr = ""+coords["x"];
                     dataArea.pixelYStr = ""+coords["y"];
-                    dataArea.pixelValStr = yarpViewCore.getPixelAsStr(coords["x"],coords["y"]);
+                    dataArea.setPixelVal(yarpViewCore.getPixelAsStr(coords["x"],coords["y"]));
                 }
                 if(pressed){
                     currX=mouse.x;

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -126,7 +126,7 @@ MenuBar {
                    }}
         MenuSeparator{}
         MenuItem { id: colorPickerItem
-                   text: "Display px value"
+                   text: "Display pixel value"
                    checkable: true
                    onTriggered: {
                        pickColor(colorPickerItem.checked);

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -32,6 +32,7 @@ MenuBar {
     signal changeRefreshInterval()
     signal saveSingleImage(bool checked)
     signal saveSetImages(bool checked)
+    signal pickColor(bool checked)
 
     function enableSynch(check){
         if(check === true){
@@ -122,6 +123,13 @@ MenuBar {
                    checkable: true
                    onTriggered: {
                        synchDisplaySize(autosizeItem.checked)
+                   }}
+        MenuSeparator{}
+        MenuItem { id: colorPickerItem
+                   text: "Display px value"
+                   checkable: true
+                   onTriggered: {
+                       pickColor(colorPickerItem.checked);
                    }}
         MenuSeparator{}
         MenuItem { text: "Change refresh interval"

--- a/src/yarpview/plugin/YARPViewStatusBar.qml
+++ b/src/yarpview/plugin/YARPViewStatusBar.qml
@@ -18,10 +18,11 @@
 
 import QtQuick 2.0
 import QtQuick.Controls 1.1
+import QtQuick.Layouts 1.0
 
 StatusBar {
     id: bar
-    height: 60
+    height: 20*(3+pixelValPresent)
     property string avgFps: "0.0"
     property string minFps: "0.0"
     property string maxFps: "0.0"
@@ -36,67 +37,92 @@ StatusBar {
 
     property string name: "/name"
 
-    property string pixelValStr: "0"
+    property string pixelValStr: "#00000000"
     property string pixelXStr: "0"
     property string pixelYStr: "0"
-    property color pixelValCol: "white"
+    property color pixelValCol: "#00000000"
+    property int pixelValPresent: 0
 
     function setName(name){
         bar.name = name
     }
+    /*! \brief Determines whether or not the information about the currently selected pixel have to be visible
+     *  \param flag Boolean: If true the information about the currently selected pixel are visible
+     */
+    function setPixelValVisibility(flag){
+        pixelValPresent = flag ? 1 : 0;
+    }
 
-    Column{
+    /*! \brief Sets the pixelValStr and pixelValCol values
+     *  \param hexstring String: The hexadecimal string representing the selected pixel color
+     */
+    function setPixelVal(hexstring){
+        pixelValStr = hexstring;
+        pixelValCol = hexstring !== "Invalid" ? pixelValCol = hexstring : "#00000000";
+    }
+
+    ColumnLayout{
         anchors.fill: parent
-        spacing: 2
 
         Label{
             id: fps
-
-            //anchors.bottom: displayFps.top
-
             text: "Port: " + bar.avgFps +
                   " (min:" + bar.minFps +
                   " max:" + bar.maxFps +") fps; " +
                   "(size: " + bar.portSizeX + "x" + bar.portSizeY + ")"
-            fontSizeMode: Text.VerticalFit
-            height: parent.height/4 - 2
+            fontSizeMode: Text.HorizontalFit
+            Layout.fillHeight: true
+            Layout.fillWidth: true
         }
 
         Label{
             id: displayFps
-
-            //anchors.bottom: name.top
-
-
             text: "Display: " + bar.displayAvgFps +
                   " (min:" + bar.displayMinFps +
                   " max:" + bar.displayMaxFps +") fps; "+
                   "(size: " + bar.displaySizeX + "x" + bar.displaySizeY + ")"
-            fontSizeMode: Text.VerticalFit
-            height: parent.height/4 - 2
+            fontSizeMode: Text.HorizontalFit
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
 
+        RowLayout{
+            id: pixelValRowLO
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            visible: pixelValPresent==1
 
+            Label{
+                id: pixelValLabel
+                text: "Pixel ("+bar.pixelXStr+", "+bar.pixelYStr+") = "+bar.pixelValStr
+                fontSizeMode: Text.VerticalFit
+                Layout.fillHeight: true
+            }
+
+            Rectangle{
+                id: pixelValRect
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                Layout.minimumWidth: height
+                Layout.maximumWidth: height
+                color: pixelValCol
+            }
+
+            Item{
+                id: pixelValSpacer
+                Layout.fillWidth: true
+                Layout.minimumWidth: pixelValLabel
+                Layout.maximumWidth: pixelValLabel
+            }
         }
 
         Label{
             id: name
-
-
             text: bar.name
             fontSizeMode: Text.VerticalFit
-            height: parent.height/4 - 2
-
-
+            Layout.fillHeight: true
+            Layout.fillWidth: true
         }
-
-        Label{
-            id: pixelValueLabel
-            text: "Pixel ("+bar.pixelXStr+", "+bar.pixelYStr+") = "+bar.pixelValStr
-            fontSizeMode: Text.VerticalFit
-            height: parent.height/4 - 2
-
-        }
-
     }
 
 

--- a/src/yarpview/plugin/YARPViewStatusBar.qml
+++ b/src/yarpview/plugin/YARPViewStatusBar.qml
@@ -36,6 +36,11 @@ StatusBar {
 
     property string name: "/name"
 
+    property string pixelValStr: "0"
+    property string pixelXStr: "0"
+    property string pixelYStr: "0"
+    property color pixelValCol: "white"
+
     function setName(name){
         bar.name = name
     }
@@ -54,7 +59,7 @@ StatusBar {
                   " max:" + bar.maxFps +") fps; " +
                   "(size: " + bar.portSizeX + "x" + bar.portSizeY + ")"
             fontSizeMode: Text.VerticalFit
-            height: parent.height/3 - 2
+            height: parent.height/4 - 2
         }
 
         Label{
@@ -68,7 +73,7 @@ StatusBar {
                   " max:" + bar.displayMaxFps +") fps; "+
                   "(size: " + bar.displaySizeX + "x" + bar.displaySizeY + ")"
             fontSizeMode: Text.VerticalFit
-            height: parent.height/3 - 2
+            height: parent.height/4 - 2
 
 
         }
@@ -79,10 +84,19 @@ StatusBar {
 
             text: bar.name
             fontSizeMode: Text.VerticalFit
-            height: parent.height/3 - 2
+            height: parent.height/4 - 2
 
 
         }
+
+        Label{
+            id: pixelValueLabel
+            text: "Pixel ("+bar.pixelXStr+", "+bar.pixelYStr+") = "+bar.pixelValStr
+            fontSizeMode: Text.VerticalFit
+            height: parent.height/4 - 2
+
+        }
+
     }
 
 

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -155,6 +155,18 @@ void QtYARPView::stopDumpFrames()
     sigHandler.stopDumpFrames();
 }
 
+/*! \brief Pics the rgb value of the pixel specified by x and y and return it as a string
+ *  \param x Integer: The x coordinate of the pixel
+ *  \param y Integer: The y coordinate of the pixel
+ */
+
+QString QtYARPView::getPixelAsStr(int x, int y){
+
+    QString rgbToReturn = videoProducer.getPixelAsStr(x,y);
+
+    return rgbToReturn;
+}
+
 void QtYARPView::periodToFreq(double avT, double mT, double MT, double &avH, double &mH, double &MH)
 {
     if (avT!=0)
@@ -509,3 +521,4 @@ void QtYARPView::onWindowSizeChangeRequested()
         emit sizeChanged();
     }
 }
+

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -521,4 +521,3 @@ void QtYARPView::onWindowSizeChangeRequested()
         emit sizeChanged();
     }
 }
-

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -92,6 +92,8 @@ public:
     Q_INVOKABLE void clickCoords_2(int x, int y);
     Q_INVOKABLE void clickCoords_4(int start_x, int start_y, int end_x, int end_y);
 
+    Q_INVOKABLE QString getPixelAsStr(int x, int y);
+
     QObject *getVideoProducer();
     int posX();
     int posY();

--- a/src/yarpview/plugin/videoproducer.cpp
+++ b/src/yarpview/plugin/videoproducer.cpp
@@ -25,7 +25,6 @@ VideoProducer::VideoProducer(QObject *parent) :
     m_format = nullptr;
     m_surface = nullptr;
     m_frame = nullptr;
-    framed = false;
 }
 
 VideoProducer::~VideoProducer()
@@ -130,7 +129,6 @@ void VideoProducer::onNewVideoContentReceived(QVideoFrame *frame)
             }
             m_frame = new QVideoFrame(*frame);
             mutex.unlock();
-            framed = true;
         }
     }
 
@@ -139,11 +137,11 @@ void VideoProducer::onNewVideoContentReceived(QVideoFrame *frame)
 /*! \brief Pics the rgb value of the pixel specified by x and y and return it as a string
  *  \param x Integer: The x coordinate of the pixel
  *  \param y Integer: The y coordinate of the pixel
+ *  \return rgbHex QString: The hexadecimal string containing the pixel color value
  */
-
 QString VideoProducer::getPixelAsStr(int x, int y){
     mutex.lock();
-    if (m_frame == nullptr || x>m_frame->size().width() || y>m_frame->size().height() || x<0 || y<0){
+    if (m_frame == nullptr || x>=m_frame->size().width() || y>=m_frame->size().height() || x<0 || y<0){
         mutex.unlock();
         return QString("Invalid");
     }
@@ -152,9 +150,9 @@ QString VideoProducer::getPixelAsStr(int x, int y){
                  m_frame->height(), m_frame->bytesPerLine(),
                  QImage::Format_RGB32);
     mutex.unlock();
-    QRgb testPixel = image.pixel(x,y);
-    QString rgb("");
-    rgb += QString::number(testPixel,16);
+    QRgb pixelVal = image.pixel(x,y);
+    QString rgbHex("#");
+    rgbHex += QString::number(pixelVal,16);
 
-    return rgb;
+    return rgbHex;
 }

--- a/src/yarpview/plugin/videoproducer.cpp
+++ b/src/yarpview/plugin/videoproducer.cpp
@@ -24,6 +24,8 @@ VideoProducer::VideoProducer(QObject *parent) :
 {
     m_format = nullptr;
     m_surface = nullptr;
+    m_frame = nullptr;
+    framed = false;
 }
 
 VideoProducer::~VideoProducer()
@@ -121,6 +123,38 @@ void VideoProducer::onNewVideoContentReceived(QVideoFrame *frame)
         if (!b) {
             qWarning("Surface PRESENT ERROR");
         }
+        else{
+            mutex.lock();
+            if(m_frame != nullptr){
+                delete m_frame;
+            }
+            m_frame = new QVideoFrame(*frame);
+            mutex.unlock();
+            framed = true;
+        }
     }
 
+}
+
+/*! \brief Pics the rgb value of the pixel specified by x and y and return it as a string
+ *  \param x Integer: The x coordinate of the pixel
+ *  \param y Integer: The y coordinate of the pixel
+ */
+
+QString VideoProducer::getPixelAsStr(int x, int y){
+    mutex.lock();
+    if (m_frame == nullptr || x>m_frame->size().width() || y>m_frame->size().height() || x<0 || y<0){
+        mutex.unlock();
+        return QString("Invalid");
+    }
+    m_frame->map( QAbstractVideoBuffer::ReadOnly );
+    QImage image(m_frame->bits(), m_frame->width(),
+                 m_frame->height(), m_frame->bytesPerLine(),
+                 QImage::Format_RGB32);
+    mutex.unlock();
+    QRgb testPixel = image.pixel(x,y);
+    QString rgb("");
+    rgb += QString::number(testPixel,16);
+
+    return rgb;
 }

--- a/src/yarpview/plugin/videoproducer.h
+++ b/src/yarpview/plugin/videoproducer.h
@@ -20,6 +20,7 @@
 #define VIDEOPRODUCER_H
 
 #include <QObject>
+#include <QMutex>
 #include <QAbstractVideoSurface>
 #include <QVideoSurfaceFormat>
 
@@ -38,6 +39,7 @@ class VideoProducer : public QObject
 public:
     VideoProducer(QObject *parent = 0);
     ~VideoProducer();
+    QString getPixelAsStr(int x, int y);
 
     QAbstractVideoSurface *videoSurface() const;
     void setVideoSurface(QAbstractVideoSurface *surface);
@@ -48,6 +50,9 @@ public:
 private:
     QAbstractVideoSurface *m_surface;
     QVideoSurfaceFormat *m_format;
+    QVideoFrame *m_frame;
+    bool framed;
+    QMutex mutex;
 
 signals:
     void resizeWindowRequest();

--- a/src/yarpview/plugin/videoproducer.h
+++ b/src/yarpview/plugin/videoproducer.h
@@ -50,8 +50,7 @@ public:
 private:
     QAbstractVideoSurface *m_surface;
     QVideoSurfaceFormat *m_format;
-    QVideoFrame *m_frame;
-    bool framed;
+    QVideoFrame *m_frame;  // Stores the value of the current video frame to allow "color picking"
     QMutex mutex;
 
 signals:

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -128,6 +128,11 @@ ApplicationWindow {
             vSurface.saveSetImages(checked)
 
         }
+
+        onPickColor:{
+            vSurface.enableColorPicking(checked);
+        }
+
         onAbout:{
             vSurface.about()
         }

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -131,6 +131,7 @@ ApplicationWindow {
 
         onPickColor:{
             vSurface.enableColorPicking(checked);
+            statusBar.setPixelValVisibility(checked);
         }
 
         onAbout:{
@@ -139,6 +140,15 @@ ApplicationWindow {
 
         onQuit:{
             Qt.quit()
+        }
+    }
+
+    Connections{
+        target: statusBar
+
+        onHeightChanged:{
+            calc();
+            vSurface.setOriginalAspectRatio()
         }
     }
 }


### PR DESCRIPTION
* Added a checkable menu item that, if checked, shows an additional line in the `status bar` that display the color value of the pixel pointed by the mouse cursor.
  
  The string has the following format 
  ```
  Pixel("x","y") = "hexstring"
  ```
  Where  `x` and `y` are the coordinates of the pixel and `hexstring` is the hexadecimal (in the ARGB format) string representing the pixel color
  
  The additional line on the `status bar` contains also a little rectangle that will turn the same color of the currently selected pixel.