### PR TITLE
Add custom time

### DIFF
--- a/doc/release/master/log_customTime.md
+++ b/doc/release/master/log_customTime.md
@@ -1,0 +1,76 @@
+log_customTime {#master}
+-----------
+
+### Libraries
+
+#### `os`
+
+##### `Log`
+
+* Added the following new macros with customTime implementation:
+  * `yTraceCustomTime`
+  * `yTraceCustomTimeOnce`
+  * `yTraceCustomTimeThreadOnce`
+  * `yTraceCustomTimeThrottle`
+  * `yTraceCustomTimeThreadThrottle`
+
+  * `yDebugCustomTime`
+  * `yDebugCustomTimeOnce`
+  * `yDebugCustomTimeThreadOnce`
+  * `yDebugCustomTimeThrottle`
+  * `yDebugCustomTimeThreadThrottle`
+
+  * `yInfoCustomTime`
+  * `yInfoCustomTimeOnce`
+  * `yInfoCustomTimeThreadOnce`
+  * `yInfoCustomTimeThrottle`
+  * `yInfoCustomTimeThreadThrottle`
+
+  * `yWarningCustomTime`
+  * `yWarningCustomTimeOnce`
+  * `yWarningCustomTimeThreadOnce`
+  * `yWarningCustomTimeThrottle`
+  * `yWarningCustomTimeThreadThrottle`
+
+  * `yErrorCustomTime`
+  * `yErrorCustomTimeOnce`
+  * `yErrorCustomTimeThreadOnce`
+  * `yErrorCustomTimeThrottle`
+  * `yErrorCustomTimeThreadThrottle`
+
+  * `yFatalCustomTime`
+
+##### `LogComponent`
+
+* Added the following new macros with customTime implementation:
+  * `yCTraceCustomTime`
+  * `yCTraceCustomTimeOnce`
+  * `yCTraceCustomTimeThreadOnce`
+  * `yCTraceCustomTimeThrottle`
+  * `yCTraceCustomTimeThreadThrottle`
+
+  * `yCDebugCustomTime`
+  * `yCDebugCustomTimeOnce`
+  * `yCDebugCustomTimeThreadOnce`
+  * `yCDebugCustomTimeThrottle`
+  * `yCDebugCustomTimeThreadThrottle`
+
+  * `yCInfoCustomTime`
+  * `yCInfoCustomTimeOnce`
+  * `yCInfoCustomTimeThreadOnce`
+  * `yCInfoCustomTimeThrottle`
+  * `yCInfoCustomTimeThreadThrottle`
+
+  * `yCWarningCustomTime`
+  * `yCWarningCustomTimeOnce`
+  * `yCWarningCustomTimeThreadOnce`
+  * `yCWarningCustomTimeThrottle`
+  * `yCWarningCustomTimeThreadThrottle`
+
+  * `yCErrorCustomTime`
+  * `yCErrorCustomTimeOnce`
+  * `yCErrorCustomTimeThreadOnce`
+  * `yCErrorCustomTimeThrottle`
+  * `yCErrorCustomTimeThreadThrottle`
+
+  * `yCFatalCustomTime`

--- a/doc/yarp_logging.md
+++ b/doc/yarp_logging.md
@@ -292,9 +292,114 @@ is not true.
 When the code is compiled in release mode, these assertion will just disappear
 from the compiled code.
 
+## y*CustomTime family
+
+Users have the possibility of logging information using a custom timestamp, 
+including the timestamp in the macro. These macros expand on the previous macros'
+by including a customtime term.
+
+### Generic Macros
+
+| Level       | C-Style                                                       | Stream                                  |
+|:-----------:|---------------------------------------------------------------|-----------------------------------------|
+| `[TRACE]`   | `yTraceCustomTime(double customtime, const char* msg, ...)`   | `yTraceCustomTime(double customtime)`   |
+| `[DEBUG]`   | `yDebugCustomTime(double customtime, const char* msg, ...)`   | `yDebugCustomTime(double customtime)`   |
+| `[INFO]`    | `yInfoCustomTime(double customtime, const char* msg, ...)`    | `yInfoCustomTime(double customtime)`    |
+| `[WARNING]` | `yWarningCustomTime(double customtime, const char* msg, ...)` | `yWarningCustomTime(double customtime)` |
+| `[ERROR]`   | `yErrorCustomTime(double customtime, const char* msg, ...)`   | `yErrorCustomTime(double customtime)`   |
+| `[FATAL]`   | `yFatalCustomTime(double customtime, const char* msg, ...)`   | `yFatalCustomTime(double customtime)`   |
+
+### Macros with Components
+
+| Level       | Component C-Style                                                                                  | Component Stream                                                             |
+|:-----------:|----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `[TRACE]`   | `yCTraceCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCTraceCustomTime(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[DEBUG]`   | `yCDebugCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCDebugCustomTime(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[INFO]`    | `yCInfoCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`    | `yCInfoCustomTime(double customtime, const yarp::os::Logcomponent& comp)`    |
+| `[WARNING]` | `yCWarningCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)` | `yCWarningCustomTime(double customtime, const yarp::os::Logcomponent& comp)` |
+| `[ERROR]`   | `yCErrorCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCErrorCustomTime(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[FATAL]`   | `yCFatalCustomTime(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCFatalCustomTime(double customtime, const yarp::os::Logcomponent& comp)`   |
+
+### Limited Macros
+
+| Level       | C-Style                                                           | Stream                                      |
+|:-----------:|-------------------------------------------------------------------|---------------------------------------------|
+| `[TRACE]`   | `yTraceCustomTimeOnce(double customtime, const char* msg, ...)`   | `yTraceCustomTimeOnce(double customtime)`   |
+| `[DEBUG]`   | `yDebugCustomTimeOnce(double customtime, const char* msg, ...)`   | `yDebugCustomTimeOnce(double customtime)`   |
+| `[INFO]`    | `yInfoCustomTimeOnce(double customtime, const char* msg, ...)`    | `yInfoCustomTimeOnce(double customtime)`    |
+| `[WARNING]` | `yWarningCustomTimeOnce(double customtime, const char* msg, ...)` | `yWarningCustomTimeOnce(double customtime)` |
+| `[ERROR]`   | `yErrorCustomTimeOnce(double customtime, const char* msg, ...)`   | `yErrorCustomTimeOnce(double customtime)`   |
+| `[FATAL]`   | N/A                                                               | N/A                                         |
 
 
+| Level       | Component C-Style                                                                                      | Component Stream                                                                |
+|:-----------:|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| `[TRACE]`   | `yCTraceCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCTraceCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[DEBUG]`   | `yCDebugCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCDebugCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[INFO]`    | `yCInfoCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`    | `yCInfoCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp)`    |
+| `[WARNING]` | `yCWarningCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)` | `yCWarningCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp)` |
+| `[ERROR]`   | `yCErrorCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCErrorCustomTimeOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[FATAL]`   | N/A                                                                                                    | N/A                                                                             |
 
+| Level       | C-Style                                                                 | Stream                                            |
+|:-----------:|-------------------------------------------------------------------------|---------------------------------------------------|
+| `[TRACE]`   | `yTraceCustomTimeThreadOnce(double customtime, const char* msg, ...)`   | `yTraceCustomTimeThreadOnce(double customtime)`   |
+| `[DEBUG]`   | `yDebugCustomTimeThreadOnce(double customtime, const char* msg, ...)`   | `yDebugCustomTimeThreadOnce(double customtime)`   |
+| `[INFO]`    | `yInfoCustomTimeThreadOnce(double customtime, const char* msg, ...)`    | `yInfoCustomTimeThreadOnce(double customtime)`    |
+| `[WARNING]` | `yWarningCustomTimeThreadOnce(double customtime, const char* msg, ...)` | `yWarningCustomTimeThreadOnce(double customtime)` |
+| `[ERROR]`   | `yErrorCustomTimeThreadOnce(double customtime, const char* msg, ...)`   | `yErrorCustomTimeThreadOnce(double customtime)`   |
+| `[FATAL]`   | N/A                                                                     | N/A                                               |
+
+
+| Level       | Component C-Style                                                                                            | Component Stream                                                                      |
+|:-----------:|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `[TRACE]`   | `yCTraceCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCTraceCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[DEBUG]`   | `yCDebugCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCDebugCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[INFO]`    | `yCInfoCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`    | `yCInfoCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp)`    |
+| `[WARNING]` | `yCWarningCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)` | `yCWarningCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp)` |
+| `[ERROR]`   | `yCErrorCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp, const char* msg, ...)`   | `yCErrorCustomTimeThreadOnce(double customtime, const yarp::os::Logcomponent& comp)`   |
+| `[FATAL]`   | N/A                                                                                                          | N/A                                                                                   |
+
+| Level       | C-Style                                                                              | Stream                                                         |
+|:-----------:|--------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `[TRACE]`   | `yTraceCustomTimeThrottle(double customtime, double period, const char* msg, ...)`   | `yTraceCustomTimeThrottle(double customtime, double period)`   |
+| `[DEBUG]`   | `yDebugCustomTimeThrottle(double customtime, double period, const char* msg, ...)`   | `yDebugCustomTimeThrottle(double customtime, double period)`   |
+| `[INFO]`    | `yInfoCustomTimeThrottle(double customtime, double period, const char* msg, ...)`    | `yInfoCustomTimeThrottle(double customtime, double period)`    |
+| `[WARNING]` | `yWarningCustomTimeThrottle(double customtime, double period, const char* msg, ...)` | `yWarningCustomTimeThrottle(double customtime, double period)` |
+| `[ERROR]`   | `yErrorCustomTimeThrottle(double customtime, double period, const char* msg, ...)`   | `yErrorCustomTimeThrottle(double customtime, double period)`   |
+| `[FATAL]`   | N/A                                                                                  | N/A                                                            |
+
+
+| Level       | Component C-Style                                                                                                         | Component Stream                                                                                   |
+|:-----------:|---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------
+------------------------------------------------|
+| `[TRACE]`   | `yCTraceCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCTraceCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[DEBUG]`   | `yCDebugCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCDebugCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[INFO]`    | `yCInfoCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`    | `yCInfoCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`    |
+| `[WARNING]` | `yCWarningCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)` | `yCWarningCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)` |
+| `[ERROR]`   | `yCErrorCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCErrorCustomTimeThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[FATAL]`   | N/A                                                                                                                       | N/A                                                                                                |
+
+
+| Level       | C-Style                                                                                    | Stream                                                               |
+|:-----------:|--------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `[TRACE]`   | `yTraceCustomTimeThreadThrottle(double customtime, double period, const char* msg, ...)`   | `yTraceCustomTimeThreadThrottle(double customtime, double period)`   |
+| `[DEBUG]`   | `yDebugCustomTimeThreadThrottle(double customtime, double period, const char* msg, ...)`   | `yDebugCustomTimeThreadThrottle(double customtime, double period)`   |
+| `[INFO]`    | `yInfoCustomTimeThreadThrottle(double customtime, double period, const char* msg, ...)`    | `yInfoCustomTimeThreadThrottle(double customtime, double period)`    |
+| `[WARNING]` | `yWarningCustomTimeThreadThrottle(double customtime, double period, const char* msg, ...)` | `yWarningCustomTimeThreadThrottle(double customtime, double period)` |
+| `[ERROR]`   | `yErrorCustomTimeThreadThrottle(double customtime, double period, const char* msg, ...)`   | `yErrorCustomTimeThreadThrottle(double customtime, double period)`   |
+| `[FATAL]`   | N/A                                                                                        | N/A                                                                  |
+
+
+| Level       | Component C-Style                                                                                                               | Component Stream                                                                                         |
+|:-----------:|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------
+------------------------------------------------------|
+| `[TRACE]`   | `yCTraceCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCTraceCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[DEBUG]`   | `yCDebugCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCDebugCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[INFO]`    | `yCInfoCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`    | `yCInfoCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`    |
+| `[WARNING]` | `yCWarningCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)` | `yCWarningCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)` |
+| `[ERROR]`   | `yCErrorCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period, const char* msg, ...)`   | `yCErrorCustomTimeThreadThrottle(double customtime, const yarp::os::Logcomponent& comp, double period)`   |
+| `[FATAL]`   | N/A                                                                                                                             | N/A                                                                                                      |
 
 
 ## Configuration

--- a/src/carriers/tcpros_carrier/yarpros.cpp
+++ b/src/carriers/tcpros_carrier/yarpros.cpp
@@ -30,6 +30,7 @@ void print_callback(yarp::os::Log::LogType type,
                     const char* func,
                     double systemtime,
                     double networktime,
+                    double customtime,
                     const char* comp_name)
 {
     YARP_UNUSED(type);
@@ -38,6 +39,7 @@ void print_callback(yarp::os::Log::LogType type,
     YARP_UNUSED(func);
     YARP_UNUSED(systemtime);
     YARP_UNUSED(networktime);
+    YARP_UNUSED(customtime);
     YARP_UNUSED(comp_name);
     static const char* err_str = "[ERROR] ";
     static const char* warn_str = "[WARNING] ";

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -29,6 +29,7 @@ void print_callback(yarp::os::Log::LogType type,
                     const char* func,
                     double systemtime,
                     double networktime,
+                    double customtime,
                     const char* comp_name)
 {
     YARP_UNUSED(type);
@@ -37,6 +38,7 @@ void print_callback(yarp::os::Log::LogType type,
     YARP_UNUSED(func);
     YARP_UNUSED(systemtime);
     YARP_UNUSED(networktime);
+    YARP_UNUSED(customtime);
     YARP_UNUSED(comp_name);
     static const char* err_str = "[ERROR] ";
     static const char* warn_str = "[WARNING] ";

--- a/src/libYARP_os/src/yarp/os/Log.h
+++ b/src/libYARP_os/src/yarp/os/Log.h
@@ -60,6 +60,14 @@ public:
         const Predicate pred = nullptr,
         const LogComponent& comp = defaultLogComponent());
 
+    // constructor with customtime
+    Log(const char* file,
+        const unsigned int line,
+        const char* func,
+        const double customtime,
+        const Predicate pred = nullptr,
+        const LogComponent& comp = defaultLogComponent());
+
     Log();
     virtual ~Log();
 
@@ -96,6 +104,7 @@ public:
                                  const char* func,
                                  double systemtime,
                                  double networktime,
+                                 double customtime,
                                  const char* comp_name);
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.4
@@ -145,6 +154,7 @@ private:
                        const char* func,
                        double systemtime,
                        double networktime,
+                       double customtime,
                        const LogComponent& comp_name);
 
     // This component is used for yDebug-family output, and is called by LogStream
@@ -205,12 +215,22 @@ private:
 #  define yTraceThreadOnce(...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK).trace(__VA_ARGS__)
 #  define yTraceThrottle(period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period)).trace(__VA_ARGS__)
 #  define yTraceThreadThrottle(period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period)).trace(__VA_ARGS__)
+#  define yTraceCustomTime(customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).trace(__VA_ARGS__)
+#  define yTraceCustomTimeOnce(customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK).trace(__VA_ARGS__)
+#  define yTraceCustomTimeThreadOnce(customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK).trace(__VA_ARGS__)
+#  define yTraceCustomTimeThrottle(customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period)).trace(__VA_ARGS__)
+#  define yTraceCustomTimeThreadThrottle(customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period)).trace(__VA_ARGS__)
 #else
 #  define yTrace(...)                       yarp::os::Log::nolog(__VA_ARGS__)
 #  define yTraceOnce(...)                   yarp::os::Log::nolog(__VA_ARGS__)
 #  define yTraceThreadOnce(...)             yarp::os::Log::nolog(__VA_ARGS__)
 #  define yTraceThrottle(period, ...)       yarp::os::Log::nolog(__VA_ARGS__)
 #  define yTraceThreadThrottle(period, ...) yarp::os::Log::nolog(__VA_ARGS__)
+#  define yTraceCustomTime(customtime, ...)                       yarp::os::Log::nolog(__VA_ARGS__)
+#  define yTraceCustomTimeOnce(customtime, ...)                   yarp::os::Log::nolog(__VA_ARGS__)
+#  define yTraceCustomTimeThreadOnce(customtime, ...)             yarp::os::Log::nolog(__VA_ARGS__)
+#  define yTraceCustomTimeThrottle(customtime, period, ...)       yarp::os::Log::nolog(__VA_ARGS__)
+#  define yTraceCustomTimeThreadThrottle(customtime, period, ...) yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
 #ifndef YARP_NO_DEBUG_OUTPUT
@@ -219,12 +239,22 @@ private:
 #  define yDebugThreadOnce(...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK).debug(__VA_ARGS__)
 #  define yDebugThrottle(period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period)).debug(__VA_ARGS__)
 #  define yDebugThreadThrottle(period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period)).debug(__VA_ARGS__)
+#  define yDebugCustomTime(customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).debug(__VA_ARGS__)
+#  define yDebugCustomTimeOnce(customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK).debug(__VA_ARGS__)
+#  define yDebugCustomTimeThreadOnce(customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK).debug(__VA_ARGS__)
+#  define yDebugCustomTimeThrottle(customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period)).debug(__VA_ARGS__)
+#  define yDebugCustomTimeThreadThrottle(customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period)).debug(__VA_ARGS__)
 #else
 #  define yDebug(...)                       yarp::os::Log::nolog(__VA_ARGS__)
 #  define yDebugOnce(...)                   yarp::os::Log::nolog(__VA_ARGS__)
 #  define yDebugThreadOnce(...)             yarp::os::Log::nolog(__VA_ARGS__)
 #  define yDebugThrottle(period, ...)       yarp::os::Log::nolog(__VA_ARGS__)
 #  define yDebugThreadThrottle(period, ...) yarp::os::Log::nolog(__VA_ARGS__)
+#  define yDebugCustomTime(customtime, ...)                       yarp::os::Log::nolog(__VA_ARGS__)
+#  define yDebugCustomTimeOnce(customtime, ...)                   yarp::os::Log::nolog(__VA_ARGS__)
+#  define yDebugCustomTimeThreadOnce(customtime, ...)             yarp::os::Log::nolog(__VA_ARGS__)
+#  define yDebugCustomTimeThrottle(customtime, period, ...)       yarp::os::Log::nolog(__VA_ARGS__)
+#  define yDebugCustomTimeThreadThrottle(customtime, period, ...) yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
 #define yInfo(...)                          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).info(__VA_ARGS__)
@@ -232,20 +262,36 @@ private:
 #define yInfoThreadOnce(...)                yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK).info(__VA_ARGS__)
 #define yInfoThrottle(period, ...)          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period)).info(__VA_ARGS__)
 #define yInfoThreadThrottle(period, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period)).info(__VA_ARGS__)
+#define yInfoCustomTime(customtime, ...)                          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).info(__VA_ARGS__)
+#define yInfoCustomTimeOnce(customtime, ...)                      yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK).info(__VA_ARGS__)
+#define yInfoCustomTimeThreadOnce(customtime, ...)                yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK).info(__VA_ARGS__)
+#define yInfoCustomTimeThrottle(customtime, period, ...)          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period)).info(__VA_ARGS__)
+#define yInfoCustomTimeThreadThrottle(customtime, period, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period)).info(__VA_ARGS__)
 
 #define yWarning(...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).warning(__VA_ARGS__)
 #define yWarningOnce(...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK).warning(__VA_ARGS__)
 #define yWarningThreadOnce(...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK).warning(__VA_ARGS__)
 #define yWarningThrottle(period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period)).warning(__VA_ARGS__)
 #define yWarningThreadThrottle(period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period)).warning(__VA_ARGS__)
+#define yWarningCustomTime(customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).warning(__VA_ARGS__)
+#define yWarningCustomTimeOnce(customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK).warning(__VA_ARGS__)
+#define yWarningCustomTimeThreadOnce(customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK).warning(__VA_ARGS__)
+#define yWarningCustomTimeThrottle(customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period)).warning(__VA_ARGS__)
+#define yWarningCustomTimeThreadThrottle(customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period)).warning(__VA_ARGS__)
 
 #define yError(...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).error(__VA_ARGS__)
 #define yErrorOnce(...)                     yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK).error(__VA_ARGS__)
 #define yErrorThreadOnce(...)               yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK).error(__VA_ARGS__)
 #define yErrorThrottle(period, ...)         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period)).error(__VA_ARGS__)
 #define yErrorThreadThrottle(period, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period)).error(__VA_ARGS__)
+#define yErrorCustomTime(customtime, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).error(__VA_ARGS__)
+#define yErrorCustomTimeOnce(customtime, ...)                     yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK).error(__VA_ARGS__)
+#define yErrorCustomTimeThreadOnce(customtime, ...)               yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK).error(__VA_ARGS__)
+#define yErrorCustomTimeThrottle(customtime, period, ...)         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period)).error(__VA_ARGS__)
+#define yErrorCustomTimeThreadThrottle(customtime, period, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period)).error(__VA_ARGS__)
 
 #define yFatal(...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__).fatal(__VA_ARGS__)
+#define yFatalCustomTime(customtime, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime).fatal(__VA_ARGS__)
 
 
 

--- a/src/libYARP_os/src/yarp/os/LogComponent.h
+++ b/src/libYARP_os/src/yarp/os/LogComponent.h
@@ -90,12 +90,22 @@ private:
 #  define yCTraceThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).trace(__VA_ARGS__)
 #  define yCTraceThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
 #  define yCTraceThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
+#  define yCTraceCustomTime(component, customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).trace(__VA_ARGS__)
+#  define yCTraceCustomTimeOnce(component, customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK, component()).trace(__VA_ARGS__)
+#  define yCTraceCustomTimeThreadOnce(component, customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK, component()).trace(__VA_ARGS__)
+#  define yCTraceCustomTimeThrottle(component, customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
+#  define yCTraceCustomTimeThreadThrottle(component, customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period), component()).trace(__VA_ARGS__)
 #else
 #  define yCTrace(component, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCTraceOnce(component, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCTraceThreadOnce(component, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCTraceThrottle(component, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCTraceThreadThrottle(component, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceCustomTime(component, customtime, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceCustomTimeOnce(component, customtime, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceCustomTimeThreadOnce(component, customtime, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceCustomTimeThrottle(component, customtime, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCTraceCustomTimeThreadThrottle(component, customtime, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
 #ifndef YARP_NO_DEBUG_OUTPUT
@@ -104,12 +114,22 @@ private:
 #  define yCDebugThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).debug(__VA_ARGS__)
 #  define yCDebugThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
 #  define yCDebugThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
+#  define yCDebugCustomTime(component, customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).debug(__VA_ARGS__)
+#  define yCDebugCustomTimeOnce(component, customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK, component()).debug(__VA_ARGS__)
+#  define yCDebugCustomTimeThreadOnce(component, customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK, component()).debug(__VA_ARGS__)
+#  define yCDebugCustomTimeThrottle(component, customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
+#  define yCDebugCustomTimeThreadThrottle(component, customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period), component()).debug(__VA_ARGS__)
 #else
 #  define yCDebug(component, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCDebugOnce(component, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCDebugThreadOnce(component, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCDebugThrottle(component, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #  define yCDebugThreadThrottle(component, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugCustomTime(component, customtime, ...)                       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugCustomTimeOnce(component, customtime, ...)                   YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugCustomTimeThreadOnce(component, customtime, ...)             YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugCustomTimeThrottle(component, customtime, period, ...)       YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
+#  define yCDebugCustomTimeThreadThrottle(component, customtime, period, ...) YARP_UNUSED(component); yarp::os::Log::nolog(__VA_ARGS__)
 #endif
 
 #define yCInfo(component, ...)                          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).info(__VA_ARGS__)
@@ -117,20 +137,36 @@ private:
 #define yCInfoThreadOnce(component, ...)                yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).info(__VA_ARGS__)
 #define yCInfoThrottle(component, period, ...)          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
 #define yCInfoThreadThrottle(component, period, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
+#define yCInfoCustomTime(component, customtime, ...)                          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).info(__VA_ARGS__)
+#define yCInfoCustomTimeOnce(component, customtime, ...)                      yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK, component()).info(__VA_ARGS__)
+#define yCInfoCustomTimeThreadOnce(component, customtime, ...)                yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK, component()).info(__VA_ARGS__)
+#define yCInfoCustomTimeThrottle(component, customtime, period, ...)          yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
+#define yCInfoCustomTimeThreadThrottle(component, customtime, period, ...)    yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period), component()).info(__VA_ARGS__)
 
 #define yCWarning(component, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).warning(__VA_ARGS__)
 #define yCWarningOnce(component, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).warning(__VA_ARGS__)
 #define yCWarningThreadOnce(component, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).warning(__VA_ARGS__)
 #define yCWarningThrottle(component, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
 #define yCWarningThreadThrottle(component, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
+#define yCWarningCustomTime(component, customtime, ...)                       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).warning(__VA_ARGS__)
+#define yCWarningCustomTimeOnce(component, customtime, ...)                   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK, component()).warning(__VA_ARGS__)
+#define yCWarningCustomTimeThreadOnce(component, customtime, ...)             yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK, component()).warning(__VA_ARGS__)
+#define yCWarningCustomTimeThrottle(component, customtime, period, ...)       yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
+#define yCWarningCustomTimeThreadThrottle(component, customtime, period, ...) yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period), component()).warning(__VA_ARGS__)
 
 #define yCError(component, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).error(__VA_ARGS__)
 #define yCErrorOnce(component, ...)                     yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_ONCE_CALLBACK, component()).error(__VA_ARGS__)
 #define yCErrorThreadOnce(component, ...)               yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADONCE_CALLBACK, component()).error(__VA_ARGS__)
 #define yCErrorThrottle(component, period, ...)         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
 #define yCErrorThreadThrottle(component, period, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, YARP_THREADTHROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
+#define yCErrorCustomTime(component, customtime, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).error(__VA_ARGS__)
+#define yCErrorCustomTimeOnce(component, customtime, ...)                     yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_ONCE_CALLBACK, component()).error(__VA_ARGS__)
+#define yCErrorCustomTimeThreadOnce(component, customtime, ...)               yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADONCE_CALLBACK, component()).error(__VA_ARGS__)
+#define yCErrorCustomTimeThrottle(component, customtime, period, ...)         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
+#define yCErrorCustomTimeThreadThrottle(component, customtime, period, ...)   yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, YARP_THREADTHROTTLE_CALLBACK(period), component()).error(__VA_ARGS__)
 
 #define yCFatal(component, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, nullptr, component()).fatal(__VA_ARGS__)
+#define yCFatalCustomTime(component, customtime, ...)                         yarp::os::Log(__FILE__, __LINE__, __YFUNCTION__, customtime, nullptr, component()).fatal(__VA_ARGS__)
 
 #ifndef NDEBUG
 #  define yCAssert(component, x)                                                       \

--- a/src/libYARP_os/src/yarp/os/LogStream.h
+++ b/src/libYARP_os/src/yarp/os/LogStream.h
@@ -41,6 +41,7 @@ class YARP_os_API LogStream
                const char* fn,
                unsigned int l,
                const char* f,
+               const double ct,
                const yarp::os::Log::Predicate pred,
                const LogComponent& c) :
                 type(t),
@@ -49,6 +50,7 @@ class YARP_os_API LogStream
                 func(f),
                 systemtime(yarp::os::SystemClock::nowSystem()),
                 networktime(!yarp::os::Time::isClockInitialized() ? 0.0 : (yarp::os::Time::isSystemClock() ? systemtime : yarp::os::Time::now())),
+                customtime(ct),
                 pred(pred),
                 comp(c),
                 ref(1)
@@ -61,6 +63,7 @@ class YARP_os_API LogStream
         const char* func;                    // NOLINT(misc-non-private-member-variables-in-classes)
         double systemtime;                   // NOLINT(misc-non-private-member-variables-in-classes)
         double networktime;                  // NOLINT(misc-non-private-member-variables-in-classes)
+        double customtime;                   // NOLINT(misc-non-private-member-variables-in-classes)
         const yarp::os::Log::Predicate pred; // NOLINT(misc-non-private-member-variables-in-classes)
         const LogComponent& comp;            // NOLINT(misc-non-private-member-variables-in-classes)
         int ref;                             // NOLINT(misc-non-private-member-variables-in-classes)
@@ -71,9 +74,10 @@ public:
                      const char* file,
                      unsigned int line,
                      const char* func,
+                     const double customtime,
                      const yarp::os::Log::Predicate pred = nullptr,
                      const LogComponent& comp = Log::defaultLogComponent()) :
-            stream(new Stream(type, file, line, func, pred, comp))
+            stream(new Stream(type, file, line, func, customtime, pred, comp))
     {
     }
 
@@ -112,6 +116,7 @@ public:
                             stream->func,
                             stream->systemtime,
                             stream->networktime,
+                            stream->customtime,
                             stream->comp);
             }
 

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
@@ -57,10 +57,11 @@ void yarp::os::impl::LogComponent::print_callback(yarp::os::Log::LogType type,
                                                   const char* func,
                                                   double systemtime,
                                                   double networktime,
+                                                  double customtime,
                                                   const char* comp_name)
 {
     if (type >= minimumOsPrintLevel.load()) {
-        yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, comp_name);
+        yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, customtime, comp_name);
     }
 }
 

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.h
@@ -24,6 +24,7 @@ void print_callback(yarp::os::Log::LogType type,
                     const char* func,
                     double systemtime,
                     double networktime,
+                    double customtime,
                     const char* comp_name);
 
 void setMinumumLogType(yarp::os::Log::LogType minumumLogType);

--- a/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.cpp
@@ -23,12 +23,13 @@ void yarp::serversql::impl::LogComponent::print_callback(yarp::os::Log::LogType 
                                                          const char* func,
                                                          double systemtime,
                                                          double networktime,
+                                                         double customtime,
                                                          const char* comp_name)
 {
     auto minlev = minimumServersqlPrintLevel.load();
     if (type >= minlev) {
         if (minlev <= yarp::os::Log::DebugType) {
-            yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, comp_name);
+            yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, customtime, comp_name);
         } else {
             static const char* err_str = "[ERROR] ";
             static const char* warn_str = "[WARNING] ";

--- a/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.h
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/LogComponent.h
@@ -24,6 +24,7 @@ void print_callback(yarp::os::Log::LogType type,
                     const char* func,
                     double systemtime,
                     double networktime,
+                    double customtime,
                     const char* comp_name);
 
 void setMinumumLogType(yarp::os::Log::LogType minumumLogType);

--- a/tests/libYARP_os/LogStreamTest.cpp
+++ b/tests/libYARP_os/LogStreamTest.cpp
@@ -540,6 +540,474 @@ TEST_CASE("os::LogStreamTest", "[yarp::os]")
         }
     }
 
+    // customtime tests
+    SECTION("Test yTraceCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        // Warning: By default, trace lines not using the component are
+        //          not printed
+        CNT yTraceCustomTime(now, "This is a trace");
+        CNT yTraceCustomTime(now, "This is %s (%d)", "a trace", i);
+        CNT yTraceCustomTime(now, "The end of line is removed from this trace\n");
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "This is a trace with a component");
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a trace with a component", i);
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "The end of line is removed from this trace with a component\n");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NOFW, now, "This trace with a component is not forwarded");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NULL, now, "This trace with a component is neither not printed nor forwarded");
+
+        CNT yTraceCustomTime(now);
+        CNT yTraceCustomTime(now) << "This is" << "another" << "trace" << i;
+        CNT yTraceCustomTime(now) << v;
+        CNT yTraceCustomTime(now) << "The end of line is removed from this trace\n";
+        CNT yCTraceCustomTime(LOGSTREAM_COMPONENT, now);
+        CNT yCTraceCustomTime(LOGSTREAM_COMPONENT, now) << "This is" << "another" << "trace with a component" << i;
+        CNT yCTraceCustomTime(LOGSTREAM_COMPONENT, now) << v;
+        CNT yCTraceCustomTime(LOGSTREAM_COMPONENT_NOFW, now) << "This trace with a component is not forwarded" << i;
+        CNT yCTraceCustomTime(LOGSTREAM_COMPONENT_NULL, now) << "This trace with a component is neither not printed nor forwarded";
+    }
+
+    SECTION("Test yDebugCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yDebugCustomTime(now, "This is a debug");
+        CNT yDebugCustomTime(now, "This is %s (%d)", "a debug", i);
+        CNT yDebugCustomTime(now, "The end of line is removed from this debug\n");
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "This is a debug with a component");
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a debug with a component", i);
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "The end of line is removed from this debug with a component\n");
+        CNT yCDebugCustomTime(LOG_COMPONENT_NOFW, now, "This debug with a component is not forwarded");
+        CNT yCDebugCustomTime(LOG_COMPONENT_NULL, now, "This debug with a component is neither not printed nor forwarded");
+
+        CNT yDebugCustomTime(now);
+        CNT yDebugCustomTime(now) << "This is" << "another" << "debug" << i;
+        CNT yDebugCustomTime(now) << v;
+        CNT yDebugCustomTime(now) << "The end of line is removed from this debug\n";
+        CNT yCDebugCustomTime(LOGSTREAM_COMPONENT, now);
+        CNT yCDebugCustomTime(LOGSTREAM_COMPONENT, now) << "This is" << "another" << "debug with a component" << i;
+        CNT yCDebugCustomTime(LOGSTREAM_COMPONENT, now) << v;
+        CNT yCDebugCustomTime(LOGSTREAM_COMPONENT_NOFW, now) << "This debug with a component is not forwarded" << i;
+        CNT yCDebugCustomTime(LOGSTREAM_COMPONENT_NULL, now) << "This debug with a component is neither not printed nor forwarded";
+    }
+
+    SECTION("Test yInfoCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yInfoCustomTime(now, "This is info");
+        CNT yInfoCustomTime(now, "This is %s (%d)", "info", i);
+        CNT yInfoCustomTime(now, "The end of line is removed from this info\n");
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "This is info with a component");
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "info with a component", i);
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "The end of line is removed from this info with a component\n");
+        CNT yCInfoCustomTime(LOG_COMPONENT_NOFW, now, "This info with a component is not forwarded");
+        CNT yCInfoCustomTime(LOG_COMPONENT_NULL, now, "This info with a component is neither not printed nor forwarded");
+
+        CNT yInfoCustomTime(now);
+        CNT yInfoCustomTime(now) << "This is" << "more" << "info" << i;
+        CNT yInfoCustomTime(now) << v;
+        CNT yInfoCustomTime(now) << "The end of line is removed from this info\n";
+        CNT yCInfoCustomTime(LOGSTREAM_COMPONENT, now);
+        CNT yCInfoCustomTime(LOGSTREAM_COMPONENT, now) << "This is" << "more" << "info with a component" << i;
+        CNT yCInfoCustomTime(LOGSTREAM_COMPONENT, now) << v;
+        CNT yCInfoCustomTime(LOGSTREAM_COMPONENT_NOFW, now) << "This info with a component is not forwarded" << i;
+        CNT yCInfoCustomTime(LOGSTREAM_COMPONENT_NULL, now) << "This info with a component is neither not printed nor forwarded";
+    }
+
+    SECTION("Test yWarningCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yWarningCustomTime(now, "This is a warning");
+        CNT yWarningCustomTime(now, "This is %s (%d)", "a warning", i);
+        CNT yWarningCustomTime(now, "The end of line is removed from this warning\n");
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "This is a warning with a component");
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a warning with a component", i);
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "The end of line is removed from this warning with a component\n");
+        CNT yCWarningCustomTime(LOG_COMPONENT_NOFW, now, "This warning with a component is not forwarded");
+        CNT yCWarningCustomTime(LOG_COMPONENT_NULL, now, "This warning with a component is neither not printed nor forwarded");
+
+        CNT yWarningCustomTime(now);
+        CNT yWarningCustomTime(now) << "This is" << "another" << "warning" << i;
+        CNT yWarningCustomTime(now) << v;
+        CNT yWarningCustomTime(now) << "The end of line is removed from this warning\n";
+        CNT yCWarningCustomTime(LOGSTREAM_COMPONENT, now);
+        CNT yCWarningCustomTime(LOGSTREAM_COMPONENT, now) << "This is" << "another" << "warning with a component" << i;
+        CNT yCWarningCustomTime(LOGSTREAM_COMPONENT, now) << v;
+        CNT yCWarningCustomTime(LOGSTREAM_COMPONENT_NOFW, now) << "This warning with a component is not forwarded" << i;
+        CNT yCWarningCustomTime(LOGSTREAM_COMPONENT_NULL, now) << "This warning with a component is neither not printed nor forwarded";
+    }
+
+    SECTION("Test yErrorCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yErrorCustomTime(now, "This is a error");
+        CNT yErrorCustomTime(now, "This is %s (%d)", "a error", i);
+        CNT yErrorCustomTime(now, "The end of line is removed from this error\n");
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "This is a error with a component");
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a error with a component", i);
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "The end of line is removed from this error with a component\n");
+        CNT yCErrorCustomTime(LOG_COMPONENT_NOFW, now, "This error with a component is not forwarded");
+        CNT yCErrorCustomTime(LOG_COMPONENT_NULL, now, "This error with a component is neither not printed nor forwarded");
+
+        CNT yErrorCustomTime(now);
+        CNT yErrorCustomTime(now) << "This is" << "another" << "error" << i;
+        CNT yErrorCustomTime(now) << v;
+        CNT yErrorCustomTime(now) << "The end of line is removed from this error\n";
+        CNT yCErrorCustomTime(LOGSTREAM_COMPONENT, now);
+        CNT yCErrorCustomTime(LOGSTREAM_COMPONENT, now) << "This is" << "another" << "error with a component" << i;
+        CNT yCErrorCustomTime(LOGSTREAM_COMPONENT, now) << v;
+        CNT yCErrorCustomTime(LOGSTREAM_COMPONENT_NOFW, now) << "This error with a component is not forwarded" << i;
+        CNT yCErrorCustomTime(LOGSTREAM_COMPONENT_NULL, now) << "This error with a component is neither not printed nor forwarded";
+    }
+
+    SECTION("Test yTraceCustomTimeOnce and yTraceCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yTraceCustomTimeOnce(start) << "This line is printed only once.";
+            CNT yTraceCustomTimeOnce(start) << "Also this line is printed only once.";
+
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+
+                    CNT yTraceCustomTimeOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yTraceCustomTimeThreadOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yTraceCustomTimeThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yTraceCustomTimeThreadThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+
+                    CNT yCTraceCustomTimeOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yCTraceCustomTimeThreadOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yCTraceCustomTimeThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yCTraceCustomTimeThreadThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yDebugCustomTimeOnce and yDebugCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yDebugCustomTimeOnce(start) << "This line is printed only once.";
+            CNT yDebugCustomTimeOnce(start) << "Also this line is printed only once.";
+
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+
+                    CNT yDebugCustomTimeOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yDebugCustomTimeThreadOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yDebugCustomTimeThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yDebugCustomTimeThreadThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+
+                    CNT yCDebugCustomTimeOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yCDebugCustomTimeThreadOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yCDebugCustomTimeThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yCDebugCustomTimeThreadThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yInfoCustomTimeOnce and yInfoCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yInfoCustomTimeOnce(start) << "This line is printed only once.";
+            CNT yInfoCustomTimeOnce(start) << "Also this line is printed only once.";
+
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+
+                    CNT yInfoCustomTimeOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yInfoCustomTimeThreadOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yInfoCustomTimeThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yInfoCustomTimeThreadThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+
+                    CNT yCInfoCustomTimeOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yCInfoCustomTimeThreadOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yCInfoCustomTimeThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yCInfoCustomTimeThreadThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yWarningCustomTimeOnce and yWarningCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yWarningCustomTimeOnce(start) << "This line is printed only once.";
+            CNT yWarningCustomTimeOnce(start) << "Also this line is printed only once.";
+
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+
+                    CNT yWarningCustomTimeOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yWarningCustomTimeThreadOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yWarningCustomTimeThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yWarningCustomTimeThreadThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+
+                    CNT yCWarningCustomTimeOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yCWarningCustomTimeThreadOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yCWarningCustomTimeThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yCWarningCustomTimeThreadThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yErrorCustomTimeOnce and yErrorCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yErrorCustomTimeOnce(start) << "This line is printed only once.";
+            CNT yErrorCustomTimeOnce(start) << "Also this line is printed only once.";
+
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+
+                    CNT yErrorCustomTimeOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yErrorCustomTimeThreadOnce(now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yErrorCustomTimeThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yErrorCustomTimeThreadThrottle(now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+
+                    CNT yCErrorCustomTimeOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "] This line is printed only by the first thread coming here";
+
+                    CNT yCErrorCustomTimeThreadOnce(LOGSTREAM_COMPONENT, now)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed by every thread";
+
+                    CNT yCErrorCustomTimeThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s";
+
+                    CNT yCErrorCustomTimeThreadThrottle(LOGSTREAM_COMPONENT, now, period)
+                        << "[Time:" << now - start
+                        << "][Thread id: 0x" << yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str()
+                        << "This line is printed at most once every" << period << "s by every thread";
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
     SECTION("Other log tests")
     {
         CNT_RESET

--- a/tests/libYARP_os/LogTest.cpp
+++ b/tests/libYARP_os/LogTest.cpp
@@ -442,6 +442,399 @@ TEST_CASE("os::LogTest", "[yarp::os]")
         }
     }
 
+    // same tests, but for customTime now
+    SECTION("Test yTraceCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        // Warning: By default, trace lines not using the component are
+        //          not printed
+        CNT yTraceCustomTime(now, "This is a trace");
+        CNT yTraceCustomTime(now, "This is %s (%d)", "a trace", i);
+        CNT yTraceCustomTime(now, "The end of line is removed from this trace\n");
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "This is a trace with a component");
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a trace with a component", i);
+        CNT yCTraceCustomTime(LOG_COMPONENT, now, "The end of line is removed from this trace with a component\n");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NOFW, now, "This trace with a component is not forwarded");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NULL, now, "This trace with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yDebugCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yDebugCustomTime(now, "This is a debug");
+        CNT yDebugCustomTime(now, "This is %s (%d)", "a debug", i);
+        CNT yDebugCustomTime(now, "The end of line is removed from this debug\n");
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "This is a debug with a component");
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a debug with a component", i);
+        CNT yCDebugCustomTime(LOG_COMPONENT, now, "The end of line is removed from this debug with a component\n");
+        CNT yCDebugCustomTime(LOG_COMPONENT_NOFW, now, "This debug with a component is not forwarded");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NULL, now, "This trace with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yInfoCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yInfoCustomTime(now, "This is info");
+        CNT yInfoCustomTime(now, "This is %s (%d)", "info", i);
+        CNT yInfoCustomTime(now, "The end of line is removed from this info\n");
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "This is info with a component");
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "info with a component", i);
+        CNT yCInfoCustomTime(LOG_COMPONENT, now, "The end of line is removed from this info with a component\n");
+        CNT yCInfoCustomTime(LOG_COMPONENT_NOFW, now, "This info with a component is not forwarded");
+        CNT yCTraceCustomTime(LOG_COMPONENT_NULL, now, "This trace with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yWarningCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yWarningCustomTime(now, "This is a warning");
+        CNT yWarningCustomTime(now, "This is %s (%d)", "a warning", i);
+        CNT yWarningCustomTime(now, "The end of line is removed from this warning\n");
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "This is a warning with a component");
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "a warning with a component", i);
+        CNT yCWarningCustomTime(LOG_COMPONENT, now, "The end of line is removed from this warning with a component\n");
+        CNT yCWarningCustomTime(LOG_COMPONENT_NOFW, now, "This warning with a component is not forwarded");
+        CNT yCWarningCustomTime(LOG_COMPONENT_NULL, now, "This warning with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yErrorCustomTime")
+    {
+        CNT_RESET
+
+        double now = yarp::os::SystemClock::nowSystem();
+        CNT yErrorCustomTime(now, "This is an error");
+        CNT yErrorCustomTime(now, "This is %s (%d)", "an error", i);
+        CNT yErrorCustomTime(now, "The end of line is removed from this error\n");
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "This is an error with a component");
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "This is %s (%d)", "an error with a component", i);
+        CNT yCErrorCustomTime(LOG_COMPONENT, now, "The end of line is removed from this error with a component\n");
+        CNT yCErrorCustomTime(LOG_COMPONENT_NOFW, now, "This error with a component is not forwarded");
+        CNT yCErrorCustomTime(LOG_COMPONENT_NULL, now, "This error with a component is neither not printed nor forwarded");
+    }
+
+    SECTION("Test yTraceCustomTimeOnce, yTraceCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yTraceCustomTimeOnce(start, "This line is printed only once.");
+            CNT yTraceCustomTimeOnce(start, "Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yTraceCustomTimeOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yTraceCustomTimeThreadOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yTraceCustomTimeThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yTraceCustomTimeThreadThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCTraceCustomTimeOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCTraceCustomTimeThreadOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCTraceCustomTimeThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCTraceCustomTimeThreadThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yDebugCustomTimeOnce, yDebugCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yDebugCustomTimeOnce(start, "This line is printed only once.");
+            CNT yDebugCustomTimeOnce(start, "Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yDebugCustomTimeOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yDebugCustomTimeThreadOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yDebugCustomTimeThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yDebugCustomTimeThreadThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCDebugCustomTimeOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCDebugCustomTimeThreadOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCDebugCustomTimeThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCDebugCustomTimeThreadThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yInfoCustomTimeOnce, yInfoCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yInfoCustomTimeOnce(start, "This line is printed only once.");
+            CNT yInfoCustomTimeOnce(start, "Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yInfoCustomTimeOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yInfoCustomTimeThreadOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yInfoCustomTimeThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yInfoCustomTimeThreadThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCInfoCustomTimeOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCInfoCustomTimeThreadOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCInfoCustomTimeThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCInfoCustomTimeThreadThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yWarningCustomTimeOnce, yWarningCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yWarningCustomTimeOnce(start, "This line is printed only once.");
+            CNT yWarningCustomTimeOnce(start, "Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yWarningCustomTimeOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yWarningCustomTimeThreadOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yWarningCustomTimeThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yWarningCustomTimeThreadThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCWarningCustomTimeOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCWarningCustomTimeThreadOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCWarningCustomTimeThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCWarningCustomTimeThreadThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    SECTION("Test yErrorCustomTimeOnce, yErrorCustomTimeThrottle")
+    {
+        CNT_RESET
+
+        const double start = yarp::os::SystemClock::nowSystem();
+        static constexpr double test_duration = 1.3;
+        static constexpr double period = 0.3;
+        static constexpr size_t SZ = 4;
+        std::array<std::thread, SZ> threads;
+        for (auto& t : threads) {
+            CNT yErrorCustomTimeOnce(start, "This line is printed only once.");
+            CNT yErrorCustomTimeOnce(start, "Also this line is printed only once.");
+            t = std::thread([start]()
+            {
+                while (true) {
+                    double now = yarp::os::SystemClock::nowSystem();
+                    if ((now - start) > test_duration) {
+                        break;
+                    }
+                    CNT yErrorCustomTimeOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yErrorCustomTimeThreadOnce(now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yErrorCustomTimeThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yErrorCustomTimeThreadThrottle(now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCErrorCustomTimeOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed only by the first thread coming here",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCErrorCustomTimeThreadOnce(LOG_COMPONENT, now,
+                        "[Time: %f][Thread id: 0x%s] This line is printed by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str());
+                    CNT yCErrorCustomTimeThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                    CNT yCErrorCustomTimeThreadThrottle(LOG_COMPONENT, now, period,
+                        "[Time: %f][Thread id: 0x%s] This line is printed at most once every %fs by every thread",
+                        now - start,
+                        yarp::os::NetType::toHexString(yarp::os::Thread::getKeyOfCaller()).c_str(),
+                        period);
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
     SECTION("Other log tests")
     {
         CNT_RESET


### PR DESCRIPTION
In this pull request, we introduce a "customTime" term to the logger.

This will be used to include timestamps from "external" sources, e.g.: control boards.

We include also y*CustomTime functions (e.g.: yDebugCustomTime) that will be used to send these external timestamps to the logger.