### PR TITLE
[Discussion] Add yarp::conf::environment::{get,set,unset}Environment() functions and deprecate NetworkBase version and yarp::os::getenv

### DIFF
--- a/doc/release/master/conf_getEnvironment.md
+++ b/doc/release/master/conf_getEnvironment.md
@@ -1,0 +1,22 @@
+conf_getEnvironment {#master}
+-------------------
+
+### Libraries
+
+#### `conf`
+
+* Added the `yarp/conf/environment.h` header.
+* Added the following functions:
+  * `yarp::conf::environment::getEnvironment()`
+  * `yarp::conf::environment::setEnvironment()`
+  * `yarp::conf::environment::unsetEnvironment()`
+
+#### `os`
+
+* The method `yarp::os::getenv()` is now deprecated in favour of `std::getenv()`
+
+##### `Network`
+
+* `getEnvironment()` is now deprecated in favour of `yarp::conf::environment::getEnvironment()`
+* `setEnvironment()` is now deprecated in favour of `yarp::conf::environment::setEnvironment()`
+* `unsetEnvironment()` is now deprecated in favour of `yarp::conf::environment::unsetEnvironment()`

--- a/src/carriers/tcpros_carrier/RosLookup.cpp
+++ b/src/carriers/tcpros_carrier/RosLookup.cpp
@@ -9,6 +9,8 @@
 #include "RosLookup.h"
 #include "TcpRosLogComponent.h"
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ContactStyle.h>
 #include <yarp/os/Network.h>
@@ -117,7 +119,7 @@ bool RosLookup::lookupTopic(const std::string& name) {
 }
 
 yarp::os::Contact RosLookup::getRosCoreAddressFromEnv() {
-    std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+    std::string addr = yarp::conf::environment::getEnvironment("ROS_MASTER_URI");
     Contact c = Contact::fromString(addr);
     if (c.isValid()) {
         c.setCarrier("xmlrpc");

--- a/src/carriers/unix/UnixSocketCarrier.cpp
+++ b/src/carriers/unix/UnixSocketCarrier.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "UnixSocketCarrier.h"
+
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
 
 #include <yarp/os/ConnectionState.h>
@@ -39,20 +41,20 @@ std::string getYARPRuntimeDir()
     }
 
     // Check YARP_RUNTIME_DIR
-    yarp_runtime_dir = NetworkBase::getEnvironment("YARP_RUNTIME_DIR", &found);
+    yarp_runtime_dir = yarp::conf::environment::getEnvironment("YARP_RUNTIME_DIR", &found);
     if (found) {
         return yarp_runtime_dir;
     }
 
     // Check XDG_RUNTIME_DIR
-    std::string xdg_runtime_dir = NetworkBase::getEnvironment("XDG_RUNTIME_DIR", &found);
+    std::string xdg_runtime_dir = yarp::conf::environment::getEnvironment("XDG_RUNTIME_DIR", &found);
     if (found) {
         yarp_runtime_dir = xdg_runtime_dir + fs::preferred_separator + "yarp";
         return yarp_runtime_dir;
     }
 
     // Use /tmp/runtime-user
-    std::string user = NetworkBase::getEnvironment("USER", &found);
+    std::string user = yarp::conf::environment::getEnvironment("USER", &found);
     if (found) {
         yarp_runtime_dir = "/tmp/runtime-" + user + fs::preferred_separator + "yarp";
         return yarp_runtime_dir;

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -8,6 +8,8 @@
 
 #include "fakeMotionControl.h"
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/LogComponent.h>
@@ -453,7 +455,7 @@ FakeMotionControl::FakeMotionControl() :
     verbose                 (VERY_VERBOSE)
 {
     resizeBuffers();
-    std::string tmp = NetworkBase::getEnvironment("VERBOSE_STICA");
+    std::string tmp = yarp::conf::environment::getEnvironment("VERBOSE_STICA");
     verbosewhenok = (tmp != "") ? (bool)NetType::toInt(tmp) :
                                   false;
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdClock.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdClock.cpp
@@ -8,6 +8,8 @@
 
 #include <yarp/companion/impl/Companion.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>
@@ -61,11 +63,10 @@ int Companion::cmdClock(int argc, char *argv[])
      * If not, we check the environment variable.
      * If no env variable is present, use the '/clock' as fallback.
      */
-    portName = [](){
-        const char *result = yarp::os::getenv("YARP_CLOCK");
-        return std::string{result != nullptr ? result : "/clock"};
-    }();
-
+    portName = yarp::conf::environment::getEnvironment("YARP_CLOCK");
+    if (portName.empty()) {
+        portName = "/clock";
+    }
 
     portName = config.check("name", Value(portName), "name of port broadcasting the time").asString();
 

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
@@ -9,6 +9,8 @@
 
 #include <yarp/companion/impl/Companion.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Contact.h>
 #include <yarp/os/Carriers.h>
 #include <yarp/os/Carrier.h>
@@ -48,7 +50,7 @@ int Companion::detectRos(bool write)
         return 1;
     }
 
-    std::string uri = NetworkBase::getEnvironment("ROS_MASTER_URI");
+    std::string uri = yarp::conf::environment::getEnvironment("ROS_MASTER_URI");
     if (uri=="") {
         yCError(COMPANION, "ROS_MASTER_URI environment variable not set.");
         uri = "http://127.0.0.1:11311/";

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
@@ -8,6 +8,8 @@
 
 #include <yarp/companion/impl/Companion.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Network.h>
 #include <yarp/os/Vocab.h>
 
@@ -125,7 +127,7 @@ int Companion::cmdPray(int argc, char *argv[])
             state = "displeased";
         }
         bool found = false;
-        name = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        name = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             name = "YARPino";
         }

--- a/src/libYARP_conf/src/yarp/conf/environment.h
+++ b/src/libYARP_conf/src/yarp/conf/environment.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_CONF_ENVIRONMENT_H
+#define YARP_CONF_ENVIRONMENT_H
+
+#include <yarp/conf/system.h>
+
+#include <string>
+#include <cstdlib>
+
+namespace yarp {
+namespace conf {
+namespace environment {
+
+/**
+ * Read a variable from the environment.
+ *
+ * @param key the variable to read
+ * @param found an optional variable to set to true iff variable is found
+ * @return the value of the environment variable, or "" if not found
+ *
+ * @since YARP 3.4
+ */
+inline std::string getEnvironment(const char* key, bool* found = nullptr)
+{
+    const char* result = std::getenv(key);
+    if (found != nullptr) {
+        *found = (result != nullptr);
+    }
+    if (result == nullptr) {
+        return {};
+    }
+    return std::string(result);
+}
+
+/**
+ * Set or change an environment variable.
+ *
+ * @param key the variable to set or change
+ * @param val the target value
+ *
+ * @since YARP 3.4
+ */
+inline void setEnvironment(const std::string& key, const std::string& val)
+{
+#if defined(_MSC_VER)
+    _putenv_s(key.c_str(), val.c_str());
+#else
+    ::setenv(key.c_str(), val.c_str(), 1);
+#endif
+}
+
+/**
+ * Remove an environment variable.
+ *
+ * @param key the variable to remove
+ *
+ * @since YARP 3.4
+ */
+inline void unsetEnvironment(const std::string& key)
+{
+#if defined(_MSC_VER)
+    _putenv_s(key.c_str(), "");
+#else
+    ::unsetenv(key.c_str());
+#endif
+}
+
+
+} // namespace filesystem
+} // namespace conf
+} // namespace yarp
+
+#endif // YARP_CONF_ENVIRONMENT_H

--- a/src/libYARP_manager/src/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/src/yarp/manager/impl/textparser.h
@@ -10,6 +10,7 @@
 #define TEXTPARSER_H
 #include <string>
 #include <map>
+#include <yarp/conf/environment.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/LogStream.h>
 #include <iostream>
@@ -63,7 +64,7 @@ public:
                 std::string envName, envValue;
 
                 envName   = ret.substr(s + startKeyword.size(), e - s -startKeyword.size());
-                envValue  = yarp::os::NetworkBase::getEnvironment(envName.c_str());
+                envValue  = yarp::conf::environment::getEnvironment(envName.c_str());
                 ret       = ret.substr(0, s)+ envValue + ret.substr(e + endKeyword.size(), ret.size() - endKeyword.size());
                 return parseText(ret.c_str());
             }

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
@@ -8,9 +8,12 @@
 
 #include <yarp/manager/scriptbroker.h>
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
+
 #include <string>
 
 #define CONNECTION_TIMEOUT      5.0         //seconds
@@ -69,7 +72,7 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
     std::string strCmd;
     if(szcmd)
     {
-        yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+        yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::getEnvironment("PATH"));
         for (size_t i=0; i<possiblePaths.size(); ++i)
         {
             std::string guessString=possiblePaths.get(i).asString() +

--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -292,7 +292,6 @@ set(YARP_os_IMPL_HDRS yarp/os/impl/AuthHMAC.h
                       yarp/os/impl/PlatformNetdb.h
                       yarp/os/impl/PlatformSignal.h
                       yarp/os/impl/PlatformStdio.h
-                      yarp/os/impl/PlatformStdlib.h
                       yarp/os/impl/PlatformSysStat.h
                       yarp/os/impl/PlatformSysWait.h
                       yarp/os/impl/PlatformTime.h

--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -201,7 +201,7 @@ namespace {
 
 inline bool from_env(const char* name, bool defaultvalue)
 {
-    const char *strvalue = yarp::os::getenv(name);
+    const char *strvalue = std::getenv(name);
 
     if(!strvalue) { return defaultvalue; }
 

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -962,7 +962,7 @@ void yarp::os::NetworkBase::yarpClockInit(yarp::os::yarpClockType clockType, Clo
 {
     std::string clock;
     if (clockType == YARP_CLOCK_DEFAULT) {
-        clock = yarp::os::Network::getEnvironment("YARP_CLOCK");
+        clock = yarp::conf::environment::getEnvironment("YARP_CLOCK");
         if (!clock.empty()) {
             clockType = YARP_CLOCK_NETWORK;
         } else {
@@ -978,7 +978,7 @@ void yarp::os::NetworkBase::yarpClockInit(yarp::os::yarpClockType clockType, Clo
 
     case YARP_CLOCK_NETWORK:
         yCDebug(NETWORK, "Using NETWORK clock");
-        clock = yarp::os::Network::getEnvironment("YARP_CLOCK");
+        clock = yarp::conf::environment::getEnvironment("YARP_CLOCK");
         // check of valid parameter is done inside the call, throws YARP_FAIL in case of error
         yarp::os::Time::useNetworkClock(clock);
         break;
@@ -2004,7 +2004,7 @@ std::string NetworkBase::getConfigFile(const char* fname)
 
 int NetworkBase::getDefaultPortRange()
 {
-    std::string range = NetworkBase::getEnvironment("YARP_PORT_RANGE");
+    std::string range = yarp::conf::environment::getEnvironment("YARP_PORT_RANGE");
     if (!range.empty()) {
         int irange = NetType::toInt(range);
         if (irange != 0) {

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -9,6 +9,7 @@
 
 #include <yarp/os/Network.h>
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Carriers.h>
@@ -28,7 +29,6 @@
 #include <yarp/os/impl/NameConfig.h>
 #include <yarp/os/impl/PlatformSignal.h>
 #include <yarp/os/impl/PlatformStdio.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformUnistd.h>
 #include <yarp/os/impl/PortCommand.h>
 #include <yarp/os/impl/Terminal.h>
@@ -1417,29 +1417,25 @@ NameStore* NetworkBase::getQueryBypass()
     return getNameSpace().getQueryBypass();
 }
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4.0
 
 std::string NetworkBase::getEnvironment(const char* key,
                                         bool* found)
 {
-    const char* result = yarp::os::impl::getenv(key);
-    if (found != nullptr) {
-        *found = (result != nullptr);
-    }
-    if (result == nullptr) {
-        return {};
-    }
-    return std::string(result);
+    return yarp::conf::environment::getEnvironment(key, found);
 }
 
 void NetworkBase::setEnvironment(const std::string& key, const std::string& val)
 {
-    yarp::os::impl::setenv(key.c_str(), val.c_str(), 1);
+    return yarp::conf::environment::setEnvironment(key, val);
 }
 
 void NetworkBase::unsetEnvironment(const std::string& key)
 {
-    yarp::os::impl::unsetenv(key.c_str());
+    return yarp::conf::environment::unsetEnvironment(key);
 }
+
+#endif
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3.0
 

--- a/src/libYARP_os/src/yarp/os/Network.h
+++ b/src/libYARP_os/src/yarp/os/Network.h
@@ -535,38 +535,42 @@ public:
 
     static NameStore* getQueryBypass();
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
     /**
-     *
      * Read a variable from the environment.
      *
      * @param key the variable to read
      * @param found an optional variable to set to true iff variable is found
      * @return the value of the environment variable, or "" if not found
      *
+     * @deprecated Since YARP 3.4. Use yarp::conf::environment::getEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::conf::environment::getEnvironment instead")
     static std::string getEnvironment(const char* key,
                                       bool* found = nullptr);
 
     /**
-     *
      * Set or change an environment variable.
      *
      * @param key the variable to set or change
      * @param val the target value
      *
+     * @deprecated Since YARP 3.4. Use yarp::conf::environment::setEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::conf::environment::setEnvironment instead")
     static void setEnvironment(const std::string& key,
                                const std::string& val);
 
     /**
-     *
      * Remove an environment variable.
      *
      * @param key the variable to remove
      *
+     * @deprecated Since YARP 3.4. Use yarp::conf::environment::unsetEnvironment instead
      */
+    YARP_DEPRECATED_MSG("Use yarp::conf::environment::unsetEnvironment instead")
     static void unsetEnvironment(const std::string& key);
-
+#endif // YARP_NO_DEPRECATED
 
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.3.0

--- a/src/libYARP_os/src/yarp/os/Node.cpp
+++ b/src/libYARP_os/src/yarp/os/Node.cpp
@@ -9,6 +9,7 @@
 #include <yarp/os/Node.h>
 
 #include <yarp/conf/compiler.h>
+#include <yarp/conf/environment.h>
 
 #include <yarp/os/NestedContact.h>
 #include <yarp/os/Network.h>
@@ -300,7 +301,7 @@ public:
 
     void getMasterUri(NodeArgs& na)
     {
-        na.reply = Value(NetworkBase::getEnvironment("ROS_MASTER_URI"));
+        na.reply = Value(yarp::conf::environment::getEnvironment("ROS_MASTER_URI"));
         na.success();
     }
 

--- a/src/libYARP_os/src/yarp/os/Os.cpp
+++ b/src/libYARP_os/src/yarp/os/Os.cpp
@@ -11,7 +11,6 @@
 #include <yarp/os/impl/NameConfig.h>
 #include <yarp/os/impl/PlatformLimits.h>
 #include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformSysStat.h>
 #include <yarp/os/impl/PlatformUnistd.h>
 
@@ -31,10 +30,12 @@
 #    include <yarp/os/impl/macos/MacOSAPI.h>
 #endif
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4.0
 const char* yarp::os::getenv(const char* var)
 {
-    return yarp::os::impl::getenv(var);
+    return std::getenv(var);
 }
+#endif
 
 int yarp::os::mkdir(const char* p)
 {

--- a/src/libYARP_os/src/yarp/os/Os.h
+++ b/src/libYARP_os/src/yarp/os/Os.h
@@ -19,6 +19,7 @@
 namespace yarp {
 namespace os {
 
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4.0
 /**
  * @brief Portable wrapper for the getenv() function.
  *
@@ -26,8 +27,12 @@ namespace os {
  *
  * @param[in] var string that contains the environment variable name
  * @return the value corresponding to the envarionment variable v
+ *
+ * @deprecated since YARP 3.4.0. Use std::getenv instead.
  */
+YARP_DEPRECATED_MSG("Use std::getenv instead")
 YARP_os_API const char* getenv(const char* var);
+#endif // YARP_NO_DEPRECATED
 
 /**
  * @brief Portable wrapper for the getppid() function.

--- a/src/libYARP_os/src/yarp/os/Port.cpp
+++ b/src/libYARP_os/src/yarp/os/Port.cpp
@@ -10,6 +10,7 @@
 #include <yarp/os/Port.h>
 
 #include <yarp/conf/system.h>
+#include <yarp/conf/environment.h>
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Contact.h>
@@ -101,7 +102,7 @@ bool Port::open(const Contact& contact, bool registerName, const char* fakeName)
 
     NameConfig conf;
     std::string nenv = std::string("YARP_RENAME") + conf.getSafeString(n);
-    std::string rename = NetworkBase::getEnvironment(nenv.c_str());
+    std::string rename = yarp::conf::environment::getEnvironment(nenv.c_str());
     if (!rename.empty()) {
         n = rename;
         contact2.setName(n);
@@ -147,7 +148,7 @@ bool Port::open(const Contact& contact, bool registerName, const char* fakeName)
     }
     if (!n.empty() && n != "..." && n[0] != '=' && n.substr(0, 3) != "...") {
         if (fakeName == nullptr) {
-            std::string prefix = NetworkBase::getEnvironment("YARP_PORT_PREFIX");
+            std::string prefix = yarp::conf::environment::getEnvironment("YARP_PORT_PREFIX");
             if (!prefix.empty()) {
                 n = prefix + n;
                 contact2.setName(n);

--- a/src/libYARP_os/src/yarp/os/Property.cpp
+++ b/src/libYARP_os/src/yarp/os/Property.cpp
@@ -9,9 +9,9 @@
 
 #include <yarp/os/Property.h>
 
+#include <yarp/conf/environment.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetType.h>
-#include <yarp/os/Network.h>
 #include <yarp/os/StringInputStream.h>
 #include <yarp/os/impl/BottleImpl.h>
 #include <yarp/os/impl/LogComponent.h>
@@ -791,7 +791,7 @@ public:
                 }
                 inVar = false;
                 yCTrace(PROPERTY, "VARIABLE %s\n", var.c_str());
-                std::string add = NetworkBase::getEnvironment(var.c_str());
+                std::string add = yarp::conf::environment::getEnvironment(var.c_str());
                 if (add.empty()) {
                     add = env.find(var).toString();
                 }

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
@@ -9,7 +9,9 @@
 
 #include <yarp/os/ResourceFinder.h>
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
@@ -476,7 +478,7 @@ public:
         if ((locs & ResourceFinderOptions::Robot) != 0) {
             std::string slash{fs::preferred_separator};
             bool found = false;
-            std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+            std::string robot = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME", &found);
             if (!found) {
                 robot = "default";
             }
@@ -716,7 +718,7 @@ public:
             return configFilePath;
         }
         bool found = false;
-        std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        std::string robot = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             robot = "default";
         }
@@ -981,23 +983,23 @@ std::string ResourceFinder::getDataHomeWithPossibleCreation(bool mayCreate)
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    std::string yarp_version = NetworkBase::getEnvironment("YARP_DATA_HOME",
+    std::string yarp_version = yarp::conf::environment::getEnvironment("YARP_DATA_HOME",
                                                            &found);
     if (!yarp_version.empty()) {
         return yarp_version;
     }
-    std::string xdg_version = NetworkBase::getEnvironment("XDG_DATA_HOME",
+    std::string xdg_version = yarp::conf::environment::getEnvironment("XDG_DATA_HOME",
                                                           &found);
     if (found) {
         return createIfAbsent(mayCreate, xdg_version + slash + "yarp");
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("APPDATA");
+    std::string app_version = yarp::conf::environment::getEnvironment("APPDATA");
     if (app_version != "") {
         return createIfAbsent(mayCreate, app_version + slash + "yarp");
     }
 #endif
-    std::string home_version = NetworkBase::getEnvironment("HOME");
+    std::string home_version = yarp::conf::environment::getEnvironment("HOME");
 #if defined(__APPLE__)
     if (home_version != "") {
         return createIfAbsent(mayCreate,
@@ -1022,18 +1024,18 @@ std::string ResourceFinder::getConfigHomeWithPossibleCreation(bool mayCreate)
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    std::string yarp_version = NetworkBase::getEnvironment("YARP_CONFIG_HOME",
+    std::string yarp_version = yarp::conf::environment::getEnvironment("YARP_CONFIG_HOME",
                                                            &found);
     if (found) {
         return yarp_version;
     }
-    std::string xdg_version = NetworkBase::getEnvironment("XDG_CONFIG_HOME",
+    std::string xdg_version = yarp::conf::environment::getEnvironment("XDG_CONFIG_HOME",
                                                           &found);
     if (found) {
         return createIfAbsent(mayCreate, xdg_version + slash + "yarp");
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("APPDATA");
+    std::string app_version = yarp::conf::environment::getEnvironment("APPDATA");
     if (app_version != "") {
         return createIfAbsent(mayCreate,
                               app_version + slash + "yarp" + slash + "config");
@@ -1048,7 +1050,7 @@ std::string ResourceFinder::getConfigHomeWithPossibleCreation(bool mayCreate)
                                   + slash + "config");
     }
 #endif
-    std::string home_version = NetworkBase::getEnvironment("HOME");
+    std::string home_version = yarp::conf::environment::getEnvironment("HOME");
     if (!home_version.empty()) {
         return createIfAbsent(mayCreate,
                               home_version
@@ -1072,19 +1074,19 @@ Bottle ResourceFinder::getDataDirs()
 {
     std::string slash{fs::preferred_separator};
     bool found = false;
-    Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_DATA_DIRS",
+    Bottle yarp_version = parsePaths(yarp::conf::environment::getEnvironment("YARP_DATA_DIRS",
                                                                  &found));
     if (found) {
         return yarp_version;
     }
-    Bottle xdg_version = parsePaths(NetworkBase::getEnvironment("XDG_DATA_DIRS",
+    Bottle xdg_version = parsePaths(yarp::conf::environment::getEnvironment("XDG_DATA_DIRS",
                                                                 &found));
     if (found) {
         appendResourceType(xdg_version, "yarp");
         return xdg_version;
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("YARP_DIR");
+    std::string app_version = yarp::conf::environment::getEnvironment("YARP_DIR");
     if (app_version != "") {
         appendResourceType(app_version, "share");
         appendResourceType(app_version, "yarp");
@@ -1103,19 +1105,19 @@ Bottle ResourceFinder::getDataDirs()
 Bottle ResourceFinder::getConfigDirs()
 {
     bool found = false;
-    Bottle yarp_version = parsePaths(NetworkBase::getEnvironment("YARP_CONFIG_DIRS",
+    Bottle yarp_version = parsePaths(yarp::conf::environment::getEnvironment("YARP_CONFIG_DIRS",
                                                                  &found));
     if (found) {
         return yarp_version;
     }
-    Bottle xdg_version = parsePaths(NetworkBase::getEnvironment("XDG_CONFIG_DIRS",
+    Bottle xdg_version = parsePaths(yarp::conf::environment::getEnvironment("XDG_CONFIG_DIRS",
                                                                 &found));
     if (found) {
         appendResourceType(xdg_version, "yarp");
         return xdg_version;
     }
 #if defined(_WIN32)
-    std::string app_version = NetworkBase::getEnvironment("ALLUSERSPROFILE");
+    std::string app_version = yarp::conf::environment::getEnvironment("ALLUSERSPROFILE");
     if (app_version != "") {
         appendResourceType(app_version, "yarp");
         Bottle result;

--- a/src/libYARP_os/src/yarp/os/RosNameSpace.cpp
+++ b/src/libYARP_os/src/yarp/os/RosNameSpace.cpp
@@ -8,6 +8,8 @@
 
 #include <yarp/os/RosNameSpace.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/DummyConnector.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Vocab.h>
@@ -554,7 +556,7 @@ Contact RosNameSpace::detectNameServer(bool useDetectedServer,
     if (!c.isValid()) {
         scanNeeded = true;
         yCInfo(ROSNAMESPACE, "Checking for ROS_MASTER_URI...");
-        std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+        std::string addr = yarp::conf::environment::getEnvironment("ROS_MASTER_URI");
         c = Contact::fromString(addr);
         if (c.isValid()) {
             c.setCarrier("xmlrpc");

--- a/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
@@ -10,6 +10,7 @@
 #include <yarp/os/impl/DgramTwoWayStream.h>
 
 #include <yarp/conf/system.h>
+#include <yarp/conf/environment.h>
 
 #include <yarp/os/NetType.h>
 #include <yarp/os/Time.h>
@@ -188,12 +189,12 @@ void DgramTwoWayStream::allocate(int readSize, int writeSize)
     int _read_size = -1;
     int _write_size = -1;
 
-    std::string _env_dgram = NetworkBase::getEnvironment("YARP_DGRAM_SIZE");
+    std::string _env_dgram = yarp::conf::environment::getEnvironment("YARP_DGRAM_SIZE");
     std::string _env_mode;
     if (multiMode) {
-        _env_mode = NetworkBase::getEnvironment("YARP_MCAST_SIZE");
+        _env_mode = yarp::conf::environment::getEnvironment("YARP_MCAST_SIZE");
     } else {
-        _env_mode = NetworkBase::getEnvironment("YARP_UDP_SIZE");
+        _env_mode = yarp::conf::environment::getEnvironment("YARP_UDP_SIZE");
     }
     if (!_env_mode.empty()) {
         _env_dgram = _env_mode;
@@ -258,11 +259,11 @@ void DgramTwoWayStream::configureSystemBuffers()
     //By default the buffers are forced to the datagram size limit.
     //These can be overwritten by environment variables
     //Generic variable
-    std::string socketBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
+    std::string socketBufferSize = yarp::conf::environment::getEnvironment("YARP_DGRAM_BUFFER_SIZE");
     //Specific read
-    std::string socketReadBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_RECV_BUFFER_SIZE");
+    std::string socketReadBufferSize = yarp::conf::environment::getEnvironment("YARP_DGRAM_RECV_BUFFER_SIZE");
     //Specific write
-    std::string socketSendBufferSize = NetworkBase::getEnvironment("YARP_DGRAM_SND_BUFFER_SIZE");
+    std::string socketSendBufferSize = yarp::conf::environment::getEnvironment("YARP_DGRAM_SND_BUFFER_SIZE");
 
     int readBufferSize = -1;
     if (!socketReadBufferSize.empty()) {

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
@@ -12,12 +12,13 @@
 
 #include <atomic>
 #include <cstring>
+#include <cstdlib>
 
 namespace {
 
 inline bool from_env(const char* name, bool defaultvalue)
 {
-    const char *strvalue = yarp::os::getenv(name);
+    const char *strvalue = std::getenv(name);
 
     if(!strvalue) { return defaultvalue; }
 

--- a/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
@@ -9,6 +9,8 @@
 
 #include <yarp/os/impl/NameClient.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Carriers.h>
 #include <yarp/os/NameStore.h>
@@ -175,7 +177,7 @@ Contact NameClient::registerName(const std::string& name, const Contact& suggest
     } else {
         cmd.addString("...");
     }
-    std::string prefix = NetworkBase::getEnvironment("YARP_IP");
+    std::string prefix = yarp::conf::environment::getEnvironment("YARP_IP");
     const NestedContact& nc = suggest.getNested();
     std::string typ = nc.getTypeNameStar();
     if (suggest.isValid() || !prefix.empty() || typ != "*") {

--- a/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
@@ -12,6 +12,7 @@
 
 #include <yarp/conf/system.h>
 #include <yarp/conf/filesystem.h>
+#include <yarp/conf/environment.h>
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/NetType.h>
@@ -435,7 +436,7 @@ void NameConfig::setNamespace(const std::string& ns)
 std::string NameConfig::getNamespace(bool refresh)
 {
     if (space.empty() || refresh) {
-        std::string senv = NetworkBase::getEnvironment("YARP_NAMESPACE");
+        std::string senv = yarp::conf::environment::getEnvironment("YARP_NAMESPACE");
         if (!senv.empty()) {
             spaces.fromString(senv);
         } else {

--- a/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCore.cpp
@@ -9,6 +9,8 @@
 
 #include <yarp/os/impl/PortCore.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/DummyConnector.h>
 #include <yarp/os/InputProtocol.h>
@@ -1767,7 +1769,7 @@ bool PortCore::adminBlock(ConnectionReader& reader,
         Bottle result;
 
         bool found = false;
-        std::string name = NetworkBase::getEnvironment("YARP_ROBOT_NAME", &found);
+        std::string name = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME", &found);
         if (!found) {
             name = getName();
             // Remove initial "/"

--- a/src/libYARP_run/src/CMakeLists.txt
+++ b/src/libYARP_run/src/CMakeLists.txt
@@ -12,7 +12,9 @@ set(YARP_run_HDRS yarp/run/Run.h)
 set(YARP_run_IMPL_HDRS yarp/run/impl/RunCheckpoints.h
                        yarp/run/impl/RunProcManager.h
                        yarp/run/impl/RunReadWrite.h
-                       yarp/run/impl/PlatformSysPrctl.h)
+                       yarp/run/impl/PlatformSysPrctl.h
+                       yarp/run/impl/PlatformStdlib.h
+                       yarp/run/impl/PlatformUnistd.h)
 
 if(NOT YARP_NO_DEPRECATED) # Since YARP 3.0.0
   set(YARP_run_os_HDRS yarp/os/Run.h)

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -11,10 +11,13 @@
 #include <yarp/run/impl/RunCheckpoints.h>
 #include <yarp/run/impl/RunProcManager.h>
 #include <yarp/run/impl/RunReadWrite.h>
+#include <yarp/run/impl/PlatformStdlib.h>
 #include <yarp/run/impl/PlatformUnistd.h>
 #include <yarp/run/impl/PlatformSysPrctl.h>
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
+
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/LogStream.h>
@@ -28,7 +31,6 @@
 #include <yarp/os/impl/NameClient.h>
 #include <yarp/os/impl/SplitString.h>
 #include <yarp/os/impl/PlatformSignal.h>
-#include <yarp/os/impl/PlatformStdlib.h>
 #include <yarp/os/impl/PlatformStdio.h>
 
 #include <cstdio>
@@ -695,7 +697,7 @@ int yarp::run::Run::server()
             std::string fileName=msg.find("which").asString();
             if (fileName!="")
             {
-                yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+                yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::getEnvironment("PATH"));
                 for (int i=0; i<possiblePaths.size(); ++i)
                 {
                     std::string guessString=possiblePaths.get(i).asString() +
@@ -920,7 +922,7 @@ int yarp::run::Run::server()
                 std::string fileName=msg.find("which").asString();
                 if (fileName!="")
                 {
-                    yarp::os::Bottle possiblePaths = parsePaths(yarp::os::NetworkBase::getEnvironment("PATH"));
+                    yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::getEnvironment("PATH"));
                     for (size_t i=0; i<possiblePaths.size(); ++i)
                     {
                         std::string guessString=possiblePaths.get(i).asString() + slash + fileName;
@@ -2659,11 +2661,11 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
 
                 // Set the YARP_IS_YARPRUN environment variable to 1, so that the child
                 // process will now that is running inside yarprun.
-                yarp::os::impl::putenv(strdup("YARP_IS_YARPRUN=1"));
+                yarp::conf::environment::setEnvironment("YARP_IS_YARPRUN", "1");
 
                 // Set the YARPRUN_IS_FORWARDING_LOG environment variable to 1, so that
                 // the child process will now that yarprun is not logging the output.
-                yarp::os::impl::putenv(strdup("YARPRUN_IS_FORWARDING_LOG=1"));
+                yarp::conf::environment::setEnvironment("YARPRUN_IS_FORWARDING_LOG", "1");
 
                 if (msg.check("env"))
                 {
@@ -2671,7 +2673,7 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
                     for(int i=0; i<ss.size(); i++) {
                         char* szenv = new char[strlen(ss.get(i))+1];
                         strcpy(szenv, ss.get(i));
-                        yarp::os::impl::putenv(szenv); // putenv doesn't make copy of the string
+                        yarp::run::impl::putenv(szenv); // putenv doesn't make copy of the string
                     }
                     //delete [] szenv;
                 }
@@ -3023,11 +3025,11 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
 
                 // Set the YARP_IS_YARPRUN environment variable to 1, so that the child
                 // process will now that is running inside yarprun.
-                yarp::os::impl::putenv(strdup("YARP_IS_YARPRUN=1"));
+                yarp::conf::environment::setEnvironment("YARP_IS_YARPRUN", "1");
 
                 // Set the YARPRUN_IS_FORWARDING_LOG environment variable to 1, so that
                 // the child process will now that yarprun is not logging the output.
-                yarp::os::impl::putenv(strdup("YARPRUN_IS_FORWARDING_LOG=1"));
+                yarp::conf::environment::setEnvironment("YARPRUN_IS_FORWARDING_LOG", "1");
 
                 if (msg.check("env"))
                 {
@@ -3035,7 +3037,7 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
                     for(int i=0; i<ss.size(); i++) {
                         char* szenv = new char[strlen(ss.get(i))+1];
                         strcpy(szenv, ss.get(i));
-                        yarp::os::impl::putenv(szenv); // putenv doesn't make copy of the string
+                        yarp::run::impl::putenv(szenv); // putenv doesn't make copy of the string
                     }
                     //delete [] szenv;
                 }
@@ -3465,11 +3467,11 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
 
         // Set the YARP_IS_YARPRUN environment variable to 1, so that the child
         // process will now that is running inside yarprun.
-        yarp::os::impl::putenv(strdup("YARP_IS_YARPRUN=1"));
+        yarp::conf::environment::setEnvironment("YARP_IS_YARPRUN", "1");
 
         // Set the YARPRUN_IS_FORWARDING_LOG environment variable to 0, so that
         // the child process will now that yarprun is not logging the output.
-        yarp::os::impl::putenv(strdup("YARPRUN_IS_FORWARDING_LOG=0"));
+        yarp::conf::environment::setEnvironment("YARPRUN_IS_FORWARDING_LOG", "0");
 
         if (msg.check("env"))
         {
@@ -3477,7 +3479,7 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
             for(int i=0; i<ss.size(); i++) {
                 char* szenv = new char[strlen(ss.get(i))+1];
                 strcpy(szenv, ss.get(i));
-                yarp::os::impl::putenv(szenv); // putenv doesn't make copy of the string
+                yarp::run::impl::putenv(szenv); // putenv doesn't make copy of the string
             }
         }
 

--- a/src/libYARP_run/src/yarp/run/impl/PlatformStdlib.h
+++ b/src/libYARP_run/src/yarp/run/impl/PlatformStdlib.h
@@ -6,8 +6,8 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef YARP_OS_IMPL_PLATFORMSTDLIB_H
-#define YARP_OS_IMPL_PLATFORMSTDLIB_H
+#ifndef YARP_RUN_IMPL_PLATFORMSTDLIB_H
+#define YARP_RUN_IMPL_PLATFORMSTDLIB_H
 
 #include <yarp/conf/system.h>
 #ifdef YARP_HAS_ACE
@@ -21,7 +21,7 @@
 #endif
 
 namespace yarp {
-namespace os {
+namespace run {
 namespace impl {
 
 
@@ -52,7 +52,7 @@ using ::putenv;
 #endif
 
 } // namespace impl
-} // namespace os
+} // namespace run
 } // namespace yarp
 
-#endif // YARP_OS_IMPL_PLATFORMSTDLIB_H
+#endif // YARP_RUN_IMPL_PLATFORMSTDLIB_H

--- a/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
@@ -9,6 +9,8 @@
 
 #include <yarp/serversql/impl/NameServerContainer.h>
 
+#include <yarp/conf/environment.h>
+
 #include <yarp/os/Carriers.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/RosNameSpace.h>
@@ -127,7 +129,7 @@ bool NameServerContainer::open(Searchable& options)
         }
     }
 
-    if (options.check("ros") || NetworkBase::getEnvironment("YARP_USE_ROS")!="") {
+    if (options.check("ros") || yarp::conf::environment::getEnvironment("YARP_USE_ROS")!="") {
         yarp::os::Bottle lst = yarp::os::Carriers::listCarriers();
         std::string lstStr(lst.toString());
         if (lstStr.find("rossrv") == std::string::npos ||
@@ -139,7 +141,7 @@ bool NameServerContainer::open(Searchable& options)
             yCError(NAMESERVERCONTAINER, "Aborting.\n");
             return false;
         }
-        std::string addr = NetworkBase::getEnvironment("ROS_MASTER_URI");
+        std::string addr = yarp::conf::environment::getEnvironment("ROS_MASTER_URI");
         Contact c = Contact::fromString(addr);
         if (c.isValid()) {
             c.setCarrier("xmlrpc");

--- a/src/yarp-config/yarprobot.cpp
+++ b/src/yarp-config/yarprobot.cpp
@@ -6,11 +6,11 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#include <yarp/conf/environment.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/ResourceFinderOptions.h>
 #include <yarp/os/Bottle.h>
-#include <yarp/os/Os.h>
 #include <cstdio>
 
 #include "yarpcontextutils.h"
@@ -136,9 +136,9 @@ YARP_WARNING_POP
     }
     if(options.check("current"))
     {
-        const char *result = yarp::os::getenv("YARP_ROBOT_NAME");
-        if (result != nullptr)
-            printf("Current robot is %s, identified by the environment variable YARP_ROBOT_NAME\n", result);
+        std::string result = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME");
+        if (result.empty())
+            printf("Current robot is %s, identified by the environment variable YARP_ROBOT_NAME\n", result.c_str());
         else
             printf("No robot is set; please set the YARP_ROBOT_NAME environment variable.\n");
         return 0;

--- a/tests/devices/harness_devices.cpp
+++ b/tests/devices/harness_devices.cpp
@@ -9,6 +9,7 @@
 
 #include "YarpBuildLocation.h"
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
@@ -112,7 +113,7 @@ static void setup_Environment()
             "yarp" +
             std::string{yarp::conf::filesystem::path_separator} +
             TEST_DATA_DIR;
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
+    yarp::conf::environment::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
@@ -124,7 +125,7 @@ static void setup_Environment()
             ".local" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
+    yarp::conf::environment::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
     // To ensure that this will behave in the same way if YARP is configured on
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
@@ -134,7 +135,7 @@ static void setup_Environment()
             "etc" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
             std::string{yarp::conf::filesystem::preferred_separator} +
@@ -145,13 +146,13 @@ static void setup_Environment()
             ".config" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 
     if (verbose) {
-        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_DIRS").c_str());
-        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_HOME").c_str());
-        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_DIRS").c_str());
-        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_HOME").c_str());
+        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_DATA_DIRS").c_str());
+        printf("YARP_DATA_HOME=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_DATA_HOME").c_str());
+        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_CONFIG_DIRS").c_str());
+        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_CONFIG_HOME").c_str());
     }
 }
 

--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -10,6 +10,7 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
 
+#include <yarp/conf/environment.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
@@ -43,7 +44,7 @@ static void setup_Environment()
             "yarp" +
             std::string{yarp::conf::filesystem::path_separator}  +
             TEST_DATA_DIR;
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
+    yarp::conf::environment::setEnvironment("YARP_DATA_DIRS", yarp_data_dirs);
 
     std::string yarp_data_home =
             CMAKE_BINARY_DIR +
@@ -55,7 +56,7 @@ static void setup_Environment()
             ".local" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_DATA_HOME", yarp_data_home);
+    yarp::conf::environment::setEnvironment("YARP_DATA_HOME", yarp_data_home);
 
     // To ensure that this will behave in the same way if YARP is configured on
     // the user's system and on the build machines, YARP_CONFIG_DIRS and
@@ -65,7 +66,7 @@ static void setup_Environment()
             "etc" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_DIRS", yarp_config_dirs);
 
     std::string yarp_config_home = CMAKE_BINARY_DIR +
             std::string{yarp::conf::filesystem::preferred_separator} +
@@ -76,13 +77,13 @@ static void setup_Environment()
             ".config" +
             std::string{yarp::conf::filesystem::preferred_separator} +
             "yarp";
-    yarp::os::NetworkBase::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_HOME", yarp_config_home);
 
     if (verbose) {
-        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_DIRS").c_str());
-        printf("YARP_DATA_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_DATA_HOME").c_str());
-        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_DIRS").c_str());
-        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::os::NetworkBase::getEnvironment("YARP_CONFIG_HOME").c_str());
+        printf("YARP_DATA_DIRS=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_DATA_DIRS").c_str());
+        printf("YARP_DATA_HOME=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_DATA_HOME").c_str());
+        printf("YARP_CONFIG_DIRS=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_CONFIG_DIRS").c_str());
+        printf("YARP_CONFIG_HOME=\"%s\"\n", yarp::conf::environment::getEnvironment("YARP_CONFIG_HOME").c_str());
     }
 }
 

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -7,8 +7,11 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/conf/filesystem.h>
 #include <yarp/os/ResourceFinder.h>
+
+#include <yarp/conf/environment.h>
+#include <yarp/conf/filesystem.h>
+
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/YarpPlugin.h>
@@ -27,7 +30,7 @@ static yarp::os::Bottle env;
 static void saveEnvironment(const char *key)
 {
     bool found = false;
-    std::string val = NetworkBase::getEnvironment(key, &found);
+    std::string val = yarp::conf::environment::getEnvironment(key, &found);
     Bottle& lst = env.addList();
     lst.addString(key);
     lst.addString(val);
@@ -43,9 +46,9 @@ static void restoreEnvironment()
         std::string val = lst->get(1).asString();
         bool found = lst->get(2).asInt32()?true:false;
         if (!found) {
-            NetworkBase::unsetEnvironment(key);
+            yarp::conf::environment::unsetEnvironment(key);
         } else {
-            NetworkBase::setEnvironment(key, val);
+            yarp::conf::environment::setEnvironment(key, val);
         }
     }
     env.clear();
@@ -230,14 +233,14 @@ static void setUpTestArea(bool etc_pathd)
     saveEnvironment("YARP_CONFIG_DIRS");
     saveEnvironment("YARP_ROBOT_NAME");
 
-    Network::setEnvironment("YARP_DATA_HOME", pathify(yarp_data_home));
-    Network::setEnvironment("YARP_CONFIG_HOME", pathify(yarp_config_home));
-    Network::setEnvironment("YARP_DATA_DIRS",
+    yarp::conf::environment::setEnvironment("YARP_DATA_HOME", pathify(yarp_data_home));
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_HOME", pathify(yarp_config_home));
+    yarp::conf::environment::setEnvironment("YARP_DATA_DIRS",
                             pathify(yarp_data_dir0) +
                             colon +
                             pathify(yarp_data_dir1));
-    Network::setEnvironment("YARP_CONFIG_DIRS", pathify(yarp_config_dir0));
-    Network::setEnvironment("YARP_ROBOT_NAME", "dummyRobot");
+    yarp::conf::environment::setEnvironment("YARP_CONFIG_DIRS", pathify(yarp_config_dir0));
+    yarp::conf::environment::setEnvironment("YARP_ROBOT_NAME", "dummyRobot");
 
 
     fout = fopen((pathify(yarp_data_home)+slash+"data.ini").c_str(), "w");
@@ -514,15 +517,15 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         saveEnvironment("YARP_DATA_HOME");
         saveEnvironment("XDG_DATA_HOME");
         saveEnvironment("HOME");
-        Network::setEnvironment("YARP_DATA_HOME", "/foo");
+        yarp::conf::environment::setEnvironment("YARP_DATA_HOME", "/foo");
         CHECK(ResourceFinder::getDataHome() == "/foo"); // YARP_DATA_HOME noticed
-        Network::unsetEnvironment("YARP_DATA_HOME");
-        Network::setEnvironment("XDG_DATA_HOME", "/foo");
+        yarp::conf::environment::unsetEnvironment("YARP_DATA_HOME");
+        yarp::conf::environment::setEnvironment("XDG_DATA_HOME", "/foo");
         std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getDataHome() == (std::string("/foo") + slash + "yarp")); // XDG_DATA_HOME noticed
-        Network::unsetEnvironment("XDG_DATA_HOME");
+        yarp::conf::environment::unsetEnvironment("XDG_DATA_HOME");
 #ifdef __linux__
-        Network::setEnvironment("HOME", "/foo");
+        yarp::conf::environment::setEnvironment("HOME", "/foo");
         CHECK(ResourceFinder::getDataHome() == "/foo/.local/share/yarp"); // HOME noticed
 #endif
         restoreEnvironment();
@@ -533,15 +536,15 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         saveEnvironment("YARP_CONFIG_HOME");
         saveEnvironment("XDG_CONFIG_HOME");
         saveEnvironment("HOME");
-        Network::setEnvironment("YARP_CONFIG_HOME", "/foo");
+        yarp::conf::environment::setEnvironment("YARP_CONFIG_HOME", "/foo");
         CHECK(ResourceFinder::getConfigHome() == "/foo"); // YARP_CONFIG_HOME noticed
-        Network::unsetEnvironment("YARP_CONFIG_HOME");
-        Network::setEnvironment("XDG_CONFIG_HOME", "/foo");
+        yarp::conf::environment::unsetEnvironment("YARP_CONFIG_HOME");
+        yarp::conf::environment::setEnvironment("XDG_CONFIG_HOME", "/foo");
         std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
         CHECK(ResourceFinder::getConfigHome() == (std::string("/foo") + slash + "yarp")); // XDG_CONFIG_HOME noticed
-        Network::unsetEnvironment("XDG_CONFIG_HOME");
+        yarp::conf::environment::unsetEnvironment("XDG_CONFIG_HOME");
 #ifdef __linux__
-        Network::setEnvironment("HOME", "/foo");
+        yarp::conf::environment::setEnvironment("HOME", "/foo");
         CHECK(ResourceFinder::getConfigHome() == "/foo/.config/yarp"); // HOME noticed
 #endif
         restoreEnvironment();
@@ -556,25 +559,25 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
-        Network::setEnvironment("YARP_DATA_DIRS", foobar);
+        yarp::conf::environment::setEnvironment("YARP_DATA_DIRS", foobar);
         Bottle dirs;
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // YARP_DATA_DIRS parsed as two directories
         CHECK(dirs.get(0).asString() == "/foo"); // YARP_DATA_DIRS first dir ok
         CHECK(dirs.get(1).asString() == "/bar"); // YARP_DATA_DIRS second dir ok
 
-        Network::setEnvironment("YARP_DATA_DIRS", "/foo");
+        yarp::conf::environment::setEnvironment("YARP_DATA_DIRS", "/foo");
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 1); // YARP_DATA_DIRS parsed as one directory
 
-        Network::unsetEnvironment("YARP_DATA_DIRS");
-        Network::setEnvironment("XDG_DATA_DIRS", foobar);
+        yarp::conf::environment::unsetEnvironment("YARP_DATA_DIRS");
+        yarp::conf::environment::setEnvironment("XDG_DATA_DIRS", foobar);
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // XDG_DATA_DIRS gives two directories
         CHECK(dirs.get(0).asString() == yfoo); // XDG_DATA_DIRS first dir ok
         CHECK(dirs.get(1).asString() == ybar); // XDG_DATA_DIRS second dir ok
 
-        Network::unsetEnvironment("XDG_DATA_DIRS");
+        yarp::conf::environment::unsetEnvironment("XDG_DATA_DIRS");
 #ifdef __linux__
         dirs = ResourceFinder::getDataDirs();
         CHECK(dirs.size() == (size_t) 2); // DATA_DIRS default length 2
@@ -594,21 +597,21 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
         std::string foobar = std::string("/foo") + colon + "/bar";
         std::string yfoo = std::string("/foo") + slash + "yarp";
         std::string ybar = std::string("/bar") + slash + "yarp";
-        Network::setEnvironment("YARP_CONFIG_DIRS", foobar);
+        yarp::conf::environment::setEnvironment("YARP_CONFIG_DIRS", foobar);
         Bottle dirs;
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 2); // YARP_CONFIG_DIRS parsed as two directories
         CHECK(dirs.get(0).asString() == "/foo"); // YARP_CONFIG_DIRS first dir ok
         CHECK(dirs.get(1).asString() == "/bar"); // YARP_CONFIG_DIRS second dir ok
 
-        Network::unsetEnvironment("YARP_CONFIG_DIRS");
-        Network::setEnvironment("XDG_CONFIG_DIRS", foobar);
+        yarp::conf::environment::unsetEnvironment("YARP_CONFIG_DIRS");
+        yarp::conf::environment::setEnvironment("XDG_CONFIG_DIRS", foobar);
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 2); // XDG_CONFIG_DIRS gives two directories
         CHECK(dirs.get(0).asString() == yfoo); // XDG_CONFIG_DIRS first dir ok
         CHECK(dirs.get(1).asString() == ybar); // XDG_CONFIG_DIRS second dir ok
 
-        Network::unsetEnvironment("XDG_CONFIG_DIRS");
+        yarp::conf::environment::unsetEnvironment("XDG_CONFIG_DIRS");
 #ifdef __linux__
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 1); // CONFIG_DIRS default length 1
@@ -760,8 +763,7 @@ TEST_CASE("os::ResourceFinderTest", "[yarp::os]")
             rf.configure(0, nullptr);
 
             bool found;
-            std::string robot = NetworkBase::getEnvironment("YARP_ROBOT_NAME",
-                                                            &found);
+            std::string robot = yarp::conf::environment::getEnvironment("YARP_ROBOT_NAME", &found);
             if (!found) robot = "default";
             CHECK(rf.getHomeContextPath() == ResourceFinder::getDataHome() + slash + "contexts" + slash + "my_app"); // $YARP_DATA_HOME/contexts/my_app found as directory for writing
             CHECK(rf.getHomeRobotPath() == ResourceFinder::getDataHome() + slash + "robots" + slash + robot); // $YARP_DATA_HOME/robots/dummyRobot found as directory for writing


### PR DESCRIPTION
This is the alternative version for #2333 which moves these functions in the `yarp::conf::environment` namespace.

Please keep the discussion on #2333

---------

### Libraries

#### `conf`

* Added the `yarp/conf/environment.h` header.
* Added the following functions:
  * `yarp::conf::environment::getEnvironment()`
  * `yarp::conf::environment::setEnvironment()`
  * `yarp::conf::environment::unsetEnvironment()`

#### `os`

* The method `yarp::os::getenv()` is now deprecated in favour of `std::getenv()`

##### `Network`

* `getEnvironment()` is now deprecated in favour of `yarp::conf::environment::getEnvironment()`
* `setEnvironment()` is now deprecated in favour of `yarp::conf::environment::setEnvironment()`
* `unsetEnvironment()` is now deprecated in favour of `yarp::conf::environment::unsetEnvironment()`

--------

Fixes #1853