### PR TITLE
libYARP_robotinterface: Add a method to specify an external device list to be used as a target for actions of internal devices

### DIFF
--- a/doc/release/master/addYarpRobotinterfaceLibrary.md
+++ b/doc/release/master/addYarpRobotinterfaceLibrary.md
@@ -6,4 +6,5 @@ feature/robotinterface {#master}
 #### `robotinterface`
 
 * Created `YARP_robotinterface` library by refactoring as a library the logic of
-  the `yarprobotinterface` tool.
+  the `yarprobotinterface` tool, including support for attaching `YARP_robotinterface`
+  devices to external devices not created by the `YARP_robotinterface`.

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
@@ -341,7 +341,7 @@ void yarp::robotinterface::Device::stopThreads() const
     mPriv->stopThreads();
 }
 
-bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device &target) const
+bool yarp::robotinterface::Device::calibrate(const yarp::dev::PolyDriverDescriptor &target) const
 {
     if(!driver()) {
        yDebug() << "Device do not exists, cannot do " << ActionTypeToString(ActionTypeDetach) << "action";
@@ -355,8 +355,8 @@ bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device 
     }
 
     yarp::dev::IControlCalibration *controlCalibrator;
-    if (!target.driver()->view(controlCalibrator)) {
-        yError() << target.name() << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypeCalibrate) << "actions";
+    if (!target.poly->view(controlCalibrator)) {
+        yError() << target.key << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypeCalibrate) << "actions";
         return false;
     }
 
@@ -368,8 +368,8 @@ bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device 
     yarp::dev::IRemoteCalibrator *rem_calibrator_calib;
     bool rem_calibrator_available = true;
 
-    if(!target.driver()->view(rem_calibrator_wrap)) {
-        yWarning() << "Device " << target.name() << "is not implementing a yarp::dev::IRemoteCalibrator, therefore it cannot attach to a Calibrator device. \n \
+    if(!target.poly->view(rem_calibrator_wrap)) {
+        yWarning() << "Device " << target.key << "is not implementing a yarp::dev::IRemoteCalibrator, therefore it cannot attach to a Calibrator device. \n \
                                                      Please verify that the target of calibrate action is a controlBoardWrapper2 device.  \
                                                      This doesn't prevent the yarprobotinterface to correctly operate, but no remote calibration and homing will be available";
         rem_calibrator_available = false;
@@ -387,13 +387,13 @@ bool yarp::robotinterface::Device::calibrate(const yarp::robotinterface::Device 
     // Start the calibrator thread
     yarp::os::Thread *calibratorThread = new yarp::robotinterface::CalibratorThread(calibrator,
                                                                               name(),
-                                                                              target.driver(),
-                                                                              target.name(),
+                                                                              target.poly,
+                                                                              target.key,
                                                                               yarp::robotinterface::CalibratorThread::ActionCalibrate);
     registerThread(calibratorThread);
 
     if (!calibratorThread->start()) {
-        yError() << "Device" << name() << "cannot execute" << ActionTypeToString(ActionTypeCalibrate) << "on device" << target.name();
+        yError() << "Device" << name() << "cannot execute" << ActionTypeToString(ActionTypeCalibrate) << "on device" << target.key;
         return false;
     }
 
@@ -442,7 +442,7 @@ bool yarp::robotinterface::Device::detach() const
     return true;
 }
 
-bool yarp::robotinterface::Device::park(const Device &target) const
+bool yarp::robotinterface::Device::park(const yarp::dev::PolyDriverDescriptor &target) const
 {
     yarp::dev::ICalibrator *calibrator;
     if(!driver()) {
@@ -461,8 +461,8 @@ bool yarp::robotinterface::Device::park(const Device &target) const
     }
 
     yarp::dev::IControlCalibration *controlCalibrator;
-    if (!target.driver()->view(controlCalibrator)) {
-        yError() << target.name() << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypePark) << "actions";
+    if (!target.poly->view(controlCalibrator)) {
+        yError() << target.key << "is not a yarp::dev::IControlCalibration2, therefore it cannot have" << ActionTypeToString(ActionTypePark) << "actions";
         return false;
     }
 
@@ -470,13 +470,13 @@ bool yarp::robotinterface::Device::park(const Device &target) const
 
     yarp::os::Thread *parkerThread = new yarp::robotinterface::CalibratorThread(calibrator,
                                                                           name(),
-                                                                          target.driver(),
-                                                                          target.name(),
+                                                                          target.poly,
+                                                                          target.key,
                                                                           yarp::robotinterface::CalibratorThread::ActionPark);
     registerThread(parkerThread);
 
     if (!parkerThread->start()) {
-        yError() << "Device" << name() << "cannot execute" << ActionTypeToString(ActionTypePark) << "on device" << target.name();
+        yError() << "Device" << name() << "cannot execute" << ActionTypeToString(ActionTypePark) << "on device" << target.key;
         return false;
     }
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.h
@@ -15,6 +15,7 @@
 #include <yarp/robotinterface/Param.h>
 
 namespace yarp { namespace dev { class PolyDriver; } }
+namespace yarp { namespace dev { class PolyDriverDescriptor; } }
 namespace yarp { namespace dev { class PolyDriverList; } }
 
 namespace yarp {
@@ -60,7 +61,7 @@ public:
     bool configure(const Device &target, const ParamList& params) const;
 
     // calibrate one device
-    bool calibrate(const Device &target) const;
+    bool calibrate(const yarp::dev::PolyDriverDescriptor &target) const;
 
     // attach a list of drivers to this wrapper
     bool attach(const yarp::dev::PolyDriverList &drivers) const;
@@ -72,7 +73,7 @@ public:
     bool detach() const;
 
     // park
-    bool park(const Device &target) const;
+    bool park(const yarp::dev::PolyDriverDescriptor &target) const;
 
     // custom action
     bool custom(const ParamList &params) const;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -49,6 +49,7 @@ public:
     std::string findParam(const std::string &name) const;
 
     void interrupt();
+    bool setExternalDevices(const yarp::dev::PolyDriverList& list);
     bool enterPhase(yarp::robotinterface::ActionPhase phase);
     yarp::robotinterface::ActionPhase currentPhase() const;
     int currentLevel() const;

--- a/tests/libYARP_robotinterface/RobotinterfaceTest.cpp
+++ b/tests/libYARP_robotinterface/RobotinterfaceTest.cpp
@@ -10,6 +10,7 @@
 #include <yarp/robotinterface/XMLReader.h>
 
 #include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/PolyDriverList.h>
 #include <yarp/dev/IMultipleWrapper.h>
 
 #include <catch.hpp>
@@ -235,5 +236,139 @@ TEST_CASE("robotinterface::XMLReaderTest", "[yarp::robotinterface]")
         CHECK(globalState.mockDetachWasCalled);
         CHECK(globalState.mockWrapperWasClosed);
         CHECK(globalState.mockDriverWasClosed);
+    }
+
+    SECTION("Check valid robot file with one device attaching to an external device")
+    {
+        // Reset test flags
+        globalState.reset();
+
+        // Add dummy devices to YARP drivers factory
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockDriver>("robotinterface_test_mock_device", "", "RobotInterfaceTestMockDriver"));
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockWrapper>("robotinterface_test_mock_wrapper", "", "RobotInterfaceTestMockWrapper"));
+
+        // Create dummy device externally
+        yarp::os::Property p;
+        p.put("device", "robotinterface_test_mock_device");
+
+        yarp::dev::PolyDriver dummyDevice;
+        dummyDevice.open(p);
+
+        // Add the dummy device to the PolyDriverList with the appropriate name
+        yarp::dev::PolyDriverList externalDriverList;
+        externalDriverList.push(&dummyDevice, "dummy_device");
+
+        // Load  XML configuration file
+        std::string XMLString = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                                "<!DOCTYPE robot PUBLIC \"-//YARP//DTD yarprobotinterface 3.0//EN\" \"http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd\">\n"
+                                "<robot name=\"RobotWithOneDevice\" prefix=\"RobotWithOneDevice\">\n"
+                                "  <devices>\n"
+                                "    <device name=\"dummy_wrapper\" type=\"robotinterface_test_mock_wrapper\">\n"
+                                "      <action phase=\"startup\" level=\"5\" type=\"attach\">\n"
+                                "        <paramlist name=\"networks\">\n"
+                                "          <elem name=\"attached_device\">  dummy_device </elem>\n"
+                                "        </paramlist>\n"
+                                "      </action>\n"
+                                "      <action phase=\"shutdown\" level=\"5\" type=\"detach\" />\n"
+                                "    </device>\n"
+                                "  </devices>\n"
+                                "</robot>\n";
+
+        yarp::robotinterface::XMLReader reader;
+        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);
+
+        // Check parsing fails on empty string
+        CHECK(result.parsingIsSuccessful);
+
+        // Verify that only one (internal) device has been loaded
+        CHECK(result.robot.devices().size() == 1);
+
+        // Verify that only the robotinterface_test_mock_device device opened and the attach was not called
+        CHECK(globalState.mockDriverWasOpened);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockAttachWasCalled);
+        CHECK(!globalState.mockDetachWasCalled);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockDriverWasClosed);
+
+        // Start the robot (open the device and call "attach" actions)
+        bool ok = result.robot.setExternalDevices(externalDriverList);
+        CHECK(ok);
+        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseStartup);
+        CHECK(ok);
+
+        // Check that the also the wrapper was opened and attach called
+        CHECK(globalState.mockDriverWasOpened);
+        CHECK(globalState.mockWrapperWasOpened);
+        CHECK(globalState.mockAttachWasCalled);
+        CHECK(!globalState.mockDetachWasCalled);
+        CHECK(!globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockDriverWasClosed);
+
+        // Stop the robot
+        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
+        CHECK(ok);
+        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
+        CHECK(ok);
+
+        // Check that the wrapper device was closed and detach called, while the external device was not closed
+        CHECK(globalState.mockDriverWasOpened);
+        CHECK(globalState.mockWrapperWasOpened);
+        CHECK(globalState.mockAttachWasCalled);
+        CHECK(globalState.mockDetachWasCalled);
+        CHECK(globalState.mockWrapperWasClosed);
+        CHECK(!globalState.mockDriverWasClosed);
+
+        ok = dummyDevice.close();
+        CHECK(ok);
+
+        CHECK(globalState.mockDriverWasClosed);
+    }
+
+    SECTION("Check error in case of name conflict between internal devices and external devices")
+    {
+        // Reset test flags
+        globalState.reset();
+
+        // Add dummy devices to YARP drivers factory
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockDriver>("robotinterface_test_mock_device", "", "RobotInterfaceTestMockDriver"));
+        yarp::dev::Drivers::factory().add(new yarp::dev::DriverCreatorOf<yarp::dev::RobotInterfaceTestMockWrapper>("robotinterface_test_mock_wrapper", "", "RobotInterfaceTestMockWrapper"));
+
+        // Create dummy device externally
+        yarp::os::Property p;
+        p.put("device", "robotinterface_test_mock_device");
+
+        yarp::dev::PolyDriver dummyDevice;
+        dummyDevice.open(p);
+
+        // Add the dummy device to the PolyDriverList with the name "dummy_device"
+        yarp::dev::PolyDriverList externalDriverList;
+        externalDriverList.push(&dummyDevice, "dummy_device");
+
+        // Load  XML configuration file that also contains an internal device with name "dummy_device"
+        std::string XMLString = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                                "<!DOCTYPE robot PUBLIC \"-//YARP//DTD yarprobotinterface 3.0//EN\" \"http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd\">\n"
+                                "<robot name=\"RobotWithOneDevice\" prefix=\"RobotWithOneDevice\">\n"
+                                "  <devices>\n"
+                                "    <device name=\"dummy_device\" type=\"robotinterface_test_mock_wrapper\">\n"
+                                "    </device>\n"
+                                "  </devices>\n"
+                                "</robot>\n";
+
+        yarp::robotinterface::XMLReader reader;
+        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);
+
+        CHECK(result.parsingIsSuccessful);
+
+        // Verify that only one (internal) device has been loaded
+        CHECK(result.robot.devices().size() == 1);
+
+        // Set the external devices list and check that it fails due to naming conflicts
+        bool ok = result.robot.setExternalDevices(externalDriverList);
+        CHECK(!ok);
+
+        // Cleanup
+        ok = dummyDevice.close();
+        CHECK(ok);
     }
 }


### PR DESCRIPTION
This feature can be used to instantiated a set of devices via the libYARP_robotinterface (for example a group of network wrappers), but making them attach to some devices that already exists and have been created independently from the libYARP_robotinterface.

An example of the use of such feature can  be found in the `"Check valid robot file with one device attaching to an external device"` section of the `RobotInterface` test, an abridged version is available in the following: 

~~~cxx
        // Create a device externally
        yarp::os::Property p;
        p.put("device", "robotinterface_test_mock_device");

        yarp::dev::PolyDriver physicalDevice;
        physicalDevice.open(p);

        // Add the device to the PolyDriverList with the appropriate name, 
        // the name will then be used to refer to the device as part of "action" of the 
        // robotinterface xml, including the "attach" action 
        yarp::dev::PolyDriverList externalDriverList;
        externalDriverList.push(&physicalDevice, "physical_device");

        // Load  XML configuration file
        std::string XMLString = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
                                "<!DOCTYPE robot PUBLIC \"-//YARP//DTD yarprobotinterface 3.0//EN\" \"http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd\">\n"
                                "<robot name=\"RobotWithOneDevice\" prefix=\"RobotWithOneDevice\">\n"
                                "  <devices>\n"
                                "    <device name=\"wrapper\" type=\"robotinterface_test_mock_wrapper\">\n"
                                "      <action phase=\"startup\" level=\"5\" type=\"attach\">\n"
                                "        <paramlist name=\"networks\">\n"
                                "          <elem name=\"attached_device\">  physical_device </elem>\n"
                                "        </paramlist>\n"
                                "      </action>\n"
                                "      <action phase=\"shutdown\" level=\"5\" type=\"detach\" />\n"
                                "    </device>\n"
                                "  </devices>\n"
                                "</robot>\n";

        yarp::robotinterface::XMLReader reader;
        yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(XMLString);

        // Start the robot (open the device and call "attach" actions)
        // It is assume that the devices contained in externalDriverList will remain valid and open until 
        // result.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown) will be called
       bool ok = result.robot.setExternalDevices(externalDriverList);
       ok = ok && result.robot.enterPhase(yarp::robotinterface::ActionPhaseStartup);
   
        // Do what you want, at this point the wrapper has been opened and has been attached to the device
        // ...
  
        // Shutdown sequence 

        // Stop the robot
        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
        ok = result.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);

        // Now that the Robot object that was using this device has been closed, we can close the device as well
        ok = physicalDevice.close();
~~~

This PR fixes https://github.com/robotology/yarp/issues/2005 .
This PR is a follow up to  https://github.com/robotology/yarp/pull/2168 and  https://github.com/robotology/yarp/pull/2288. Furthermore, it is a simplified version of https://github.com/robotology/yarp/pull/2304 , the major differences are: 
* `yarp::robotinterface::Device` objects are not copied, as that process at the moment is not clear
* The ownership of the external devices passed to the `yarp::robotinterface::Robot` is explicitly not passed to the object, so the caller should make sure that the device will remain open and active until the `yarp::robotinterface::Robot`  is closed
* The external devices are passed as `yarp::dev::PolyDriverList`, so that they can be passed also devices that are not created by a `yarp::robotinterface::Robot` object
* To avoid ambiguity, if an external device with the same name of an internal device is passed to `enterPhase`, an error is raised. 
* Similarly to what already happens with other uses of `yarp::dev::PolyDriverList` (i.e. `yarp::dev::IMultipleWrapper`) the passed devices are not opened  nor  closed, and they are just passed to the devices that contain an action related to them without perturbing their state. 