### PR TITLE
os/Log: Print colored components when colors are enabled

### DIFF
--- a/doc/release/yarp_3_4/log_component_color.md
+++ b/doc/release/yarp_3_4/log_component_color.md
@@ -1,0 +1,6 @@
+log_component_color {#yarp_3_4}
+-------------------
+
+* Log components are now printed in colors when `YARP_COLORED_OUTPUT` is
+  enabled.
+


### PR DESCRIPTION
This isn't actually a bugfix, but it is a tiny enhancement that helps **a lot** while debugging, therefore, unless someone is against this, I'd like to merge it in the stable branch.

![image](https://user-images.githubusercontent.com/1100056/95331708-ad4e8980-08aa-11eb-8b90-69357407e046.png)

(With `YARP_COMPACT_OUTPUT`):
![image](https://user-images.githubusercontent.com/1100056/95331562-76787380-08aa-11eb-8b18-2146af53bb86.png)