### PR TITLE
Fixed realsense2tracking device timestamp

### DIFF
--- a/doc/release/yarp_3_4/fix_realsense2Tracking_timestamp.md
+++ b/doc/release/yarp_3_4/fix_realsense2Tracking_timestamp.md
@@ -1,0 +1,11 @@
+fix_realsense2Tracking_timestamp {#yarp_3_4}
+--------------------------
+
+### Devices
+
+#### `realsense2Tracking`
+
+* Fixed missing timestamp for device `realsense2Tracking`
+* added option `--timestamp yarp` : yarp timestamp will be used
+* added option `--timestamp realsense` : realsense timestamp will be used
+* default value is `yarp timestamp`.

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -116,6 +116,8 @@ protected:
     rs2::pipeline m_pipeline;
     rs2::pipeline_profile m_profile;
     std::string m_lastError;
+    enum timestamp_enumtype {yarp_timestamp=0, rs_timestamp};
+    timestamp_enumtype m_timestamp_type;
 
     /*
     rs2::context m_ctx;


### PR DESCRIPTION
Fixed missing timestamp for device `realsense2tracking`
added option `--timestamp yarp` : yarp timestamp will be used
added option `--timestamp realsense` : realsense timestamp will be used
default value is yarp timestamp.

