### PR TITLE
Fix ffmpeg get audio

### DIFF
--- a/doc/release/yarp_3_4/fix_ffmpeg_getAudio.md
+++ b/doc/release/yarp_3_4/fix_ffmpeg_getAudio.md
@@ -1,0 +1,10 @@
+fix_ffmpeg_getAudio {#yarp_3_4}
+---------------
+
+### device
+
+#### `ffmpeg`
+
+* Corrected a minor error in `FfmpegGrabber.cpp` that caused a segmentation fault when using a video with audio track as a `source` for the device
+
+* **N.B.** The device can now be used and do not crash but the actual audio grabbing has not been tested yet.

--- a/src/devices/ffmpeg/FfmpegGrabber.cpp
+++ b/src/devices/ffmpeg/FfmpegGrabber.cpp
@@ -220,7 +220,7 @@ public:
             if (gotFrame) {
                 ct = av_samples_get_buffer_size(nullptr,
                                                 pCodecCtx->channels,
-                                                pFrame->nb_samples,
+                                                pAudio->nb_samples,
                                                 pCodecCtx->sample_fmt,
                                                 1);
             }


### PR DESCRIPTION
* Corrected a minor error in `FfmpegGrabber.cpp` that caused a segmentation fault when using a video with audio track as a `source` for the device

* **N.B.** The device can now be used and do not crash but the actual audio grabbing has not been tested yet.