### PR TITLE
devices: Fix include directories variable for PortAudio

### DIFF
--- a/src/devices/portaudio/CMakeLists.txt
+++ b/src/devices/portaudio/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT SKIP_portaudio)
                                                       YARP_sig
                                                       YARP_dev)
 
-  target_include_directories(yarp_portaudio SYSTEM PRIVATE ${PortAudio_INCLUDE_DIR})
+  target_include_directories(yarp_portaudio SYSTEM PRIVATE ${PortAudio_INCLUDE_DIRS})
   target_link_libraries(yarp_portaudio PRIVATE ${PortAudio_LIBRARIES})
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS PortAudio) (not using targets)
 

--- a/src/devices/portaudioPlayer/CMakeLists.txt
+++ b/src/devices/portaudioPlayer/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT SKIP_portaudioPlayer)
                                                       YARP_sig
                                                       YARP_dev)
 
-  target_include_directories(yarp_portaudioPlayer SYSTEM PRIVATE ${PortAudio_INCLUDE_DIR})
+  target_include_directories(yarp_portaudioPlayer SYSTEM PRIVATE ${PortAudio_INCLUDE_DIRS})
   target_link_libraries(yarp_portaudioPlayer PRIVATE ${PortAudio_LIBRARIES})
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS PortAudio) (not using targets)
 

--- a/src/devices/portaudioRecorder/CMakeLists.txt
+++ b/src/devices/portaudioRecorder/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT SKIP_portaudioRecorder)
                                                       YARP_sig
                                                       YARP_dev)
 
-  target_include_directories(yarp_portaudioRecorder SYSTEM PRIVATE ${PortAudio_INCLUDE_DIR})
+  target_include_directories(yarp_portaudioRecorder SYSTEM PRIVATE ${PortAudio_INCLUDE_DIRS})
   target_link_libraries(yarp_portaudioRecorder PRIVATE ${PortAudio_LIBRARIES})
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS PortAudio) (not using targets)
 


### PR DESCRIPTION
The `FindPortAudio` CMake module from YCM ( https://github.com/robotology/ycm/blob/master/find-modules/FindPortAudio.cmake ) uses the `PortAudio_INCLUDE_DIRS` variable to contain the include directories, while YARP CMake was using `PortAudio_INCLUDE_DIR` that was empty. 

Related issue: https://github.com/robotology/yarp/issues/2117 .