### PR TITLE
Modify libYARP_robotinterface to enable proper error propagation

### DIFF
--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
@@ -72,6 +72,7 @@ public:
                 }
             }
 
+            delete driver->driver;
             delete driver;
             driver = nullptr;
         }

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
@@ -12,6 +12,8 @@
 #include <string>
 
 #include <yarp/robotinterface/api.h>
+#include <yarp/robotinterface/Robot.h>
+
 
 namespace yarp {
 namespace robotinterface {
@@ -19,13 +21,50 @@ namespace robotinterface {
 class Robot;
 class XMLReaderFileVx;
 
+/**
+ * Result of the parsing of XMLReader.
+ */
+class YARP_robotinterface_API XMLReaderResult
+{
+public:
+    static XMLReaderResult ParsingFailed() {
+        XMLReaderResult result;
+        result.parsingIsSuccessful = false;
+        return result;
+    }
+
+    /**
+     * True if the parsing was successful, false otherwise.
+     */
+    bool parsingIsSuccessful = false;
+
+    /**
+     * If parsingIsSuccessful is true, contains a valid robot instance.
+     */
+    Robot robot;
+};
+
 class YARP_robotinterface_API XMLReader
 {
 public:
     XMLReader();
     virtual ~XMLReader();
 
-    Robot& getRobot(const std::string &filename);
+    /**
+     * Parse the XML description of a robotinterface from a file.
+     *
+     * \param filename path to the XML file to load.
+     * \return result of parsing.
+     */
+    XMLReaderResult getRobotFromFile(const std::string &filename);
+
+    /**
+     * Parse the XML description of a robotinterface from a string.
+     *
+     * \param xmlString string containing the XML code to parse.
+     * \return result of parsing.
+     */
+    XMLReaderResult getRobotFromString(const std::string& xmlString);
     void setVerbose(bool verbose);
     void setEnableDeprecated(bool enab);
 private:

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
@@ -12,6 +12,7 @@
 #include "Param.h"
 #include "Robot.h"
 #include "Types.h"
+#include "XMLReader.h"
 #include "impl/XMLReaderFileVx.h"
 
 #include <yarp/os/LogStream.h>
@@ -25,9 +26,8 @@
 #include <iterator>
 #include <algorithm>
 
-#define SYNTAX_ERROR(line) yFatal() << "Syntax error while loading" << curr_filename << "at line" << line << "."
+#define SYNTAX_ERROR(line) yError() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
-
 
 // BUG in TinyXML, see
 // https://sourceforge.net/tracker/?func=detail&aid=3567726&group_id=13559&atid=113559
@@ -40,23 +40,24 @@ public:
     explicit privateXMLReaderFileV3(XMLReaderFileV3 *parent);
     virtual ~privateXMLReaderFileV3();
 
-    yarp::robotinterface::Robot& readRobotFile(const std::string &fileName);
-    yarp::robotinterface::Robot& readRobotTag(TiXmlElement *robotElem);
+    yarp::robotinterface::XMLReaderResult readRobotFromFile(const std::string &fileName);
+    yarp::robotinterface::XMLReaderResult readRobotFromString(const std::string& xmlString);
+    yarp::robotinterface::XMLReaderResult readRobotTag(TiXmlElement *robotElem);
 
-    yarp::robotinterface::DeviceList readDevices(TiXmlElement *devicesElem);
-    yarp::robotinterface::Device readDeviceTag(TiXmlElement *deviceElem);
-    yarp::robotinterface::DeviceList readDevicesTag(TiXmlElement *devicesElem);
+    yarp::robotinterface::DeviceList readDevices(TiXmlElement* devicesElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::Device readDeviceTag(TiXmlElement* deviceElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::DeviceList readDevicesTag(TiXmlElement* devicesElem, yarp::robotinterface::XMLReaderResult& result);
 
-    yarp::robotinterface::ParamList readParams(TiXmlElement *paramsElem);
-    yarp::robotinterface::Param readParamTag(TiXmlElement *paramElem);
-    yarp::robotinterface::Param readGroupTag(TiXmlElement *groupElem);
-    yarp::robotinterface::ParamList readParamListTag(TiXmlElement *paramListElem);
-    yarp::robotinterface::ParamList readSubDeviceTag(TiXmlElement *subDeviceElem);
-    yarp::robotinterface::ParamList readParamsTag(TiXmlElement *paramsElem);
+    yarp::robotinterface::ParamList readParams(TiXmlElement* paramsElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::Param readParamTag(TiXmlElement* paramElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::Param readGroupTag(TiXmlElement* groupElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::ParamList readParamListTag(TiXmlElement* paramListElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::ParamList readSubDeviceTag(TiXmlElement* subDeviceElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::ParamList readParamsTag(TiXmlElement* paramsElem, yarp::robotinterface::XMLReaderResult& result);
 
-    yarp::robotinterface::ActionList readActions(TiXmlElement *actionsElem);
-    yarp::robotinterface::Action readActionTag(TiXmlElement *actionElem);
-    yarp::robotinterface::ActionList readActionsTag(TiXmlElement *actionsElem);
+    yarp::robotinterface::ActionList readActions(TiXmlElement* actionsElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::Action readActionTag(TiXmlElement* actionElem, yarp::robotinterface::XMLReaderResult& result);
+    yarp::robotinterface::ActionList readActionsTag(TiXmlElement* actionsElem, yarp::robotinterface::XMLReaderResult& result);
 
     bool PerformInclusions(TiXmlNode* pParent, const std::string& parent_fileName, const std::string& current_path);
 
@@ -66,7 +67,6 @@ public:
     RobotInterfaceDTD dtd;
 #endif
 
-    Robot robot;
     bool verbose_output;
     std::string curr_filename;
     unsigned int minorVersion;
@@ -84,16 +84,18 @@ yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::privateXMLReaderF
 
 yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::~privateXMLReaderFileV3() = default;
 
-yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotFile(const std::string &fileName)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotFromFile(const std::string &fileName)
 {
     yDebug() << "Reading file" << fileName.c_str();
     auto* doc = new TiXmlDocument(fileName.c_str());
     if (!doc->LoadFile()) {
         SYNTAX_ERROR(doc->ErrorRow()) << doc->ErrorDesc();
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
     }
 
     if (!doc->RootElement()) {
         SYNTAX_ERROR(doc->Row()) << "No root element.";
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
     }
 
 #ifdef USE_DTD
@@ -139,12 +141,32 @@ yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::privateXMLRe
         yDebug() << "Preprocessor output stored in: " << full_log_withpath;
         doc->SaveFile(full_log_withpath);
     }
-    readRobotTag(doc->RootElement());
+    yarp::robotinterface::XMLReaderResult result = readRobotTag(doc->RootElement());
     delete doc;
 
     // yDebug() << robot;
 
-    return robot;
+    return result;
+}
+
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotFromString(const std::string& xmlString)
+{
+    curr_filename = " XML runtime string ";
+    auto* doc = new TiXmlDocument();
+    if (!doc->Parse(xmlString.c_str())) {
+        SYNTAX_ERROR(doc->ErrorRow()) << doc->ErrorDesc();
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
+    }
+
+    if (!doc->RootElement()) {
+        SYNTAX_ERROR(doc->Row()) << "No root element.";
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
+    }
+
+    yarp::robotinterface::XMLReaderResult result = readRobotTag(doc->RootElement());
+    delete doc;
+
+    return result;
 }
 
 bool yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::PerformInclusions(TiXmlNode* pParent, const std::string& parent_fileName, const std::string& current_path)
@@ -213,18 +235,23 @@ bool yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::PerformInclu
     return true;
 }
 
-yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotTag(TiXmlElement *robotElem)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotTag(TiXmlElement *robotElem)
 {
+    yarp::robotinterface::XMLReaderResult result;
+    result.parsingIsSuccessful = true;
+
     if (robotElem->ValueStr() != "robot") {
         SYNTAX_ERROR(robotElem->Row()) << "Root element should be \"robot\". Found" << robotElem->ValueStr();
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
     }
 
-    if (robotElem->QueryStringAttribute("name", &robot.name()) != TIXML_SUCCESS) {
+    if (robotElem->QueryStringAttribute("name", &result.robot.name()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(robotElem->Row()) << R"("robot" element should contain the "name" attribute)";
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
     }
 
 #if TINYXML_UNSIGNED_INT_BUG
-    if (robotElem->QueryUnsignedAttribute("build", &robot.build()) != TIXML_SUCCESS) {
+    if (robotElem->QueryUnsignedAttribute("build", &result.robot.build()) != TIXML_SUCCESS) {
         // No build attribute. Assuming build="0"
         SYNTAX_WARNING(robotElem->Row()) << "\"robot\" element should contain the \"build\" attribute [unsigned int]. Assuming 0";
     }
@@ -235,12 +262,12 @@ yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::privateXMLRe
         SYNTAX_WARNING(robotElem->Row()) << R"("robot" element should contain the "build" attribute [unsigned int]. Assuming 0)";
         tmp = 0;
     }
-    robot.build() = (unsigned)tmp;
+    result.robot.build() = (unsigned)tmp;
 #endif
 
-    if (robotElem->QueryStringAttribute("portprefix", &robot.portprefix()) != TIXML_SUCCESS) {
+    if (robotElem->QueryStringAttribute("portprefix", &result.robot.portprefix()) != TIXML_SUCCESS) {
         SYNTAX_WARNING(robotElem->Row()) << R"("robot" element should contain the "portprefix" attribute. Using "name" attribute)";
-        robot.portprefix() = robot.name();
+        result.robot.portprefix() = result.robot.name();
     }
 
     // yDebug() << "Found robot [" << robot.name() << "] build [" << robot.build() << "] portprefix [" << robot.portprefix() << "]";
@@ -250,74 +277,83 @@ yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::privateXMLRe
         std::string elemString = childElem->ValueStr();
         if (elemString == "device" || elemString == "devices")
         {
-            DeviceList childDevices = readDevices(childElem);
+            DeviceList childDevices = readDevices(childElem, result);
             for (DeviceList::const_iterator it = childDevices.begin(); it != childDevices.end(); ++it) {
-                robot.devices().push_back(*it);
+                result.robot.devices().push_back(*it);
             }
         }
         else
         {
-            ParamList childParams = readParams(childElem);
+            ParamList childParams = readParams(childElem, result);
             for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
-                robot.params().push_back(*it);
+                result.robot.params().push_back(*it);
             }
         }
     }
 
-    return robot;
+    return result;
 }
 
 
 
-yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevices(TiXmlElement *devicesElem)
+yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevices(TiXmlElement *devicesElem,
+                                                                                                            yarp::robotinterface::XMLReaderResult& result)
 {
     const std::string &valueStr = devicesElem->ValueStr();
 
     if (valueStr == "device") {
         // yDebug() << valueStr;
         DeviceList deviceList;
-        deviceList.push_back(readDeviceTag(devicesElem));
+        deviceList.push_back(readDeviceTag(devicesElem, result));
         return deviceList;
     }
     else if (valueStr == "devices") {
         // "devices"
-        return readDevicesTag(devicesElem);
+        return readDevicesTag(devicesElem, result);
     }
     else
     {
         SYNTAX_ERROR(devicesElem->Row()) << R"(Expected "device" or "devices". Found)" << valueStr;
+        result.parsingIsSuccessful = false;
     }
     return DeviceList();
 }
 
-yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDeviceTag(TiXmlElement *deviceElem)
+yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDeviceTag(TiXmlElement *deviceElem,
+                                                                                                          yarp::robotinterface::XMLReaderResult& result)
 {
     const std::string &valueStr = deviceElem->ValueStr();
 
     if (valueStr != "device") {
         SYNTAX_ERROR(deviceElem->Row()) << "Expected \"device\". Found" << valueStr;
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Device();
     }
 
     Device device;
 
     if (deviceElem->QueryStringAttribute("name", &device.name()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(deviceElem->Row()) << R"("device" element should contain the "name" attribute)";
+        result.parsingIsSuccessful = false;
+        return device;
     }
 
     // yDebug() << "Found device [" << device.name() << "]";
 
     if (deviceElem->QueryStringAttribute("type", &device.type()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(deviceElem->Row()) << R"("device" element should contain the "type" attribute)";
+        result.parsingIsSuccessful = false;
+        return device;
     }
 
-    device.params().push_back(Param("robotName", robot.portprefix()));
+    device.params().push_back(Param("robotName", result.robot.portprefix()));
 
     for (TiXmlElement* childElem = deviceElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement())
     {
         if (childElem->ValueStr() == "action" ||
             childElem->ValueStr() == "actions")
         {
-            ActionList childActions = readActions(childElem);
+            ActionList childActions = readActions(childElem, result);
             for (ActionList::const_iterator it = childActions.begin(); it != childActions.end(); ++it)
             {
                 device.actions().push_back(*it);
@@ -325,7 +361,7 @@ yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLRe
         }
         else
         {
-            ParamList childParams = readParams(childElem);
+            ParamList childParams = readParams(childElem, result);
             for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it)
             {
                 device.params().push_back(*it);
@@ -337,13 +373,14 @@ yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLRe
     return device;
 }
 
-yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevicesTag(TiXmlElement *devicesElem)
+yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevicesTag(TiXmlElement *devicesElem,
+                                                                                                               yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = devicesElem->ValueStr();
 
     DeviceList devices;
     for (TiXmlElement* childElem = devicesElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        DeviceList childDevices = readDevices(childElem);
+        DeviceList childDevices = readDevices(childElem, result);
         for (DeviceList::const_iterator it = childDevices.begin(); it != childDevices.end(); ++it) {
             devices.push_back(*it);
         }
@@ -352,43 +389,50 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateX
     return devices;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParams(TiXmlElement* paramsElem)
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParams(TiXmlElement* paramsElem,
+                                                                                                          yarp::robotinterface::XMLReaderResult& result)
 {
     const std::string &valueStr = paramsElem->ValueStr();
 
     if (valueStr == "param") {
         ParamList params;
-        params.push_back(readParamTag(paramsElem));
+        params.push_back(readParamTag(paramsElem, result));
         return params;
     } else if (valueStr == "group") {
         ParamList params;
-        params.push_back(readGroupTag(paramsElem));
+        params.push_back(readGroupTag(paramsElem, result));
         return params;
     } else if (valueStr == "paramlist") {
-        return readParamListTag(paramsElem);
+        return readParamListTag(paramsElem, result);
     } else if (valueStr == "subdevice") {
-        return readSubDeviceTag(paramsElem);
+        return readSubDeviceTag(paramsElem, result);
     } else if (valueStr == "params") {
-        return readParamsTag(paramsElem);
+        return readParamsTag(paramsElem, result);
     }
     else
     {
         SYNTAX_ERROR(paramsElem->Row()) << R"(Expected "param", "group", "paramlist", "subdevice", or "params". Found)" << valueStr;
+        result.parsingIsSuccessful = false;
     }
     return ParamList();
 }
 
 
-yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamTag(TiXmlElement *paramElem)
+yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamTag(TiXmlElement *paramElem,
+                                                                                                        yarp::robotinterface::XMLReaderResult& result)
 {
     if (paramElem->ValueStr() != "param") {
         SYNTAX_ERROR(paramElem->Row()) << "Expected \"param\". Found" << paramElem->ValueStr();
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
 
     Param param;
 
     if (paramElem->QueryStringAttribute("name", &param.name()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(paramElem->Row()) << R"("param" element should contain the "name" attribute)";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
 
     // yDebug() << "Found param [" << param.name() << "]";
@@ -396,6 +440,8 @@ yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLRea
     const char *valueText = paramElem->GetText();
     if (!valueText) {
         SYNTAX_ERROR(paramElem->Row()) << R"("param" element should have a value [ "name" = )" << param.name() << "]";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
     param.value() = valueText;
 
@@ -403,29 +449,36 @@ yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLRea
     return param;
 }
 
-yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readGroupTag(TiXmlElement* groupElem)
+yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readGroupTag(TiXmlElement* groupElem,
+                                                                                                        yarp::robotinterface::XMLReaderResult& result)
 {
     if (groupElem->ValueStr() != "group") {
         SYNTAX_ERROR(groupElem->Row()) << "Expected \"group\". Found" << groupElem->ValueStr();
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
 
     Param group(true);
 
     if (groupElem->QueryStringAttribute("name", &group.name()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(groupElem->Row()) << R"("group" element should contain the "name" attribute)";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
 
     // yDebug() << "Found group [" << group.name() << "]";
 
     ParamList params;
     for (TiXmlElement* childElem = groupElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        ParamList childParams = readParams(childElem);
+        ParamList childParams = readParams(childElem, result);
         for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
             params.push_back(*it);
         }
     }
     if (params.empty()) {
         SYNTAX_ERROR(groupElem->Row()) << "\"group\" cannot be empty";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Param();
     }
 
     std::string groupString;
@@ -441,10 +494,13 @@ yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLRea
     return group;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamListTag(TiXmlElement* paramListElem)
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamListTag(TiXmlElement* paramListElem,
+                                                                                                                yarp::robotinterface::XMLReaderResult& result)
 {
     if (paramListElem->ValueStr() != "paramlist") {
         SYNTAX_ERROR(paramListElem->Row()) << "Expected \"paramlist\". Found" << paramListElem->ValueStr();
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::ParamList();
     }
 
     ParamList params;
@@ -452,6 +508,8 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 
     if (paramListElem->QueryStringAttribute("name", &mainparam.name()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(paramListElem->Row()) << R"("paramlist" element should contain the "name" attribute)";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::ParamList();
     }
 
     params.push_back(mainparam);
@@ -461,17 +519,23 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     for (TiXmlElement* childElem = paramListElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
         if (childElem->ValueStr() != "elem") {
             SYNTAX_ERROR(childElem->Row()) << "Expected \"elem\". Found" << childElem->ValueStr();
+            result.parsingIsSuccessful = false;
+            return yarp::robotinterface::ParamList();
         }
 
         Param childParam;
 
         if (childElem->QueryStringAttribute("name", &childParam.name()) != TIXML_SUCCESS) {
             SYNTAX_ERROR(childElem->Row()) << R"("elem" element should contain the "name" attribute)";
+            result.parsingIsSuccessful = false;
+            return yarp::robotinterface::ParamList();
         }
 
         const char *valueText = childElem->GetText();
         if (!valueText) {
             SYNTAX_ERROR(childElem->Row()) << R"("elem" element should have a value [ "name" = )" << childParam.name() << "]";
+            result.parsingIsSuccessful = false;
+            return yarp::robotinterface::ParamList();
         }
         childParam.value() = valueText;
 
@@ -480,6 +544,8 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 
     if (params.empty()) {
         SYNTAX_ERROR(paramListElem->Row()) << "\"paramlist\" cannot be empty";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::ParamList();
     }
 
     // +1 skips the first element, that is the main param
@@ -493,10 +559,13 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readSubDeviceTag(TiXmlElement *subDeviceElem)
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readSubDeviceTag(TiXmlElement *subDeviceElem,
+                                                                                                                yarp::robotinterface::XMLReaderResult& result)
 {
     if (subDeviceElem->ValueStr() != "subdevice") {
         SYNTAX_ERROR(subDeviceElem->Row()) << "Expected \"subdevice\". Found" << subDeviceElem->ValueStr();
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::ParamList();
     }
 
     ParamList params;
@@ -513,6 +582,8 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 
     if (subDeviceElem->QueryStringAttribute("type", &subDeviceParam.value()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(subDeviceElem->Row()) << R"("subdevice" element should contain the "type" attribute)";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::ParamList();
     }
 
 //FIXME    params.push_back(featIdParam);
@@ -521,7 +592,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     // yDebug() << "Found subdevice [" << params.at(0).value() << "]";
 
     for (TiXmlElement* childElem = subDeviceElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        ParamList childParams = readParams(childElem);
+        ParamList childParams = readParams(childElem, result);
         for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
             params.push_back(Param(it->name(), it->value()));
         }
@@ -531,13 +602,14 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamsTag(TiXmlElement *paramsElem)
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamsTag(TiXmlElement *paramsElem,
+                                                                                                             yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = paramsElem->ValueStr();
 
     ParamList params;
     for (TiXmlElement* childElem = paramsElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        ParamList childParams = readParams(childElem);
+        ParamList childParams = readParams(childElem, result);
         for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
             params.push_back(*it);
         }
@@ -546,7 +618,8 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActions(TiXmlElement *actionsElem)
+yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActions(TiXmlElement *actionsElem,
+                                                                                                            yarp::robotinterface::XMLReaderResult& result)
 {
     const std::string &valueStr = actionsElem->ValueStr();
 
@@ -558,28 +631,35 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateX
 
     if (valueStr == "action") {
         ActionList actionList;
-        actionList.push_back(readActionTag(actionsElem));
+        actionList.push_back(readActionTag(actionsElem, result));
         return actionList;
     }
     // "actions"
-    return readActionsTag(actionsElem);
+    return readActionsTag(actionsElem, result);
 }
 
-yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionTag(TiXmlElement* actionElem)
+yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionTag(TiXmlElement* actionElem,
+                                                                                                          yarp::robotinterface::XMLReaderResult& result)
 {
     if (actionElem->ValueStr() != "action") {
         SYNTAX_ERROR(actionElem->Row()) << "Expected \"action\". Found" << actionElem->ValueStr();
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Action();
     }
 
     Action action;
 
     if (actionElem->QueryValueAttribute<ActionPhase>("phase", &action.phase()) != TIXML_SUCCESS || action.phase() == ActionPhaseUnknown) {
         SYNTAX_ERROR(actionElem->Row()) << R"("action" element should contain the "phase" attribute [startup|interrupt{1,2,3}|shutdown])";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Action();
     }
 
 
     if (actionElem->QueryValueAttribute<ActionType>("type", &action.type()) != TIXML_SUCCESS || action.type() == ActionTypeUnknown) {
         SYNTAX_ERROR(actionElem->Row()) << R"("action" element should contain the "type" attribute [configure|calibrate|attach|abort|detach|park|custom])";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Action();
     }
 
     // yDebug() << "Found action [ ]";
@@ -592,12 +672,14 @@ yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV3::privateXMLRe
     int tmp;
     if (actionElem->QueryIntAttribute("level", &tmp) != TIXML_SUCCESS || tmp < 0) {
         SYNTAX_ERROR(actionElem->Row()) << R"("action" element should contain the "level" attribute [unsigned int])";
+        result.parsingIsSuccessful = false;
+        return yarp::robotinterface::Action();
     }
     action.level() = (unsigned)tmp;
 #endif
 
     for (TiXmlElement* childElem = actionElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        ParamList childParams = readParams(childElem);
+        ParamList childParams = readParams(childElem, result);
         for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
             action.params().push_back(*it);
         }
@@ -607,7 +689,8 @@ yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV3::privateXMLRe
     return action;
 }
 
-yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionsTag(TiXmlElement *actionsElem)
+yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionsTag(TiXmlElement *actionsElem,
+                                                                                                               yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = actionsElem->ValueStr();
 
@@ -616,8 +699,8 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateX
         SYNTAX_WARNING(actionsElem->Row()) << R"("actions" element should contain the "robot" attribute)";
     }
 
-    if (robotName != robot.name()) {
-        SYNTAX_WARNING(actionsElem->Row()) << "Trying to import a file for the wrong robot. Found" << robotName << "instead of" << robot.name();
+    if (robotName != result.robot.name()) {
+        SYNTAX_WARNING(actionsElem->Row()) << "Trying to import a file for the wrong robot. Found" << robotName << "instead of" << result.robot.name();
     }
 
     unsigned int build;
@@ -636,13 +719,13 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateX
     build = (unsigned)tmp;
 #endif
 
-    if (build != robot.build()) {
-        SYNTAX_WARNING(actionsElem->Row()) << "Import a file for a different robot build. Found" << build << "instead of" << robot.build();
+    if (build != result.robot.build()) {
+        SYNTAX_WARNING(actionsElem->Row()) << "Import a file for a different robot build. Found" << build << "instead of" << result.robot.build();
     }
 
     ActionList actions;
     for (TiXmlElement* childElem = actionsElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        ActionList childActions = readActions(childElem);
+        ActionList childActions = readActions(childElem, result);
         for (ActionList::const_iterator it = childActions.begin(); it != childActions.end(); ++it) {
             actions.push_back(*it);
         }
@@ -652,11 +735,18 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateX
 }
 
 
-yarp::robotinterface::Robot& yarp::robotinterface::XMLReaderFileV3::getRobotFile(const std::string& filename, bool verb)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::getRobotFromFile(const std::string& filename, bool verb)
 {
     mPriv->verbose_output = verb;
-    return mPriv->readRobotFile(filename);
+    return mPriv->readRobotFromFile(filename);
 }
+
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::getRobotFromString(const std::string& xmlString, bool verb)
+{
+    mPriv->verbose_output = verb;
+    return mPriv->readRobotFromString(xmlString);
+}
+
 
 yarp::robotinterface::XMLReaderFileV3::XMLReaderFileV3() : mPriv(new privateXMLReaderFileV3(this))
 {

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
@@ -21,6 +21,7 @@
 #include <yarp/os/Property.h>
 
 #include <tinyxml.h>
+#include <memory>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -133,7 +134,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReader::getRobotF
 yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReader::getRobotFromString(const std::string& xmlString)
 {
     std::string curr_filename = " XML runtime string ";
-    auto* doc = new TiXmlDocument();
+    std::unique_ptr<TiXmlDocument> doc = std::make_unique<TiXmlDocument>();
     if (!doc->Parse(xmlString.data())) {
         SYNTAX_ERROR(doc->ErrorRow()) << doc->ErrorDesc();
         return yarp::robotinterface::XMLReaderResult::ParsingFailed();

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
@@ -16,12 +16,15 @@
 namespace yarp {
 namespace robotinterface {
 
+class XMLReaderResult;
+
 class XMLReaderFileVx
 {
 public:
     bool verbose;
     virtual ~XMLReaderFileVx() {};
-    virtual  Robot& getRobotFile(const std::string &filename, bool verbose = false)=0;
+    virtual XMLReaderResult getRobotFromFile(const std::string& filename, bool verbose = false) = 0;
+    virtual XMLReaderResult getRobotFromString(const std::string& xmlString, bool verbose = false) = 0;
 };
 
 class XMLReaderFileV1 : public XMLReaderFileVx
@@ -30,8 +33,8 @@ public:
     XMLReaderFileV1();
     virtual ~XMLReaderFileV1();
 
-    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
-
+    XMLReaderResult getRobotFromFile(const std::string& filename, bool verbose = false) override;
+    XMLReaderResult getRobotFromString(const std::string& xmlString, bool verbose = false) override;
 private:
     class privateXMLReaderFileV1;
     privateXMLReaderFileV1 * const mPriv;
@@ -43,7 +46,8 @@ public:
     XMLReaderFileV3();
     virtual ~XMLReaderFileV3();
 
-    Robot& getRobotFile(const std::string &filename, bool verbose = false) override;
+    XMLReaderResult getRobotFromFile(const std::string& filename, bool verbose = false) override;
+    XMLReaderResult getRobotFromString(const std::string& xmlString, bool verbose = false) override;
 
 private:
     class privateXMLReaderFileV3;

--- a/src/yarprobotinterface/Module.cpp
+++ b/src/yarprobotinterface/Module.cpp
@@ -111,13 +111,13 @@ yarprobotinterface::Module::~Module()
     delete mPriv;
 }
 
-bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder &rf)
+bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder& rf)
 {
     if (!rf.check("config")) {
         yFatal() << "Missing \"config\" argument";
     }
 
-    const std::string &filename = rf.findFile("config");
+    const std::string& filename = rf.findFile("config");
     yTrace() << "Reading robot config file" << filename;
 
     bool verbosity = rf.check("verbose");
@@ -125,7 +125,14 @@ bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder &rf)
     yarp::robotinterface::XMLReader reader;
     reader.setVerbose(verbosity);
     reader.setEnableDeprecated(deprecated);
-    mPriv->robot = reader.getRobot(filename);
+
+    yarp::robotinterface::XMLReaderResult result = reader.getRobotFromFile(filename);
+
+    if (!result.parsingIsSuccessful) {
+        yFatal() << "Config file " << filename << " not parsed correctly.";
+    }
+
+    mPriv->robot = std::move(result.robot);
     // yDebug() << mPriv->robot;
 
     // User can use YARP_PORT_PREFIX environment variable to override

--- a/tests/libYARP_robotinterface/RobotinterfaceTest.cpp
+++ b/tests/libYARP_robotinterface/RobotinterfaceTest.cpp
@@ -7,13 +7,16 @@
  */
 
 #include <yarp/robotinterface/Param.h>
+#include <yarp/robotinterface/XMLReader.h>
+
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <catch.hpp>
 #include <harness.h>
 
 TEST_CASE("robotinterface::ParamTest", "[yarp::robotinterface]")
 {
-
     SECTION("Check yarp::robotinterface::Param")
     {
         std::string name = "name";
@@ -26,3 +29,211 @@ TEST_CASE("robotinterface::ParamTest", "[yarp::robotinterface]")
         CHECK(param.isGroup() ==  isGroup);
     }
 };
+
+// Dummy device used in "Check valid robot file with two devices" test
+namespace yarp {
+    namespace dev {
+        class RobotInterfaceTestMockDriver;
+        class RobotInterfaceTestMockWrapper;
+    }
+}
+
+struct GlobalState
+{
+    bool mockDriverWasOpened;
+    bool mockWrapperWasOpened;
+    bool mockAttachWasCalled;
+    bool mockDetachWasCalled;
+    bool mockWrapperWasClosed;
+    bool mockDriverWasClosed;
+
+    void reset()
+    {
+        mockDriverWasOpened = false;
+        mockWrapperWasOpened = false;
+        mockAttachWasCalled = false;
+        mockDetachWasCalled = false;
+        mockWrapperWasClosed = false;
+        mockDriverWasClosed = false;
+    }
+};
+
+GlobalState globalState;
+
+class yarp::dev::RobotInterfaceTestMockDriver :
+        public yarp::dev::DeviceDriver
+{
+public:
+    virtual ~RobotInterfaceTestMockDriver();
+
+    //DEVICE DRIVER
+    virtual bool open(yarp::os::Searchable& config);
+    virtual bool close();
+};
+
+yarp::dev::RobotInterfaceTestMockDriver::~RobotInterfaceTestMockDriver()
+{
+}
+
+bool yarp::dev::RobotInterfaceTestMockDriver::open(yarp::os::Searchable& config)
+{
+    globalState.mockDriverWasOpened = true;
+    return true;
+}
+
+bool yarp::dev::RobotInterfaceTestMockDriver::close()
+{
+    globalState.mockDriverWasClosed = true;
+    return true;
+}
+
+class yarp::dev::RobotInterfaceTestMockWrapper :
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IMultipleWrapper
+{
+public:
+    virtual ~RobotInterfaceTestMockWrapper();
+
+    //DEVICE DRIVER
+    virtual bool open(yarp::os::Searchable& config);
+    virtual bool close();
+
+    //IMULTIPLEWRAPPER
+    virtual bool attachAll(const PolyDriverList&);
+    virtual bool detachAll();
+};
+
+yarp::dev::RobotInterfaceTestMockWrapper::~RobotInterfaceTestMockWrapper()
+{
+}
+
+bool yarp::dev::RobotInterfaceTestMockWrapper::open(yarp::os::Searchable&)
+{
+    globalState.mockWrapperWasOpened = true;
+    return true;
+}
+
+bool yarp::dev::RobotInterfaceTestMockWrapper::close()
+{
+    globalState.mockWrapperWasClosed = true;
+    return true;
+}
+
+bool yarp::dev::RobotInterfaceTestMockWrapper::attachAll(const PolyDriverList&)
+{
+    globalState.mockAttachWasCalled = true;
+    return true;
+}
+
+bool yarp::dev::RobotInterfaceTestMockWrapper::detachAll()
+{
+    globalState.mockDetachWasCalled = true;
+    return true;
+}
+
+
+
+TEST_CASE("robotinterface::XMLReaderTest", "[yarp::robotinterface]")
+{
+    SECTION("Check empty string")
+    {
+        // Load empty XML configuration file
+        std::string XMLString = "";
+        yarp::robotinterface::XMLReader reader;
+        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);
+
+        // Check parsing fails on empty string
+        CHECK(!result.parsingIsSuccessful);
+    }
+
+    SECTION("Check valid robot file with no devices")
+    {
+        // Load empty XML configuration file
+        std::string XMLString = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                                "<!DOCTYPE robot PUBLIC \"-//YARP//DTD yarprobotinterface 3.0//EN\" \"http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd\">\n"
+                                "<robot name=\"RobotWithNoDevices\" prefix=\"RobotWithNoDevices\">\n"
+                                "  <devices>\n"
+                                "  </devices>\n"
+                                "</robot>\n";
+
+        yarp::robotinterface::XMLReader reader;
+        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);
+
+        // Check parsing fails on empty string
+        CHECK(result.parsingIsSuccessful);
+
+        // Verify that no device has been loaded
+        CHECK(result.robot.devices().size() == 0);
+    }
+
+    SECTION("Check valid robot file with two devices")
+    {
+        // Reset test flags
+        globalState.reset();
+
+        // Add dummy devices to YARP drivers factory
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockDriver>("robotinterface_test_mock_device", "", "RobotInterfaceTestMockDriver"));
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockWrapper>("robotinterface_test_mock_wrapper", "", "RobotInterfaceTestMockWrapper"));
+
+        // Load empty XML configuration file
+        std::string XMLString = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                                "<!DOCTYPE robot PUBLIC \"-//YARP//DTD yarprobotinterface 3.0//EN\" \"http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd\">\n"
+                                "<robot name=\"RobotWithOneDevice\" prefix=\"RobotWithOneDevice\">\n"
+                                "  <devices>\n"
+                                "    <device name=\"dummy_device\" type=\"robotinterface_test_mock_device\">\n"
+                                "    </device>\n"
+                                "    <device name=\"dummy_wrapper\" type=\"robotinterface_test_mock_wrapper\">\n"
+                                "      <action phase=\"startup\" level=\"5\" type=\"attach\">\n"
+                                "        <paramlist name=\"networks\">\n"
+                                "          <elem name=\"attached_device\">  dummy_device </elem>\n"
+                                "        </paramlist>\n"
+                                "      </action>\n"
+                                "      <action phase=\"shutdown\" level=\"5\" type=\"detach\" />\n"
+                                "    </device>\n"
+                                "  </devices>\n"
+                                "</robot>\n";
+
+        yarp::robotinterface::XMLReader reader;
+        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);
+
+        // Check parsing fails on empty string
+        CHECK(result.parsingIsSuccessful);
+
+        // Verify that only one device has been loaded
+        CHECK(result.robot.devices().size() == 2);
+
+        // Verify that the devices were not opened and the attach was not called
+        CHECK(!globalState.mockDriverWasOpened);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockAttachWasCalled);
+        CHECK(!globalState.mockDetachWasCalled);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockDriverWasClosed);
+
+        // Start the robot (open the device and call "attach" actions)
+        bool ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseStartup);
+        CHECK(ok);
+
+        // Check that the device was opened and attach called
+        CHECK(globalState.mockDriverWasOpened);
+        CHECK(globalState.mockWrapperWasOpened);
+        CHECK(globalState.mockAttachWasCalled);
+        CHECK(!globalState.mockDetachWasCalled);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockDriverWasClosed);
+
+        // Stop the robot
+        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
+        CHECK(ok);
+        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
+        CHECK(ok);
+
+        // Check that the device was closed and detach called
+        CHECK(globalState.mockDriverWasOpened);
+        CHECK(globalState.mockWrapperWasOpened);
+        CHECK(globalState.mockAttachWasCalled);
+        CHECK(globalState.mockDetachWasCalled);
+        CHECK(globalState.mockWrapperWasClosed);
+        CHECK(globalState.mockDriverWasClosed);
+    }
+}


### PR DESCRIPTION
This PR completes what was originally added in https://github.com/robotology/yarp/pull/2168, and finish the implementation of Part 1 of https://github.com/robotology/yarp/issues/2005 . 

In particular, the main difference w.r.t.  https://github.com/robotology/yarp/pull/2168 is that in that case, the API exposed was extremely complicated to use: as soon as there was an error in the input XML file, the whole process that called the `YARP_robotinterface` library was crashed. Clearly, this is not ideal for a library, and this PR modifies the library to ensure that the error is correctly propagated to the caller. Furthermore, to test this functionality this PR also restructure the parser to permit to load the XML configuration also from directly a string, and not from a file.

The public API changed w.r.t.  https://github.com/robotology/yarp/pull/2168, but this is not a big problem as the API was never released as part of a YARP release since the merge of   https://github.com/robotology/yarp/pull/2168 .  

Example code snippet that uses the new API:
~~~cpp
// Load the XML configuration file 
std::string pathToXmlConfigurationFile = ...;
yarp::robotinterface::XMLReader reader;
yarp::robotinterface::XMLReaderResult result = reader.getRobotFromFile(pathToXmlConfigurationFile);

if (!result.isParsingSuccessful) {
    // Handle error 
    // ...
}

// Enter the startup phase, that will open all the devices and  call attach if necessary
bool ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseStartup);

if (!ok) {
    // Handle error 
    // ...
}


// At this point, the system is running and the thread that called the 
// enterPhase methods does not need to do anything else 

// This code need to be executed when you want to close the robot
// Close robot, that will close all the devices and  call detach if necessary
ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
ok = ok && result.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
if (!ok) {
    // Handle error 
    // ...
}
~~~
