### PR TITLE
devices/controlboardwrapper2: Fix access to time not protected by mutex

### DIFF
--- a/doc/release/yarp_3_4/controlboardwrapper2_timeMutex.md
+++ b/doc/release/yarp_3_4/controlboardwrapper2_timeMutex.md
@@ -1,0 +1,8 @@
+controlboardwrapper2_timeMutex {#yarp_3_4}
+------------------------------
+
+### Devices
+
+#### `controlboardwrapper2`
+
+Fix access to the timestamp not protected by mutex (#2396).


### PR DESCRIPTION
# Devices

#### `controlboardwrapper2`

Fix access to the timestamp not protected by mutex (#2396).

---------------------------

Instead of repeatedly accessing the `time` variable, I saved it in while protected by the mutex, and used the same timestamp for the whole `run` function.

Fixes #2396