### PR TITLE
Fix stamp max count

### DIFF
--- a/doc/release/yarp_3_4/fix_stamp_max_count.md
+++ b/doc/release/yarp_3_4/fix_stamp_max_count.md
@@ -1,0 +1,8 @@
+fix_stamp_max_count {#yarp_3_4}
+-------------------------------
+
+### yarp::os
+
+#### `Stamp`
+
+* Fixed the max count using std::numeric_limits.

--- a/src/libYARP_os/src/yarp/os/Stamp.cpp
+++ b/src/libYARP_os/src/yarp/os/Stamp.cpp
@@ -15,6 +15,7 @@
 #include <yarp/os/Time.h>
 
 #include <cfloat>
+#include <limits>
 
 yarp::os::Stamp::Stamp(int count, double time)
 {
@@ -106,8 +107,7 @@ bool yarp::os::Stamp::write(ConnectionWriter& connection) const
 
 int yarp::os::Stamp::getMaxCount() const
 {
-    // a very conservative maximum
-    return 32767;
+    return std::numeric_limits<int>::max();
 }
 
 void yarp::os::Stamp::update()


### PR DESCRIPTION
It adds the usage of `std::numeric_limits` in `getMaxCount()`

Please review code.