### PR TITLE
Fake battery improvements

### DIFF
--- a/doc/release/master/fakeBatteryImprovements3.md
+++ b/doc/release/master/fakeBatteryImprovements3.md
@@ -1,0 +1,10 @@
+fakeBatteryImprovements3 {#master}
+------------------------
+
+## New Features
+
+### Devices
+
+#### `fakeBattery`
+
+* Added new methods to the RPC port to get current values.

--- a/src/devices/fakeBattery/FakeBatteryService.thrift
+++ b/src/devices/fakeBattery/FakeBatteryService.thrift
@@ -13,4 +13,11 @@ service FakeBatteryService
     oneway void setBatteryCharge(1: double charge);
     oneway void setBatteryInfo(1: string info);
     oneway void setBatteryTemperature(1: double temperature);
+
+    double getBatteryVoltage();
+    double getBatteryCurrent();
+    double getBatteryCharge();
+    string getBatteryStatus();
+    string getBatteryInfo();
+    double getBatteryTemperature();
 }

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -45,13 +45,6 @@ bool FakeBattery::open(yarp::os::Searchable& config)
         battery_info = std::move(info);
         updateStatus();
     }
-    Bottle& group_general = config.findGroup("GENERAL");
-    if (group_general.isNull()) {
-        yWarning() << "GENERAL group parameters missing, assuming default";
-    } else {
-        // Other options
-        this->debugEnable = group_general.check("debug", Value(0), "enable/disable the debug mode").asBool();
-    }
 
     std::string name = config.find("name").asString();
     this->yarp().attachAsServer(ctrl_port);

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -163,6 +163,60 @@ void FakeBattery::setBatteryTemperature(const double temperature)
     battery_temperature = temperature;
 }
 
+double FakeBattery::getBatteryVoltage()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return battery_voltage;
+}
+
+double FakeBattery::getBatteryCurrent()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return battery_current;
+}
+
+double FakeBattery::getBatteryCharge()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return battery_charge;
+}
+
+std::string FakeBattery::getBatteryStatus()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    switch (battery_status) {
+    case BATTERY_OK_STANBY:
+        return "0: BATTERY_OK_STANBY";
+    case BATTERY_OK_IN_CHARGE:
+        return "1: BATTERY_OK_IN_CHARGE";
+    case BATTERY_OK_IN_USE:
+        return "2: BATTERY_OK_IN_USE";
+    case BATTERY_GENERAL_ERROR:
+        return "3: BATTERY_GENERAL_ERROR";
+    case BATTERY_TIMEOUT:
+        return "4: BATTERY_TIMEOUT";
+    case BATTERY_LOW_WARNING:
+        return "5: BATTERY_LOW_WARNING";
+    case BATTERY_CRITICAL_WARNING:
+        return "6: BATTERY_CRITICAL_WARNING";
+    default:
+        return "Invalid battery status";
+    };
+}
+
+std::string FakeBattery::getBatteryInfo()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return battery_info;
+}
+
+double FakeBattery::getBatteryTemperature()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return battery_temperature;
+}
+
+
 void FakeBattery::updateStatus()
 {
     battery_charge = yarp::conf::clamp(battery_charge, 0.0, 100.0);

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -19,23 +19,31 @@ using namespace std;
 using namespace yarp::os;
 using namespace yarp::dev;
 
+namespace {
+constexpr double default_period = 0.02;
+constexpr double default_charge = 50.0;
+constexpr double default_voltage = 30.0;
+constexpr double default_current = 3.0;
+constexpr double default_temperature = 20.0;
+constexpr const char* default_info = "Fake battery system v2.0";
+}
 
 FakeBattery::FakeBattery() :
-        PeriodicThread(0.02)
+        PeriodicThread(default_period)
 {
 }
 
 
 bool FakeBattery::open(yarp::os::Searchable& config)
 {
-    double period = config.check("thread_period", Value(0.02), "Thread period (smaller implies faster charge/discharge)").asFloat64();
+    double period = config.check("thread_period", Value(default_period), "Thread period (smaller implies faster charge/discharge)").asFloat64();
     setPeriod(period);
 
-    double charge = config.check("charge", Value(50.0), "Initial charge (%)").asFloat64();
-    double voltage = config.check("voltage", Value(30.0), "Initial voltage (V)").asFloat64();
-    double current = config.check("current", Value(3.0), "Initial current (A)").asFloat64();
-    double temperature = config.check("temperature", Value(20.0), "Initial temperature (°C)").asFloat64();
-    std::string info = config.check("info", Value("Fake battery system v2.0"), "Initial battery information").asString();
+    double charge = config.check("charge", Value(default_charge), "Initial charge (%)").asFloat64();
+    double voltage = config.check("voltage", Value(default_voltage), "Initial voltage (V)").asFloat64();
+    double current = config.check("current", Value(default_current), "Initial current (A)").asFloat64();
+    double temperature = config.check("temperature", Value(default_temperature), "Initial temperature (°C)").asFloat64();
+    std::string info = config.check("info", Value(default_info), "Initial battery information").asString();
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         battery_charge = charge;

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -9,6 +9,7 @@
 #include "fakeBattery.h"
 
 #include <yarp/os/Log.h>
+#include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Time.h>
 
@@ -20,6 +21,7 @@ using namespace yarp::os;
 using namespace yarp::dev;
 
 namespace {
+YARP_LOG_COMPONENT(FAKEBATTERY, "yarp.device.fakeBattery")
 constexpr double default_period = 0.02;
 constexpr double default_charge = 50.0;
 constexpr double default_voltage = 30.0;
@@ -57,7 +59,7 @@ bool FakeBattery::open(yarp::os::Searchable& config)
     std::string name = config.find("name").asString();
     this->yarp().attachAsServer(ctrl_port);
     if (!ctrl_port.open(name + "/control/rpc:i")) {
-        yError("Could not open rpc port");
+        yCError(FAKEBATTERY, "Could not open rpc port");
         close();
         return false;
     }

--- a/src/devices/fakeBattery/fakeBattery.h
+++ b/src/devices/fakeBattery/fakeBattery.h
@@ -46,11 +46,14 @@ public:
 
     ~FakeBattery() override = default;
 
+    // yarp::dev::DeviceDriver
     bool open(yarp::os::Searchable& config) override;
     bool close() override;
 
+    // yarp::os::PeriodicThread
     void run() override;
 
+    // yarp::dev::IBattery
     bool getBatteryVoltage(double& voltage) override;
     bool getBatteryCurrent(double& current) override;
     bool getBatteryCharge(double& charge) override;
@@ -58,11 +61,18 @@ public:
     bool getBatteryInfo(std::string& info) override;
     bool getBatteryTemperature(double& temperature) override;
 
+    // FakeBatteryService
     void setBatteryVoltage(const double voltage) override;
     void setBatteryCurrent(const double current) override;
     void setBatteryCharge(const double charge) override;
     void setBatteryInfo(const std::string& info) override;
     void setBatteryTemperature(const double temperature) override;
+    double getBatteryVoltage() override;
+    double getBatteryCurrent() override;
+    double getBatteryCharge() override;
+    std::string getBatteryStatus() override;
+    std::string getBatteryInfo() override;
+    double getBatteryTemperature() override;
 
 private:
     void updateStatus();

--- a/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.cpp
+++ b/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.cpp
@@ -200,6 +200,264 @@ bool FakeBatteryService_setBatteryTemperature_helper::read(yarp::os::ConnectionR
     return true;
 }
 
+class FakeBatteryService_getBatteryVoltage_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryVoltage_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static double s_return_helper;
+};
+
+thread_local double FakeBatteryService_getBatteryVoltage_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryVoltage_helper::FakeBatteryService_getBatteryVoltage_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryVoltage_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryVoltage", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryVoltage_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readFloat64(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+class FakeBatteryService_getBatteryCurrent_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryCurrent_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static double s_return_helper;
+};
+
+thread_local double FakeBatteryService_getBatteryCurrent_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryCurrent_helper::FakeBatteryService_getBatteryCurrent_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryCurrent_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryCurrent", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryCurrent_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readFloat64(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+class FakeBatteryService_getBatteryCharge_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryCharge_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static double s_return_helper;
+};
+
+thread_local double FakeBatteryService_getBatteryCharge_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryCharge_helper::FakeBatteryService_getBatteryCharge_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryCharge_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryCharge", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryCharge_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readFloat64(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+class FakeBatteryService_getBatteryStatus_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryStatus_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static std::string s_return_helper;
+};
+
+thread_local std::string FakeBatteryService_getBatteryStatus_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryStatus_helper::FakeBatteryService_getBatteryStatus_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryStatus_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryStatus", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryStatus_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readString(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+class FakeBatteryService_getBatteryInfo_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryInfo_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static std::string s_return_helper;
+};
+
+thread_local std::string FakeBatteryService_getBatteryInfo_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryInfo_helper::FakeBatteryService_getBatteryInfo_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryInfo_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryInfo", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryInfo_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readString(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+class FakeBatteryService_getBatteryTemperature_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit FakeBatteryService_getBatteryTemperature_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static double s_return_helper;
+};
+
+thread_local double FakeBatteryService_getBatteryTemperature_helper::s_return_helper = {};
+
+FakeBatteryService_getBatteryTemperature_helper::FakeBatteryService_getBatteryTemperature_helper()
+{
+    s_return_helper = {};
+}
+
+bool FakeBatteryService_getBatteryTemperature_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("getBatteryTemperature", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool FakeBatteryService_getBatteryTemperature_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readFloat64(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
 // Constructor
 FakeBatteryService::FakeBatteryService()
 {
@@ -251,6 +509,66 @@ void FakeBatteryService::setBatteryTemperature(const double temperature)
     yarp().write(helper);
 }
 
+double FakeBatteryService::getBatteryVoltage()
+{
+    FakeBatteryService_getBatteryVoltage_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "double FakeBatteryService::getBatteryVoltage()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryVoltage_helper::s_return_helper : double{};
+}
+
+double FakeBatteryService::getBatteryCurrent()
+{
+    FakeBatteryService_getBatteryCurrent_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "double FakeBatteryService::getBatteryCurrent()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryCurrent_helper::s_return_helper : double{};
+}
+
+double FakeBatteryService::getBatteryCharge()
+{
+    FakeBatteryService_getBatteryCharge_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "double FakeBatteryService::getBatteryCharge()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryCharge_helper::s_return_helper : double{};
+}
+
+std::string FakeBatteryService::getBatteryStatus()
+{
+    FakeBatteryService_getBatteryStatus_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "std::string FakeBatteryService::getBatteryStatus()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryStatus_helper::s_return_helper : std::string{};
+}
+
+std::string FakeBatteryService::getBatteryInfo()
+{
+    FakeBatteryService_getBatteryInfo_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "std::string FakeBatteryService::getBatteryInfo()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryInfo_helper::s_return_helper : std::string{};
+}
+
+double FakeBatteryService::getBatteryTemperature()
+{
+    FakeBatteryService_getBatteryTemperature_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "double FakeBatteryService::getBatteryTemperature()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? FakeBatteryService_getBatteryTemperature_helper::s_return_helper : double{};
+}
+
 // help method
 std::vector<std::string> FakeBatteryService::help(const std::string& functionName)
 {
@@ -263,6 +581,12 @@ std::vector<std::string> FakeBatteryService::help(const std::string& functionNam
         helpString.emplace_back("setBatteryCharge");
         helpString.emplace_back("setBatteryInfo");
         helpString.emplace_back("setBatteryTemperature");
+        helpString.emplace_back("getBatteryVoltage");
+        helpString.emplace_back("getBatteryCurrent");
+        helpString.emplace_back("getBatteryCharge");
+        helpString.emplace_back("getBatteryStatus");
+        helpString.emplace_back("getBatteryInfo");
+        helpString.emplace_back("getBatteryTemperature");
         helpString.emplace_back("help");
     } else {
         if (functionName == "setBatteryVoltage") {
@@ -279,6 +603,24 @@ std::vector<std::string> FakeBatteryService::help(const std::string& functionNam
         }
         if (functionName == "setBatteryTemperature") {
             helpString.emplace_back("void setBatteryTemperature(const double temperature) ");
+        }
+        if (functionName == "getBatteryVoltage") {
+            helpString.emplace_back("double getBatteryVoltage() ");
+        }
+        if (functionName == "getBatteryCurrent") {
+            helpString.emplace_back("double getBatteryCurrent() ");
+        }
+        if (functionName == "getBatteryCharge") {
+            helpString.emplace_back("double getBatteryCharge() ");
+        }
+        if (functionName == "getBatteryStatus") {
+            helpString.emplace_back("std::string getBatteryStatus() ");
+        }
+        if (functionName == "getBatteryInfo") {
+            helpString.emplace_back("std::string getBatteryInfo() ");
+        }
+        if (functionName == "getBatteryTemperature") {
+            helpString.emplace_back("double getBatteryTemperature() ");
         }
         if (functionName == "help") {
             helpString.emplace_back("std::vector<std::string> help(const std::string& functionName = \"--all\")");
@@ -408,6 +750,90 @@ bool FakeBatteryService::read(yarp::os::ConnectionReader& connection)
             yarp::os::idl::WireWriter writer(reader);
             if (!writer.isNull()) {
                 if (!writer.writeOnewayResponse()) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryVoltage") {
+            FakeBatteryService_getBatteryVoltage_helper::s_return_helper = getBatteryVoltage();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeFloat64(FakeBatteryService_getBatteryVoltage_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryCurrent") {
+            FakeBatteryService_getBatteryCurrent_helper::s_return_helper = getBatteryCurrent();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeFloat64(FakeBatteryService_getBatteryCurrent_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryCharge") {
+            FakeBatteryService_getBatteryCharge_helper::s_return_helper = getBatteryCharge();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeFloat64(FakeBatteryService_getBatteryCharge_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryStatus") {
+            FakeBatteryService_getBatteryStatus_helper::s_return_helper = getBatteryStatus();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeString(FakeBatteryService_getBatteryStatus_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryInfo") {
+            FakeBatteryService_getBatteryInfo_helper::s_return_helper = getBatteryInfo();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeString(FakeBatteryService_getBatteryInfo_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "getBatteryTemperature") {
+            FakeBatteryService_getBatteryTemperature_helper::s_return_helper = getBatteryTemperature();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeFloat64(FakeBatteryService_getBatteryTemperature_helper::s_return_helper)) {
                     return false;
                 }
             }

--- a/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.h
+++ b/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.h
@@ -34,6 +34,18 @@ public:
 
     virtual void setBatteryTemperature(const double temperature);
 
+    virtual double getBatteryVoltage();
+
+    virtual double getBatteryCurrent();
+
+    virtual double getBatteryCharge();
+
+    virtual std::string getBatteryStatus();
+
+    virtual std::string getBatteryInfo();
+
+    virtual double getBatteryTemperature();
+
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");
 


### PR DESCRIPTION
At the moment, the only way to get these info is through the server, which "speaks" a protocol that is very hard to use without the client.
This PR adds methods to the rpc interface to get these information

## New Features

### Devices

#### `fakeBattery`

* Added new methods to the RPC port to get current values.

---

Also

* Do not use magic numbers
* Remove unused options (`[GENERAL]` group and `debug`)
* Port to the new logging system