### PR TITLE
yarpview-feature: Added mouse button right click interception

### DIFF
--- a/doc/release/master/feature_yarpview_right_click.md
+++ b/doc/release/master/feature_yarpview_right_click.md
@@ -1,0 +1,17 @@
+feature_yarpview_right_click {#master}
+---------------
+
+### GUIs
+
+#### `yarpview`
+
+* Added the possibility to intercept the mouse right button click event.
+* As for the mouse left button click event, there are two possibilities:
+   * Single click (sends the current cursor coordinates to the specified output port)
+   * Press, drag, and release (sends the coordinates of the `press` point and of the `release` one to the specified output port)
+* To enable this feature the user has to specify a name for the output port that will send the cursor coordinates to the YARP network using the `--rightout` option with the desired output port name, e.g.
+     ```
+     yarpview --rightout /outRight
+     ```
+* If the ouput port has been specified, menu bar, under the voice `Image`, will have a new checkable menu item, i.e. `Intercept right click` (checked by default) that will allow the user to enable/disable the right click interception, if he/she erver needs to (obviously this option is not available in `minimal` or `compact` mode since the menu is not accessible).
+* The line drawn while dragging with the right button will be green in order to easily distinguish it from the one drawn with the left button.

--- a/src/yarpview/plugin/YARPViewMenu.qml
+++ b/src/yarpview/plugin/YARPViewMenu.qml
@@ -22,6 +22,8 @@ import QtQuick.Controls 1.1
 
 MenuBar {
 
+    property bool rightClickVisible: false;
+
     signal quit()
     signal about()
     signal freeze(bool checked)
@@ -33,6 +35,7 @@ MenuBar {
     signal saveSingleImage(bool checked)
     signal saveSetImages(bool checked)
     signal pickColor(bool checked)
+    signal rightClickEnable(bool checked)
 
     function enableSynch(check){
         if(check === true){
@@ -40,6 +43,11 @@ MenuBar {
         }else{
             synchItem.checked = false
         }
+    }
+
+    function externallyCheckRightClick(check){
+        rightClickVisible = check;
+        rightClickItem.checked = check;
     }
 
     function enableAutosize(check){
@@ -132,6 +140,16 @@ MenuBar {
                        pickColor(colorPickerItem.checked);
                    }}
         MenuSeparator{}
+        MenuItem { id: rightClickItem
+                   text: "Intercept right click"
+                   visible: rightClickVisible
+                   checkable: true
+                   onTriggered: {
+                       rightClickEnable(rightClickItem.checked);
+                   }}
+        MenuSeparator{
+                   visible: rightClickVisible
+        }
         MenuItem { text: "Change refresh interval"
                     onTriggered: {
                         changeRefreshInterval()

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -49,8 +49,10 @@ struct mOptions
     char            m_fileName[256];
     int             m_saveOnExit;
     char            m_outPortName[256];
+    char            m_outRightPortName[256]; //Name for the mouse right click related port
     char            m_outNetworkName[256];
     int             m_outputEnabled;
+    int             m_rightEnabled; //If true the right click related output is enabled
     bool            m_synchRate;
     bool            m_autosize;
 };
@@ -89,8 +91,11 @@ public:
     Q_INVOKABLE void startDumpFrames();
     Q_INVOKABLE void stopDumpFrames();
     Q_INVOKABLE bool parseParameters(QStringList);
+    Q_INVOKABLE bool rightClickEnabled();
     Q_INVOKABLE void clickCoords_2(int x, int y);
     Q_INVOKABLE void clickCoords_4(int start_x, int start_y, int end_x, int end_y);
+    Q_INVOKABLE void rightClickCoords_2(int x, int y);
+    Q_INVOKABLE void rightClickCoords_4(int start_x, int start_y, int end_x, int end_y);
 
     Q_INVOKABLE QString getPixelAsStr(int x, int y);
 
@@ -124,10 +129,12 @@ private:
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgba> > *ptr_inputPort;
 #endif
     yarp::os::BufferedPort<yarp::os::Bottle> *_pOutPort;
+    yarp::os::BufferedPort<yarp::os::Bottle> *_pOutRightPort;
     InputCallback *ptr_portCallback;
     pgmOptions _options;
 
 signals:
+    void optionsSet();
     void refreshIntervalChanged();
     void videoProducerChanged();
     void posXChanged();

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -37,6 +37,10 @@ ApplicationWindow {
     property int menuH: 0
     title: vSurface.moduleTitle
 
+    Component.onCompleted: function(){
+        vSurface.synchronizeRightEnabled();
+    }
+
     function calc()    {
         if(menuH != 0){
             return;
@@ -91,6 +95,9 @@ ApplicationWindow {
         onSaveSingleClosed:{
             menu.saveSingleChecked(check);
         }
+        onRightClickEnabled:{
+            menu.externallyCheckRightClick(enabled);
+        }
     }
 
     Connections{
@@ -132,6 +139,10 @@ ApplicationWindow {
         onPickColor:{
             vSurface.enableColorPicking(checked);
             statusBar.setPixelValVisibility(checked);
+        }
+
+        onRightClickEnable:{
+            vSurface.enableRightClick(checked);
         }
 
         onAbout:{


### PR DESCRIPTION
* Added the possibility to intercept the mouse right button click event.
* As for the mouse left button click event, there are two possibilities:
   * Single click (sends the current cursor coordinates to the specified output port)
   * Press, drag, and release (sends the coordinates of the `press` point and of the `release` one to the specified output port)
* To enable this feature the user has to specify a name for the output port that will send the cursor coordinates to the YARP network using the `--rightout` option with the desired output port name, e.g.
     ```
     yarpview --rightout /outRight
     ```
* If the ouput port has been specified, menu bar, under the voice `Image`, will have a new checkable menu item, i.e. `Intercept right click` (checked by default) that will allow the user to enable/disable the right click interception, if he/she erver needs to (obviously this option is not available in `minimal` or `compact` mode since the menu is not accessible).
* The line drawn while dragging with the right button will be green in order to easily distinguish it from the one drawn with the left button.