### PR TITLE
[Discussion] Add yarp::os::getEnvironment(), yarp::os::setEnvironment() and yarp::os::unsetEnvironment() functions and deprecate NetworkBase version.

### DIFF
--- a/doc/release/master/os_getEnvironment.md
+++ b/doc/release/master/os_getEnvironment.md
@@ -1,0 +1,15 @@
+os_getEnvironment {#master}
+-----------------
+
+### Libraries
+
+#### `os`
+
+* Add `yarp::os::getEnvironment()`, `yarp::os::setEnvironment()` and
+  `yarp::os::unsetEnvironment()` functions.
+
+##### `Network`
+
+* `getEnvironment()` is now deprecated in favour of `yarp::os::getEnvironment()`
+* `setEnvironment()` is now deprecated in favour of `yarp::os::setEnvironment()`
+* `unsetEnvironment()` is now deprecated in favour of `yarp::os::unsetEnvironment()`

--- a/src/carriers/tcpros_carrier/RosLookup.cpp
+++ b/src/carriers/tcpros_carrier/RosLookup.cpp
@@ -12,6 +12,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ContactStyle.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 
 #include <cstdlib>
 
@@ -117,7 +118,7 @@ bool RosLookup::lookupTopic(const std::string& name) {
 }
 
 yarp::os::Contact RosLookup::getRosCoreAddressFromEnv() {
-    std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+    std::string addr = yarp::os::getEnvironment("ROS_MASTER_URI");
     Contact c = Contact::fromString(addr);
     if (c.isValid()) {
         c.setCarrier("xmlrpc");

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -39,20 +39,20 @@ std::string getYARPRuntimeDir()
     }
 
     // Check YARP_RUNTIME_DIR
-    yarp_runtime_dir = NetworkBase::getEnvironment("YARP_RUNTIME_DIR", &found);
+    yarp_runtime_dir = yarp::os::getEnvironment("YARP_RUNTIME_DIR", &found);
     if (found) {
         return yarp_runtime_dir;
     }
 
     // Check XDG_RUNTIME_DIR
-    std::string xdg_runtime_dir = NetworkBase::getEnvironment("XDG_RUNTIME_DIR", &found);
+    std::string xdg_runtime_dir = yarp::os::getEnvironment("XDG_RUNTIME_DIR", &found);
     if (found) {
         yarp_runtime_dir = xdg_runtime_dir + fs::preferred_separator + "yarp";
         return yarp_runtime_dir;
     }
 
     // Use /tmp/runtime-user
-    std::string user = NetworkBase::getEnvironment("USER", &found);
+    std::string user = yarp::os::getEnvironment("USER", &found);
     if (found) {
         yarp_runtime_dir = "/tmp/runtime-" + user + fs::preferred_separator + "yarp";
         return yarp_runtime_dir;

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -453,7 +453,7 @@ FakeMotionControl::FakeMotionControl() :
     verbose                 (VERY_VERBOSE)
 {
     resizeBuffers();
-    std::string tmp = NetworkBase::getEnvironment("VERBOSE_STICA");
+    std::string tmp = yarp::os::getEnvironment("VERBOSE_STICA");
     verbosewhenok = (tmp != "") ? (bool)NetType::toInt(tmp) :
                                   false;
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
@@ -48,7 +48,7 @@ int Companion::detectRos(bool write)
         return 1;
     }
 
-    std::string uri = NetworkBase::getEnvironment("ROS_MASTER_URI");
+    std::string uri = yarp::os::getEnvironment("ROS_MASTER_URI");
     if (uri=="") {
         yCError(COMPANION, "ROS_MASTER_URI environment variable not set.");
         uri = "http://127.0.0.1:11311/";

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
@@ -9,6 +9,7 @@
 #include <yarp/companion/impl/Companion.h>
 
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/Vocab.h>
 
 #include <algorithm>
@@ -125,7 +126,7 @@ int Companion::cmdPray(int argc, char *argv[])
             state = "displeased";
         }
         bool found = false;
-        name = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        name = yarp::os::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             name = "YARPino";
         }

--- a/src/libYARP_manager/src/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/src/yarp/manager/impl/textparser.h
@@ -63,7 +63,7 @@ public:
                 std::string envName, envValue;
 
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
-                envValue  = yarp::os::NetworkBase::getEnvironment(envName.c_str());
+                envValue  = yarp::os::getEnvironment(envName.c_str());
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
                 return parseText(ret.c_str());
             }

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
@@ -11,6 +11,7 @@
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <string>
 
 #define CONNECTION_TIMEOUT      5.0         //seconds
@@ -69,7 +70,7 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
     std::string strCmd;
     if(szcmd)
     {
-        yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+        yarp::os::Bottle possiblePaths = parsePaths(yarp::os::getEnvironment("PATH"));
         for (size_t i=0; i<possiblePaths.size(); ++i)
         {
             std::string guessString=possiblePaths.get(i).asString() +

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -962,7 +962,7 @@ void yarp::os::NetworkBase::yarpClockInit(yarp::os::yarpClockType clockType, Clo
 {
     std::string clock;
     if (clockType == YARP_CLOCK_DEFAULT) {
-        clock = yarp::os::Network::getEnvironment("YARP_CLOCK");
+        clock = yarp::os::getEnvironment("YARP_CLOCK");
         if (!clock.empty()) {
             clockType = YARP_CLOCK_NETWORK;
         } else {
@@ -978,7 +978,7 @@ void yarp::os::NetworkBase::yarpClockInit(yarp::os::yarpClockType clockType, Clo
 
     case YARP_CLOCK_NETWORK:
         yCDebug(NETWORK, "Using NETWORK clock");
-        clock = yarp::os::Network::getEnvironment("YARP_CLOCK");
+        clock = yarp::os::getEnvironment("YARP_CLOCK");
         // check of valid parameter is done inside the call, throws YARP_FAIL in case of error
         yarp::os::Time::useNetworkClock(clock);
         break;
@@ -2004,7 +2004,7 @@ std::string NetworkBase::getConfigFile(const char* fname)
 
 int NetworkBase::getDefaultPortRange()
 {
-    std::string range = NetworkBase::getEnvironment("YARP_PORT_RANGE");
+    std::string range = yarp::os::getEnvironment("YARP_PORT_RANGE");
     if (!range.empty()) {
         int irange = NetType::toInt(range);
         if (irange != 0) {

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -16,6 +16,7 @@
 #include <yarp/os/MultiNameSpace.h>
 #include <yarp/os/NameSpace.h>
 #include <yarp/os/NetType.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/OutputProtocol.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/Route.h>
@@ -1416,29 +1417,25 @@ NameStore* NetworkBase::getQueryBypass()
     return getNameSpace().getQueryBypass();
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4.0
 
 std::string NetworkBase::getEnvironment(const char* key,
                                         bool* found)
 {
-    const char* result = yarp::os::impl::getenv(key);
-    if (found != nullptr) {
-        *found = (result != nullptr);
-    }
-    if (result == nullptr) {
-        return {};
-    }
-    return std::string(result);
+    return yarp::os::getEnvironment(key, found);
 }
 
 void NetworkBase::setEnvironment(const std::string& key, const std::string& val)
 {
-    yarp::os::impl::setenv(key.c_str(), val.c_str(), 1);
+    return yarp::os::setEnvironment(key, val);
 }
 
 void NetworkBase::unsetEnvironment(const std::string& key)
 {
-    yarp::os::impl::unsetenv(key.c_str());
+    return yarp::os::unsetEnvironment(key);
 }
+
+#endif
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3.0
 

--- a/src/libYARP_os/src/yarp/os/Network.h
+++ b/src/libYARP_os/src/yarp/os/Network.h
@@ -535,38 +535,42 @@ public:
 
     static NameStore* getQueryBypass();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
-     *
      * Read a variable from the environment.
      *
      * @param key the variable to read
      * @param found an optional variable to set to true iff variable is found
      * @return the value of the environment variable, or "" if not found
      *
+     * @deprecated Since YARP 3.4. Use yarp::os::getEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::os::getEnvironment instead")
     static std::string getEnvironment(const char* key,
                                       bool* found = nullptr);
 
     /**
-     *
      * Set or change an environment variable.
      *
      * @param key the variable to set or change
      * @param val the target value
      *
+     * @deprecated Since YARP 3.4. Use yarp::os::setEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::os::setEnvironment instead")
     static void setEnvironment(const std::string& key,
                                const std::string& val);
 
     /**
-     *
      * Remove an environment variable.
      *
      * @param key the variable to remove
      *
+     * @deprecated Since YARP 3.4. Use yarp::os::unsetEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::os::unsetEnvironment instead")
     static void unsetEnvironment(const std::string& key);
-
+#endif // YARP_NO_DEPRECATED
 
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3.0

--- a/src/libYARP_os/src/yarp/os/Node.cpp
+++ b/src/libYARP_os/src/yarp/os/Node.cpp
@@ -300,7 +300,7 @@ public:
 
     void getMasterUri(NodeArgs& na)
     {
-        na.reply = Value(NetworkBase::getEnvironment("ROS_MASTER_URI"));
+        na.reply = Value(yarp::os::getEnvironment("ROS_MASTER_URI"));
         na.success();
     }
 

--- a/src/libYARP_os/src/yarp/os/Os.cpp
+++ b/src/libYARP_os/src/yarp/os/Os.cpp
@@ -36,6 +36,28 @@ const char* yarp::os::getenv(const char* var)
     return yarp::os::impl::getenv(var);
 }
 
+std::string yarp::os::getEnvironment(const char* key, bool* found)
+{
+    const char* result = yarp::os::impl::getenv(key);
+    if (found != nullptr) {
+        *found = (result != nullptr);
+    }
+    if (result == nullptr) {
+        return {};
+    }
+    return std::string(result);
+}
+
+void yarp::os::setEnvironment(const std::string& key, const std::string& val)
+{
+    yarp::os::impl::setenv(key.c_str(), val.c_str(), 1);
+}
+
+void yarp::os::unsetEnvironment(const std::string& key)
+{
+    yarp::os::impl::unsetenv(key.c_str());
+}
+
 int yarp::os::mkdir(const char* p)
 {
     return yarp::os::impl::mkdir(p, 0755);

--- a/src/libYARP_os/src/yarp/os/Os.h
+++ b/src/libYARP_os/src/yarp/os/Os.h
@@ -30,6 +30,36 @@ namespace os {
 YARP_os_API const char* getenv(const char* var);
 
 /**
+ * Read a variable from the environment.
+ *
+ * @param key the variable to read
+ * @param found an optional variable to set to true iff variable is found
+ * @return the value of the environment variable, or "" if not found
+ *
+ * @since YARP 3.4
+ */
+YARP_os_API std::string getEnvironment(const char* key, bool* found = nullptr);
+
+/**
+ * Set or change an environment variable.
+ *
+ * @param key the variable to set or change
+ * @param val the target value
+ *
+ * @since YARP 3.4
+ */
+YARP_os_API void setEnvironment(const std::string& key, const std::string& val);
+
+/**
+ * Remove an environment variable.
+ *
+ * @param key the variable to remove
+ *
+ * @since YARP 3.4
+ */
+YARP_os_API void unsetEnvironment(const std::string& key);
+
+/**
  * @brief Portable wrapper for the getppid() function.
  *
  * Get process identification.

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -14,6 +14,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Contact.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/Portable.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/LogComponent.h>
@@ -101,7 +102,7 @@ bool Port::open(const Contact& contact, bool registerName, const char* fakeName)
 
     NameConfig conf;
     std::string nenv = std::string("YARP_RENAME") + conf.getSafeString(n);
-    std::string rename = NetworkBase::getEnvironment(nenv.c_str());
+    std::string rename = yarp::os::getEnvironment(nenv.c_str());
     if (!rename.empty()) {
         n = rename;
         contact2.setName(n);
@@ -147,7 +148,7 @@ bool Port::open(const Contact& contact, bool registerName, const char* fakeName)
     }
     if (!n.empty() && n != "..." && n[0] != '=' && n.substr(0, 3) != "...") {
         if (fakeName == nullptr) {
-            std::string prefix = NetworkBase::getEnvironment("YARP_PORT_PREFIX");
+            std::string prefix = yarp::os::getEnvironment("YARP_PORT_PREFIX");
             if (!prefix.empty()) {
                 n = prefix + n;
                 contact2.setName(n);

--- a/src/libYARP_os/src/yarp/os/Property.cpp
+++ b/src/libYARP_os/src/yarp/os/Property.cpp
@@ -11,7 +11,7 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/StringInputStream.h>
 #include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/LogComponent.h>
@@ -791,7 +791,7 @@ public:
                 }
                 inVar = false;
                 yCTrace(PROPERTY, "VARIABLE %s\n", var.c_str());
-                std::string add = NetworkBase::getEnvironment(var.c_str());
+                std::string add = yarp::os::getEnvironment(var.c_str());
                 if (add.empty()) {
                     add = env.find(var).toString();
                 }

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
@@ -476,7 +476,7 @@ public:
         if ((locs & ResourceFinderOptions::Robot) != 0) {
             std::string slash{fs::preferred_separator};
             bool found = false;
-            std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+            std::string robot = yarp::os::getEnvironment("YARP_ROBOT_NAME", &found);
             if (!found) {
                 robot = "default";
             }
@@ -716,7 +716,7 @@ public:
             return configFilePath;
         }
         bool found = false;
-        std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        std::string robot = yarp::os::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             robot = "default";
         }
@@ -981,23 +981,23 @@ std::string ResourceFinder::getDataHomeWithPossibleCreation(bool mayCreate)
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    std::string yarp_version = NetworkBase::getEnvironment("YARP_DATA_HOME",
+    std::string yarp_version = yarp::os::getEnvironment("YARP_DATA_HOME",
                                                            &found);
     if (!yarp_version.empty()) {
         return yarp_version;
     }
-    std::string xdg_version = NetworkBase::getEnvironment("XDG_DATA_HOME",
+    std::string xdg_version = yarp::os::getEnvironment("XDG_DATA_HOME",
                                                           &found);
     if (found) {
         return createIfAbsent(mayCreate, xdg_version + slash + "yarp");
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("APPDATA");
+    std::string app_version = yarp::os::getEnvironment("APPDATA");
     if (app_version != "") {
         return createIfAbsent(mayCreate, app_version + slash + "yarp");
     }
 #endif
-    std::string home_version = NetworkBase::getEnvironment("HOME");
+    std::string home_version = yarp::os::getEnvironment("HOME");
 #if defined(__APPLE__)
     if (home_version != "") {
         return createIfAbsent(mayCreate,
@@ -1022,18 +1022,18 @@ std::string ResourceFinder::getConfigHomeWithPossibleCreation(bool mayCreate)
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    std::string yarp_version = NetworkBase::getEnvironment("YARP_CONFIG_HOME",
+    std::string yarp_version = yarp::os::getEnvironment("YARP_CONFIG_HOME",
                                                            &found);
     if (found) {
         return yarp_version;
     }
-    std::string xdg_version = NetworkBase::getEnvironment("XDG_CONFIG_HOME",
+    std::string xdg_version = yarp::os::getEnvironment("XDG_CONFIG_HOME",
                                                           &found);
     if (found) {
         return createIfAbsent(mayCreate, xdg_version + slash + "yarp");
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("APPDATA");
+    std::string app_version = yarp::os::getEnvironment("APPDATA");
     if (app_version != "") {
         return createIfAbsent(mayCreate,
                               app_version + slash + "yarp" + slash + "config");
@@ -1048,7 +1048,7 @@ std::string ResourceFinder::getConfigHomeWithPossibleCreation(bool mayCreate)
                                   + slash + "config");
     }
 #endif
-    std::string home_version = NetworkBase::getEnvironment("HOME");
+    std::string home_version = yarp::os::getEnvironment("HOME");
     if (!home_version.empty()) {
         return createIfAbsent(mayCreate,
                               home_version
@@ -1072,19 +1072,19 @@ Bottle ResourceFinder::getDataDirs()
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_DATA_DIRS",
+    Bottle yarp_version = parsePaths(yarp::os::getEnvironment("YARP_DATA_DIRS",
                                                                  &found));
     if (found) {
         return yarp_version;
     }
-    Bottle xdg_version = parsePaths(NetworkBase::getEnvironment("XDG_DATA_DIRS",
+    Bottle xdg_version = parsePaths(yarp::os::getEnvironment("XDG_DATA_DIRS",
                                                                 &found));
     if (found) {
         appendResourceType(xdg_version, "yarp");
         return xdg_version;
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("YARP_DIR");
+    std::string app_version = yarp::os::getEnvironment("YARP_DIR");
     if (app_version != "") {
         appendResourceType(app_version, "share");
         appendResourceType(app_version, "yarp");
@@ -1103,19 +1103,19 @@ Bottle ResourceFinder::getDataDirs()
 Bottle ResourceFinder::getConfigDirs()
 {
     bool found = false;
-    Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_CONFIG_DIRS",
+    Bottle yarp_version = parsePaths(yarp::os::getEnvironment("YARP_CONFIG_DIRS",
                                                                  &found));
     if (found) {
         return yarp_version;
     }
-    Bottle xdg_version = parsePaths(NetworkBase::getEnvironment("XDG_CONFIG_DIRS",
+    Bottle xdg_version = parsePaths(yarp::os::getEnvironment("XDG_CONFIG_DIRS",
                                                                 &found));
     if (found) {
         appendResourceType(xdg_version, "yarp");
         return xdg_version;
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("ALLUSERSPROFILE");
+    std::string app_version = yarp::os::getEnvironment("ALLUSERSPROFILE");
     if (app_version != "") {
         appendResourceType(app_version, "yarp");
         Bottle result;

--- a/src/libYARP_os/src/yarp/os/RosNameSpace.cpp
+++ b/src/libYARP_os/src/yarp/os/RosNameSpace.cpp
@@ -554,7 +554,7 @@ Contact RosNameSpace::detectNameServer(bool useDetectedServer,
     if (!c.isValid()) {
         scanNeeded = true;
         yCInfo(ROSNAMESPACE, "Checking for ROS_MASTER_URI...");
-        std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+        std::string addr = yarp::os::getEnvironment("ROS_MASTER_URI");
         c = Contact::fromString(addr);
         if (c.isValid()) {
             c.setCarrier("xmlrpc");

--- a/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
@@ -12,6 +12,7 @@
 #include <yarp/conf/system.h>
 
 #include <yarp/os/NetType.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/LogComponent.h>
 
@@ -188,12 +189,12 @@ void DgramTwoWayStream::allocate(int readSize, int writeSize)
     int _read_size = -1;
     int _write_size = -1;
 
-    std::string _env_dgram = NetworkBase::getEnvironment("YARP_DGRAM_SIZE");
+    std::string _env_dgram = yarp::os::getEnvironment("YARP_DGRAM_SIZE");
     std::string _env_mode;
     if (multiMode) {
-        _env_mode = NetworkBase::getEnvironment("YARP_MCAST_SIZE");
+        _env_mode = yarp::os::getEnvironment("YARP_MCAST_SIZE");
     } else {
-        _env_mode = NetworkBase::getEnvironment("YARP_UDP_SIZE");
+        _env_mode = yarp::os::getEnvironment("YARP_UDP_SIZE");
     }
     if (!_env_mode.empty()) {
         _env_dgram = _env_mode;
@@ -258,11 +259,11 @@ void DgramTwoWayStream::configureSystemBuffers()
     //By default the buffers are forced to the datagram size limit.
     //These can be overwritten by environment variables
     //Generic variable
-    std::string socketBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
+    std::string socketBufferSize = yarp::os::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
     //Specific read
-    std::string socketReadBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_RECV_BUFFER_SIZE");
+    std::string socketReadBufferSize = yarp::os::getEnvironment("YARP_DGRAM_RECV_BUFFER_SIZE");
     //Specific write
-    std::string socketSendBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_SND_BUFFER_SIZE");
+    std::string socketSendBufferSize = yarp::os::getEnvironment("YARP_DGRAM_SND_BUFFER_SIZE");
 
     int readBufferSize = -1;
     if (!socketReadBufferSize.empty()) {

--- a/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
@@ -175,7 +175,7 @@ Contact NameClient::registerName(const std::string& name, const Contact& suggest
     } else {
         cmd.addString("...");
     }
-    std::string prefix = NetworkBase::getEnvironment("YARP_IP");
+    std::string prefix = yarp::os::getEnvironment("YARP_IP");
     const NestedContact& nc = suggest.getNested();
     std::string typ = nc.getTypeNameStar();
     if (suggest.isValid() || !prefix.empty() || typ != "*") {

--- a/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
@@ -435,7 +435,7 @@ void NameConfig::setNamespace(const std::string& ns)
 std::string NameConfig::getNamespace(bool refresh)
 {
     if (space.empty() || refresh) {
-        std::string senv = NetworkBase::getEnvironment("YARP_NAMESPACE");
+        std::string senv = yarp::os::getEnvironment("YARP_NAMESPACE");
         if (!senv.empty()) {
             spaces.fromString(senv);
         } else {

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
@@ -14,6 +14,7 @@
 #include <yarp/os/InputProtocol.h>
 #include <yarp/os/Name.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/PortInfo.h>
 #include <yarp/os/RosNameSpace.h>
 #include <yarp/os/StringOutputStream.h>
@@ -1767,7 +1768,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         Bottle result;
 
         bool found = false;
-        std::string name = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        std::string name = yarp::os::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             name = getName();
             // Remove initial "/"

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -695,7 +695,7 @@ int yarp::run::Run::server()
             std::string fileName=msg.find("which").asString();
             if (fileName!="")
             {
-                yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+                yarp::os::Bottle possiblePaths = parsePaths(yarp::os::getEnvironment("PATH"));
                 for (int i=0; i<possiblePaths.size(); ++i)
                 {
                     std::string guessString=possiblePaths.get(i).asString() +
@@ -920,7 +920,7 @@ int yarp::run::Run::server()
                 std::string fileName=msg.find("which").asString();
                 if (fileName!="")
                 {
-                    yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+                    yarp::os::Bottle possiblePaths = parsePaths(yarp::os::getEnvironment("PATH"));
                     for (size_t i=0; i<possiblePaths.size(); ++i)
                     {
                         std::string guessString=possiblePaths.get(i).asString() + slash + fileName;

--- a/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
@@ -11,6 +11,7 @@
 
 #include <yarp/os/Carriers.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/RosNameSpace.h>
 #include <yarp/os/Value.h>
 #include <yarp/name/BootstrapServer.h>
@@ -127,7 +128,7 @@ bool NameServerContainer::open(Searchable& options)
         }
     }
 
-    if (options.check("ros") || NetworkBase::getEnvironment("YARP_USE_ROS")!="") {
+    if (options.check("ros") || yarp::os::getEnvironment("YARP_USE_ROS")!="") {
         yarp::os::Bottle lst = yarp::os::Carriers::listCarriers();
         std::string lstStr(lst.toString());
         if (lstStr.find("rossrv") == std::string::npos ||
@@ -139,7 +140,7 @@ bool NameServerContainer::open(Searchable& options)
             yCError(NAMESERVERCONTAINER, "Aborting.\n");
             return false;
         }
-        std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+        std::string addr = yarp::os::getEnvironment("ROS_MASTER_URI");
         Contact c = Contact::fromString(addr);
         if (c.isValid()) {
             c.setCarrier("xmlrpc");

--- a/tests/devices/harness_devices.cpp
+++ b/tests/devices/harness_devices.cpp
@@ -12,6 +12,7 @@
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/Drivers.h>
 
@@ -112,7 +113,7 @@ static void setup_Environment()
             "yarp" +
             std::string{yarp::conf::filesystem::path_separator} +
             TEST_DATA_DIR;
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
+    yarp::os::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
@@ -124,7 +125,7 @@ static void setup_Environment()
             ".local" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
+    yarp::os::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
     // To ensure that this will behave in the same way if YARP is configured on
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
@@ -134,7 +135,7 @@ static void setup_Environment()
             "etc" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
+    yarp::os::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
             std::string{yarp::conf::filesystem::preferred_separator} +
@@ -145,13 +146,13 @@ static void setup_Environment()
             ".config" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
+    yarp::os::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 
     if (verbose) {
-        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_DIRS").c_str());
-        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_HOME").c_str());
-        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_DIRS").c_str());
-        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_HOME").c_str());
+        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::getEnvironment("YARP_DATA_DIRS").c_str());
+        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::getEnvironment("YARP_DATA_HOME").c_str());
+        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::getEnvironment("YARP_CONFIG_DIRS").c_str());
+        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::getEnvironment("YARP_CONFIG_HOME").c_str());
     }
 }
 

--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -12,6 +12,7 @@
 
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/NameStore.h>
 #include <yarp/os/YarpPlugin.h>
@@ -43,7 +44,7 @@ static void setup_Environment()
             "yarp" +
             std::string{yarp::conf::filesystem::path_separator}  +
             TEST_DATA_DIR;
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
+    yarp::os::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
@@ -55,7 +56,7 @@ static void setup_Environment()
             ".local" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
+    yarp::os::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
     // To ensure that this will behave in the same way if YARP is configured on
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
@@ -65,7 +66,7 @@ static void setup_Environment()
             "etc" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
+    yarp::os::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
             std::string{yarp::conf::filesystem::preferred_separator} +
@@ -76,13 +77,13 @@ static void setup_Environment()
             ".config" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
+    yarp::os::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 
     if (verbose) {
-        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_DIRS").c_str());
-        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_HOME").c_str());
-        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_DIRS").c_str());
-        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_HOME").c_str());
+        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::getEnvironment("YARP_DATA_DIRS").c_str());
+        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::getEnvironment("YARP_DATA_HOME").c_str());
+        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::getEnvironment("YARP_CONFIG_DIRS").c_str());
+        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::getEnvironment("YARP_CONFIG_HOME").c_str());
     }
 }
 

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -27,7 +27,7 @@ static yarp::os::Bottle env;
 static void saveEnvironment(const char *key)
 {
     bool found = false;
-    std::string val = NetworkBase::getEnvironment(key, &found);
+    std::string val = yarp::os::getEnvironment(key, &found);
     Bottle& lst = env.addList();
     lst.addString(key);
     lst.addString(val);
@@ -43,9 +43,9 @@ static void restoreEnvironment()
         std::string val = lst->get(1).asString();
         bool found = lst->get(2).asInt32()?true:false;
         if (!found) {
-            NetworkBase::unsetEnvironment(key);
+            yarp::os::unsetEnvironment(key);
         } else {
-            NetworkBase::setEnvironment(key, val);
+            yarp::os::setEnvironment(key, val);
         }
     }
     env.clear();
@@ -230,14 +230,14 @@ static void setUpTestArea(bool etc_pathd)
     saveEnvironment("YARP_CONFIG_DIRS");
     saveEnvironment("YARP_ROBOT_NAME");
 
-    Network::setEnvironment("YARP_DATA_HOME", pathify(yarp_data_home));
-    Network::setEnvironment("YARP_CONFIG_HOME", pathify(yarp_config_home));
-    Network::setEnvironment("YARP_DATA_DIRS",
+    yarp::os::setEnvironment("YARP_DATA_HOME", pathify(yarp_data_home));
+    yarp::os::setEnvironment("YARP_CONFIG_HOME", pathify(yarp_config_home));
+    yarp::os::setEnvironment("YARP_DATA_DIRS",
                             pathify(yarp_data_dir0) +
                             colon +
                             pathify(yarp_data_dir1));
-    Network::setEnvironment("YARP_CONFIG_DIRS", pathify(yarp_config_dir0));
-    Network::setEnvironment("YARP_ROBOT_NAME", "dummyRobot");
+    yarp::os::setEnvironment("YARP_CONFIG_DIRS", pathify(yarp_config_dir0));
+    yarp::os::setEnvironment("YARP_ROBOT_NAME", "dummyRobot");
 
 
     fout = fopen((pathify(yarp_data_home)+slash+"data.ini").c_str(), "w");
@@ -514,15 +514,15 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         saveEnvironment("YARP_DATA_HOME");
         saveEnvironment("XDG_DATA_HOME");
         saveEnvironment("HOME");
-        Network::setEnvironment("YARP_DATA_HOME", "/foo");
+        yarp::os::setEnvironment("YARP_DATA_HOME", "/foo");
         CHECK(ResourceFinder::getDataHome() == "/foo"); // YARP_DATA_HOME noticed
-        Network::unsetEnvironment("YARP_DATA_HOME");
-        Network::setEnvironment("XDG_DATA_HOME", "/foo");
+        yarp::os::unsetEnvironment("YARP_DATA_HOME");
+        yarp::os::setEnvironment("XDG_DATA_HOME", "/foo");
         std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getDataHome() == (std::string("/foo") + slash + "yarp")); // XDG_DATA_HOME noticed
-        Network::unsetEnvironment("XDG_DATA_HOME");
+        yarp::os::unsetEnvironment("XDG_DATA_HOME");
 #ifdef __linux__
-        Network::setEnvironment("HOME", "/foo");
+        yarp::os::setEnvironment("HOME", "/foo");
         CHECK(ResourceFinder::getDataHome() == "/foo/.local/share/yarp"); // HOME noticed
 #endif
         restoreEnvironment();
@@ -533,15 +533,15 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         saveEnvironment("YARP_CONFIG_HOME");
         saveEnvironment("XDG_CONFIG_HOME");
         saveEnvironment("HOME");
-        Network::setEnvironment("YARP_CONFIG_HOME", "/foo");
+        yarp::os::setEnvironment("YARP_CONFIG_HOME", "/foo");
         CHECK(ResourceFinder::getConfigHome() == "/foo"); // YARP_CONFIG_HOME noticed
-        Network::unsetEnvironment("YARP_CONFIG_HOME");
-        Network::setEnvironment("XDG_CONFIG_HOME", "/foo");
+        yarp::os::unsetEnvironment("YARP_CONFIG_HOME");
+        yarp::os::setEnvironment("XDG_CONFIG_HOME", "/foo");
         std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getConfigHome() == (std::string("/foo") + slash + "yarp")); // XDG_CONFIG_HOME noticed
-        Network::unsetEnvironment("XDG_CONFIG_HOME");
+        yarp::os::unsetEnvironment("XDG_CONFIG_HOME");
 #ifdef __linux__
-        Network::setEnvironment("HOME", "/foo");
+        yarp::os::setEnvironment("HOME", "/foo");
         CHECK(ResourceFinder::getConfigHome() == "/foo/.config/yarp"); // HOME noticed
 #endif
         restoreEnvironment();
@@ -556,25 +556,25 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
-        Network::setEnvironment("YARP_DATA_DIRS", foobar);
+        yarp::os::setEnvironment("YARP_DATA_DIRS", foobar);
         Bottle dirs;
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // YARP_DATA_DIRS parsed as two directories
         CHECK(dirs.get(0).asString() == "/foo"); // YARP_DATA_DIRS first dir ok
         CHECK(dirs.get(1).asString() == "/bar"); // YARP_DATA_DIRS second dir ok
 
-        Network::setEnvironment("YARP_DATA_DIRS", "/foo");
+        yarp::os::setEnvironment("YARP_DATA_DIRS", "/foo");
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 1); // YARP_DATA_DIRS parsed as one directory
 
-        Network::unsetEnvironment("YARP_DATA_DIRS");
-        Network::setEnvironment("XDG_DATA_DIRS", foobar);
+        yarp::os::unsetEnvironment("YARP_DATA_DIRS");
+        yarp::os::setEnvironment("XDG_DATA_DIRS", foobar);
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // XDG_DATA_DIRS gives two directories
         CHECK(dirs.get(0).asString() == yfoo); // XDG_DATA_DIRS first dir ok
         CHECK(dirs.get(1).asString() == ybar); // XDG_DATA_DIRS second dir ok
 
-        Network::unsetEnvironment("XDG_DATA_DIRS");
+        yarp::os::unsetEnvironment("XDG_DATA_DIRS");
 #ifdef __linux__
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // DATA_DIRS default length 2
@@ -594,21 +594,21 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
-        Network::setEnvironment("YARP_CONFIG_DIRS", foobar);
+        yarp::os::setEnvironment("YARP_CONFIG_DIRS", foobar);
         Bottle dirs;
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 2); // YARP_CONFIG_DIRS parsed as two directories
         CHECK(dirs.get(0).asString() == "/foo"); // YARP_CONFIG_DIRS first dir ok
         CHECK(dirs.get(1).asString() == "/bar"); // YARP_CONFIG_DIRS second dir ok
 
-        Network::unsetEnvironment("YARP_CONFIG_DIRS");
-        Network::setEnvironment("XDG_CONFIG_DIRS", foobar);
+        yarp::os::unsetEnvironment("YARP_CONFIG_DIRS");
+        yarp::os::setEnvironment("XDG_CONFIG_DIRS", foobar);
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 2); // XDG_CONFIG_DIRS gives two directories
         CHECK(dirs.get(0).asString() == yfoo); // XDG_CONFIG_DIRS first dir ok
         CHECK(dirs.get(1).asString() == ybar); // XDG_CONFIG_DIRS second dir ok
 
-        Network::unsetEnvironment("XDG_CONFIG_DIRS");
+        yarp::os::unsetEnvironment("XDG_CONFIG_DIRS");
 #ifdef __linux__
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 1); // CONFIG_DIRS default length 1
@@ -760,8 +760,7 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
             rf.configure(0, nullptr);
 
             bool found;
-            std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME",
-                                                            &found);
+            std::string robot = yarp::os::getEnvironment("YARP_ROBOT_NAME", &found);
             if (!found) robot = "default";
             CHECK(rf.getHomeContextPath() == ResourceFinder::getDataHome() + slash + "contexts" + slash + "my_app"); // $YARP_DATA_HOME/contexts/my_app found as directory for writing
             CHECK(rf.getHomeRobotPath() == ResourceFinder::getDataHome() + slash + "robots" + slash + robot); // $YARP_DATA_HOME/robots/dummyRobot found as directory for writing


### PR DESCRIPTION
This PR is a "Discussion PR" (which is a term I just made up), I will not merge this without a proper discussion.

-----------

### Libraries

#### `os`

* Add `yarp::os::getEnvironment()`, `yarp::os::setEnvironment()` and `yarp::os::unsetEnvironment()` functions.

##### `Network`

* `getEnvironment()` is now deprecated in favour of `yarp::os::getEnvironment()`
* `setEnvironment()` is now deprecated in favour of `yarp::os::setEnvironment()`
* `unsetEnvironment()` is now deprecated in favour of `yarp::os::unsetEnvironment()`

-----------

As discussed in several occasions (#1853), there is no reason for having these static methods in `yarp::os::Network`, it is actually misleading and a source of circular dependencies. `Network` should be a class related to "YARP Network", and the system environment has nothing to do with that.

This patch moves these methods in the `yarp::os` namespace and deprecates the `yarp::os::Network` and `yarp::os::NetworkBase` versions

It's quite late for the release, but this should be a rather "safe" change, but there is a deprecation involved.

In #1853 @Nicogene proposed to move these methods in the `yarp::conf::environment` namespace, but these methods depend on functions that are currently in `yarp::os` and that depend on stuff in `yarp::os::impl` therefore it is not so easy to move them outside `yarp::os`.
Therefore, even if this is probably not an ideal solution, I suggest to move these methods in the `yarp::os` namespace, removing in this way the circular dependencies. AFAIK, here is no c++ proposal for handling the environment variables yet, therefore the `yarp::conf` version could be reserved in case there will be one in the future, and could have the same API.

CC @pattacini, @vtikha, @traversaro, @randaz81, @Nicogene, @elandini84, @lornat75, @robotology/yarp-developers 

Fixes #1853  