### PR TITLE
carrier/unix_stream: Merge unix_stream and unix_stream_ack

### DIFF
--- a/src/carriers/unix/CMakeLists.txt
+++ b/src/carriers/unix/CMakeLists.txt
@@ -8,15 +8,7 @@ yarp_prepare_plugin(unix_stream
                     CATEGORY carrier
                     TYPE UnixSocketCarrier
                     INCLUDE UnixSocketCarrier.h
-                    EXTRA_CONFIG CODE="UNIX_STR"
-                    DEPENDS UNIX
-                    DEFAULT ON)
-
-yarp_prepare_plugin(unix_stream_ack
-                    CATEGORY carrier
-                    TYPE UnixSocketCarrierAck
-                    INCLUDE UnixSocketCarrier.h
-                    EXTRA_CONFIG CODE="UNIX_ACK"
+                    EXTRA_CONFIG CODE=\"UNIX_\"\ \(any\)\ \(any\)\ \(any\)
                     DEPENDS UNIX
                     DEFAULT ON)
 
@@ -44,3 +36,5 @@ if(ENABLE_unix_stream OR ENABLE_unix_stream_ack)
 
   set_property(TARGET yarp_unix PROPERTY FOLDER "Plugins/Carrier")
 endif()
+
+yarp_remove_file("${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}/unix_stream_ack.ini") # YARP_DEPRECATED never released

--- a/src/carriers/unix/UnixSocketCarrier.h
+++ b/src/carriers/unix/UnixSocketCarrier.h
@@ -27,7 +27,12 @@ class UnixSocketCarrier :
         public yarp::os::AbstractCarrier
 {
 public:
-    UnixSocketCarrier(bool requireAckFlag = false);
+    UnixSocketCarrier() = default;
+    UnixSocketCarrier(const UnixSocketCarrier&) = delete;
+    UnixSocketCarrier(UnixSocketCarrier&&) = delete;
+    UnixSocketCarrier& operator=(const UnixSocketCarrier&) = delete;
+    UnixSocketCarrier& operator=(UnixSocketCarrier&&) = delete;
+
     ~UnixSocketCarrier() override = default;
 
     yarp::os::Carrier* create() const override;
@@ -49,6 +54,13 @@ public:
     bool expectAck(yarp::os::ConnectionState& proto) override;
     bool sendAck(yarp::os::ConnectionState& proto) override;
 
+    // The initiator reads the carrier parameters from the connection string (i.e. unix_stream+ack)
+    bool configure(yarp::os::ConnectionState& proto) override;
+    bool configureFromProperty(yarp::os::Property& options) override;
+
+    // The recipients must decipher the parameters from the first 8 bytes (i.e. UNIX_ACK)
+    void setParameters(const yarp::os::Bytes& header) override;
+
 private:
     static constexpr const char* name = "unix_stream";
     static constexpr int specifierCode = 11;
@@ -68,13 +80,6 @@ private:
     UnixSockTwoWayStream* stream{nullptr};
 
     bool becomeUnixSocket(yarp::os::ConnectionState& proto, bool sender = false);
-};
-
-class UnixSocketCarrierAck :
-        public UnixSocketCarrier
-{
-public:
-    UnixSocketCarrierAck() : UnixSocketCarrier(true) {}
 };
 
 #endif // YARP_UNIX_UNIXSOCKETCARRIER_H


### PR DESCRIPTION
Instead of having a separate carrier for the ack version, it is a parameter of the carrier

Therefore, instead of using

```diff
-yarp connect /a /b unix_stream_ack
```

The ack version can be requested as

```diff
+yarp connect /a /b unix_stream+ack
```

This is what I understood:

Basically, the initiator side parses the "sender specifier" (`unix_stream+ack`) in the `configure` method (and for some reason, also the `configureFromProperty` seems to be involved in some way). If the `ack` option is found, `requireAckFlag` is set to true, and the carrier starts sending data using `UNIX_ACK` instead of `UNIX_STR`, and waiting for the ack after each data transmission.

On the recipients side, the `.ini` file is involved, the `code "UNIX_" (any) (any) (any)` should be matched in order to satisfy the plugin system to believe that the plugin can handle the connection. I'm not sure about how this works internally, but `(any)` is actually matching any character.

The `checkHeader` method is then called, and it should return `true` if the `Carrier` is able to handle the protocol. Another instance of the Carrier is then created, and therefore it is useless to set the `requireAckFlag` here. Instead, the `setParameters` method is immediately called on the new Carrier instance. Here there is the actual check on the first 8 bytes received, to understand which version of the protocol is in use (`UNIX_ACK` or `UNIX_STR`). if `UNIX_ACK` is found, `requireAckFlag` is set, 
and the carrier starts receiving data, and sending the ack after each transmission.

I think this is nicer, and (even though we are limited by the 8 bytes) we could easily add other options (we could also rename the carrier `unix` and, when we make the datagram version, use an option for that i.e. `unix+dgram`), but I am not 100% sure that this is better, and would like to hear some opinions.

One possible question here is why this was not used when fast_tcp was implemented (see 86ed663f096ded3f4422e03f9d04158270248904)

CC @Nicogene, @randaz81, @elandini84