### PR TITLE
Fix compilation against OpenCV 2.x in yarpdatadumper

### DIFF
--- a/doc/release/yarp_3_4/fix_yarpdatadumper_opencv2.md
+++ b/doc/release/yarp_3_4/fix_yarpdatadumper_opencv2.md
@@ -1,0 +1,6 @@
+fix_yarpdatadumper_opencv2 {#yarp_3_4}
+-----------
+
+### yarpdatadumper
+
+* Fixed a regression that broke support for OpenCV 2.x.

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -486,7 +486,11 @@ public:
                 double dt=itemEnd.timeStamp.getStamp()-t0;
                 fps=(dt<=0.0)?25:int(double(sz-1)/dt);
 
+#if CV_MAJOR_VERSION >= 3
                 videoWriter.open(videoFile.c_str(),cv::VideoWriter::fourcc('H','F','Y','U'),
+#else
+                videoWriter.open(videoFile.c_str(),CV_FOURCC('H','F','Y','U'),
+#endif
                                  fps,cvSize(frameW,frameH),true);
 
                 doImgParamsExtraction=false;


### PR DESCRIPTION
Per https://github.com/robotology/yarp/pull/2194#issuecomment-691230360:

> This change is not compatible with OpenCV 2.4.9.1 (latest `apt` package on Ubuntu 16.04). There is no `cv::VideoWriter::fourcc` function in OpenCV 2.x ([ref](https://docs.opencv.org/ref/2.4/dd/d9e/classcv_1_1VideoWriter.html), cf. [OpenCV 3.x](https://docs.opencv.org/3.4/dd/d9e/classcv_1_1VideoWriter.html)).
>
> ```
> /home/teo/repos/yarp/src/yarpdatadumper/main.cpp: In member function ‘virtual void DumpThread::run()’:
> /home/teo/repos/yarp/src/yarpdatadumper/main.cpp:489:69: error: ‘fourcc’ is not a member of ‘cv::VideoWriter’
>                  videoWriter.open(videoFile.c_str(),cv::VideoWriter::fourcc('H','F','Y','U'),
>                                                                      ^~~~~~
> ```
> (...)

In case this patch is approved (might not be since OpenCV 2.x is about to lose support, I guess), please consider backporting it to `yarp-3.3` as the change that broke compatibility with OpenCV 2.x was released in YARP 3.3.2 (https://github.com/robotology/yarp/commit/e10d44326b28ac2e1864f77dd98fcbe20a3a45a8). Besides, I noticed AppVeyor builds do **not** consume OpenCV despite version 2.4.13 being present.