### PR TITLE
yarpbatterygui fixes

### DIFF
--- a/doc/release/yarp_3_4/yarpbatterygui_fixes.md
+++ b/doc/release/yarp_3_4/yarpbatterygui_fixes.md
@@ -1,0 +1,12 @@
+yarpbatterygui_fixes {#yarp_3_4}
+--------------------
+
+
+### Tools
+
+#### `yarpbatterygui`
+
+* The window can no longer be resized.
+* The window background can no longer be moved around.
+* The window no longer stays on top automatically. A new `--keep-above` switch
+  is provided to restore this behavior.

--- a/src/yarpbatterygui/display.cpp
+++ b/src/yarpbatterygui/display.cpp
@@ -215,8 +215,8 @@ MainWindow::MainWindow(const yarp::os::ResourceFinder& rf, yarp::dev::IBattery* 
     //this->setWindowFlags(Qt::BypassWindowManagerHint); //Set window with no title bar
     //this->setWindowFlags(Qt::CustomizeWindowHint); //Set window with no title bar
     this->setWindowFlags(Qt::MSWindowsFixedSizeDialogHint); //Set window to fixed size
-   // this->setWindowFlags(Qt::FramelessWindowHint); //Set a frameless window
-    this->setWindowFlags(Qt::WindowStaysOnTopHint); //Always on  top
+    //this->setWindowFlags(Qt::FramelessWindowHint); //Set a frameless window
+    //this->setWindowFlags(Qt::WindowStaysOnTopHint); //Always on  top
 
     bool ret_load = true;
     ret_load &= img_background1.load(":/images/background.bmp");

--- a/src/yarpbatterygui/display.cpp
+++ b/src/yarpbatterygui/display.cpp
@@ -91,7 +91,6 @@ void MainWindow::updateMain()
         QPixmap qpm = img_background1.copy(rect);
         QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
         p1->setScale(1);
-        p1->setFlag(QGraphicsItem::ItemIsMovable, true);
         p1->setPos(0, 0);
     }
     else
@@ -100,7 +99,6 @@ void MainWindow::updateMain()
         QPixmap qpm = img_background2.copy(rect);
         QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
         p1->setScale(1);
-        p1->setFlag(QGraphicsItem::ItemIsMovable, true);
         p1->setPos(0, 0);
     }
 
@@ -112,7 +110,6 @@ void MainWindow::updateMain()
             QPixmap qpm = img_charge.copy(rect);
             QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
             p1->setScale(1);
-            p1->setFlag(QGraphicsItem::ItemIsMovable, true);
             p1->setPos(56, 77);
         }
         else
@@ -121,7 +118,6 @@ void MainWindow::updateMain()
             QPixmap qpm = img_charge.copy(rect);
             QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
             p1->setScale(1);
-            p1->setFlag(QGraphicsItem::ItemIsMovable, true);
             p1->setPos(56, 77);
         }
     }
@@ -146,7 +142,6 @@ void MainWindow::updateMain()
 
             QGraphicsPixmapItem *p1 = scene->addPixmap(*qpp);
             p1->setScale(1);
-            p1->setFlag(QGraphicsItem::ItemIsMovable, true);
             p1->setPos(xpos, ypos);
         }
     }
@@ -166,7 +161,6 @@ void MainWindow::updateMain()
                 QPixmap  qpm = img_numbers.copy(rect);
                 QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
                 p1->setScale(1);
-                p1->setFlag(QGraphicsItem::ItemIsMovable, true);
                 p1->setPos(19 + i * 29 - point_off, 21);
             }
         }
@@ -187,7 +181,6 @@ void MainWindow::updateMain()
                 QPixmap  qpm = img_numbers.copy(rect);
                 QGraphicsPixmapItem *p1 = scene->addPixmap(qpm);
                 p1->setScale(1);
-                p1->setFlag(QGraphicsItem::ItemIsMovable, true);
                 p1->setPos(19 + i * 29 - point_off, 88);
             }
         }

--- a/src/yarpbatterygui/display.ui
+++ b/src/yarpbatterygui/display.ui
@@ -16,6 +16,12 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="maximumSize">
+   <size>
+    <width>200</width>
+    <height>180</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>yarpBatteryGui</string>
   </property>

--- a/src/yarpbatterygui/main.cpp
+++ b/src/yarpbatterygui/main.cpp
@@ -61,9 +61,11 @@ int main(int argc, char *argv[])
     if (rf.check("help"))
     {
         yInfo() << "Options:";
-        yInfo() << "--local <name> The name of local opened by this module. e.g. batteryMonitor";
-        yInfo() << "--remote <name> The prefix name of the port to connect to, e.g. /mybattery. The port name is completed by the client adding /data:o, /rpc:i";
-        yInfo() << "--refresh_period <seconds> Refresh period of the gui. Default value: 10s";
+        yInfo() << "--local <name>              The name of local opened by this module. e.g. batteryMonitor";
+        yInfo() << "--remote <name>             The prefix name of the port to connect to, e.g. /mybattery.";
+        yInfo() << "                            The port name is completed by the client adding /data:o, /rpc:i";
+        yInfo() << "--refresh_period <seconds>  Refresh period of the gui. Default value: 10s";
+        yInfo() << "--keep-above                Keep window above the others";
         return 0;
     }
 
@@ -144,6 +146,12 @@ int main(int argc, char *argv[])
     }
 
     MainWindow w(rf, ibat, nullptr, refresh_period);
+
+    if (rf.check("keep-above"))
+    {
+        w.setWindowFlags(Qt::WindowStaysOnTopHint);
+    }
+
     w.show();
     int ret = a.exec();
 


### PR DESCRIPTION
### Tools

#### `yarpbatterygui`

* The window can no longer be resized.
* The window background can no longer be moved around.
* The window no longer stays on top automatically. A new `--keep-above` switch
  is provided to restore this behavior.

Fixes #2207 