### PR TITLE
Allow passing a list of external devices when using the yarprobotinterface as a library

### DIFF
--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Action.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Action.cpp
@@ -7,18 +7,17 @@
  */
 
 #include "Action.h"
-#include "Param.h"
 
 #include <yarp/os/LogStream.h>
 
+#include "Param.h"
 #include <string>
-
 
 
 class yarp::robotinterface::Action::Private
 {
 public:
-    Private(Action * /*parent*/) :
+    Private(Action* /*parent*/) :
             phase(ActionPhaseUnknown),
             type(ActionTypeUnknown),
             level(0)
@@ -31,7 +30,7 @@ public:
     ParamList params;
 };
 
-std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Action &t)
+std::ostream& std::operator<<(std::ostream& oss, const yarp::robotinterface::Action& t)
 {
     oss << "(\"" << ActionPhaseToString(t.phase()) << ":" << ActionTypeToString(t.type()) << ":" << t.level() << "\"";
     if (!t.params().empty()) {
@@ -44,7 +43,7 @@ std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Act
 }
 
 
-yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Action &t)
+yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Action& t)
 {
     std::ostringstream oss;
     oss << t;
@@ -53,12 +52,12 @@ yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterfa
 }
 
 yarp::robotinterface::Action::Action() :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
 }
 
 yarp::robotinterface::Action::Action(const std::string& phase, const std::string& type, unsigned int level) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->phase = StringToActionPhase(phase);
     mPriv->type = StringToActionType(type);
@@ -66,7 +65,7 @@ yarp::robotinterface::Action::Action(const std::string& phase, const std::string
 }
 
 yarp::robotinterface::Action::Action(yarp::robotinterface::ActionPhase phase, yarp::robotinterface::ActionType type, unsigned int level) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->phase = phase;
     mPriv->type = type;
@@ -74,7 +73,7 @@ yarp::robotinterface::Action::Action(yarp::robotinterface::ActionPhase phase, ya
 }
 
 yarp::robotinterface::Action::Action(const yarp::robotinterface::Action& other) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->phase = other.mPriv->phase;
     mPriv->type = other.mPriv->type;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Action.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Action.h
@@ -19,9 +19,9 @@ class YARP_robotinterface_API Action
 public:
     explicit Action();
     Action(ActionPhase phase, ActionType type, unsigned int level);
-    Action(const std::string &phase, const std::string &type, unsigned int level);
-    Action(const Action &other);
-    Action& operator=(const Action &other);
+    Action(const std::string& phase, const std::string& type, unsigned int level);
+    Action(const Action& other);
+    Action& operator=(const Action& other);
 
     ActionPhase& phase();
     ActionType& type();
@@ -33,22 +33,24 @@ public:
     unsigned int level() const;
     const ParamList& params() const;
 
-    bool hasParam(const std::string &name) const;
-    std::string findParam(const std::string &name) const;
+    bool hasParam(const std::string& name) const;
+    std::string findParam(const std::string& name) const;
 
     virtual ~Action();
 
 private:
     class Private;
-    Private * const mPriv;
+    Private* const mPriv;
 }; // class Action
 
 } // namespace robotinterface
 } // namespace yarp
 
 
-namespace std { YARP_robotinterface_API std::ostream& operator<<(std::ostream &oss, const yarp::robotinterface::Action &t); }
-YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Action &t);
+namespace std {
+YARP_robotinterface_API std::ostream& operator<<(std::ostream& oss, const yarp::robotinterface::Action& t);
+}
+YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Action& t);
 
 
 #endif // YARP_ROBOTINTERFACE_ACTION_H

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/CalibratorThread.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/CalibratorThread.cpp
@@ -8,16 +8,16 @@
 
 #include "CalibratorThread.h"
 
+#include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 
-#include <yarp/os/Log.h>
 #include <yarp/dev/CalibratorInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 
 class yarp::robotinterface::CalibratorThread::Private
 {
 public:
-    Private(CalibratorThread *parent) :
+    Private(CalibratorThread* parent) :
             parent(parent),
             calibrator(nullptr),
             target(nullptr),
@@ -27,8 +27,7 @@ public:
 
     void run()
     {
-        switch (action)
-        {
+        switch (action) {
         case ActionCalibrate:
             yDebug() << calibratorName << "starting calibration of device" << targetName;
             calibrator->calibrate(target);
@@ -44,8 +43,7 @@ public:
 
     void stop()
     {
-        switch (action)
-        {
+        switch (action) {
         case ActionCalibrate:
             yDebug() << calibratorName << "killing calibration of device" << targetName;
             calibrator->quitCalibrate();
@@ -57,22 +55,21 @@ public:
         }
     }
 
-    yarp::robotinterface::CalibratorThread * const parent;
+    yarp::robotinterface::CalibratorThread* const parent;
 
-    yarp::dev::ICalibrator *calibrator;
+    yarp::dev::ICalibrator* calibrator;
     std::string calibratorName;
-    yarp::dev::DeviceDriver *target;
+    yarp::dev::DeviceDriver* target;
     std::string targetName;
     yarp::robotinterface::CalibratorThread::Action action;
 }; // class yarp::robotinterface::CalibratorThread::Private
 
 
-
-yarp::robotinterface::CalibratorThread::CalibratorThread(yarp::dev::ICalibrator *calibrator,
-                                                   const std::string &calibratorName,
-                                                   yarp::dev::DeviceDriver *target,
-                                                   const std::string &targetName,
-                                                   yarp::robotinterface::CalibratorThread::Action action) :
+yarp::robotinterface::CalibratorThread::CalibratorThread(yarp::dev::ICalibrator* calibrator,
+                                                         const std::string& calibratorName,
+                                                         yarp::dev::DeviceDriver* target,
+                                                         const std::string& targetName,
+                                                         yarp::robotinterface::CalibratorThread::Action action) :
         mPriv(new Private(this))
 {
     yAssert(calibrator);

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/CalibratorThread.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/CalibratorThread.h
@@ -9,31 +9,44 @@
 #ifndef YARP_ROBOTINTERFACE_CALIBRATORTHREAD_H
 #define YARP_ROBOTINTERFACE_CALIBRATORTHREAD_H
 
-#include <yarp/robotinterface/Types.h>
+#include <yarp/robotinterface/api.h>
 
 #include <yarp/os/Thread.h>
 
-#include <yarp/robotinterface/api.h>
+#include <yarp/robotinterface/Types.h>
 
-namespace yarp { namespace os { class Semaphore; } }
-namespace yarp { namespace dev { class ICalibrator; } }
-namespace yarp { namespace dev { class DeviceDriver; } }
+namespace yarp {
+namespace os {
+class Semaphore;
+}
+}
+namespace yarp {
+namespace dev {
+class ICalibrator;
+}
+}
+namespace yarp {
+namespace dev {
+class DeviceDriver;
+}
+}
 
 namespace yarp {
 namespace robotinterface {
 
-class YARP_robotinterface_API CalibratorThread: public yarp::os::Thread
+class YARP_robotinterface_API CalibratorThread : public yarp::os::Thread
 {
 public:
-    enum Action {
+    enum Action
+    {
         ActionCalibrate,
         ActionPark
     };
 
-    CalibratorThread(yarp::dev::ICalibrator *calibrator,
-                     const std::string &calibratorName,
-                     yarp::dev::DeviceDriver *target,
-                     const std::string &targetName,
+    CalibratorThread(yarp::dev::ICalibrator* calibrator,
+                     const std::string& calibratorName,
+                     yarp::dev::DeviceDriver* target,
+                     const std::string& targetName,
                      yarp::robotinterface::CalibratorThread::Action action);
     virtual ~CalibratorThread();
 
@@ -42,7 +55,7 @@ public:
 
 private:
     class Private;
-    Private * const mPriv;
+    Private* const mPriv;
 };
 
 } // namespace robotinterface

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
@@ -7,21 +7,19 @@
  */
 
 #include "Device.h"
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/Semaphore.h>
+
+#include <yarp/dev/CalibratorInterfaces.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/PolyDriver.h>
+
 #include "Action.h"
 #include "CalibratorThread.h"
 #include "Param.h"
-
-
-#include <yarp/os/LogStream.h>
-
-#include <yarp/os/Property.h>
-#include <yarp/os/Semaphore.h>
-#include <yarp/dev/CalibratorInterfaces.h>
-#include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/IMultipleWrapper.h>
-
-
 #include <string>
 
 
@@ -31,25 +29,25 @@ class yarp::robotinterface::Device::Private
 public:
     struct Driver
     {
-        Driver(yarp::dev::PolyDriver *d) :
-            driver(d),
-            ref(1)
+        Driver(yarp::dev::PolyDriver* d) :
+                driver(d),
+                ref(1)
         {
         }
-        yarp::dev::PolyDriver *driver;
+        yarp::dev::PolyDriver* driver;
         ThreadList runningThreads;
         yarp::os::Semaphore registerThreadSemaphore;
         yarp::os::Semaphore threadListSemaphore;
         int ref;
     };
 
-    Private(Device * /*parent*/) :
-        driver(new Driver(new yarp::dev::PolyDriver()))
+    Private(Device* /*parent*/) :
+            driver(new Driver(new yarp::dev::PolyDriver()))
     {
     }
 
-    Private(const Private &other) :
-        driver(other.driver)
+    Private(const Private& other) :
+            driver(other.driver)
     {
         ++driver->ref;
     }
@@ -78,16 +76,38 @@ public:
         }
     }
 
-    inline yarp::dev::PolyDriver* drv() const { return driver->driver; }
-    inline yarp::robotinterface::ThreadList* thr() const { return &driver->runningThreads; }
-    inline yarp::os::Semaphore* reg_sem() const { return &driver->registerThreadSemaphore; }
-    inline yarp::os::Semaphore* lst_sem() const { return &driver->threadListSemaphore; }
+    inline yarp::dev::PolyDriver* drv() const
+    {
+        return driver->driver;
+    }
+    inline yarp::robotinterface::ThreadList* thr() const
+    {
+        return &driver->runningThreads;
+    }
+    inline yarp::os::Semaphore* reg_sem() const
+    {
+        return &driver->registerThreadSemaphore;
+    }
+    inline yarp::os::Semaphore* lst_sem() const
+    {
+        return &driver->threadListSemaphore;
+    }
 
-    inline bool isValid() const { return drv()->isValid(); }
-    inline bool open() { yarp::os::Property p = paramsAsProperty(); return drv()->open(p); }
-    inline bool close() { return drv()->close(); }
+    inline bool isValid() const
+    {
+        return drv()->isValid();
+    }
+    inline bool open()
+    {
+        yarp::os::Property p = paramsAsProperty();
+        return drv()->open(p);
+    }
+    inline bool close()
+    {
+        return drv()->close();
+    }
 
-    inline void registerThread(yarp::os::Thread *thread) const
+    inline void registerThread(yarp::os::Thread* thread) const
     {
         reg_sem()->wait();
         lst_sem()->wait();
@@ -108,7 +128,7 @@ public:
         reg_sem()->wait();
         auto tit = thr()->begin();
         while (tit != thr()->end()) {
-            yarp::os::Thread *thread = *tit;
+            yarp::os::Thread* thread = *tit;
             thread->join();
             lst_sem()->wait();
             thr()->erase(tit++);
@@ -132,22 +152,22 @@ public:
         ParamList p = yarp::robotinterface::mergeDuplicateGroups(params);
 
         yarp::os::Property prop;
-        prop.put("device",type);
+        prop.put("device", type);
 
         for (yarp::robotinterface::ParamList::const_iterator it = p.begin(); it != p.end(); ++it) {
-            const yarp::robotinterface::Param &param = *it;
+            const yarp::robotinterface::Param& param = *it;
 
             // check if parentheses are balanced
             std::string stringFormatValue = param.value();
             int counter = 0;
-            for (size_t i = 0; i < stringFormatValue.size() && counter >= 0; i++){
-                if (stringFormatValue[i] == '('){
+            for (size_t i = 0; i < stringFormatValue.size() && counter >= 0; i++) {
+                if (stringFormatValue[i] == '(') {
                     counter++;
-                } else if (stringFormatValue[i] == ')'){
+                } else if (stringFormatValue[i] == ')') {
                     counter--;
                 }
             }
-            if (counter != 0){
+            if (counter != 0) {
                 yWarning() << "Parentheses not balanced for param " << param.name();
             }
 
@@ -162,10 +182,10 @@ public:
     std::string type;
     ParamList params;
     ActionList actions;
-    Driver *driver;
+    Driver* driver;
 };
 
-std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Device &t)
+std::ostream& std::operator<<(std::ostream& oss, const yarp::robotinterface::Device& t)
 {
     oss << "(name = \"" << t.name() << "\", type = \"" << t.type() << "\"";
     if (!t.params().empty()) {
@@ -182,7 +202,7 @@ std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Dev
     return oss;
 }
 
-yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Device &t)
+yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Device& t)
 {
     std::ostringstream oss;
     oss << t;
@@ -191,16 +211,16 @@ yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterfa
 }
 
 yarp::robotinterface::Device::Device() :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->close();
 }
 
 yarp::robotinterface::Device::Device(const std::string& name,
-                               const std::string& type,
-                               const yarp::robotinterface::ParamList& params,
-                               const yarp::robotinterface::ActionList& actions) :
-    mPriv(new Private(this))
+                                     const std::string& type,
+                                     const yarp::robotinterface::ParamList& params,
+                                     const yarp::robotinterface::ActionList& actions) :
+        mPriv(new Private(this))
 {
     mPriv->name = name;
     mPriv->type = type;
@@ -209,7 +229,7 @@ yarp::robotinterface::Device::Device(const std::string& name,
 }
 
 yarp::robotinterface::Device::Device(const yarp::robotinterface::Device& other) :
-    mPriv(new Private(*other.mPriv))
+        mPriv(new Private(*other.mPriv))
 {
     mPriv->name = other.mPriv->name;
     mPriv->type = other.mPriv->type;
@@ -282,7 +302,7 @@ const yarp::robotinterface::ActionList& yarp::robotinterface::Device::actions() 
 
 bool yarp::robotinterface::Device::open()
 {
-    if (mPriv->isValid()) {
+    if (this->isOpen()) {
         yError() << "Trying to open an already opened device.";
         return false;
     }
@@ -311,6 +331,11 @@ bool yarp::robotinterface::Device::close()
     return true;
 }
 
+bool yarp::robotinterface::Device::isOpen() const
+{
+    return mPriv->isValid();
+}
+
 bool yarp::robotinterface::Device::hasParam(const std::string& name) const
 {
     return yarp::robotinterface::hasParam(mPriv->params, name);
@@ -326,7 +351,7 @@ yarp::dev::PolyDriver* yarp::robotinterface::Device::driver() const
     return mPriv->drv();
 }
 
-void yarp::robotinterface::Device::registerThread(yarp::os::Thread *thread) const
+void yarp::robotinterface::Device::registerThread(yarp::os::Thread* thread) const
 {
     mPriv->registerThread(thread);
 }
@@ -341,20 +366,20 @@ void yarp::robotinterface::Device::stopThreads() const
     mPriv->stopThreads();
 }
 
-bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device &target) const
+bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device& target) const
 {
-    if(!driver()) {
-       yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
-       return false;
+    if (!driver()) {
+        yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
+        return false;
     }
 
-    yarp::dev::ICalibrator *calibrator;
+    yarp::dev::ICalibrator* calibrator;
     if (!driver()->view(calibrator)) {
         yError() << name() << "is not a yarp::dev::ICalibrator, therefore it cannot have" << ActionTypeToString(ActionTypeCalibrate) << "actions";
         return false;
     }
 
-    yarp::dev::IControlCalibration *controlCalibrator;
+    yarp::dev::IControlCalibration* controlCalibrator;
     if (!target.driver()->view(controlCalibrator)) {
         yError() << target.name() << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypeCalibrate) << "actions";
         return false;
@@ -364,32 +389,32 @@ bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device 
 
     // Saving pointer to Calibrator device into Wrapper to later use
     // (NOTE this make sense if the target device is a ControlBoardWrapper2, as it should be)
-    yarp::dev::IRemoteCalibrator *rem_calibrator_wrap;
-    yarp::dev::IRemoteCalibrator *rem_calibrator_calib;
+    yarp::dev::IRemoteCalibrator* rem_calibrator_wrap;
+    yarp::dev::IRemoteCalibrator* rem_calibrator_calib;
     bool rem_calibrator_available = true;
 
-    if(!target.driver()->view(rem_calibrator_wrap)) {
+    if (!target.driver()->view(rem_calibrator_wrap)) {
         yWarning() << "Device " << target.name() << "is not implementing a yarp::dev::IRemoteCalibrator, therefore it cannot attach to a Calibrator device. \n \
                                                      Please verify that the target of calibrate action is a controlBoardWrapper2 device.  \
                                                      This doesn't prevent the yarprobotinterface to correctly operate, but no remote calibration and homing will be available";
         rem_calibrator_available = false;
     }
 
-    if( (rem_calibrator_available) && (!driver()->view(rem_calibrator_calib)) ) {
-        yWarning() << "Device " << name() <<  "is not implementing a yarp::dev::IRemoteCalibrator, therefore it cannot be used as a remote calibration device. \n \
+    if ((rem_calibrator_available) && (!driver()->view(rem_calibrator_calib))) {
+        yWarning() << "Device " << name() << "is not implementing a yarp::dev::IRemoteCalibrator, therefore it cannot be used as a remote calibration device. \n \
                                                This doesn't prevent the yarprobotinterface to correctly operate, but no remote calibration and homing will be available";
         rem_calibrator_available = false;
     }
 
-    if(rem_calibrator_available)
+    if (rem_calibrator_available)
         rem_calibrator_wrap->setCalibratorDevice(rem_calibrator_calib);
 
     // Start the calibrator thread
-    yarp::os::Thread *calibratorThread = new yarp::robotinterface::CalibratorThread(calibrator,
-                                                                              name(),
-                                                                              target.driver(),
-                                                                              target.name(),
-                                                                              yarp::robotinterface::CalibratorThread::ActionCalibrate);
+    yarp::os::Thread* calibratorThread = new yarp::robotinterface::CalibratorThread(calibrator,
+                                                                                    name(),
+                                                                                    target.driver(),
+                                                                                    target.name(),
+                                                                                    yarp::robotinterface::CalibratorThread::ActionCalibrate);
     registerThread(calibratorThread);
 
     if (!calibratorThread->start()) {
@@ -400,14 +425,14 @@ bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device 
     return true;
 }
 
-bool yarp::robotinterface::Device::attach(const yarp::dev::PolyDriverList &drivers) const
+bool yarp::robotinterface::Device::attach(const yarp::dev::PolyDriverList& drivers) const
 {
-    if(!driver()) {
-       yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
-       return false;
+    if (!driver()) {
+        yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
+        return false;
     }
 
-    yarp::dev::IMultipleWrapper *wrapper;
+    yarp::dev::IMultipleWrapper* wrapper;
     if (!driver()->view(wrapper)) {
         yError() << name() << "is not a wrapper, therefore it cannot have" << ActionTypeToString(ActionTypeAttach) << "actions";
         return false;
@@ -423,10 +448,10 @@ bool yarp::robotinterface::Device::attach(const yarp::dev::PolyDriverList &drive
 
 bool yarp::robotinterface::Device::detach() const
 {
-    yarp::dev::IMultipleWrapper *wrapper;
-    if(!driver()) {
-       yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
-       return false;
+    yarp::dev::IMultipleWrapper* wrapper;
+    if (!driver()) {
+        yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
+        return false;
     }
 
     if (!driver()->view(wrapper)) {
@@ -442,15 +467,15 @@ bool yarp::robotinterface::Device::detach() const
     return true;
 }
 
-bool yarp::robotinterface::Device::park(const Device &target) const
+bool yarp::robotinterface::Device::park(const Device& target) const
 {
-    yarp::dev::ICalibrator *calibrator;
-    if(!driver()) {
-       yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
-       return false;
+    yarp::dev::ICalibrator* calibrator;
+    if (!driver()) {
+        yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
+        return false;
     }
 
-    if(!driver()->isValid()) {
+    if (!driver()->isValid()) {
         yError() << "park device do not exists";
         return false;
     }
@@ -460,7 +485,7 @@ bool yarp::robotinterface::Device::park(const Device &target) const
         return false;
     }
 
-    yarp::dev::IControlCalibration *controlCalibrator;
+    yarp::dev::IControlCalibration* controlCalibrator;
     if (!target.driver()->view(controlCalibrator)) {
         yError() << target.name() << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypePark) << "actions";
         return false;
@@ -468,11 +493,11 @@ bool yarp::robotinterface::Device::park(const Device &target) const
 
     controlCalibrator->setCalibrator(calibrator); // TODO Check if this should be removed
 
-    yarp::os::Thread *parkerThread = new yarp::robotinterface::CalibratorThread(calibrator,
-                                                                          name(),
-                                                                          target.driver(),
-                                                                          target.name(),
-                                                                          yarp::robotinterface::CalibratorThread::ActionPark);
+    yarp::os::Thread* parkerThread = new yarp::robotinterface::CalibratorThread(calibrator,
+                                                                                name(),
+                                                                                target.driver(),
+                                                                                target.name(),
+                                                                                yarp::robotinterface::CalibratorThread::ActionPark);
     registerThread(parkerThread);
 
     if (!parkerThread->start()) {

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.h
@@ -9,13 +9,20 @@
 #ifndef YARP_ROBOTINTERFACE_DEVICE_H
 #define YARP_ROBOTINTERFACE_DEVICE_H
 
-#include <yarp/robotinterface/Types.h>
-
 #include <yarp/robotinterface/Action.h>
 #include <yarp/robotinterface/Param.h>
+#include <yarp/robotinterface/Types.h>
 
-namespace yarp { namespace dev { class PolyDriver; } }
-namespace yarp { namespace dev { class PolyDriverList; } }
+namespace yarp {
+namespace dev {
+class PolyDriver;
+}
+}
+namespace yarp {
+namespace dev {
+class PolyDriverList;
+}
+}
 
 namespace yarp {
 namespace robotinterface {
@@ -24,12 +31,12 @@ class YARP_robotinterface_API Device
 {
 public:
     explicit Device();
-    Device(const std::string &name,
-           const std::string &type,
-           const ParamList &params = ParamList(),
-           const ActionList &actions = ActionList());
-    Device(const Device &other);
-    Device& operator=(const Device &other);
+    Device(const std::string& name,
+           const std::string& type,
+           const ParamList& params = ParamList(),
+           const ActionList& actions = ActionList());
+    Device(const Device& other);
+    Device& operator=(const Device& other);
 
     virtual ~Device();
 
@@ -43,27 +50,29 @@ public:
     const ParamList& params() const;
     const ActionList& actions() const;
 
-    bool hasParam(const std::string &name) const;
-    std::string findParam(const std::string &name) const;
+    bool hasParam(const std::string& name) const;
+    std::string findParam(const std::string& name) const;
 
     bool open();
     bool close();
 
-    yarp::dev::PolyDriver *driver() const;
+    bool isOpen() const;
+
+    yarp::dev::PolyDriver* driver() const;
 
     // thread handling methods
-    void registerThread(yarp::os::Thread *thread) const;
+    void registerThread(yarp::os::Thread* thread) const;
     void joinThreads() const;
     void stopThreads() const;
 
     // configure action
-    bool configure(const Device &target, const ParamList& params) const;
+    bool configure(const Device& target, const ParamList& params) const;
 
     // calibrate one device
-    bool calibrate(const Device &target) const;
+    bool calibrate(const Device& target) const;
 
     // attach a list of drivers to this wrapper
-    bool attach(const yarp::dev::PolyDriverList &drivers) const;
+    bool attach(const yarp::dev::PolyDriverList& drivers) const;
 
     // abort action
     bool abort() const;
@@ -72,22 +81,24 @@ public:
     bool detach() const;
 
     // park
-    bool park(const Device &target) const;
+    bool park(const Device& target) const;
 
     // custom action
-    bool custom(const ParamList &params) const;
+    bool custom(const ParamList& params) const;
 
 
 private:
     class Private;
-    Private * const mPriv;
+    Private* const mPriv;
 }; // class Device
 
 } // namespace robotinterface
 } // namespace yarp
 
-namespace std { YARP_robotinterface_API std::ostream& operator<<(std::ostream &oss, const yarp::robotinterface::Device &t); }
-YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Device &t);
+namespace std {
+YARP_robotinterface_API std::ostream& operator<<(std::ostream& oss, const yarp::robotinterface::Device& t);
+}
+YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Device& t);
 
 
 #endif // YARP_ROBOTINTERFACE_DEVICE_H

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Param.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Param.cpp
@@ -9,13 +9,12 @@
 #include "Param.h"
 
 #include <yarp/os/LogStream.h>
-
 #include <yarp/os/Property.h>
 
 #include <string>
 
 
-std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Param &t)
+std::ostream& std::operator<<(std::ostream& oss, const yarp::robotinterface::Param& t)
 {
     oss << "(\"" << t.name() << "\"" << (t.isGroup() ? " [group]" : "") << " = \"" << t.value() << "\")";
     return oss;
@@ -25,7 +24,7 @@ std::ostream& std::operator<<(std::ostream &oss, const yarp::robotinterface::Par
 class yarp::robotinterface::Param::Private
 {
 public:
-    Private(Param * /*parent*/) :
+    Private(Param* /*parent*/) :
             isGroup(false)
     {
     }
@@ -35,7 +34,7 @@ public:
     bool isGroup;
 };
 
-yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Param &t)
+yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Param& t)
 {
     std::ostringstream oss;
     oss << t;
@@ -44,13 +43,13 @@ yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterfa
 }
 
 yarp::robotinterface::Param::Param(bool isGroup) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->isGroup = isGroup;
 }
 
-yarp::robotinterface::Param::Param(const std::string &name, const std::string &value, bool isGroup) :
-    mPriv(new Private(this))
+yarp::robotinterface::Param::Param(const std::string& name, const std::string& value, bool isGroup) :
+        mPriv(new Private(this))
 {
     mPriv->name = name;
     mPriv->value = value;
@@ -58,7 +57,7 @@ yarp::robotinterface::Param::Param(const std::string &name, const std::string &v
 }
 
 yarp::robotinterface::Param::Param(const ::yarp::robotinterface::Param& other) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->name = other.mPriv->name;
     mPriv->value = other.mPriv->value;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Param.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Param.h
@@ -11,7 +11,11 @@
 
 #include <yarp/robotinterface/Types.h>
 
-namespace yarp { namespace os { class Property; } }
+namespace yarp {
+namespace os {
+class Property;
+}
+}
 
 namespace yarp {
 namespace robotinterface {
@@ -20,8 +24,8 @@ class YARP_robotinterface_API Param
 {
 public:
     explicit Param(bool isGroup = false);
-    Param(const std::string &name, const std::string &value, bool isGroup = false);
-    Param(const Param &other);
+    Param(const std::string& name, const std::string& value, bool isGroup = false);
+    Param(const Param& other);
     Param& operator=(const Param& other);
 
     virtual ~Param();
@@ -38,14 +42,16 @@ public:
 
 private:
     class Private;
-    Private * const mPriv;
+    Private* const mPriv;
 }; // class Param
 
 } // namespace robotinterface
 } // namespace yarp
 
-namespace std { YARP_robotinterface_API std::ostream& operator<<(std::ostream &oss, const yarp::robotinterface::Param &t); }
-YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Param &t);
+namespace std {
+YARP_robotinterface_API std::ostream& operator<<(std::ostream& oss, const yarp::robotinterface::Param& t);
+}
+YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Param& t);
 
 
 #endif // YARP_ROBOTINTERFACE_PARAM_H

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -7,21 +7,21 @@
  */
 
 #include "Robot.h"
-#include "Action.h"
-#include "Device.h"
-#include "Param.h"
 
 #include <yarp/os/LogStream.h>
 
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 
-#include <string>
-#include <iostream>
+#include "Action.h"
+#include "Device.h"
+#include "Param.h"
 #include <algorithm>
+#include <iostream>
+#include <string>
 
 
-std::ostringstream& operator<<(std::ostringstream &oss, const yarp::robotinterface::Robot &t)
+std::ostringstream& operator<<(std::ostringstream& oss, const yarp::robotinterface::Robot& t)
 {
     oss << "(name = \"" << t.name() << "\"";
     if (!t.params().empty()) {
@@ -42,18 +42,18 @@ std::ostringstream& operator<<(std::ostringstream &oss, const yarp::robotinterfa
 class yarp::robotinterface::Robot::Private
 {
 public:
-    Private(Robot * /*parent*/) :
+    Private(Robot* /*parent*/) :
             build(0),
-                currentPhase(ActionPhaseUnknown),
-        currentLevel(0)
+            currentPhase(ActionPhaseUnknown),
+            currentLevel(0)
     {
     }
 
     // return true if a device with the given name exists
-    bool hasDevice(const std::string &name) const;
+    bool hasDevice(const std::string& name) const;
 
     // return the device with the given name or <fatal error> if not found
-    Device* findDevice(const std::string &name);
+    Device* findDevice(const std::string& name);
 
     // open all the devices and return true if all the open calls were successful
     bool openDevices();
@@ -65,29 +65,29 @@ public:
     std::vector<unsigned int> getLevels(ActionPhase phase) const;
 
     // return a vector of actions for that phase and that level
-    std::vector<std::pair<Device, Action> > getActions(ActionPhase phase, unsigned int level) const;
+    std::vector<std::pair<Device, Action>> getActions(ActionPhase phase, unsigned int level) const;
 
 
     // run configure action on one device
-    bool configure(const Device &device, const ParamList &params);
+    bool configure(const Device& device, const ParamList& params);
 
     // run calibrate action on one device
-    bool calibrate(const Device &device, const ParamList &params);
+    bool calibrate(const Device& device, const ParamList& params);
 
     // run attach action on one device
-    bool attach(const Device &device, const ParamList &params);
+    bool attach(const Device& device, const ParamList& params);
 
     // run abort action on one device
-    bool abort(const Device &device, const ParamList &params);
+    bool abort(const Device& device, const ParamList& params);
 
     // run detach action on one device
-    bool detach(const Device &device, const ParamList &params);
+    bool detach(const Device& device, const ParamList& params);
 
     // run park action on one device
-    bool park(const Device &device, const ParamList &params);
+    bool park(const Device& device, const ParamList& params);
 
     // run custom action on one device
-    bool custom(const Device &device, const ParamList &params);
+    bool custom(const Device& device, const ParamList& params);
 
     std::string name;
     unsigned int build;
@@ -98,7 +98,7 @@ public:
     unsigned int currentLevel;
 }; // class yarp::robotinterface::Robot::Private
 
-bool yarp::robotinterface::Robot::Private::hasDevice(const std::string &name) const
+bool yarp::robotinterface::Robot::Private::hasDevice(const std::string& name) const
 {
     for (const auto& device : devices) {
         if (name == device.name()) {
@@ -108,7 +108,7 @@ bool yarp::robotinterface::Robot::Private::hasDevice(const std::string &name) co
     return false;
 }
 
-yarp::robotinterface::Device* yarp::robotinterface::Robot::Private::findDevice(const std::string &name)
+yarp::robotinterface::Device* yarp::robotinterface::Robot::Private::findDevice(const std::string& name)
 {
     for (auto& device : devices) {
         if (name == device.name()) {
@@ -129,7 +129,6 @@ bool yarp::robotinterface::Robot::Private::openDevices()
             yWarning() << "Cannot open device" << device.name();
             ret = false;
         }
-
     }
     if (ret) {
         // yDebug() << "All devices opened.";
@@ -144,7 +143,7 @@ bool yarp::robotinterface::Robot::Private::closeDevices()
 {
     bool ret = true;
     for (auto it = devices.rbegin(); it != devices.rend(); ++it) {
-        yarp::robotinterface::Device &device = *it;
+        yarp::robotinterface::Device& device = *it;
 
         // yDebug() << device;
 
@@ -152,7 +151,6 @@ bool yarp::robotinterface::Robot::Private::closeDevices()
             yWarning() << "Cannot close device" << device.name();
             ret = false;
         }
-
     }
     if (ret) {
         // yDebug() << "All devices closed.";
@@ -186,9 +184,9 @@ std::vector<unsigned int> yarp::robotinterface::Robot::Private::getLevels(yarp::
 }
 
 
-std::vector<std::pair<yarp::robotinterface::Device, yarp::robotinterface::Action> > yarp::robotinterface::Robot::Private::getActions(yarp::robotinterface::ActionPhase phase, unsigned int level) const
+std::vector<std::pair<yarp::robotinterface::Device, yarp::robotinterface::Action>> yarp::robotinterface::Robot::Private::getActions(yarp::robotinterface::ActionPhase phase, unsigned int level) const
 {
-    std::vector<std::pair<yarp::robotinterface::Device, yarp::robotinterface::Action> > actions;
+    std::vector<std::pair<yarp::robotinterface::Device, yarp::robotinterface::Action>> actions;
     for (const auto& device : devices) {
         if (device.actions().empty()) {
             continue;
@@ -204,13 +202,13 @@ std::vector<std::pair<yarp::robotinterface::Device, yarp::robotinterface::Action
 }
 
 
-bool yarp::robotinterface::Robot::Private::configure(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::configure(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     YARP_FIXME_NOTIMPLEMENTED("configure action")
     return true;
 }
 
-bool yarp::robotinterface::Robot::Private::calibrate(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::calibrate(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     if (!yarp::robotinterface::hasParam(params, "target")) {
         yError() << "Action \"" << ActionTypeToString(ActionTypeCalibrate) << R"(" requires "target" parameter)";
@@ -222,20 +220,22 @@ bool yarp::robotinterface::Robot::Private::calibrate(const yarp::robotinterface:
         yError() << "Target device" << targetDeviceName << "does not exist.";
         return false;
     }
-    Device &targetDevice = *findDevice(targetDeviceName);
+    Device& targetDevice = *findDevice(targetDeviceName);
 
     return device.calibrate(targetDevice);
 }
 
-bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     int check = 0;
-    if (yarp::robotinterface::hasParam(params, "network")) check++;
-    if (yarp::robotinterface::hasParam(params, "networks")) check++;
-    if (yarp::robotinterface::hasParam(params, "all")) check++;
+    if (yarp::robotinterface::hasParam(params, "network"))
+        check++;
+    if (yarp::robotinterface::hasParam(params, "networks"))
+        check++;
+    if (yarp::robotinterface::hasParam(params, "all"))
+        check++;
 
-    if (check>1)
-    {
+    if (check > 1) {
         yError() << "Action \"" << ActionTypeToString(ActionTypeAttach) << R"(" : you can have only one option: "network" , "networks" or "all" )";
         return false;
     }
@@ -255,23 +255,19 @@ bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::De
             yError() << "Target device" << targetDeviceName << "(network =" << targetNetwork << ") does not exist.";
             return false;
         }
-        Device &targetDevice = *findDevice(targetDeviceName);
+        Device& targetDevice = *findDevice(targetDeviceName);
 
         // yDebug() << "Attach device" << device.name() << "to" << targetDevice.name() << "as" << targetNetwork;
         drivers.push(targetDevice.driver(), targetNetwork.c_str());
 
-    }
-    else if (yarp::robotinterface::hasParam(params, "all"))
-    {
-        for (auto& device : devices)
-        {
+    } else if (yarp::robotinterface::hasParam(params, "all")) {
+        for (auto& device : devices) {
             drivers.push(device.driver(), "all");
         }
-    }
-    else if (yarp::robotinterface::hasParam(params, "networks")) {
+    } else if (yarp::robotinterface::hasParam(params, "networks")) {
         yarp::os::Value v;
         v.fromString(yarp::robotinterface::findParam(params, "networks").c_str());
-        yarp::os::Bottle &targetNetworks = *(v.asList());
+        yarp::os::Bottle& targetNetworks = *(v.asList());
 
         for (size_t i = 0; i < targetNetworks.size(); ++i) {
             std::string targetNetwork = targetNetworks.get(i).toString();
@@ -285,14 +281,12 @@ bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::De
                 yError() << "Target device" << targetDeviceName << "(network =" << targetNetwork << ") does not exist.";
                 return false;
             }
-            Device &targetDevice = *findDevice(targetDeviceName);
+            Device& targetDevice = *findDevice(targetDeviceName);
 
             // yDebug() << "Attach device" << device.name() << "to" << targetDevice.name() << "as" << targetNetwork;
             drivers.push(targetDevice.driver(), targetNetwork.c_str());
         }
-    }
-    else
-    {
+    } else {
         yError() << "Action \"" << ActionTypeToString(ActionTypeAttach) << R"(" requires either "network" or "networks" parameter)";
         return false;
     }
@@ -305,14 +299,14 @@ bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::De
     return device.attach(drivers);
 }
 
-bool yarp::robotinterface::Robot::Private::abort(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::abort(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     YARP_FIXME_NOTIMPLEMENTED("abort action")
     return true;
 }
 
 
-bool yarp::robotinterface::Robot::Private::detach(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::detach(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
 
     if (!params.empty()) {
@@ -322,7 +316,7 @@ bool yarp::robotinterface::Robot::Private::detach(const yarp::robotinterface::De
     return device.detach();
 }
 
-bool yarp::robotinterface::Robot::Private::park(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::park(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     if (!yarp::robotinterface::hasParam(params, "target")) {
         yError() << "Action \"" << ActionTypeToString(ActionTypePark) << R"(" requires "target" parameter)";
@@ -334,18 +328,18 @@ bool yarp::robotinterface::Robot::Private::park(const yarp::robotinterface::Devi
         yError() << "Target device" << targetDeviceName << "does not exist.";
         return false;
     }
-    Device &targetDevice = *findDevice(targetDeviceName);
+    Device& targetDevice = *findDevice(targetDeviceName);
 
     return device.park(targetDevice);
 }
 
-bool yarp::robotinterface::Robot::Private::custom(const yarp::robotinterface::Device &device, const yarp::robotinterface::ParamList &params)
+bool yarp::robotinterface::Robot::Private::custom(const yarp::robotinterface::Device& device, const yarp::robotinterface::ParamList& params)
 {
     YARP_FIXME_NOTIMPLEMENTED("custom action")
     return true;
 }
 
-yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Robot &t)
+yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Robot& t)
 {
     std::ostringstream oss;
     oss << t;
@@ -354,20 +348,19 @@ yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterfa
 }
 
 yarp::robotinterface::Robot::Robot() :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
-
 }
 
 yarp::robotinterface::Robot::Robot(const std::string& name, const yarp::robotinterface::DeviceList& devices) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->name = name;
     mPriv->devices = devices;
 }
 
 yarp::robotinterface::Robot::Robot(const yarp::robotinterface::Robot& other) :
-    mPriv(new Private(this))
+        mPriv(new Private(this))
 {
     mPriv->name = other.mPriv->name;
     mPriv->build = other.mPriv->build;
@@ -420,9 +413,9 @@ std::string& yarp::robotinterface::Robot::portprefix()
 void yarp::robotinterface::Robot::setVerbose(bool verbose)
 {
     for (auto& device : devices()) {
-        ParamList &params = device.params();
+        ParamList& params = device.params();
         // Do not override "verbose" param if explicitly set in the xml
-        if(verbose && !yarp::robotinterface::hasParam(params, "verbose")) {
+        if (verbose && !yarp::robotinterface::hasParam(params, "verbose")) {
             device.params().push_back(Param("verbose", "1"));
         }
     }
@@ -431,9 +424,9 @@ void yarp::robotinterface::Robot::setVerbose(bool verbose)
 void yarp::robotinterface::Robot::setAllowDeprecatedDevices(bool allowDeprecatedDevices)
 {
     for (auto& device : devices()) {
-        ParamList &params = device.params();
+        ParamList& params = device.params();
         // Do not override "allow-deprecated-devices" param if explicitly set in the xml
-        if(allowDeprecatedDevices && !yarp::robotinterface::hasParam(params, "allow-deprecated-devices")) {
+        if (allowDeprecatedDevices && !yarp::robotinterface::hasParam(params, "allow-deprecated-devices")) {
             device.params().push_back(Param("allow-deprecated-devices", "1"));
         }
     }
@@ -515,7 +508,7 @@ bool yarp::robotinterface::Robot::enterPhase(yarp::robotinterface::ActionPhase p
 
     // run phase does not accept actions
     if (phase == ActionPhaseRun) {
-        if(mPriv->getLevels(phase).size() != 0) {
+        if (mPriv->getLevels(phase).size() != 0) {
             yWarning() << "Phase" << ActionPhaseToString(phase) << "does not accept actions. Skipping all actions for this phase";
         }
         return true;
@@ -545,34 +538,34 @@ bool yarp::robotinterface::Robot::enterPhase(yarp::robotinterface::ActionPhase p
 
         // If current phase was changed by some other thread, we should
         // exit the loop and avoid starting further actions.
-        if(mPriv->currentPhase != phase) {
+        if (mPriv->currentPhase != phase) {
             ret = false;
             break;
         }
 
-        std::vector<std::pair<Device, Action> > actions = mPriv->getActions(phase, level);
+        std::vector<std::pair<Device, Action>> actions = mPriv->getActions(phase, level);
 
         for (auto& ait : actions) {
             // for each action in that level
-            Device &device = ait.first;
-            Action &action = ait.second;
+            Device& device = ait.first;
+            Action& action = ait.second;
 
             // If current phase was changed by some other thread, we should
             // exit the loop and avoid starting further actions.
-            if(mPriv->currentPhase != phase) {
+            if (mPriv->currentPhase != phase) {
                 ret = false;
                 break;
             }
 
             switch (action.type()) {
             case ActionTypeConfigure:
-                if(!mPriv->configure(device, action.params())) {
+                if (!mPriv->configure(device, action.params())) {
                     yError() << "Cannot run configure action on device" << device.name();
                     ret = false;
                 }
                 break;
             case ActionTypeCalibrate:
-                if(!mPriv->calibrate(device, action.params())) {
+                if (!mPriv->calibrate(device, action.params())) {
                     yError() << "Cannot run calibrate action on device" << device.name();
                     ret = false;
                 }
@@ -584,7 +577,7 @@ bool yarp::robotinterface::Robot::enterPhase(yarp::robotinterface::ActionPhase p
                 }
                 break;
             case ActionTypeAbort:
-                if(!mPriv->abort(device, action.params())) {
+                if (!mPriv->abort(device, action.params())) {
                     yError() << "Cannot run abort action on device" << device.name();
                     ret = false;
                 }

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -9,10 +9,10 @@
 #ifndef YARP_ROBOTINTERFACE_ROBOT_H
 #define YARP_ROBOTINTERFACE_ROBOT_H
 
-#include <yarp/robotinterface/Types.h>
-#include <yarp/robotinterface/Device.h>
-
 #include <yarp/robotinterface/api.h>
+
+#include <yarp/robotinterface/Device.h>
+#include <yarp/robotinterface/Types.h>
 
 namespace yarp {
 namespace robotinterface {
@@ -21,9 +21,9 @@ class YARP_robotinterface_API Robot
 {
 public:
     explicit Robot();
-    explicit Robot(const std::string &name, const DeviceList &devices = DeviceList());
-    Robot(const Robot &other);
-    Robot& operator=(const Robot &other);
+    explicit Robot(const std::string& name, const DeviceList& devices = DeviceList());
+    Robot(const Robot& other);
+    Robot& operator=(const Robot& other);
 
     virtual ~Robot();
 
@@ -36,17 +36,17 @@ public:
 
     ParamList& params();
     DeviceList& devices();
-    Device& device(const std::string &name);
+    Device& device(const std::string& name);
 
     const std::string& name() const;
     const unsigned int& build() const;
     const std::string& portprefix() const;
     const ParamList& params() const;
     const DeviceList& devices() const;
-    const Device& device(const std::string &name) const;
+    const Device& device(const std::string& name) const;
 
-    bool hasParam(const std::string &name) const;
-    std::string findParam(const std::string &name) const;
+    bool hasParam(const std::string& name) const;
+    std::string findParam(const std::string& name) const;
 
     void interrupt();
     bool enterPhase(yarp::robotinterface::ActionPhase phase);
@@ -55,14 +55,14 @@ public:
 
 private:
     class Private;
-    Private * const mPriv;
+    Private* const mPriv;
 }; // class Robot
 
 } // namespace robotinterface
 } // namespace yarp
 
-YARP_robotinterface_API std::ostringstream& operator<<(std::ostringstream &oss, const yarp::robotinterface::Robot &t);
-YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Robot &t);
+YARP_robotinterface_API std::ostringstream& operator<<(std::ostringstream& oss, const yarp::robotinterface::Robot& t);
+YARP_robotinterface_API yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterface::Robot& t);
 
 
 #endif // YARP_ROBOTINTERFACE_ROBOT_H

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -49,7 +49,8 @@ public:
     std::string findParam(const std::string& name) const;
 
     void interrupt();
-    bool enterPhase(yarp::robotinterface::ActionPhase phase);
+    bool enterPhase(yarp::robotinterface::ActionPhase phase,
+                    const DeviceList& externalDevices = {});
     yarp::robotinterface::ActionPhase currentPhase() const;
     int currentLevel() const;
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -43,6 +43,7 @@ public:
     const std::string& portprefix() const;
     const ParamList& params() const;
     const DeviceList& devices() const;
+    const DevicePtrList devicePtrs() const;
     const Device& device(const std::string& name) const;
 
     bool hasParam(const std::string& name) const;
@@ -50,7 +51,7 @@ public:
 
     void interrupt();
     bool enterPhase(yarp::robotinterface::ActionPhase phase,
-                    const DeviceList& externalDevices = {});
+                    const DevicePtrList externalDevices = {});
     yarp::robotinterface::ActionPhase currentPhase() const;
     int currentLevel() const;
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/RobotInterfaceDTD.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/RobotInterfaceDTD.cpp
@@ -6,24 +6,24 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include "XMLReader.h"
-#include "Action.h"
-#include "Device.h"
-#include "Param.h"
-#include "Robot.h"
-#include "Types.h"
 #include "impl/RobotInterfaceDTD.h"
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
 
-#include <tinyxml.h>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <iterator>
+#include "Action.h"
+#include "Device.h"
+#include "Param.h"
+#include "Robot.h"
+#include "Types.h"
+#include "XMLReader.h"
 #include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <tinyxml.h>
+#include <vector>
 
 #define SYNTAX_ERROR(line) yFatal() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
@@ -38,7 +38,8 @@ const std::string RobotInterfaceDTD::baseUri("http://www.yarp.it/DTD/yarprobotin
 const std::string RobotInterfaceDTD::ext(".dtd");
 
 
-RobotInterfaceDTD::DocType StringToDocType(const std::string &type) {
+RobotInterfaceDTD::DocType StringToDocType(const std::string& type)
+{
     if (type == "robot") {
         return RobotInterfaceDTD::DocTypeRobot;
     } else if (type == "devices") {
@@ -53,8 +54,7 @@ RobotInterfaceDTD::DocType StringToDocType(const std::string &type) {
 
 std::string DocTypeToString(RobotInterfaceDTD::DocType doctype)
 {
-    switch (doctype)
-    {
+    switch (doctype) {
     case RobotInterfaceDTD::DocTypeRobot:
         return std::string("robot");
     case RobotInterfaceDTD::DocTypeDevices:
@@ -82,7 +82,8 @@ void RobotInterfaceDTD::setDefault()
     minorVersion = 0;
 }
 
-bool RobotInterfaceDTD::parse(TiXmlUnknown* unknownNode, const std::string& curr_filename) {
+bool RobotInterfaceDTD::parse(TiXmlUnknown* unknownNode, const std::string& curr_filename)
+{
     // Very basic and ugly DTD tag parsing as TinyXML does not support it
     // We just need the version numbers.
 
@@ -91,16 +92,16 @@ bool RobotInterfaceDTD::parse(TiXmlUnknown* unknownNode, const std::string& curr
     std::vector<std::string> tokens;
     std::copy(std::istream_iterator<std::string>(iss),
               std::istream_iterator<std::string>(),
-              std::back_inserter<std::vector<std::string> >(tokens));
+              std::back_inserter<std::vector<std::string>>(tokens));
 
     // Merge token in quotes (and remove quotes)
     for (auto it = tokens.begin(); it != tokens.end(); ++it) {
-        if(it->at(0) == '"' ) {
+        if (it->at(0) == '"') {
             if (it->at(it->size() - 1) == '"') {
                 *it = it->substr(1, it->size() - 2);
             } else {
                 std::string s = it->substr(1) + " ";
-                for (auto cit = it + 1; cit != tokens.end(); ) {
+                for (auto cit = it + 1; cit != tokens.end();) {
                     if (cit->at(cit->size() - 1) == '"') {
                         s += cit->substr(0, cit->size() - 1);
                         cit = tokens.erase(cit);
@@ -115,21 +116,20 @@ bool RobotInterfaceDTD::parse(TiXmlUnknown* unknownNode, const std::string& curr
         }
     }
 
-    if(tokens.size() != 5) {
+    if (tokens.size() != 5) {
         SYNTAX_WARNING(unknownNode->Row()) << "Unknown node found" << tokens.size();
     }
 
-    if(tokens.at(0) != "!DOCTYPE") {
+    if (tokens.at(0) != "!DOCTYPE") {
         SYNTAX_WARNING(unknownNode->Row()) << "Unknown node found";
     }
 
     type = StringToDocType(tokens.at(1));
-    if(type == RobotInterfaceDTD::DocTypeUnknown)
-    {
+    if (type == RobotInterfaceDTD::DocTypeUnknown) {
         SYNTAX_WARNING(unknownNode->Row()) << R"(Unknown document type. Supported document types are: "robot", "devices", "params")";
     }
 
-    if(tokens.at(2) != "PUBLIC") {
+    if (tokens.at(2) != "PUBLIC") {
         SYNTAX_WARNING(unknownNode->Row()) << "Unknown document type. Expected \"PUBLIC\", found" << tokens.at(2);
     }
 
@@ -154,11 +154,11 @@ bool RobotInterfaceDTD::parse(TiXmlUnknown* unknownNode, const std::string& curr
     std::string majorVersionString = versionString.substr(0, dot);
     std::string minorVersionString = versionString.substr(dot + 1);
     std::istringstream majiss(majorVersionString);
-    if ( !(majiss >> majorVersion) ) {
+    if (!(majiss >> majorVersion)) {
         SYNTAX_WARNING(unknownNode->Row()) << "Unknown document type. Missing version in Url" << uri;
     }
     std::istringstream miniss(minorVersionString);
-    if ( !(miniss >> minorVersion) ) {
+    if (!(miniss >> minorVersion)) {
         SYNTAX_WARNING(unknownNode->Row()) << "Unknown document type. Missing version in Url" << uri;
     }
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Types.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Types.cpp
@@ -7,16 +7,15 @@
  */
 
 #include "Types.h"
-#include "Param.h"
-
-#include <string>
-#include <sstream>
-
 
 #include <yarp/os/LogStream.h>
 
+#include "Param.h"
+#include <sstream>
+#include <string>
 
-bool yarp::robotinterface::hasParam(const yarp::robotinterface::ParamList &list, const std::string& name)
+
+bool yarp::robotinterface::hasParam(const yarp::robotinterface::ParamList& list, const std::string& name)
 {
     for (const auto& param : list) {
         if (name == param.name()) {
@@ -26,7 +25,7 @@ bool yarp::robotinterface::hasParam(const yarp::robotinterface::ParamList &list,
     return false;
 }
 
-std::string yarp::robotinterface::findParam(const yarp::robotinterface::ParamList &list, const std::string& name)
+std::string yarp::robotinterface::findParam(const yarp::robotinterface::ParamList& list, const std::string& name)
 {
     for (const auto& param : list) {
         if (name == param.name()) {
@@ -37,7 +36,7 @@ std::string yarp::robotinterface::findParam(const yarp::robotinterface::ParamLis
     return {};
 }
 
-bool yarp::robotinterface::hasGroup(const yarp::robotinterface::ParamList &list, const std::string& name)
+bool yarp::robotinterface::hasGroup(const yarp::robotinterface::ParamList& list, const std::string& name)
 {
     for (const auto& param : list) {
         if (param.isGroup() && name == param.name()) {
@@ -47,7 +46,7 @@ bool yarp::robotinterface::hasGroup(const yarp::robotinterface::ParamList &list,
     return false;
 }
 
-std::string yarp::robotinterface::findGroup(const yarp::robotinterface::ParamList &list, const std::string& name)
+std::string yarp::robotinterface::findGroup(const yarp::robotinterface::ParamList& list, const std::string& name)
 {
     for (const auto& param : list) {
         if (param.isGroup() && name == param.name()) {
@@ -58,13 +57,13 @@ std::string yarp::robotinterface::findGroup(const yarp::robotinterface::ParamLis
     return {};
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::mergeDuplicateGroups(const yarp::robotinterface::ParamList &list)
+yarp::robotinterface::ParamList yarp::robotinterface::mergeDuplicateGroups(const yarp::robotinterface::ParamList& list)
 {
     yarp::robotinterface::ParamList params = list;
     for (auto it1 = params.begin(); it1 != params.end(); ++it1) {
-        yarp::robotinterface::Param &param1 = *it1;
-        for (auto it2 = it1 + 1; it2 != params.end(); ) {
-            yarp::robotinterface::Param &param2 = *it2;
+        yarp::robotinterface::Param& param1 = *it1;
+        for (auto it2 = it1 + 1; it2 != params.end();) {
+            yarp::robotinterface::Param& param2 = *it2;
             if (param1.name() == param2.name()) {
                 if (!param1.isGroup() || !param2.isGroup()) {
                     yFatal() << "Duplicate parameter \"" << param1.name() << "\" found and at least one of them is not a group.";
@@ -72,15 +71,15 @@ yarp::robotinterface::ParamList yarp::robotinterface::mergeDuplicateGroups(const
                 param1.value() += std::string(" ");
                 param1.value() += param2.value();
                 it2 = params.erase(it2);
-            }
-            else it2++;
+            } else
+                it2++;
         }
     }
     return params;
 }
 
 
-yarp::robotinterface::ActionPhase yarp::robotinterface::StringToActionPhase(const std::string &phase)
+yarp::robotinterface::ActionPhase yarp::robotinterface::StringToActionPhase(const std::string& phase)
 {
     if (phase == "startup") {
         return yarp::robotinterface::ActionPhaseStartup;
@@ -119,13 +118,13 @@ std::string yarp::robotinterface::ActionPhaseToString(yarp::robotinterface::Acti
     }
 }
 
-void yarp::robotinterface::operator>>(const std::stringstream &sstream, yarp::robotinterface::ActionPhase &actionphase)
+void yarp::robotinterface::operator>>(const std::stringstream& sstream, yarp::robotinterface::ActionPhase& actionphase)
 {
     actionphase = yarp::robotinterface::StringToActionPhase(sstream.str());
 }
 
 
-yarp::robotinterface::ActionType yarp::robotinterface::StringToActionType(const std::string &type)
+yarp::robotinterface::ActionType yarp::robotinterface::StringToActionType(const std::string& type)
 {
     if (type == "configure") {
         return yarp::robotinterface::ActionTypeConfigure;
@@ -169,7 +168,7 @@ std::string yarp::robotinterface::ActionTypeToString(yarp::robotinterface::Actio
     }
 }
 
-void yarp::robotinterface::operator>>(const std::stringstream &sstream, yarp::robotinterface::ActionType &actiontype)
+void yarp::robotinterface::operator>>(const std::stringstream& sstream, yarp::robotinterface::ActionType& actiontype)
 {
     actiontype = yarp::robotinterface::StringToActionType(sstream.str());
 }

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Types.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Types.h
@@ -39,6 +39,7 @@ class Robot;
 typedef std::vector<robotinterface::Param> ParamList;
 typedef std::vector<robotinterface::Action> ActionList;
 typedef std::vector<robotinterface::Device> DeviceList;
+typedef std::vector<robotinterface::Device*> DevicePtrList;
 typedef std::list<yarp::os::Thread*> ThreadList;
 
 YARP_robotinterface_API bool hasParam(const robotinterface::ParamList& list, const std::string& name);

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Types.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Types.h
@@ -9,16 +9,24 @@
 #ifndef YARP_ROBOTINTERFACE_TYPES_H
 #define YARP_ROBOTINTERFACE_TYPES_H
 
-#include <vector>
+#include <yarp/robotinterface/api.h>
+
 #include <iosfwd>
 #include <list>
 #include <string>
+#include <vector>
 
-#include <yarp/robotinterface/api.h>
 
-
-namespace yarp { namespace os { class Thread; } }
-namespace yarp { namespace os { class LogStream; } }
+namespace yarp {
+namespace os {
+class Thread;
+}
+}
+namespace yarp {
+namespace os {
+class LogStream;
+}
+}
 
 namespace yarp {
 namespace robotinterface {
@@ -33,11 +41,11 @@ typedef std::vector<robotinterface::Action> ActionList;
 typedef std::vector<robotinterface::Device> DeviceList;
 typedef std::list<yarp::os::Thread*> ThreadList;
 
-YARP_robotinterface_API bool hasParam(const robotinterface::ParamList &list, const std::string& name);
-YARP_robotinterface_API std::string findParam(const robotinterface::ParamList &list, const std::string& name);
-YARP_robotinterface_API bool hasGroup(const robotinterface::ParamList &list, const std::string& name);
-YARP_robotinterface_API std::string findGroup(const robotinterface::ParamList &list, const std::string& name);
-YARP_robotinterface_API robotinterface::ParamList mergeDuplicateGroups(const robotinterface::ParamList &list);
+YARP_robotinterface_API bool hasParam(const robotinterface::ParamList& list, const std::string& name);
+YARP_robotinterface_API std::string findParam(const robotinterface::ParamList& list, const std::string& name);
+YARP_robotinterface_API bool hasGroup(const robotinterface::ParamList& list, const std::string& name);
+YARP_robotinterface_API std::string findGroup(const robotinterface::ParamList& list, const std::string& name);
+YARP_robotinterface_API robotinterface::ParamList mergeDuplicateGroups(const robotinterface::ParamList& list);
 
 enum ActionPhase
 {
@@ -52,10 +60,10 @@ enum ActionPhase
     ActionPhaseReserved = 0xFF
 };
 
-YARP_robotinterface_API robotinterface::ActionPhase StringToActionPhase(const std::string &phase);
+YARP_robotinterface_API robotinterface::ActionPhase StringToActionPhase(const std::string& phase);
 YARP_robotinterface_API std::string ActionPhaseToString(robotinterface::ActionPhase actionphase);
 // Required by TiXmlElement::QueryValueAttribute<robotinterface::ActionPhase>
-YARP_robotinterface_API void operator>>(const std::stringstream &sstream, robotinterface::ActionPhase &actionphase);
+YARP_robotinterface_API void operator>>(const std::stringstream& sstream, robotinterface::ActionPhase& actionphase);
 
 
 enum ActionType
@@ -72,10 +80,10 @@ enum ActionType
     ActionTypeCustom = 0xFF
 };
 
-YARP_robotinterface_API robotinterface::ActionType StringToActionType(const std::string &type);
+YARP_robotinterface_API robotinterface::ActionType StringToActionType(const std::string& type);
 YARP_robotinterface_API std::string ActionTypeToString(robotinterface::ActionType actiontype);
 // Required by TiXmlElement::QueryValueAttribute<robotinterface::ActionType>
-YARP_robotinterface_API void operator>>(const std::stringstream &sstream, robotinterface::ActionType &actiontype);
+YARP_robotinterface_API void operator>>(const std::stringstream& sstream, robotinterface::ActionType& actiontype);
 
 } // namespace robotinterface
 } // namespace yarp

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReader.h
@@ -9,10 +9,11 @@
 #ifndef YARP_ROBOTINTERFACE_XMLREADER_H
 #define YARP_ROBOTINTERFACE_XMLREADER_H
 
-#include <string>
-
 #include <yarp/robotinterface/api.h>
+
 #include <yarp/robotinterface/Robot.h>
+
+#include <string>
 
 
 namespace yarp {
@@ -27,7 +28,8 @@ class XMLReaderFileVx;
 class YARP_robotinterface_API XMLReaderResult
 {
 public:
-    static XMLReaderResult ParsingFailed() {
+    static XMLReaderResult ParsingFailed()
+    {
         XMLReaderResult result;
         result.parsingIsSuccessful = false;
         return result;
@@ -56,7 +58,7 @@ public:
      * \param filename path to the XML file to load.
      * \return result of parsing.
      */
-    XMLReaderResult getRobotFromFile(const std::string &filename);
+    XMLReaderResult getRobotFromFile(const std::string& filename);
 
     /**
      * Parse the XML description of a robotinterface from a string.
@@ -67,10 +69,11 @@ public:
     XMLReaderResult getRobotFromString(const std::string& xmlString);
     void setVerbose(bool verbose);
     void setEnableDeprecated(bool enab);
+
 private:
     bool verbose;
     bool enable_deprecated;
-    XMLReaderFileVx * mReader;
+    XMLReaderFileVx* mReader;
 }; // class XMLReader
 
 } // namespace robotinterface

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV1.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV1.cpp
@@ -6,8 +6,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
 
-#include "XMLReader.h"
 #include "Action.h"
 #include "Device.h"
 #include "Param.h"
@@ -15,18 +17,13 @@
 #include "Types.h"
 #include "XMLReader.h"
 #include "impl/XMLReaderFileVx.h"
-
-#include <yarp/os/LogStream.h>
-#include <yarp/os/Network.h>
-#include <yarp/os/Property.h>
-
-#include <tinyxml.h>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <iterator>
 #include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <tinyxml.h>
 #include <utility>
+#include <vector>
 
 #define SYNTAX_ERROR(line) yFatal() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
@@ -39,12 +36,12 @@
 class yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1
 {
 public:
-    explicit privateXMLReaderFileV1(XMLReaderFileV1 *parent);
+    explicit privateXMLReaderFileV1(XMLReaderFileV1* parent);
     virtual ~privateXMLReaderFileV1();
 
-    yarp::robotinterface::XMLReaderResult readRobotFromFile(const std::string &fileName);
+    yarp::robotinterface::XMLReaderResult readRobotFromFile(const std::string& fileName);
     yarp::robotinterface::XMLReaderResult readRobotFromString(const std::string& xmlString);
-    yarp::robotinterface::XMLReaderResult readRobotTag(TiXmlElement *robotElem);
+    yarp::robotinterface::XMLReaderResult readRobotTag(TiXmlElement* robotElem);
 
     yarp::robotinterface::DeviceList readDevices(TiXmlElement* devicesElem, yarp::robotinterface::XMLReaderResult& result);
     yarp::robotinterface::Device readDeviceTag(TiXmlElement* deviceElem, yarp::robotinterface::XMLReaderResult& result);
@@ -64,7 +61,7 @@ public:
     yarp::robotinterface::ActionList readActionsTag(TiXmlElement* actionsElem, yarp::robotinterface::XMLReaderResult& result);
     yarp::robotinterface::ActionList readActionsFile(const std::string& fileName, yarp::robotinterface::XMLReaderResult& result);
 
-    XMLReaderFileV1 * const parent;
+    XMLReaderFileV1* const parent;
     std::string filename;
     std::string path;
 #ifdef USE_DTD
@@ -78,7 +75,7 @@ public:
 };
 
 
-yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::privateXMLReaderFileV1(XMLReaderFileV1 *p) :
+yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::privateXMLReaderFileV1(XMLReaderFileV1* p) :
         parent(p),
         minorVersion(0),
         majorVersion(0)
@@ -88,7 +85,7 @@ yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::privateXMLReaderF
 
 yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::~privateXMLReaderFileV1() = default;
 
-yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readRobotFromFile(const std::string &fileName)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readRobotFromFile(const std::string& fileName)
 {
     filename = fileName;
 #ifdef WIN32
@@ -98,7 +95,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::pri
     curr_filename = fileName;
 #ifdef WIN32
     path = filename.substr(0, filename.rfind("\\"));
-#else // WIN32
+#else  // WIN32
     path = filename.substr(0, filename.rfind('/'));
 #endif //WIN32
 
@@ -117,7 +114,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::pri
 #ifdef USE_DTD
     for (TiXmlNode* childNode = doc->FirstChild(); childNode != 0; childNode = childNode->NextSibling()) {
         if (childNode->Type() == TiXmlNode::TINYXML_UNKNOWN) {
-            if(dtd.parse(childNode->ToUnknown(), curr_filename)) {
+            if (dtd.parse(childNode->ToUnknown(), curr_filename)) {
                 break;
             }
         }
@@ -129,12 +126,12 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::pri
         dtd.type = RobotInterfaceDTD::DocTypeRobot;
     }
 
-    if(dtd.type != RobotInterfaceDTD::DocTypeRobot) {
+    if (dtd.type != RobotInterfaceDTD::DocTypeRobot) {
         SYNTAX_WARNING(doc->Row()) << "Expected document of type" << DocTypeToString(RobotInterfaceDTD::DocTypeRobot)
-                                       << ". Found" << DocTypeToString(dtd.type);
+                                   << ". Found" << DocTypeToString(dtd.type);
     }
 
-    if(dtd.majorVersion != 1 || dtd.minorVersion != 0) {
+    if (dtd.majorVersion != 1 || dtd.minorVersion != 0) {
         SYNTAX_WARNING(doc->Row()) << "Only yarprobotinterface DTD version 1.0 is supported";
     }
 #endif
@@ -168,7 +165,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::pri
 }
 
 
-yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readRobotTag(TiXmlElement *robotElem)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readRobotTag(TiXmlElement* robotElem)
 {
     yarp::robotinterface::XMLReaderResult result;
     result.parsingIsSuccessful = true;
@@ -223,24 +220,20 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::pri
 }
 
 
-
-yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readDevices(TiXmlElement *devicesElem,
+yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readDevices(TiXmlElement* devicesElem,
                                                                                                             yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = devicesElem->ValueStr();
+    const std::string& valueStr = devicesElem->ValueStr();
 
     if (valueStr == "device") {
         // yDebug() << valueStr;
         DeviceList deviceList;
         deviceList.push_back(readDeviceTag(devicesElem, result));
         return deviceList;
-    }
-    else if (valueStr == "devices") {
+    } else if (valueStr == "devices") {
         // "devices"
         return readDevicesTag(devicesElem, result);
-    }
-    else
-    {
+    } else {
         SYNTAX_ERROR(devicesElem->Row()) << R"(Expected "device" or "devices". Found)" << valueStr;
         result.parsingIsSuccessful = false;
     }
@@ -250,7 +243,7 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateX
 yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readDeviceTag(TiXmlElement* deviceElem,
                                                                                                           yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = deviceElem->ValueStr();
+    const std::string& valueStr = deviceElem->ValueStr();
 
     if (valueStr != "device") {
         SYNTAX_ERROR(deviceElem->Row()) << "Expected \"device\". Found" << valueStr;
@@ -274,8 +267,7 @@ yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV1::privateXMLRe
     device.params().push_back(Param("robotName", result.robot.portprefix()));
 
     for (TiXmlElement* childElem = deviceElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        if (childElem->ValueStr() == "action" ||
-            childElem->ValueStr() == "actions") {
+        if (childElem->ValueStr() == "action" || childElem->ValueStr() == "actions") {
             ActionList childActions = readActions(childElem, result);
             for (ActionList::const_iterator it = childActions.begin(); it != childActions.end(); ++it) {
                 device.actions().push_back(*it);
@@ -303,7 +295,7 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateX
 #ifdef WIN32
         std::replace(filename.begin(), filename.end(), '/', '\\');
         filename = path + "\\" + filename;
-#else // WIN32
+#else  // WIN32
         filename = path + "/" + filename;
 #endif //WIN32
         return readDevicesFile(filename, result);
@@ -376,7 +368,7 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateX
     RobotInterfaceDTD devicesFileDTD;
     for (TiXmlNode* childNode = doc->FirstChild(); childNode != 0; childNode = childNode->NextSibling()) {
         if (childNode->Type() == TiXmlNode::TINYXML_UNKNOWN) {
-            if(devicesFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
+            if (devicesFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
                 break;
             }
         }
@@ -390,7 +382,7 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateX
 
     if (devicesFileDTD.type != RobotInterfaceDTD::DocTypeDevices) {
         SYNTAX_ERROR(doc->Row()) << "Expected document of type" << DocTypeToString(RobotInterfaceDTD::DocTypeDevices)
-                                       << ". Found" << DocTypeToString(devicesFileDTD.type);
+                                 << ". Found" << DocTypeToString(devicesFileDTD.type);
     }
 
     if (devicesFileDTD.majorVersion != dtd.majorVersion) {
@@ -405,11 +397,10 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV1::privateX
 }
 
 
-
 yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readParams(TiXmlElement* paramsElem,
                                                                                                           yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = paramsElem->ValueStr();
+    const std::string& valueStr = paramsElem->ValueStr();
 
     if (valueStr == "param") {
         ParamList params;
@@ -425,9 +416,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
         return readSubDeviceTag(paramsElem, result);
     } else if (valueStr == "params") {
         return readParamsTag(paramsElem, result);
-    }
-    else
-    {
+    } else {
         SYNTAX_ERROR(paramsElem->Row()) << R"(Expected "param", "group", "paramlist", "subdevice", or "params". Found)" << valueStr;
     }
     return ParamList();
@@ -451,13 +440,10 @@ yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV1::privateXMLRea
 
     // yDebug() << "Found param [" << param.name() << "]";
 
-    const char *valueText = paramElem->GetText();
-    if (!valueText)
-    {
+    const char* valueText = paramElem->GetText();
+    if (!valueText) {
         SYNTAX_ERROR(paramElem->Row()) << R"("param" element should have a value [ "name" = )" << param.name() << "]";
-    }
-    else
-    {
+    } else {
         param.value() = valueText;
     }
 
@@ -538,14 +524,11 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
             result.parsingIsSuccessful = false;
         }
 
-        const char *valueText = childElem->GetText();
-        if (!valueText)
-        {
+        const char* valueText = childElem->GetText();
+        if (!valueText) {
             SYNTAX_ERROR(childElem->Row()) << R"("elem" element should have a value [ "name" = )" << childParam.name() << "]";
             result.parsingIsSuccessful = false;
-        }
-        else
-        {
+        } else {
             childParam.value() = valueText;
         }
 
@@ -559,7 +542,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
 
     // +1 skips the first element, that is the main param
     for (auto it = params.begin() + 1; it != params.end(); ++it) {
-        Param &param = *it;
+        Param& param = *it;
         params.at(0).value() += (params.at(0).value().empty() ? "(" : " ") + param.name();
     }
     params.at(0).value() += ")";
@@ -578,21 +561,21 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
 
     ParamList params;
 
-//FIXME    Param featIdParam;
+    //FIXME    Param featIdParam;
     Param subDeviceParam;
 
-//FIXME    featIdParam.name() = "FeatId";
+    //FIXME    featIdParam.name() = "FeatId";
     subDeviceParam.name() = "subdevice";
 
-//FIXME    if (subDeviceElem->QueryStringAttribute("name", &featIdParam.value()) != TIXML_SUCCESS) {
-//        SYNTAX_ERROR(subDeviceElem->Row()) << "\"subdevice\" element should contain the \"name\" attribute";
-//    }
+    //FIXME    if (subDeviceElem->QueryStringAttribute("name", &featIdParam.value()) != TIXML_SUCCESS) {
+    //        SYNTAX_ERROR(subDeviceElem->Row()) << "\"subdevice\" element should contain the \"name\" attribute";
+    //    }
 
     if (subDeviceElem->QueryStringAttribute("type", &subDeviceParam.value()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(subDeviceElem->Row()) << R"("subdevice" element should contain the "type" attribute)";
     }
 
-//FIXME    params.push_back(featIdParam);
+    //FIXME    params.push_back(featIdParam);
     params.push_back(subDeviceParam);
 
     // yDebug() << "Found subdevice [" << params.at(0).value() << "]";
@@ -619,7 +602,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
 #ifdef WIN32
         std::replace(filename.begin(), filename.end(), '/', '\\');
         filename = path + "\\" + filename;
-#else // WIN32
+#else  // WIN32
         filename = path + "/" + filename;
 #endif //WIN32
         return readParamsFile(filename, result);
@@ -690,7 +673,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
     RobotInterfaceDTD paramsFileDTD;
     for (TiXmlNode* childNode = doc->FirstChild(); childNode != 0; childNode = childNode->NextSibling()) {
         if (childNode->Type() == TiXmlNode::TINYXML_UNKNOWN) {
-            if(paramsFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
+            if (paramsFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
                 break;
             }
         }
@@ -704,7 +687,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
 
     if (paramsFileDTD.type != RobotInterfaceDTD::DocTypeParams) {
         SYNTAX_ERROR(doc->Row()) << "Expected document of type" << DocTypeToString(RobotInterfaceDTD::DocTypeParams)
-                                       << ". Found" << DocTypeToString(paramsFileDTD.type);
+                                 << ". Found" << DocTypeToString(paramsFileDTD.type);
     }
 
     if (paramsFileDTD.majorVersion != dtd.majorVersion) {
@@ -721,11 +704,9 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV1::privateXM
 yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readActions(TiXmlElement* actionsElem,
                                                                                                             yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = actionsElem->ValueStr();
+    const std::string& valueStr = actionsElem->ValueStr();
 
-    if (valueStr != "action" &&
-        valueStr != "actions")
-    {
+    if (valueStr != "action" && valueStr != "actions") {
         SYNTAX_ERROR(actionsElem->Row()) << R"(Expected "action" or "actions". Found)" << valueStr;
     }
 
@@ -781,7 +762,7 @@ yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV1::privateXMLRe
     return action;
 }
 
-yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readActionsTag(TiXmlElement *actionsElem,
+yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV1::privateXMLReaderFileV1::readActionsTag(TiXmlElement* actionsElem,
                                                                                                                yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = actionsElem->ValueStr();
@@ -792,7 +773,7 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV1::privateX
 #ifdef WIN32
         std::replace(filename.begin(), filename.end(), '/', '\\');
         filename = path + "\\" + filename;
-#else // WIN32
+#else  // WIN32
         filename = path + "/" + filename;
 #endif //WIN32
         return readActionsFile(filename, result);
@@ -858,7 +839,7 @@ yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV1::privateX
     RobotInterfaceDTD actionsFileDTD;
     for (TiXmlNode* childNode = doc->FirstChild(); childNode != 0; childNode = childNode->NextSibling()) {
         if (childNode->Type() == TiXmlNode::TINYXML_UNKNOWN) {
-            if(actionsFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
+            if (actionsFileDTD.parse(childNode->ToUnknown(), curr_filename)) {
                 break;
             }
         }
@@ -898,15 +879,14 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV1::get
     return mPriv->readRobotFromString(xmlString);
 }
 
-yarp::robotinterface::XMLReaderFileV1::XMLReaderFileV1() : mPriv(new privateXMLReaderFileV1(this))
+yarp::robotinterface::XMLReaderFileV1::XMLReaderFileV1() :
+        mPriv(new privateXMLReaderFileV1(this))
 {
-
 }
 
 yarp::robotinterface::XMLReaderFileV1::~XMLReaderFileV1()
 {
-    if (mPriv)
-    {
+    if (mPriv) {
         delete mPriv;
     }
 }

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderV3.cpp
@@ -6,7 +6,10 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include "XMLReader.h"
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+
 #include "Action.h"
 #include "Device.h"
 #include "Param.h"
@@ -14,17 +17,12 @@
 #include "Types.h"
 #include "XMLReader.h"
 #include "impl/XMLReaderFileVx.h"
-
-#include <yarp/os/LogStream.h>
-#include <yarp/os/Network.h>
-#include <yarp/os/Property.h>
-
-#include <tinyxml.h>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <iterator>
 #include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <tinyxml.h>
+#include <vector>
 
 #define SYNTAX_ERROR(line) yError() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
@@ -37,12 +35,12 @@
 class yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3
 {
 public:
-    explicit privateXMLReaderFileV3(XMLReaderFileV3 *parent);
+    explicit privateXMLReaderFileV3(XMLReaderFileV3* parent);
     virtual ~privateXMLReaderFileV3();
 
-    yarp::robotinterface::XMLReaderResult readRobotFromFile(const std::string &fileName);
+    yarp::robotinterface::XMLReaderResult readRobotFromFile(const std::string& fileName);
     yarp::robotinterface::XMLReaderResult readRobotFromString(const std::string& xmlString);
-    yarp::robotinterface::XMLReaderResult readRobotTag(TiXmlElement *robotElem);
+    yarp::robotinterface::XMLReaderResult readRobotTag(TiXmlElement* robotElem);
 
     yarp::robotinterface::DeviceList readDevices(TiXmlElement* devicesElem, yarp::robotinterface::XMLReaderResult& result);
     yarp::robotinterface::Device readDeviceTag(TiXmlElement* deviceElem, yarp::robotinterface::XMLReaderResult& result);
@@ -61,7 +59,7 @@ public:
 
     bool PerformInclusions(TiXmlNode* pParent, const std::string& parent_fileName, const std::string& current_path);
 
-    XMLReaderFileV3 * const parent;
+    XMLReaderFileV3* const parent;
 
 #ifdef USE_DTD
     RobotInterfaceDTD dtd;
@@ -74,7 +72,7 @@ public:
 };
 
 
-yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::privateXMLReaderFileV3(XMLReaderFileV3 *p) :
+yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::privateXMLReaderFileV3(XMLReaderFileV3* p) :
         parent(p),
         minorVersion(0),
         majorVersion(0)
@@ -84,7 +82,7 @@ yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::privateXMLReaderF
 
 yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::~privateXMLReaderFileV3() = default;
 
-yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotFromFile(const std::string &fileName)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotFromFile(const std::string& fileName)
 {
     yDebug() << "Reading file" << fileName.c_str();
     auto* doc = new TiXmlDocument(fileName.c_str());
@@ -101,7 +99,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
 #ifdef USE_DTD
     for (TiXmlNode* childNode = doc->FirstChild(); childNode != 0; childNode = childNode->NextSibling()) {
         if (childNode->Type() == TiXmlNode::TINYXML_UNKNOWN) {
-            if(dtd.parse(childNode->ToUnknown(), curr_filename)) {
+            if (dtd.parse(childNode->ToUnknown(), curr_filename)) {
                 break;
             }
         }
@@ -113,12 +111,12 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
         dtd.type = RobotInterfaceDTD::DocTypeRobot;
     }
 
-    if(dtd.type != RobotInterfaceDTD::DocTypeRobot) {
+    if (dtd.type != RobotInterfaceDTD::DocTypeRobot) {
         SYNTAX_WARNING(doc->Row()) << "Expected document of type" << DocTypeToString(RobotInterfaceDTD::DocTypeRobot)
-                                       << ". Found" << DocTypeToString(dtd.type);
+                                   << ". Found" << DocTypeToString(dtd.type);
     }
 
-    if(dtd.majorVersion != 1 || dtd.minorVersion != 0) {
+    if (dtd.majorVersion != 1 || dtd.minorVersion != 0) {
         SYNTAX_WARNING(doc->Row()) << "Only yarprobotinterface DTD version 1.0 is supported";
     }
 #endif
@@ -127,8 +125,8 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
     current_path = fileName.substr(0, fileName.find_last_of("\\/"));
     std::string current_filename;
     std::string log_filename;
-    current_filename = fileName.substr(fileName.find_last_of("\\/") +1);
-    log_filename = current_filename.substr(0,current_filename.find(".xml"));
+    current_filename = fileName.substr(fileName.find_last_of("\\/") + 1);
+    log_filename = current_filename.substr(0, current_filename.find(".xml"));
     log_filename += "_preprocessor_log.xml";
     double start_time = yarp::os::Time::now();
     PerformInclusions(doc->RootElement(), current_filename, current_path);
@@ -136,8 +134,7 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
     std::string full_log_withpath = current_path + std::string("\\") + log_filename;
     std::replace(full_log_withpath.begin(), full_log_withpath.end(), '\\', '/');
     yDebug() << "Preprocessor complete in: " << end_time - start_time << "s";
-    if (verbose_output)
-    {
+    if (verbose_output) {
         yDebug() << "Preprocessor output stored in: " << full_log_withpath;
         doc->SaveFile(full_log_withpath);
     }
@@ -171,60 +168,48 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
 
 bool yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::PerformInclusions(TiXmlNode* pParent, const std::string& parent_fileName, const std::string& current_path)
 {
-    loop_start: //goto label
-    for (TiXmlElement* childElem = pParent->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement())
-    {
+loop_start: //goto label
+    for (TiXmlElement* childElem = pParent->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
 #ifdef DEBUG_PARSER
         std::string a;
-        if (childElem->FirstAttribute()) a= childElem->FirstAttribute()->Value();
+        if (childElem->FirstAttribute())
+            a = childElem->FirstAttribute()->Value();
         yDebug() << "Parsing" << childElem->Value() << a;
 #endif
         std::string elemString = childElem->ValueStr();
-        if (elemString == "file")
-        {
+        if (elemString == "file") {
             yFatal() << "'file' attribute is forbidden in yarprobotinterface DTD format 3.0. Error found in " << parent_fileName;
             return false;
-        }
-        else if (elemString == "xi:include")
-        {
+        } else if (elemString == "xi:include") {
             std::string href_filename;
             std::string included_filename;
             std::string included_path;
-            if (childElem->QueryStringAttribute("href", &href_filename) == TIXML_SUCCESS)
-            {
+            if (childElem->QueryStringAttribute("href", &href_filename) == TIXML_SUCCESS) {
                 included_path = std::string(current_path).append("\\").append(href_filename.substr(0, href_filename.find_last_of("\\/")));
                 included_filename = href_filename.substr(href_filename.find_last_of("\\/") + 1);
                 std::string full_path_file = std::string(included_path).append("\\").append(included_filename);
                 TiXmlDocument included_file;
 
                 std::replace(full_path_file.begin(), full_path_file.end(), '\\', '/');
-                if (included_file.LoadFile(full_path_file))
-                {
+                if (included_file.LoadFile(full_path_file)) {
                     PerformInclusions(included_file.RootElement(), included_filename, included_path);
                     //included_file.RootElement()->SetAttribute("xml:base", href_filename); //not yet implemented
                     included_file.RootElement()->RemoveAttribute("xmlns:xi");
-                    if (pParent->ReplaceChild(childElem, *included_file.FirstChildElement()))
-                    {
+                    if (pParent->ReplaceChild(childElem, *included_file.FirstChildElement())) {
                         //the replace operation invalidates the iterator, hence we need to restart the parsing of this level
                         goto loop_start;
-                    }
-                    else
-                    {
+                    } else {
                         //fatal error
                         yFatal() << "Failed to include: " << included_filename << " in: " << parent_fileName;
                         return false;
                     }
-                }
-                else
-                {
+                } else {
                     //fatal error
                     yError() << included_file.ErrorDesc() << " file" << full_path_file << "included by " << parent_fileName << "at line" << childElem->Row();
                     yFatal() << "In file:" << included_filename << " included by: " << parent_fileName << " at line: " << childElem->Row();
                     return false;
                 }
-            }
-            else
-            {
+            } else {
                 //fatal error
                 yFatal() << "Syntax error in: " << parent_fileName << " while searching for href attribute";
                 return false;
@@ -235,7 +220,7 @@ bool yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::PerformInclu
     return true;
 }
 
-yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotTag(TiXmlElement *robotElem)
+yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readRobotTag(TiXmlElement* robotElem)
 {
     yarp::robotinterface::XMLReaderResult result;
     result.parsingIsSuccessful = true;
@@ -272,18 +257,14 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
 
     // yDebug() << "Found robot [" << robot.name() << "] build [" << robot.build() << "] portprefix [" << robot.portprefix() << "]";
 
-    for (TiXmlElement* childElem = robotElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement())
-    {
+    for (TiXmlElement* childElem = robotElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
         std::string elemString = childElem->ValueStr();
-        if (elemString == "device" || elemString == "devices")
-        {
+        if (elemString == "device" || elemString == "devices") {
             DeviceList childDevices = readDevices(childElem, result);
             for (DeviceList::const_iterator it = childDevices.begin(); it != childDevices.end(); ++it) {
                 result.robot.devices().push_back(*it);
             }
-        }
-        else
-        {
+        } else {
             ParamList childParams = readParams(childElem, result);
             for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
                 result.robot.params().push_back(*it);
@@ -295,34 +276,30 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::pri
 }
 
 
-
-yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevices(TiXmlElement *devicesElem,
+yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevices(TiXmlElement* devicesElem,
                                                                                                             yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = devicesElem->ValueStr();
+    const std::string& valueStr = devicesElem->ValueStr();
 
     if (valueStr == "device") {
         // yDebug() << valueStr;
         DeviceList deviceList;
         deviceList.push_back(readDeviceTag(devicesElem, result));
         return deviceList;
-    }
-    else if (valueStr == "devices") {
+    } else if (valueStr == "devices") {
         // "devices"
         return readDevicesTag(devicesElem, result);
-    }
-    else
-    {
+    } else {
         SYNTAX_ERROR(devicesElem->Row()) << R"(Expected "device" or "devices". Found)" << valueStr;
         result.parsingIsSuccessful = false;
     }
     return DeviceList();
 }
 
-yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDeviceTag(TiXmlElement *deviceElem,
+yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDeviceTag(TiXmlElement* deviceElem,
                                                                                                           yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = deviceElem->ValueStr();
+    const std::string& valueStr = deviceElem->ValueStr();
 
     if (valueStr != "device") {
         SYNTAX_ERROR(deviceElem->Row()) << "Expected \"device\". Found" << valueStr;
@@ -348,22 +325,15 @@ yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLRe
 
     device.params().push_back(Param("robotName", result.robot.portprefix()));
 
-    for (TiXmlElement* childElem = deviceElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement())
-    {
-        if (childElem->ValueStr() == "action" ||
-            childElem->ValueStr() == "actions")
-        {
+    for (TiXmlElement* childElem = deviceElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
+        if (childElem->ValueStr() == "action" || childElem->ValueStr() == "actions") {
             ActionList childActions = readActions(childElem, result);
-            for (ActionList::const_iterator it = childActions.begin(); it != childActions.end(); ++it)
-            {
+            for (ActionList::const_iterator it = childActions.begin(); it != childActions.end(); ++it) {
                 device.actions().push_back(*it);
             }
-        }
-        else
-        {
+        } else {
             ParamList childParams = readParams(childElem, result);
-            for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it)
-            {
+            for (ParamList::const_iterator it = childParams.begin(); it != childParams.end(); ++it) {
                 device.params().push_back(*it);
             }
         }
@@ -373,7 +343,7 @@ yarp::robotinterface::Device yarp::robotinterface::XMLReaderFileV3::privateXMLRe
     return device;
 }
 
-yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevicesTag(TiXmlElement *devicesElem,
+yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readDevicesTag(TiXmlElement* devicesElem,
                                                                                                                yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = devicesElem->ValueStr();
@@ -392,7 +362,7 @@ yarp::robotinterface::DeviceList yarp::robotinterface::XMLReaderFileV3::privateX
 yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParams(TiXmlElement* paramsElem,
                                                                                                           yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = paramsElem->ValueStr();
+    const std::string& valueStr = paramsElem->ValueStr();
 
     if (valueStr == "param") {
         ParamList params;
@@ -408,9 +378,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
         return readSubDeviceTag(paramsElem, result);
     } else if (valueStr == "params") {
         return readParamsTag(paramsElem, result);
-    }
-    else
-    {
+    } else {
         SYNTAX_ERROR(paramsElem->Row()) << R"(Expected "param", "group", "paramlist", "subdevice", or "params". Found)" << valueStr;
         result.parsingIsSuccessful = false;
     }
@@ -418,7 +386,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 }
 
 
-yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamTag(TiXmlElement *paramElem,
+yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamTag(TiXmlElement* paramElem,
                                                                                                         yarp::robotinterface::XMLReaderResult& result)
 {
     if (paramElem->ValueStr() != "param") {
@@ -437,7 +405,7 @@ yarp::robotinterface::Param yarp::robotinterface::XMLReaderFileV3::privateXMLRea
 
     // yDebug() << "Found param [" << param.name() << "]";
 
-    const char *valueText = paramElem->GetText();
+    const char* valueText = paramElem->GetText();
     if (!valueText) {
         SYNTAX_ERROR(paramElem->Row()) << R"("param" element should have a value [ "name" = )" << param.name() << "]";
         result.parsingIsSuccessful = false;
@@ -531,7 +499,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
             return yarp::robotinterface::ParamList();
         }
 
-        const char *valueText = childElem->GetText();
+        const char* valueText = childElem->GetText();
         if (!valueText) {
             SYNTAX_ERROR(childElem->Row()) << R"("elem" element should have a value [ "name" = )" << childParam.name() << "]";
             result.parsingIsSuccessful = false;
@@ -550,7 +518,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 
     // +1 skips the first element, that is the main param
     for (auto it = params.begin() + 1; it != params.end(); ++it) {
-        Param &param = *it;
+        Param& param = *it;
         params.at(0).value() += (params.at(0).value().empty() ? "(" : " ") + param.name();
     }
     params.at(0).value() += ")";
@@ -559,7 +527,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readSubDeviceTag(TiXmlElement *subDeviceElem,
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readSubDeviceTag(TiXmlElement* subDeviceElem,
                                                                                                                 yarp::robotinterface::XMLReaderResult& result)
 {
     if (subDeviceElem->ValueStr() != "subdevice") {
@@ -570,15 +538,15 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
 
     ParamList params;
 
-//FIXME    Param featIdParam;
+    //FIXME    Param featIdParam;
     Param subDeviceParam;
 
-//FIXME    featIdParam.name() = "FeatId";
+    //FIXME    featIdParam.name() = "FeatId";
     subDeviceParam.name() = "subdevice";
 
-//FIXME    if (subDeviceElem->QueryStringAttribute("name", &featIdParam.value()) != TIXML_SUCCESS) {
-//        SYNTAX_ERROR(subDeviceElem->Row()) << "\"subdevice\" element should contain the \"name\" attribute";
-//    }
+    //FIXME    if (subDeviceElem->QueryStringAttribute("name", &featIdParam.value()) != TIXML_SUCCESS) {
+    //        SYNTAX_ERROR(subDeviceElem->Row()) << "\"subdevice\" element should contain the \"name\" attribute";
+    //    }
 
     if (subDeviceElem->QueryStringAttribute("type", &subDeviceParam.value()) != TIXML_SUCCESS) {
         SYNTAX_ERROR(subDeviceElem->Row()) << R"("subdevice" element should contain the "type" attribute)";
@@ -586,7 +554,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
         return yarp::robotinterface::ParamList();
     }
 
-//FIXME    params.push_back(featIdParam);
+    //FIXME    params.push_back(featIdParam);
     params.push_back(subDeviceParam);
 
     // yDebug() << "Found subdevice [" << params.at(0).value() << "]";
@@ -602,7 +570,7 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamsTag(TiXmlElement *paramsElem,
+yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readParamsTag(TiXmlElement* paramsElem,
                                                                                                              yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = paramsElem->ValueStr();
@@ -618,14 +586,12 @@ yarp::robotinterface::ParamList yarp::robotinterface::XMLReaderFileV3::privateXM
     return params;
 }
 
-yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActions(TiXmlElement *actionsElem,
+yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActions(TiXmlElement* actionsElem,
                                                                                                             yarp::robotinterface::XMLReaderResult& result)
 {
-    const std::string &valueStr = actionsElem->ValueStr();
+    const std::string& valueStr = actionsElem->ValueStr();
 
-    if (valueStr != "action" &&
-        valueStr != "actions")
-    {
+    if (valueStr != "action" && valueStr != "actions") {
         SYNTAX_ERROR(actionsElem->Row()) << R"(Expected "action" or "actions". Found)" << valueStr;
     }
 
@@ -689,7 +655,7 @@ yarp::robotinterface::Action yarp::robotinterface::XMLReaderFileV3::privateXMLRe
     return action;
 }
 
-yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionsTag(TiXmlElement *actionsElem,
+yarp::robotinterface::ActionList yarp::robotinterface::XMLReaderFileV3::privateXMLReaderFileV3::readActionsTag(TiXmlElement* actionsElem,
                                                                                                                yarp::robotinterface::XMLReaderResult& result)
 {
     //const std::string &valueStr = actionsElem->ValueStr();
@@ -748,14 +714,14 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReaderFileV3::get
 }
 
 
-yarp::robotinterface::XMLReaderFileV3::XMLReaderFileV3() : mPriv(new privateXMLReaderFileV3(this))
+yarp::robotinterface::XMLReaderFileV3::XMLReaderFileV3() :
+        mPriv(new privateXMLReaderFileV3(this))
 {
 }
 
 yarp::robotinterface::XMLReaderFileV3::~XMLReaderFileV3()
 {
-    if (mPriv)
-    {
+    if (mPriv) {
         delete mPriv;
     }
 }

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/XMLReaderVx.cpp
@@ -6,27 +6,26 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include "XMLReader.h"
+#include <yarp/conf/filesystem.h>
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Property.h>
+
 #include "Action.h"
 #include "Device.h"
 #include "Param.h"
 #include "Robot.h"
 #include "Types.h"
+#include "XMLReader.h"
 #include "impl/RobotInterfaceDTD.h"
 #include "impl/XMLReaderFileVx.h"
-
-
-#include <yarp/conf/filesystem.h>
-#include <yarp/os/LogStream.h>
-#include <yarp/os/Property.h>
-
-#include <tinyxml.h>
-#include <memory>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <iterator>
 #include <algorithm>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <tinyxml.h>
+#include <vector>
 
 #define SYNTAX_ERROR(line) yError() << "Syntax error while loading" << curr_filename << "at line" << line << "."
 #define SYNTAX_WARNING(line) yWarning() << "Invalid syntax while loading" << curr_filename << "at line" << line << "."
@@ -37,7 +36,7 @@
 #define TINYXML_UNSIGNED_INT_BUG 0
 
 yarp::robotinterface::XMLReader::XMLReader() :
-    mReader(nullptr)
+        mReader(nullptr)
 {
     enable_deprecated = false;
     verbose = false;
@@ -45,8 +44,7 @@ yarp::robotinterface::XMLReader::XMLReader() :
 
 yarp::robotinterface::XMLReader::~XMLReader()
 {
-    if (mReader)
-    {
+    if (mReader) {
         delete mReader;
         mReader = nullptr;
     }
@@ -101,26 +99,20 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::XMLReader::getRobotF
 
     if (dtd.type != RobotInterfaceDTD::DocTypeRobot) {
         SYNTAX_WARNING(doc->Row()) << "Expected document of type" << DocTypeToString(RobotInterfaceDTD::DocTypeRobot)
-            << ". Found" << DocTypeToString(dtd.type);
+                                   << ". Found" << DocTypeToString(dtd.type);
     }
 
-    if (dtd.majorVersion == 1)
-    {
+    if (dtd.majorVersion == 1) {
         yError() << "DTD V1.x has been deprecated. Please update your configuration files to DTD v3.x";
-        if (enable_deprecated)
-        {
+        if (enable_deprecated) {
             yWarning() << "yarprobotinterface: using DEPRECATED xml parser for DTD v1.x";
             mReader = new yarp::robotinterface::XMLReaderFileV1;
             return mReader->getRobotFromFile(filename, verbose);
-        }
-        else
-        {
+        } else {
             yError("Invalid DTD version, execution stopped.");
             return yarp::robotinterface::XMLReaderResult::ParsingFailed();
         }
-    }
-    else if (dtd.majorVersion == 3)
-    {
+    } else if (dtd.majorVersion == 3) {
         yDebug() << "yarprobotinterface: using xml parser for DTD v3.x";
         mReader = new yarp::robotinterface::XMLReaderFileV3;
         return mReader->getRobotFromFile(filename, verbose);

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/api.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/api.h
@@ -11,15 +11,15 @@
 
 #include <yarp/conf/api.h>
 #ifndef YARP_robotinterface_API
-#  ifdef YARP_robotinterface_EXPORTS
-#    define YARP_robotinterface_API YARP_EXPORT
-#    define YARP_robotinterface_EXTERN YARP_EXPORT_EXTERN
-#  else
-#    define YARP_robotinterface_API YARP_IMPORT
-#    define YARP_robotinterface_EXTERN YARP_IMPORT_EXTERN
-#  endif
-#  define YARP_robotinterface_DEPRECATED_API YARP_DEPRECATED_API
-#  define YARP_robotinterface_DEPRECATED_API_MSG(X) YARP_DEPRECATED_API_MSG(X)
+#    ifdef YARP_robotinterface_EXPORTS
+#        define YARP_robotinterface_API YARP_EXPORT
+#        define YARP_robotinterface_EXTERN YARP_EXPORT_EXTERN
+#    else
+#        define YARP_robotinterface_API YARP_IMPORT
+#        define YARP_robotinterface_EXTERN YARP_IMPORT_EXTERN
+#    endif
+#    define YARP_robotinterface_DEPRECATED_API YARP_DEPRECATED_API
+#    define YARP_robotinterface_DEPRECATED_API_MSG(X) YARP_DEPRECATED_API_MSG(X)
 #endif
 
 #endif // YARP_ROBOTINTERFACE_API_H


### PR DESCRIPTION
This PR finalizes the refactoring of the yarprobotinterface from an executable to a library as described in https://github.com/robotology/yarp/issues/2005. The previous related PRs are https://github.com/robotology/yarp/pull/2168 and  https://github.com/robotology/yarp/pull/2288.

- e586238 Only real commit
- ccc660f Applied YARP's clang-format to all the yarprobotinterface module (I can split this in another PR if needed)

This PR targets specifically the usage of `libYARP_robotinterface` as a library, modifying the method `Robot::enterPhase` to accept an optional list of external devices. For each phase, is up to the user whether to pass or not pass the list of external devices. The only relevant phase where this can be useful is the `ActionPhaseStartup`. In fact, if the user passes an external list of devices and names match:

1. if a device already exists in the list of external devices, the internal device does not get started (the external device is opened if it was not)
1. if the same device has also to be attached to another internal device, the external device is selected with higher priority
 
Note that this logic does not break the detach phase. In fact, in the detach phase all the devices can perform pre-detach operations since they still have a pointer to the device-to-detach, and detaching means only releasing the pointer (they don't own its memory, so no deallocation should happen). This fact allows avoiding to pass again the same list of external devices when `ActionPhaseShutdown` is triggered.

I'm not very familiar with the `ActionTypeCalibrate` and `ActionTypePark`, if while reviewing the code you realize that something is missing there, let me know. We can either update this PR or address the problem in a future one. These changes for sure will not break the APIs.

A caveat of this PR is that, after `ActionPhaseStartup` is called and the start of the internal device is prevented due to the presence of an external device, its corresponding `robotinterface::Device` internal object still exists. It will contain an allocated but not started `PolyDriver`. I didn't like the idea to replace it with the corresponding external device since otherwise its memory would be owned by two different `robotinterface::Robot` objects, leading probably to double frees. Should it be deleted, instead? If it's not a problem, I propose to try to get merged this PR as it is so that it can target the next YARP release (and this library is anyway experimental), and keep the discussion of this caveat in https://github.com/robotology/yarp/issues/2005.

cc @drdanz @traversaro 