### PR TITLE
bindings/ruby: Do not use deprecated CMake variables

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -16,7 +16,7 @@ swig_add_library(yarp_ruby
                  LANGUAGE ruby
                  SOURCES ${SWIG_BINDINGS_SOURCE_FILE})
 swig_link_libraries(yarp_ruby ${RUBY_LIBRARY} ${SWIG_YARP_LIBRARIES})
-target_include_directories(${SWIG_MODULE_yarp_ruby_REAL_NAME} SYSTEM PRIVATE ${RUBY_INCLUDE_PATH})
+target_include_directories(${SWIG_MODULE_yarp_ruby_REAL_NAME} SYSTEM PRIVATE ${RUBY_INCLUDE_DIRS})
 
 set_target_properties(${SWIG_MODULE_yarp_ruby_REAL_NAME} PROPERTIES PREFIX ""
                                                                     OUTPUT_NAME "yarp")

--- a/doc/release/yarp_3_4/cmake_3_18_ruby.md
+++ b/doc/release/yarp_3_4/cmake_3_18_ruby.md
@@ -1,0 +1,4 @@
+cmake_3_18_ruby {#yarp_3_4}
+---------------
+
+* Fixed Ruby bindings with CMake 3.18


### PR DESCRIPTION
Fixes Ruby bindings on CMake 3.18