### PR TITLE
os/Log: Add limited debug methods

### DIFF
--- a/doc/release/master/log_limiter.md
+++ b/doc/release/master/log_limiter.md
@@ -1,0 +1,22 @@
+log_limiter {#master}
+-----------
+
+### Libraries
+
+#### `os`
+
+##### `Log`
+
+* Added the following new debug macros:
+  * `yDebugOnce`
+  * `yDebugThreadOnce`
+  * `yDebugThrottle`
+  * `yDebugThreadThrottle`
+
+##### `LogComponent`
+
+* Added the following new debug macros:
+  * `yCDebugOnce`
+  * `yCDebugThreadOnce`
+  * `yCDebugThrottle`
+  * `yCDebugThreadThrottle`

--- a/src/libYARP_os/src/yarp/os/LogComponent.h
+++ b/src/libYARP_os/src/yarp/os/LogComponent.h
@@ -85,21 +85,52 @@ private:
     }
 
 #ifndef NDEBUG
-#  define yCTrace(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).trace(__VA_ARGS__)
+#  define yCTrace(component, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).trace(__VA_ARGS__)
+#  define yCTraceOnce(component, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).trace(__VA_ARGS__)
+#  define yCTraceThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).trace(__VA_ARGS__)
+#  define yCTraceThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
+#  define yCTraceThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
 #else
-#  define yCTrace(component, ...)   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTrace(component, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceOnce(component, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceThreadOnce(component, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceThrottle(component, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceThreadThrottle(component, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
 #ifndef YARP_NO_DEBUG_OUTPUT
-#  define yCDebug(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).debug(__VA_ARGS__)
+#  define yCDebug(component, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).debug(__VA_ARGS__)
+#  define yCDebugOnce(component, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).debug(__VA_ARGS__)
+#  define yCDebugThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).debug(__VA_ARGS__)
+#  define yCDebugThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
+#  define yCDebugThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
 #else
-#  define yCDebug(component, ...)   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebug(component, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugOnce(component, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugThreadOnce(component, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugThrottle(component, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugThreadThrottle(component, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
-#define yCInfo(component, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).info(__VA_ARGS__)
-#define yCWarning(component, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).warning(__VA_ARGS__)
-#define yCError(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).error(__VA_ARGS__)
-#define yCFatal(component, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, component()).fatal(__VA_ARGS__)
+#define yCInfo(component, ...)                          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).info(__VA_ARGS__)
+#define yCInfoOnce(component, ...)                      yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).info(__VA_ARGS__)
+#define yCInfoThreadOnce(component, ...)                yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).info(__VA_ARGS__)
+#define yCInfoThrottle(component, period, ...)          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
+#define yCInfoThreadThrottle(component, period, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
+
+#define yCWarning(component, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).warning(__VA_ARGS__)
+#define yCWarningOnce(component, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).warning(__VA_ARGS__)
+#define yCWarningThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).warning(__VA_ARGS__)
+#define yCWarningThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
+#define yCWarningThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
+
+#define yCError(component, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).error(__VA_ARGS__)
+#define yCErrorOnce(component, ...)                     yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).error(__VA_ARGS__)
+#define yCErrorThreadOnce(component, ...)               yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).error(__VA_ARGS__)
+#define yCErrorThrottle(component, period, ...)         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
+#define yCErrorThreadThrottle(component, period, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
+
+#define yCFatal(component, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).fatal(__VA_ARGS__)
 
 #ifndef NDEBUG
 #  define yCAssert(component, x)                                                       \

--- a/tests/libYARP_os/CMakeLists.txt
+++ b/tests/libYARP_os/CMakeLists.txt
@@ -49,6 +49,8 @@ target_link_libraries(harness_os PRIVATE YARP_harness
 if(YARP_HAS_ACE)
   target_compile_definitions(harness_os PRIVATE YARP_HAS_ACE)
   target_link_libraries(harness_os PRIVATE ACE::ACE_INLINE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(harness_os PRIVATE pthread)
 endif()
 
 set_property(TARGET harness_os PROPERTY FOLDER "Test")

--- a/tests/libYARP_os/LogTest.cpp
+++ b/tests/libYARP_os/LogTest.cpp
@@ -8,8 +8,14 @@
 
 #include <yarp/os/Log.h>
 #include <yarp/os/LogComponent.h>
+#include <yarp/os/SystemClock.h>
+#include <yarp/os/Thread.h>
+#include <yarp/os/NetType.h>
 
 #include <yarp/os/impl/LogForwarder.h>
+
+#include <array>
+#include <thread>
 
 #include <catch.hpp>
 #include <harness.h>
@@ -119,6 +125,321 @@ TEST_CASE("os::LogTest", "[yarp::os]")
         CNT yCError(LOG_COMPONENT, "The end of line is removed from this error with a component\n");
         CNT yCError(LOG_COMPONENT_NOFW, "This error with a component is not forwarded");
         CNT yCError(LOG_COMPONENT_NULL, "This error with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yTraceOnce, yTraceThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yTraceOnce("This line is printed only once.");
+            CNT yTraceOnce("Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yTraceOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yTraceThreadOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yTraceThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yTraceThreadThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCTraceOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCTraceThreadOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCTraceThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCTraceThreadThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yDebugOnce, yDebugThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yDebugOnce("This line is printed only once.");
+            CNT yDebugOnce("Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yDebugOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yDebugThreadOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yDebugThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yDebugThreadThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCDebugOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCDebugThreadOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCDebugThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCDebugThreadThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yInfoOnce, yInfoThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yInfoOnce("This line is printed only once.");
+            CNT yInfoOnce("Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yInfoOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yInfoThreadOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yInfoThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yInfoThreadThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCInfoOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCInfoThreadOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCInfoThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCInfoThreadThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yWarningOnce, yWarningThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yWarningOnce("This line is printed only once.");
+            CNT yWarningOnce("Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yWarningOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yWarningThreadOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yWarningThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yWarningThreadThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCWarningOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCWarningThreadOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCWarningThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCWarningThreadThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yErrorOnce, yErrorThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yErrorOnce("This line is printed only once.");
+            CNT yErrorOnce("Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yErrorOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yErrorThreadOnce(
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yErrorThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yErrorThreadThrottle(period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCErrorOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCErrorThreadOnce(LOG_COMPONENT,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCErrorThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCErrorThreadThrottle(LOG_COMPONENT, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
     }
 
     SECTION("Other log tests")


### PR DESCRIPTION
### Libraries

#### `os`

##### `Log`

* Added the following new debug macros:
  * `yDebugOnce`
  * `yDebugThreadOnce`
  * `yDebugThrottle`
  * `yDebugThreadThrottle`

##### `LogComponent`

* Added the following new debug macros:
  * `yCDebugOnce`
  * `yCDebugThreadOnce`
  * `yCDebugThrottle`
  * `yCDebugThreadThrottle`