### PR TITLE
sig/PointCloudUtils: Use SFINAE to avoid failure for types without alpha channel

### DIFF
--- a/doc/release/yarp_3_4/fix_1959.md
+++ b/doc/release/yarp_3_4/fix_1959.md
@@ -1,0 +1,11 @@
+fix_1959 {#yarp_3_4}
+--------
+
+### Libraries
+
+#### `sig`
+
+##### `PointCloudUtils`
+
+* Fixed `yarp::sig::utils::depthRgbToPC` for types without alpha channel
+  (#1959).

--- a/tests/libYARP_sig/PointCloudTest.cpp
+++ b/tests/libYARP_sig/PointCloudTest.cpp
@@ -931,8 +931,6 @@ TEST_CASE("sig::PointCloudTest", "[yarp::sig]")
         CHECK(pcCol.height() == depth.height()); // Checking PC height
     }
 
-#if defined(ENABLE_BROKEN_TESTS)
-    // Broken, see https://github.com/robotology/yarp/issues/1959
     SECTION("Testing depthToPC BGR")
     {
         ImageOf<PixelFloat> depth;
@@ -951,7 +949,6 @@ TEST_CASE("sig::PointCloudTest", "[yarp::sig]")
         CHECK(pcCol.width() == depth.width()); // Checking PC width
         CHECK(pcCol.height() == depth.height()); // Checking PC height
     }
-#endif // ENABLE_BROKEN_TESTS
 
     SECTION("Testing move semantics")
     {


### PR DESCRIPTION
### Libraries

#### `sig`

##### `PointCloudUtils`

* Fixed `yarp::sig::utils::depthRgbToPC` for types without alpha channel (#1959).