### PR TITLE
Fix NameSpace::checkNetwork(timeout) when NetworkBase::setLocalMode(true) is called

### DIFF
--- a/doc/release/yarp_3_4/fix_check_network_local_with_timeout.md
+++ b/doc/release/yarp_3_4/fix_check_network_local_with_timeout.md
@@ -1,0 +1,9 @@
+fix_check_network_local_with_timeout {#yarp_3_4}
+-------------------------------
+
+### yarp::os
+
+#### `NameSpace`
+
+* Fix `checkNetwork` timeout variant not working as `checkNetwork`
+  when `NetworkBase::setLocalMode(true)` is called.

--- a/src/libYARP_os/src/yarp/os/NameSpace.cpp
+++ b/src/libYARP_os/src/yarp/os/NameSpace.cpp
@@ -42,6 +42,10 @@ bool NameSpace::checkNetwork()
 
 bool NameSpace::checkNetwork(double timeout)
 {
+    if (localOnly()) {
+        return true;
+    }
+
     Contact c = queryName(getNameServerName());
     if (!c.isValid()) {
         return false;


### PR DESCRIPTION
`NameSpace::checkNetwork(timeout)` was actually checking if a `yarpserver`  is running even if `NetworkBase::setLocalMode(true)` was caled, differently from `NameSpace::checkNetwork()` . This PR fixes  `NameSpace::checkNetwork(timeout)` so that it behaves like `NameSpace::checkNetwork()`  .