### PR TITLE
Small refactor of the RGBDSensorClient device

### DIFF
--- a/doc/release/master/RGBDSensorClient_refactor.md
+++ b/doc/release/master/RGBDSensorClient_refactor.md
@@ -1,0 +1,11 @@
+RGBDSensorClient_refactor {#master}
+-------------------------
+
+## Bug Fixes
+
+### Devices
+
+#### `RGBDSensorClient`
+
+* The device no longer crashes when no image was received yet (#2349).
+* The timestamp is now correct.

--- a/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
@@ -320,34 +320,20 @@ std::string RGBDSensorClient::getLastErrorMsg(yarp::os::Stamp* /*timeStamp*/)
 
 bool RGBDSensorClient::getRgbImage(yarp::sig::FlexImage &rgbImage, yarp::os::Stamp *timeStamp)
 {
-    if(timeStamp) {
-        timeStamp->update(yarp::os::Time::now());
-    }
-    return streamingReader->readRgb(rgbImage);
+    return streamingReader->readRgb(rgbImage, timeStamp);
 }
 
 bool RGBDSensorClient::getDepthImage(yarp::sig::ImageOf<yarp::sig::PixelFloat> &depthImage, yarp::os::Stamp *timeStamp)
 {
-    if(timeStamp) {
-        timeStamp->update(yarp::os::Time::now());
-    }
-    return streamingReader->readDepth(depthImage);
+    return streamingReader->readDepth(depthImage, timeStamp);
 }
 
 bool RGBDSensorClient::getImages(FlexImage &rgbImage, ImageOf<PixelFloat> &depthImage, Stamp *rgbStamp, Stamp *depthStamp)
 {
-    bool ret = true;
-    ret &= streamingReader->readRgb(rgbImage);
-    ret &= streamingReader->readDepth(depthImage);
-
-    if(rgbStamp) {
-        rgbStamp->update(yarp::os::Time::now());
-    }
-
-    if(depthStamp) {
-        depthStamp->update(yarp::os::Time::now());
-    }
-    return ret;
+    return streamingReader->read(rgbImage,
+                                 depthImage,
+                                 rgbStamp,
+                                 depthStamp);
 }
 
 //

--- a/src/devices/RGBDSensorClient/RGBDSensorClient.h
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient.h
@@ -9,6 +9,7 @@
 #ifndef YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_H
 #define YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_H
 
+#include "RGBDSensorClient_StreamingMsgParser.h"
 
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
@@ -96,8 +97,9 @@ protected:
     std::string remote_depthFrame_StreamingPort_name;
     std::string image_carrier_type;
     std::string depth_carrier_type;
-    yarp::os::BufferedPort<yarp::sig::FlexImage> colorFrame_StreamingPort;
-    yarp::os::BufferedPort<yarp::sig::ImageOf< yarp::sig::PixelFloat> > depthFrame_StreamingPort;
+
+    RgbImageBufferedPort   colorFrame_StreamingPort;
+    FloatImageBufferedPort depthFrame_StreamingPort;
 
     // Use a single RPC port for now
     std::string local_rpcPort_name;

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
@@ -46,11 +46,6 @@ yarp::sig::ImageOf<yarp::sig::PixelFloat> FloatImageReader_Impl::getImage()
 
 
 // Streaming handler
-RGBDSensor_StreamingMsgParser::RGBDSensor_StreamingMsgParser() :
-    port_rgb(nullptr),
-    port_depth(nullptr)
-{}
-
 bool RGBDSensor_StreamingMsgParser::readRgb(yarp::sig::FlexImage &data, yarp::os::Stamp *timeStamp)
 {
     data = read_rgb.getImage();

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
@@ -17,11 +17,13 @@ RgbImageReader_Impl::~RgbImageReader_Impl() = default;
 
 void RgbImageReader_Impl::onRead(yarp::sig::FlexImage& datum)
 {
+    std::lock_guard<std::mutex> lock(mutex);
     last_rgb = datum;
 }
 
 yarp::sig::FlexImage RgbImageReader_Impl::getImage()
 {
+    std::lock_guard<std::mutex> lock(mutex);
     return last_rgb;
 }
 
@@ -32,11 +34,13 @@ FloatImageReader_Impl::~FloatImageReader_Impl() = default;
 
 void FloatImageReader_Impl::onRead(yarp::sig::ImageOf< yarp::sig::PixelFloat> & datum)
 {
+    std::lock_guard<std::mutex> lock(mutex);
     last_depth = datum;
 }
 
 yarp::sig::ImageOf<yarp::sig::PixelFloat> FloatImageReader_Impl::getImage()
 {
+    std::lock_guard<std::mutex> lock(mutex);
     return last_depth;
 }
 

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
@@ -18,7 +18,7 @@ RgbImageReader_Impl::~RgbImageReader_Impl() = default;
 void RgbImageReader_Impl::onRead(yarp::sig::FlexImage& datum)
 {
     std::lock_guard<std::mutex> lock(mutex);
-    last_rgb = datum;
+    std::swap(datum, last_rgb);
 }
 
 yarp::sig::FlexImage RgbImageReader_Impl::getImage()
@@ -35,7 +35,7 @@ FloatImageReader_Impl::~FloatImageReader_Impl() = default;
 void FloatImageReader_Impl::onRead(yarp::sig::ImageOf< yarp::sig::PixelFloat> & datum)
 {
     std::lock_guard<std::mutex> lock(mutex);
-    last_depth = datum;
+    std::swap(datum, last_depth);
 }
 
 yarp::sig::ImageOf<yarp::sig::PixelFloat> FloatImageReader_Impl::getImage()

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.cpp
@@ -9,66 +9,108 @@
 
 #include "RGBDSensorClient_StreamingMsgParser.h"
 
+#include <yarp/os/Time.h>
+
 using namespace yarp::dev;
 
 // Callback reader for rgb
-RgbImageReader_Impl::RgbImageReader_Impl() = default;
-RgbImageReader_Impl::~RgbImageReader_Impl() = default;
-
-void RgbImageReader_Impl::onRead(yarp::sig::FlexImage& datum)
+void RgbImageBufferedPort::onRead(yarp::sig::FlexImage& datum)
 {
     std::lock_guard<std::mutex> lock(mutex);
+    local_arrival_time = yarp::os::Time::now();
     std::swap(datum, last_rgb);
+    getEnvelope(stamp);
 }
 
-yarp::sig::FlexImage RgbImageReader_Impl::getImage()
+std::tuple<bool, yarp::sig::FlexImage, yarp::os::Stamp> RgbImageBufferedPort::getImage() const
 {
     std::lock_guard<std::mutex> lock(mutex);
-    return last_rgb;
+    if (local_arrival_time <= 0.0) {
+        // No image received yet
+        // FIXME C++17:
+        // return {false, yarp::sig::FlexImage(), yarp::os::Stamp()};
+        // or perhaps just return {false, {}, {}}; ?
+        return std::make_tuple(false, yarp::sig::FlexImage(), yarp::os::Stamp());
+    }
+    // FIXME C++17:
+    // return {true, last_rgb, stamp};
+    return std::make_tuple(true, last_rgb, stamp);
 }
 
 
 // callback reader for depthImage
-FloatImageReader_Impl::FloatImageReader_Impl() = default;
-FloatImageReader_Impl::~FloatImageReader_Impl() = default;
-
-void FloatImageReader_Impl::onRead(yarp::sig::ImageOf< yarp::sig::PixelFloat> & datum)
+void FloatImageBufferedPort::onRead(yarp::sig::ImageOf< yarp::sig::PixelFloat> & datum)
 {
     std::lock_guard<std::mutex> lock(mutex);
+    local_arrival_time = yarp::os::Time::now();
     std::swap(datum, last_depth);
+    getEnvelope(stamp);
 }
 
-yarp::sig::ImageOf<yarp::sig::PixelFloat> FloatImageReader_Impl::getImage()
+std::tuple<bool, yarp::sig::ImageOf<yarp::sig::PixelFloat>, yarp::os::Stamp> FloatImageBufferedPort::getImage() const
 {
     std::lock_guard<std::mutex> lock(mutex);
-    return last_depth;
+    if (local_arrival_time <= 0.0) {
+        // No image received yet
+        // FIXME C++17:
+        // return {false, yarp::sig::ImageOf<yarp::sig::PixelFloat>(), yarp::os::Stamp()};
+        // or perhaps just return {false, {}, {}}; ?
+        return std::make_tuple(false, yarp::sig::ImageOf<yarp::sig::PixelFloat>(), yarp::os::Stamp());
+
+    }
+    // FIXME C++17:
+    // return {true, last_depth, stamp};
+    return std::make_tuple(true, last_depth, stamp);
 }
 
 
 // Streaming handler
 bool RGBDSensor_StreamingMsgParser::readRgb(yarp::sig::FlexImage &data, yarp::os::Stamp *timeStamp)
 {
-    data = read_rgb.getImage();
-    if(timeStamp) {
-        port_rgb->getEnvelope(*timeStamp);
+    auto result = port_rgb->getImage();
+
+    if (!std::get<0>(result)) {
+        return false;
     }
+
+    data = std::get<1>(result);
+    if (timeStamp) {
+        *timeStamp = std::get<2>(result);
+    }
+
     return true;
 }
 
 bool RGBDSensor_StreamingMsgParser::readDepth(yarp::sig::ImageOf< yarp::sig::PixelFloat > &data, yarp::os::Stamp *timeStamp)
 {
-    data = read_depth.getImage();
-    if(timeStamp) {
-        port_depth->getEnvelope(*timeStamp);
+    auto result = port_depth->getImage();
+
+    if (!std::get<0>(result)) {
+        return false;
     }
+
+    data = std::get<1>(result);
+    if(timeStamp) {
+        *timeStamp = std::get<2>(result);
+    }
+
     return true;
 }
 
 bool RGBDSensor_StreamingMsgParser::read(yarp::sig::FlexImage &rgbImage, yarp::sig::ImageOf< yarp::sig::PixelFloat > &depthImage, yarp::os::Stamp *rgbStamp, yarp::os::Stamp *depthStamp)
 {
-    rgbImage = read_rgb.getImage();
-    depthImage = read_depth.getImage();
+    auto resultRgb = port_rgb->getImage();
+    auto resultDepth = port_depth->getImage();
 
+    bool retRgb = std::get<0>(resultRgb);
+    bool retDepth = std::get<0>(resultDepth);
+
+    if (!retRgb || !retDepth) {
+        return false;
+    }
+
+    rgbImage = std::get<1>(resultRgb);
+    depthImage = std::get<1>(resultDepth);
     if(rgbStamp) {
         port_rgb->getEnvelope(*rgbStamp);
     }
@@ -79,11 +121,11 @@ bool RGBDSensor_StreamingMsgParser::read(yarp::sig::FlexImage &rgbImage, yarp::s
     return true;
 }
 
-void RGBDSensor_StreamingMsgParser::attach(yarp::os::BufferedPort<yarp::sig::FlexImage> *_port_rgb,
-            yarp::os::BufferedPort<yarp::sig::ImageOf< yarp::sig::PixelFloat> > *_port_depth)
+void RGBDSensor_StreamingMsgParser::attach(RgbImageBufferedPort* _port_rgb,
+                                           FloatImageBufferedPort* _port_depth)
 {
     port_rgb = _port_rgb;
     port_depth = _port_depth;
-    port_rgb->useCallback(read_rgb);
-    port_depth->useCallback(read_depth);
+    port_rgb->useCallback();
+    port_depth->useCallback();
 }

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.h
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.h
@@ -9,11 +9,11 @@
 #ifndef YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_STREAMINGMSGPARSER_H
 #define YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_STREAMINGMSGPARSER_H
 
+#include <yarp/os/LogStream.h>
+#include <yarp/os/PortablePair.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Image.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/os/PortablePair.h>
-#include <yarp/os/LogStream.h>
 
 #include <list>
 #include <mutex>
@@ -59,17 +59,22 @@ private:
     RgbImageReader_Impl   read_rgb;
     FloatImageReader_Impl read_depth;
 
-    yarp::os::BufferedPort<yarp::sig::FlexImage> *port_rgb;
-    yarp::os::BufferedPort<yarp::sig::ImageOf< yarp::sig::PixelFloat>> *port_depth;
+    yarp::os::BufferedPort<yarp::sig::FlexImage> *port_rgb {nullptr};
+    yarp::os::BufferedPort<yarp::sig::ImageOf< yarp::sig::PixelFloat>> *port_depth {nullptr};
 
 public:
-    RGBDSensor_StreamingMsgParser();
+    RGBDSensor_StreamingMsgParser() = default;
 
-    bool readRgb(yarp::sig::FlexImage &data, yarp::os::Stamp *timeStamp = nullptr);
+    bool readRgb(yarp::sig::FlexImage &data,
+                 yarp::os::Stamp *timeStamp = nullptr);
 
-    bool readDepth(yarp::sig::ImageOf< yarp::sig::PixelFloat > &data, yarp::os::Stamp *timeStamp = nullptr);
+    bool readDepth(yarp::sig::ImageOf< yarp::sig::PixelFloat > &data,
+                   yarp::os::Stamp *timeStamp = nullptr);
 
-    bool read(yarp::sig::FlexImage &rgbImage, yarp::sig::ImageOf< yarp::sig::PixelFloat > &depthImage, yarp::os::Stamp *rgbStamp = nullptr, yarp::os::Stamp *depthStamp = nullptr);
+    bool read(yarp::sig::FlexImage &rgbImage,
+              yarp::sig::ImageOf< yarp::sig::PixelFloat > &depthImage,
+              yarp::os::Stamp *rgbStamp = nullptr,
+              yarp::os::Stamp *depthStamp = nullptr);
 
     void attach(yarp::os::BufferedPort<yarp::sig::FlexImage> *_port_rgb,
                 yarp::os::BufferedPort<yarp::sig::ImageOf< yarp::sig::PixelFloat>> *_port_depth);

--- a/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.h
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient_StreamingMsgParser.h
@@ -9,19 +9,22 @@
 #ifndef YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_STREAMINGMSGPARSER_H
 #define YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_STREAMINGMSGPARSER_H
 
-#include <list>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Image.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PortablePair.h>
 #include <yarp/os/LogStream.h>
 
+#include <list>
+#include <mutex>
+
 
 class RgbImageReader_Impl :
         public yarp::os::TypedReaderCallback<yarp::sig::FlexImage>
 {
 private:
-    yarp::sig::FlexImage  last_rgb;
+    yarp::sig::FlexImage last_rgb;
+    mutable std::mutex mutex;
 
 public:
     RgbImageReader_Impl();
@@ -37,7 +40,8 @@ class FloatImageReader_Impl :
         public yarp::os::TypedReaderCallback<yarp::sig::ImageOf< yarp::sig::PixelFloat>>
 {
 private:
-    yarp::sig::ImageOf< yarp::sig::PixelFloat>  last_depth;
+    yarp::sig::ImageOf< yarp::sig::PixelFloat> last_depth;
+    mutable std::mutex mutex;
 
 public:
     FloatImageReader_Impl();


### PR DESCRIPTION
## Bug Fixes

### Devices

#### `RGBDSensorClient`

* The device no longer crashes when no image was received yet (#2349).
* The timestamp is now correct.

----

Fixes #2349