### PR TITLE
Zlib depth

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -348,6 +348,9 @@ checkandset_dependency(Libdc1394)
 find_package(JPEG QUIET)
 checkandset_dependency(JPEG)
 
+find_package(ZLIB QUIET)
+checkandset_dependency(ZLIB)
+
 find_package(PNG QUIET)
 checkandset_dependency(PNG)
 
@@ -627,6 +630,7 @@ print_dependency(I2C)
 print_dependency(Libv4l2)
 print_dependency(Libv4lconvert)
 print_dependency(Fuse)
+print_dependency(ZLIB)
 
 ################################################################################
 # Print information for user

--- a/doc/cmd_yarpdatadumper.dox
+++ b/doc/cmd_yarpdatadumper.dox
@@ -11,7 +11,7 @@ port.
 \section yarpdatadumper_intro Description
 
 When launched, the service monitors the presence of incoming
-data (bottles or images) and stores it within a folder called
+data (bottles,images,etc.) and stores it within a folder called
 with the same name as the service port (or with a proper suffix
 appended if other data is present in the current path). In this
 folder the file 'data.log' contains the information (taken from
@@ -36,7 +36,7 @@ yarp ports connected or disconnected to the dumper,
 as in the following:
 
 \code
-Type: [Bottle; | Image; | Image; Video:ext(huffyuv);]
+Type: [Bottle; | Image; | Image:jpg | Image:png | Depth | DepthCompressed | Image; Video:ext(huffyuv);]
 Stamp: [rx; | tx; | tx+rx;]
 [local-timestamp] /yarp-port-name [connected]
 [local-timestamp] /yarp-port-name [disconnected]
@@ -112,10 +112,15 @@ by the \ref yarpdatadumper.
 
 `--type datatype`
 - The parameter `datatype` selects the type of items to be
-  stored. It can be \e bottle, \e image, \e image_jpg, \e image_png or
-  \e video; if not specified \e bottle is assumed. Note that images are
-  stored using the corresponding file formats. The data type \e video
-  is available if OpenCV is found and the codec \e huffyuv is installed.
+  stored. It can be one of the following (if not specified \e bottle is assumed):
+  + \e bottle (text file)
+  + \e image  (standard uncompressed bitmap, ppm (rgb) or pgm (monochrome 8bit)
+  + \e image_jpg (jpg compressed, lossy)
+  + \e image_png (png compression, lossless)
+  + \e depth (32-bit float raw, yarp custom format) 
+  + \e depth_compressed (32-bit float, zlib compressed, yarp custom format) 
+  + \e video (.mkv format)
+  The data type \e video is available if OpenCV is found and the codec \e huffyuv is installed.
 
 `--addVideo`
 - In case images are acquired with this option enabled, a video

--- a/doc/release/master/Zlib_depth.md
+++ b/doc/release/master/Zlib_depth.md
@@ -1,0 +1,29 @@
+Zlib_depth {#master}
+-----------------------
+
+### CMake
+
+* added optional `zlib` dependency
+
+### yarp::sig
+
+#### ImageFile.cpp
+
+* added enum::image_fileformat::FORMAT_NUMERIC_COMPRESSED
+* added methods: ImageReadFloat_CompressedHeaderless()
+* added methods: ImageReadFloat_PlainHeaderless()
+* fixed bug in: SavePNG() the output file was corrupted
+
+### yarp guis
+
+#### yarpdataplayer
+
+* `yarpdataplayer` is now able to reproduce depth and depth_compressed data types
+
+### yarp command line tools
+
+#### yarpdatadumper
+
+* `yarpdatadumper` now supports the following data outputs for parameter --type bottle(default), image, image_jpg, image_png, video, depth, depth_compressed
+
+

--- a/src/libYARP_sig/src/CMakeLists.txt
+++ b/src/libYARP_sig/src/CMakeLists.txt
@@ -88,6 +88,13 @@ if(YARP_HAS_JPEG)
   list(APPEND YARP_sig_PRIVATE_DEPS JPEG)
 endif()
 
+if(YARP_HAS_ZLIB)
+  target_include_directories(YARP_sig SYSTEM PRIVATE ${ZLIB_INCLUDE_DIR})
+  target_compile_definitions(YARP_sig PRIVATE YARP_HAS_ZLIB)
+  target_link_libraries(YARP_sig PRIVATE ${ZLIB_LIBRARY})
+  list(APPEND YARP_sig_PRIVATE_DEPS ZLIB)
+endif()
+
 if(YARP_HAS_PNG)
   target_include_directories(YARP_sig SYSTEM PRIVATE ${PNG_INCLUDE_DIR})
   target_compile_definitions(YARP_sig PRIVATE YARP_HAS_PNG)

--- a/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
+++ b/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
@@ -52,15 +52,15 @@ namespace
     bool ImageReadFloat_CompressedHeaderless(ImageOf<PixelFloat>& dest, const std::string& filename);
 #endif
 
-    bool SaveJPG(char* src, const char* filename, int h, int w, int rowSize);
-    bool SavePGM(char* src, const char* filename, int h, int w, int rowSize);
-    bool SavePPM(char* src, const char* filename, int h, int w, int rowSize);
+    bool SaveJPG(char* src, const char* filename, size_t h, size_t w, size_t rowSize);
+    bool SavePGM(char* src, const char* filename, size_t h, size_t w, size_t rowSize);
+    bool SavePPM(char* src, const char* filename, size_t h, size_t w, size_t rowSize);
 #if defined (YARP_HAS_PNG)
     bool SavePNG(char* src, const char* filename, size_t h, size_t w, size_t rowSize, png_byte color_type, png_byte bit_depth);
 #endif
-    bool SaveFloatRaw(char* src, const char* filename, int h, int w, int rowSize);
+    bool SaveFloatRaw(char* src, const char* filename, size_t h, size_t w, size_t rowSize);
 #if defined (YARP_HAS_ZLIB)
-    bool SaveFloatCompressed(char* src, const char* filename, int h, int w, int rowSize);
+    bool SaveFloatCompressed(char* src, const char* filename, size_t h, size_t w, size_t rowSize);
 #endif
 
     bool ImageWriteJPG(ImageOf<PixelRgb>& img, const char* filename);
@@ -607,7 +607,7 @@ bool SavePNG(char *src, const char *filename, size_t h, size_t w, size_t rowSize
 }
 #endif
 
-bool SaveJPG(char *src, const char *filename, int h, int w, int rowSize)
+bool SaveJPG(char *src, const char *filename, size_t h, size_t w, size_t rowSize)
 {
 #if YARP_HAS_JPEG_C
     int quality = 100;
@@ -654,7 +654,7 @@ bool SaveJPG(char *src, const char *filename, int h, int w, int rowSize)
 #endif
 }
 
-bool SavePGM(char *src, const char *filename, int h, int w, int rowSize)
+bool SavePGM(char *src, const char *filename, size_t h, size_t w, size_t rowSize)
 {
     FILE *fp = fopen(filename, "wb");
     if (!fp)
@@ -680,7 +680,7 @@ bool SavePGM(char *src, const char *filename, int h, int w, int rowSize)
 }
 
 
-bool SavePPM(char *src, const char *filename, int h, int w, int rowSize)
+bool SavePPM(char *src, const char *filename, size_t h, size_t w, size_t rowSize)
 {
     FILE *fp = fopen(filename, "wb");
     if (!fp)
@@ -707,7 +707,7 @@ bool SavePPM(char *src, const char *filename, int h, int w, int rowSize)
 }
 
 #if defined (YARP_HAS_ZLIB)
-bool SaveFloatCompressed(char* src, const char* filename, int h, int w, int rowSize)
+bool SaveFloatCompressed(char* src, const char* filename, size_t h, size_t w, size_t rowSize)
 {
     size_t sizeDataOriginal=w*h*sizeof(float);
     size_t sizeDataCompressed = (sizeDataOriginal * 1.1) + 12;
@@ -748,7 +748,7 @@ bool SaveFloatCompressed(char* src, const char* filename, int h, int w, int rowS
 }
 #endif
 
-bool SaveFloatRaw(char* src, const char* filename, int h, int w, int rowSize)
+bool SaveFloatRaw(char* src, const char* filename, size_t h, size_t w, size_t rowSize)
 {
     FILE* fp = fopen(filename, "wb");
     if (fp == nullptr)
@@ -954,7 +954,12 @@ bool file::read(ImageOf<PixelFloat>& dest, const std::string& src, image_filefor
     else if (strcmp(file_ext, ".floatzip") == 0 ||
         format == FORMAT_NUMERIC_COMPRESSED)
     {
+#if defined (YARP_HAS_ZLIB)
         return ImageReadFloat_CompressedHeaderless(dest, src);
+#else
+        yCError(IMAGEFILE) << "YARP was not built with zlib support";
+        return false;
+#endif
     }
     yCError(IMAGEFILE) << "unsupported file format";
     return false;

--- a/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
+++ b/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
@@ -327,7 +327,7 @@ bool ImageReadFloat_CompressedHeaderless(ImageOf<PixelFloat>& dest, const std::s
     br = fread(dataReadInCompressed, 1, sizeDataCompressed, fp);
     fclose(fp);
 
-    if (br != sizeDataCompressed) { yError() << "problems reading file!"; return false; }
+    if (br != sizeDataCompressed) { yError() << "problems reading file!"; delete [] dataReadInCompressed; return false; }
 
     size_t h = ((size_t*)(dataReadInCompressed))[0]; //byte 0
     size_t w = ((size_t*)(dataReadInCompressed))[1]; //byte 8, because size_t is 8 bytes long
@@ -386,7 +386,7 @@ bool ImageReadFloat_PlainHeaderless(ImageOf<PixelFloat>& dest, const std::string
     }
 
     size_t dims[2];
-    if (fread(dims, sizeof(dims), 1, fp) <= 0)
+    if (fread(dims, sizeof(dims), 1, fp) == 0)
     {
         fclose(fp);
         return false;

--- a/src/libYARP_sig/src/yarp/sig/ImageFile.h
+++ b/src/libYARP_sig/src/yarp/sig/ImageFile.h
@@ -30,6 +30,7 @@ namespace yarp {
                     FORMAT_PPM,
                     FORMAT_JPG,
                     FORMAT_NUMERIC,
+                    FORMAT_NUMERIC_COMPRESSED,
                     FORMAT_PNG
                 };
 

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -461,7 +461,7 @@ public:
         else if (txTime)
             finfo<<"tx;";
         else
-            finfo<<"ex;";
+            finfo<<"rx;";
         finfo<<endl;
 
         fdata.open(dataFile.c_str());
@@ -651,7 +651,6 @@ public:
         if (portName[0]!='/')
             portName="/"+portName;
 
-      //  DumpFormat tmp_format=DumpFormat::bottle;
         bool saveData=true;
         bool videoOn=false;
         string videoType=rf.check("videoType",Value("mkv")).asString();

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -133,7 +133,12 @@ public:
 
             //grayscale images
             case VOCAB_PIXEL_MONO:
-                if (1)
+                if (m_dump_format == DumpFormat::image_png)
+                {
+                    fileformat = file::FORMAT_PNG;
+                    ext = ".png";
+                }
+                else
                 {
                     fileformat = file::FORMAT_PGM;
                     ext = ".pgm";

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -434,7 +434,7 @@ public:
             if (videoOn) finfo<<" Video:"<<videoType<<"(huffyuv);";
         }
         else if (type == DumpFormat::depth)
-        { 
+        {
             finfo << "Depth;";
         }
         else if (type == DumpFormat::depth_compressed)

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -118,11 +118,12 @@ MainWindow::MainWindow(yarp::os::ResourceFinder &rf, QWidget *parent) :
     connect(this,SIGNAL(internalQuit()),this,SLOT(onInternalQuit()),Qt::QueuedConnection);
     connect(this,SIGNAL(internalGetSliderPercentage(int*)),this,SLOT(onInternalGetSliderPercentage(int*)),Qt::BlockingQueuedConnection);
 
-    QShortcut *openShortcut = new QShortcut(QKeySequence("Ctrl+O"), parent);
-    QObject::connect(openShortcut, SIGNAL(activated()), this, SLOT(onInternalLoad(QString)));
 
-    QShortcut *closeShortcut = new QShortcut(QKeySequence("Ctrl+Q"), parent);
-    QObject::connect(closeShortcut, SIGNAL(activated()), this, SLOT(onInternalQuit()));
+  //    QShortcut *openShortcut = new QShortcut(QKeySequence("Ctrl+O"), parent);
+  //  QObject::connect(openShortcut, SIGNAL(activated()), this, SLOT(onInternalLoad(QString)));
+
+  //  QShortcut *closeShortcut = new QShortcut(QKeySequence("Ctrl+Q"), parent);
+  //  QObject::connect(closeShortcut, SIGNAL(activated()), this, SLOT(onInternalQuit()));
 
 }
 

--- a/src/yarpdataplayer/src/utils.cpp
+++ b/src/yarpdataplayer/src/utils.cpp
@@ -270,6 +270,11 @@ bool Utilities::setupDataFromParts(partsData &part)
             Bottle b( line );
             if (itr == 0){
                 part.type = b.get(1).toString();
+                if (part.type == "")
+                {
+                    LOG("Invalid format, missing data type?!");
+                    return false;
+                }
                 part.type.erase(part.type.size() -1 );          // remove the ";" character
             }
             else{
@@ -377,7 +382,14 @@ bool Utilities::configurePorts(partsData &part)
     if (strcmp (part.type.c_str(),"Bottle") == 0)   {
         if (part.outputPort == nullptr) { part.outputPort = new BufferedPort<yarp::os::Bottle>; }
     }
-    else if (strcmp (part.type.c_str(),"Image:ppm") == 0 || strcmp (part.type.c_str(),"Image") == 0)  {
+    else if (strcmp (part.type.c_str(),"Image") == 0 || 
+             strcmp(part.type.c_str(), "Image:ppm") == 0 ||
+             strcmp(part.type.c_str(), "Image:jpg") == 0 ||
+             strcmp (part.type.c_str(),"Image:png") == 0 ||
+             strcmp(part.type.c_str(), "Depth") == 0 ||
+             strcmp(part.type.c_str(), "DepthCompressed") == 0
+            )
+    {
         if (part.outputPort == nullptr) { part.outputPort = new BufferedPort<yarp::sig::Image>; }
     }
     else if (strcmp(part.type.c_str(), "sensor_msgs/LaserScan") == 0 ) {
@@ -397,7 +409,7 @@ bool Utilities::configurePorts(partsData &part)
     }
     else
     {
-        LOG("Something is wrong with the data...%s\nIt seems its missing a type \n",part.name.c_str());
+        LOG("Something is wrong with the data...%s\nIt seems it is type (%s) is unrecognized\n",part.name.c_str(), part.type.c_str());
         return false;
     }
 

--- a/src/yarpdataplayer/src/utils.cpp
+++ b/src/yarpdataplayer/src/utils.cpp
@@ -382,7 +382,7 @@ bool Utilities::configurePorts(partsData &part)
     if (strcmp (part.type.c_str(),"Bottle") == 0)   {
         if (part.outputPort == nullptr) { part.outputPort = new BufferedPort<yarp::os::Bottle>; }
     }
-    else if (strcmp (part.type.c_str(),"Image") == 0 || 
+    else if (strcmp (part.type.c_str(),"Image") == 0 ||
              strcmp(part.type.c_str(), "Image:ppm") == 0 ||
              strcmp(part.type.c_str(), "Image:jpg") == 0 ||
              strcmp (part.type.c_str(),"Image:png") == 0 ||
@@ -409,7 +409,7 @@ bool Utilities::configurePorts(partsData &part)
     }
     else
     {
-        LOG("Something is wrong with the data...%s\nIt seems it is type (%s) is unrecognized\n",part.name.c_str(), part.type.c_str());
+        LOG("Something is wrong with the data...%s\nType (%s) is unrecognized\n",part.name.c_str(), part.type.c_str());
         return false;
     }
 

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -120,8 +120,16 @@ void WorkerClass::run()
     if (isActive)
     {
         int ret=-1;
-        if (strcmp (utilities->partDetails[part].type.c_str(),"Image:ppm") == 0 ||
-            strcmp (utilities->partDetails[part].type.c_str(),"Image") == 0)  {
+        if (strcmp (utilities->partDetails[part].type.c_str(),"Image") == 0 ||
+            strcmp (utilities->partDetails[part].type.c_str(),"Image:ppm") == 0 ||
+            strcmp(utilities->partDetails[part].type.c_str(), "Image:png") == 0 ||
+            strcmp(utilities->partDetails[part].type.c_str(), "Image:jpg") == 0)
+        {
+            ret = sendImages(part, frame);
+        }
+        else if (strcmp(utilities->partDetails[part].type.c_str(), "Depth") == 0 ||
+                 strcmp(utilities->partDetails[part].type.c_str(), "DepthCompressed") == 0) {
+            //I am keeping depth separated from images only for clarity
             ret = sendImages(part, frame);
         }
         else if (strcmp(utilities->partDetails[part].type.c_str(), "Bottle") == 0)  {


### PR DESCRIPTION
The purpose of this PR is to introduce a new data format to read/write **compressed** depth images on disk

* added optional **zlib dependency** to compress data
* added enum::image_fileformat::FORMAT_NUMERIC_COMPRESSED
* yarpdatadumper now is able to save depth and **depth_compressed** data types. Use --help to see the new options.
* yarpdatadumper documentation updated
* yarpdataplayer is now able to reproduce depth and **depth_compressed** data types
