### PR TITLE
Fix bug of use forward/print callback user defined 

### DIFF
--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -764,22 +764,11 @@ yarp::os::Log::LogCallback yarp::os::Log::defaultForwardCallback()
 // BEGIN Log Components
 const yarp::os::LogComponent& yarp::os::Log::defaultLogComponent()
 {
-    yarp::os::Log::LogCallback fwCbk = defaultForwardCallback();
-    if(nullptr != forwardCallback())
-    {
-        fwCbk = forwardCallback();
-    }
-    
-    yarp::os::Log::LogCallback printCbk = defaultPrintCallback();
-    if(nullptr != printCallback())
-    {
-        printCbk = printCallback();
-    }
     static const yarp::os::LogComponent component(nullptr,
                                                   defaultMinimumPrintLevel(),
                                                   defaultMinimumForwardLevel(),
-                                                  printCbk,
-                                                  fwCbk);
+                                                  printCallback(),
+                                                  forwardCallback());
     return component;
 }
 

--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -764,11 +764,22 @@ yarp::os::Log::LogCallback yarp::os::Log::defaultForwardCallback()
 // BEGIN Log Components
 const yarp::os::LogComponent& yarp::os::Log::defaultLogComponent()
 {
+    yarp::os::Log::LogCallback fwCbk = defaultForwardCallback();
+    if(nullptr != forwardCallback())
+    {
+        fwCbk = forwardCallback();
+    }
+    
+    yarp::os::Log::LogCallback printCbk = defaultPrintCallback();
+    if(nullptr != printCallback())
+    {
+        printCbk = printCallback();
+    }
     static const yarp::os::LogComponent component(nullptr,
                                                   defaultMinimumPrintLevel(),
                                                   defaultMinimumForwardLevel(),
-                                                  defaultPrintCallback(),
-                                                  defaultForwardCallback());
+                                                  printCbk,
+                                                  fwCbk);
     return component;
 }
 

--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -765,8 +765,8 @@ yarp::os::Log::LogCallback yarp::os::Log::defaultForwardCallback()
 const yarp::os::LogComponent& yarp::os::Log::defaultLogComponent()
 {
     static const yarp::os::LogComponent component(nullptr,
-                                                  defaultMinimumPrintLevel(),
-                                                  defaultMinimumForwardLevel(),
+                                                  minimumPrintLevel(),
+                                                  minimumForwardLevel(),
                                                   printCallback(),
                                                   forwardCallback());
     return component;

--- a/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.cpp
@@ -28,7 +28,7 @@ void yarp::serversql::impl::LogComponent::print_callback(yarp::os::Log::LogType 
     auto minlev = minimumServersqlPrintLevel.load();
     if (type >= minlev) {
         if (minlev <= yarp::os::Log::DebugType) {
-            yarp::os::Log::defaultPrintCallback()(type, msg, file, line, func, systemtime, networktime, comp_name);
+            yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, comp_name);
         } else {
             static const char* err_str = "[ERROR] ";
             static const char* warn_str = "[WARNING] ";

--- a/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.h
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.h
@@ -40,7 +40,7 @@ void setMinumumLogType(yarp::os::Log::LogType minumumLogType);
                                                       yarp::os::Log::TraceType, \
                                                       yarp::os::Log::DebugType, \
                                                       yarp::serversql::impl::LogComponent::print_callback, \
-                                                      yarp::os::Log::defaultForwardCallback()); \
+                                                      yarp::os::Log::forwardCallback()); \
         return component; \
     }
 


### PR DESCRIPTION
In this PR, I fix a bug regarding the call of forward/print callback: the default component was created using the default-forward/default-print callback instead of the user defined one; in this way, the user callbacks were not invoked.

I fix this bug, creati g the default component with the user callbacks if they are defined.

To test this patch I defined a forward user callback in embobjMotionControl
```
static void testForwarderLog(yarp::os::Log::LogType t,
                                 const char* msg,
                                 const char* file,
                                 const unsigned int line,
                                 const char* func,
                                 double systemtime,
                                 double networktime,
                                 const char* comp_name)
{
    std::string type = "type:unknown" ;
    switch(t)
    {
        case yarp::os::Log::LogType::TraceType: type = "type:Trace" ;
            break;
        case yarp::os::Log::LogType::DebugType: type = "type:Debug" ;
            break;
        case yarp::os::Log::LogType::InfoType: type = "type:Info" ;
            break;
        case yarp::os::Log::LogType::WarningType: type = "type:Warning" ;
            break;
        case yarp::os::Log::LogType::ErrorType: type = "type:Error" ;
            break;
        case yarp::os::Log::LogType::FatalType: type = "type:Fatal" ;
            break;
        default:
            break;
    };
    
    
    yarp::os::Log::LogCallback defaultcbk=yarp::os::Log::defaultForwardCallback();

    defaultcbk(t,
               msg,
               file,
               line,
               func,
               systemtime,
               networktime,
               comp_name);
    
    std::cout << "@@@TEST USER-FW-CBK: ==> " << type << "  @" <<systemtime << " " <<msg << std::endl;

}
```

and set it in the open function

```
bool embObjMotionControl::open(yarp::os::Searchable &config)
{
    // - first thing to do is verify if the eth manager is available. then i parse info about the eth board.

    yarp::os::Log::setForwardCallback(testForwarderLog);
    //yErrorCustomTime(111.22) << "embObjMotionControl::open(): first test of timed y*";
    
    ethManager = eth::TheEthManager::instance();
....
```

The output I get is this:
![Screenshot from 2020-05-29 16-01-27](https://user-images.githubusercontent.com/4233231/83268301-b5dcd800-a1c5-11ea-9860-876a29850052.png)

As you can see, each debug message is duplicated by the forward callback invocation.

