### PR TITLE
Fix/add envelope mas server

### DIFF
--- a/doc/release/yarp_3_4/fix_addEnvelopeMASServer.md
+++ b/doc/release/yarp_3_4/fix_addEnvelopeMASServer.md
@@ -1,0 +1,9 @@
+fix_addEnvelopeMASServer {#yarp_3_4}
+------------------------
+
+### Devices
+
+#### `multipleanalogsensorsserver`
+
+* Fixed missing timestamp and and sequence number in
+  messages streamed by `measures:o` port.

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -448,6 +448,8 @@ void MultipleAnalogSensorsServer::run()
 
     if (ok)
     {
+        m_stamp.update();
+        m_streamingPort.setEnvelope(m_stamp);
         m_streamingPort.write();
     }
     else

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -11,6 +11,7 @@
 #define YARP_DEV_MULTIPLEANALOGSENSORSSERVER_MULTIPLEANALOGSENSORSSERVER_H
 
 #include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Stamp.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IMultipleWrapper.h>
@@ -25,6 +26,9 @@
  * @ingroup dev_impl_wrapper
  *
  * \brief The server side of the MultipleAnalogSensorsClient, useful to expose device implementing MultipleAnalogSensors interfaces over the YARP network.
+ * This device opens two ports: /${name}/measures:o that streams the data of the sensors, and /${name}/rpc:o that is a YARP RPC port that exposes the metadata.
+ * The data on the /${name}/measures:o is streamed every ${period} milliseconds, and an envelope to each data is added with a timestamp obtained by calling the
+ * yarp::os::Time::now() method when the message is written on the port.
  *
  * | YARP device name |
  * |:-----------------:|
@@ -43,6 +47,7 @@ class MultipleAnalogSensorsServer :
         public MultipleAnalogSensorsMetadata
 {
     double m_periodInS{0.01};
+    yarp::os::Stamp m_stamp;
     std::string m_streamingPortName;
     std::string m_RPCPortName;
     yarp::os::BufferedPort<SensorStreamingData> m_streamingPort;


### PR DESCRIPTION
This PR adds the envelope to the messages streamed by the `measures:o` port of `multipleanalogsensorsserver`.

Please review code.