### PR TITLE
Fetch actual getInteractionModes data from stream

### DIFF
--- a/doc/release/yarp_3_3/fix_remoteCB_getInteractionModesGroup.md
+++ b/doc/release/yarp_3_3/fix_remoteCB_getInteractionModesGroup.md
@@ -1,0 +1,8 @@
+fix_remoteCB_getInteractionModesGroup {#yarp_3_3}
+------------------
+
+### Devices
+
+#### `remote_controlboard`
+
+* Fixed group command `yarp::dev::IInteractionMode::getInteractionModes`.

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2441,7 +2441,7 @@ bool RemoteControlBoard::getInteractionModes(int n_joints, int *joints, yarp::de
     double localArrivalTime=0.0;
 
     extendedPortMutex.lock();
-    bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.interactionMode.data(), lastStamp, localArrivalTime);
+    bool ret = extendedIntputStatePort.getLastVector(VOCAB_INTERACTION_MODES, last_wholePart.interactionMode.data(), lastStamp, localArrivalTime);
     if(ret)
     {
         for (int i = 0; i < n_joints; i++)


### PR DESCRIPTION
Typo fix. Prior to this, `getInteractionModes` was looking for control modes instead.