### PR TITLE
fix_bug_checkNearToLocation

### DIFF
--- a/doc/release/yarp_3_3/fix_bug_checkNearToLocation.md
+++ b/doc/release/yarp_3_3/fix_bug_checkNearToLocation.md
@@ -1,0 +1,14 @@
+fix_bug_checkNearToLocation {#yarp_3_3}
+----------------------
+
+### devices
+
+#### Navigation2DClient
+* The method `checkNearToLocation` now correctly checks if two orientations are similar (below a certain threshold),
+also considering the critical points 0,180,360,-180,-180 etc.
+
+### libYARP_dev
+
+#### Navigation2DClientTest
+* New tests have been added to check method `checkNearToLocation` in different cases.
+

--- a/src/devices/navigation2DClient/Navigation2DClient.cpp
+++ b/src/devices/navigation2DClient/Navigation2DClient.cpp
@@ -546,10 +546,30 @@ bool Navigation2DClient::locations_are_similar(Map2DLocation loc1, Map2DLocation
         return false;
     }
 
-    if (angular_tolerance != std::numeric_limits<double>::infinity() &&
-        fabs(normalize_angle(loc1.theta) - normalize_angle(loc2.theta)) > angular_tolerance)
+    if (angular_tolerance != std::numeric_limits<double>::infinity())
     {
-        return false;
+        //In the following blocks, I'm giving two possibile solution to the problem of
+        //determining if the difference of two angles is below a certain threshold.
+        //The problem is tricky, because it must take in account the critical points 0,180,360,-180, -360 etc.
+        //Both the formulas lead to the same result, however I'm not sure I they have the same performances.
+        //Please do not remove the unused block, since it may be a useful reference for the future.
+#if 1
+        //check in the range 0-360
+        double diff = loc2.theta - loc1.theta + 180.0;
+        diff = fmod(diff, 360.0) - 180.0;
+        diff = (diff < -180.0) ? (diff + 360.0) : (diff);
+        if (fabs(diff) > angular_tolerance)
+#else
+        //check in the range 0-180
+        double angle1 = normalize_angle(loc1.theta);
+        double angle2 = normalize_angle(loc2.theta);
+        double diff = angle1 - angle2;
+        diff += (diff > 180) ? -360 : (diff < -180) ? 360 : 0;
+        if (fabs(diff) > angular_tolerance)
+#endif
+        {
+            return false;
+        }
     }
     return true;
 }

--- a/tests/libYARP_dev/Navigation2DClientTest.cpp
+++ b/tests/libYARP_dev/Navigation2DClientTest.cpp
@@ -11,6 +11,7 @@
 #include <yarp/dev/Map2DLocation.h>
 #include <yarp/dev/Map2DArea.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/dev/PolyDriver.h>
 
 #include <catch.hpp>
@@ -19,6 +20,23 @@
 using namespace yarp::dev;
 using namespace yarp::sig;
 using namespace yarp::os;
+
+void test_similar_angles(INavigation2D* inav, double angle1, double angle2)
+{
+    bool b0, b1;
+    b0 = inav->setInitialPose(Map2DLocation("map_1", 10.2, 20.1, angle1)); CHECK(b0);
+    yarp::os::Time::delay(0.1);
+    yInfo() << "Testing angle" << angle1 << " is similar to:" << angle2;
+    b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, angle2), 0.1, 10.0); CHECK(b1);
+    yInfo() << "Testing angle" << angle1 << " is similar to:" << angle2+5.0;
+    b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, angle2 + 5.0), 0.1, 10.0); CHECK(b1);
+    yInfo() << "Testing angle" << angle1 << " is different from:" << angle2 + 20.0;
+    b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, angle2 + 20.0), 0.1, 10.0); CHECK(!b1);
+    yInfo() << "Testing angle" << angle1 << " is similar to:" << angle2-5.0;
+    b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, angle2 - 5.0), 0.1, 10.0); CHECK(b1);
+    yInfo() << "Testing angle" << angle1 << " is different from:" << angle2 - 20.0;
+    b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, angle2 - 20.0), 0.1, 10.0); CHECK(!b1);
+}
 
 TEST_CASE("dev::Navigation2DClientTest", "[yarp::dev]")
 {
@@ -136,6 +154,27 @@ TEST_CASE("dev::Navigation2DClientTest", "[yarp::dev]")
                 b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, 15.5 - 180), lin_tol, ang_tol); CHECK(b1 == false);
                 b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, 15.5 - 360), lin_tol, ang_tol); CHECK(b1);
                 b1 = inav->checkNearToLocation(Map2DLocation("map_1", 10.2, 20.1, 15.5 - 720), lin_tol, ang_tol); CHECK(b1);
+
+                //in the following tests, the tolerance is set to 10.0 deg
+                test_similar_angles(inav,   +2.0,   +2.0);
+                test_similar_angles(inav,   -2.0,   +2.0);
+                test_similar_angles(inav,   +2.0,   -2.0);
+                test_similar_angles(inav,   -2.0,   -2.0);
+
+                test_similar_angles(inav, +182.0, +182.0);
+                test_similar_angles(inav, -182.0, +182.0);
+                test_similar_angles(inav, +182.0, -182.0);
+                test_similar_angles(inav, -182.0, -182.0);
+
+                test_similar_angles(inav,   2.0,  358.0);
+                test_similar_angles(inav,  -2.0,  358.0);
+                test_similar_angles(inav,   2.0, -358.0);
+                test_similar_angles(inav,  -2.0, -358.0);
+
+                test_similar_angles(inav,  +2.0,  718.0);
+                test_similar_angles(inav,  -2.0,  718.0);
+                test_similar_angles(inav,  +2.0, -718.0);
+                test_similar_angles(inav,  -2.0, -718.0);
             }
         }
 


### PR DESCRIPTION
The method `checkNearToLocation()` now correctly checks if two orientations are similar (below a certain threshold), also considering the critical points 0,180,360,-180,-360 etc.