### PR TITLE
FakeFrameGrabber fix

### DIFF
--- a/doc/release/yarp_3_4/fix_FakeFrameGrabber.md
+++ b/doc/release/yarp_3_4/fix_FakeFrameGrabber.md
@@ -1,0 +1,8 @@
+fix_FakeFrameGrabber {#yarp_3_4}
+--------------------------
+
+### Devices
+
+#### `FakeFrameGrabber`
+
+* The ball test is now displayed in the center of the image instead of the right-bottom corner. The bug was affecting windows only.

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -365,10 +365,12 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>&
             if (ct%5!=0) {
                 rnd *= 65537;
                 rnd += 17;
-                bx += (rnd%5)-2;
+                int delta_x = (rnd % 5) - 2;
+                bx += delta_x;
                 rnd *= 65537;
                 rnd += 17;
-                by += (rnd%5)-2;
+                int delta_y = (rnd % 5) - 2;
+                by += delta_y;
             } else {
                 int dx = w/2 - bx;
                 int dy = h/2 - by;


### PR DESCRIPTION
The ball test is now displayed in the center of the image instead of the right-bottom corner. The bug was affecting windows only. The bug was introduced by a recent refactor in which some variables were modified from int to size_t