### PR TITLE
os/PortCore: Do not set TOS to 0 if DSCP is an unknown string

### DIFF
--- a/doc/release/master/fix_qos_invalid_dscp.md
+++ b/doc/release/master/fix_qos_invalid_dscp.md
@@ -1,0 +1,10 @@
+fix_qos_invalid_dscp {#master}
+--------------------
+
+### Libraries
+
+#### `os`
+
+##### `Port`
+
+* Passing an invalid string when setting the QoS by DSCP no longer sets it to 0.

--- a/src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.cpp
@@ -143,6 +143,7 @@ void SocketTwoWayStream::updateAddresses()
 
 bool SocketTwoWayStream::setTypeOfService(int tos)
 {
+    yCDebug(SOCKETTWOWAYSTREAM, "Setting tos = %d", tos);
     return (stream.set_option(IPPROTO_IP, IP_TOS, (int*)&tos, (int)sizeof(tos)) == 0);
 }
 


### PR DESCRIPTION
Also improve debugging by adding a few debug messages