### PR TITLE
Add IMotor::setGearboxRatio in control board client-server pair

### DIFF
--- a/doc/release/yarp_3_3/fix_controlBoard_setGearboxRatio.md
+++ b/doc/release/yarp_3_3/fix_controlBoard_setGearboxRatio.md
@@ -1,0 +1,12 @@
+fix_controlBoard_setGearboxRatio {#yarp_3_3}
+------------------
+
+### Devices
+
+#### `controlboardwrapper2`
+
+* Exposed missing `yarp::dev::IMotor::setGearboxRatio` method via RPC.
+
+#### `remote_controlboard`
+
+* Implemented missing `yarp::dev::IMotor::setGearboxRatio` method.

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -2154,6 +2154,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                             }
                             break;
 
+                            case VOCAB_GEARBOX_RATIO:
+                            {
+                                ok = rpc_IMotor->setGearboxRatio(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                            }
+                            break;
+
                             case VOCAB_VEL_LIMITS:
                             {
                                 ok = rcp_Ilim->setVelLimits(cmd.get(2).asInt32(), cmd.get(3).asFloat64(), cmd.get(4).asFloat64());

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -1502,6 +1502,11 @@ bool RemoteControlBoard::getGearboxRatio(int m, double* val)
     return get1V1I1D(VOCAB_GEARBOX_RATIO, m, val);
 }
 
+bool RemoteControlBoard::setGearboxRatio(int m, const double val)
+{
+    return set1V1I1D(VOCAB_GEARBOX_RATIO, m, val);
+}
+
 // END IMotor
 
 // BEGIN IMotorEncoder

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.h
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.h
@@ -334,6 +334,7 @@ public:
     bool getTemperatureLimit (int m, double* val) override;
     bool setTemperatureLimit (int m, const double val) override;
     bool getGearboxRatio(int m, double* val) override;
+    bool setGearboxRatio(int m, const double val) override;
 
     // IMotorEncoder
     bool resetMotorEncoder(int j) override;


### PR DESCRIPTION
This patch exposes [`yarp::dev::IMotor::setGearboxRatio`](http://www.yarp.it/classyarp_1_1dev_1_1IMotor.html#aacb74f2baff8e03481adb515edfe8d3e) from wrapped devices, previously was missing.