### PR TITLE
Fix bug by updating MAS_NrOfSensorTypes in multipleanalogsensorsremapper to be inclusive of PositionSensors

### DIFF
--- a/doc/release/master/fix_bug_MASRemapper.md
+++ b/doc/release/master/fix_bug_MASRemapper.md
@@ -1,0 +1,9 @@
+## fix_bug_MASRemapper {#master}
+
+### Devices
+
+#### `multipleanalogsensorsremapper`
+
+- update MAS_NrOfSensorTypes in multipleanalogsensorsremapper. This avoids segfaults due to uninitialized PositionSensors interfaces.
+
+

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -17,8 +17,8 @@ using namespace yarp::os;
 using namespace yarp::dev;
 
 
-const size_t MAS_NrOfSensorTypes{9};
-static_assert(MAS_SensorType::SkinPatches+1 == MAS_NrOfSensorTypes, "Consistency error between MAS_NrOfSensorTypes and MAS_SensorType");
+const size_t MAS_NrOfSensorTypes{10};
+static_assert(MAS_SensorType::PositionSensors+1 == MAS_NrOfSensorTypes, "Consistency error between MAS_NrOfSensorTypes and MAS_SensorType");
 
 /**
  * Internal identifier of the type of sensors.


### PR DESCRIPTION
Notice: Sorry for spamming everyone. I pushed the rebased branch before changing the base, causing to add every other code-owners as reviewers.

#### PR content
The for loop in `parseOptions()` method was iterating in a way that it ignored to parse the options for PositionSensors interface.
This consequently resulted in an uninitialized buffer, causing segfaults while trying to attach PositionSensorInterfaces.

This PR updates the `MAS_NrOfSensorTypes` variable from 9 to 10 and modifies the static_assert condition that checks the consistency error between `MAS_NrOfSensorTypes` and `MAS_SensorType`.