### PR TITLE
Expose several missing methods from motor interfaces in language bindings

### DIFF
--- a/doc/release/master/bindings_addMissing.md
+++ b/doc/release/master/bindings_addMissing.md
@@ -1,0 +1,9 @@
+bindings_addMissing {#master}
+-----------------------
+
+### Bindings
+
+* Several previously inaccessible methods from motor interfaces are now correctly wrapped.
+  This covers pretty much everything the pair `remote_controlboard`/`controlboardwrapper2`
+  wraps and implements, only excluding calibration interfaces. In addition, two more
+  interfaces can be accessed through the PolyDriver idiom: `IEncodersTimed` and `IMotor`.


### PR DESCRIPTION
A bunch of methods pertaining to joint control interfaces, namely [motor interfaces](http://www.yarp.it/group__dev__iface__motor.html), needed to be properly extended in *yarp.i* for use in scripting languages. Most notably, every method that contains a pointer argument requires a simple workaround for translation into Python, Java, etc. This patch adds support for several previously omitted methods from already wrapped interfaces (with partial or even no prior support), and also exposes `IEncodersTimed` and `IMotor`.

Closes https://github.com/robotology/yarp/issues/1966.