### PR TITLE
Add unix_stream and unix_stream_ack carriers

### DIFF
--- a/doc/release/master/unix_socket.md
+++ b/doc/release/master/unix_socket.md
@@ -1,0 +1,7 @@
+unix_socket {#master}
+-----------
+
+### Carriers
+
+* Added the new `unix_stream` and `unix_stream_ack` carriers to communicate with
+  a process on the same machine using a unix socket.

--- a/src/carriers/CMakeLists.txt
+++ b/src/carriers/CMakeLists.txt
@@ -24,6 +24,7 @@ yarp_begin_plugin_library(yarpcar OPTION YARP_COMPILE_CARRIER_PLUGINS
   add_subdirectory(segmentationimage_portmonitor)
   add_subdirectory(zfp_portmonitor)
   add_subdirectory(h264_carrier)
+  add_subdirectory(unix)
 yarp_end_plugin_library(yarpcar QUIET)
 add_library(YARP::yarpcar ALIAS yarpcar)
 

--- a/src/carriers/unix/CMakeLists.txt
+++ b/src/carriers/unix/CMakeLists.txt
@@ -12,7 +12,15 @@ yarp_prepare_plugin(unix_stream
                     DEPENDS UNIX
                     DEFAULT ON)
 
-if(ENABLE_unix_stream)
+yarp_prepare_plugin(unix_stream_ack
+                    CATEGORY carrier
+                    TYPE UnixSocketCarrierAck
+                    INCLUDE UnixSocketCarrier.h
+                    EXTRA_CONFIG CODE="UNIX_ACK"
+                    DEPENDS UNIX
+                    DEFAULT ON)
+
+if(ENABLE_unix_stream OR ENABLE_unix_stream_ack)
   yarp_add_plugin(yarp_unix)
 
   target_sources(yarp_unix PRIVATE UnixSocketCarrier.cpp

--- a/src/carriers/unix/CMakeLists.txt
+++ b/src/carriers/unix/CMakeLists.txt
@@ -18,7 +18,9 @@ if(ENABLE_unix_stream)
   target_sources(yarp_unix PRIVATE UnixSocketCarrier.cpp
                                    UnixSocketCarrier.h
                                    UnixSockTwoWayStream.cpp
-                                   UnixSockTwoWayStream.h)
+                                   UnixSockTwoWayStream.h
+                                   UnixSocketLogComponent.cpp
+                                   UnixSocketLogComponent.h)
 
   target_link_libraries(yarp_unix YARP::YARP_os)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os)

--- a/src/carriers/unix/CMakeLists.txt
+++ b/src/carriers/unix/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(unix_stream
+                    CATEGORY carrier
+                    TYPE UnixSocketCarrier
+                    INCLUDE UnixSocketCarrier.h
+                    EXTRA_CONFIG CODE="UNIX_STR"
+                    DEPENDS UNIX
+                    DEFAULT ON)
+
+if(ENABLE_unix_stream)
+  yarp_add_plugin(yarp_unix)
+
+  target_sources(yarp_unix PRIVATE UnixSocketCarrier.cpp
+                                   UnixSocketCarrier.h
+                                   UnixSockTwoWayStream.cpp
+                                   UnixSockTwoWayStream.h)
+
+  target_link_libraries(yarp_unix YARP::YARP_os)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os)
+
+  yarp_install(TARGETS yarp_unix
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_unix PROPERTY FOLDER "Plugins/Carrier")
+endif()

--- a/src/carriers/unix/UnixSockTwoWayStream.cpp
+++ b/src/carriers/unix/UnixSockTwoWayStream.cpp
@@ -8,25 +8,22 @@
 
 #include <yarp/conf/system.h>
 
+#include <yarp/os/LogStream.h>
+#include <yarp/os/NetType.h>
+#include <yarp/os/Time.h>
+
 #include "UnixSockTwoWayStream.h"
 #include "UnixSocketLogComponent.h"
-
-//#include <yarp/os/impl/Logger.h>
-#include <yarp/os/Time.h>
-#include <yarp/os/NetType.h>
-#include <yarp/os/LogStream.h>
-#include <sys/stat.h>        /* For mode constants */
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-#include <fcntl.h>           /* For O_* constants */
-
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h> /* For O_* constants */
+#include <sys/socket.h>
+#include <sys/stat.h> /* For mode constants */
+#include <sys/un.h>
+#include <unistd.h>
 
 using namespace yarp::os;
 using namespace std;
-
 
 UnixSockTwoWayStream::UnixSockTwoWayStream(const std::string& _socketPath) :
         socketPath(_socketPath)
@@ -37,8 +34,7 @@ bool UnixSockTwoWayStream::open(bool sender)
 {
     openedAsReader = !sender;
     struct sockaddr_un addr;
-    if ((reader_fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
-    {
+    if ((reader_fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
         perror("UnixSockTwoWayStream error:");
         return false;
     }
@@ -46,72 +42,58 @@ bool UnixSockTwoWayStream::open(bool sender)
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
 
-    if (socketPath.empty())
-    {
-      *addr.sun_path = '\0';
-      strncpy(addr.sun_path+1, socketPath.c_str()+1, sizeof(addr.sun_path)-2);
-    }
-    else
-    {
-      strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path)-1);
-      if (!sender)
-      {
-          ::unlink(socketPath.c_str());
-      }
+    if (socketPath.empty()) {
+        *addr.sun_path = '\0';
+        strncpy(addr.sun_path + 1, socketPath.c_str() + 1, sizeof(addr.sun_path) - 2);
+    } else {
+        strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+        if (!sender) {
+            ::unlink(socketPath.c_str());
+        }
     }
 
-    if (sender)
-    {
+    if (sender) {
         int attempts = 0;
-        //try connection 5 times, waiting that the receiver bind the socket
-        while (attempts < 5)
-        {
+        // try connection 5 times, waiting that the receiver bind the socket
+        while (attempts < 5) {
             int result = ::connect(reader_fd, (struct sockaddr*)&addr, sizeof(addr));
-            if (result == 0)
-            {
+            if (result == 0) {
                 break;
             }
             yarp::os::Time::delay(0.01);
             attempts++;
         }
 
-        if (attempts >= 5)
-        {
+        if (attempts >= 5) {
             perror("UnixSockTwoWayStream connect error, I tried 5 times...");
             return false;
         }
-    }
-    else
-    {
-        if (::bind(reader_fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
-        {
+    } else {
+        if (::bind(reader_fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
             perror("UnixSockTwoWayStream bind error");
             return false;
         }
 
         // the socket will listen only 1 client
-        if (::listen(reader_fd, 2) == -1)
-        {
+        if (::listen(reader_fd, 2) == -1) {
             perror("UnixSockTwoWayStream listen error");
             return false;
         }
         struct sockaddr_un remote;
         uint lenRemote = sizeof(remote);
 
-        if ((sender_fd = ::accept(reader_fd, (struct sockaddr *)&remote, &lenRemote)) == -1)
-        {
+        if ((sender_fd = ::accept(reader_fd, (struct sockaddr*)&remote, &lenRemote)) == -1) {
             perror("UnixSockTwoWayStream accept error");
             return false;
         }
     }
-
 
     return true;
 }
 
 UnixSockTwoWayStream::~UnixSockTwoWayStream()
 {
-    closeMain();
+    close();
 }
 
 InputStream& UnixSockTwoWayStream::getInputStream()
@@ -134,12 +116,12 @@ const Contact& UnixSockTwoWayStream::getRemoteAddress() const
     return remoteAddress;
 }
 
-void UnixSockTwoWayStream::setLocalAddress(Contact &_localAddress)
+void UnixSockTwoWayStream::setLocalAddress(Contact& _localAddress)
 {
     localAddress = _localAddress;
 }
 
-void UnixSockTwoWayStream::setRemoteAddress(Contact &_remoteAddress)
+void UnixSockTwoWayStream::setRemoteAddress(Contact& _remoteAddress)
 {
     remoteAddress = _remoteAddress;
 }
@@ -156,15 +138,14 @@ void UnixSockTwoWayStream::interrupt()
     }
     mutex.unlock();
     if (act) {
-        if(openedAsReader)
-        {
+        if (openedAsReader) {
             int ct = 3;
-            while (happy && ct>0) {
+            while (happy && ct > 0) {
                 ct--;
                 UnixSockTwoWayStream tmp(socketPath);
                 tmp.open(true);
                 ManagedBytes empty(10);
-                for (size_t i=0; i<empty.length(); i++) {
+                for (size_t i = 0; i < empty.length(); i++) {
                     empty.get()[i] = 0;
                 }
 
@@ -194,13 +175,7 @@ void UnixSockTwoWayStream::interrupt()
 
 void UnixSockTwoWayStream::close()
 {
-    closeMain();
-
-}
-
-void UnixSockTwoWayStream::closeMain()
-{
-    if (reader_fd > 0) //check socket id
+    if (reader_fd > 0) // check socket id
     {
         interrupt();
         mutex.lock();
@@ -213,20 +188,16 @@ void UnixSockTwoWayStream::closeMain()
         mutex.lock();
         // If the connect descriptor is valid close socket
         // and free the memory dedicated.
-        //socket closure
-        if (openedAsReader)
-        {
+        // socket closure
+        if (openedAsReader) {
             ::shutdown(sender_fd, SHUT_RDWR);
             ::close(sender_fd);
             ::unlink(socketPath.c_str());
             sender_fd = -1;
-        }
-        else
-        {
+        } else {
             ::shutdown(reader_fd, SHUT_RDWR);
             ::close(reader_fd);
             reader_fd = -1;
-
         }
         happy = false;
         mutex.unlock();
@@ -236,17 +207,16 @@ void UnixSockTwoWayStream::closeMain()
 
 yarp::conf::ssize_t UnixSockTwoWayStream::read(Bytes& b)
 {
-    if(closed || !happy){
+    if (closed || !happy) {
         return -1;
     }
     int result;
-    result = ::read(openedAsReader?sender_fd:reader_fd, b.get(), b.length());
+    result = ::read(openedAsReader ? sender_fd : reader_fd, b.get(), b.length());
     if (closed || result == 0) {
         happy = false;
         return -1;
     }
-    if (result<0)
-    {
+    if (result < 0) {
         perror("unixSock::read():Packet payload");
         return -1;
     }
@@ -255,17 +225,14 @@ yarp::conf::ssize_t UnixSockTwoWayStream::read(Bytes& b)
 
 void UnixSockTwoWayStream::write(const Bytes& b)
 {
-    if (reader_fd < 0)
-    {
+    if (reader_fd < 0) {
         close();
         return;
     }
-    int writtenMem = ::write(openedAsReader?sender_fd:reader_fd, b.get(), b.length());
-    if (writtenMem < 0)
-    {
+    int writtenMem = ::write(openedAsReader ? sender_fd : reader_fd, b.get(), b.length());
+    if (writtenMem < 0) {
         perror("unixSock::write:Packet payload");
-        if(errno != ETIMEDOUT)
-        {
+        if (errno != ETIMEDOUT) {
             close();
         }
         return;
@@ -298,7 +265,7 @@ Bytes UnixSockTwoWayStream::getMonitor()
     return monitor.bytes();
 }
 
-void UnixSockTwoWayStream::setMonitor(const Bytes &data)
+void UnixSockTwoWayStream::setMonitor(const Bytes& data)
 {
     monitor = yarp::os::ManagedBytes(data, false);
     monitor.copy();

--- a/src/carriers/unix/UnixSockTwoWayStream.cpp
+++ b/src/carriers/unix/UnixSockTwoWayStream.cpp
@@ -9,6 +9,7 @@
 #include <yarp/conf/system.h>
 
 #include "UnixSockTwoWayStream.h"
+#include "UnixSocketLogComponent.h"
 
 //#include <yarp/os/impl/Logger.h>
 #include <yarp/os/Time.h>
@@ -144,6 +145,7 @@ void UnixSockTwoWayStream::setRemoteAddress(Contact &_remoteAddress)
 
 void UnixSockTwoWayStream::interrupt()
 {
+    yCDebug(UNIXSOCK_CARRIER, " interrupting socket");
     bool act = false;
     mutex.lock();
     if ((!closed) && (!interrupting) && happy) {
@@ -182,7 +184,7 @@ void UnixSockTwoWayStream::interrupt()
         // wait for interruption to be done
         if (interrupting) {
             while (interrupting) {
-                yDebug("waiting for dgram interrupt to be finished...");
+                yCDebug(UNIXSOCK_CARRIER,"waiting for dgram interrupt to be finished...");
                 yarp::os::SystemClock::delaySystem(0.1);
             }
         }

--- a/src/carriers/unix/UnixSockTwoWayStream.cpp
+++ b/src/carriers/unix/UnixSockTwoWayStream.cpp
@@ -10,7 +10,7 @@
 
 #include "UnixSockTwoWayStream.h"
 
-#include <yarp/os/impl/Logger.h>
+//#include <yarp/os/impl/Logger.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/NetType.h>
 #include <yarp/os/LogStream.h>

--- a/src/carriers/unix/UnixSockTwoWayStream.cpp
+++ b/src/carriers/unix/UnixSockTwoWayStream.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/conf/system.h>
+
+#include "UnixSockTwoWayStream.h"
+
+#include <yarp/os/impl/Logger.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/NetType.h>
+#include <yarp/os/LogStream.h>
+#include <sys/stat.h>        /* For mode constants */
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <fcntl.h>           /* For O_* constants */
+
+#include <cerrno>
+#include <cstring>
+
+using namespace yarp::os;
+using namespace std;
+
+
+UnixSockTwoWayStream::UnixSockTwoWayStream(const std::string& _socketPath) :
+        socketPath(_socketPath)
+{
+}
+
+bool UnixSockTwoWayStream::open(bool sender)
+{
+    struct sockaddr_un addr;
+    if ((fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+    {
+        perror("UnixSockTwoWayStream error:");
+        return false;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+
+    if (socketPath.empty())
+    {
+      *addr.sun_path = '\0';
+      strncpy(addr.sun_path+1, socketPath.c_str()+1, sizeof(addr.sun_path)-2);
+    }
+    else
+    {
+      strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path)-1);
+      if (!sender)
+      {
+          ::unlink(socketPath.c_str());
+      }
+    }
+
+    if (sender)
+    {
+        int attempts = 0;
+        //try connection 5 times, waiting that the receiver bind the socket
+        while (attempts < 5)
+        {
+            int result = ::connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+            if (result == 0)
+            {
+                break;
+            }
+            yarp::os::Time::delay(0.01);
+            attempts++;
+        }
+
+        if (attempts >= 5)
+        {
+            perror("UnixSockTwoWayStream connect error, I tried 5 times...");
+            return false;
+        }
+    }
+    else
+    {
+        if (::bind(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+        {
+            perror("UnixSockTwoWayStream bind error");
+            return false;
+        }
+
+        // the socket will listen only 1 client
+        if (::listen(fd, 2) == -1)
+        {
+            perror("UnixSockTwoWayStream listen error");
+            return false;
+        }
+        struct sockaddr_un remote;
+        uint lenRemote = sizeof(remote);
+
+        if ((cl = ::accept(fd, (struct sockaddr *)&remote, &lenRemote)) == -1)
+        {
+            perror("UnixSockTwoWayStream accept error");
+            return false;
+        }
+    }
+
+
+    return true;
+}
+
+UnixSockTwoWayStream::~UnixSockTwoWayStream()
+{
+    closeMain();
+}
+
+InputStream& UnixSockTwoWayStream::getInputStream()
+{
+    return *this;
+}
+
+OutputStream& UnixSockTwoWayStream::getOutputStream()
+{
+    return *this;
+}
+
+const Contact& UnixSockTwoWayStream::getLocalAddress() const
+{
+    return localAddress;
+}
+
+const Contact& UnixSockTwoWayStream::getRemoteAddress() const
+{
+    return remoteAddress;
+}
+
+void UnixSockTwoWayStream::setLocalAddress(Contact &_localAddress)
+{
+    localAddress = _localAddress;
+}
+
+void UnixSockTwoWayStream::setRemoteAddress(Contact &_remoteAddress)
+{
+    remoteAddress = _remoteAddress;
+}
+
+void UnixSockTwoWayStream::interrupt()
+{
+    bool act = false;
+    mutex.lock();
+    if ((!closed) && (!interrupting) && happy) {
+        act = true;
+        interrupting = true;
+        closed = true;
+    }
+    mutex.unlock();
+    if (act) {
+        if(reader)
+        {
+            int ct = 3;
+            while (happy && ct>0) {
+                ct--;
+                UnixSockTwoWayStream tmp(socketPath);
+                tmp.open(true);
+                ManagedBytes empty(10);
+                for (size_t i=0; i<empty.length(); i++) {
+                    empty.get()[i] = 0;
+                }
+
+                tmp.fd = cl; // this allows the fake stream to write on the socket waiting something to read.
+                tmp.write(empty.bytes());
+                tmp.flush();
+                tmp.close();
+                if (happy) {
+                    yarp::os::SystemClock::delaySystem(0.25);
+                }
+            }
+            yDebug("dgram interrupt done");
+        }
+        mutex.lock();
+        interrupting = false;
+        mutex.unlock();
+    } else {
+        // wait for interruption to be done
+        if (interrupting) {
+            while (interrupting) {
+                yDebug("waiting for dgram interrupt to be finished...");
+                yarp::os::SystemClock::delaySystem(0.1);
+            }
+        }
+    }
+}
+
+void UnixSockTwoWayStream::close()
+{
+    closeMain();
+
+}
+
+void UnixSockTwoWayStream::closeMain()
+{
+    if (fd > 0) //check socket id
+    {
+        interrupt();
+        mutex.lock();
+        closed = true;
+        mutex.unlock();
+        while (interrupting) {
+            happy = false;
+            yarp::os::SystemClock::delaySystem(0.1);
+        }
+        mutex.lock();
+        // If the connect descriptor is valid close socket
+        // and free the memory dedicated.
+        //socket closure
+        if (reader)
+        {
+            ::shutdown(cl, SHUT_RDWR);
+            ::close(cl);
+            ::unlink(socketPath.c_str());
+            cl = -1;
+        }
+        else
+        {
+            ::shutdown(fd, SHUT_RDWR);
+            ::close(fd);
+            fd = -1;
+
+        }
+        happy = false;
+        mutex.unlock();
+    }
+    happy = false;
+
+}
+
+yarp::conf::ssize_t UnixSockTwoWayStream::read(Bytes& b)
+{
+    reader = true;
+
+    int result;
+    result = ::read(cl, b.get(), b.length());
+    if (closed || result == 0) {
+        happy = false;
+        return -1;
+    }
+    if (result<0)
+    {
+        perror("unixSock::read():Packet payload");
+        return -1;
+    }
+    return result;
+}
+
+void UnixSockTwoWayStream::write(const Bytes& b)
+{
+    if (reader) {
+        return;
+    }
+
+    if (fd < 0)
+    {
+        close();
+        return;
+    }
+
+    int writtenMem = ::write(fd, b.get(), b.length());
+    if (writtenMem < 0)
+    {
+        perror("unixSock::write:Packet payload");
+        if(errno != ETIMEDOUT)
+        {
+            close();
+        }
+        return;
+    }
+}
+
+void UnixSockTwoWayStream::flush()
+{
+}
+
+bool UnixSockTwoWayStream::isOk() const
+{
+    return happy;
+}
+
+void UnixSockTwoWayStream::reset()
+{
+}
+
+void UnixSockTwoWayStream::beginPacket()
+{
+}
+
+void UnixSockTwoWayStream::endPacket()
+{
+}
+
+Bytes UnixSockTwoWayStream::getMonitor()
+{
+    return monitor.bytes();
+}
+
+void UnixSockTwoWayStream::setMonitor(const Bytes &data)
+{
+    monitor = yarp::os::ManagedBytes(data, false);
+    monitor.copy();
+}
+
+void UnixSockTwoWayStream::removeMonitor()
+{
+    monitor.clear();
+}

--- a/src/carriers/unix/UnixSockTwoWayStream.cpp
+++ b/src/carriers/unix/UnixSockTwoWayStream.cpp
@@ -10,7 +10,7 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/Time.h>
+#include <yarp/os/SystemClock.h>
 
 #include "UnixSockTwoWayStream.h"
 #include "UnixSocketLogComponent.h"
@@ -59,7 +59,7 @@ bool UnixSockTwoWayStream::open(bool sender)
             if (result == 0) {
                 break;
             }
-            yarp::os::Time::delay(delayBetweenAttempts);
+            yarp::os::SystemClock::delaySystem(delayBetweenAttempts);
             attempts++;
         }
 

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -47,8 +47,6 @@ public:
     using yarp::os::OutputStream::write;
     void write(const yarp::os::Bytes& b) override;
 
-    void flush() override;
-
     bool isOk() const override;
 
     void reset() override;
@@ -56,24 +54,15 @@ public:
     void beginPacket() override;
     void endPacket() override;
 
-    yarp::os::Bytes getMonitor();
-
-    void setMonitor(const yarp::os::Bytes& data);
-
-    void removeMonitor();
-
     bool open(bool sender = false);
     void setLocalAddress(yarp::os::Contact& _localAddress);
     void setRemoteAddress(yarp::os::Contact& _remoteAddress);
 
 private:
-    yarp::os::ManagedBytes monitor;
     bool closed{false};
-    bool interrupting{false};
     bool openedAsReader{false};
     yarp::os::Contact localAddress;
     yarp::os::Contact remoteAddress;
-    std::mutex mutex;
     bool happy{true};
 
     std::string socketPath;

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -79,8 +79,8 @@ private:
     bool happy {true};
 
     std::string socketPath;
-    int fd {-1};
-    int cl {-1};
+    int reader_fd {-1};
+    int sender_fd {-1};
 };
 
 #endif // YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -72,7 +72,7 @@ private:
     yarp::os::ManagedBytes monitor;
     bool closed {false};
     bool interrupting {false};
-    bool reader {false};
+    bool openedAsReader {false};
     yarp::os::Contact localAddress;
     yarp::os::Contact remoteAddress;
     std::mutex mutex;

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -68,6 +68,9 @@ private:
     std::string socketPath;
     int reader_fd{-1};
     int sender_fd{-1};
+
+    static constexpr size_t maxAttempts = 5;
+    static constexpr double delayBetweenAttempts = 0.01;
 };
 
 #endif // YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H
+#define YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H
+
+#include <yarp/os/TwoWayStream.h>
+#include <yarp/os/ManagedBytes.h>
+#include <yarp/os/Semaphore.h>
+
+#include <mutex>
+
+/**
+ * A stream abstraction for unix socket communication.
+ */
+class UnixSockTwoWayStream :
+        public yarp::os::TwoWayStream,
+        public yarp::os::InputStream,
+        public yarp::os::OutputStream
+{
+
+public:
+    UnixSockTwoWayStream(const std::string& _socketPath="");
+
+    ~UnixSockTwoWayStream() override;
+
+    InputStream& getInputStream() override;
+
+    OutputStream& getOutputStream() override;
+
+    const yarp::os::Contact& getLocalAddress() const override;
+
+    const yarp::os::Contact& getRemoteAddress() const override;
+
+    void interrupt() override;
+
+    void close() override;
+
+    void closeMain();
+
+    using yarp::os::InputStream::read;
+    yarp::conf::ssize_t read(yarp::os::Bytes& b) override;
+
+    using yarp::os::OutputStream::write;
+    void write(const yarp::os::Bytes& b) override;
+
+    void flush() override;
+
+    bool isOk() const override;
+
+    void reset() override;
+
+    void beginPacket() override;
+    void endPacket() override;
+
+    yarp::os::Bytes getMonitor();
+
+    void setMonitor(const yarp::os::Bytes& data);
+
+    void removeMonitor();
+
+    bool open(bool sender = false);
+    void setLocalAddress(yarp::os::Contact& _localAddress);
+    void setRemoteAddress(yarp::os::Contact& _remoteAddress);
+
+private:
+    yarp::os::ManagedBytes monitor;
+    bool closed {false};
+    bool interrupting {false};
+    bool reader {false};
+    yarp::os::Contact localAddress;
+    yarp::os::Contact remoteAddress;
+    std::mutex mutex;
+    bool happy {true};
+
+    std::string socketPath;
+    int fd {-1};
+    int cl {-1};
+};
+
+#endif // YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -70,7 +70,7 @@ private:
     int sender_fd{-1};
 
     static constexpr size_t maxAttempts = 5;
-    static constexpr double delayBetweenAttempts = 0.01;
+    static constexpr double delayBetweenAttempts = 0.1;
 };
 
 #endif // YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H

--- a/src/carriers/unix/UnixSockTwoWayStream.h
+++ b/src/carriers/unix/UnixSockTwoWayStream.h
@@ -9,9 +9,9 @@
 #ifndef YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H
 #define YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H
 
-#include <yarp/os/TwoWayStream.h>
 #include <yarp/os/ManagedBytes.h>
 #include <yarp/os/Semaphore.h>
+#include <yarp/os/TwoWayStream.h>
 
 #include <mutex>
 
@@ -25,7 +25,7 @@ class UnixSockTwoWayStream :
 {
 
 public:
-    UnixSockTwoWayStream(const std::string& _socketPath="");
+    UnixSockTwoWayStream(const std::string& _socketPath = "");
 
     ~UnixSockTwoWayStream() override;
 
@@ -40,8 +40,6 @@ public:
     void interrupt() override;
 
     void close() override;
-
-    void closeMain();
 
     using yarp::os::InputStream::read;
     yarp::conf::ssize_t read(yarp::os::Bytes& b) override;
@@ -70,17 +68,17 @@ public:
 
 private:
     yarp::os::ManagedBytes monitor;
-    bool closed {false};
-    bool interrupting {false};
-    bool openedAsReader {false};
+    bool closed{false};
+    bool interrupting{false};
+    bool openedAsReader{false};
     yarp::os::Contact localAddress;
     yarp::os::Contact remoteAddress;
     std::mutex mutex;
-    bool happy {true};
+    bool happy{true};
 
     std::string socketPath;
-    int reader_fd {-1};
-    int sender_fd {-1};
+    int reader_fd{-1};
+    int sender_fd{-1};
 };
 
 #endif // YARP_UNIX_UNIXSOCKTWOWAYSTREAM_H

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -99,11 +99,6 @@ bool UnixSocketCarrier::isConnectionless() const
     return false;
 }
 
-bool UnixSocketCarrier::canEscape() const
-{
-    return true;
-}
-
 bool UnixSocketCarrier::checkHeader(const Bytes& header)
 {
     if (header.length() != headerSize) {

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -16,6 +16,9 @@
 
 #include "UnixSocketLogComponent.h"
 
+#include <array>
+#include <mutex>
+
 using namespace yarp::os;
 namespace fs = yarp::conf::filesystem;
 

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -10,6 +10,8 @@
 
 #include <yarp/os/ConnectionState.h>
 #include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include "UnixSocketLogComponent.h"
 
 using namespace yarp::os;
 
@@ -45,7 +47,7 @@ bool UnixSocketCarrier::isUnixSockSupported(ConnectionState& proto)
 
     if(remote.getHost() != local.getHost())
     {
-        yError("UnixSocketCarrier: The ports are on different machines, unix socket not supported...");
+        yCError(UNIXSOCK_CARRIER,"The ports are on different machines, unix socket not supported...");
         return false;
     }
     return true;

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -128,11 +128,16 @@ void UnixSocketCarrier::getHeader(Bytes& header) const
 
 bool UnixSocketCarrier::sendIndex(ConnectionState& proto, SizedWriter& writer)
 {
+    YARP_UNUSED(proto);
+    YARP_UNUSED(writer);
+
     return true;
 }
 
 bool UnixSocketCarrier::expectIndex(ConnectionState& proto)
 {
+    YARP_UNUSED(proto);
+
     return true;
 }
 
@@ -153,8 +158,7 @@ bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
     Contact remote = proto.getStreams().getRemoteAddress();
     Contact local = proto.getStreams().getLocalAddress();
 
-    proto.takeStreams(YARP_NULLPTR); // free up port from tcp
-
+    proto.takeStreams(nullptr); // free up port from tcp
 
     std::string runtime_dir = getYARPRuntimeDir();
 
@@ -175,10 +179,10 @@ bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
 
     if (!stream->open(sender)) {
         delete stream;
-        stream = YARP_NULLPTR;
+        stream = nullptr;
         return false;
     }
-    yAssert(stream != YARP_NULLPTR);
+    yAssert(stream != nullptr);
 
     proto.takeStreams(stream);
     return true;

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -27,16 +27,16 @@ std::string getYARPRuntimeDir()
     static std::mutex m;
     std::lock_guard<std::mutex> lock(m);
 
-    static std::string socketDir;
+    static std::string yarp_runtime_dir;
     bool found = false;
 
     // If already populated, there is nothing to do
-    if (!socketDir.empty()) {
-        return socketDir;
+    if (!yarp_runtime_dir.empty()) {
+        return yarp_runtime_dir;
     }
 
     // Check YARP_RUNTIME_DIR
-    std::string yarp_runtime_dir = NetworkBase::getEnvironment("YARP_RUNTIME_DIR", &found);
+    yarp_runtime_dir = NetworkBase::getEnvironment("YARP_RUNTIME_DIR", &found);
     if (found) {
         return yarp_runtime_dir;
     }

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "UnixSocketCarrier.h"
+
+#include <yarp/os/ConnectionState.h>
+#include <yarp/os/Log.h>
+
+using namespace yarp::os;
+
+yarp::os::Carrier *UnixSocketCarrier::create() const
+{
+    return new UnixSocketCarrier();
+}
+
+std::string UnixSocketCarrier::getName() const
+{
+    return name;
+}
+
+bool UnixSocketCarrier::requireAck() const
+{
+    return false;
+}
+
+bool UnixSocketCarrier::isConnectionless() const
+{
+    return true;
+}
+
+bool UnixSocketCarrier::canEscape() const
+{
+    return true;
+}
+
+bool UnixSocketCarrier::isUnixSockSupported(ConnectionState& proto)
+{
+    yarp::os::Contact remote = proto.getStreams().getRemoteAddress();
+    yarp::os::Contact local  = proto.getStreams().getLocalAddress();
+
+    if(remote.getHost() != local.getHost())
+    {
+        yError("UnixSocketCarrier: The ports are on different machines, unix socket not supported...");
+        return false;
+    }
+    return true;
+
+}
+
+bool UnixSocketCarrier::checkHeader(const Bytes& header)
+{
+    if (header.length() != headerSize) {
+        return false;
+    }
+    const char *target = headerCode;
+    for (size_t i = 0; i < headerSize; i++) {
+        if (header.get()[i] != target[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void UnixSocketCarrier::getHeader(Bytes& header) const
+{
+    const char *target = headerCode;
+    for (size_t i = 0; i < headerSize && i < header.length(); i++)
+    {
+        header.get()[i] = target[i];
+    }
+}
+
+bool UnixSocketCarrier::sendIndex(ConnectionState& proto, SizedWriter& writer)
+{
+    return true;
+}
+
+bool UnixSocketCarrier::expectIndex(ConnectionState& proto)
+{
+    return true;
+}
+
+
+
+bool UnixSocketCarrier::respondToHeader(ConnectionState& proto)
+{
+    // I am the receiver
+    return becomeUnixSocket(proto, false);
+}
+
+bool UnixSocketCarrier::expectReplyToHeader(ConnectionState& proto)
+{
+    // I am the sender
+    return becomeUnixSocket(proto, true);
+}
+
+bool UnixSocketCarrier::becomeUnixSocket(ConnectionState &proto, bool sender)
+{
+    Contact remote = proto.getStreams().getRemoteAddress();
+    Contact local  = proto.getStreams().getLocalAddress();
+
+    proto.takeStreams(YARP_NULLPTR); // free up port from tcp
+
+    if(sender)
+    {
+        socketPath = "/tmp/yarp-" + std::to_string(remote.getPort()) + "_" + std::to_string(local.getPort())+".sock";
+    }
+    else
+    {
+        socketPath = "/tmp/yarp-" + std::to_string(local.getPort()) + "_" + std::to_string(remote.getPort())+".sock";
+
+    }
+
+    if (!socketPath.empty())
+    {
+        stream = new UnixSockTwoWayStream(socketPath);
+    }
+    else
+    {
+        return false;
+    }
+
+    stream->setLocalAddress(local);
+    stream->setRemoteAddress(remote);
+
+
+    if (!stream->open(sender))
+    {
+        delete stream;
+        stream = YARP_NULLPTR;
+        return false;
+    }
+    yAssert(stream!=YARP_NULLPTR);
+
+    proto.takeStreams(stream);
+    return true;
+
+}
+

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -155,6 +155,10 @@ bool UnixSocketCarrier::expectReplyToHeader(ConnectionState& proto)
 
 bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
 {
+    if (!isUnixSockSupported(proto)) {
+        return false;
+    }
+
     Contact remote = proto.getStreams().getRemoteAddress();
     Contact local = proto.getStreams().getLocalAddress();
 

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -32,7 +32,7 @@ bool UnixSocketCarrier::requireAck() const
 
 bool UnixSocketCarrier::isConnectionless() const
 {
-    return true;
+    return false;
 }
 
 bool UnixSocketCarrier::canEscape() const

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -19,9 +19,10 @@
 using namespace yarp::os;
 namespace fs = yarp::conf::filesystem;
 
+namespace {
 
 // FIXME: This method should be available somewhere in YARP
-static std::string getYARPRuntimeDir()
+std::string getYARPRuntimeDir()
 {
     static std::mutex m;
     std::lock_guard<std::mutex> lock(m);
@@ -57,6 +58,8 @@ static std::string getYARPRuntimeDir()
     // ERROR
     return {};
 }
+
+} // namespace
 
 yarp::os::Carrier* UnixSocketCarrier::create() const
 {

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -163,6 +163,7 @@ bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
 
     // Make sure that the path exists
     if (runtime_dir.empty() || yarp::os::mkdir_p(runtime_dir.c_str(), 0) != 0) {
+        yCError(UNIXSOCK_CARRIER, "Failed to create directory %s", runtime_dir.c_str());
         return false;
     }
 
@@ -179,10 +180,13 @@ bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
     if (!stream->open(sender)) {
         delete stream;
         stream = nullptr;
+        yCError(UNIXSOCK_CARRIER, "Failed to open stream on socket %s as %s", socketPath.c_str(), (sender ? "sender" : "receiver"));
         return false;
     }
     yAssert(stream != nullptr);
 
     proto.takeStreams(stream);
+
+    yCDebug(UNIXSOCK_CARRIER, "Connected on socket %s as %s", socketPath.c_str(), (sender ? "sender" : "receiver"));
     return true;
 }

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -59,6 +59,24 @@ std::string getYARPRuntimeDir()
     return {};
 }
 
+/**
+ * @brief isUnixSockSupported
+ * @param proto, contains the information of the connection
+ * @return true if the remote and the local port are on the same host
+ */
+bool isUnixSockSupported(ConnectionState& proto) // FIXME Why is this method unused?
+{
+    yarp::os::Contact remote = proto.getStreams().getRemoteAddress();
+    yarp::os::Contact local = proto.getStreams().getLocalAddress();
+
+    if (remote.getHost() != local.getHost()) {
+        yCError(UNIXSOCK_CARRIER,
+                "The ports are on different machines, unix socket not supported...");
+        return false;
+    }
+    return true;
+}
+
 } // namespace
 
 yarp::os::Carrier* UnixSocketCarrier::create() const
@@ -83,20 +101,6 @@ bool UnixSocketCarrier::isConnectionless() const
 
 bool UnixSocketCarrier::canEscape() const
 {
-    return true;
-}
-
-bool UnixSocketCarrier::isUnixSockSupported(ConnectionState& proto)
-{
-    yarp::os::Contact remote = proto.getStreams().getRemoteAddress();
-    yarp::os::Contact local = proto.getStreams().getLocalAddress();
-
-    if (remote.getHost() != local.getHost()) {
-        yCError(
-            UNIXSOCK_CARRIER,
-            "The ports are on different machines, unix socket not supported...");
-        return false;
-    }
     return true;
 }
 

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -11,11 +11,12 @@
 #include <yarp/os/ConnectionState.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
 #include "UnixSocketLogComponent.h"
 
 using namespace yarp::os;
 
-yarp::os::Carrier *UnixSocketCarrier::create() const
+yarp::os::Carrier* UnixSocketCarrier::create() const
 {
     return new UnixSocketCarrier();
 }
@@ -43,15 +44,15 @@ bool UnixSocketCarrier::canEscape() const
 bool UnixSocketCarrier::isUnixSockSupported(ConnectionState& proto)
 {
     yarp::os::Contact remote = proto.getStreams().getRemoteAddress();
-    yarp::os::Contact local  = proto.getStreams().getLocalAddress();
+    yarp::os::Contact local = proto.getStreams().getLocalAddress();
 
-    if(remote.getHost() != local.getHost())
-    {
-        yCError(UNIXSOCK_CARRIER,"The ports are on different machines, unix socket not supported...");
+    if (remote.getHost() != local.getHost()) {
+        yCError(
+            UNIXSOCK_CARRIER,
+            "The ports are on different machines, unix socket not supported...");
         return false;
     }
     return true;
-
 }
 
 bool UnixSocketCarrier::checkHeader(const Bytes& header)
@@ -59,7 +60,7 @@ bool UnixSocketCarrier::checkHeader(const Bytes& header)
     if (header.length() != headerSize) {
         return false;
     }
-    const char *target = headerCode;
+    const char* target = headerCode;
     for (size_t i = 0; i < headerSize; i++) {
         if (header.get()[i] != target[i]) {
             return false;
@@ -70,9 +71,8 @@ bool UnixSocketCarrier::checkHeader(const Bytes& header)
 
 void UnixSocketCarrier::getHeader(Bytes& header) const
 {
-    const char *target = headerCode;
-    for (size_t i = 0; i < headerSize && i < header.length(); i++)
-    {
+    const char* target = headerCode;
+    for (size_t i = 0; i < headerSize && i < header.length(); i++) {
         header.get()[i] = target[i];
     }
 }
@@ -87,8 +87,6 @@ bool UnixSocketCarrier::expectIndex(ConnectionState& proto)
     return true;
 }
 
-
-
 bool UnixSocketCarrier::respondToHeader(ConnectionState& proto)
 {
     // I am the receiver
@@ -101,46 +99,35 @@ bool UnixSocketCarrier::expectReplyToHeader(ConnectionState& proto)
     return becomeUnixSocket(proto, true);
 }
 
-bool UnixSocketCarrier::becomeUnixSocket(ConnectionState &proto, bool sender)
+bool UnixSocketCarrier::becomeUnixSocket(ConnectionState& proto, bool sender)
 {
     Contact remote = proto.getStreams().getRemoteAddress();
-    Contact local  = proto.getStreams().getLocalAddress();
+    Contact local = proto.getStreams().getLocalAddress();
 
     proto.takeStreams(YARP_NULLPTR); // free up port from tcp
 
-    if(sender)
-    {
-        socketPath = "/tmp/yarp-" + std::to_string(remote.getPort()) + "_" + std::to_string(local.getPort())+".sock";
-    }
-    else
-    {
-        socketPath = "/tmp/yarp-" + std::to_string(local.getPort()) + "_" + std::to_string(remote.getPort())+".sock";
-
+    if (sender) {
+        socketPath = "/tmp/yarp-" + std::to_string(remote.getPort()) + "_" + std::to_string(local.getPort()) + ".sock";
+    } else {
+        socketPath = "/tmp/yarp-" + std::to_string(local.getPort()) + "_" + std::to_string(remote.getPort()) + ".sock";
     }
 
-    if (!socketPath.empty())
-    {
+    if (!socketPath.empty()) {
         stream = new UnixSockTwoWayStream(socketPath);
-    }
-    else
-    {
+    } else {
         return false;
     }
 
     stream->setLocalAddress(local);
     stream->setRemoteAddress(remote);
 
-
-    if (!stream->open(sender))
-    {
+    if (!stream->open(sender)) {
         delete stream;
         stream = YARP_NULLPTR;
         return false;
     }
-    yAssert(stream!=YARP_NULLPTR);
+    yAssert(stream != YARP_NULLPTR);
 
     proto.takeStreams(stream);
     return true;
-
 }
-

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -27,7 +27,7 @@ class UnixSocketCarrier :
         public yarp::os::AbstractCarrier
 {
 public:
-    UnixSocketCarrier() = default;
+    UnixSocketCarrier(bool requireAckFlag = false);
     ~UnixSocketCarrier() override = default;
 
     yarp::os::Carrier* create() const override;
@@ -46,17 +46,35 @@ public:
     bool expectIndex(yarp::os::ConnectionState& proto) override;
     bool sendIndex(yarp::os::ConnectionState& proto, yarp::os::SizedWriter& writer) override;
 
+    bool expectAck(yarp::os::ConnectionState& proto) override;
+    bool sendAck(yarp::os::ConnectionState& proto) override;
 
 private:
     static constexpr const char* name = "unix_stream";
     static constexpr int specifierCode = 11;
     static constexpr const char* headerCode = "UNIX_STR";
+
+    static constexpr const char* name_ack = "unix_stream_ack";
+    static constexpr int specifierCode_ack = 12;
+    static constexpr const char* headerCode_ack = "UNIX_ACK";
+
     static constexpr size_t headerSize = 8;
 
+    static constexpr const char* ack_string = "ACK";
+    static constexpr size_t ack_string_size = 4;
+
     std::string socketPath;
+    bool requireAckFlag{false};
     UnixSockTwoWayStream* stream{nullptr};
 
     bool becomeUnixSocket(yarp::os::ConnectionState& proto, bool sender = false);
+};
+
+class UnixSocketCarrierAck :
+        public UnixSocketCarrier
+{
+public:
+    UnixSocketCarrierAck() : UnixSocketCarrier(true) {}
 };
 
 #endif // YARP_UNIX_UNIXSOCKETCARRIER_H

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -28,7 +28,7 @@ class UnixSocketCarrier :
 {
 public:
     UnixSocketCarrier() = default;
-    ~UnixSocketCarrier() = default;
+    ~UnixSocketCarrier() override = default;
 
     yarp::os::Carrier* create() const override;
 
@@ -55,7 +55,7 @@ private:
     static constexpr size_t headerSize = 8;
 
     std::string socketPath;
-    UnixSockTwoWayStream* stream;
+    UnixSockTwoWayStream* stream{nullptr};
 
     bool becomeUnixSocket(yarp::os::ConnectionState& proto, bool sender = false);
 };

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -57,12 +57,6 @@ private:
     std::string socketPath;
     UnixSockTwoWayStream* stream;
 
-    /**
-     * @brief isUnixSockSupported
-     * @param proto, contains the information of the connection
-     * @return true if the remote and the local port are on the same host
-     */
-    bool isUnixSockSupported(yarp::os::ConnectionState& proto);
     bool becomeUnixSocket(yarp::os::ConnectionState& proto, bool sender = false);
 };
 

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -34,7 +34,6 @@ public:
 
     std::string getName() const override;
 
-    bool canEscape() const override;
     bool requireAck() const override;
     bool isConnectionless() const override;
 

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -11,12 +11,13 @@
 #define YARP_UNIX_UNIXSOCKETCARRIER_H
 
 #include <yarp/os/AbstractCarrier.h>
+
 #include "UnixSockTwoWayStream.h"
 
 // The compile pre-defines the "unix" macro, but we don't use it, and it
 // conflicts with the generated yarp_plugin_unix.cpp file
 #ifdef unix
-#  undef unix
+#    undef unix
 #endif
 
 /**
@@ -29,7 +30,7 @@ public:
     UnixSocketCarrier() = default;
     ~UnixSocketCarrier() = default;
 
-    yarp::os::Carrier *create() const override;
+    yarp::os::Carrier* create() const override;
 
     std::string getName() const override;
 
@@ -48,7 +49,6 @@ public:
 
 
 private:
-
     static constexpr const char* name = "unix_stream";
     static constexpr int specifierCode = 11;
     static constexpr const char* headerCode = "UNIX_STR";

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_UNIX_UNIXSOCKETCARRIER_H
+#define YARP_UNIX_UNIXSOCKETCARRIER_H
+
+#include <yarp/os/AbstractCarrier.h>
+#include "UnixSockTwoWayStream.h"
+
+// The compile pre-defines the "unix" macro, but we don't use it, and it
+// conflicts with the generated yarp_plugin_unix.cpp file
+#ifdef unix
+#  undef unix
+#endif
+
+/**
+ * Communicating between two ports(IPC) via Unix Socket.
+ */
+class UnixSocketCarrier :
+        public yarp::os::AbstractCarrier
+{
+public:
+    UnixSocketCarrier() = default;
+    ~UnixSocketCarrier() = default;
+
+    yarp::os::Carrier *create() const override;
+
+    std::string getName() const override;
+
+    bool canEscape() const override;
+    bool requireAck() const override;
+    bool isConnectionless() const override;
+
+    bool checkHeader(const yarp::os::Bytes& header) override;
+    void getHeader(yarp::os::Bytes& header) const override;
+
+    bool respondToHeader(yarp::os::ConnectionState& proto) override;
+    bool expectReplyToHeader(yarp::os::ConnectionState& proto) override;
+
+    bool expectIndex(yarp::os::ConnectionState& proto) override;
+    bool sendIndex(yarp::os::ConnectionState& proto, yarp::os::SizedWriter& writer) override;
+
+
+private:
+
+    static constexpr const char* name = "unix_stream";
+    static constexpr int specifierCode = 11;
+    static constexpr const char* headerCode = "UNIX_STR";
+    static constexpr size_t headerSize = 8;
+
+    std::string socketPath;
+    UnixSockTwoWayStream* stream;
+
+    /**
+     * @brief isUnixSockSupported
+     * @param proto, contains the information of the connection
+     * @return true if the remote and the local port are on the same host
+     */
+    bool isUnixSockSupported(yarp::os::ConnectionState& proto);
+    bool becomeUnixSocket(yarp::os::ConnectionState& proto, bool sender = false);
+};
+
+#endif // YARP_UNIX_UNIXSOCKETCARRIER_H

--- a/src/carriers/unix/UnixSocketLogComponent.cpp
+++ b/src/carriers/unix/UnixSocketLogComponent.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "UnixSocketLogComponent.h"
+
+YARP_LOG_COMPONENT(UNIXSOCK_CARRIER,
+                   "yarp.carrier.UnixSocketCarrier",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)

--- a/src/carriers/unix/UnixSocketLogComponent.h
+++ b/src/carriers/unix/UnixSocketLogComponent.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_MJPEGLOGCOMPONENT_H
+#define YARP_MJPEGLOGCOMPONENT_H
+
+#include <yarp/os/LogComponent.h>
+
+YARP_DECLARE_LOG_COMPONENT(UNIXSOCK_CARRIER)
+
+#endif // YARP_MJPEGLOGCOMPONENT_H


### PR DESCRIPTION
### Carriers

* Added the new `unix_stream` and `unix_stream_ack` carriers to communicate with
  a process on the same machine using a unix socket.

---

This PR includes the `unix_stream` and `unix_stream_ack` carriers, formerly developed separately, in YARP.

These carrier have been tested on Linux and on Windows using WSL, have proven to be very reliable and fast, and they were able to transfer up to 4K video (3840x2160) at 30fps (28.7fps the version with ack). Therefore we believe that, even if the release is very close, they deserve to be included in the next release, since this is a great improvement when transferring large data between processes on the same machine.

![Screenshot_20200724_125555](https://user-images.githubusercontent.com/1100056/88531522-4471a800-d003-11ea-8ee9-bd695b071378.png)

If you had the version developed externally installed, please remove it before installing this.

---

Credits and thanks to @Nicogene for the first implementation, @elandini84 for fixing the bidirectional stream and helping with the testing on wsl, @randaz81 for helping.