### PR TITLE
Fix typo on TextureBuffer.cpp

### DIFF
--- a/doc/release/yarp_3_4/fix_typo_texture_buffer.md
+++ b/doc/release/yarp_3_4/fix_typo_texture_buffer.md
@@ -1,0 +1,8 @@
+fix_typo_texture_buffer {#yarp_3_4}
+--------------------------
+
+### Devices
+
+#### `ovrheadset`
+
+* Fixed a typo in `TextureBuffer.cpp`

--- a/src/devices/ovrheadset/TextureBuffer.cpp
+++ b/src/devices/ovrheadset/TextureBuffer.cpp
@@ -257,7 +257,7 @@ void TextureBuffer::createTextureAndBuffers()
     desc.StaticImage = ovrFalse;
 
     if (!ovr_CreateTextureSwapChainGL(session, &desc, &textureSwapChain) == ovrSuccess) {
-        yCError(OVRHEADSET); << "Failed to create texture swap chain";
+        yCError(OVRHEADSET) << "Failed to create texture swap chain";
         return;
     }
     checkGlErrorMacro;


### PR DESCRIPTION
When trying to compile on Windows with Visual Studio 16 2019 I had the following error:
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2059	syntax error: '<<' [C:\robotology-superbuild\build\robotology\YARP\src\devices\ovrheadset\yarp_ovrheadset.vcxproj]	YARP (ExternalProjectTargets\YARP\YARP)	C:\robotology-superbuild\robotology\YARP\src\devices\ovrheadset\TextureBuffer.cpp	260	
```

