### PR TITLE
frameTransformServer: display transform tree 

### DIFF
--- a/doc/release/master/frameTransform_displayTree.md
+++ b/doc/release/master/frameTransform_displayTree.md
@@ -1,0 +1,13 @@
+frameTransform_displayTree {#master}
+-----------------------
+
+### Devices
+
+#### frameTransformServer
+
+* Added a new rpc command `generate_view` which generates via `dot (graphviz)` a pdf file, containing a diagram of the transforms tree
+
+
+
+
+

--- a/src/devices/transformServer/FrameTransformServer.h
+++ b/src/devices/transformServer/FrameTransformServer.h
@@ -106,6 +106,15 @@ private:
     Transforms_server_storage*   m_yarp_static_transform_storage;
     double                       m_FrameTransformTimeout;
 
+    enum show_transforms_in_diagram_t
+    {
+        do_not_show=0,
+        show_quaternion=1,
+        show_matrix=2,
+        show_rpy=3
+    };
+    show_transforms_in_diagram_t  m_show_transforms_in_diagram= do_not_show;
+
     yarp::os::RpcServer                      m_rpcPort;
     yarp::os::BufferedPort<yarp::os::Bottle> m_streamingPort;
     yarp::os::Publisher<yarp::rosmsg::tf2_msgs::TFMessage> m_rosPublisherPort_tf_timed;

--- a/src/devices/transformServer/FrameTransformServer.h
+++ b/src/devices/transformServer/FrameTransformServer.h
@@ -115,6 +115,7 @@ private:
 
     bool read(yarp::os::ConnectionReader& connection) override;
     inline  void list_response(yarp::os::Bottle& out);
+    bool         generate_view();
     bool         parseStartingTf(yarp::os::Searchable &config);
 };
 

--- a/src/devices/transformServer/FrameTransformServer.h
+++ b/src/devices/transformServer/FrameTransformServer.h
@@ -116,6 +116,7 @@ private:
     bool read(yarp::os::ConnectionReader& connection) override;
     inline  void list_response(yarp::os::Bottle& out);
     bool         generate_view();
+    std::string  get_matrix_as_text(Transforms_server_storage* storage, int i);
     bool         parseStartingTf(yarp::os::Searchable &config);
 };
 

--- a/src/libYARP_math/src/yarp/math/FrameTransform.h
+++ b/src/libYARP_math/src/yarp/math/FrameTransform.h
@@ -61,7 +61,13 @@ public:
     yarp::sig::Matrix toMatrix() const;
     bool fromMatrix(const yarp::sig::Matrix& mat);
 
-    std::string toString() const;
+    enum display_transform_mode_t
+    {
+       rotation_as_quaternion=0,
+       rotation_as_matrix=1,
+       rotation_as_rpy=2
+    };
+    std::string toString(display_transform_mode_t format= rotation_as_quaternion) const;
 };
 
 } // namespace sig


### PR DESCRIPTION
frameTransformServer: added a new rpc command 'generate_view' which generates via dot (graphviz) a `frames.pdf` file, containing a diagram of the transforms tree.

You can use a pdf viewer, i.e. `evince frames.pdf` to display the transforms tree and obtain a plot such as:
![image](https://user-images.githubusercontent.com/2869969/89438817-92945300-d749-11ea-8ff0-be0b01229164.png)
