### PR TITLE
os/DummyConnector: Add optional replyWriter parameter

### DIFF
--- a/doc/release/master/DummyConnector_reply_writer.md
+++ b/doc/release/master/DummyConnector_reply_writer.md
@@ -1,0 +1,14 @@
+DummyConnector_reply_writer {#master}
+---------------------------
+
+
+### Libraries
+
+#### os
+
+##### `yarp::os::DummyConnector`
+
+* The `getReader` methods now accepts a `ConnectionWriter` as optional
+  parameter. This writer is returned by `getWriter` is called on the
+  `ConnectionReader` returned by the writer, and it is therefore used for the
+  replies in `Portable`s and in a few other cases.

--- a/src/libYARP_os/src/yarp/os/DummyConnector.h
+++ b/src/libYARP_os/src/yarp/os/DummyConnector.h
@@ -69,11 +69,12 @@ public:
     /**
      * Get the dummy ConnectionReader loaded with whatever was written the ConnectionWriter since
      * it was last reset.
+     * \param replyWriter A writer to be used for replies received on the connection.
      * \return a loaded ConnectionReader if it was previously written to
      * \sa ConnectionReader Portable
      * \warning Calling this method twice will reset the reader
      */
-    ConnectionReader& getReader();
+    ConnectionReader& getReader(ConnectionWriter* replyWriter = nullptr);
 
     /**
      * Reset and clear the current ConnectionWriter


### PR DESCRIPTION
### Libraries

#### os

##### `yarp::os::DummyConnector`

* The `getReader` methods now accepts a `ConnectionWriter` as optional parameter. This writer is returned by `getWriter` is called on the `ConnectionReader` returned by the writer, and it is therefore used for the replies in `Portable`s and in a few other cases.

At the moment replies are written on the same writer that is used for writing the input for the `DummyConnector` this makes it impossible to receive a reply.

This is the first of a series of patch that will allow portmonitors to inspect RPC connections.

It's very similar to a bugfix, but unfortunately it requires some changes in the API, therefore it is on `master`