### PR TITLE
devices/controlboardwrapper2: Tentative to make it maintainable.

### DIFF
--- a/src/devices/ControlBoardWrapper/CMakeLists.txt
+++ b/src/devices/ControlBoardWrapper/CMakeLists.txt
@@ -4,42 +4,97 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-yarp_prepare_plugin(controlboardwrapper2
-                    CATEGORY device
-                    TYPE ControlBoardWrapper
-                    INCLUDE ControlBoardWrapper.h
-                    EXTRA_CONFIG WRAPPER=controlboardwrapper2
-                    DEFAULT ON)
+yarp_prepare_plugin(
+  controlboardwrapper2
+  CATEGORY device
+  TYPE ControlBoardWrapper
+  INCLUDE ControlBoardWrapper.h
+  EXTRA_CONFIG WRAPPER=controlboardwrapper2
+  DEFAULT ON
+)
 
 if(NOT SKIP_controlboardwrapper2)
   yarp_add_plugin(yarp_controlboardwrapper2)
 
-  target_sources(yarp_controlboardwrapper2 PRIVATE ControlBoardWrapper.cpp
-                                                   ControlBoardWrapper.h
-                                                   ControlBoardWrapperLogComponent.cpp
-                                                   ControlBoardWrapperLogComponent.h
-                                                   RPCMessagesParser.cpp
-                                                   RPCMessagesParser.h
-                                                   StreamingMessagesParser.cpp
-                                                   StreamingMessagesParser.h
-                                                   SubDevice.cpp
-                                                   SubDevice.h)
+  target_sources(yarp_controlboardwrapper2
+    PRIVATE
+      ControlBoardWrapper.cpp
+      ControlBoardWrapper.h
+      ControlBoardWrapperAmplifierControl.cpp
+      ControlBoardWrapperAmplifierControl.h
+      ControlBoardWrapperAxisInfo.cpp
+      ControlBoardWrapperAxisInfo.h
+      ControlBoardWrapperCommon.cpp
+      ControlBoardWrapperCommon.h
+      ControlBoardWrapperControlCalibration.cpp
+      ControlBoardWrapperControlCalibration.h
+      ControlBoardWrapperControlLimits.cpp
+      ControlBoardWrapperControlLimits.h
+      ControlBoardWrapperControlMode.cpp
+      ControlBoardWrapperControlMode.h
+      ControlBoardWrapperCurrentControl.cpp
+      ControlBoardWrapperCurrentControl.h
+      ControlBoardWrapperEncodersTimed.cpp
+      ControlBoardWrapperEncodersTimed.h
+      ControlBoardWrapperImpedanceControl.cpp
+      ControlBoardWrapperImpedanceControl.h
+      ControlBoardWrapperInteractionMode.cpp
+      ControlBoardWrapperInteractionMode.h
+      ControlBoardWrapperLogComponent.cpp
+      ControlBoardWrapperLogComponent.h
+      ControlBoardWrapperMotor.cpp
+      ControlBoardWrapperMotor.h
+      ControlBoardWrapperMotorEncoders.cpp
+      ControlBoardWrapperMotorEncoders.h
+      ControlBoardWrapperPWMControl.cpp
+      ControlBoardWrapperPWMControl.h
+      ControlBoardWrapperPidControl.cpp
+      ControlBoardWrapperPidControl.h
+      ControlBoardWrapperPositionControl.cpp
+      ControlBoardWrapperPositionControl.h
+      ControlBoardWrapperPositionDirect.cpp
+      ControlBoardWrapperPositionDirect.h
+      ControlBoardWrapperPreciselyTimed.cpp
+      ControlBoardWrapperPreciselyTimed.h
+      ControlBoardWrapperRemoteCalibrator.cpp
+      ControlBoardWrapperRemoteCalibrator.h
+      ControlBoardWrapperRemoteVariables.cpp
+      ControlBoardWrapperRemoteVariables.h
+      ControlBoardWrapperTorqueControl.cpp
+      ControlBoardWrapperTorqueControl.h
+      ControlBoardWrapperVelocityControl.cpp
+      ControlBoardWrapperVelocityControl.h
+      MultiJointData.h
+      RPCMessagesParser.cpp
+      RPCMessagesParser.h
+      StreamingMessagesParser.cpp
+      StreamingMessagesParser.h
+      SubDevice.cpp
+      SubDevice.h
+  )
 
-  target_link_libraries(yarp_controlboardwrapper2 PRIVATE YARP::YARP_os
-                                                          YARP::YARP_sig
-                                                          YARP::YARP_dev
-                                                          YARP::YARP_rosmsg)
-  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
-                                                      YARP_sig
-                                                      YARP_dev
-                                                      YARP_rosmsg)
+  target_link_libraries(yarp_controlboardwrapper2
+    PRIVATE
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+      YARP::YARP_rosmsg
+  )
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+    YARP_os
+    YARP_sig
+    YARP_dev
+    YARP_rosmsg
+  )
 
-  yarp_install(TARGETS yarp_controlboardwrapper2
-               EXPORT YARP_${YARP_PLUGIN_MASTER}
-               COMPONENT ${YARP_PLUGIN_MASTER}
-               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
-               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+  yarp_install(
+    TARGETS yarp_controlboardwrapper2
+    EXPORT YARP_${YARP_PLUGIN_MASTER}
+    COMPONENT ${YARP_PLUGIN_MASTER}
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
 
   set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -457,6 +457,8 @@ bool ControlBoardWrapper::openDeferredAttach(Property& prop)
         Bottle parameters;
         int wBase;
         int wTop;
+        int base;
+        int top;
 
         parameters = prop.findGroup(nets->get(k).asString());
 
@@ -587,8 +589,8 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     device.subdevices.resize(1);
 
     // configure the device
-    base = 0;
-    top = controlledJoints - 1;
+    int base = 0;
+    int top = controlledJoints - 1;
 
     int wbase = base;
     int wtop = top;

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -8,18 +8,20 @@
  */
 
 #include "ControlBoardWrapper.h"
-#include "StreamingMessagesParser.h"
-#include "RPCMessagesParser.h"
-#include "ControlBoardWrapperLogComponent.h"
-#include <yarp/dev/impl/jointData.h>
-#include <iostream>
+
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
-#include <sstream>
-#include <numeric>
-#include <algorithm>
 
-#include <cstring>         // for memset function
+#include <yarp/dev/impl/jointData.h>
+
+#include "ControlBoardWrapperLogComponent.h"
+#include "RPCMessagesParser.h"
+#include "StreamingMessagesParser.h"
+#include <algorithm>
+#include <cstring> // for memset function
+#include <iostream>
+#include <numeric>
+#include <sstream>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -28,25 +30,12 @@ using namespace yarp::sig;
 using namespace std;
 
 
-ControlBoardWrapper::ControlBoardWrapper() :yarp::os::PeriodicThread(0.02),
-                                            ownDevices(true)
+ControlBoardWrapper::ControlBoardWrapper() :
+        yarp::os::PeriodicThread(default_period),
+        ownDevices(true)
 {
     streaming_parser.init(this);
     RPC_parser.init(this);
-    controlledJoints = 0;
-    period = 0.02; // s.
-    base = 0;
-    top = 0;
-    subDeviceOwned = nullptr;
-    _verb = false;
-
-    // init ROS data
-    rosNodeName = "";
-    rosTopicName = "";
-    rosNode = nullptr;
-    rosMsgCounter = 0;
-    useROS = ROS_disabled;
-    jointNames.clear();
 }
 
 void ControlBoardWrapper::cleanup_yarpPorts()
@@ -75,47 +64,39 @@ bool ControlBoardWrapper::close()
     //stop thread if running
     detachAll();
 
-    if (yarp::os::PeriodicThread::isRunning())
-    {
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
     }
 
-    if(useROS != ROS_only)
-    {
+    if (useROS != ROS_only) {
         cleanup_yarpPorts();
     }
 
-    if(rosNode != nullptr)
-    {
+    if (rosNode != nullptr) {
         delete rosNode;
         rosNode = nullptr;
     }
 
     //if we own a deviced we have to close and delete it
-    if (ownDevices)
-    {
+    if (ownDevices) {
         // we should have created a new devices which we need to delete
-        if(subDeviceOwned != nullptr)
-        {
+        if (subDeviceOwned != nullptr) {
             subDeviceOwned->close();
             delete subDeviceOwned;
             subDeviceOwned = nullptr;
         }
-    }
-    else
-    {
+    } else {
         detachAll();
     }
     return true;
 }
 
-bool ControlBoardWrapper::checkPortName(Searchable &params)
+bool ControlBoardWrapper::checkPortName(Searchable& params)
 {
     /* see if rootName is present in the config file, this param is not used from long time, so it'll be
      * marked as deprecated.
      */
-    if(params.check("rootName"))
-    {
+    if (params.check("rootName")) {
         yCWarning(CONTROLBOARDWRAPPER) <<
             "************************************************************************************\n"
             "* controlboardwrapper2 is using the deprecated parameter 'rootName' for port name, *\n"
@@ -126,8 +107,7 @@ bool ControlBoardWrapper::checkPortName(Searchable &params)
     }
 
     // find name as port name (similar both in new and old policy
-    if(!params.check("name"))
-    {
+    if (!params.check("name")) {
         yCError(CONTROLBOARDWRAPPER) <<
             "************************************************************************************\n"
             "* controlboardwrapper2 missing mandatory parameter 'name' for port name, usage is: *\n"
@@ -137,8 +117,7 @@ bool ControlBoardWrapper::checkPortName(Searchable &params)
     }
 
     partName = params.find("name").asString();
-    if(partName[0] != '/')
-    {
+    if (partName[0] != '/') {
         yCWarning(CONTROLBOARDWRAPPER) <<
             "************************************************************************************\n"
             "* controlboardwrapper2 'name' parameter for port name does not follow convention,  *\n"
@@ -147,79 +126,67 @@ bool ControlBoardWrapper::checkPortName(Searchable &params)
             "* A temporary automatic fix will be done for you, but please fix your config file  *\n"
             "************************************************************************************";
         rootName = "/" + partName;
-    }
-    else
-    {
+    } else {
         rootName = partName;
     }
 
     return true;
 }
 
-bool ControlBoardWrapper::checkROSParams(Searchable &config)
+bool ControlBoardWrapper::checkROSParams(Searchable& config)
 {
     // check for ROS parameter group
-    if(!config.check("ROS") )
-    {
+    if (!config.check("ROS")) {
         useROS = ROS_disabled;
         return true;
     }
 
-    yCInfo(CONTROLBOARDWRAPPER)  << "ROS group was FOUND in config file.";
+    yCInfo(CONTROLBOARDWRAPPER) << "ROS group was FOUND in config file.";
 
-    Bottle &rosGroup = config.findGroup("ROS");
-    if(rosGroup.isNull())
-    {
+    Bottle& rosGroup = config.findGroup("ROS");
+    if (rosGroup.isNull()) {
         yCError(CONTROLBOARDWRAPPER) << partName << "ROS group params is not a valid group or empty";
         useROS = ROS_config_error;
         return false;
     }
 
     // check for useROS parameter
-    if(!rosGroup.check("useROS"))
-    {
+    if (!rosGroup.check("useROS")) {
         yCError(CONTROLBOARDWRAPPER) << partName << " cannot find useROS parameter, mandatory when using ROS message. \n \
                     Allowed values are true, false, ROS_only";
         useROS = ROS_config_error;
         return false;
     }
     std::string ros_use_type = rosGroup.find("useROS").asString();
-    if(ros_use_type == "false")
-    {
+    if (ros_use_type == "false") {
         yCInfo(CONTROLBOARDWRAPPER) << partName << "useROS topic if set to 'false'";
         useROS = ROS_disabled;
         return true;
     }
-    else if(ros_use_type == "true")
-    {
+
+    if (ros_use_type == "true") {
         yCInfo(CONTROLBOARDWRAPPER) << partName << "useROS topic if set to 'true'";
         useROS = ROS_enabled;
-    }
-    else if(ros_use_type == "only")
-    {
+    } else if (ros_use_type == "only") {
         yCInfo(CONTROLBOARDWRAPPER) << partName << "useROS topic if set to 'only";
         useROS = ROS_only;
-    }
-    else
-    {
+    } else {
         yCInfo(CONTROLBOARDWRAPPER) << partName << "useROS parameter is seet to unvalid value ('" << ros_use_type << "'), supported values are 'true', 'false', 'only'";
         useROS = ROS_config_error;
         return false;
     }
 
     // check for ROS_nodeName parameter
-    if(!rosGroup.check("ROS_nodeName"))
-    {
+    if (!rosGroup.check("ROS_nodeName")) {
         yCError(CONTROLBOARDWRAPPER) << partName << " cannot find ROS_nodeName parameter, mandatory when using ROS message";
         useROS = ROS_config_error;
         return false;
     }
-    rosNodeName = rosGroup.find("ROS_nodeName").asString();  // TODO: check name is correct
+    rosNodeName = rosGroup.find("ROS_nodeName").asString(); // TODO: check name is correct
     yCInfo(CONTROLBOARDWRAPPER) << partName << "rosNodeName is " << rosNodeName;
 
     // check for ROS_topicName parameter
-    if(!rosGroup.check("ROS_topicName"))
-    {
+    if (!rosGroup.check("ROS_topicName")) {
         yCError(CONTROLBOARDWRAPPER) << partName << " cannot find rosTopicName parameter, mandatory when using ROS message";
         useROS = ROS_config_error;
         return false;
@@ -230,30 +197,25 @@ bool ControlBoardWrapper::checkROSParams(Searchable &config)
     // check for rosNodeName parameter
     // UPDATE: joint names are got from MotionControl subdevice now.
     // An error should be thrown later on in case we fail getting names from device
-    if(!rosGroup.check("jointNames"))
-    {
+    if (!rosGroup.check("jointNames")) {
         yCInfo(CONTROLBOARDWRAPPER) << partName << "ROS topic has been required, jointNames will be got from motionControl subdevice.";
-    }
-    else  // if names are there, store them. They will be used for back compatibility if old policy is used.
+    } else // if names are there, store them. They will be used for back compatibility if old policy is used.
     {
         Bottle nameList = rosGroup.findGroup("jointNames").tail();
-        if (nameList.isNull())
-        {
+        if (nameList.isNull()) {
             yCError(CONTROLBOARDWRAPPER) << partName << " jointNames not found";
             useROS = ROS_config_error;
             return false;
         }
 
-        if(nameList.size() != (size_t) controlledJoints)
-        {
+        if (nameList.size() != static_cast<size_t>(controlledJoints)) {
             yCError(CONTROLBOARDWRAPPER) << partName << " jointNames incorrect number of entries. \n jointNames is " << nameList.toString() << "while expected length is " << controlledJoints;
             useROS = ROS_config_error;
             return false;
         }
 
         jointNames.clear();
-        for(int i=0; i<controlledJoints; i++)
-        {
+        for (int i = 0; i < controlledJoints; i++) {
             jointNames.push_back(nameList.get(i).toString());
         }
     }
@@ -263,125 +225,110 @@ bool ControlBoardWrapper::checkROSParams(Searchable &config)
 bool ControlBoardWrapper::initialize_ROS()
 {
     bool success = false;
-    switch(useROS)
+    switch (useROS) {
+    case ROS_enabled:
+    case ROS_only: {
+        rosNode = new yarp::os::Node(rosNodeName); // add a ROS node
+
+        if (rosNode == nullptr) {
+            yCError(CONTROLBOARDWRAPPER) << " opening " << rosNodeName << " Node, check your yarp-ROS network configuration";
+            success = false;
+            break;
+        }
+
+        if (!rosPublisherPort.topic(rosTopicName)) {
+            yCError(CONTROLBOARDWRAPPER) << " opening " << rosTopicName << " Topic, check your yarp-ROS network configuration";
+            success = false;
+            break;
+        }
+        success = true;
+    } break;
+
+    case ROS_disabled: {
+        yCInfo(CONTROLBOARDWRAPPER) << partName << ": no ROS initialization required";
+        success = true;
+    } break;
+
+    case ROS_config_error: {
+        yCError(CONTROLBOARDWRAPPER) << partName << " ROS parameter are not correct, check your configuration file";
+        success = false;
+    } break;
+
+    default:
     {
-        case ROS_enabled:
-        case ROS_only:
-        {
-            rosNode = new yarp::os::Node(rosNodeName);   // add a ROS node
-
-            if(rosNode == nullptr)
-            {
-                yCError(CONTROLBOARDWRAPPER) << " opening " << rosNodeName << " Node, check your yarp-ROS network configuration";
-                success = false;
-                break;
-            }
-
-            if (!rosPublisherPort.topic(rosTopicName) )
-            {
-                yCError(CONTROLBOARDWRAPPER) << " opening " << rosTopicName << " Topic, check your yarp-ROS network configuration";
-                success = false;
-                break;
-            }
-            success = true;
-        } break;
-
-        case ROS_disabled:
-        {
-            yCInfo(CONTROLBOARDWRAPPER) << partName << ": no ROS initialization required";
-            success = true;
-        } break;
-
-        case ROS_config_error:
-        {
-            yCError(CONTROLBOARDWRAPPER) << partName << " ROS parameter are not correct, check your configuration file";
-            success = false;
-        } break;
-
-        default:
-        {
-            yCError(CONTROLBOARDWRAPPER) << partName << " something went wrong with ROS configuration, we should never be here!!!";
-            success = false;
-        } break;
+        yCError(CONTROLBOARDWRAPPER) << partName << " something went wrong with ROS configuration, we should never be here!!!";
+        success = false;
+    } break;
     }
     return success;
 }
 
-bool ControlBoardWrapper::initialize_YARP(yarp::os::Searchable &prop)
+bool ControlBoardWrapper::initialize_YARP(yarp::os::Searchable& prop)
 {
     bool success = false;
 
-    switch(useROS)
+    switch (useROS) {
+    case ROS_only: {
+        yCInfo(CONTROLBOARDWRAPPER) << partName << " No YARP initialization required";
+        success = true;
+    } break;
+
+    default:
     {
-        case ROS_only:
-        {
-            yCInfo(CONTROLBOARDWRAPPER) << partName << " No YARP initialization required";
-            success = true;
-        } break;
+        yCInfo(CONTROLBOARDWRAPPER) << partName << " initting YARP initialization";
+        // initialize callback
+        if (!streaming_parser.initialize()) {
+            yCError(CONTROLBOARDWRAPPER) << "Error could not initialize callback object";
+            success = false;
+            break;
+        }
 
-        default:
-        {
-            yCInfo(CONTROLBOARDWRAPPER) << partName << " initting YARP initialization";
-            // initialize callback
-            if (!streaming_parser.initialize())
-            {
-                yCError(CONTROLBOARDWRAPPER) <<"Error could not initialize callback object";
-                success = false;
-                break;
-            }
+        rootName = prop.check("rootName", Value("/"), "starting '/' if needed.").asString();
+        partName = prop.check("name", Value("controlboard"), "prefix for port names").asString();
+        rootName += (partName);
+        if (rootName.find("//") != std::string::npos) {
+            rootName.replace(rootName.find("//"), 2, "/");
+        }
 
-            rootName = prop.check("rootName",Value("/"), "starting '/' if needed.").asString();
-            partName=prop.check("name",Value("controlboard"), "prefix for port names").asString();
-            rootName+=(partName);
-            if( rootName.find("//") != std::string::npos )
-            {
-                rootName.replace(rootName.find("//"), 2, "/");
-            }
+        ///// We now open ports, then attach the readers or callbacks
+        if (!inputRPCPort.open((rootName + "/rpc:i"))) {
+            yCError(CONTROLBOARDWRAPPER) << "Error opening port " << rootName + "/rpc:i";
+            success = false;
+            break;
+        }
+        inputRPCPort.setReader(RPC_parser);
+        inputRPC_buffer.attach(inputRPCPort);
+        RPC_parser.attach(inputRPC_buffer);
 
-            ///// We now open ports, then attach the readers or callbacks
-            if(! inputRPCPort.open((rootName+"/rpc:i")) )
-            {
-                yCError(CONTROLBOARDWRAPPER) <<"Error opening port "<< rootName+"/rpc:i";
-                success = false;
-                break;
-            }
-            inputRPCPort.setReader(RPC_parser);
-            inputRPC_buffer.attach(inputRPCPort);
-            RPC_parser.attach(inputRPC_buffer);
+        if (!inputStreamingPort.open(rootName + "/command:i")) {
+            yCError(CONTROLBOARDWRAPPER) << "Error opening port " << rootName + "/rpc:i";
+            success = false;
+            break;
+        }
 
-            if(!inputStreamingPort.open(rootName+"/command:i") )
-            {
-                yCError(CONTROLBOARDWRAPPER) <<"Error opening port "<< rootName+"/rpc:i";
-                success = false;
-                break;
-            }
+        // attach callback.
+        inputStreamingPort.setStrict();
+        inputStreamingPort.useCallback(streaming_parser);
 
-            // attach callback.
-            inputStreamingPort.setStrict();
-            inputStreamingPort.useCallback(streaming_parser);
+        if (!outputPositionStatePort.open(rootName + "/state:o")) {
+            yCError(CONTROLBOARDWRAPPER) << "Error opening port " << rootName + "/state:o";
+            success = false;
+            break;
+        }
 
-            if(!outputPositionStatePort.open(rootName+"/state:o") )
-            {
-                yCError(CONTROLBOARDWRAPPER) <<"Error opening port "<< rootName+"/state:o";
-                success = false;
-                break;
-            }
-
-            // new extended output state port
-            if(!extendedOutputStatePort.open(rootName+"/stateExt:o") )
-            {
-                yCError(CONTROLBOARDWRAPPER) <<"Error opening port "<< rootName+"/state:o";
-                success = false;
-                break;
-            }
-            extendedOutputState_buffer.attach(extendedOutputStatePort);
-            success = true;
-        } break;
-    }  // end switch
+        // new extended output state port
+        if (!extendedOutputStatePort.open(rootName + "/stateExt:o")) {
+            yCError(CONTROLBOARDWRAPPER) << "Error opening port " << rootName + "/state:o";
+            success = false;
+            break;
+        }
+        extendedOutputState_buffer.attach(extendedOutputStatePort);
+        success = true;
+    } break;
+    } // end switch
 
     // cleanup if something went wrong
-    if(!success)
-    {
+    if (!success) {
         cleanup_yarpPorts();
     }
     return success;
@@ -393,83 +340,70 @@ bool ControlBoardWrapper::open(Searchable& config)
     Property prop;
     prop.fromString(config.toString());
 
-    _verb = (prop.check("verbose","if present, give detailed output"));
-    if (_verb)
-        yCInfo(CONTROLBOARDWRAPPER, "Running with verbose output");
+    if (prop.check("verbose", "Deprecated flag. Use log components instead")) {
+        yCWarning(CONTROLBOARDWRAPPER) << "'verbose' flag is deprecated. Use log components instead";
+    }
 
-    if(!checkPortName(config) )
-    {
+    if (!checkPortName(config)) {
         yCError(CONTROLBOARDWRAPPER) << "'portName' was not correctly set, check you r configuration file";
         return false;
     }
 
     // check FIRST for deprecated parameter
-    if(prop.check("threadrate"))
-    {
+    if (prop.check("threadrate")) {
         yCError(CONTROLBOARDWRAPPER) << "Using removed parameter 'threadrate', use 'period' instead";
         return false;
     }
 
     // NOW, check for correct parameter, so if both are present we use the correct one
-    if(prop.check("period"))
-    {
-        if(!prop.find("period").isInt32())
-        {
+    if (prop.check("period")) {
+        if (!prop.find("period").isInt32()) {
             yCError(CONTROLBOARDWRAPPER) << "'period' parameter is not an integer value";
             return false;
         }
         period = prop.find("period").asInt32() / 1000.0;
-        if(period <= 0)
-        {
+        if (period <= 0) {
             yCError(CONTROLBOARDWRAPPER) << "'period' parameter is not valid, read value is" << period;
             return false;
         }
-    }
-    else
-    {
+    } else {
         yCDebug(CONTROLBOARDWRAPPER) << "'period' parameter missing, using default thread period = 20ms";
-        period = 0.02;
+        period = default_period;
     }
 
     // check if we need to create subdevice or if they are
     // passed later on thorugh attachAll()
-    if(prop.check("subdevice"))
-    {
-        ownDevices=true;
+    if (prop.check("subdevice")) {
+        ownDevices = true;
         prop.setMonitor(config.getMonitor());
-        if(! openAndAttachSubDevice(prop))
-        {
+        if (!openAndAttachSubDevice(prop)) {
             yCError(CONTROLBOARDWRAPPER, "Error while opening subdevice");
             return false;
         }
-    }
-    else
-    {
-        ownDevices=false;
-        if(!openDeferredAttach(prop))
+    } else {
+        ownDevices = false;
+        if (!openDeferredAttach(prop)) {
             return false;
+        }
     }
 
     // using controlledJoints here will allocate more memory than required, but not so much.
     rpcData.resize(device.subdevices.size(), controlledJoints, &device);
 
-     /* This must be after the openAndAttachSubDevice() or openDeferredAttach() in order to have the correct number of controlledJoints,
+    /* This must be after the openAndAttachSubDevice() or openDeferredAttach() in order to have the correct number of controlledJoints,
         but before the initialize_ROS and initialize_YARP */
-    if(!checkROSParams(config) )
-    {
+    if (!checkROSParams(config)) {
         yCError(CONTROLBOARDWRAPPER) << partName << " ROS parameter are not correct, check your configuration file";
         return false;
     }
 
     // call ROS node/topic initialization, if needed
-    if(!initialize_ROS() )
-    {
+    if (!initialize_ROS()) {
         return false;
     }
 
     // call YARP port initialization, if needed
-    if(!initialize_YARP(prop) )
-    {
+    if (!initialize_YARP(prop)) {
         yCError(CONTROLBOARDWRAPPER) << partName << "Something wrong when initting yarp ports";
         return false;
     }
@@ -482,11 +416,11 @@ bool ControlBoardWrapper::open(Searchable& config)
 
     // In case attach is not deferred and the controlboard already owns a valid device
     // we can start the thread. Otherwise this will happen when attachAll is called
-    if (ownDevices)
-    {
-       PeriodicThread::setPeriod(period);
-       if (!PeriodicThread::start())
-           return false;
+    if (ownDevices) {
+        PeriodicThread::setPeriod(period);
+        if (!PeriodicThread::start()) {
+            return false;
+        }
     }
     return true;
 }
@@ -496,134 +430,114 @@ bool ControlBoardWrapper::open(Searchable& config)
 // Open the wrapper only, the attach method needs to be called before using it
 bool ControlBoardWrapper::openDeferredAttach(Property& prop)
 {
-    if (!prop.check("networks", "list of networks merged by this wrapper"))
-    {
+    if (!prop.check("networks", "list of networks merged by this wrapper")) {
         yCError(CONTROLBOARDWRAPPER) << "List of networks to attach to was not found.";
         return false;
     }
 
-    Bottle *nets=prop.find("networks").asList();
-    if(nets==nullptr)
-    {
-       yCError(CONTROLBOARDWRAPPER) << "Error parsing parameters: \"networks\" should be followed by a list";
-       return false;
+    Bottle* nets = prop.find("networks").asList();
+    if (nets == nullptr) {
+        yCError(CONTROLBOARDWRAPPER) << "Error parsing parameters: \"networks\" should be followed by a list";
+        return false;
     }
 
-    if (!prop.check("joints", "number of joints of the part"))
+    if (!prop.check("joints", "number of joints of the part")) {
         return false;
+    }
 
-    controlledJoints=prop.find("joints").asInt32();
+    controlledJoints = prop.find("joints").asInt32();
 
-    int nsubdevices=nets->size();
+    int nsubdevices = nets->size();
     device.lut.resize(controlledJoints);
     device.subdevices.resize(nsubdevices);
 
     // configure the devices
-    int totalJ=0;
-    for(size_t k=0;k<nets->size();k++)
-    {
+    int totalJ = 0;
+    for (size_t k = 0; k < nets->size(); k++) {
         Bottle parameters;
         int wBase;
         int wTop;
 
-        parameters=prop.findGroup(nets->get(k).asString());
+        parameters = prop.findGroup(nets->get(k).asString());
 
-        if(parameters.size()==2)
-        {
-            Bottle *bot=parameters.get(1).asList();
+        if (parameters.size() == 2) {
+            Bottle* bot = parameters.get(1).asList();
             Bottle tmpBot;
-            if(bot==nullptr)
-            {
+            if (bot == nullptr) {
                 // probably data are not passed in the correct way, try to read them as a string.
                 std::string bString(parameters.get(1).asString());
                 tmpBot.fromString(bString);
 
-                if(tmpBot.size() != 4)
-                {
+                if (tmpBot.size() != 4) {
                     yCError(CONTROLBOARDWRAPPER) << "Error: check network parameters in part description"
-                             << "--> I was expecting "<<nets->get(k).asString() << " followed by a list of four integers in parenthesis"
-                             << "Got: "<< parameters.toString();
+                                                 << "--> I was expecting " << nets->get(k).asString() << " followed by a list of four integers in parenthesis"
+                                                 << "Got: " << parameters.toString();
                     return false;
                 }
-                else
-                {
-                    bot = &tmpBot;
-                }
+
+                bot = &tmpBot;
             }
 
             // If I came here, bot is correct
-            wBase=bot->get(0).asInt32();
-            wTop=bot->get(1).asInt32();
-            base=bot->get(2).asInt32();
-            top=bot->get(3).asInt32();
-        }
-        else if (parameters.size()==5)
-        {
+            wBase = bot->get(0).asInt32();
+            wTop = bot->get(1).asInt32();
+            base = bot->get(2).asInt32();
+            top = bot->get(3).asInt32();
+        } else if (parameters.size() == 5) {
             yCError(CONTROLBOARDWRAPPER) << "Parameter networks use deprecated syntax";
-            wBase=parameters.get(1).asInt32();
-            wTop=parameters.get(2).asInt32();
-            base=parameters.get(3).asInt32();
-            top=parameters.get(4).asInt32();
-        }
-        else
-        {
-            yCError(CONTROLBOARDWRAPPER) <<"Error: check network parameters in part description"
-                     <<"--> I was expecting "<<nets->get(k).asString() << " followed by a list of four integers in parenthesis"
-                     <<"Got: "<< parameters.toString();
+            wBase = parameters.get(1).asInt32();
+            wTop = parameters.get(2).asInt32();
+            base = parameters.get(3).asInt32();
+            top = parameters.get(4).asInt32();
+        } else {
+            yCError(CONTROLBOARDWRAPPER) << "Error: check network parameters in part description"
+                                         << "--> I was expecting " << nets->get(k).asString() << " followed by a list of four integers in parenthesis"
+                                         << "Got: " << parameters.toString();
             return false;
         }
 
-        SubDevice *tmpDevice = device.getSubdevice(k);
-        if (!tmpDevice)
-        {
+        SubDevice* tmpDevice = device.getSubdevice(k);
+        if (!tmpDevice) {
             yCError(CONTROLBOARDWRAPPER) << "Get of subdevice returned null";
             return false;
         }
 
-        tmpDevice->setVerbose(_verb);
-
-        int axes=top-base+1;
-        if (!tmpDevice->configure(wBase, wTop, base, top, axes, nets->get(k).asString(), this))
-        {
-            yCError(CONTROLBOARDWRAPPER) <<"Configure of subdevice ret false";
+        int axes = top - base + 1;
+        if (!tmpDevice->configure(wBase, wTop, base, top, axes, nets->get(k).asString(), this)) {
+            yCError(CONTROLBOARDWRAPPER) << "Configure of subdevice ret false";
             return false;
         }
 
         // Check input values are in range
-        if( (wBase < 0) || (wBase >= controlledJoints) )
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map." << \
-                        "First index " << wBase << "must be inside range from 0 to 'joints' ("<< controlledJoints << ")";
+        if ((wBase < 0) || (wBase >= controlledJoints)) {
+            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map."
+                                         << "First index " << wBase << "must be inside range from 0 to 'joints' (" << controlledJoints << ")";
             return false;
         }
 
-        if( (wTop < 0) || (wTop >= controlledJoints) )
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map." << \
-                        "Second index " << wTop << "must be inside range from 0 to 'joints' ("<< controlledJoints << ")";
+        if ((wTop < 0) || (wTop >= controlledJoints)) {
+            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map."
+                                         << "Second index " << wTop << "must be inside range from 0 to 'joints' (" << controlledJoints << ")";
             return false;
         }
 
-        if(wBase > wTop)
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map." << \
-                        "First index " << wBase << "must be lower than  second index " << wTop;
+        if (wBase > wTop) {
+            yCError(CONTROLBOARDWRAPPER) << "Input configuration for device " << partName << "has a wrong attach map."
+                                         << "First index " << wBase << "must be lower than  second index " << wTop;
             return false;
         }
 
-        for(int j=wBase, jInDev=base;j<=wTop;j++, jInDev++)
-        {
-            device.lut[j].deviceEntry=k;
-            device.lut[j].offset=j-wBase;
-            device.lut[j].jointIndexInDev=jInDev;
+        for (int j = wBase, jInDev = base; j <= wTop; j++, jInDev++) {
+            device.lut[j].deviceEntry = k;
+            device.lut[j].offset = j - wBase;
+            device.lut[j].jointIndexInDev = jInDev;
         }
 
-        totalJ+=axes;
+        totalJ += axes;
     }
 
-    if (totalJ!=controlledJoints)
-    {
-        yCError(CONTROLBOARDWRAPPER) <<"Error total number of mapped joints ("<< totalJ <<") does not correspond to part joints (" << controlledJoints << ")";
+    if (totalJ != controlledJoints) {
+        yCError(CONTROLBOARDWRAPPER) << "Error total number of mapped joints (" << totalJ << ") does not correspond to part joints (" << controlledJoints << ")";
         return false;
     }
     return true;
@@ -640,32 +554,29 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
     std::string subdevice = prop.find("subdevice").asString();
     p.setMonitor(prop.getMonitor(), subdevice.c_str()); // pass on any monitoring
     p.unput("device");
-    p.put("device", subdevice);  // subdevice was already checked before
+    p.put("device", subdevice); // subdevice was already checked before
 
     // if errors occurred during open, quit here.
     yCDebug(CONTROLBOARDWRAPPER, "opening subdevice");
     subDeviceOwned->open(p);
 
-    if (!subDeviceOwned->isValid())
-    {
+    if (!subDeviceOwned->isValid()) {
         yCError(CONTROLBOARDWRAPPER, "opening subdevice... FAILED");
         return false;
     }
 
-    yarp::dev::IEncoders * iencs = nullptr;
+    yarp::dev::IEncoders* iencs = nullptr;
 
     subDeviceOwned->view(iencs);
 
-    if (iencs == nullptr)
-    {
+    if (iencs == nullptr) {
         yCError(CONTROLBOARDWRAPPER, "Opening IEncoders interface of subdevice... FAILED");
         return false;
     }
 
     bool getAx = iencs->getAxes(&controlledJoints);
 
-    if (!getAx)
-    {
+    if (!getAx) {
         yCError(CONTROLBOARDWRAPPER, "Calling getAxes of subdevice... FAILED");
         return false;
     }
@@ -677,29 +588,27 @@ bool ControlBoardWrapper::openAndAttachSubDevice(Property& prop)
 
     // configure the device
     base = 0;
-    top  = controlledJoints-1;
+    top = controlledJoints - 1;
 
     int wbase = base;
     int wtop = top;
-    SubDevice *tmpDevice=device.getSubdevice(0);
-    tmpDevice->setVerbose(_verb);
+    SubDevice* tmpDevice = device.getSubdevice(0);
 
-    std::string subDevName ((partName + "_" + subdevice));
-    if (!tmpDevice->configure(wbase, wtop, base, top, controlledJoints, subDevName, this) )
-    {
+    std::string subDevName((partName + "_" + subdevice));
+    if (!tmpDevice->configure(wbase, wtop, base, top, controlledJoints, subDevName, this)) {
         yCError(CONTROLBOARDWRAPPER) << "Configure of subdevice ret false";
         return false;
     }
 
-    for(int j=0; j<controlledJoints; j++)
-    {
+    for (int j = 0; j < controlledJoints; j++) {
         device.lut[j].deviceEntry = 0;
         device.lut[j].offset = j;
     }
 
 
-    if (!device.subdevices[0].attach(subDeviceOwned, subDevName))
+    if (!device.subdevices[0].attach(subDeviceOwned, subDevName)) {
         return false;
+    }
 
     // initialization.
     RPC_parser.initialize();
@@ -712,11 +621,11 @@ void ControlBoardWrapper::calculateMaxNumOfJointsInDevices()
 {
     device.maxNumOfJointsInDevices = 0;
 
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p = device.getSubdevice(d);
-        if(p->totalAxis > device.maxNumOfJointsInDevices)
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (p->totalAxis > device.maxNumOfJointsInDevices) {
             device.maxNumOfJointsInDevices = p->totalAxis;
+        }
     }
 }
 
@@ -731,8 +640,9 @@ bool ControlBoardWrapper::updateAxisName()
     // from the motionControl device will be considered good
 
     // no need to update this variable if we are not using ROS. Yarp RPC will always call the sudevice.
-    if(useROS == ROS_disabled )
+    if (useROS == ROS_disabled) {
         return true;
+    }
 
     std::string tmp;
     // I need a temporary vector because if I'm wrapping more than one subdevice, and one of them
@@ -741,62 +651,54 @@ bool ControlBoardWrapper::updateAxisName()
     bool ret = true;
 
     tmpVect.clear();
-    for(int i=0; i < controlledJoints; i++)
-    {
-        if( (ret = getAxisName(i, tmp) && ret) )
-        {
+    for (int i = 0; i < controlledJoints; i++) {
+        if ((ret = getAxisName(i, tmp) && ret)) {
             std::string tmp2(tmp);
             tmpVect.push_back(tmp2);
         }
     }
 
-    if(ret)
-    {
-        if(jointNames.size() != 0)
-        {
+    if (ret) {
+        if (!jointNames.empty()) {
             yCWarning(CONTROLBOARDWRAPPER) << "Found 2 instance of jointNames parameter: one in the wrapper [ROS] group and another one in the subdevice, the latter one will be used.";
             std::string fullNames;
-            for(int i=0; i < controlledJoints; i++)  fullNames.append(tmpVect[i]);
+            for (int i = 0; i < controlledJoints; i++) {
+                fullNames.append(tmpVect[i]);
+            }
         }
 
         jointNames.clear();
         jointNames = tmpVect;
-    }
-    else
-    {
-        if(jointNames.size() == 0)
-        {
+    } else {
+        if (jointNames.empty()) {
             yCError(CONTROLBOARDWRAPPER) << "Joint names were not found! they are mandatory when using ROS topic";
             return false;
         }
-        else
-        {
-            yCWarning(CONTROLBOARDWRAPPER) << "\n" <<
-                "************************************************************************************************** \n" <<
-                "* Joint names for ROS topic were found in the [ROS] group in the wrapper config file for\n" <<
-                "* '" << partName << "' device.\n" <<
-                "* They should be in the MotionControl device(s) instead. Please update the config files.\n" <<
-                "**************************************************************************************************";
-        }
+
+        yCWarning(CONTROLBOARDWRAPPER) << "\n" <<
+            "************************************************************************************************** \n" <<
+            "* Joint names for ROS topic were found in the [ROS] group in the wrapper config file for\n" <<
+            "* '" << partName << "' device.\n" <<
+            "* They should be in the MotionControl device(s) instead. Please update the config files.\n" <<
+            "**************************************************************************************************";
     }
     return true;
 }
 
 
-bool ControlBoardWrapper::attachAll(const PolyDriverList &polylist)
+bool ControlBoardWrapper::attachAll(const PolyDriverList& polylist)
 {
     //check if we already instantiated a subdevice previously
-    if (ownDevices)
+    if (ownDevices) {
         return false;
+    }
 
-    for(int p=0;p<polylist.size();p++)
-    {
+    for (int p = 0; p < polylist.size(); p++) {
         // look if we have to attach to a calibrator
-        std::string tmpKey=polylist[p]->key;
-        if(tmpKey == "Calibrator" || tmpKey == "calibrator")
-        {
+        std::string tmpKey = polylist[p]->key;
+        if (tmpKey == "Calibrator" || tmpKey == "calibrator") {
             // Set the IRemoteCalibrator interface, the wrapper must point to the calibrato rdevice
-            yarp::dev::IRemoteCalibrator *calibrator;
+            yarp::dev::IRemoteCalibrator* calibrator;
             polylist[p]->poly->view(calibrator);
 
             IRemoteCalibrator::setCalibratorDevice(calibrator);
@@ -804,13 +706,10 @@ bool ControlBoardWrapper::attachAll(const PolyDriverList &polylist)
         }
 
         // find appropriate entry in list of subdevices and attach
-        unsigned int k=0;
-        for(k=0; k<device.subdevices.size(); k++)
-        {
-            if (device.subdevices[k].id==tmpKey)
-            {
-                if (!device.subdevices[k].attach(polylist[p]->poly, tmpKey))
-                {
+        unsigned int k = 0;
+        for (k = 0; k < device.subdevices.size(); k++) {
+            if (device.subdevices[k].id == tmpKey) {
+                if (!device.subdevices[k].attach(polylist[p]->poly, tmpKey)) {
                     yCError(CONTROLBOARDWRAPPER, "Attach to subdevice %s failed", polylist[p]->key.c_str());
                     return false;
                 }
@@ -819,22 +718,18 @@ bool ControlBoardWrapper::attachAll(const PolyDriverList &polylist)
     }
 
     //check if all devices are attached to the driver
-    bool ready=true;
-    for(auto& subdevice : device.subdevices)
-    {
-        if (!subdevice.isAttached())
-        {
+    bool ready = true;
+    for (auto& subdevice : device.subdevices) {
+        if (!subdevice.isAttached()) {
             yCError(CONTROLBOARDWRAPPER, "Device %s was not found in the list passed to attachAll", subdevice.id.c_str());
-            ready=false;
+            ready = false;
         }
     }
 
-    if (!ready)
-    {
+    if (!ready) {
         yCError(CONTROLBOARDWRAPPER, "AttachAll failed, some subdevice was not found or its attach failed");
         stringstream ss;
-        for(int p=0;p<polylist.size();p++)
-        {
+        for (int p = 0; p < polylist.size(); p++) {
             ss << polylist[p]->key.c_str() << " ";
         }
         yCError(CONTROLBOARDWRAPPER, "List of devices keys passed to attachAll: %s", ss.str().c_str());
@@ -852,29 +747,32 @@ bool ControlBoardWrapper::attachAll(const PolyDriverList &polylist)
 
 bool ControlBoardWrapper::detachAll()
 {
-        //check if we already instantiated a subdevice previously
-        if (ownDevices)
-            return false;
+    //check if we already instantiated a subdevice previously
+    if (ownDevices) {
+        return false;
+    }
 
-        if (yarp::os::PeriodicThread::isRunning())
-            yarp::os::PeriodicThread::stop();
+    if (yarp::os::PeriodicThread::isRunning()) {
+        yarp::os::PeriodicThread::stop();
+    }
 
-        int devices=device.subdevices.size();
+    int devices = device.subdevices.size();
 
-        for(int k=0;k<devices;k++) {
-            SubDevice* sub = device.getSubdevice(k);
-            if (sub) sub->detach();
+    for (int k = 0; k < devices; k++) {
+        SubDevice* sub = device.getSubdevice(k);
+        if (sub) {
+            sub->detach();
         }
+    }
 
-        IRemoteCalibrator::releaseCalibratorDevice();
-        return true;
+    IRemoteCalibrator::releaseCalibratorDevice();
+    return true;
 }
 
 void ControlBoardWrapper::run()
 {
     // check we are not overflowing with input messages
-    if(inputStreamingPort.getPendingReads() >= 20)
-    {
+    if (inputStreamingPort.getPendingReads() >= 20) {
         yCWarning(CONTROLBOARDWRAPPER) << "Number of streaming intput messages to be read is " << inputStreamingPort.getPendingReads() << " and can overflow";
     }
 
@@ -887,8 +785,8 @@ void ControlBoardWrapper::run()
     // not do if the wrapper is in ROS_only configuration.
 
     bool positionsOk = getEncodersTimed(ros_struct.position.data(), times.data());
-    bool speedsOk    = getEncoderSpeeds(ros_struct.velocity.data());
-    bool torqueOk    = getTorques(ros_struct.effort.data());
+    bool speedsOk = getEncoderSpeeds(ros_struct.velocity.data());
+    bool torqueOk = getTorques(ros_struct.effort.data());
 
     // Update the port envelope time by averaging all timestamps
     timeMutex.lock();
@@ -896,10 +794,9 @@ void ControlBoardWrapper::run()
     yarp::os::Stamp averageTime = time;
     timeMutex.unlock();
 
-    if(useROS != ROS_only)
-    {
+    if (useROS != ROS_only) {
         // handle stateExt first
-        jointData &yarp_struct = extendedOutputState_buffer.get();
+        jointData& yarp_struct = extendedOutputState_buffer.get();
 
         yarp_struct.jointPosition.resize(controlledJoints);
         yarp_struct.jointVelocity.resize(controlledJoints);
@@ -915,25 +812,25 @@ void ControlBoardWrapper::run()
 
         // Get already stored data from before. This is to avoid a double call to HW device,
         // which may require more time.        //
-        yarp_struct.jointPosition_isValid       = positionsOk;
-        std::copy(ros_struct.position.begin(), ros_struct.position.end(),  yarp_struct.jointPosition.begin());
+        yarp_struct.jointPosition_isValid = positionsOk;
+        std::copy(ros_struct.position.begin(), ros_struct.position.end(), yarp_struct.jointPosition.begin());
 
-        yarp_struct.jointVelocity_isValid       = speedsOk;
-        std::copy(ros_struct.velocity.begin(), ros_struct.velocity.end(),  yarp_struct.jointVelocity.begin());
+        yarp_struct.jointVelocity_isValid = speedsOk;
+        std::copy(ros_struct.velocity.begin(), ros_struct.velocity.end(), yarp_struct.jointVelocity.begin());
 
-        yarp_struct.torque_isValid              = torqueOk;
-        std::copy(ros_struct.effort.begin(), ros_struct.effort.end(),  yarp_struct.torque.begin());
+        yarp_struct.torque_isValid = torqueOk;
+        std::copy(ros_struct.effort.begin(), ros_struct.effort.end(), yarp_struct.torque.begin());
 
         // Get remaining data from HW
-        yarp_struct.jointAcceleration_isValid   = getEncoderAccelerations(yarp_struct.jointAcceleration.data());
-        yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.data());
-        yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
-        yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
-        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.data());
-        yarp_struct.pwmDutycycle_isValid        = getDutyCycles(yarp_struct.pwmDutycycle.data());
-        yarp_struct.current_isValid             = getCurrents(yarp_struct.current.data());
-        yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.data());
-        yarp_struct.interactionMode_isValid     = getInteractionModes((yarp::dev::InteractionModeEnum* ) yarp_struct.interactionMode.data());
+        yarp_struct.jointAcceleration_isValid = getEncoderAccelerations(yarp_struct.jointAcceleration.data());
+        yarp_struct.motorPosition_isValid = getMotorEncoders(yarp_struct.motorPosition.data());
+        yarp_struct.motorVelocity_isValid = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
+        yarp_struct.motorAcceleration_isValid = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
+        yarp_struct.torque_isValid = getTorques(yarp_struct.torque.data());
+        yarp_struct.pwmDutycycle_isValid = getDutyCycles(yarp_struct.pwmDutycycle.data());
+        yarp_struct.current_isValid = ControlBoardWrapperCommon::getCurrents(yarp_struct.current.data());
+        yarp_struct.controlMode_isValid = getControlModes(yarp_struct.controlMode.data());
+        yarp_struct.interactionMode_isValid = getInteractionModes(reinterpret_cast<yarp::dev::InteractionModeEnum*>(yarp_struct.interactionMode.data()));
 
         extendedOutputStatePort.setEnvelope(averageTime);
         extendedOutputState_buffer.write();
@@ -947,4213 +844,22 @@ void ControlBoardWrapper::run()
         outputPositionStatePort.write();
     }
 
-    if(useROS != ROS_disabled)
-    {
+    if (useROS != ROS_disabled) {
         // Data from HW have been gathered few lines before
         JointTypeEnum jType;
-        for(int i=0; i< controlledJoints; i++)
-        {
+        for (int i = 0; i < controlledJoints; i++) {
             getJointType(i, jType);
-            if(jType == VOCAB_JOINTTYPE_REVOLUTE)
-            {
+            if (jType == VOCAB_JOINTTYPE_REVOLUTE) {
                 ros_struct.position[i] = convertDegreesToRadians(ros_struct.position[i]);
                 ros_struct.velocity[i] = convertDegreesToRadians(ros_struct.velocity[i]);
             }
         }
 
-        ros_struct.name=jointNames;
+        ros_struct.name = jointNames;
 
         ros_struct.header.seq = rosMsgCounter++;
         ros_struct.header.stamp = averageTime.getTime();
 
         rosPublisherPort.write(ros_struct);
     }
-}
-
-//
-//  IPid Interface
-//
-bool ControlBoardWrapper::setPid(const PidControlTypeEnum& pidtype, int j, const Pid &p)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *s=device.getSubdevice(subIndex);
-    if (!s)
-        return false;
-
-    if (s->pid)
-    {
-        return s->pid->setPid(pidtype, off+s->base, p);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setPids(const PidControlTypeEnum& pidtype, const Pid *ps)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
-        {
-            ret=ret&&p->pid->setPid(pidtype, off+p->base, ps[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setPidReference(const PidControlTypeEnum& pidtype, int j, double ref)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->setPidReference(pidtype, off+p->base, ref);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setPidReferences(const PidControlTypeEnum& pidtype, const double *refs)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
-        {
-            ret=ret&&p->pid->setPidReference(pidtype, off+p->base, refs[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->setPidErrorLimit(pidtype, off+p->base, limit);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setPidErrorLimits(const PidControlTypeEnum& pidtype, const double *limits)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pid)
-        {
-            ret=ret&&p->pid->setPidErrorLimit(pidtype, off+p->base, limits[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::getPidError(const PidControlTypeEnum& pidtype, int j, double *err)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->getPidError(pidtype, off+p->base, err);
-    }
-    *err = 0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getPidErrors(const PidControlTypeEnum& pidtype, double *errs)
-{
-    auto* errors = new double [device.maxNumOfJointsInDevices];
-
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-        if( (p->pid) &&(ret = p->pid->getPidErrors(pidtype, errors)) )
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                errs[juser] = errors[jdevice];
-            }
-        }
-        else
-        {
-            printError("getPidErrors", p->id, ret);
-            ret =  false;
-            break;
-        }
-    }
-
-    delete[] errors;
-    return ret;
-}
-
-bool ControlBoardWrapper::getPidOutput(const PidControlTypeEnum& pidtype, int j, double *out)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->getPidOutput(pidtype, off+p->base, out);
-    }
-    *out=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getPidOutputs(const PidControlTypeEnum& pidtype, double *outs)
-{
-    auto* outputs = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pid) &&(ret = p->pid->getPidOutputs(pidtype, outputs)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                outs[juser] = outputs[jdevice];
-            }
-        }
-        else
-        {
-            printError("getPidOutouts", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] outputs;
-    return ret;
-}
-
-bool ControlBoardWrapper::setPidOffset(const PidControlTypeEnum& pidtype, int j, double v)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->setPidOffset(pidtype, off+p->base, v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getPid(const PidControlTypeEnum& pidtype, int j, Pid *p)
-{
-//#warning "check for max number of joints!?!?!"
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *s=device.getSubdevice(subIndex);
-    if (!s)
-        return false;
-
-    if (s->pid)
-    {
-        return s->pid->getPid(pidtype, off+s->base, p);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getPids(const PidControlTypeEnum& pidtype, Pid *pids)
-{
-    Pid *pids_device = new Pid[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pid) &&(ret = p->pid->getPids(pidtype, pids_device)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                pids[juser] = pids_device[jdevice];
-            }
-        }
-        else
-        {
-            printError("getPids", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete[] pids_device;
-    return ret;
-}
-
-bool ControlBoardWrapper::getPidReference(const PidControlTypeEnum& pidtype, int j, double *ref) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-    if (p->pid)
-    {
-        return p->pid->getPidReference(pidtype, off+p->base, ref);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getPidReferences(const PidControlTypeEnum& pidtype, double *refs)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pid) &&(ret = p->pid->getPidReferences(pidtype, references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                refs[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getPidReferences", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-}
-
-bool ControlBoardWrapper::getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double *limit) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->getPidErrorLimit(pidtype, off+p->base, limit);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getPidErrorLimits(const PidControlTypeEnum& pidtype, double *limits)
-{
-    auto* lims = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pid) &&(ret = p->pid->getPidErrorLimits(pidtype, lims)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                limits[juser] = lims[jdevice];
-            }
-        }
-        else
-        {
-            printError("getPidErrorLimits", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] lims;
-    return ret;
-}
-
-bool ControlBoardWrapper::resetPid(const PidControlTypeEnum& pidtype, int j) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->resetPid(pidtype, off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::disablePid(const PidControlTypeEnum& pidtype, int j) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->disablePid(pidtype, off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::enablePid(const PidControlTypeEnum& pidtype, int j) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pid)
-    {
-        return p->pid->enablePid(pidtype, off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if(p->pid)
-        return p->pid->isPidEnabled(pidtype, off+p->base, enabled);
-
-    return false;
-}
-
-//
-// IPOSITIONCONTROL
-//
-/* IPositionControl */
-
-/**
-* Get the number of controlled axes. This command asks the number of controlled
-* axes for the current physical interface.
-* @param ax pointer to storage
-* @return true/false.
-*/
-bool ControlBoardWrapper::getAxes(int *ax) {
-    *ax=controlledJoints;
-    return true;
-}
-
-/**
-* Set new reference point for a single axis.
-* @param j joint number
-* @param ref specifies the new ref point
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::positionMove(int j, double ref) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->positionMove(off+p->base, ref);
-    }
-
-    return false;
-}
-
-/** Set new reference point for all axes.
-* @param refs array, new reference points.
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::positionMove(const double *refs)
-{
-    bool ret = true;
-    int j_wrap = 0;         // index of the wrapper joint
-
-    int nDev = device.subdevices.size();
-    for(int subDev_idx=0; subDev_idx < nDev; subDev_idx++)
-    {
-        int subIndex=device.lut[j_wrap].deviceEntry;
-        SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-        {
-            return false;
-        }
-
-        int wrapped_joints=(p->top - p->base) + 1;
-        int *joints = new int[wrapped_joints];
-
-        if(p->pos)
-        {
-            // versione comandi su subset di giunti
-            for(int j_dev = 0; j_dev < wrapped_joints; j_dev++)
-            {
-                joints[j_dev] = p->base + j_dev;  // for all joints is equivalent to add offset term
-            }
-
-            ret = ret && p->pos->positionMove(wrapped_joints, joints, &refs[j_wrap]);
-            j_wrap+=wrapped_joints;
-        }
-        else
-        {
-            ret=false;
-        }
-
-        if(joints!=nullptr)
-        { delete [] joints;
-          joints = nullptr;}
-    }
-
-    return ret;
-}
-
-/** Set new reference point for a subset of axis.
- * @param joints pointer to the array of joint numbers
- * @param refs   pointer to the array specifying the new reference points
- * @return true/false on success/failure
- */
-bool ControlBoardWrapper::positionMove(const int n_joints, const int *joints, const double *refs)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = refs[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->positionMove(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                           rpcData.jointNumbers[subIndex],
-                                                                           rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getTargetPosition(const int j, double* ref)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        bool ret = p->pos->getTargetPosition(off+p->base, ref);
-        return ret;
-    }
-    *ref=0;
-    return false;
-}
-
-
-/** Get reference speed of all joints. These are the  values used during the
-* interpolation of the trajectory.
-* @param spds pointer to the array that will store the speed values.
-* @return true/false on success/failure.
-*/
-bool ControlBoardWrapper::getTargetPositions(double *spds)
-{
-    auto* targets = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pos) &&(ret = p->pos->getTargetPositions(targets)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                spds[juser] = targets[jdevice];
-            }
-        }
-        else
-        {
-            printError("getTargetPositions", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] targets;
-    return ret;
-}
-
-
-bool ControlBoardWrapper::getTargetPositions(const int n_joints, const int *joints, double *targets)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->getTargetPositions( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                            rpcData.jointNumbers[subIndex],
-                                                                            rpcData.values[subIndex]);
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;                  // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            targets[j]  = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            targets[j] = 0;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/** Set relative position. The command is relative to the
-* current position of the axis.
-* @param j joint axis number
-* @param delta relative command
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::relativeMove(int j, double delta) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->relativeMove(off+p->base, delta);
-    }
-
-    return false;
-}
-
-/** Set relative position, all joints.
-* @param deltas pointer to the relative commands
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::relativeMove(const double *deltas) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->pos)
-        {
-            ret=ret&&p->pos->relativeMove(off+p->base, deltas[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-/** Set relative position for a subset of joints.
- * @param joints pointer to the array of joint numbers
- * @param deltas pointer to the array of relative commands
- * @return true/false on success/failure
- */
-bool ControlBoardWrapper::relativeMove(const int n_joints, const int *joints, const double *deltas)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = deltas[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->relativeMove(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                           rpcData.jointNumbers[subIndex],
-                                                                           rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/**
-* Check if the current trajectory is terminated. Non blocking.
-* @param j the axis
-* @param flag true if the trajectory is terminated, false otherwise
-* @return false on failure
-*/
-bool ControlBoardWrapper::checkMotionDone(int j, bool *flag) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->checkMotionDone(off+p->base, flag);
-    }
-
-    return false;
-}
-
-/**
-* Check if the current trajectory is terminated. Non blocking.
-* @param flag true if the trajectory is terminated, false otherwise
-* @return false on failure
-*/
-bool ControlBoardWrapper::checkMotionDone(bool *flag)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    // In this case the "all joint version" of checkMotionDone(bool *flag) cannot be
-    // called because the return value is an 'and' of all joints.
-    // Therefore only the corret joints must be evaluated.
-
-    int subIndex = 0;
-    for(int j=0; j<controlledJoints; j++)
-    {
-        subIndex = device.lut[j].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[j].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    bool tmp_subdeviceDone  = true;
-    bool tmp_deviceDone     = true;
-
-    // for each subdevice wrapped call checkmotiondone only on interested joints
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->checkMotionDone( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                              rpcData.jointNumbers[subIndex],
-                                                                              &tmp_subdeviceDone);
-            tmp_deviceDone &= tmp_subdeviceDone;
-        }
-    }
-    rpcDataMutex.unlock();
-
-    // return a single value to the caller
-    *flag = tmp_deviceDone;
-    return ret;
-}
-
-
-/** Check if the current trajectory is terminated. Non blocking.
- * @param joints pointer to the array of joint numbers
- * @param flag   true if the trajectory is terminated, false otherwise
- *               (a single value which is the 'and' of all joints')
- * @return true/false if network communication went well.
- */
-bool ControlBoardWrapper::checkMotionDone(const int n_joints, const int *joints, bool *flags)
-{
-    bool ret = true;
-    bool tmp = true;
-    bool XFlags = true;
-
-   rpcDataMutex.lock();
-   //Reset subdev_jointsVectorLen vector
-   memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-   // Create a map of joints for each subDevice
-   int subIndex = 0;
-   for(int j=0; j<n_joints; j++)
-   {
-       subIndex = device.lut[joints[j]].deviceEntry;
-       rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-       rpcData.subdev_jointsVectorLen[subIndex]++;
-   }
-
-   for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-   {
-       if(rpcData.subdevices_p[subIndex]->pos)
-       {
-           ret= ret && rpcData.subdevices_p[subIndex]->pos->checkMotionDone(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                             rpcData.jointNumbers[subIndex],
-                                                                             &XFlags);
-           tmp = tmp && XFlags;
-       }
-       else
-       {
-           ret=false;
-       }
-   }
-    if(ret)
-        *flags = tmp;
-    else
-        *flags = false;
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/** Set reference speed for a joint, this is the speed used during the
-* interpolation of the trajectory.
-* @param j joint number
-* @param sp speed value
-* @return true/false upon success/failure
-*/
-bool ControlBoardWrapper::setRefSpeed(int j, double sp) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->setRefSpeed(off+p->base, sp);
-    }
-    return false;
-}
-
-/** Set reference speed on all joints. These values are used during the
-* interpolation of the trajectory.
-* @param spds pointer to the array of speed values.
-* @return true/false upon success/failure
-*/
-bool ControlBoardWrapper::setRefSpeeds(const double *spds)
-{
-    bool ret = true;
-    int j_wrap = 0;         // index of the wrapper joint
-
-    for(unsigned int subDev_idx=0; subDev_idx < device.subdevices.size(); subDev_idx++)
-    {
-        SubDevice *p=device.getSubdevice(subDev_idx);
-
-        if(!p)
-            return false;
-
-        int wrapped_joints=(p->top - p->base) + 1;
-        int *joints = new int[wrapped_joints];
-
-        if(p->pos)
-        {
-            // verione comandi su subset di giunti
-            for(int j_dev = 0; j_dev < wrapped_joints; j_dev++)
-            {
-                joints[j_dev] = p->base + j_dev;
-            }
-
-            ret = ret && p->pos->setRefSpeeds(wrapped_joints, joints, &spds[j_wrap]);
-            j_wrap += wrapped_joints;
-        }
-        else
-        {
-            ret=false;
-        }
-
-        if(joints!=nullptr)
-        { delete [] joints;
-          joints = nullptr;}
-    }
-
-    return ret;
-}
-
-
-/** Set reference speed on all joints. These values are used during the
- * interpolation of the trajectory.
- * @param joints pointer to the array of joint numbers
- * @param spds   pointer to the array with speed values.
- * @return true/false upon success/failure
- */
-bool ControlBoardWrapper::setRefSpeeds(const int n_joints, const int *joints, const double *spds)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =  device.lut[joints[j]].offset +
-                                                                            rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = spds[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->setRefSpeeds( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                            rpcData.jointNumbers[subIndex],
-                                                                            rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/** Set reference acceleration for a joint. This value is used during the
-* trajectory generation.
-* @param j joint number
-* @param acc acceleration value
-* @return true/false upon success/failure
-*/
-bool ControlBoardWrapper::setRefAcceleration(int j, double acc) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->setRefAcceleration(off+p->base, acc);
-    }
-    return false;
-}
-
-/** Set reference acceleration on all joints. This is the valure that is
-* used during the generation of the trajectory.
-* @param accs pointer to the array of acceleration values
-* @return true/false upon success/failure
-*/
-bool ControlBoardWrapper::setRefAccelerations(const double *accs)
-{
-    bool ret = true;
-    int j_wrap = 0;    // index of the joint from the wrapper side (useful if wrapper joins 2 subdevices)
-
-    // for all subdevices
-    for(unsigned int subDev_idx=0; subDev_idx < device.subdevices.size(); subDev_idx++)
-    {
-        SubDevice *p=device.getSubdevice(subDev_idx);
-
-        if(!p)
-            return false;
-
-        int wrapped_joints=(p->top - p->base) + 1;
-        int *joints = new int[wrapped_joints];  // to be defined once and for all?
-
-        if(p->pos)
-        {
-            // verione comandi su subset di giunti
-            for(int j_dev = 0; j_dev < wrapped_joints; j_dev++)
-            {
-                joints[j_dev] = p->base + j_dev;
-            }
-
-            ret = ret && p->pos->setRefAccelerations(wrapped_joints, joints, &accs[j_wrap]);
-            j_wrap += wrapped_joints;
-        }
-        else
-        {
-            ret=false;
-        }
-
-        if(joints!=nullptr)
-        { delete [] joints;
-        joints = nullptr;}
-    }
-
-    return ret;
-}
-
-/** Set reference acceleration on all joints. This is the valure that is
- * used during the generation of the trajectory.
- * @param joints pointer to the array of joint numbers
- * @param accs   pointer to the array with acceleration values
- * @return true/false upon success/failure
- */
-bool ControlBoardWrapper::setRefAccelerations(const int n_joints, const int *joints, const double *accs)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =  device.lut[joints[j]].offset +
-        rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = accs[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->setRefAccelerations(  rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                    rpcData.jointNumbers[subIndex],
-                                                                                    rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-
-/** Get reference speed for a joint. Returns the speed used to
- * generate the trajectory profile.
- * @param j joint number
- * @param ref pointer to storage for the return value
- * @return true/false on success or failure
- */
-bool ControlBoardWrapper::getRefSpeed(int j, double *ref) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->getRefSpeed(off+p->base, ref);
-    }
-    *ref=0;
-    return false;
-}
-
-
-/** Get reference speed of all joints. These are the  values used during the
-* interpolation of the trajectory.
-* @param spds pointer to the array that will store the speed values.
-* @return true/false on success/failure.
-*/
-bool ControlBoardWrapper::getRefSpeeds(double *spds)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pos) &&(ret = p->pos->getRefSpeeds(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                spds[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefSpeeds", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-}
-
-
-/** Get reference speed of all joints. These are the  values used during the
- * interpolation of the trajectory.
- * @param joints pointer to the array of joint numbers
- * @param spds   pointer to the array that will store the speed values.
- * @return true/false upon success/failure
- */
-bool ControlBoardWrapper::getRefSpeeds(const int n_joints, const int *joints, double *spds)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->getRefSpeeds( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                            rpcData.jointNumbers[subIndex],
-                                                                            rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;                  // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            spds[j]  = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            spds[j] = 0;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/** Get reference acceleration for a joint. Returns the acceleration used to
-* generate the trajectory profile.
-* @param j joint number
-* @param acc pointer to storage for the return value
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::getRefAcceleration(int j, double *acc) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->getRefAcceleration(off+p->base, acc);
-    }
-    *acc=0;
-    return false;
-}
-
-
-/** Get reference acceleration of all joints. These are the values used during the
-* interpolation of the trajectory.
-* @param accs pointer to the array that will store the acceleration values.
-* @return true/false on success or failure
-*/
-bool ControlBoardWrapper::getRefAccelerations(double *accs)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->pos) &&(ret = p->pos->getRefAccelerations(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                accs[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefAccelerations", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-}
-
-
-/** Get reference acceleration for a joint. Returns the acceleration used to
- * generate the trajectory profile.
- * @param joints pointer to the array of joint numbers
- * @param accs   pointer to the array that will store the acceleration values
- * @return true/false on success/failure
- */
-bool ControlBoardWrapper::getRefAccelerations(const int n_joints, const int *joints, double *accs)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->getRefAccelerations(  rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                    rpcData.jointNumbers[subIndex],
-                                                                                    rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;                  // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            accs[j]  = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            accs[j] = 0;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-/** Stop motion, single joint
-* @param j joint number
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::stop(int j) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->pos)
-    {
-        return p->pos->stop(off+p->base);
-    }
-    return false;
-}
-
-
-/**
-* Stop motion, multiple joints
-* @return true/false on success/failure
-*/
-bool ControlBoardWrapper::stop() {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-
-        if (!p)
-            return false;
-
-        if (p->pos)
-        {
-            ret=ret&&p->pos->stop(off+p->base);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-
-/** Stop motion for subset of joints
- * @param joints pointer to the array of joint numbers
- * @return true/false on success/failure
- */
-bool ControlBoardWrapper::stop(const int n_joints, const int *joints)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =  device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->pos)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->pos->stop(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                   rpcData.jointNumbers[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-
-/* IVelocityControl */
-
-bool ControlBoardWrapper::velocityMove(int j, double v) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->vel)
-    {
-        return p->vel->velocityMove(off+p->base, v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::velocityMove(const double *v)
-{
-    bool ret = true;
-    int j_wrap = 0;         // index of the wrapper joint
-
-    for(unsigned int subDev_idx=0; subDev_idx < device.subdevices.size(); subDev_idx++)
-    {
-        SubDevice *p=device.getSubdevice(subDev_idx);
-
-        if(!p)
-            return false;
-
-        int wrapped_joints=(p->top - p->base) + 1;
-        int *joints = new int[wrapped_joints];
-
-        if(p->vel)
-        {
-            // verione comandi su subset di giunti
-            for(int j_dev = 0; j_dev < wrapped_joints; j_dev++)
-            {
-                joints[j_dev] = p->base + j_dev;
-            }
-
-            ret = ret && p->vel->velocityMove(wrapped_joints, joints, &v[j_wrap]);
-            j_wrap += wrapped_joints;
-        }
-        else
-        {
-            ret=false;
-        }
-
-        if(joints!=nullptr)
-        { delete [] joints;
-          joints = nullptr;}
-    }
-
-    return ret;
-}
-
-/* IEncoders */
-
-bool ControlBoardWrapper::resetEncoder(int j) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->resetEncoder(off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::resetEncoders() {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
-        {
-            ret=ret&&p->iJntEnc->resetEncoder(off+p->base);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setEncoder(int j, double val) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->setEncoder(off+p->base,val);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setEncoders(const double *vals) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iJntEnc)
-        {
-            ret=ret&&p->iJntEnc->setEncoder(off+p->base, vals[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::getEncoder(int j, double *v) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->getEncoder(off+p->base, v);
-    }
-    *v=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getEncoders(double *encs)
-{
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoders(encValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                encs[juser] = encValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getEncoders", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] encValues;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::getEncodersTimed(double *encs, double *t)
-{
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    auto* tValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncodersTimed(encValues, tValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                encs[juser] = encValues[jdevice];
-                t[juser] = tValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getEncodersTimed", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] encValues;
-    delete [] tValues;
-    return ret;
-}
-
-bool ControlBoardWrapper::getEncoderTimed(int j, double *v, double *t) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->getEncoderTimed(off+p->base, v, t);
-    }
-    *v=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getEncoderSpeed(int j, double *sp) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->getEncoderSpeed(off+p->base, sp);
-    }
-    *sp=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getEncoderSpeeds(double *spds)
-{
-    auto* sValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoderSpeeds(sValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                spds[juser] = sValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getEncoderSpeeds", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] sValues;
-    return ret;
-}
-
-bool ControlBoardWrapper::getEncoderAcceleration(int j, double *acc) {
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iJntEnc)
-    {
-        return p->iJntEnc->getEncoderAcceleration(off+p->base,acc);
-    }
-    *acc=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getEncoderAccelerations(double *accs)
-{
-    auto* aValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iJntEnc) &&(ret = p->iJntEnc->getEncoderAccelerations(aValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                accs[juser] = aValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getEncoderAccelerations", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] aValues;
-    return ret;
-}
-
-/* IMotor */
-bool ControlBoardWrapper::getNumberOfMotors   (int *num) {
-    *num=controlledJoints;
-    return true;
-}
-
-bool ControlBoardWrapper::getTemperature      (int m, double* val) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->imotor)
-    {
-        return p->imotor->getTemperature(off+p->base, val);
-    }
-    *val=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getTemperatures     (double *vals)
-{
-    auto* temps = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->imotor) &&(ret = p->imotor->getTemperatures(temps)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                vals[juser] = temps[jdevice];
-            }
-        }
-        else
-        {
-            printError("getTemperatures", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] temps;
-    return ret;
-}
-
-bool ControlBoardWrapper::getTemperatureLimit (int m, double* val) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->imotor)
-    {
-        return p->imotor->getTemperatureLimit(off+p->base, val);
-    }
-    *val=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::setTemperatureLimit (int m, const double val) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->imotor)
-    {
-        return p->imotor->setTemperatureLimit(off+p->base,val);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getGearboxRatio(int m, double* val) {
-    int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->imotor)
-    {
-        return p->imotor->getGearboxRatio(off + p->base, val);
-    }
-    *val = 0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::setGearboxRatio(int m, const double val) {
-    int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->imotor)
-    {
-        return p->imotor->setGearboxRatio(off + p->base, val);
-    }
-    return false;
-}
-
-/* IRemoteVariables */
-bool ControlBoardWrapper::getRemoteVariable(std::string key, yarp::os::Bottle& val) {
-    bool b = true;
-
-    for (unsigned int i = 0; i < device.subdevices.size(); i++)
-    {
-        SubDevice *p = device.getSubdevice(i);
-
-        if (!p) return false;
-        if (!p->iVar) return false;
-        yarp::os::Bottle tmpval;
-        b &= p->iVar->getRemoteVariable(key, tmpval);
-        if (b) val.append(tmpval);
-    }
-
-    return b;
-}
-
-bool ControlBoardWrapper::setRemoteVariable(std::string key, const yarp::os::Bottle& val)
-{
-    size_t bottle_size = val.size();
-    size_t device_size = device.subdevices.size();
-    if (bottle_size != device_size)
-    {
-        yCError(CONTROLBOARDWRAPPER, "setRemoteVariable bottle_size != device_size failure");
-        return false;
-    }
-
-    bool b = true;
-    for (unsigned int i = 0; i < device_size; i++)
-    {
-        SubDevice *p = device.getSubdevice(i);
-        if (!p)  { yCError(CONTROLBOARDWRAPPER, "setRemoteVariable !p failure"); return false; }
-        if (!p->iVar) { yCError(CONTROLBOARDWRAPPER, "setRemoteVariable !p->iVar failure"); return false; }
-        Bottle* partial_val = val.get(i).asList();
-        if (partial_val)
-        {
-            b &= p->iVar->setRemoteVariable(key, *partial_val);
-        }
-        else
-        {
-            yCError(CONTROLBOARDWRAPPER, "setRemoteVariable general failure");
-            return false;
-        }
-    }
-
-    return b;
-}
-
-bool ControlBoardWrapper::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
-{
-    //int off = device.lut[0].offset;
-    int subIndex = device.lut[0].deviceEntry;
-    SubDevice *p = device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->iVar)
-    {
-        return p->iVar->getRemoteVariablesList(listOfKeys);
-    }
-    return false;
-}
-
-/* IMotorEncoders */
-
-bool ControlBoardWrapper::resetMotorEncoder(int m) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->resetMotorEncoder(off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::resetMotorEncoders() {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
-        {
-            ret=ret&&p->iMotEnc->resetMotorEncoder(off+p->base);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setMotorEncoder(int m, const double val) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->setMotorEncoder(off+p->base,val);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setMotorEncoders(const double *vals) {
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iMotEnc)
-        {
-            ret=ret&&p->iMotEnc->setMotorEncoder(off+p->base, vals[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setMotorEncoderCountsPerRevolution(int m, double cpr) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->setMotorEncoderCountsPerRevolution(off+p->base,cpr);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoderCountsPerRevolution(int m, double *cpr) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->getMotorEncoderCountsPerRevolution(off+p->base, cpr);
-    }
-    *cpr=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoder(int m, double *v) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->getMotorEncoder(off+p->base, v);
-    }
-    *v=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoders(double *encs)
-{
-
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoders(encValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                encs[juser] = encValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getMotorEncoders", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] encValues;
-    return ret;
-}
-
-bool ControlBoardWrapper::getMotorEncodersTimed(double *encs, double *t)
-{
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    auto* tValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncodersTimed(encValues, tValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                encs[juser] = encValues[jdevice];
-                t[juser] = tValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getMotorEncodersTimed", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] encValues;
-    delete [] tValues;
-    return ret;
-}
-
-bool ControlBoardWrapper::getMotorEncoderTimed(int m, double *v, double *t) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->getMotorEncoderTimed(off+p->base, v, t);
-    }
-    *v=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoderSpeed(int m, double *sp) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->getMotorEncoderSpeed(off+p->base, sp);
-    }
-    *sp=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoderSpeeds(double *spds)
-{
-    auto* sValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoderSpeeds(sValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                spds[juser] = sValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getMotorEncoderSpeeds", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] sValues;
-    return ret;
-}
-
-bool ControlBoardWrapper::getMotorEncoderAcceleration(int m, double *acc) {
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMotEnc)
-    {
-        return p->iMotEnc->getMotorEncoderAcceleration(off+p->base,acc);
-    }
-    *acc=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getMotorEncoderAccelerations(double *accs)
-{
-    auto* aValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iMotEnc) &&(ret = p->iMotEnc->getMotorEncoderAccelerations(aValues)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                accs[juser] = aValues[jdevice];
-            }
-        }
-        else
-        {
-            printError("getMotorEncoderAccelerations", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] aValues;
-    return ret;
-
-}
-
-
-bool ControlBoardWrapper::getNumberOfMotorEncoders(int *num) {
-    *num=controlledJoints;
-    return true;
-}
-
-/* IAmplifierControl */
-
-bool ControlBoardWrapper::enableAmp(int j)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->amp)
-    {
-        return p->amp->enableAmp(off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::disableAmp(int j)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    bool ret = true;
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    // Use the newer interface if available, otherwise fallback on the old one.
-    if(p->iMode)
-    {
-        ret = p->iMode->setControlMode(off+p->base, VOCAB_CM_IDLE);
-    }
-    else
-    {
-        if (p->pos)
-            ret = p->amp->disableAmp(off+p->base);
-        else
-            ret = false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::getAmpStatus(int *st)
-{
-    int *status = new int[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->amp) &&(ret = p->amp->getAmpStatus(status)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                st[juser] = status[jdevice];
-            }
-        }
-        else
-        {
-            printError("getAmpStatus", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] status;
-    return ret;
-}
-
-bool ControlBoardWrapper::getAmpStatus(int j, int *v)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (p && p->amp)
-        {
-            return p->amp->getAmpStatus(off+p->base,v);
-        }
-    *v=0;
-    return false;
-}
-
-bool ControlBoardWrapper::setMaxCurrent(int j, double v)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->amp)
-    {
-        return p->amp->setMaxCurrent(off+p->base,v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getMaxCurrent(int j, double* v)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-    {
-        *v=0.0;
-        return false;
-    }
-
-    if (p->amp)
-    {
-        return p->amp->getMaxCurrent(off+p->base,v);
-    }
-    *v=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getNominalCurrent(int m, double *val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if(!p)
-    {
-        *val=0.0;
-        return false;
-    }
-
-    if(!p->amp)
-    {
-        *val=0.0;
-        return false;
-    }
-    return p->amp->getNominalCurrent(off+p->base, val);
-}
-
-bool ControlBoardWrapper::getPeakCurrent(int m, double *val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if(!p)
-    {
-        *val=0.0;
-        return false;
-    }
-
-    if(!p->amp)
-    {
-        *val=0.0;
-        return false;
-    }
-    return p->amp->getPeakCurrent(off+p->base, val);
-}
-
-bool ControlBoardWrapper::setPeakCurrent(int m, const double val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (!p->amp)
-    {
-        return false;
-    }
-    return p->amp->setPeakCurrent(off+p->base, val);
-}
-
-bool ControlBoardWrapper::setNominalCurrent(int m, const double val)
-{
-    int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (!p->amp)
-    {
-        return false;
-    }
-    return p->amp->setNominalCurrent(off + p->base, val);
-}
-
-bool ControlBoardWrapper::getPWM(int m, double* val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off+p->base << " p " << (p?"1":"0") << " amp " << (p->amp?"1":"0");
-    if(!p)
-    {
-        *val=0.0;
-        return false;
-    }
-
-    if(!p->amp)
-    {
-        *val=0.0;
-        return false;
-    }
-    return p->amp->getPWM(off+p->base, val);
-}
-bool ControlBoardWrapper::getPWMLimit(int m, double* val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off+p->base << " p " << (p?"1":"0") << " amp " << (p->amp?"1":"0");
-
-    if(!p)
-    {
-        *val=0.0;
-        return false;
-    }
-
-    if(!p->amp)
-    {
-        *val=0.0;
-        return false;
-    }
-    return p->amp->getPWMLimit(off+p->base, val);
-}
-bool ControlBoardWrapper::setPWMLimit(int m, const double val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (!p->amp)
-    {
-        return false;
-    }
-    return p->amp->setPWMLimit(off+p->base, val);
-}
-
-bool ControlBoardWrapper::getPowerSupplyVoltage(int m, double* val)
-{
-    int off=device.lut[m].offset;
-    int subIndex=device.lut[m].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if(!p)
-    {
-        *val=0.0;
-        return false;
-    }
-
-    if(!p->amp)
-    {
-        *val=0.0;
-        return false;
-    }
-    return p->amp->getPowerSupplyVoltage(off+p->base, val);
-}
-
-
-/* IControlLimits */
-
-bool ControlBoardWrapper::setLimits(int j, double min, double max)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->lim)
-    {
-        return p->lim->setLimits(off+p->base,min, max);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getLimits(int j, double *min, double *max)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-    {
-        *min=0.0;
-        *max=0.0;
-        return false;
-    }
-
-    if (p->lim)
-    {
-        return p->lim->getLimits(off+p->base,min, max);
-    }
-    *min=0.0;
-    *max=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::setVelLimits(int j, double min, double max)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (!p->lim)
-    {
-        return false;
-    }
-    return p->lim->setVelLimits(off+p->base,min, max);
-}
-
-bool ControlBoardWrapper::getVelLimits(int j, double *min, double *max)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    *min=0.0;
-    *max=0.0;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-    {
-        return false;
-    }
-
-    if(!p->lim)
-    {
-        return false;
-    }
-    return p->lim->getVelLimits(off+p->base,min, max);
-}
-
-/* IRemoteCalibrator */
-IRemoteCalibrator *ControlBoardWrapper::getCalibratorDevice()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    return yarp::dev::IRemoteCalibrator::getCalibratorDevice();
-}
-
-bool ControlBoardWrapper::isCalibratorDevicePresent(bool *isCalib)
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    return yarp::dev::IRemoteCalibrator::isCalibratorDevicePresent(isCalib);
-}
-
-bool ControlBoardWrapper::calibrateSingleJoint(int j)
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-    return IRemoteCalibrator::getCalibratorDevice()->calibrateSingleJoint(j);
-}
-
-bool ControlBoardWrapper::calibrateWholePart()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->calibrateWholePart();
-}
-
-bool ControlBoardWrapper::homingSingleJoint(int j)
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->homingSingleJoint(j);
-}
-
-bool ControlBoardWrapper::homingWholePart()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->homingWholePart();
-}
-
-bool ControlBoardWrapper::parkSingleJoint(int j, bool _wait)
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->parkSingleJoint(j, _wait);
-}
-
-bool ControlBoardWrapper::parkWholePart()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->parkWholePart();
-}
-
-bool ControlBoardWrapper::quitCalibrate()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->quitCalibrate();
-}
-
-bool ControlBoardWrapper::quitPark()
-{
-    yCTrace(CONTROLBOARDWRAPPER);
-    if(!getCalibratorDevice())
-        return false;
-
-    return getCalibratorDevice()->quitPark();
-}
-
-
-/* IControlCalibration */
-bool ControlBoardWrapper::calibrateAxisWithParams(int j, unsigned int ui, double v1, double v2, double v3)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (p && p->calib)
-    {
-        return p->calib->calibrateAxisWithParams(off+p->base, ui,v1,v2,v3);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setCalibrationParameters(int j, const CalibrationParameters& params)
-{
-    int off = device.lut[j].offset;
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (p && p->calib)
-    {
-        return p->calib->setCalibrationParameters(off + p->base, params);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::calibrationDone(int j)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->calib)
-    {
-        return p->calib->calibrationDone(off+p->base);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::abortPark()
-{
-    yCError(CONTROLBOARDWRAPPER, "Calling abortPark -- not implemented");
-    return false;
-}
-
-bool ControlBoardWrapper::abortCalibration()
-{
-    yCError(CONTROLBOARDWRAPPER, "Calling abortCalibration -- not implemented");
-    return false;
-}
-
-/* IAxisInfo */
-
-bool ControlBoardWrapper::getAxisName(int j, std::string& name)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->info)
-    {
-        return p->info->getAxisName(off+p->base, name);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getJointType(int j, yarp::dev::JointTypeEnum& type)
-{
-    int off = device.lut[j].offset;
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->info)
-    {
-        return p->info->getJointType(off + p->base, type);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getRefTorques(double *refs)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iTorque) &&(ret = p->iTorque->getRefTorques(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                refs[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefTorques", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-}
-
-bool ControlBoardWrapper::getRefTorque(int j, double *t)
-{
-
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->getRefTorque(off+p->base, t);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setRefTorques(const double *t)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iTorque)
-        {
-            ret=ret&&p->iTorque->setRefTorque(off+p->base, t[l]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setRefTorque(int j, double t)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->setRefTorque(off+p->base, t);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setRefTorques(const int n_joints, const int *joints, const double *t)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->iTorque)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->iTorque->setRefTorques(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                               rpcData.jointNumbers[subIndex],
-                                                                               rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->getMotorTorqueParams(off+p->base, params);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->setMotorTorqueParams(off+p->base, params);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setImpedance(int j, double stiff, double damp)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iImpedance)
-    {
-        return p->iImpedance->setImpedance(off+p->base, stiff, damp);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setImpedanceOffset(int j, double offset)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iImpedance)
-    {
-        return p->iImpedance->setImpedanceOffset(off+p->base, offset);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getTorque(int j, double *t)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->getTorque(off+p->base, t);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getTorques(double *t)
-{
-    auto* trqs = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iTorque) &&(ret = p->iTorque->getTorques(trqs)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                t[juser] = trqs[jdevice];
-            }
-        }
-        else
-        {
-            printError("getTorques", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] trqs;
-    return ret;
-
- }
-
-bool ControlBoardWrapper::getTorqueRange(int j, double *min, double *max)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iTorque)
-    {
-        return p->iTorque->getTorqueRange(off+p->base, min, max);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getTorqueRanges(double *min, double *max)
-{
-    auto* t_min = new double[device.maxNumOfJointsInDevices];
-    auto* t_max = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iTorque) &&(ret = p->iTorque->getTorqueRanges(t_min, t_max)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                min[juser] = t_min[jdevice];
-                max[juser] = t_max[jdevice];
-            }
-        }
-        else
-        {
-            printError("getTorqueRanges", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] t_min;
-    delete [] t_max;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::getImpedance(int j, double* stiff, double* damp)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iImpedance)
-    {
-        return p->iImpedance->getImpedance(off+p->base, stiff, damp);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getImpedanceOffset(int j, double* offset)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iImpedance)
-    {
-        return p->iImpedance->getImpedanceOffset(off+p->base, offset);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iImpedance)
-    {
-        return p->iImpedance->getCurrentImpedanceLimit(off+p->base, min_stiff, max_stiff, min_damp, max_damp);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getControlMode(int j, int *mode)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMode)
-    {
-        return p->iMode->getControlMode(off+p->base, mode);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getControlModes(int *modes)
-{
-    int *all_mode = new int[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iMode) &&(ret = p->iMode->getControlModes(all_mode)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                modes[juser] = all_mode[jdevice];
-            }
-        }
-        else
-        {
-            printError("getControlModes", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] all_mode;
-    return ret;
-
-}
-
-// iControlMode2
-bool ControlBoardWrapper::getControlModes(const int n_joint, const int *joints, int *modes)
-{
-    bool ret=true;
-
-     for(int l=0; l<n_joint; l++)
-     {
-         int off=device.lut[joints[l]].offset;
-         int subIndex=device.lut[joints[l]].deviceEntry;
-
-         SubDevice *p=device.getSubdevice(subIndex);
-         if (!p)
-             return false;
-
-         if (p->iMode)
-         {
-             ret=ret&&p->iMode->getControlMode(off+p->base, &modes[l]);
-         }
-         else
-             ret=false;
-     }
-     return ret;
-}
-
-bool ControlBoardWrapper::setControlMode(const int j, const int mode)
-{
-    bool ret = true;
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iMode)
-    {
-        ret = p->iMode->setControlMode(off+p->base, mode);
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setControlModes(const int n_joints, const int *joints, int *modes)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = modes[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->iMode)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->iMode->setControlModes(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                rpcData.jointNumbers[subIndex],
-                                                                                rpcData.modes[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::setControlModes(int *modes)
-{
-    bool ret = true;
-    int j_wrap = 0;         // index of the wrapper joint
-
-    int nDev = device.subdevices.size();
-    for(int subDev_idx=0; subDev_idx < nDev; subDev_idx++)
-    {
-        int subIndex=device.lut[j_wrap].deviceEntry;
-        SubDevice *p = device.getSubdevice(subIndex);
-        if(!p) {
-            return false;
-        }
-
-        int wrapped_joints=(p->top - p->base) + 1;
-        int *joints = new int[wrapped_joints];
-
-        if(p->iMode)
-        {
-            // versione comandi su subset di giunti
-            for(int j_dev = 0; j_dev < wrapped_joints; j_dev++)
-            {
-                joints[j_dev] = p->base + j_dev;  // for all joints is equivalent to add offset term
-            }
-
-            ret = ret && p->iMode->setControlModes(wrapped_joints, joints, &modes[j_wrap]);
-            j_wrap+=wrapped_joints;
-        }
-
-        if(joints!=nullptr)
-        {
-            delete [] joints;
-            joints = nullptr;
-        }
-    }
-
-    return ret;
-}
-
-bool ControlBoardWrapper::setPosition(int j, double ref)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->posDir)
-    {
-        return p->posDir->setPosition(off+p->base, ref);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::setPositions(const int n_joints, const int *joints, const double *dpos)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        int offset = device.lut[joints[j]].offset;
-        int base = rpcData.subdevices_p[subIndex]->base;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =  offset + base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = dpos[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->posDir)   // Position Direct
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->posDir->setPositions(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                             rpcData.jointNumbers[subIndex],
-                                                                             rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::setPositions(const double *refs)
-{
-    bool ret=true;
-
-    for(int l=0;l<controlledJoints;l++)
-    {
-        int off=device.lut[l].offset;
-        int subIndex=device.lut[l].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->posDir)
-        {
-            ret = p->posDir->setPosition(off+p->base, refs[l]) && ret;
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-yarp::os::Stamp ControlBoardWrapper::getLastInputStamp() {
-    timeMutex.lock();
-    yarp::os::Stamp ret=time;
-    timeMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getRefPosition(const int j, double* ref)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->posDir)
-    {
-        bool ret = p->posDir->getRefPosition(off+p->base, ref);
-        return ret;
-    }
-    *ref=0;
-    return false;
-}
-
-bool ControlBoardWrapper::getRefPositions(double *spds)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->posDir) &&(ret = p->posDir->getRefPositions(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                spds[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefPositions", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-
-}
-
-
-bool ControlBoardWrapper::getRefPositions(const int n_joints, const int *joints, double *targets)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->posDir)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->posDir->getRefPositions( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                            rpcData.jointNumbers[subIndex],
-                                                                            rpcData.values[subIndex]);
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;                  // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            targets[j]  = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            targets[j] = 0;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-
-//
-// IVelocityControl2 Interface
-//
-bool ControlBoardWrapper::velocityMove(const int n_joints, const int *joints, const double *spds)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = spds[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->vel)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->vel->velocityMove(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                           rpcData.jointNumbers[subIndex],
-                                                                           rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getRefVelocity(const int j, double* vel)
-{
-    if(verbose())
-        yCTrace(CONTROLBOARDWRAPPER);
-
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-
-    if (!p)
-        return false;
-
-    if (p->vel)
-    {
-        bool ret = p->vel->getRefVelocity(off+p->base, vel);
-        return ret;
-    }
-    *vel=0;
-    return false;
-}
-
-
-bool ControlBoardWrapper::getRefVelocities(double* vels)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->vel) &&(ret = p->vel->getRefVelocities(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                vels[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefVelocities", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::getRefVelocities(const int n_joints, const int* joints, double* vels)
-{
-    if(verbose())
-        yCTrace(CONTROLBOARDWRAPPER);
-
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->vel)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->vel->getRefVelocities( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                rpcData.jointNumbers[subIndex],
-                                                                                rpcData.values[subIndex]);
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;    // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            vels[j]  = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            vels[j] = 0;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *s=device.getSubdevice(subIndex);
-    if (!s)
-        return false;
-
-    if (s->iInteract)
-    {
-        return s->iInteract->getInteractionMode(off+s->base, mode);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->iInteract)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->iInteract->getInteractionModes(rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                       rpcData.jointNumbers[subIndex],
-                                                                                       (yarp::dev::InteractionModeEnum*) rpcData.modes[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-
-    if(ret)
-    {
-        // ReMix values by user expectations
-        for(int i=0; i<rpcData.deviceNum; i++)
-            rpcData.subdev_jointsVectorLen[i]=0;                  // reset tmp index
-
-        // fill the output vector
-        for(int j=0; j<n_joints; j++)
-        {
-            subIndex = device.lut[joints[j]].deviceEntry;
-            modes[j] = (yarp::dev::InteractionModeEnum) rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
-            rpcData.subdev_jointsVectorLen[subIndex]++;
-        }
-    }
-    else
-    {
-        for(int j=0; j<n_joints; j++)
-        {
-            modes[j] = VOCAB_IM_UNKNOWN;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
-{
-
-    auto* imodes = new yarp::dev::InteractionModeEnum[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iInteract) &&(ret = p->iInteract->getInteractionModes(imodes)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                modes[juser] = imodes[jdevice];
-            }
-        }
-        else
-        {
-            printError("getInteractionModes", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] imodes;
-    return ret;
-}
-
-bool ControlBoardWrapper::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *s=device.getSubdevice(subIndex);
-    if (!s)
-        return false;
-
-    if (s->iInteract)
-    {
-        return s->iInteract->setInteractionMode(off+s->base, mode);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for(int j=0; j<n_joints; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = (int) modes[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for(subIndex=0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if(rpcData.subdevices_p[subIndex]->iInteract)
-        {
-            ret= ret && rpcData.subdevices_p[subIndex]->iInteract->setInteractionModes( rpcData.subdev_jointsVectorLen[subIndex],
-                                                                                        rpcData.jointNumbers[subIndex],
-                                                                                        (yarp::dev::InteractionModeEnum*) rpcData.modes[subIndex]);
-        }
-        else
-        {
-            ret=false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
-{
-    bool ret = true;
-
-    for(int j=0; j<controlledJoints; j++)
-    {
-        int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-        int subIndex=device.lut[j].deviceEntry;
-
-        SubDevice *p=device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iInteract)
-        {
-            ret=ret && p->iInteract->setInteractionMode(off+p->base, modes[j]);
-        }
-        else
-            ret=false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setRefDutyCycle(int j, double v)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iPWM)
-    {
-        return p->iPWM->setRefDutyCycle(off + p->base, v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setRefDutyCycles(const double *v)
-{
-    bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
-    {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iPWM)
-        {
-            ret = ret&&p->iPWM->setRefDutyCycle(off + p->base, v[l]);
-        }
-        else
-            ret = false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::getRefDutyCycle(int j, double *v)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iPWM)
-    {
-        return p->iPWM->getRefDutyCycle(off + p->base, v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getRefDutyCycles(double *v)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iPWM) &&(ret = p->iPWM->getRefDutyCycles(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                v[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefDutyCycles", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::getDutyCycle(int j, double *v)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iPWM)
-    {
-        return p->iPWM->getDutyCycle(off + p->base, v);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::getDutyCycles(double *v)
-{
-    auto* dutyCicles = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iPWM) &&(ret = p->iPWM->getDutyCycles(dutyCicles)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                v[juser] = dutyCicles[jdevice];
-            }
-        }
-        else
-        {
-            printError("getDutyCycles", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] dutyCicles;
-    return ret;
-
-}
-
-
-//
-// ICurrentControl Interface
-//
-
-//bool ControlBoardWrapper::getAxes(int *ax);
-
-bool ControlBoardWrapper::getCurrents(double *vals)
-{
-    auto* currs = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        ret = false;
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            break;
-        }
-
-        if(p->iCurr)
-        {
-            ret = p->iCurr->getCurrents(currs);
-        }
-        else if(p->amp)
-        {
-            ret = p->amp->getCurrents(currs);
-        }
-
-        if(ret)
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                vals[juser] = currs[jdevice];
-            }
-        }
-        else
-        {
-            printError("getCurrents", p->id, ret);
-            break;
-        }
-    }
-    delete [] currs;
-    return ret;
-}
-
-bool ControlBoardWrapper::getCurrent(int j, double *val)
-{
-    int off; try { off = device.lut.at(j).offset; } catch(...) { yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex=device.lut[j].deviceEntry;
-
-    SubDevice *p=device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iCurr)
-    {
-        return p->iCurr->getCurrent(off+p->base,val);
-    }
-    else if (p->amp)
-    {
-        return p->amp->getCurrent(off+p->base,val);
-    }
-    *val=0.0;
-    return false;
-}
-
-bool ControlBoardWrapper::getCurrentRange(int j, double *min, double *max)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iCurr)
-    {
-        return p->iCurr->getCurrentRange(off + p->base, min, max);
-    }
-
-    return false;
-}
-
-bool ControlBoardWrapper::getCurrentRanges(double *min, double *max)
-{
-    auto* c_min = new double[device.maxNumOfJointsInDevices];
-    auto* c_max = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iCurr) &&(ret = p->iCurr->getCurrentRanges(c_min, c_max)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                min[juser] = c_min[jdevice];
-                max[juser] = c_max[jdevice];
-            }
-        }
-        else
-        {
-            printError("getCurrentRanges", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] c_min;
-    delete [] c_max;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::setRefCurrents(const double *t)
-{
-    bool ret = true;
-
-    for (int l = 0; l<controlledJoints; l++)
-    {
-        int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
-
-        SubDevice *p = device.getSubdevice(subIndex);
-        if (!p)
-            return false;
-
-        if (p->iCurr)
-        {
-            ret = ret&&p->iCurr->setRefCurrent(off + p->base, t[l]);
-        }
-        else
-            ret = false;
-    }
-    return ret;
-}
-
-bool ControlBoardWrapper::setRefCurrent(int j, double t)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iCurr)
-    {
-        return p->iCurr->setRefCurrent(off + p->base, t);
-    }
-    return false;
-}
-
-bool ControlBoardWrapper::setRefCurrents(const int n_joint, const int *joints, const double *t)
-{
-    bool ret = true;
-
-    rpcDataMutex.lock();
-    //Reset subdev_jointsVectorLen vector
-    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
-
-    // Create a map of joints for each subDevice
-    int subIndex = 0;
-    for (int j = 0; j<n_joint; j++)
-    {
-        subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
-        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
-        rpcData.subdev_jointsVectorLen[subIndex]++;
-    }
-
-    for (subIndex = 0; subIndex<rpcData.deviceNum; subIndex++)
-    {
-        if (rpcData.subdevices_p[subIndex]->iCurr)
-        {
-            ret = ret && rpcData.subdevices_p[subIndex]->iCurr->setRefCurrents(rpcData.subdev_jointsVectorLen[subIndex],
-                rpcData.jointNumbers[subIndex],
-                rpcData.values[subIndex]);
-        }
-        else
-        {
-            ret = false;
-        }
-    }
-    rpcDataMutex.unlock();
-    return ret;
-}
-
-bool ControlBoardWrapper::getRefCurrents(double *t)
-{
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for(unsigned int d=0; d<device.subdevices.size(); d++)
-    {
-        SubDevice *p=device.getSubdevice(d);
-        if(!p)
-        {
-            ret = false;
-            break;
-        }
-
-        if( (p->iCurr) &&(ret = p->iCurr->getRefCurrents(references)))
-        {
-            for(int juser= p->wbase, jdevice=p->base; juser<=p->wtop; juser++, jdevice++)
-            {
-                t[juser] = references[jdevice];
-            }
-        }
-        else
-        {
-            printError("getRefCurrents", p->id, ret);
-            ret = false;
-            break;
-        }
-    }
-
-    delete [] references;
-    return ret;
-
-}
-
-bool ControlBoardWrapper::getRefCurrent(int j, double *t)
-{
-    int off; try{ off = device.lut.at(j).offset; }
-    catch (...){ yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str()); return false; }
-    int subIndex = device.lut[j].deviceEntry;
-
-    SubDevice *p = device.getSubdevice(subIndex);
-    if (!p)
-        return false;
-
-    if (p->iCurr)
-    {
-        return p->iCurr->getRefCurrent(off + p->base, t);
-    }
-
-    return false;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -233,10 +233,6 @@ private:
     RPCMessagesParser              RPC_parser;                     // Message parser associated to the inputRPCPort port
     StreamingMessagesParser        streaming_parser;               // Message parser associated to the inputStreamingPort port
 
-
-    int               base {0};         // to be removed // FIXME
-    int               top {0};          // to be removed // FIXME
-
     static constexpr double default_period = 0.02; // s
     double period {default_period};
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -13,33 +13,22 @@
 // ControlBoardWrapper
 // A modified version of the remote control board class
 // which remaps joints, it can also merge networks into a single part.
-//
 
-#include <yarp/os/PortablePair.h>
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IMultipleWrapper.h>
+
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/Time.h>
-#include <yarp/os/Network.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/os/Vocab.h>
-
-#include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/ControlBoardInterfacesImpl.h>
-#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/ControlBoardHelpers.h>
+
+#include <yarp/dev/impl/jointData.h> // struct for YARP extended port
 
 #include <mutex>
 #include <string>
 #include <vector>
-
-#include <yarp/dev/impl/jointData.h>           // struct for YARP extended port
-
-#include "SubDevice.h"
-#include "StreamingMessagesParser.h"
-#include "RPCMessagesParser.h"
 
 // ROS state publisher
 #include <yarp/os/Node.h>
@@ -47,13 +36,36 @@
 #include <yarp/rosmsg/sensor_msgs/JointState.h>
 #include <yarp/rosmsg/impl/yarpRosHelper.h>
 
+
+#include "ControlBoardWrapperPidControl.h"
+#include "ControlBoardWrapperPositionControl.h"
+#include "ControlBoardWrapperPositionDirect.h"
+#include "ControlBoardWrapperVelocityControl.h"
+#include "ControlBoardWrapperEncodersTimed.h"
+#include "ControlBoardWrapperMotor.h"
+#include "ControlBoardWrapperMotorEncoders.h"
+#include "ControlBoardWrapperAmplifierControl.h"
+#include "ControlBoardWrapperControlLimits.h"
+#include "ControlBoardWrapperRemoteCalibrator.h"
+#include "ControlBoardWrapperControlCalibration.h"
+#include "ControlBoardWrapperTorqueControl.h"
+#include "ControlBoardWrapperImpedanceControl.h"
+#include "ControlBoardWrapperControlMode.h"
+#include "ControlBoardWrapperAxisInfo.h"
+#include "ControlBoardWrapperInteractionMode.h"
+#include "ControlBoardWrapperRemoteVariables.h"
+#include "ControlBoardWrapperPWMControl.h"
+#include "ControlBoardWrapperCurrentControl.h"
+#include "ControlBoardWrapperPreciselyTimed.h"
+
+#include "SubDevice.h"
+#include "StreamingMessagesParser.h"
+#include "RPCMessagesParser.h"
+
+
 #ifdef MSVC
     #pragma warning(disable:4355)
 #endif
-
-#define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 9
-#define PROTOCOL_VERSION_TWEAK 0
 
 /*
  * To optimize memory allocation, for group of joints we can have one mem reserver for rpc port
@@ -63,65 +75,7 @@
 
 class CommandsHelper;
 class SubDevice;
-class WrappedDevice;
 
-class MultiJointData
-{
-public:
-    int deviceNum{0};
-    int maxJointsNumForDevice{0};
-
-    int *subdev_jointsVectorLen{nullptr}; // number of joints belonging to each subdevice
-    int **jointNumbers{nullptr};
-    int **modes{nullptr};
-    double **values{nullptr};
-    SubDevice **subdevices_p{nullptr};
-
-    MultiJointData() = default;
-
-    void resize(int _deviceNum, int _maxJointsNumForDevice, WrappedDevice *_device)
-    {
-        deviceNum = _deviceNum;
-        maxJointsNumForDevice = _maxJointsNumForDevice;
-        subdev_jointsVectorLen    = new int  [deviceNum];
-        jointNumbers    = new int *[deviceNum];                             // alloc a vector of pointers
-        jointNumbers[0] = new int[deviceNum * _maxJointsNumForDevice];      // alloc real memory for data
-
-        modes           = new int *[deviceNum];                             // alloc a vector of pointers
-        modes[0]        = new int[deviceNum * _maxJointsNumForDevice];      // alloc real memory for data
-
-        values      = new double *[deviceNum];                          // alloc a vector of pointers
-        values[0]   = new double[deviceNum * _maxJointsNumForDevice];   // alloc real memory for data
-
-        subdevices_p = new SubDevice *[deviceNum];
-        subdevices_p[0] = _device->getSubdevice(0);
-
-        for (int i = 1; i < deviceNum; i++)
-        {
-            jointNumbers[i] =  jointNumbers[i-1] + _maxJointsNumForDevice;   // set pointer to correct location
-            values      [i] = values[i-1] + _maxJointsNumForDevice;      // set pointer to correct location
-            modes       [i] = modes[i-1]  + _maxJointsNumForDevice;      // set pointer to correct location
-            subdevices_p[i] = _device->getSubdevice(i);
-        }
-    }
-
-    void destroy()
-    {
-        // release matrix memory
-        delete[] jointNumbers[0];
-        delete[] values[0];
-        delete[] modes[0];
-
-        // release vector of pointers
-        delete[] jointNumbers;
-        delete[] values;
-        delete[] modes;
-
-        // delete other vectors
-        delete[] subdev_jointsVectorLen;
-        delete[] subdevices_p;
-    }
-};
 
 /**
  *  @ingroup dev_impl_wrapper
@@ -225,31 +179,31 @@ public:
 class ControlBoardWrapper :
         public yarp::dev::DeviceDriver,
         public yarp::os::PeriodicThread,
-        public yarp::dev::IPidControl,
-        public yarp::dev::IPositionControl,
-        public yarp::dev::IPositionDirect,
-        public yarp::dev::IVelocityControl,
-        public yarp::dev::IEncodersTimed,
-        public yarp::dev::IMotor,
-        public yarp::dev::IMotorEncoders,
-        public yarp::dev::IAmplifierControl,
-        public yarp::dev::IControlLimits,
-        public yarp::dev::IRemoteCalibrator,
-        public yarp::dev::IControlCalibration,
-        public yarp::dev::ITorqueControl,
-        public yarp::dev::IImpedanceControl,
-        public yarp::dev::IControlMode,
         public yarp::dev::IMultipleWrapper,
-        public yarp::dev::IAxisInfo,
-        public yarp::dev::IPreciselyTimed,
-        public yarp::dev::IInteractionMode,
-        public yarp::dev::IRemoteVariables,
-        public yarp::dev::IPWMControl,
-        public yarp::dev::ICurrentControl
+        virtual public ControlBoardWrapperCommon,
+        public ControlBoardWrapperPidControl,
+        public ControlBoardWrapperPositionControl,
+        public ControlBoardWrapperPositionDirect,
+        public ControlBoardWrapperVelocityControl,
+        public ControlBoardWrapperEncodersTimed,
+        public ControlBoardWrapperMotor,
+        public ControlBoardWrapperMotorEncoders,
+        public ControlBoardWrapperAmplifierControl,
+        public ControlBoardWrapperControlLimits,
+        public ControlBoardWrapperRemoteCalibrator,
+        public ControlBoardWrapperControlCalibration,
+        public ControlBoardWrapperTorqueControl,
+        public ControlBoardWrapperImpedanceControl,
+        public ControlBoardWrapperControlMode,
+        public ControlBoardWrapperAxisInfo,
+        public ControlBoardWrapperPreciselyTimed,
+        public ControlBoardWrapperInteractionMode,
+        public ControlBoardWrapperRemoteVariables,
+        public ControlBoardWrapperPWMControl,
+        public ControlBoardWrapperCurrentControl
 {
 private:
     std::string rootName;
-    WrappedDevice device;
 
     bool checkPortName(yarp::os::Searchable &params);
 
@@ -258,9 +212,7 @@ private:
     yarp::os::BufferedPort<yarp::sig::Vector>  outputPositionStatePort;   // Port /state:o streaming out the encoder positions
     yarp::os::BufferedPort<CommandMessage>     inputStreamingPort;        // Input streaming port for high frequency commands
     yarp::os::Port inputRPCPort;                // Input RPC port for set/get remote calls
-    yarp::os::Stamp time;                       // envelope to attach to the state port
     yarp::sig::Vector times;                    // time for each joint
-    std::mutex timeMutex;
 
     // Buffer associated to the extendedOutputStatePort port; in this case we will use the type generated
     // from the YARP .thrift file
@@ -268,31 +220,25 @@ private:
     yarp::os::Port extendedOutputStatePort;         // Port /stateExt:o streaming out the struct with the robot data
 
     // ROS state publisher
-    ROSTopicUsageType                                   useROS;                     // decide if open ROS topic or not
-    std::vector<std::string>                            jointNames;                 // name of the joints
-    std::string                                         rosNodeName;                // name of the rosNode
-    std::string                                         rosTopicName;               // name of the rosTopic
-    yarp::os::Node                                      *rosNode;                   // add a ROS node
-    yarp::os::NetUint32                                 rosMsgCounter;              // incremental counter in the ROS message
+    ROSTopicUsageType                                   useROS {ROS_disabled};               // decide if open ROS topic or not
+    std::vector<std::string>                            jointNames;                          // name of the joints
+    std::string                                         rosNodeName;                         // name of the rosNode
+    std::string                                         rosTopicName;                        // name of the rosTopic
+    yarp::os::Node                                      *rosNode {nullptr};                  // add a ROS node
+    yarp::os::NetUint32                                 rosMsgCounter {0};                   // incremental counter in the ROS message
     yarp::os::PortWriterBuffer<yarp::rosmsg::sensor_msgs::JointState> rosOutputState_buffer; // Buffer associated to the ROS topic
-    yarp::os::Publisher<yarp::rosmsg::sensor_msgs::JointState> rosPublisherPort;    // Dedicated ROS topic publisher
+    yarp::os::Publisher<yarp::rosmsg::sensor_msgs::JointState> rosPublisherPort;             // Dedicated ROS topic publisher
 
     yarp::os::PortReaderBuffer<yarp::os::Bottle>    inputRPC_buffer;                // Buffer associated to the inputRPCPort port
     RPCMessagesParser              RPC_parser;                     // Message parser associated to the inputRPCPort port
     StreamingMessagesParser        streaming_parser;               // Message parser associated to the inputStreamingPort port
 
 
-    // RPC calls are concurrent from multiple clients, data used inside the calls has to be protected
-    std::mutex                                 rpcDataMutex;                   // mutex to avoid concurrency between more clients using rppc port
-    MultiJointData                 rpcData;                        // Structure used to re-arrange data from "multiple_joints" calls.
+    int               base {0};         // to be removed // FIXME
+    int               top {0};          // to be removed // FIXME
 
-    std::string         partName;               // to open ports and print more detailed debug messages
-
-    int               controlledJoints;
-    int               base;         // to be removed
-    int               top;          // to be removed
-    double            period;       // thread rate for publishing data
-    bool              _verb;        // make it work and propagate to subdevice if --subdevice option is used
+    static constexpr double default_period = 0.02; // s
+    double period {default_period};
 
     yarp::os::Bottle getOptions();
     bool updateAxisName();
@@ -307,19 +253,10 @@ private:
 
     // For the simulator, if a subdevice parameter is given to the wrapper, it will
     // open it and attach to it immediately.
-    yarp::dev::PolyDriver *subDeviceOwned;
+    yarp::dev::PolyDriver *subDeviceOwned {nullptr};
     bool openAndAttachSubDevice(yarp::os::Property& prop);
 
     bool ownDevices;
-    inline void printError(std::string func_name, std::string info, bool result)
-    {
-        //If result is false, this means that en error occurred in function named func_name, otherwise means that the device doesn't implement the interface to witch func_name belongs to.
-       // if(false == result)
-       //    yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << " returns false";
-        //Commented in order to maintain the old behaviour (none message appear if device desn't implement the interface)
-        //else
-            // yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << ": the interface is not available.";
-    }
 
     void calculateMaxNumOfJointsInDevices();
 
@@ -331,14 +268,6 @@ public:
     ControlBoardWrapper& operator=(ControlBoardWrapper&&) = delete;
     ~ControlBoardWrapper() override;
 
-    /**
-    * Return the value of the verbose flag.
-    * @return the verbose flag.
-    */
-    bool verbose() const
-    {
-        return _verb;
-    }
 
     /* Return id of this device */
     std::string getId()
@@ -357,7 +286,6 @@ public:
     * Open the device driver.
     * @param prop is a Searchable object which contains the parameters.
     * Allowed parameters are:
-    * - verbose or v to print diagnostic information while running..
     * - name to specify the prefix of the port names.
     * - subdevice [optional] if specified, the openAndAttachSubDevice will be
     *             called, otherwise openDeferredAttach is called.
@@ -373,862 +301,6 @@ public:
     * The thread main loop deals with writing on ports here.
     */
     void run() override;
-
-    /* IPidControl
-    These methods are documented by Doxygen in IPidControl.h*/
-    bool setPid(const yarp::dev::PidControlTypeEnum& pidtype, int j, const yarp::dev::Pid &p) override;
-    bool setPids(const yarp::dev::PidControlTypeEnum& pidtype, const yarp::dev::Pid *ps) override;
-    bool setPidReference(const yarp::dev::PidControlTypeEnum& pidtype, int j, double ref) override;
-    bool setPidReferences(const yarp::dev::PidControlTypeEnum& pidtype, const double *refs) override;
-    bool setPidErrorLimit(const yarp::dev::PidControlTypeEnum& pidtype, int j, double limit) override;
-    bool setPidErrorLimits(const yarp::dev::PidControlTypeEnum& pidtype, const double *limits) override;
-    bool getPidError(const yarp::dev::PidControlTypeEnum& pidtype, int j, double *err) override;
-    bool getPidErrors(const yarp::dev::PidControlTypeEnum& pidtype, double *errs) override;
-    bool getPidOutput(const yarp::dev::PidControlTypeEnum& pidtype, int j, double *out) override;
-    bool getPidOutputs(const yarp::dev::PidControlTypeEnum& pidtype, double *outs) override;
-    bool setPidOffset(const yarp::dev::PidControlTypeEnum& pidtype, int j, double v) override;
-    bool getPid(const yarp::dev::PidControlTypeEnum& pidtype, int j, yarp::dev::Pid *p) override;
-    bool getPids(const yarp::dev::PidControlTypeEnum& pidtype, yarp::dev::Pid *pids) override;
-    bool getPidReference(const yarp::dev::PidControlTypeEnum& pidtype, int j, double *ref) override;
-    bool getPidReferences(const yarp::dev::PidControlTypeEnum& pidtype, double *refs) override;
-    bool getPidErrorLimit(const yarp::dev::PidControlTypeEnum& pidtype, int j, double *limit) override;
-    bool getPidErrorLimits(const yarp::dev::PidControlTypeEnum& pidtype, double *limits) override;
-    bool resetPid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
-    bool disablePid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
-    bool enablePid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
-    bool isPidEnabled(const yarp::dev::PidControlTypeEnum& pidtype, int j, bool* enabled) override;
-
-    /* IPositionControl */
-
-    /**
-    * Get the number of controlled axes. This command asks the number of controlled
-    * axes for the current physical interface.
-    * @param ax pointer to storage
-    * @return true/false.
-    */
-    bool getAxes(int *ax) override;
-
-    /**
-    * Set new reference point for a single axis.
-    * @param j joint number
-    * @param ref specifies the new ref point
-    * @return true/false on success/failure
-    */
-    bool positionMove(int j, double ref) override;
-
-    /** Set new reference point for all axes.
-    * @param refs array, new reference points.
-    * @return true/false on success/failure
-    */
-    bool positionMove(const double *refs) override;
-
-    /** Set new reference point for a subset of axis.
-     * @param joints pointer to the array of joint numbers
-     * @param refs   pointer to the array specifying the new reference points
-     * @return true/false on success/failure
-     */
-    bool positionMove(const int n_joints, const int *joints, const double *refs) override;
-
-/** Get the last position reference for the specified axis.
-     *  This is the dual of PositionMove and shall return only values sent using
-     *  IPositionControl interface.
-     *  If other interfaces like IPositionDirect are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionDirect::SetPosition
-     * @param ref last reference sent using PositionMove functions
-     * @return true/false on success/failure
-     */
-    bool getTargetPosition(const int joint, double *ref) override;
-
-    /** Get the last position reference for all axes.
-     *  This is the dual of PositionMove and shall return only values sent using
-     *  IPositionControl interface.
-     *  If other interfaces like IPositionDirect are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionDirect::SetPosition
-     * @param ref last reference sent using PositionMove functions
-     * @return true/false on success/failure
-     */
-    bool getTargetPositions(double *refs) override;
-
-    /** Get the last position reference for the specified group of axes.
-     *  This is the dual of PositionMove and shall return only values sent using
-     *  IPositionControl interface.
-     *  If other interfaces like IPositionDirect are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionDirect::SetPosition
-     * @param ref last reference sent using PositionMove functions
-     * @return true/false on success/failure
-     */
-    bool getTargetPositions(const int n_joint, const int *joints, double *refs) override;
-
-    /** Set relative position. The command is relative to the
-    * current position of the axis.
-    * @param j joint axis number
-    * @param delta relative command
-    * @return true/false on success/failure
-    */
-    bool relativeMove(int j, double delta) override;
-
-    /** Set relative position, all joints.
-    * @param deltas pointer to the relative commands
-    * @return true/false on success/failure
-    */
-    bool relativeMove(const double *deltas) override;
-
-    /** Set relative position for a subset of joints.
-     * @param joints pointer to the array of joint numbers
-     * @param deltas pointer to the array of relative commands
-     * @return true/false on success/failure
-     */
-    bool relativeMove(const int n_joints, const int *joints, const double *deltas) override;
-
-    /**
-    * Check if the current trajectory is terminated. Non blocking.
-    * @param j the axis
-    * @param flag true if the trajectory is terminated, false otherwise
-    * @return false on failure
-    */
-    bool checkMotionDone(int j, bool *flag) override;
-    /**
-    * Check if the current trajectory is terminated. Non blocking.
-    * @param flag true if the trajectory is terminated, false otherwise
-    *        (a single value which is the 'and' of all joints')
-    * @return false on failure
-    */
-    bool checkMotionDone(bool *flag) override;
-
-    /** Check if the current trajectory is terminated. Non blocking.
-     * @param joints pointer to the array of joint numbers
-     * @param flag true if the trajectory is terminated, false otherwise
-     *        (a single value which is the 'and' of all joints')
-     * @return true/false if network communication went well.
-     */
-    bool checkMotionDone(const int n_joints, const int *joints, bool *flags) override;
-
-    /** Set reference speed for a joint, this is the speed used during the
-    * interpolation of the trajectory.
-    * @param j joint number
-    * @param sp speed value
-    * @return true/false upon success/failure
-    */
-    bool setRefSpeed(int j, double sp) override;
-
-    /** Set reference speed on all joints. These values are used during the
-    * interpolation of the trajectory.
-    * @param spds pointer to the array of speed values.
-    * @return true/false upon success/failure
-    */
-    bool setRefSpeeds(const double *spds) override;
-
-    /** Set reference speed on all joints. These values are used during the
-     * interpolation of the trajectory.
-     * @param joints pointer to the array of joint numbers
-     * @param spds   pointer to the array with speed values.
-     * @return true/false upon success/failure
-     */
-    bool setRefSpeeds(const int n_joints, const int *joints, const double *spds) override;
-
-    /** Set reference acceleration for a joint. This value is used during the
-    * trajectory generation.
-    * @param j joint number
-    * @param acc acceleration value
-    * @return true/false upon success/failure
-    */
-    bool setRefAcceleration(int j, double acc) override;
-
-    /** Set reference acceleration on all joints. This is the valure that is
-    * used during the generation of the trajectory.
-    * @param accs pointer to the array of acceleration values
-    * @return true/false upon success/failure
-    */
-    bool setRefAccelerations(const double *accs) override;
-
-    /** Set reference acceleration on all joints. This is the valure that is
-     * used during the generation of the trajectory.
-     * @param joints pointer to the array of joint numbers
-     * @param accs   pointer to the array with acceleration values
-     * @return true/false upon success/failure
-     */
-    bool setRefAccelerations(const int n_joints, const int *joints, const double *accs) override;
-
-    /** Get reference speed for a joint. Returns the speed used to
-     * generate the trajectory profile.
-     * @param j joint number
-     * @param ref pointer to storage for the return value
-     * @return true/false on success or failure
-     */
-    bool getRefSpeed(int j, double *ref) override;
-
-    /** Get reference speed of all joints. These are the  values used during the
-    * interpolation of the trajectory.
-    * @param spds pointer to the array that will store the speed values.
-    * @return true/false on success/failure.
-    */
-    bool getRefSpeeds(double *spds) override;
-
-    /** Get reference speed of all joints. These are the  values used during the
-     * interpolation of the trajectory.
-     * @param joints pointer to the array of joint numbers
-     * @param spds   pointer to the array that will store the speed values.
-     * @return true/false upon success/failure
-     */
-    bool getRefSpeeds(const int n_joints, const int *joints, double *spds) override;
-
-    /** Get reference acceleration for a joint. Returns the acceleration used to
-    * generate the trajectory profile.
-    * @param j joint number
-    * @param acc pointer to storage for the return value
-    * @return true/false on success/failure
-    */
-    bool getRefAcceleration(int j, double *acc) override;
-
-    /** Get reference acceleration of all joints. These are the values used during the
-    * interpolation of the trajectory.
-    * @param accs pointer to the array that will store the acceleration values.
-    * @return true/false on success or failure
-    */
-    bool getRefAccelerations(double *accs) override;
-
-    /** Get reference acceleration for a joint. Returns the acceleration used to
-     * generate the trajectory profile.
-     * @param joints pointer to the array of joint numbers
-     * @param accs   pointer to the array that will store the acceleration values
-     * @return true/false on success/failure
-     */
-    bool getRefAccelerations(const int n_joints, const int *joints, double *accs) override;
-
-    /** Stop motion, single joint
-    * @param j joint number
-    * @return true/false on success/failure
-    */
-    bool stop(int j) override;
-
-    /**
-    * Stop motion, multiple joints
-    * @return true/false on success/failure
-    */
-    bool stop() override;
-
-
-    /** Stop motion for subset of joints
-     * @param joints pointer to the array of joint numbers
-     * @return true/false on success/failure
-     */
-    bool stop(const int n_joints, const int *joints) override;
-
-    /* IVelocityControl */
-
-    /**
-    * Set new reference speed for a single axis.
-    * @param j joint number
-    * @param v specifies the new ref speed
-    * @return true/false on success/failure
-    */
-    bool velocityMove(int j, double v) override;
-
-    /**
-    * Set a new reference speed for all axes.
-    * @param v is a vector of double representing the requested speed.
-    * @return true/false on success/failure.
-    */
-    bool velocityMove(const double *v) override;
-
-    /* IEncoders */
-
-    /**
-    * Reset encoder, single joint. Set the encoder value to zero
-    * @param j is the axis number
-    * @return true/false on success/failure
-    */
-    bool resetEncoder(int j) override;
-
-    /**
-    * Reset encoders. Set the encoder values to zero for all axes
-    * @return true/false
-    */
-    bool resetEncoders() override;
-
-    /**
-    * Set the value of the encoder for a given joint.
-    * @param j encoder number
-    * @param val new value
-    * @return true/false
-    */
-    bool setEncoder(int j, double val) override;
-
-    /**
-    * Set the value of all encoders.
-    * @param vals pointer to the new values
-    * @return true/false
-    */
-    bool setEncoders(const double *vals) override;
-
-    /**
-    * Read the value of an encoder.
-    * @param j encoder number
-    * @param v pointer to storage for the return value
-    * @return true/false, upon success/failure (you knew it, uh?)
-    */
-    bool getEncoder(int j, double *v) override;
-
-    /**
-    * Read the position of all axes.
-    * @param encs pointer to the array that will contain the output
-    * @return true/false on success/failure
-    */
-    bool getEncoders(double *encs) override;
-
-    bool getEncodersTimed(double *encs, double *t) override;
-
-    bool getEncoderTimed(int j, double *v, double *t) override;
-
-    /**
-    * Read the istantaneous speed of an axis.
-    * @param j axis number
-    * @param sp pointer to storage for the output
-    * @return true if successful, false ... otherwise.
-    */
-    bool getEncoderSpeed(int j, double *sp) override;
-
-    /**
-    * Read the instantaneous speed of all axes.
-    * @param spds pointer to storage for the output values
-    * @return guess what? (true/false on success or failure).
-    */
-    bool getEncoderSpeeds(double *spds) override;
-
-    /**
-    * Read the instantaneous acceleration of an axis.
-    * @param j axis number
-    * @param acc pointer to the array that will contain the output
-    */
-    bool getEncoderAcceleration(int j, double *acc) override;
-    /**
-    * Read the istantaneous acceleration of all axes.
-    * @param accs pointer to the array that will contain the output
-    * @return true if all goes well, false if anything bad happens.
-    */
-    bool getEncoderAccelerations(double *accs) override;
-
-    /* IMotorEncoders */
-
-    /**
-     * Get the number of available motor encoders.
-     * @param m pointer to a value representing the number of available motor encoders.
-     * @return true/false
-     */
-    bool getNumberOfMotorEncoders(int *num) override;
-
-    /**
-    * Reset encoder, single joint. Set the encoder value to zero
-    * @param j is the axis number
-    * @return true/false on success/failure
-    */
-    bool resetMotorEncoder(int m) override;
-
-    /**
-    * Reset encoders. Set the encoder values to zero for all axes
-    * @return true/false
-    */
-    bool resetMotorEncoders() override;
-
-    /**
-     * Sets number of counts per revolution for motor encoder m.
-     * @param m motor encoder number
-     * @param cpr new parameter
-     * @return true/false
-     */
-    bool setMotorEncoderCountsPerRevolution(int m, const double cpr) override;
-
-    /**
-     * gets number of counts per revolution for motor encoder m.
-     * @param m motor encoder number
-     * @param cpr pointer to storage for the return value
-     * @return true/false
-     */
-    bool getMotorEncoderCountsPerRevolution(int m, double *cpr) override;
-
-    /**
-    * Set the value of the encoder for a given joint.
-    * @param j encoder number
-    * @param val new value
-    * @return true/false
-    */
-    bool setMotorEncoder(int m, const double val) override;
-
-    /**
-    * Set the value of all encoders.
-    * @param vals pointer to the new values
-    * @return true/false
-    */
-    bool setMotorEncoders(const double *vals) override;
-
-    /**
-    * Read the value of an encoder.
-    * @param j encoder number
-    * @param v pointer to storage for the return value
-    * @return true/false, upon success/failure (you knew it, uh?)
-    */
-    bool getMotorEncoder(int m, double *v) override;
-
-    /**
-    * Read the position of all axes.
-    * @param encs pointer to the array that will contain the output
-    * @return true/false on success/failure
-    */
-    bool getMotorEncoders(double *encs) override;
-
-    bool getMotorEncodersTimed(double *encs, double *t) override;
-
-    bool getMotorEncoderTimed(int m, double *v, double *t) override;
-
-    /**
-    * Read the istantaneous speed of an axis.
-    * @param j axis number
-    * @param sp pointer to storage for the output
-    * @return true if successful, false ... otherwise.
-    */
-    bool getMotorEncoderSpeed(int m, double *sp) override;
-
-    /**
-    * Read the instantaneous speed of all axes.
-    * @param spds pointer to storage for the output values
-    * @return guess what? (true/false on success or failure).
-    */
-    bool getMotorEncoderSpeeds(double *spds) override;
-
-    /**
-    * Read the instantaneous acceleration of an axis.
-    * @param j axis number
-    * @param acc pointer to the array that will contain the output
-    */
-    bool getMotorEncoderAcceleration(int m, double *acc) override;
-    /**
-    * Read the istantaneous acceleration of all axes.
-    * @param accs pointer to the array that will contain the output
-    * @return true if all goes well, false if anything bad happens.
-    */
-    bool getMotorEncoderAccelerations(double *accs) override;
-
-    /* IAmplifierControl */
-
-    /**
-    * Enable the amplifier on a specific joint. Be careful, check that the output
-    * of the controller is appropriate (usually zero), to avoid
-    * generating abrupt movements.
-    * @return true/false on success/failure
-    */
-    bool enableAmp(int j) override;
-
-    /**
-    * Disable the amplifier on a specific joint. All computations within the board
-    * will be carried out normally, but the output will be disabled.
-    * @return true/false on success/failure
-    */
-    bool disableAmp(int j) override;
-
-    /**
-    * Get the status of the amplifiers, coded in a 32 bits integer for
-    * each amplifier (at the moment contains only the fault, it will be
-    * expanded in the future).
-    * @param st pointer to storage
-    * @return true in good luck, false otherwise.
-    */
-    bool getAmpStatus(int *st) override;
-
-    bool getAmpStatus(int j, int *v) override;
-
-    /**
-    * Read the electric current going to all motors.
-    * @param vals pointer to storage for the output values
-    * @return hopefully true, false in bad luck.
-    */
-    bool getCurrents(double *vals) override;
-
-    /**
-    * Read the electric current going to a given motor.
-    * @param j motor number
-    * @param val pointer to storage for the output value
-    * @return probably true, might return false in bad times
-    */
-    bool getCurrent(int j, double *val) override;
-
-    /**
-    * Set the maximum electric current going to a given motor. The behavior
-    * of the board/amplifier when this limit is reached depends on the
-    * implementation.
-    * @param j motor number
-    * @param v the new value
-    * @return probably true, might return false in bad times
-    */
-    bool setMaxCurrent(int j, double v) override;
-
-    /**
-    * Returns the maximum electric current allowed for a given motor. The behavior
-    * of the board/amplifier when this limit is reached depends on the
-    * implementation.
-    * @param j motor number
-    * @param v the return value
-    * @return probably true, might return false in bad times
-    */
-    bool getMaxCurrent(int j, double *v) override;
-
-    /* Get the the nominal current which can be kept for an indefinite amount of time
-     * without harming the motor. This value is specific for each motor and it is typically
-     * found in its datasheet. The units are Ampere.
-     * This value and the peak current may be used by the firmware to configure
-     * an I2T filter.
-     * @param m motor number
-     * @param val storage for return value. [Ampere]
-     * @return true/false success failure.
-     */
-    bool getNominalCurrent(int m, double *val) override;
-
-    /* Set the the nominal current which can be kept for an indefinite amount of time
-    * without harming the motor. This value is specific for each motor and it is typically
-    * found in its datasheet. The units are Ampere.
-    * This value and the peak current may be used by the firmware to configure
-    * an I2T filter.
-    * @param m motor number
-    * @param val storage for return value. [Ampere]
-    * @return true/false success failure.
-    */
-    bool setNominalCurrent(int m, const double val) override;
-
-    /* Get the the peak current which causes damage to the motor if maintained
-     * for a long amount of time.
-     * The value is often found in the motor datasheet, units are Ampere.
-     * This value and the nominal current may be used by the firmware to configure
-     * an I2T filter.
-     * @param m motor number
-     * @param val storage for return value. [Ampere]
-     * @return true/false success failure.
-     */
-    bool getPeakCurrent(int m, double *val) override;
-
-    /* Set the the peak current. This value  which causes damage to the motor if maintained
-     * for a long amount of time.
-     * The value is often found in the motor datasheet, units are Ampere.
-     * This value and the nominal current may be used by the firmware to configure
-     * an I2T filter.
-     * @param m motor number
-     * @param val storage for return value. [Ampere]
-     * @return true/false success failure.
-     */
-    bool setPeakCurrent(int m, const double val) override;
-
-    /* Get the the current PWM value used to control the motor.
-     * The units are firmware dependent, either machine units or percentage.
-     * @param m motor number
-     * @param val filled with PWM value.
-     * @return true/false success failure.
-     */
-    bool getPWM(int m, double* val) override;
-
-    /* Get the PWM limit for the given motor.
-     * The units are firmware dependent, either machine units or percentage.
-     * @param m motor number
-     * @param val filled with PWM limit value.
-     * @return true/false success failure.
-     */
-    bool getPWMLimit(int m, double* val) override;
-
-    /* Set the PWM limit for the given motor.
-     * The units are firmware dependent, either machine units or percentage.
-     * @param m motor number
-     * @param val new value for the PWM limit.
-     * @return true/false success failure.
-     */
-    bool setPWMLimit(int m, const double val) override;
-
-    /* Get the power source voltage for the given motor in Volt.
-     * @param m motor number
-     * @param val filled with return value.
-     * @return true/false success failure.
-     */
-    bool getPowerSupplyVoltage(int m, double* val) override;
-
-    /* IControlLimits */
-
-    /**
-    * Set the software limits for a particular axis, the behavior of the
-    * control card when these limits are exceeded, depends on the implementation.
-    * @param j joint number (why am I telling you this)
-    * @param min the value of the lower limit
-    * @param max the value of the upper limit
-    * @return true or false on success or failure
-    */
-    bool setLimits(int j, double min, double max) override;
-
-    /**
-    * Get the software limits for a particular axis.
-    * @param j joint number
-    * @param min pointer to store the value of the lower limit
-    * @param max pointer to store the value of the upper limit
-    * @return true if everything goes fine, false if something bad happens (yes, sometimes life is tough)
-    */
-    bool getLimits(int j, double *min, double *max) override;
-
-    /**
-    * Set the software velocity limits for a particular axis, the behavior of the
-    * control card when these limits are exceeded, depends on the implementation.
-    * @param j joint number
-    * @param min the value of the lower limit
-    * @param max the value of the upper limit
-    * @return true or false on success or failure
-    */
-    bool setVelLimits(int j, double min, double max) override;
-
-    /**
-    * Get the software velocity limits for a particular axis.
-    * @param j joint number
-    * @param min pointer to store the value of the lower limit
-    * @param max pointer to store the value of the upper limit
-    * @return true if everything goes fine, false if something bad happens
-    */
-    bool getVelLimits(int j, double *min, double *max) override;
-
-    /* IRemoteVariables */
-
-    bool getRemoteVariable(std::string key, yarp::os::Bottle& val) override;
-
-    bool setRemoteVariable(std::string key, const yarp::os::Bottle& val) override;
-
-    bool getRemoteVariablesList(yarp::os::Bottle* listOfKeys) override;
-
-    /* IRemoteCalibrator */
-
-    bool isCalibratorDevicePresent(bool *isCalib) override;
-
-    /**
-     * @brief getCalibratorDevice: return the pointer stored with the setCalibratorDevice
-     * @return yarp::dev::IRemotizableCalibrator pointer or NULL if not valid
-     */
-    yarp::dev::IRemoteCalibrator *getCalibratorDevice() override;
-
-    /**
-     * @brief calibrateSingleJoint: call the calibration procedure for the single joint
-     * @param j: joint to be calibrated
-     * @return true if calibration was successful
-     */
-    bool calibrateSingleJoint(int j) override;
-
-    /**
-     * @brief calibrateWholePart: call the procedure for calibrating the whole device
-     * @return true if calibration was successful
-     */
-    bool calibrateWholePart() override;
-
-    /**
-     * @brief homingSingleJoint: call the homing procedure for a single joint
-     * @param j: joint to be calibrated
-     * @return true if homing was successful, false otherwise
-     */
-    bool homingSingleJoint(int j) override;
-
-    /**
-     * @brief homingWholePart: call the homing procedure for a the whole part/device
-     * @return true if homing was successful, false otherwise
-     */
-    bool homingWholePart() override;
-
-    /**
-     * @brief parkSingleJoint(): start the parking procedure for the single joint
-     * @return true if successful
-     */
-    bool parkSingleJoint(int j, bool _wait=true) override;
-
-    /**
-     * @brief parkWholePart: start the parking procedure for the whole part
-     * @return true if successful
-     */
-    bool parkWholePart() override;
-
-    /**
-     * @brief quitCalibrate: interrupt the calibration procedure
-     * @return true if successful
-     */
-    bool quitCalibrate() override;
-
-    /**
-     * @brief quitPark: interrupt the park procedure
-     * @return true if successful
-     */
-    bool quitPark() override;
-
-    /* IControlCalibration */
-    bool calibrateAxisWithParams(int j, unsigned int ui, double v1, double v2, double v3) override;
-
-    bool setCalibrationParameters(int j, const yarp::dev::CalibrationParameters& params) override;
-
-    /**
-    * Check whether the calibration has been completed.
-    * @param j is the joint that has started a calibration procedure.
-    * @return true/false on success/failure.
-    */
-    bool calibrationDone(int j) override;
-
-    bool abortPark() override;
-
-    bool abortCalibration() override;
-
-    /* IMotor */
-    bool getNumberOfMotors   (int *num) override;
-
-    bool getTemperature      (int m, double* val) override;
-
-    bool getTemperatures     (double *vals) override;
-
-    bool getTemperatureLimit (int m, double* val) override;
-
-    bool setTemperatureLimit (int m, const double val) override;
-
-    bool getGearboxRatio(int m, double* val) override;
-
-    bool setGearboxRatio(int m, const double val) override;
-
-    /* IAxisInfo */
-    bool getAxisName(int j, std::string& name) override;
-
-    bool getJointType(int j, yarp::dev::JointTypeEnum& type) override;
-
-    bool getRefTorques(double *refs) override;
-
-    bool getRefTorque(int j, double *t) override;
-
-    bool setRefTorques(const double *t) override;
-
-    bool setRefTorque(int j, double t) override;
-
-    bool setRefTorques(const int n_joint, const int *joints, const double *t) override;
-
-    bool getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params) override;
-
-    bool setMotorTorqueParams(int j,  const yarp::dev::MotorTorqueParameters params) override;
-
-     bool setImpedance(int j, double stiff, double damp) override;
-
-    bool setImpedanceOffset(int j, double offset) override;
-
-    bool getTorque(int j, double *t) override;
-
-    bool getTorques(double *t) override;
-
-    bool getTorqueRange(int j, double *min, double *max) override;
-
-    bool getTorqueRanges(double *min, double *max) override;
-
-    bool getImpedance(int j, double* stiff, double* damp) override;
-
-    bool getImpedanceOffset(int j, double* offset) override;
-
-    bool getCurrentImpedanceLimit(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp) override;
-
-    bool getControlMode(int j, int *mode) override;
-
-    bool getControlModes(int *modes) override;
-
-    // iControlMode2
-    bool getControlModes(const int n_joint, const int *joints, int *modes) override;
-
-    bool setControlMode(const int j, const int mode) override;
-
-    bool setControlModes(const int n_joints, const int *joints, int *modes) override;
-
-    bool setControlModes(int *modes) override;
-
-    // IPositionDirect
-
-    bool setPosition(int j, double ref) override;
-
-    bool setPositions(const int n_joints, const int *joints, const double *dpos) override;
-
-    bool setPositions(const double *refs) override;
-
-        /** Get the last position reference for the specified axis.
-     *  This is the dual of setPositions and shall return only values sent using
-     *  IPositionDirect interface.
-     *  If other interfaces like IPositionControl are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionControl::PositionMove.
-     * @param ref last reference sent using setPosition(s) functions
-     * @return true/false on success/failure
-     */
-    bool getRefPosition(const int joint, double *ref) override;
-
-    /** Get the last position reference for all axes.
-     *  This is the dual of setPositions and shall return only values sent using
-     *  IPositionDirect interface.
-     *  If other interfaces like IPositionControl are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionControl::PositionMove.
-     * @param ref array containing last reference sent using setPosition(s) functions
-     * @return true/false on success/failure
-     */
-    bool getRefPositions(double *refs) override;
-
-    /** Get the last position reference for the specified group of axes.
-     *  This is the dual of setPositions and shall return only values sent using
-     *  IPositionDirect interface.
-     *  If other interfaces like IPositionControl are implemented by the device, this call
-     *  must ignore their values, i.e. this call must never return a reference sent using
-     *  IPositionControl::PositionMove.
-     * @param ref array containing last reference sent using setPosition(s) functions
-     * @return true/false on success/failure
-     */
-    bool getRefPositions(const int n_joint, const int *joints, double *refs) override;
-
-    yarp::os::Stamp getLastInputStamp() override;
-
-    //
-    // IVelocityControl2 Interface
-    //
-    bool velocityMove(const int n_joints, const int *joints, const double *spds) override;
-
-    bool getRefVelocity(const int joint, double* vel) override;
-
-    bool getRefVelocities(double* vels) override;
-
-    bool getRefVelocities(const int n_joint, const int* joints, double* vels) override;
-
-    bool getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode) override;
-
-    bool getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes) override;
-
-    bool getInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
-
-    bool setInteractionMode(int j, yarp::dev::InteractionModeEnum mode) override;
-
-    bool setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes) override;
-
-    bool setInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
-
-    //
-    // IPWMControl Interface
-    //
-
-    bool setRefDutyCycle(int j, double v) override;
-    bool setRefDutyCycles(const double *v) override;
-    bool getRefDutyCycle(int j, double *v) override;
-    bool getRefDutyCycles(double *v) override;
-    bool getDutyCycle(int j, double *v) override;
-    bool getDutyCycles(double *v) override;
-
-    //
-    // ICurrentControl Interface
-    //
-
-    //bool getAxes(int *ax) override;
-    //bool getCurrent(int j, double *t) override;
-    //bool getCurrents(double *t) override;
-    bool getCurrentRange(int j, double *min, double *max) override;
-    bool getCurrentRanges(double *min, double *max) override;
-    bool setRefCurrents(const double *t) override;
-    bool setRefCurrent(int j, double t) override;
-    bool setRefCurrents(const int n_joint, const int *joints, const double *t) override;
-    bool getRefCurrents(double *t) override;
-    bool getRefCurrent(int j, double *t) override;
 };
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperAmplifierControl.h"
+
+#include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperAmplifierControl::enableAmp(int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->amp) {
+        return p->amp->enableAmp(off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::disableAmp(int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    bool ret = true;
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    // Use the newer interface if available, otherwise fallback on the old one.
+    if (p->iMode) {
+        ret = p->iMode->setControlMode(off + p->base, VOCAB_CM_IDLE);
+    } else {
+        if (p->pos) {
+            ret = p->amp->disableAmp(off + p->base);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getAmpStatus(int* st)
+{
+    int* status = new int[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->amp) && (ret = p->amp->getAmpStatus(status))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                st[juser] = status[jdevice];
+            }
+        } else {
+            printError("getAmpStatus", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] status;
+    return ret;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getAmpStatus(int j, int* v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (p && p->amp) {
+        return p->amp->getAmpStatus(off + p->base, v);
+    }
+    *v = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::setMaxCurrent(int j, double v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->amp) {
+        return p->amp->setMaxCurrent(off + p->base, v);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getMaxCurrent(int j, double* v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        *v = 0.0;
+        return false;
+    }
+
+    if (p->amp) {
+        return p->amp->getMaxCurrent(off + p->base, v);
+    }
+    *v = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getNominalCurrent(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        *val = 0.0;
+        return false;
+    }
+
+    if (!p->amp) {
+        *val = 0.0;
+        return false;
+    }
+    return p->amp->getNominalCurrent(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getPeakCurrent(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        *val = 0.0;
+        return false;
+    }
+
+    if (!p->amp) {
+        *val = 0.0;
+        return false;
+    }
+    return p->amp->getPeakCurrent(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::setPeakCurrent(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (!p->amp) {
+        return false;
+    }
+    return p->amp->setPeakCurrent(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::setNominalCurrent(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (!p->amp) {
+        return false;
+    }
+    return p->amp->setNominalCurrent(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getPWM(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off + p->base << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
+    if (!p) {
+        *val = 0.0;
+        return false;
+    }
+
+    if (!p->amp) {
+        *val = 0.0;
+        return false;
+    }
+    return p->amp->getPWM(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getPWMLimit(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off + p->base << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
+
+    if (!p) {
+        *val = 0.0;
+        return false;
+    }
+
+    if (!p->amp) {
+        *val = 0.0;
+        return false;
+    }
+    return p->amp->getPWMLimit(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::setPWMLimit(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (!p->amp) {
+        return false;
+    }
+    return p->amp->setPWMLimit(off + p->base, val);
+}
+
+
+bool ControlBoardWrapperAmplifierControl::getPowerSupplyVoltage(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        *val = 0.0;
+        return false;
+    }
+
+    if (!p->amp) {
+        *val = 0.0;
+        return false;
+    }
+    return p->amp->getPowerSupplyVoltage(off + p->base, val);
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
@@ -15,14 +15,14 @@
 
 bool ControlBoardWrapperAmplifierControl::enableAmp(int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -30,7 +30,7 @@ bool ControlBoardWrapperAmplifierControl::enableAmp(int j)
     }
 
     if (p->amp) {
-        return p->amp->enableAmp(off + p->base);
+        return p->amp->enableAmp(static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -38,14 +38,14 @@ bool ControlBoardWrapperAmplifierControl::enableAmp(int j)
 
 bool ControlBoardWrapperAmplifierControl::disableAmp(int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     bool ret = true;
     SubDevice* p = device.getSubdevice(subIndex);
@@ -55,10 +55,10 @@ bool ControlBoardWrapperAmplifierControl::disableAmp(int j)
 
     // Use the newer interface if available, otherwise fallback on the old one.
     if (p->iMode) {
-        ret = p->iMode->setControlMode(off + p->base, VOCAB_CM_IDLE);
+        ret = p->iMode->setControlMode(static_cast<int>(off + p->base), VOCAB_CM_IDLE);
     } else {
         if (p->pos) {
-            ret = p->amp->disableAmp(off + p->base);
+            ret = p->amp->disableAmp(static_cast<int>(off + p->base));
         } else {
             ret = false;
         }
@@ -71,7 +71,7 @@ bool ControlBoardWrapperAmplifierControl::getAmpStatus(int* st)
 {
     int* status = new int[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -79,7 +79,7 @@ bool ControlBoardWrapperAmplifierControl::getAmpStatus(int* st)
         }
 
         if ((p->amp) && (ret = p->amp->getAmpStatus(status))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 st[juser] = status[jdevice];
             }
         } else {
@@ -96,18 +96,18 @@ bool ControlBoardWrapperAmplifierControl::getAmpStatus(int* st)
 
 bool ControlBoardWrapperAmplifierControl::getAmpStatus(int j, int* v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (p && p->amp) {
-        return p->amp->getAmpStatus(off + p->base, v);
+        return p->amp->getAmpStatus(static_cast<int>(off + p->base), v);
     }
     *v = 0;
     return false;
@@ -116,14 +116,14 @@ bool ControlBoardWrapperAmplifierControl::getAmpStatus(int j, int* v)
 
 bool ControlBoardWrapperAmplifierControl::setMaxCurrent(int j, double v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -131,7 +131,7 @@ bool ControlBoardWrapperAmplifierControl::setMaxCurrent(int j, double v)
     }
 
     if (p->amp) {
-        return p->amp->setMaxCurrent(off + p->base, v);
+        return p->amp->setMaxCurrent(static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -139,14 +139,14 @@ bool ControlBoardWrapperAmplifierControl::setMaxCurrent(int j, double v)
 
 bool ControlBoardWrapperAmplifierControl::getMaxCurrent(int j, double* v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -155,7 +155,7 @@ bool ControlBoardWrapperAmplifierControl::getMaxCurrent(int j, double* v)
     }
 
     if (p->amp) {
-        return p->amp->getMaxCurrent(off + p->base, v);
+        return p->amp->getMaxCurrent(static_cast<int>(off + p->base), v);
     }
     *v = 0.0;
     return false;
@@ -165,7 +165,7 @@ bool ControlBoardWrapperAmplifierControl::getMaxCurrent(int j, double* v)
 bool ControlBoardWrapperAmplifierControl::getNominalCurrent(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -177,14 +177,14 @@ bool ControlBoardWrapperAmplifierControl::getNominalCurrent(int m, double* val)
         *val = 0.0;
         return false;
     }
-    return p->amp->getNominalCurrent(off + p->base, val);
+    return p->amp->getNominalCurrent(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::getPeakCurrent(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -196,14 +196,14 @@ bool ControlBoardWrapperAmplifierControl::getPeakCurrent(int m, double* val)
         *val = 0.0;
         return false;
     }
-    return p->amp->getPeakCurrent(off + p->base, val);
+    return p->amp->getPeakCurrent(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::setPeakCurrent(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -213,14 +213,14 @@ bool ControlBoardWrapperAmplifierControl::setPeakCurrent(int m, const double val
     if (!p->amp) {
         return false;
     }
-    return p->amp->setPeakCurrent(off + p->base, val);
+    return p->amp->setPeakCurrent(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::setNominalCurrent(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -230,17 +230,17 @@ bool ControlBoardWrapperAmplifierControl::setNominalCurrent(int m, const double 
     if (!p->amp) {
         return false;
     }
-    return p->amp->setNominalCurrent(off + p->base, val);
+    return p->amp->setNominalCurrent(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::getPWM(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
     SubDevice* p = device.getSubdevice(subIndex);
 
-    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off + p->base << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
+    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << static_cast<int>(off + p->base) << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
     if (!p) {
         *val = 0.0;
         return false;
@@ -250,17 +250,17 @@ bool ControlBoardWrapperAmplifierControl::getPWM(int m, double* val)
         *val = 0.0;
         return false;
     }
-    return p->amp->getPWM(off + p->base, val);
+    return p->amp->getPWM(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::getPWMLimit(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
-    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << off + p->base << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
+    yCTrace(CONTROLBOARDWRAPPER) << "CBW2::getPWMlimit j" << static_cast<int>(off + p->base) << " p " << (p ? "1" : "0") << " amp " << (p->amp ? "1" : "0");
 
     if (!p) {
         *val = 0.0;
@@ -271,14 +271,14 @@ bool ControlBoardWrapperAmplifierControl::getPWMLimit(int m, double* val)
         *val = 0.0;
         return false;
     }
-    return p->amp->getPWMLimit(off + p->base, val);
+    return p->amp->getPWMLimit(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::setPWMLimit(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -288,14 +288,14 @@ bool ControlBoardWrapperAmplifierControl::setPWMLimit(int m, const double val)
     if (!p->amp) {
         return false;
     }
-    return p->amp->setPWMLimit(off + p->base, val);
+    return p->amp->setPWMLimit(static_cast<int>(off + p->base), val);
 }
 
 
 bool ControlBoardWrapperAmplifierControl::getPowerSupplyVoltage(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -307,5 +307,5 @@ bool ControlBoardWrapperAmplifierControl::getPowerSupplyVoltage(int m, double* v
         *val = 0.0;
         return false;
     }
-    return p->amp->getPowerSupplyVoltage(off + p->base, val);
+    return p->amp->getPowerSupplyVoltage(static_cast<int>(off + p->base), val);
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAMPLIFIERCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAMPLIFIERCONTROL_H
+
+#include <yarp/dev/IAmplifierControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperAmplifierControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IAmplifierControl
+{
+public:
+    bool enableAmp(int j) override;
+    bool disableAmp(int j) override;
+    bool getAmpStatus(int* st) override;
+    bool getAmpStatus(int j, int* v) override;
+    inline bool getCurrent(int m, double *curr) override { return ControlBoardWrapperCommon::getCurrent(m, curr); }
+    inline bool getCurrents(double *currs) override { return ControlBoardWrapperCommon::getCurrents(currs); }
+    bool setMaxCurrent(int j, double v) override;
+    bool getMaxCurrent(int j, double* v) override;
+    bool getNominalCurrent(int m, double* val) override;
+    bool setNominalCurrent(int m, const double val) override;
+    bool getPeakCurrent(int m, double* val) override;
+    bool setPeakCurrent(int m, const double val) override;
+    bool getPWM(int m, double* val) override;
+    bool getPWMLimit(int m, double* val) override;
+    bool setPWMLimit(int m, const double val) override;
+    bool getPowerSupplyVoltage(int m, double* val) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAMPLIFIERCONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperAxisInfo.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperAxisInfo::getAxisName(int j, std::string& name)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->info) {
+        return p->info->getAxisName(off + p->base, name);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperAxisInfo::getJointType(int j, yarp::dev::JointTypeEnum& type)
+{
+    int off = device.lut[j].offset;
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->info) {
+        return p->info->getJointType(off + p->base, type);
+    }
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperAxisInfo::getAxisName(int j, std::string& name)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,7 +28,7 @@ bool ControlBoardWrapperAxisInfo::getAxisName(int j, std::string& name)
     }
 
     if (p->info) {
-        return p->info->getAxisName(off + p->base, name);
+        return p->info->getAxisName(static_cast<int>(off + p->base), name);
     }
     return false;
 }
@@ -36,7 +36,7 @@ bool ControlBoardWrapperAxisInfo::getAxisName(int j, std::string& name)
 bool ControlBoardWrapperAxisInfo::getJointType(int j, yarp::dev::JointTypeEnum& type)
 {
     int off = device.lut[j].offset;
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -44,7 +44,7 @@ bool ControlBoardWrapperAxisInfo::getJointType(int j, yarp::dev::JointTypeEnum& 
     }
 
     if (p->info) {
-        return p->info->getJointType(off + p->base, type);
+        return p->info->getJointType(static_cast<int>(off + p->base), type);
     }
     return false;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAxisInfo.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAXISINFO_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAXISINFO_H
+
+#include <yarp/dev/IAxisInfo.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperAxisInfo :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IAxisInfo
+{
+public:
+    bool getAxisName(int j, std::string& name) override;
+    bool getJointType(int j, yarp::dev::JointTypeEnum& type) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERAXISINFO_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.cpp
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperCommon.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperCommon::getAxes(int* ax)
+{
+    *ax = controlledJoints;
+    return true;
+}
+
+
+bool ControlBoardWrapperCommon::setRefAcceleration(int j, double acc)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->setRefAcceleration(off + p->base, acc);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperCommon::setRefAccelerations(const double* accs)
+{
+    bool ret = true;
+    int j_wrap = 0; // index of the joint from the wrapper side (useful if wrapper joins 2 subdevices)
+
+    // for all subdevices
+    for (unsigned int subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+        SubDevice* p = device.getSubdevice(subDev_idx);
+
+        if (!p) {
+            return false;
+        }
+
+        int wrapped_joints = (p->top - p->base) + 1;
+        int* joints = new int[wrapped_joints]; // to be defined once and for all?
+
+        if (p->pos) {
+            // verione comandi su subset di giunti
+            for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
+                joints[j_dev] = p->base + j_dev;
+            }
+
+            ret = ret && p->pos->setRefAccelerations(wrapped_joints, joints, &accs[j_wrap]);
+            j_wrap += wrapped_joints;
+        } else {
+            ret = false;
+        }
+
+        if (joints != nullptr) {
+            delete[] joints;
+            joints = nullptr;
+        }
+    }
+
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::setRefAccelerations(const int n_joints, const int* joints, const double* accs)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = accs[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->setRefAccelerations(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::getRefAcceleration(int j, double* acc)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->getRefAcceleration(off + p->base, acc);
+    }
+    *acc = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperCommon::getRefAccelerations(double* accs)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pos) && (ret = p->pos->getRefAccelerations(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                accs[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::getRefAccelerations(const int n_joints, const int* joints, double* accs)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->getRefAccelerations(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            accs[j] = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            accs[j] = 0;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::stop(int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->stop(off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperCommon::stop()
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+
+        if (!p) {
+            return false;
+        }
+
+        if (p->pos) {
+            ret = ret && p->pos->stop(off + p->base);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::stop(const int n_joints, const int* joints)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->stop(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::getNumberOfMotors(int* num)
+{
+    *num = controlledJoints;
+    return true;
+}
+
+
+bool ControlBoardWrapperCommon::getCurrents(double* vals)
+{
+    auto* currs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        ret = false;
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            break;
+        }
+
+        if (p->iCurr) {
+            ret = p->iCurr->getCurrents(currs);
+        } else if (p->amp) {
+            ret = p->amp->getCurrents(currs);
+        }
+
+        if (ret) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                vals[juser] = currs[jdevice];
+            }
+        } else {
+            printError("getCurrents", p->id, ret);
+            break;
+        }
+    }
+    delete[] currs;
+    return ret;
+}
+
+
+bool ControlBoardWrapperCommon::getCurrent(int j, double* val)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iCurr) {
+        return p->iCurr->getCurrent(off + p->base, val);
+    }
+
+    if (p->amp) {
+        return p->amp->getCurrent(off + p->base, val);
+    }
+    *val = 0.0;
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCOMMON_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCOMMON_H
+
+#include "MultiJointData.h"
+
+constexpr int PROTOCOL_VERSION_MAJOR = 1;
+constexpr int PROTOCOL_VERSION_MINOR = 9;
+constexpr int PROTOCOL_VERSION_TWEAK = 0;
+
+class ControlBoardWrapperCommon
+{
+public:
+// COMMON MEMBERS
+    WrappedDevice device;
+    int controlledJoints {0};
+    std::string partName; // to open ports and print more detailed debug messages
+
+    // RPC calls are concurrent from multiple clients, data used inside the calls has to be protected
+    std::mutex rpcDataMutex; // mutex to avoid concurrency between more clients using rppc port
+    MultiJointData rpcData;  // Structure used to re-arrange data from "multiple_joints" calls.
+
+    std::mutex timeMutex; // mutex to protect access to time member
+    yarp::os::Stamp time; // envelope to attach to the state port
+
+// METHODS SHARED BY MULTIPLE INTERFACES
+    /*
+     * IEncodersTimed
+     * IImpedanceControl
+     * IPositionControl
+     * IPositionDirect
+     * ITorqueControl
+     * IVelocityControl
+     */
+    bool getAxes(int* ax);
+
+    /*
+     * IPositionControl
+     * IVelocityControl
+     */
+    bool setRefAcceleration(int j, double acc);
+    bool setRefAccelerations(const double* accs);
+    bool setRefAccelerations(const int n_joints, const int* joints, const double* accs);
+    bool getRefAcceleration(int j, double* acc);
+    bool getRefAccelerations(double* accs);
+    bool getRefAccelerations(const int n_joints, const int* joints, double* accs);
+    bool stop(int j);
+    bool stop();
+    bool stop(const int n_joint, const int* joints);
+
+    /*
+     * IMotor
+     * IPWMControl
+     */
+    bool getNumberOfMotors(int* num);
+
+    /*
+     * IAmplifierControl
+     * ICurrentControl
+     */
+    bool getCurrent(int m, double* curr);
+    bool getCurrents(double* currs);
+
+// UTILITIES
+    inline void printError(const std::string& func_name, const std::string& info, bool result)
+    {
+        // FIXME: Check if it is still required.
+        //        This method was commented out by these commits:
+        //          afc039962f3667cc954e7a50ce6963ec60886611
+        //          0c0de4a9331b9b843ac4b3d3746c074dd0427249
+
+        // If result is false, this means that en error occurred in function named func_name, otherwise means that the device doesn't implement the interface to witch func_name belongs to.
+        // if(false == result) {
+        //     yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << " returns false";
+        // } else {
+        // Commented in order to maintain the old behaviour (none message appear if device desn't implement the interface)
+        // yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << ": the interface is not available.";
+        // }
+    }
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCOMMON_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
@@ -20,7 +20,7 @@ class ControlBoardWrapperCommon
 public:
 // COMMON MEMBERS
     WrappedDevice device;
-    int controlledJoints {0};
+    size_t controlledJoints {0};
     std::string partName; // to open ports and print more detailed debug messages
 
     // RPC calls are concurrent from multiple clients, data used inside the calls has to be protected

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.cpp
@@ -14,18 +14,18 @@ using yarp::dev::CalibrationParameters;
 
 bool ControlBoardWrapperControlCalibration::calibrateAxisWithParams(int j, unsigned int ui, double v1, double v2, double v3)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (p && p->calib) {
-        return p->calib->calibrateAxisWithParams(off + p->base, ui, v1, v2, v3);
+        return p->calib->calibrateAxisWithParams(static_cast<int>(off + p->base), ui, v1, v2, v3);
     }
     return false;
 }
@@ -34,11 +34,11 @@ bool ControlBoardWrapperControlCalibration::calibrateAxisWithParams(int j, unsig
 bool ControlBoardWrapperControlCalibration::setCalibrationParameters(int j, const CalibrationParameters& params)
 {
     int off = device.lut[j].offset;
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (p && p->calib) {
-        return p->calib->setCalibrationParameters(off + p->base, params);
+        return p->calib->setCalibrationParameters(static_cast<int>(off + p->base), params);
     }
     return false;
 }
@@ -46,14 +46,14 @@ bool ControlBoardWrapperControlCalibration::setCalibrationParameters(int j, cons
 
 bool ControlBoardWrapperControlCalibration::calibrationDone(int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -61,7 +61,7 @@ bool ControlBoardWrapperControlCalibration::calibrationDone(int j)
     }
 
     if (p->calib) {
-        return p->calib->calibrationDone(off + p->base);
+        return p->calib->calibrationDone(static_cast<int>(off + p->base));
     }
     return false;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperControlCalibration.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+using yarp::dev::CalibrationParameters;
+
+bool ControlBoardWrapperControlCalibration::calibrateAxisWithParams(int j, unsigned int ui, double v1, double v2, double v3)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (p && p->calib) {
+        return p->calib->calibrateAxisWithParams(off + p->base, ui, v1, v2, v3);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperControlCalibration::setCalibrationParameters(int j, const CalibrationParameters& params)
+{
+    int off = device.lut[j].offset;
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (p && p->calib) {
+        return p->calib->setCalibrationParameters(off + p->base, params);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperControlCalibration::calibrationDone(int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->calib) {
+        return p->calib->calibrationDone(off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperControlCalibration::abortPark()
+{
+    yCError(CONTROLBOARDWRAPPER, "Calling abortPark -- not implemented");
+    return false;
+}
+
+
+bool ControlBoardWrapperControlCalibration::abortCalibration()
+{
+    yCError(CONTROLBOARDWRAPPER, "Calling abortCalibration -- not implemented");
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlCalibration.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLCALIBRATION_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLCALIBRATION_H
+
+#include <yarp/dev/IControlCalibration.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperControlCalibration :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IControlCalibration
+{
+public:
+    bool calibrateAxisWithParams(int j, unsigned int ui, double v1, double v2, double v3) override;
+    bool setCalibrationParameters(int j, const yarp::dev::CalibrationParameters& params) override;
+    bool calibrationDone(int j) override;
+    bool abortPark() override;
+    bool abortCalibration() override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLCALIBRATION_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperControlLimits.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperControlLimits::setLimits(int j, double min, double max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->lim) {
+        return p->lim->setLimits(off + p->base, min, max);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperControlLimits::getLimits(int j, double* min, double* max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        *min = 0.0;
+        *max = 0.0;
+        return false;
+    }
+
+    if (p->lim) {
+        return p->lim->getLimits(off + p->base, min, max);
+    }
+    *min = 0.0;
+    *max = 0.0;
+    return false;
+}
+
+bool ControlBoardWrapperControlLimits::setVelLimits(int j, double min, double max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (!p->lim) {
+        return false;
+    }
+    return p->lim->setVelLimits(off + p->base, min, max);
+}
+
+bool ControlBoardWrapperControlLimits::getVelLimits(int j, double* min, double* max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    *min = 0.0;
+    *max = 0.0;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (!p->lim) {
+        return false;
+    }
+    return p->lim->getVelLimits(off + p->base, min, max);
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperControlLimits::setLimits(int j, double min, double max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,21 +28,21 @@ bool ControlBoardWrapperControlLimits::setLimits(int j, double min, double max)
     }
 
     if (p->lim) {
-        return p->lim->setLimits(off + p->base, min, max);
+        return p->lim->setLimits(static_cast<int>(off + p->base), min, max);
     }
     return false;
 }
 
 bool ControlBoardWrapperControlLimits::getLimits(int j, double* min, double* max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -52,7 +52,7 @@ bool ControlBoardWrapperControlLimits::getLimits(int j, double* min, double* max
     }
 
     if (p->lim) {
-        return p->lim->getLimits(off + p->base, min, max);
+        return p->lim->getLimits(static_cast<int>(off + p->base), min, max);
     }
     *min = 0.0;
     *max = 0.0;
@@ -61,14 +61,14 @@ bool ControlBoardWrapperControlLimits::getLimits(int j, double* min, double* max
 
 bool ControlBoardWrapperControlLimits::setVelLimits(int j, double min, double max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -78,19 +78,19 @@ bool ControlBoardWrapperControlLimits::setVelLimits(int j, double min, double ma
     if (!p->lim) {
         return false;
     }
-    return p->lim->setVelLimits(off + p->base, min, max);
+    return p->lim->setVelLimits(static_cast<int>(off + p->base), min, max);
 }
 
 bool ControlBoardWrapperControlLimits::getVelLimits(int j, double* min, double* max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     *min = 0.0;
     *max = 0.0;
@@ -103,5 +103,5 @@ bool ControlBoardWrapperControlLimits::getVelLimits(int j, double* min, double* 
     if (!p->lim) {
         return false;
     }
-    return p->lim->getVelLimits(off + p->base, min, max);
+    return p->lim->getVelLimits(static_cast<int>(off + p->base), min, max);
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlLimits.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLLIMITS_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLLIMITS_H
+
+#include <yarp/dev/IControlLimits.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperControlLimits :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IControlLimits
+{
+public:
+    bool setLimits(int j, double min, double max) override;
+    bool getLimits(int j, double* min, double* max) override;
+    bool setVelLimits(int j, double min, double max) override;
+    bool getVelLimits(int j, double* min, double* max) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLLIMITS_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlMode.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlMode.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperControlMode.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperControlMode::getControlMode(int j, int* mode)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMode) {
+        return p->iMode->getControlMode(off + p->base, mode);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperControlMode::getControlModes(int* modes)
+{
+    int* all_mode = new int[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iMode) && (ret = p->iMode->getControlModes(all_mode))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                modes[juser] = all_mode[jdevice];
+            }
+        } else {
+            printError("getControlModes", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] all_mode;
+    return ret;
+}
+
+
+bool ControlBoardWrapperControlMode::getControlModes(const int n_joint, const int* joints, int* modes)
+{
+    bool ret = true;
+
+    for (int l = 0; l < n_joint; l++) {
+        int off = device.lut[joints[l]].offset;
+        int subIndex = device.lut[joints[l]].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iMode) {
+            ret = ret && p->iMode->getControlMode(off + p->base, &modes[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperControlMode::setControlMode(const int j, const int mode)
+{
+    bool ret = true;
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMode) {
+        ret = p->iMode->setControlMode(off + p->base, mode);
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperControlMode::setControlModes(const int n_joints, const int* joints, int* modes)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = modes[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->iMode) {
+            ret = ret && rpcData.subdevices_p[subIndex]->iMode->setControlModes(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.modes[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperControlMode::setControlModes(int* modes)
+{
+    bool ret = true;
+    int j_wrap = 0; // index of the wrapper joint
+
+    int nDev = device.subdevices.size();
+    for (int subDev_idx = 0; subDev_idx < nDev; subDev_idx++) {
+        int subIndex = device.lut[j_wrap].deviceEntry;
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        int wrapped_joints = (p->top - p->base) + 1;
+        int* joints = new int[wrapped_joints];
+
+        if (p->iMode) {
+            // versione comandi su subset di giunti
+            for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
+                joints[j_dev] = p->base + j_dev; // for all joints is equivalent to add offset term
+            }
+
+            ret = ret && p->iMode->setControlModes(wrapped_joints, joints, &modes[j_wrap]);
+            j_wrap += wrapped_joints;
+        }
+
+        if (joints != nullptr) {
+            delete[] joints;
+            joints = nullptr;
+        }
+    }
+
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperControlMode.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperControlMode.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLMODE_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLMODE_H
+
+#include <yarp/dev/IControlMode.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperControlMode :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IControlMode
+{
+public:
+    bool getControlMode(int j, int* mode) override;
+    bool getControlModes(int* modes) override;
+    bool getControlModes(const int n_joint, const int* joints, int* modes) override;
+    bool setControlMode(const int j, const int mode) override;
+    bool setControlModes(const int n_joints, const int* joints, int* modes) override;
+    bool setControlModes(int* modes) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCONTROLMODE_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperCurrentControl::getCurrentRange(int j, double* min, double* max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,7 +28,7 @@ bool ControlBoardWrapperCurrentControl::getCurrentRange(int j, double* min, doub
     }
 
     if (p->iCurr) {
-        return p->iCurr->getCurrentRange(off + p->base, min, max);
+        return p->iCurr->getCurrentRange(static_cast<int>(off + p->base), min, max);
     }
 
     return false;
@@ -39,7 +39,7 @@ bool ControlBoardWrapperCurrentControl::getCurrentRanges(double* min, double* ma
     auto* c_min = new double[device.maxNumOfJointsInDevices];
     auto* c_max = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -47,7 +47,7 @@ bool ControlBoardWrapperCurrentControl::getCurrentRanges(double* min, double* ma
         }
 
         if ((p->iCurr) && (ret = p->iCurr->getCurrentRanges(c_min, c_max))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 min[juser] = c_min[jdevice];
                 max[juser] = c_max[jdevice];
             }
@@ -67,9 +67,9 @@ bool ControlBoardWrapperCurrentControl::setRefCurrents(const double* t)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -77,7 +77,7 @@ bool ControlBoardWrapperCurrentControl::setRefCurrents(const double* t)
         }
 
         if (p->iCurr) {
-            ret = ret && p->iCurr->setRefCurrent(off + p->base, t[l]);
+            ret = ret && p->iCurr->setRefCurrent(static_cast<int>(off + p->base), t[l]);
         } else {
             ret = false;
         }
@@ -87,14 +87,14 @@ bool ControlBoardWrapperCurrentControl::setRefCurrents(const double* t)
 
 bool ControlBoardWrapperCurrentControl::setRefCurrent(int j, double t)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -102,7 +102,7 @@ bool ControlBoardWrapperCurrentControl::setRefCurrent(int j, double t)
     }
 
     if (p->iCurr) {
-        return p->iCurr->setRefCurrent(off + p->base, t);
+        return p->iCurr->setRefCurrent(static_cast<int>(off + p->base), t);
     }
     return false;
 }
@@ -116,10 +116,11 @@ bool ControlBoardWrapperCurrentControl::setRefCurrents(const int n_joint, const 
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joint; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
@@ -139,7 +140,7 @@ bool ControlBoardWrapperCurrentControl::getRefCurrents(double* t)
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -147,7 +148,7 @@ bool ControlBoardWrapperCurrentControl::getRefCurrents(double* t)
         }
 
         if ((p->iCurr) && (ret = p->iCurr->getRefCurrents(references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 t[juser] = references[jdevice];
             }
         } else {
@@ -163,14 +164,14 @@ bool ControlBoardWrapperCurrentControl::getRefCurrents(double* t)
 
 bool ControlBoardWrapperCurrentControl::getRefCurrent(int j, double* t)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -178,7 +179,7 @@ bool ControlBoardWrapperCurrentControl::getRefCurrent(int j, double* t)
     }
 
     if (p->iCurr) {
-        return p->iCurr->getRefCurrent(off + p->base, t);
+        return p->iCurr->getRefCurrent(static_cast<int>(off + p->base), t);
     }
 
     return false;

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperCurrentControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperCurrentControl::getCurrentRange(int j, double* min, double* max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iCurr) {
+        return p->iCurr->getCurrentRange(off + p->base, min, max);
+    }
+
+    return false;
+}
+
+bool ControlBoardWrapperCurrentControl::getCurrentRanges(double* min, double* max)
+{
+    auto* c_min = new double[device.maxNumOfJointsInDevices];
+    auto* c_max = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iCurr) && (ret = p->iCurr->getCurrentRanges(c_min, c_max))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                min[juser] = c_min[jdevice];
+                max[juser] = c_max[jdevice];
+            }
+        } else {
+            printError("getCurrentRanges", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] c_min;
+    delete[] c_max;
+    return ret;
+}
+
+bool ControlBoardWrapperCurrentControl::setRefCurrents(const double* t)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iCurr) {
+            ret = ret && p->iCurr->setRefCurrent(off + p->base, t[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardWrapperCurrentControl::setRefCurrent(int j, double t)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iCurr) {
+        return p->iCurr->setRefCurrent(off + p->base, t);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperCurrentControl::setRefCurrents(const int n_joint, const int* joints, const double* t)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joint; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->iCurr) {
+            ret = ret && rpcData.subdevices_p[subIndex]->iCurr->setRefCurrents(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+bool ControlBoardWrapperCurrentControl::getRefCurrents(double* t)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iCurr) && (ret = p->iCurr->getRefCurrents(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                t[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefCurrents", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+bool ControlBoardWrapperCurrentControl::getRefCurrent(int j, double* t)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iCurr) {
+        return p->iCurr->getRefCurrent(off + p->base, t);
+    }
+
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCurrentControl.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCURRENTCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCURRENTCONTROL_H
+
+#include <yarp/dev/ICurrentControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperCurrentControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::ICurrentControl
+{
+public:
+    inline bool getNumberOfMotors(int* num) override { return ControlBoardWrapperCommon::getNumberOfMotors(num); }
+    inline bool getCurrent(int m, double *curr) override { return ControlBoardWrapperCommon::getCurrent(m, curr); }
+    inline bool getCurrents(double *currs) override { return ControlBoardWrapperCommon::getCurrents(currs); }
+    bool getCurrentRange(int j, double* min, double* max) override;
+    bool getCurrentRanges(double* min, double* max) override;
+    bool setRefCurrents(const double* t) override;
+    bool setRefCurrent(int j, double t) override;
+    bool setRefCurrents(const int n_joint, const int* joints, const double* t) override;
+    bool getRefCurrents(double* t) override;
+    bool getRefCurrent(int j, double* t) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCURRENTCONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperEncodersTimed.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+bool ControlBoardWrapperEncodersTimed::resetEncoder(int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->resetEncoder(off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::resetEncoders()
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iJntEnc) {
+            ret = ret && p->iJntEnc->resetEncoder(off + p->base);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::setEncoder(int j, double val)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->setEncoder(off + p->base, val);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::setEncoders(const double* vals)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iJntEnc) {
+            ret = ret && p->iJntEnc->setEncoder(off + p->base, vals[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoder(int j, double* v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->getEncoder(off + p->base, v);
+    }
+    *v = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoders(double* encs)
+{
+    auto* encValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoders(encValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                encs[juser] = encValues[jdevice];
+            }
+        } else {
+            printError("getEncoders", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] encValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncodersTimed(double* encs, double* t)
+{
+    auto* encValues = new double[device.maxNumOfJointsInDevices];
+    auto* tValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncodersTimed(encValues, tValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                encs[juser] = encValues[jdevice];
+                t[juser] = tValues[jdevice];
+            }
+        } else {
+            printError("getEncodersTimed", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] encValues;
+    delete[] tValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoderTimed(int j, double* v, double* t)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->getEncoderTimed(off + p->base, v, t);
+    }
+    *v = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoderSpeed(int j, double* sp)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->getEncoderSpeed(off + p->base, sp);
+    }
+    *sp = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoderSpeeds(double* spds)
+{
+    auto* sValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderSpeeds(sValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                spds[juser] = sValues[jdevice];
+            }
+        } else {
+            printError("getEncoderSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] sValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoderAcceleration(int j, double* acc)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iJntEnc) {
+        return p->iJntEnc->getEncoderAcceleration(off + p->base, acc);
+    }
+    *acc = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperEncodersTimed::getEncoderAccelerations(double* accs)
+{
+    auto* aValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderAccelerations(aValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                accs[juser] = aValues[jdevice];
+            }
+        } else {
+            printError("getEncoderAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] aValues;
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
@@ -12,14 +12,14 @@
 
 bool ControlBoardWrapperEncodersTimed::resetEncoder(int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -27,7 +27,7 @@ bool ControlBoardWrapperEncodersTimed::resetEncoder(int j)
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->resetEncoder(off + p->base);
+        return p->iJntEnc->resetEncoder(static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -37,9 +37,9 @@ bool ControlBoardWrapperEncodersTimed::resetEncoders()
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -47,7 +47,7 @@ bool ControlBoardWrapperEncodersTimed::resetEncoders()
         }
 
         if (p->iJntEnc) {
-            ret = ret && p->iJntEnc->resetEncoder(off + p->base);
+            ret = ret && p->iJntEnc->resetEncoder(static_cast<int>(off + p->base));
         } else {
             ret = false;
         }
@@ -58,14 +58,14 @@ bool ControlBoardWrapperEncodersTimed::resetEncoders()
 
 bool ControlBoardWrapperEncodersTimed::setEncoder(int j, double val)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -73,7 +73,7 @@ bool ControlBoardWrapperEncodersTimed::setEncoder(int j, double val)
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->setEncoder(off + p->base, val);
+        return p->iJntEnc->setEncoder(static_cast<int>(off + p->base), val);
     }
     return false;
 }
@@ -83,9 +83,9 @@ bool ControlBoardWrapperEncodersTimed::setEncoders(const double* vals)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -93,7 +93,7 @@ bool ControlBoardWrapperEncodersTimed::setEncoders(const double* vals)
         }
 
         if (p->iJntEnc) {
-            ret = ret && p->iJntEnc->setEncoder(off + p->base, vals[l]);
+            ret = ret && p->iJntEnc->setEncoder(static_cast<int>(off + p->base), vals[l]);
         } else {
             ret = false;
         }
@@ -104,14 +104,14 @@ bool ControlBoardWrapperEncodersTimed::setEncoders(const double* vals)
 
 bool ControlBoardWrapperEncodersTimed::getEncoder(int j, double* v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -119,7 +119,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoder(int j, double* v)
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->getEncoder(off + p->base, v);
+        return p->iJntEnc->getEncoder(static_cast<int>(off + p->base), v);
     }
     *v = 0.0;
     return false;
@@ -130,7 +130,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoders(double* encs)
 {
     auto* encValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -138,7 +138,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoders(double* encs)
         }
 
         if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoders(encValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 encs[juser] = encValues[jdevice];
             }
         } else {
@@ -158,7 +158,7 @@ bool ControlBoardWrapperEncodersTimed::getEncodersTimed(double* encs, double* t)
     auto* encValues = new double[device.maxNumOfJointsInDevices];
     auto* tValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -166,7 +166,7 @@ bool ControlBoardWrapperEncodersTimed::getEncodersTimed(double* encs, double* t)
         }
 
         if ((p->iJntEnc) && (ret = p->iJntEnc->getEncodersTimed(encValues, tValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 encs[juser] = encValues[jdevice];
                 t[juser] = tValues[jdevice];
             }
@@ -185,14 +185,14 @@ bool ControlBoardWrapperEncodersTimed::getEncodersTimed(double* encs, double* t)
 
 bool ControlBoardWrapperEncodersTimed::getEncoderTimed(int j, double* v, double* t)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -200,7 +200,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderTimed(int j, double* v, double*
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->getEncoderTimed(off + p->base, v, t);
+        return p->iJntEnc->getEncoderTimed(static_cast<int>(off + p->base), v, t);
     }
     *v = 0.0;
     return false;
@@ -209,14 +209,14 @@ bool ControlBoardWrapperEncodersTimed::getEncoderTimed(int j, double* v, double*
 
 bool ControlBoardWrapperEncodersTimed::getEncoderSpeed(int j, double* sp)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -224,7 +224,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderSpeed(int j, double* sp)
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->getEncoderSpeed(off + p->base, sp);
+        return p->iJntEnc->getEncoderSpeed(static_cast<int>(off + p->base), sp);
     }
     *sp = 0.0;
     return false;
@@ -235,7 +235,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderSpeeds(double* spds)
 {
     auto* sValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -243,7 +243,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderSpeeds(double* spds)
         }
 
         if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderSpeeds(sValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 spds[juser] = sValues[jdevice];
             }
         } else {
@@ -260,14 +260,14 @@ bool ControlBoardWrapperEncodersTimed::getEncoderSpeeds(double* spds)
 
 bool ControlBoardWrapperEncodersTimed::getEncoderAcceleration(int j, double* acc)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -275,7 +275,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderAcceleration(int j, double* acc
     }
 
     if (p->iJntEnc) {
-        return p->iJntEnc->getEncoderAcceleration(off + p->base, acc);
+        return p->iJntEnc->getEncoderAcceleration(static_cast<int>(off + p->base), acc);
     }
     *acc = 0.0;
     return false;
@@ -286,7 +286,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderAccelerations(double* accs)
 {
     auto* aValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -294,7 +294,7 @@ bool ControlBoardWrapperEncodersTimed::getEncoderAccelerations(double* accs)
         }
 
         if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderAccelerations(aValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 accs[juser] = aValues[jdevice];
             }
         } else {

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERENCODERSTIMED_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERENCODERSTIMED_H
+
+#include <yarp/dev/IEncodersTimed.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperEncodersTimed :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IEncodersTimed
+{
+public:
+    inline bool getAxes(int *ax) override { return ControlBoardWrapperCommon::getAxes(ax); }
+    bool resetEncoder(int j) override;
+    bool resetEncoders() override;
+    bool setEncoder(int j, double val) override;
+    bool setEncoders(const double* vals) override;
+    bool getEncoder(int j, double* v) override;
+    bool getEncoders(double* encs) override;
+    bool getEncoderSpeed(int j, double* sp) override;
+    bool getEncoderSpeeds(double* spds) override;
+    bool getEncoderAcceleration(int j, double* acc) override;
+    bool getEncoderAccelerations(double* accs) override;
+    bool getEncodersTimed(double* encs, double* t) override;
+    bool getEncoderTimed(int j, double* v, double* t) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERENCODERSTIMED_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperImpedanceControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperImpedanceControl::setImpedance(int j, double stiff, double damp)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iImpedance) {
+        return p->iImpedance->setImpedance(off + p->base, stiff, damp);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperImpedanceControl::setImpedanceOffset(int j, double offset)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iImpedance) {
+        return p->iImpedance->setImpedanceOffset(off + p->base, offset);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperImpedanceControl::getImpedance(int j, double* stiff, double* damp)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iImpedance) {
+        return p->iImpedance->getImpedance(off + p->base, stiff, damp);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperImpedanceControl::getImpedanceOffset(int j, double* offset)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iImpedance) {
+        return p->iImpedance->getImpedanceOffset(off + p->base, offset);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperImpedanceControl::getCurrentImpedanceLimit(int j, double* min_stiff, double* max_stiff, double* min_damp, double* max_damp)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iImpedance) {
+        return p->iImpedance->getCurrentImpedanceLimit(off + p->base, min_stiff, max_stiff, min_damp, max_damp);
+    }
+
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperImpedanceControl::setImpedance(int j, double stiff, double damp)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,7 +28,7 @@ bool ControlBoardWrapperImpedanceControl::setImpedance(int j, double stiff, doub
     }
 
     if (p->iImpedance) {
-        return p->iImpedance->setImpedance(off + p->base, stiff, damp);
+        return p->iImpedance->setImpedance(static_cast<int>(off + p->base), stiff, damp);
     }
 
     return false;
@@ -37,14 +37,14 @@ bool ControlBoardWrapperImpedanceControl::setImpedance(int j, double stiff, doub
 
 bool ControlBoardWrapperImpedanceControl::setImpedanceOffset(int j, double offset)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -52,7 +52,7 @@ bool ControlBoardWrapperImpedanceControl::setImpedanceOffset(int j, double offse
     }
 
     if (p->iImpedance) {
-        return p->iImpedance->setImpedanceOffset(off + p->base, offset);
+        return p->iImpedance->setImpedanceOffset(static_cast<int>(off + p->base), offset);
     }
 
     return false;
@@ -61,14 +61,14 @@ bool ControlBoardWrapperImpedanceControl::setImpedanceOffset(int j, double offse
 
 bool ControlBoardWrapperImpedanceControl::getImpedance(int j, double* stiff, double* damp)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -76,7 +76,7 @@ bool ControlBoardWrapperImpedanceControl::getImpedance(int j, double* stiff, dou
     }
 
     if (p->iImpedance) {
-        return p->iImpedance->getImpedance(off + p->base, stiff, damp);
+        return p->iImpedance->getImpedance(static_cast<int>(off + p->base), stiff, damp);
     }
 
     return false;
@@ -85,14 +85,14 @@ bool ControlBoardWrapperImpedanceControl::getImpedance(int j, double* stiff, dou
 
 bool ControlBoardWrapperImpedanceControl::getImpedanceOffset(int j, double* offset)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -100,7 +100,7 @@ bool ControlBoardWrapperImpedanceControl::getImpedanceOffset(int j, double* offs
     }
 
     if (p->iImpedance) {
-        return p->iImpedance->getImpedanceOffset(off + p->base, offset);
+        return p->iImpedance->getImpedanceOffset(static_cast<int>(off + p->base), offset);
     }
 
     return false;
@@ -109,14 +109,14 @@ bool ControlBoardWrapperImpedanceControl::getImpedanceOffset(int j, double* offs
 
 bool ControlBoardWrapperImpedanceControl::getCurrentImpedanceLimit(int j, double* min_stiff, double* max_stiff, double* min_damp, double* max_damp)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -124,7 +124,7 @@ bool ControlBoardWrapperImpedanceControl::getCurrentImpedanceLimit(int j, double
     }
 
     if (p->iImpedance) {
-        return p->iImpedance->getCurrentImpedanceLimit(off + p->base, min_stiff, max_stiff, min_damp, max_damp);
+        return p->iImpedance->getCurrentImpedanceLimit(static_cast<int>(off + p->base), min_stiff, max_stiff, min_damp, max_damp);
     }
 
     return false;

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperImpedanceControl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERIMPEDANCECONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERIMPEDANCECONTROL_H
+
+#include <yarp/dev/IImpedanceControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperImpedanceControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IImpedanceControl
+{
+public:
+    inline bool getAxes(int* ax) override { return ControlBoardWrapperCommon::getAxes(ax); }
+    bool setImpedance(int j, double stiff, double damp) override;
+    bool setImpedanceOffset(int j, double offset) override;
+    bool getImpedance(int j, double* stiff, double* damp) override;
+    bool getImpedanceOffset(int j, double* offset) override;
+    bool getCurrentImpedanceLimit(int j, double* min_stiff, double* max_stiff, double* min_damp, double* max_damp) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERIMPEDANCECONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperInteractionMode.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+using yarp::dev::VOCAB_IM_UNKNOWN;
+
+bool ControlBoardWrapperInteractionMode::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* s = device.getSubdevice(subIndex);
+    if (!s) {
+        return false;
+    }
+
+    if (s->iInteract) {
+        return s->iInteract->getInteractionMode(off + s->base, mode);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperInteractionMode::getInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->iInteract) {
+            ret = ret && rpcData.subdevices_p[subIndex]->iInteract->getInteractionModes(
+                    rpcData.subdev_jointsVectorLen[subIndex],
+                    rpcData.jointNumbers[subIndex],
+                    reinterpret_cast<yarp::dev::InteractionModeEnum*>(rpcData.modes[subIndex]));
+        } else {
+            ret = false;
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            modes[j] = static_cast<yarp::dev::InteractionModeEnum>(rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]]);
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            modes[j] = VOCAB_IM_UNKNOWN;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+bool ControlBoardWrapperInteractionMode::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+
+    auto* imodes = new yarp::dev::InteractionModeEnum[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iInteract) && (ret = p->iInteract->getInteractionModes(imodes))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                modes[juser] = imodes[jdevice];
+            }
+        } else {
+            printError("getInteractionModes", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] imodes;
+    return ret;
+}
+
+bool ControlBoardWrapperInteractionMode::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* s = device.getSubdevice(subIndex);
+    if (!s) {
+        return false;
+    }
+
+    if (s->iInteract) {
+        return s->iInteract->setInteractionMode(off + s->base, mode);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperInteractionMode::setInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = static_cast<int>(modes[j]);
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->iInteract) {
+            ret = ret && rpcData.subdevices_p[subIndex]->iInteract->setInteractionModes(
+                    rpcData.subdev_jointsVectorLen[subIndex],
+                    rpcData.jointNumbers[subIndex],
+                    reinterpret_cast<yarp::dev::InteractionModeEnum*>(rpcData.modes[subIndex]));
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+bool ControlBoardWrapperInteractionMode::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+    bool ret = true;
+
+    for (int j = 0; j < controlledJoints; j++) {
+        int off;
+        try {
+            off = device.lut.at(j).offset;
+        } catch (...) {
+            yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+            return false;
+        }
+        int subIndex = device.lut[j].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iInteract) {
+            ret = ret && p->iInteract->setInteractionMode(off + p->base, modes[j]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.cpp
@@ -14,14 +14,14 @@ using yarp::dev::VOCAB_IM_UNKNOWN;
 
 bool ControlBoardWrapperInteractionMode::getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* s = device.getSubdevice(subIndex);
     if (!s) {
@@ -29,7 +29,7 @@ bool ControlBoardWrapperInteractionMode::getInteractionMode(int j, yarp::dev::In
     }
 
     if (s->iInteract) {
-        return s->iInteract->getInteractionMode(off + s->base, mode);
+        return s->iInteract->getInteractionMode(static_cast<int>(off + s->base), mode);
     }
     return false;
 }
@@ -43,10 +43,11 @@ bool ControlBoardWrapperInteractionMode::getInteractionModes(int n_joints, int* 
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
 
@@ -63,7 +64,7 @@ bool ControlBoardWrapperInteractionMode::getInteractionModes(int n_joints, int* 
 
     if (ret) {
         // ReMix values by user expectations
-        for (int i = 0; i < rpcData.deviceNum; i++) {
+        for (size_t i = 0; i < rpcData.deviceNum; i++) {
             rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
         }
 
@@ -87,7 +88,7 @@ bool ControlBoardWrapperInteractionMode::getInteractionModes(yarp::dev::Interact
 
     auto* imodes = new yarp::dev::InteractionModeEnum[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -95,7 +96,7 @@ bool ControlBoardWrapperInteractionMode::getInteractionModes(yarp::dev::Interact
         }
 
         if ((p->iInteract) && (ret = p->iInteract->getInteractionModes(imodes))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 modes[juser] = imodes[jdevice];
             }
         } else {
@@ -111,14 +112,14 @@ bool ControlBoardWrapperInteractionMode::getInteractionModes(yarp::dev::Interact
 
 bool ControlBoardWrapperInteractionMode::setInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* s = device.getSubdevice(subIndex);
     if (!s) {
@@ -126,7 +127,7 @@ bool ControlBoardWrapperInteractionMode::setInteractionMode(int j, yarp::dev::In
     }
 
     if (s->iInteract) {
-        return s->iInteract->setInteractionMode(off + s->base, mode);
+        return s->iInteract->setInteractionMode(static_cast<int>(off + s->base), mode);
     }
     return false;
 }
@@ -140,10 +141,11 @@ bool ControlBoardWrapperInteractionMode::setInteractionModes(int n_joints, int* 
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.modes[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = static_cast<int>(modes[j]);
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
@@ -166,15 +168,15 @@ bool ControlBoardWrapperInteractionMode::setInteractionModes(yarp::dev::Interact
 {
     bool ret = true;
 
-    for (int j = 0; j < controlledJoints; j++) {
-        int off;
+    for (size_t j = 0; j < controlledJoints; j++) {
+        size_t off;
         try {
             off = device.lut.at(j).offset;
         } catch (...) {
-            yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+            yCError(CONTROLBOARDWRAPPER, "Joint number %zu out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
             return false;
         }
-        int subIndex = device.lut[j].deviceEntry;
+        size_t subIndex = device.lut[j].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -182,7 +184,7 @@ bool ControlBoardWrapperInteractionMode::setInteractionModes(yarp::dev::Interact
         }
 
         if (p->iInteract) {
-            ret = ret && p->iInteract->setInteractionMode(off + p->base, modes[j]);
+            ret = ret && p->iInteract->setInteractionMode(static_cast<int>(off + p->base), modes[j]);
         } else {
             ret = false;
         }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperInteractionMode.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERINTERACTIONMODE_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERINTERACTIONMODE_H
+
+#include <yarp/dev/IInteractionMode.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperInteractionMode :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IInteractionMode
+{
+public:
+    bool getInteractionMode(int j, yarp::dev::InteractionModeEnum* mode) override;
+    bool getInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+    bool getInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
+    bool setInteractionMode(int j, yarp::dev::InteractionModeEnum mode) override;
+    bool setInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+    bool setInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERINTERACTIONMODE_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperMotor.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+bool ControlBoardWrapperMotor::getTemperature(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->imotor) {
+        return p->imotor->getTemperature(off + p->base, val);
+    }
+    *val = 0.0;
+    return false;
+}
+
+bool ControlBoardWrapperMotor::getTemperatures(double* vals)
+{
+    auto* temps = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->imotor) && (ret = p->imotor->getTemperatures(temps))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                vals[juser] = temps[jdevice];
+            }
+        } else {
+            printError("getTemperatures", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] temps;
+    return ret;
+}
+
+bool ControlBoardWrapperMotor::getTemperatureLimit(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->imotor) {
+        return p->imotor->getTemperatureLimit(off + p->base, val);
+    }
+    *val = 0.0;
+    return false;
+}
+
+bool ControlBoardWrapperMotor::setTemperatureLimit(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->imotor) {
+        return p->imotor->setTemperatureLimit(off + p->base, val);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperMotor::getGearboxRatio(int m, double* val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->imotor) {
+        return p->imotor->getGearboxRatio(off + p->base, val);
+    }
+    *val = 0.0;
+    return false;
+}
+
+bool ControlBoardWrapperMotor::setGearboxRatio(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->imotor) {
+        return p->imotor->setGearboxRatio(off + p->base, val);
+    }
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
@@ -13,7 +13,7 @@
 bool ControlBoardWrapperMotor::getTemperature(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -21,7 +21,7 @@ bool ControlBoardWrapperMotor::getTemperature(int m, double* val)
     }
 
     if (p->imotor) {
-        return p->imotor->getTemperature(off + p->base, val);
+        return p->imotor->getTemperature(static_cast<int>(off + p->base), val);
     }
     *val = 0.0;
     return false;
@@ -31,7 +31,7 @@ bool ControlBoardWrapperMotor::getTemperatures(double* vals)
 {
     auto* temps = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -39,7 +39,7 @@ bool ControlBoardWrapperMotor::getTemperatures(double* vals)
         }
 
         if ((p->imotor) && (ret = p->imotor->getTemperatures(temps))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 vals[juser] = temps[jdevice];
             }
         } else {
@@ -56,7 +56,7 @@ bool ControlBoardWrapperMotor::getTemperatures(double* vals)
 bool ControlBoardWrapperMotor::getTemperatureLimit(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -64,7 +64,7 @@ bool ControlBoardWrapperMotor::getTemperatureLimit(int m, double* val)
     }
 
     if (p->imotor) {
-        return p->imotor->getTemperatureLimit(off + p->base, val);
+        return p->imotor->getTemperatureLimit(static_cast<int>(off + p->base), val);
     }
     *val = 0.0;
     return false;
@@ -73,7 +73,7 @@ bool ControlBoardWrapperMotor::getTemperatureLimit(int m, double* val)
 bool ControlBoardWrapperMotor::setTemperatureLimit(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -81,7 +81,7 @@ bool ControlBoardWrapperMotor::setTemperatureLimit(int m, const double val)
     }
 
     if (p->imotor) {
-        return p->imotor->setTemperatureLimit(off + p->base, val);
+        return p->imotor->setTemperatureLimit(static_cast<int>(off + p->base), val);
     }
     return false;
 }
@@ -89,7 +89,7 @@ bool ControlBoardWrapperMotor::setTemperatureLimit(int m, const double val)
 bool ControlBoardWrapperMotor::getGearboxRatio(int m, double* val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -97,7 +97,7 @@ bool ControlBoardWrapperMotor::getGearboxRatio(int m, double* val)
     }
 
     if (p->imotor) {
-        return p->imotor->getGearboxRatio(off + p->base, val);
+        return p->imotor->getGearboxRatio(static_cast<int>(off + p->base), val);
     }
     *val = 0.0;
     return false;
@@ -106,7 +106,7 @@ bool ControlBoardWrapperMotor::getGearboxRatio(int m, double* val)
 bool ControlBoardWrapperMotor::setGearboxRatio(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -114,7 +114,7 @@ bool ControlBoardWrapperMotor::setGearboxRatio(int m, const double val)
     }
 
     if (p->imotor) {
-        return p->imotor->setGearboxRatio(off + p->base, val);
+        return p->imotor->setGearboxRatio(static_cast<int>(off + p->base), val);
     }
     return false;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTOR_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTOR_H
+
+#include <yarp/dev/IMotor.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperMotor :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IMotor
+{
+public:
+    inline bool getNumberOfMotors(int* num) override { return ControlBoardWrapperCommon::getNumberOfMotors(num); }
+    bool getTemperature(int m, double* val) override;
+    bool getTemperatures(double* vals) override;
+    bool getTemperatureLimit(int m, double* val) override;
+    bool setTemperatureLimit(int m, const double val) override;
+    bool getGearboxRatio(int m, double* val) override;
+    bool setGearboxRatio(int m, const double val) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTOR_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperMotorEncoders.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+bool ControlBoardWrapperMotorEncoders::resetMotorEncoder(int m)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->resetMotorEncoder(off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::resetMotorEncoders()
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iMotEnc) {
+            ret = ret && p->iMotEnc->resetMotorEncoder(off + p->base);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::setMotorEncoder(int m, const double val)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->setMotorEncoder(off + p->base, val);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::setMotorEncoders(const double* vals)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iMotEnc) {
+            ret = ret && p->iMotEnc->setMotorEncoder(off + p->base, vals[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::setMotorEncoderCountsPerRevolution(int m, double cpr)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->setMotorEncoderCountsPerRevolution(off + p->base, cpr);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderCountsPerRevolution(int m, double* cpr)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->getMotorEncoderCountsPerRevolution(off + p->base, cpr);
+    }
+    *cpr = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoder(int m, double* v)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->getMotorEncoder(off + p->base, v);
+    }
+    *v = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoders(double* encs)
+{
+
+    auto* encValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoders(encValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                encs[juser] = encValues[jdevice];
+            }
+        } else {
+            printError("getMotorEncoders", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] encValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncodersTimed(double* encs, double* t)
+{
+    auto* encValues = new double[device.maxNumOfJointsInDevices];
+    auto* tValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncodersTimed(encValues, tValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                encs[juser] = encValues[jdevice];
+                t[juser] = tValues[jdevice];
+            }
+        } else {
+            printError("getMotorEncodersTimed", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] encValues;
+    delete[] tValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderTimed(int m, double* v, double* t)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->getMotorEncoderTimed(off + p->base, v, t);
+    }
+    *v = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeed(int m, double* sp)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->getMotorEncoderSpeed(off + p->base, sp);
+    }
+    *sp = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeeds(double* spds)
+{
+    auto* sValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderSpeeds(sValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                spds[juser] = sValues[jdevice];
+            }
+        } else {
+            printError("getMotorEncoderSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] sValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderAcceleration(int m, double* acc)
+{
+    int off = device.lut[m].offset;
+    int subIndex = device.lut[m].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iMotEnc) {
+        return p->iMotEnc->getMotorEncoderAcceleration(off + p->base, acc);
+    }
+    *acc = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getMotorEncoderAccelerations(double* accs)
+{
+    auto* aValues = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderAccelerations(aValues))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                accs[juser] = aValues[jdevice];
+            }
+        } else {
+            printError("getMotorEncoderAccelerations", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] aValues;
+    return ret;
+}
+
+
+bool ControlBoardWrapperMotorEncoders::getNumberOfMotorEncoders(int* num)
+{
+    *num = controlledJoints;
+    return true;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
@@ -13,7 +13,7 @@
 bool ControlBoardWrapperMotorEncoders::resetMotorEncoder(int m)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -21,7 +21,7 @@ bool ControlBoardWrapperMotorEncoders::resetMotorEncoder(int m)
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->resetMotorEncoder(off + p->base);
+        return p->iMotEnc->resetMotorEncoder(static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -31,9 +31,9 @@ bool ControlBoardWrapperMotorEncoders::resetMotorEncoders()
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -41,7 +41,7 @@ bool ControlBoardWrapperMotorEncoders::resetMotorEncoders()
         }
 
         if (p->iMotEnc) {
-            ret = ret && p->iMotEnc->resetMotorEncoder(off + p->base);
+            ret = ret && p->iMotEnc->resetMotorEncoder(static_cast<int>(off + p->base));
         } else {
             ret = false;
         }
@@ -53,7 +53,7 @@ bool ControlBoardWrapperMotorEncoders::resetMotorEncoders()
 bool ControlBoardWrapperMotorEncoders::setMotorEncoder(int m, const double val)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -61,7 +61,7 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoder(int m, const double val)
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->setMotorEncoder(off + p->base, val);
+        return p->iMotEnc->setMotorEncoder(static_cast<int>(off + p->base), val);
     }
     return false;
 }
@@ -71,9 +71,9 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoders(const double* vals)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -81,7 +81,7 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoders(const double* vals)
         }
 
         if (p->iMotEnc) {
-            ret = ret && p->iMotEnc->setMotorEncoder(off + p->base, vals[l]);
+            ret = ret && p->iMotEnc->setMotorEncoder(static_cast<int>(off + p->base), vals[l]);
         } else {
             ret = false;
         }
@@ -93,7 +93,7 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoders(const double* vals)
 bool ControlBoardWrapperMotorEncoders::setMotorEncoderCountsPerRevolution(int m, double cpr)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -101,7 +101,7 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoderCountsPerRevolution(int m,
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->setMotorEncoderCountsPerRevolution(off + p->base, cpr);
+        return p->iMotEnc->setMotorEncoderCountsPerRevolution(static_cast<int>(off + p->base), cpr);
     }
     return false;
 }
@@ -110,7 +110,7 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoderCountsPerRevolution(int m,
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderCountsPerRevolution(int m, double* cpr)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -118,7 +118,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderCountsPerRevolution(int m,
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->getMotorEncoderCountsPerRevolution(off + p->base, cpr);
+        return p->iMotEnc->getMotorEncoderCountsPerRevolution(static_cast<int>(off + p->base), cpr);
     }
     *cpr = 0.0;
     return false;
@@ -128,7 +128,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderCountsPerRevolution(int m,
 bool ControlBoardWrapperMotorEncoders::getMotorEncoder(int m, double* v)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -136,7 +136,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoder(int m, double* v)
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->getMotorEncoder(off + p->base, v);
+        return p->iMotEnc->getMotorEncoder(static_cast<int>(off + p->base), v);
     }
     *v = 0.0;
     return false;
@@ -148,7 +148,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoders(double* encs)
 
     auto* encValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -156,7 +156,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoders(double* encs)
         }
 
         if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoders(encValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 encs[juser] = encValues[jdevice];
             }
         } else {
@@ -176,7 +176,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncodersTimed(double* encs, doubl
     auto* encValues = new double[device.maxNumOfJointsInDevices];
     auto* tValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -184,7 +184,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncodersTimed(double* encs, doubl
         }
 
         if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncodersTimed(encValues, tValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 encs[juser] = encValues[jdevice];
                 t[juser] = tValues[jdevice];
             }
@@ -204,7 +204,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncodersTimed(double* encs, doubl
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderTimed(int m, double* v, double* t)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -212,7 +212,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderTimed(int m, double* v, do
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->getMotorEncoderTimed(off + p->base, v, t);
+        return p->iMotEnc->getMotorEncoderTimed(static_cast<int>(off + p->base), v, t);
     }
     *v = 0.0;
     return false;
@@ -222,7 +222,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderTimed(int m, double* v, do
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeed(int m, double* sp)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -230,7 +230,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeed(int m, double* sp)
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->getMotorEncoderSpeed(off + p->base, sp);
+        return p->iMotEnc->getMotorEncoderSpeed(static_cast<int>(off + p->base), sp);
     }
     *sp = 0.0;
     return false;
@@ -241,7 +241,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeeds(double* spds)
 {
     auto* sValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -249,7 +249,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeeds(double* spds)
         }
 
         if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderSpeeds(sValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 spds[juser] = sValues[jdevice];
             }
         } else {
@@ -267,7 +267,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeeds(double* spds)
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderAcceleration(int m, double* acc)
 {
     int off = device.lut[m].offset;
-    int subIndex = device.lut[m].deviceEntry;
+    size_t subIndex = device.lut[m].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -275,7 +275,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderAcceleration(int m, double
     }
 
     if (p->iMotEnc) {
-        return p->iMotEnc->getMotorEncoderAcceleration(off + p->base, acc);
+        return p->iMotEnc->getMotorEncoderAcceleration(static_cast<int>(off + p->base), acc);
     }
     *acc = 0.0;
     return false;
@@ -286,7 +286,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderAccelerations(double* accs
 {
     auto* aValues = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -294,7 +294,7 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderAccelerations(double* accs
         }
 
         if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderAccelerations(aValues))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 accs[juser] = aValues[jdevice];
             }
         } else {

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTORENCODERS_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTORENCODERS_H
+
+#include <yarp/dev/IMotorEncoders.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperMotorEncoders :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IMotorEncoders
+{
+public:
+    bool getNumberOfMotorEncoders(int* num) override;
+    bool resetMotorEncoder(int m) override;
+    bool resetMotorEncoders() override;
+    bool setMotorEncoderCountsPerRevolution(int m, const double cpr) override;
+    bool getMotorEncoderCountsPerRevolution(int m, double* cpr) override;
+    bool setMotorEncoder(int m, const double val) override;
+    bool setMotorEncoders(const double* vals) override;
+    bool getMotorEncoder(int m, double* v) override;
+    bool getMotorEncoders(double* encs) override;
+    bool getMotorEncodersTimed(double* encs, double* t) override;
+    bool getMotorEncoderTimed(int m, double* v, double* t) override;
+    bool getMotorEncoderSpeed(int m, double* sp) override;
+    bool getMotorEncoderSpeeds(double* spds) override;
+    bool getMotorEncoderAcceleration(int m, double* acc) override;
+    bool getMotorEncoderAccelerations(double* accs) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERMOTORENCODERS_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperPWMControl::setRefDutyCycle(int j, double v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,7 +28,7 @@ bool ControlBoardWrapperPWMControl::setRefDutyCycle(int j, double v)
     }
 
     if (p->iPWM) {
-        return p->iPWM->setRefDutyCycle(off + p->base, v);
+        return p->iPWM->setRefDutyCycle(static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -37,9 +37,9 @@ bool ControlBoardWrapperPWMControl::setRefDutyCycles(const double* v)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -47,7 +47,7 @@ bool ControlBoardWrapperPWMControl::setRefDutyCycles(const double* v)
         }
 
         if (p->iPWM) {
-            ret = ret && p->iPWM->setRefDutyCycle(off + p->base, v[l]);
+            ret = ret && p->iPWM->setRefDutyCycle(static_cast<int>(off + p->base), v[l]);
         } else {
             ret = false;
         }
@@ -57,14 +57,14 @@ bool ControlBoardWrapperPWMControl::setRefDutyCycles(const double* v)
 
 bool ControlBoardWrapperPWMControl::getRefDutyCycle(int j, double* v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -72,7 +72,7 @@ bool ControlBoardWrapperPWMControl::getRefDutyCycle(int j, double* v)
     }
 
     if (p->iPWM) {
-        return p->iPWM->getRefDutyCycle(off + p->base, v);
+        return p->iPWM->getRefDutyCycle(static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -81,7 +81,7 @@ bool ControlBoardWrapperPWMControl::getRefDutyCycles(double* v)
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -89,7 +89,7 @@ bool ControlBoardWrapperPWMControl::getRefDutyCycles(double* v)
         }
 
         if ((p->iPWM) && (ret = p->iPWM->getRefDutyCycles(references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 v[juser] = references[jdevice];
             }
         } else {
@@ -105,14 +105,14 @@ bool ControlBoardWrapperPWMControl::getRefDutyCycles(double* v)
 
 bool ControlBoardWrapperPWMControl::getDutyCycle(int j, double* v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -120,7 +120,7 @@ bool ControlBoardWrapperPWMControl::getDutyCycle(int j, double* v)
     }
 
     if (p->iPWM) {
-        return p->iPWM->getDutyCycle(off + p->base, v);
+        return p->iPWM->getDutyCycle(static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -129,7 +129,7 @@ bool ControlBoardWrapperPWMControl::getDutyCycles(double* v)
 {
     auto* dutyCicles = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -137,7 +137,7 @@ bool ControlBoardWrapperPWMControl::getDutyCycles(double* v)
         }
 
         if ((p->iPWM) && (ret = p->iPWM->getDutyCycles(dutyCicles))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 v[juser] = dutyCicles[jdevice];
             }
         } else {

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperPWMControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperPWMControl::setRefDutyCycle(int j, double v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iPWM) {
+        return p->iPWM->setRefDutyCycle(off + p->base, v);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperPWMControl::setRefDutyCycles(const double* v)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iPWM) {
+            ret = ret && p->iPWM->setRefDutyCycle(off + p->base, v[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardWrapperPWMControl::getRefDutyCycle(int j, double* v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iPWM) {
+        return p->iPWM->getRefDutyCycle(off + p->base, v);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperPWMControl::getRefDutyCycles(double* v)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iPWM) && (ret = p->iPWM->getRefDutyCycles(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                v[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefDutyCycles", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+bool ControlBoardWrapperPWMControl::getDutyCycle(int j, double* v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iPWM) {
+        return p->iPWM->getDutyCycle(off + p->base, v);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperPWMControl::getDutyCycles(double* v)
+{
+    auto* dutyCicles = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iPWM) && (ret = p->iPWM->getDutyCycles(dutyCicles))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                v[juser] = dutyCicles[jdevice];
+            }
+        } else {
+            printError("getDutyCycles", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] dutyCicles;
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPWMCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPWMCONTROL_H
+
+#include <yarp/dev/IPWMControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperPWMControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IPWMControl
+{
+public:
+    inline bool getNumberOfMotors(int* num) override { return ControlBoardWrapperCommon::getNumberOfMotors(num); }
+    bool setRefDutyCycle(int j, double v) override;
+    bool setRefDutyCycles(const double* v) override;
+    bool getRefDutyCycle(int j, double* v) override;
+    bool getRefDutyCycles(double* v) override;
+    bool getDutyCycle(int j, double* v) override;
+    bool getDutyCycles(double* v) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPWMCONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
@@ -16,18 +16,18 @@ using yarp::dev::PidControlTypeEnum;
 
 bool ControlBoardWrapperPidControl::setPid(const PidControlTypeEnum& pidtype, int j, const Pid& p)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
         yCError(CONTROLBOARDWRAPPER,
-                "Joint number %d out of bound [0-%d] for part %s",
+                "Joint number %d out of bound [0-%zu] for part %s",
                 j,
                 controlledJoints,
                 partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* s = device.getSubdevice(subIndex);
     if (!s) {
@@ -35,7 +35,7 @@ bool ControlBoardWrapperPidControl::setPid(const PidControlTypeEnum& pidtype, in
     }
 
     if (s->pid) {
-        return s->pid->setPid(pidtype, off + s->base, p);
+        return s->pid->setPid(pidtype, static_cast<int>(off + s->base), p);
     }
     return false;
 }
@@ -45,9 +45,9 @@ bool ControlBoardWrapperPidControl::setPids(const PidControlTypeEnum& pidtype, c
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -55,7 +55,7 @@ bool ControlBoardWrapperPidControl::setPids(const PidControlTypeEnum& pidtype, c
         }
 
         if (p->pid) {
-            ret = ret && p->pid->setPid(pidtype, off + p->base, ps[l]);
+            ret = ret && p->pid->setPid(pidtype, static_cast<int>(off + p->base), ps[l]);
         } else {
             ret = false;
         }
@@ -66,18 +66,18 @@ bool ControlBoardWrapperPidControl::setPids(const PidControlTypeEnum& pidtype, c
 
 bool ControlBoardWrapperPidControl::setPidReference(const PidControlTypeEnum& pidtype, int j, double ref)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
         yCError(CONTROLBOARDWRAPPER,
-                "Joint number %d out of bound [0-%d] for part %s",
+                "Joint number %d out of bound [0-%zu] for part %s",
                 j,
                 controlledJoints,
                 partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -85,7 +85,7 @@ bool ControlBoardWrapperPidControl::setPidReference(const PidControlTypeEnum& pi
     }
 
     if (p->pid) {
-        return p->pid->setPidReference(pidtype, off + p->base, ref);
+        return p->pid->setPidReference(pidtype, static_cast<int>(off + p->base), ref);
     }
     return false;
 }
@@ -95,9 +95,9 @@ bool ControlBoardWrapperPidControl::setPidReferences(const PidControlTypeEnum& p
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -105,7 +105,7 @@ bool ControlBoardWrapperPidControl::setPidReferences(const PidControlTypeEnum& p
         }
 
         if (p->pid) {
-            ret = ret && p->pid->setPidReference(pidtype, off + p->base, refs[l]);
+            ret = ret && p->pid->setPidReference(pidtype, static_cast<int>(off + p->base), refs[l]);
         } else {
             ret = false;
         }
@@ -116,14 +116,14 @@ bool ControlBoardWrapperPidControl::setPidReferences(const PidControlTypeEnum& p
 
 bool ControlBoardWrapperPidControl::setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -131,7 +131,7 @@ bool ControlBoardWrapperPidControl::setPidErrorLimit(const PidControlTypeEnum& p
     }
 
     if (p->pid) {
-        return p->pid->setPidErrorLimit(pidtype, off + p->base, limit);
+        return p->pid->setPidErrorLimit(pidtype, static_cast<int>(off + p->base), limit);
     }
     return false;
 }
@@ -141,9 +141,9 @@ bool ControlBoardWrapperPidControl::setPidErrorLimits(const PidControlTypeEnum& 
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -151,7 +151,7 @@ bool ControlBoardWrapperPidControl::setPidErrorLimits(const PidControlTypeEnum& 
         }
 
         if (p->pid) {
-            ret = ret && p->pid->setPidErrorLimit(pidtype, off + p->base, limits[l]);
+            ret = ret && p->pid->setPidErrorLimit(pidtype, static_cast<int>(off + p->base), limits[l]);
         } else {
             ret = false;
         }
@@ -162,14 +162,14 @@ bool ControlBoardWrapperPidControl::setPidErrorLimits(const PidControlTypeEnum& 
 
 bool ControlBoardWrapperPidControl::getPidError(const PidControlTypeEnum& pidtype, int j, double* err)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -177,7 +177,7 @@ bool ControlBoardWrapperPidControl::getPidError(const PidControlTypeEnum& pidtyp
     }
 
     if (p->pid) {
-        return p->pid->getPidError(pidtype, off + p->base, err);
+        return p->pid->getPidError(pidtype, static_cast<int>(off + p->base), err);
     }
     *err = 0.0;
     return false;
@@ -189,14 +189,14 @@ bool ControlBoardWrapperPidControl::getPidErrors(const PidControlTypeEnum& pidty
     auto* errors = new double[device.maxNumOfJointsInDevices];
 
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
             break;
         }
         if ((p->pid) && (ret = p->pid->getPidErrors(pidtype, errors))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 errs[juser] = errors[jdevice];
             }
         } else {
@@ -213,14 +213,14 @@ bool ControlBoardWrapperPidControl::getPidErrors(const PidControlTypeEnum& pidty
 
 bool ControlBoardWrapperPidControl::getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -228,7 +228,7 @@ bool ControlBoardWrapperPidControl::getPidOutput(const PidControlTypeEnum& pidty
     }
 
     if (p->pid) {
-        return p->pid->getPidOutput(pidtype, off + p->base, out);
+        return p->pid->getPidOutput(pidtype, static_cast<int>(off + p->base), out);
     }
     *out = 0.0;
     return false;
@@ -239,7 +239,7 @@ bool ControlBoardWrapperPidControl::getPidOutputs(const PidControlTypeEnum& pidt
 {
     auto* outputs = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -247,7 +247,7 @@ bool ControlBoardWrapperPidControl::getPidOutputs(const PidControlTypeEnum& pidt
         }
 
         if ((p->pid) && (ret = p->pid->getPidOutputs(pidtype, outputs))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 outs[juser] = outputs[jdevice];
             }
         } else {
@@ -264,14 +264,14 @@ bool ControlBoardWrapperPidControl::getPidOutputs(const PidControlTypeEnum& pidt
 
 bool ControlBoardWrapperPidControl::setPidOffset(const PidControlTypeEnum& pidtype, int j, double v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -279,7 +279,7 @@ bool ControlBoardWrapperPidControl::setPidOffset(const PidControlTypeEnum& pidty
     }
 
     if (p->pid) {
-        return p->pid->setPidOffset(pidtype, off + p->base, v);
+        return p->pid->setPidOffset(pidtype, static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -288,14 +288,14 @@ bool ControlBoardWrapperPidControl::setPidOffset(const PidControlTypeEnum& pidty
 bool ControlBoardWrapperPidControl::getPid(const PidControlTypeEnum& pidtype, int j, Pid* p)
 {
     //#warning "check for max number of joints!?!?!"
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* s = device.getSubdevice(subIndex);
     if (!s) {
@@ -303,7 +303,7 @@ bool ControlBoardWrapperPidControl::getPid(const PidControlTypeEnum& pidtype, in
     }
 
     if (s->pid) {
-        return s->pid->getPid(pidtype, off + s->base, p);
+        return s->pid->getPid(pidtype, static_cast<int>(off + s->base), p);
     }
     return false;
 }
@@ -313,7 +313,7 @@ bool ControlBoardWrapperPidControl::getPids(const PidControlTypeEnum& pidtype, P
 {
     Pid* pids_device = new Pid[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -321,7 +321,7 @@ bool ControlBoardWrapperPidControl::getPids(const PidControlTypeEnum& pidtype, P
         }
 
         if ((p->pid) && (ret = p->pid->getPids(pidtype, pids_device))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 pids[juser] = pids_device[jdevice];
             }
         } else {
@@ -338,21 +338,21 @@ bool ControlBoardWrapperPidControl::getPids(const PidControlTypeEnum& pidtype, P
 
 bool ControlBoardWrapperPidControl::getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
         return false;
     }
     if (p->pid) {
-        return p->pid->getPidReference(pidtype, off + p->base, ref);
+        return p->pid->getPidReference(pidtype, static_cast<int>(off + p->base), ref);
     }
     return false;
 }
@@ -362,7 +362,7 @@ bool ControlBoardWrapperPidControl::getPidReferences(const PidControlTypeEnum& p
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -370,7 +370,7 @@ bool ControlBoardWrapperPidControl::getPidReferences(const PidControlTypeEnum& p
         }
 
         if ((p->pid) && (ret = p->pid->getPidReferences(pidtype, references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 refs[juser] = references[jdevice];
             }
         } else {
@@ -387,14 +387,14 @@ bool ControlBoardWrapperPidControl::getPidReferences(const PidControlTypeEnum& p
 
 bool ControlBoardWrapperPidControl::getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -402,7 +402,7 @@ bool ControlBoardWrapperPidControl::getPidErrorLimit(const PidControlTypeEnum& p
     }
 
     if (p->pid) {
-        return p->pid->getPidErrorLimit(pidtype, off + p->base, limit);
+        return p->pid->getPidErrorLimit(pidtype, static_cast<int>(off + p->base), limit);
     }
     return false;
 }
@@ -412,7 +412,7 @@ bool ControlBoardWrapperPidControl::getPidErrorLimits(const PidControlTypeEnum& 
 {
     auto* lims = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -420,7 +420,7 @@ bool ControlBoardWrapperPidControl::getPidErrorLimits(const PidControlTypeEnum& 
         }
 
         if ((p->pid) && (ret = p->pid->getPidErrorLimits(pidtype, lims))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 limits[juser] = lims[jdevice];
             }
         } else {
@@ -437,14 +437,14 @@ bool ControlBoardWrapperPidControl::getPidErrorLimits(const PidControlTypeEnum& 
 
 bool ControlBoardWrapperPidControl::resetPid(const PidControlTypeEnum& pidtype, int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -452,7 +452,7 @@ bool ControlBoardWrapperPidControl::resetPid(const PidControlTypeEnum& pidtype, 
     }
 
     if (p->pid) {
-        return p->pid->resetPid(pidtype, off + p->base);
+        return p->pid->resetPid(pidtype, static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -460,14 +460,14 @@ bool ControlBoardWrapperPidControl::resetPid(const PidControlTypeEnum& pidtype, 
 
 bool ControlBoardWrapperPidControl::disablePid(const PidControlTypeEnum& pidtype, int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -475,7 +475,7 @@ bool ControlBoardWrapperPidControl::disablePid(const PidControlTypeEnum& pidtype
     }
 
     if (p->pid) {
-        return p->pid->disablePid(pidtype, off + p->base);
+        return p->pid->disablePid(pidtype, static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -483,14 +483,14 @@ bool ControlBoardWrapperPidControl::disablePid(const PidControlTypeEnum& pidtype
 
 bool ControlBoardWrapperPidControl::enablePid(const PidControlTypeEnum& pidtype, int j)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -498,7 +498,7 @@ bool ControlBoardWrapperPidControl::enablePid(const PidControlTypeEnum& pidtype,
     }
 
     if (p->pid) {
-        return p->pid->enablePid(pidtype, off + p->base);
+        return p->pid->enablePid(pidtype, static_cast<int>(off + p->base));
     }
     return false;
 }
@@ -506,14 +506,14 @@ bool ControlBoardWrapperPidControl::enablePid(const PidControlTypeEnum& pidtype,
 
 bool ControlBoardWrapperPidControl::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -521,7 +521,7 @@ bool ControlBoardWrapperPidControl::isPidEnabled(const PidControlTypeEnum& pidty
     }
 
     if (p->pid) {
-        return p->pid->isPidEnabled(pidtype, off + p->base, enabled);
+        return p->pid->isPidEnabled(pidtype, static_cast<int>(off + p->base), enabled);
     }
 
     return false;

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperPidControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+using yarp::dev::Pid;
+using yarp::dev::PidControlTypeEnum;
+
+
+bool ControlBoardWrapperPidControl::setPid(const PidControlTypeEnum& pidtype, int j, const Pid& p)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER,
+                "Joint number %d out of bound [0-%d] for part %s",
+                j,
+                controlledJoints,
+                partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* s = device.getSubdevice(subIndex);
+    if (!s) {
+        return false;
+    }
+
+    if (s->pid) {
+        return s->pid->setPid(pidtype, off + s->base, p);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::setPids(const PidControlTypeEnum& pidtype, const Pid* ps)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->pid) {
+            ret = ret && p->pid->setPid(pidtype, off + p->base, ps[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::setPidReference(const PidControlTypeEnum& pidtype, int j, double ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER,
+                "Joint number %d out of bound [0-%d] for part %s",
+                j,
+                controlledJoints,
+                partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->setPidReference(pidtype, off + p->base, ref);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::setPidReferences(const PidControlTypeEnum& pidtype, const double* refs)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->pid) {
+            ret = ret && p->pid->setPidReference(pidtype, off + p->base, refs[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->setPidErrorLimit(pidtype, off + p->base, limit);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->pid) {
+            ret = ret && p->pid->setPidErrorLimit(pidtype, off + p->base, limits[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidError(const PidControlTypeEnum& pidtype, int j, double* err)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->getPidError(pidtype, off + p->base, err);
+    }
+    *err = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidErrors(const PidControlTypeEnum& pidtype, double* errs)
+{
+    auto* errors = new double[device.maxNumOfJointsInDevices];
+
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+        if ((p->pid) && (ret = p->pid->getPidErrors(pidtype, errors))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                errs[juser] = errors[jdevice];
+            }
+        } else {
+            printError("getPidErrors", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] errors;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->getPidOutput(pidtype, off + p->base, out);
+    }
+    *out = 0.0;
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidOutputs(const PidControlTypeEnum& pidtype, double* outs)
+{
+    auto* outputs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pid) && (ret = p->pid->getPidOutputs(pidtype, outputs))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                outs[juser] = outputs[jdevice];
+            }
+        } else {
+            printError("getPidOutouts", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] outputs;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::setPidOffset(const PidControlTypeEnum& pidtype, int j, double v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->setPidOffset(pidtype, off + p->base, v);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPid(const PidControlTypeEnum& pidtype, int j, Pid* p)
+{
+    //#warning "check for max number of joints!?!?!"
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* s = device.getSubdevice(subIndex);
+    if (!s) {
+        return false;
+    }
+
+    if (s->pid) {
+        return s->pid->getPid(pidtype, off + s->base, p);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPids(const PidControlTypeEnum& pidtype, Pid* pids)
+{
+    Pid* pids_device = new Pid[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pid) && (ret = p->pid->getPids(pidtype, pids_device))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                pids[juser] = pids_device[jdevice];
+            }
+        } else {
+            printError("getPids", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] pids_device;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+    if (p->pid) {
+        return p->pid->getPidReference(pidtype, off + p->base, ref);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidReferences(const PidControlTypeEnum& pidtype, double* refs)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pid) && (ret = p->pid->getPidReferences(pidtype, references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                refs[juser] = references[jdevice];
+            }
+        } else {
+            printError("getPidReferences", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->getPidErrorLimit(pidtype, off + p->base, limit);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits)
+{
+    auto* lims = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pid) && (ret = p->pid->getPidErrorLimits(pidtype, lims))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                limits[juser] = lims[jdevice];
+            }
+        } else {
+            printError("getPidErrorLimits", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] lims;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPidControl::resetPid(const PidControlTypeEnum& pidtype, int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->resetPid(pidtype, off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::disablePid(const PidControlTypeEnum& pidtype, int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->disablePid(pidtype, off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::enablePid(const PidControlTypeEnum& pidtype, int j)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->enablePid(pidtype, off + p->base);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPidControl::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pid) {
+        return p->pid->isPidEnabled(pidtype, off + p->base, enabled);
+    }
+
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPIDCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPIDCONTROL_H
+
+#include <yarp/dev/IPidControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperPidControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IPidControl
+{
+public:
+    bool setPid(const yarp::dev::PidControlTypeEnum& pidtype, int j, const yarp::dev::Pid& p) override;
+    bool setPids(const yarp::dev::PidControlTypeEnum& pidtype, const yarp::dev::Pid* ps) override;
+    bool setPidReference(const yarp::dev::PidControlTypeEnum& pidtype, int j, double ref) override;
+    bool setPidReferences(const yarp::dev::PidControlTypeEnum& pidtype, const double* refs) override;
+    bool setPidErrorLimit(const yarp::dev::PidControlTypeEnum& pidtype, int j, double limit) override;
+    bool setPidErrorLimits(const yarp::dev::PidControlTypeEnum& pidtype, const double* limits) override;
+    bool getPidError(const yarp::dev::PidControlTypeEnum& pidtype, int j, double* err) override;
+    bool getPidErrors(const yarp::dev::PidControlTypeEnum& pidtype, double* errs) override;
+    bool getPidOutput(const yarp::dev::PidControlTypeEnum& pidtype, int j, double* out) override;
+    bool getPidOutputs(const yarp::dev::PidControlTypeEnum& pidtype, double* outs) override;
+    bool setPidOffset(const yarp::dev::PidControlTypeEnum& pidtype, int j, double v) override;
+    bool getPid(const yarp::dev::PidControlTypeEnum& pidtype, int j, yarp::dev::Pid* p) override;
+    bool getPids(const yarp::dev::PidControlTypeEnum& pidtype, yarp::dev::Pid* pids) override;
+    bool getPidReference(const yarp::dev::PidControlTypeEnum& pidtype, int j, double* ref) override;
+    bool getPidReferences(const yarp::dev::PidControlTypeEnum& pidtype, double* refs) override;
+    bool getPidErrorLimit(const yarp::dev::PidControlTypeEnum& pidtype, int j, double* limit) override;
+    bool getPidErrorLimits(const yarp::dev::PidControlTypeEnum& pidtype, double* limits) override;
+    bool resetPid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
+    bool disablePid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
+    bool enablePid(const yarp::dev::PidControlTypeEnum& pidtype, int j) override;
+    bool isPidEnabled(const yarp::dev::PidControlTypeEnum& pidtype, int j, bool* enabled) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPIDCONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionControl.cpp
@@ -1,0 +1,562 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperPositionControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperPositionControl::positionMove(int j, double ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->positionMove(off + p->base, ref);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::positionMove(const double* refs)
+{
+    bool ret = true;
+    int j_wrap = 0; // index of the wrapper joint
+
+    int nDev = device.subdevices.size();
+    for (int subDev_idx = 0; subDev_idx < nDev; subDev_idx++) {
+        int subIndex = device.lut[j_wrap].deviceEntry;
+        SubDevice* p = device.getSubdevice(subIndex);
+
+        if (!p) {
+            return false;
+        }
+
+        int wrapped_joints = (p->top - p->base) + 1;
+        int* joints = new int[wrapped_joints];
+
+        if (p->pos) {
+            // versione comandi su subset di giunti
+            for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
+                joints[j_dev] = p->base + j_dev; // for all joints is equivalent to add offset term
+            }
+
+            ret = ret && p->pos->positionMove(wrapped_joints, joints, &refs[j_wrap]);
+            j_wrap += wrapped_joints;
+        } else {
+            ret = false;
+        }
+
+        if (joints != nullptr) {
+            delete[] joints;
+            joints = nullptr;
+        }
+    }
+
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::positionMove(const int n_joints, const int* joints, const double* refs)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = refs[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->positionMove(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::getTargetPosition(const int j, double* ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        bool ret = p->pos->getTargetPosition(off + p->base, ref);
+        return ret;
+    }
+    *ref = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::getTargetPositions(double* spds)
+{
+    auto* targets = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pos) && (ret = p->pos->getTargetPositions(targets))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                spds[juser] = targets[jdevice];
+            }
+        } else {
+            printError("getTargetPositions", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] targets;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::getTargetPositions(const int n_joints, const int* joints, double* targets)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->getTargetPositions(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            targets[j] = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            targets[j] = 0;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::relativeMove(int j, double delta)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->relativeMove(off + p->base, delta);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::relativeMove(const double* deltas)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->pos) {
+            ret = ret && p->pos->relativeMove(off + p->base, deltas[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::relativeMove(const int n_joints, const int* joints, const double* deltas)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = deltas[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->relativeMove(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::checkMotionDone(int j, bool* flag)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->checkMotionDone(off + p->base, flag);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::checkMotionDone(bool* flag)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    // In this case the "all joint version" of checkMotionDone(bool *flag) cannot be
+    // called because the return value is an 'and' of all joints.
+    // Therefore only the corret joints must be evaluated.
+
+    int subIndex = 0;
+    for (int j = 0; j < controlledJoints; j++) {
+        subIndex = device.lut[j].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[j].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    bool tmp_subdeviceDone = true;
+    bool tmp_deviceDone = true;
+
+    // for each subdevice wrapped call checkmotiondone only on interested joints
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->checkMotionDone(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], &tmp_subdeviceDone);
+            tmp_deviceDone &= tmp_subdeviceDone;
+        }
+    }
+    rpcDataMutex.unlock();
+
+    // return a single value to the caller
+    *flag = tmp_deviceDone;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::checkMotionDone(const int n_joints, const int* joints, bool* flags)
+{
+    bool ret = true;
+    bool tmp = true;
+    bool XFlags = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->checkMotionDone(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], &XFlags);
+            tmp = tmp && XFlags;
+        } else {
+            ret = false;
+        }
+    }
+    if (ret) {
+        *flags = tmp;
+    } else {
+        *flags = false;
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::setRefSpeed(int j, double sp)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->setRefSpeed(off + p->base, sp);
+    }
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::setRefSpeeds(const double* spds)
+{
+    bool ret = true;
+    int j_wrap = 0; // index of the wrapper joint
+
+    for (unsigned int subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+        SubDevice* p = device.getSubdevice(subDev_idx);
+
+        if (!p) {
+            return false;
+        }
+
+        int wrapped_joints = (p->top - p->base) + 1;
+        int* joints = new int[wrapped_joints];
+
+        if (p->pos) {
+            // verione comandi su subset di giunti
+            for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
+                joints[j_dev] = p->base + j_dev;
+            }
+
+            ret = ret && p->pos->setRefSpeeds(wrapped_joints, joints, &spds[j_wrap]);
+            j_wrap += wrapped_joints;
+        } else {
+            ret = false;
+        }
+
+        if (joints != nullptr) {
+            delete[] joints;
+            joints = nullptr;
+        }
+    }
+
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::setRefSpeeds(const int n_joints, const int* joints, const double* spds)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = spds[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->setRefSpeeds(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::getRefSpeed(int j, double* ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->pos) {
+        return p->pos->getRefSpeed(off + p->base, ref);
+    }
+    *ref = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionControl::getRefSpeeds(double* spds)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->pos) && (ret = p->pos->getRefSpeeds(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                spds[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefSpeeds", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionControl::getRefSpeeds(const int n_joints, const int* joints, double* spds)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->pos) {
+            ret = ret && rpcData.subdevices_p[subIndex]->pos->getRefSpeeds(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            spds[j] = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            spds[j] = 0;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionControl.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONCONTROL_H
+
+#include <yarp/dev/IPositionControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperPositionControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IPositionControl
+{
+public:
+    inline bool getAxes(int* ax) override
+    {
+        return ControlBoardWrapperCommon::getAxes(ax);
+    }
+    bool positionMove(int j, double ref) override;
+    bool positionMove(const double* refs) override;
+    bool positionMove(const int n_joints, const int* joints, const double* refs) override;
+    bool getTargetPosition(const int joint, double* ref) override;
+    bool getTargetPositions(double* refs) override;
+    bool getTargetPositions(const int n_joint, const int* joints, double* refs) override;
+    bool relativeMove(int j, double delta) override;
+    bool relativeMove(const double* deltas) override;
+    bool relativeMove(const int n_joints, const int* joints, const double* deltas) override;
+    bool checkMotionDone(int j, bool* flag) override;
+    bool checkMotionDone(bool* flag) override;
+    bool checkMotionDone(const int n_joints, const int* joints, bool* flags) override;
+    bool setRefSpeed(int j, double sp) override;
+    bool setRefSpeeds(const double* spds) override;
+    bool setRefSpeeds(const int n_joints, const int* joints, const double* spds) override;
+    inline bool setRefAcceleration(int j, double acc) override { return ControlBoardWrapperCommon::setRefAcceleration(j, acc); }
+    inline bool setRefAccelerations(const double* accs) override { return ControlBoardWrapperCommon::setRefAccelerations(accs); }
+    inline bool setRefAccelerations(const int n_joints, const int* joints, const double* accs) override { return ControlBoardWrapperCommon::setRefAccelerations(n_joints, joints, accs); }
+    bool getRefSpeed(int j, double* ref) override;
+    bool getRefSpeeds(double* spds) override;
+    bool getRefSpeeds(const int n_joints, const int* joints, double* spds) override;
+    inline bool getRefAcceleration(int j, double* acc) override { return ControlBoardWrapperCommon::getRefAcceleration(j, acc); }
+    inline bool getRefAccelerations(double* accs) override { return ControlBoardWrapperCommon::getRefAccelerations(accs); }
+    inline bool getRefAccelerations(const int n_joints, const int* joints, double* accs) override { return ControlBoardWrapperCommon::getRefAccelerations(n_joints, joints, accs); }
+    inline bool stop(int j) override { return ControlBoardWrapperCommon::stop(j); }
+    inline bool stop() override { return ControlBoardWrapperCommon::stop(); }
+    inline bool stop(const int n_joints, const int* joints) override { return ControlBoardWrapperCommon::stop(n_joints, joints); }
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONCONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
@@ -13,14 +13,14 @@
 
 bool ControlBoardWrapperPositionDirect::setPosition(int j, double ref)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -28,7 +28,7 @@ bool ControlBoardWrapperPositionDirect::setPosition(int j, double ref)
     }
 
     if (p->posDir) {
-        return p->posDir->setPosition(off + p->base, ref);
+        return p->posDir->setPosition(static_cast<int>(off + p->base), ref);
     }
 
     return false;
@@ -44,7 +44,7 @@ bool ControlBoardWrapperPositionDirect::setPositions(const int n_joints, const i
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
         int offset = device.lut[joints[j]].offset;
@@ -71,9 +71,9 @@ bool ControlBoardWrapperPositionDirect::setPositions(const double* refs)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -81,7 +81,7 @@ bool ControlBoardWrapperPositionDirect::setPositions(const double* refs)
         }
 
         if (p->posDir) {
-            ret = p->posDir->setPosition(off + p->base, refs[l]) && ret;
+            ret = p->posDir->setPosition(static_cast<int>(off + p->base), refs[l]) && ret;
         } else {
             ret = false;
         }
@@ -92,14 +92,14 @@ bool ControlBoardWrapperPositionDirect::setPositions(const double* refs)
 
 bool ControlBoardWrapperPositionDirect::getRefPosition(const int j, double* ref)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
 
@@ -108,7 +108,7 @@ bool ControlBoardWrapperPositionDirect::getRefPosition(const int j, double* ref)
     }
 
     if (p->posDir) {
-        bool ret = p->posDir->getRefPosition(off + p->base, ref);
+        bool ret = p->posDir->getRefPosition(static_cast<int>(off + p->base), ref);
         return ret;
     }
     *ref = 0;
@@ -120,7 +120,7 @@ bool ControlBoardWrapperPositionDirect::getRefPositions(double* spds)
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -128,7 +128,7 @@ bool ControlBoardWrapperPositionDirect::getRefPositions(double* spds)
         }
 
         if ((p->posDir) && (ret = p->posDir->getRefPositions(references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 spds[juser] = references[jdevice];
             }
         } else {
@@ -152,10 +152,11 @@ bool ControlBoardWrapperPositionDirect::getRefPositions(const int n_joints, cons
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
 
@@ -167,7 +168,7 @@ bool ControlBoardWrapperPositionDirect::getRefPositions(const int n_joints, cons
 
     if (ret) {
         // ReMix values by user expectations
-        for (int i = 0; i < rpcData.deviceNum; i++) {
+        for (size_t i = 0; i < rpcData.deviceNum; i++) {
             rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
         }
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperPositionDirect.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperPositionDirect::setPosition(int j, double ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->posDir) {
+        return p->posDir->setPosition(off + p->base, ref);
+    }
+
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionDirect::setPositions(const int n_joints, const int* joints, const double* dpos)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        int offset = device.lut[joints[j]].offset;
+        int base = rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = offset + base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = dpos[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->posDir) // Position Direct
+        {
+            ret = ret && rpcData.subdevices_p[subIndex]->posDir->setPositions(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionDirect::setPositions(const double* refs)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->posDir) {
+            ret = p->posDir->setPosition(off + p->base, refs[l]) && ret;
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionDirect::getRefPosition(const int j, double* ref)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->posDir) {
+        bool ret = p->posDir->getRefPosition(off + p->base, ref);
+        return ret;
+    }
+    *ref = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperPositionDirect::getRefPositions(double* spds)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->posDir) && (ret = p->posDir->getRefPositions(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                spds[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefPositions", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+
+bool ControlBoardWrapperPositionDirect::getRefPositions(const int n_joints, const int* joints, double* targets)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->posDir) {
+            ret = ret && rpcData.subdevices_p[subIndex]->posDir->getRefPositions(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            targets[j] = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            targets[j] = 0;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONDIRECT_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONDIRECT_H
+
+#include <yarp/dev/IPositionDirect.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperPositionDirect :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IPositionDirect
+{
+public:
+    inline bool getAxes(int *ax) override { return ControlBoardWrapperCommon::getAxes(ax); }
+    bool setPosition(int j, double ref) override;
+    bool setPositions(const int n_joints, const int* joints, const double* dpos) override;
+    bool setPositions(const double* refs) override;
+    bool getRefPosition(const int joint, double* ref) override;
+    bool getRefPositions(double* refs) override;
+    bool getRefPositions(const int n_joint, const int* joints, double* refs) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPOSITIONDIRECT_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPreciselyTimed.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPreciselyTimed.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperPreciselyTimed.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+#include <yarp/os/Stamp.h>
+
+
+yarp::os::Stamp ControlBoardWrapperPreciselyTimed::getLastInputStamp()
+{
+    timeMutex.lock();
+    yarp::os::Stamp ret = time;
+    timeMutex.unlock();
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPreciselyTimed.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPreciselyTimed.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPRECISELYTIMED_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPRECISELYTIMED_H
+
+#include <yarp/dev/IPreciselyTimed.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperPreciselyTimed :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IPreciselyTimed
+{
+public:
+    yarp::os::Stamp getLastInputStamp() override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERPRECISELYTIMED_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteCalibrator.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteCalibrator.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperRemoteCalibrator.h"
+
+#include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapperLogComponent.h"
+
+using yarp::dev::IRemoteCalibrator;
+
+IRemoteCalibrator* ControlBoardWrapperRemoteCalibrator::getCalibratorDevice()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    return yarp::dev::IRemoteCalibrator::getCalibratorDevice();
+}
+
+bool ControlBoardWrapperRemoteCalibrator::isCalibratorDevicePresent(bool* isCalib)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    return yarp::dev::IRemoteCalibrator::isCalibratorDevicePresent(isCalib);
+}
+
+bool ControlBoardWrapperRemoteCalibrator::calibrateSingleJoint(int j)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return IRemoteCalibrator::getCalibratorDevice()->calibrateSingleJoint(j);
+}
+
+bool ControlBoardWrapperRemoteCalibrator::calibrateWholePart()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->calibrateWholePart();
+}
+
+bool ControlBoardWrapperRemoteCalibrator::homingSingleJoint(int j)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->homingSingleJoint(j);
+}
+
+bool ControlBoardWrapperRemoteCalibrator::homingWholePart()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->homingWholePart();
+}
+
+bool ControlBoardWrapperRemoteCalibrator::parkSingleJoint(int j, bool _wait)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->parkSingleJoint(j, _wait);
+}
+
+bool ControlBoardWrapperRemoteCalibrator::parkWholePart()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->parkWholePart();
+}
+
+bool ControlBoardWrapperRemoteCalibrator::quitCalibrate()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->quitCalibrate();
+}
+
+bool ControlBoardWrapperRemoteCalibrator::quitPark()
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+    if (!getCalibratorDevice()) {
+        return false;
+    }
+
+    return getCalibratorDevice()->quitPark();
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteCalibrator.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteCalibrator.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTECALIBRATOR_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTECALIBRATOR_H
+
+#include <yarp/dev/IRemoteCalibrator.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperRemoteCalibrator :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IRemoteCalibrator
+{
+public:
+    bool isCalibratorDevicePresent(bool* isCalib) override;
+    yarp::dev::IRemoteCalibrator* getCalibratorDevice() override;
+    bool calibrateSingleJoint(int j) override;
+    bool calibrateWholePart() override;
+    bool homingSingleJoint(int j) override;
+    bool homingWholePart() override;
+    bool parkSingleJoint(int j, bool _wait = true) override;
+    bool parkWholePart() override;
+    bool quitCalibrate() override;
+    bool quitPark() override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTECALIBRATOR_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperRemoteVariables.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+using yarp::os::Bottle;
+
+bool ControlBoardWrapperRemoteVariables::getRemoteVariable(std::string key, yarp::os::Bottle& val)
+{
+    bool b = true;
+
+    for (unsigned int i = 0; i < device.subdevices.size(); i++) {
+        SubDevice* p = device.getSubdevice(i);
+
+        if (!p) {
+            return false;
+        }
+        if (!p->iVar) {
+            return false;
+        }
+        yarp::os::Bottle tmpval;
+        b &= p->iVar->getRemoteVariable(key, tmpval);
+        if (b) {
+            val.append(tmpval);
+        }
+    }
+
+    return b;
+}
+
+bool ControlBoardWrapperRemoteVariables::setRemoteVariable(std::string key, const yarp::os::Bottle& val)
+{
+    size_t bottle_size = val.size();
+    size_t device_size = device.subdevices.size();
+    if (bottle_size != device_size) {
+        yCError(CONTROLBOARDWRAPPER, "setRemoteVariable bottle_size != device_size failure");
+        return false;
+    }
+
+    bool b = true;
+    for (unsigned int i = 0; i < device_size; i++) {
+        SubDevice* p = device.getSubdevice(i);
+        if (!p) {
+            yCError(CONTROLBOARDWRAPPER, "setRemoteVariable !p failure");
+            return false;
+        }
+        if (!p->iVar) {
+            yCError(CONTROLBOARDWRAPPER, "setRemoteVariable !p->iVar failure");
+            return false;
+        }
+        Bottle* partial_val = val.get(i).asList();
+        if (partial_val) {
+            b &= p->iVar->setRemoteVariable(key, *partial_val);
+        } else {
+            yCError(CONTROLBOARDWRAPPER, "setRemoteVariable general failure");
+            return false;
+        }
+    }
+
+    return b;
+}
+
+bool ControlBoardWrapperRemoteVariables::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
+{
+    //int off = device.lut[0].offset;
+    int subIndex = device.lut[0].deviceEntry;
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->iVar) {
+        return p->iVar->getRemoteVariablesList(listOfKeys);
+    }
+    return false;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.cpp
@@ -16,7 +16,7 @@ bool ControlBoardWrapperRemoteVariables::getRemoteVariable(std::string key, yarp
 {
     bool b = true;
 
-    for (unsigned int i = 0; i < device.subdevices.size(); i++) {
+    for (size_t i = 0; i < device.subdevices.size(); i++) {
         SubDevice* p = device.getSubdevice(i);
 
         if (!p) {
@@ -45,7 +45,7 @@ bool ControlBoardWrapperRemoteVariables::setRemoteVariable(std::string key, cons
     }
 
     bool b = true;
-    for (unsigned int i = 0; i < device_size; i++) {
+    for (size_t i = 0; i < device_size; i++) {
         SubDevice* p = device.getSubdevice(i);
         if (!p) {
             yCError(CONTROLBOARDWRAPPER, "setRemoteVariable !p failure");
@@ -70,7 +70,7 @@ bool ControlBoardWrapperRemoteVariables::setRemoteVariable(std::string key, cons
 bool ControlBoardWrapperRemoteVariables::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
 {
     //int off = device.lut[0].offset;
-    int subIndex = device.lut[0].deviceEntry;
+    size_t subIndex = device.lut[0].deviceEntry;
     SubDevice* p = device.getSubdevice(subIndex);
 
     if (!p) {

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperRemoteVariables.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTEVARIABLES_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTEVARIABLES_H
+
+#include <yarp/dev/IRemoteVariables.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperRemoteVariables :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IRemoteVariables
+{
+public:
+    bool getRemoteVariable(std::string key, yarp::os::Bottle& val) override;
+    bool setRemoteVariable(std::string key, const yarp::os::Bottle& val) override;
+    bool getRemoteVariablesList(yarp::os::Bottle* listOfKeys) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERREMOTEVARIABLES_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.cpp
@@ -15,7 +15,7 @@ bool ControlBoardWrapperTorqueControl::getRefTorques(double* refs)
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -23,7 +23,7 @@ bool ControlBoardWrapperTorqueControl::getRefTorques(double* refs)
         }
 
         if ((p->iTorque) && (ret = p->iTorque->getRefTorques(references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 refs[juser] = references[jdevice];
             }
         } else {
@@ -40,14 +40,14 @@ bool ControlBoardWrapperTorqueControl::getRefTorques(double* refs)
 bool ControlBoardWrapperTorqueControl::getRefTorque(int j, double* t)
 {
 
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -55,7 +55,7 @@ bool ControlBoardWrapperTorqueControl::getRefTorque(int j, double* t)
     }
 
     if (p->iTorque) {
-        return p->iTorque->getRefTorque(off + p->base, t);
+        return p->iTorque->getRefTorque(static_cast<int>(off + p->base), t);
     }
     return false;
 }
@@ -64,9 +64,9 @@ bool ControlBoardWrapperTorqueControl::setRefTorques(const double* t)
 {
     bool ret = true;
 
-    for (int l = 0; l < controlledJoints; l++) {
+    for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
-        int subIndex = device.lut[l].deviceEntry;
+        size_t subIndex = device.lut[l].deviceEntry;
 
         SubDevice* p = device.getSubdevice(subIndex);
         if (!p) {
@@ -74,7 +74,7 @@ bool ControlBoardWrapperTorqueControl::setRefTorques(const double* t)
         }
 
         if (p->iTorque) {
-            ret = ret && p->iTorque->setRefTorque(off + p->base, t[l]);
+            ret = ret && p->iTorque->setRefTorque(static_cast<int>(off + p->base), t[l]);
         } else {
             ret = false;
         }
@@ -84,14 +84,14 @@ bool ControlBoardWrapperTorqueControl::setRefTorques(const double* t)
 
 bool ControlBoardWrapperTorqueControl::setRefTorque(int j, double t)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -99,7 +99,7 @@ bool ControlBoardWrapperTorqueControl::setRefTorque(int j, double t)
     }
 
     if (p->iTorque) {
-        return p->iTorque->setRefTorque(off + p->base, t);
+        return p->iTorque->setRefTorque(static_cast<int>(off + p->base), t);
     }
     return false;
 }
@@ -113,10 +113,11 @@ bool ControlBoardWrapperTorqueControl::setRefTorques(const int n_joints, const i
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
@@ -134,14 +135,14 @@ bool ControlBoardWrapperTorqueControl::setRefTorques(const int n_joints, const i
 
 bool ControlBoardWrapperTorqueControl::getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -149,21 +150,21 @@ bool ControlBoardWrapperTorqueControl::getMotorTorqueParams(int j, yarp::dev::Mo
     }
 
     if (p->iTorque) {
-        return p->iTorque->getMotorTorqueParams(off + p->base, params);
+        return p->iTorque->getMotorTorqueParams(static_cast<int>(off + p->base), params);
     }
     return false;
 }
 
 bool ControlBoardWrapperTorqueControl::setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -171,21 +172,21 @@ bool ControlBoardWrapperTorqueControl::setMotorTorqueParams(int j, const yarp::d
     }
 
     if (p->iTorque) {
-        return p->iTorque->setMotorTorqueParams(off + p->base, params);
+        return p->iTorque->setMotorTorqueParams(static_cast<int>(off + p->base), params);
     }
     return false;
 }
 
 bool ControlBoardWrapperTorqueControl::getTorque(int j, double* t)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -193,7 +194,7 @@ bool ControlBoardWrapperTorqueControl::getTorque(int j, double* t)
     }
 
     if (p->iTorque) {
-        return p->iTorque->getTorque(off + p->base, t);
+        return p->iTorque->getTorque(static_cast<int>(off + p->base), t);
     }
 
     return false;
@@ -203,7 +204,7 @@ bool ControlBoardWrapperTorqueControl::getTorques(double* t)
 {
     auto* trqs = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -211,7 +212,7 @@ bool ControlBoardWrapperTorqueControl::getTorques(double* t)
         }
 
         if ((p->iTorque) && (ret = p->iTorque->getTorques(trqs))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 t[juser] = trqs[jdevice];
             }
         } else {
@@ -227,14 +228,14 @@ bool ControlBoardWrapperTorqueControl::getTorques(double* t)
 
 bool ControlBoardWrapperTorqueControl::getTorqueRange(int j, double* min, double* max)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
     if (!p) {
@@ -242,7 +243,7 @@ bool ControlBoardWrapperTorqueControl::getTorqueRange(int j, double* min, double
     }
 
     if (p->iTorque) {
-        return p->iTorque->getTorqueRange(off + p->base, min, max);
+        return p->iTorque->getTorqueRange(static_cast<int>(off + p->base), min, max);
     }
 
     return false;
@@ -253,7 +254,7 @@ bool ControlBoardWrapperTorqueControl::getTorqueRanges(double* min, double* max)
     auto* t_min = new double[device.maxNumOfJointsInDevices];
     auto* t_max = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -261,7 +262,7 @@ bool ControlBoardWrapperTorqueControl::getTorqueRanges(double* min, double* max)
         }
 
         if ((p->iTorque) && (ret = p->iTorque->getTorqueRanges(t_min, t_max))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 min[juser] = t_min[jdevice];
                 max[juser] = t_max[jdevice];
             }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperTorqueControl.h"
+
+#include "ControlBoardWrapperLogComponent.h"
+
+
+bool ControlBoardWrapperTorqueControl::getRefTorques(double* refs)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iTorque) && (ret = p->iTorque->getRefTorques(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                refs[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefTorques", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+bool ControlBoardWrapperTorqueControl::getRefTorque(int j, double* t)
+{
+
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->getRefTorque(off + p->base, t);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::setRefTorques(const double* t)
+{
+    bool ret = true;
+
+    for (int l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        int subIndex = device.lut[l].deviceEntry;
+
+        SubDevice* p = device.getSubdevice(subIndex);
+        if (!p) {
+            return false;
+        }
+
+        if (p->iTorque) {
+            ret = ret && p->iTorque->setRefTorque(off + p->base, t[l]);
+        } else {
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool ControlBoardWrapperTorqueControl::setRefTorque(int j, double t)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->setRefTorque(off + p->base, t);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::setRefTorques(const int n_joints, const int* joints, const double* t)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = t[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->iTorque) {
+            ret = ret && rpcData.subdevices_p[subIndex]->iTorque->setRefTorques(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+bool ControlBoardWrapperTorqueControl::getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->getMotorTorqueParams(off + p->base, params);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->setMotorTorqueParams(off + p->base, params);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::getTorque(int j, double* t)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->getTorque(off + p->base, t);
+    }
+
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::getTorques(double* t)
+{
+    auto* trqs = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iTorque) && (ret = p->iTorque->getTorques(trqs))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                t[juser] = trqs[jdevice];
+            }
+        } else {
+            printError("getTorques", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] trqs;
+    return ret;
+}
+
+bool ControlBoardWrapperTorqueControl::getTorqueRange(int j, double* min, double* max)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+    if (!p) {
+        return false;
+    }
+
+    if (p->iTorque) {
+        return p->iTorque->getTorqueRange(off + p->base, min, max);
+    }
+
+    return false;
+}
+
+bool ControlBoardWrapperTorqueControl::getTorqueRanges(double* min, double* max)
+{
+    auto* t_min = new double[device.maxNumOfJointsInDevices];
+    auto* t_max = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->iTorque) && (ret = p->iTorque->getTorqueRanges(t_min, t_max))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                min[juser] = t_min[jdevice];
+                max[juser] = t_max[jdevice];
+            }
+        } else {
+            printError("getTorqueRanges", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] t_min;
+    delete[] t_max;
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperTorqueControl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERTORQUECONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERTORQUECONTROL_H
+
+#include <yarp/dev/ITorqueControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+class ControlBoardWrapperTorqueControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::ITorqueControl
+{
+public:
+    inline bool getAxes(int *ax) override { return ControlBoardWrapperCommon::getAxes(ax); }
+    bool getRefTorques(double* refs) override;
+    bool getRefTorque(int j, double* t) override;
+    bool setRefTorques(const double* t) override;
+    bool setRefTorque(int j, double t) override;
+    bool setRefTorques(const int n_joint, const int* joints, const double* t) override;
+    bool getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params) override;
+    bool setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params) override;
+    bool getTorque(int j, double* t) override;
+    bool getTorques(double* t) override;
+    bool getTorqueRange(int j, double* min, double* max) override;
+    bool getTorqueRanges(double* min, double* max) override;
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERTORQUECONTROL_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "ControlBoardWrapperVelocityControl.h"
+
+#include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapperLogComponent.h"
+
+bool ControlBoardWrapperVelocityControl::velocityMove(int j, double v)
+{
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->vel) {
+        return p->vel->velocityMove(off + p->base, v);
+    }
+    return false;
+}
+
+bool ControlBoardWrapperVelocityControl::velocityMove(const double* v)
+{
+    bool ret = true;
+    int j_wrap = 0; // index of the wrapper joint
+
+    for (unsigned int subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+        SubDevice* p = device.getSubdevice(subDev_idx);
+
+        if (!p) {
+            return false;
+        }
+
+        int wrapped_joints = (p->top - p->base) + 1;
+        int* joints = new int[wrapped_joints];
+
+        if (p->vel) {
+            // verione comandi su subset di giunti
+            for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
+                joints[j_dev] = p->base + j_dev;
+            }
+
+            ret = ret && p->vel->velocityMove(wrapped_joints, joints, &v[j_wrap]);
+            j_wrap += wrapped_joints;
+        } else {
+            ret = false;
+        }
+
+        if (joints != nullptr) {
+            delete[] joints;
+            joints = nullptr;
+        }
+    }
+
+    return ret;
+}
+
+bool ControlBoardWrapperVelocityControl::velocityMove(const int n_joints, const int* joints, const double* spds)
+{
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = spds[j];
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->vel) {
+            ret = ret && rpcData.subdevices_p[subIndex]->vel->velocityMove(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        } else {
+            ret = false;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}
+
+bool ControlBoardWrapperVelocityControl::getRefVelocity(const int j, double* vel)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+
+    int off;
+    try {
+        off = device.lut.at(j).offset;
+    } catch (...) {
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        return false;
+    }
+    int subIndex = device.lut[j].deviceEntry;
+
+    SubDevice* p = device.getSubdevice(subIndex);
+
+    if (!p) {
+        return false;
+    }
+
+    if (p->vel) {
+        bool ret = p->vel->getRefVelocity(off + p->base, vel);
+        return ret;
+    }
+    *vel = 0;
+    return false;
+}
+
+
+bool ControlBoardWrapperVelocityControl::getRefVelocities(double* vels)
+{
+    auto* references = new double[device.maxNumOfJointsInDevices];
+    bool ret = true;
+    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+        SubDevice* p = device.getSubdevice(d);
+        if (!p) {
+            ret = false;
+            break;
+        }
+
+        if ((p->vel) && (ret = p->vel->getRefVelocities(references))) {
+            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+                vels[juser] = references[jdevice];
+            }
+        } else {
+            printError("getRefVelocities", p->id, ret);
+            ret = false;
+            break;
+        }
+    }
+
+    delete[] references;
+    return ret;
+}
+
+bool ControlBoardWrapperVelocityControl::getRefVelocities(const int n_joints, const int* joints, double* vels)
+{
+    yCTrace(CONTROLBOARDWRAPPER);
+
+    bool ret = true;
+
+    rpcDataMutex.lock();
+    //Reset subdev_jointsVectorLen vector
+    memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
+
+    // Create a map of joints for each subDevice
+    int subIndex = 0;
+    for (int j = 0; j < n_joints; j++) {
+        subIndex = device.lut[joints[j]].deviceEntry;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.subdev_jointsVectorLen[subIndex]++;
+    }
+
+    for (subIndex = 0; subIndex < rpcData.deviceNum; subIndex++) {
+        if (rpcData.subdevices_p[subIndex]->vel) {
+            ret = ret && rpcData.subdevices_p[subIndex]->vel->getRefVelocities(rpcData.subdev_jointsVectorLen[subIndex], rpcData.jointNumbers[subIndex], rpcData.values[subIndex]);
+        }
+    }
+
+    if (ret) {
+        // ReMix values by user expectations
+        for (int i = 0; i < rpcData.deviceNum; i++) {
+            rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
+        }
+
+        // fill the output vector
+        for (int j = 0; j < n_joints; j++) {
+            subIndex = device.lut[joints[j]].deviceEntry;
+            vels[j] = rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]];
+            rpcData.subdev_jointsVectorLen[subIndex]++;
+        }
+    } else {
+        for (int j = 0; j < n_joints; j++) {
+            vels[j] = 0;
+        }
+    }
+    rpcDataMutex.unlock();
+    return ret;
+}

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.cpp
@@ -14,14 +14,14 @@
 
 bool ControlBoardWrapperVelocityControl::velocityMove(int j, double v)
 {
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
 
@@ -30,7 +30,7 @@ bool ControlBoardWrapperVelocityControl::velocityMove(int j, double v)
     }
 
     if (p->vel) {
-        return p->vel->velocityMove(off + p->base, v);
+        return p->vel->velocityMove(static_cast<int>(off + p->base), v);
     }
     return false;
 }
@@ -40,20 +40,20 @@ bool ControlBoardWrapperVelocityControl::velocityMove(const double* v)
     bool ret = true;
     int j_wrap = 0; // index of the wrapper joint
 
-    for (unsigned int subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+    for (size_t subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
         SubDevice* p = device.getSubdevice(subDev_idx);
 
         if (!p) {
             return false;
         }
 
-        int wrapped_joints = (p->top - p->base) + 1;
+        int wrapped_joints = static_cast<int>((p->top - p->base) + 1);
         int* joints = new int[wrapped_joints];
 
         if (p->vel) {
             // verione comandi su subset di giunti
             for (int j_dev = 0; j_dev < wrapped_joints; j_dev++) {
-                joints[j_dev] = p->base + j_dev;
+                joints[j_dev] = static_cast<int>(p->base + j_dev);
             }
 
             ret = ret && p->vel->velocityMove(wrapped_joints, joints, &v[j_wrap]);
@@ -80,10 +80,11 @@ bool ControlBoardWrapperVelocityControl::velocityMove(const int n_joints, const 
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.values[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = spds[j];
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
@@ -103,14 +104,14 @@ bool ControlBoardWrapperVelocityControl::getRefVelocity(const int j, double* vel
 {
     yCTrace(CONTROLBOARDWRAPPER);
 
-    int off;
+    size_t off;
     try {
         off = device.lut.at(j).offset;
     } catch (...) {
-        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%d] for part %s", j, controlledJoints, partName.c_str());
+        yCError(CONTROLBOARDWRAPPER, "Joint number %d out of bound [0-%zu] for part %s", j, controlledJoints, partName.c_str());
         return false;
     }
-    int subIndex = device.lut[j].deviceEntry;
+    size_t subIndex = device.lut[j].deviceEntry;
 
     SubDevice* p = device.getSubdevice(subIndex);
 
@@ -119,7 +120,7 @@ bool ControlBoardWrapperVelocityControl::getRefVelocity(const int j, double* vel
     }
 
     if (p->vel) {
-        bool ret = p->vel->getRefVelocity(off + p->base, vel);
+        bool ret = p->vel->getRefVelocity(static_cast<int>(off + p->base), vel);
         return ret;
     }
     *vel = 0;
@@ -131,7 +132,7 @@ bool ControlBoardWrapperVelocityControl::getRefVelocities(double* vels)
 {
     auto* references = new double[device.maxNumOfJointsInDevices];
     bool ret = true;
-    for (unsigned int d = 0; d < device.subdevices.size(); d++) {
+    for (size_t d = 0; d < device.subdevices.size(); d++) {
         SubDevice* p = device.getSubdevice(d);
         if (!p) {
             ret = false;
@@ -139,7 +140,7 @@ bool ControlBoardWrapperVelocityControl::getRefVelocities(double* vels)
         }
 
         if ((p->vel) && (ret = p->vel->getRefVelocities(references))) {
-            for (int juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
+            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
                 vels[juser] = references[jdevice];
             }
         } else {
@@ -164,10 +165,11 @@ bool ControlBoardWrapperVelocityControl::getRefVelocities(const int n_joints, co
     memset(rpcData.subdev_jointsVectorLen, 0x00, sizeof(int) * rpcData.deviceNum);
 
     // Create a map of joints for each subDevice
-    int subIndex = 0;
+    size_t subIndex = 0;
     for (int j = 0; j < n_joints; j++) {
         subIndex = device.lut[joints[j]].deviceEntry;
-        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] = device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base;
+        rpcData.jointNumbers[subIndex][rpcData.subdev_jointsVectorLen[subIndex]] =
+            static_cast<int>(device.lut[joints[j]].offset + rpcData.subdevices_p[subIndex]->base);
         rpcData.subdev_jointsVectorLen[subIndex]++;
     }
 
@@ -179,7 +181,7 @@ bool ControlBoardWrapperVelocityControl::getRefVelocities(const int n_joints, co
 
     if (ret) {
         // ReMix values by user expectations
-        for (int i = 0; i < rpcData.deviceNum; i++) {
+        for (size_t i = 0; i < rpcData.deviceNum; i++) {
             rpcData.subdev_jointsVectorLen[i] = 0; // reset tmp index
         }
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperVelocityControl.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERVELOCITYCONTROL_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERVELOCITYCONTROL_H
+
+#include <yarp/dev/IVelocityControl.h>
+
+#include "ControlBoardWrapperCommon.h"
+
+
+class ControlBoardWrapperVelocityControl :
+        virtual public ControlBoardWrapperCommon,
+        public yarp::dev::IVelocityControl
+{
+public:
+    inline bool getAxes(int* ax) override { return ControlBoardWrapperCommon::getAxes(ax); }
+    bool velocityMove(int j, double v) override;
+    bool velocityMove(const double* v) override;
+    bool velocityMove(const int n_joints, const int* joints, const double* spds) override;
+    bool getRefVelocity(const int joint, double* vel) override;
+    bool getRefVelocities(double* vels) override;
+    bool getRefVelocities(const int n_joint, const int* joints, double* vels) override;
+    inline bool setRefAcceleration(int j, double acc) override { return ControlBoardWrapperCommon::setRefAcceleration(j, acc); }
+    inline bool setRefAccelerations(const double* accs) override { return ControlBoardWrapperCommon::setRefAccelerations(accs); }
+    inline bool setRefAccelerations(const int n_joints, const int* joints, const double* accs) override { return ControlBoardWrapperCommon::setRefAccelerations(n_joints, joints, accs); }
+    inline bool getRefAcceleration(int j, double* acc) override { return ControlBoardWrapperCommon::getRefAcceleration(j, acc); }
+    inline bool getRefAccelerations(double* accs) override { return ControlBoardWrapperCommon::getRefAccelerations(accs); }
+    inline bool getRefAccelerations(const int n_joints, const int* joints, double* accs) override { return ControlBoardWrapperCommon::getRefAccelerations(n_joints, joints, accs); }
+    inline bool stop(int j) override { return ControlBoardWrapperCommon::stop(j); }
+    inline bool stop() override { return ControlBoardWrapperCommon::stop(); }
+    inline bool stop(const int n_joint, const int* joints) override { return ControlBoardWrapperCommon::stop(n_joint, joints); }
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERVELOCITYCONTROL_H

--- a/src/devices/ControlBoardWrapper/MultiJointData.h
+++ b/src/devices/ControlBoardWrapper/MultiJointData.h
@@ -14,8 +14,8 @@
 class MultiJointData
 {
 public:
-    int deviceNum {0};
-    int maxJointsNumForDevice {0};
+    size_t deviceNum {0};
+    size_t maxJointsNumForDevice {0};
 
     int* subdev_jointsVectorLen {nullptr}; // number of joints belonging to each subdevice
     int** jointNumbers {nullptr};
@@ -42,7 +42,7 @@ public:
         subdevices_p = new SubDevice*[deviceNum];
         subdevices_p[0] = _device->getSubdevice(0);
 
-        for (int i = 1; i < deviceNum; i++) {
+        for (size_t i = 1; i < deviceNum; i++) {
             jointNumbers[i] = jointNumbers[i - 1] + _maxJointsNumForDevice; // set pointer to correct location
             values[i] = values[i - 1] + _maxJointsNumForDevice;             // set pointer to correct location
             modes[i] = modes[i - 1] + _maxJointsNumForDevice;               // set pointer to correct location

--- a/src/devices/ControlBoardWrapper/MultiJointData.h
+++ b/src/devices/ControlBoardWrapper/MultiJointData.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_CONTROLBOARDWRAPPER_MULTIJOINTDATA_H
+#define YARP_DEV_CONTROLBOARDWRAPPER_MULTIJOINTDATA_H
+
+#include "SubDevice.h"
+
+class MultiJointData
+{
+public:
+    int deviceNum {0};
+    int maxJointsNumForDevice {0};
+
+    int* subdev_jointsVectorLen {nullptr}; // number of joints belonging to each subdevice
+    int** jointNumbers {nullptr};
+    int** modes {nullptr};
+    double** values {nullptr};
+    SubDevice** subdevices_p {nullptr};
+
+    MultiJointData() = default;
+
+    void resize(int _deviceNum, int _maxJointsNumForDevice, WrappedDevice* _device)
+    {
+        deviceNum = _deviceNum;
+        maxJointsNumForDevice = _maxJointsNumForDevice;
+        subdev_jointsVectorLen = new int[deviceNum];
+        jointNumbers = new int*[deviceNum];                            // alloc a vector of pointers
+        jointNumbers[0] = new int[deviceNum * _maxJointsNumForDevice]; // alloc real memory for data
+
+        modes = new int*[deviceNum];                            // alloc a vector of pointers
+        modes[0] = new int[deviceNum * _maxJointsNumForDevice]; // alloc real memory for data
+
+        values = new double*[deviceNum];                            // alloc a vector of pointers
+        values[0] = new double[deviceNum * _maxJointsNumForDevice]; // alloc real memory for data
+
+        subdevices_p = new SubDevice*[deviceNum];
+        subdevices_p[0] = _device->getSubdevice(0);
+
+        for (int i = 1; i < deviceNum; i++) {
+            jointNumbers[i] = jointNumbers[i - 1] + _maxJointsNumForDevice; // set pointer to correct location
+            values[i] = values[i - 1] + _maxJointsNumForDevice;             // set pointer to correct location
+            modes[i] = modes[i - 1] + _maxJointsNumForDevice;               // set pointer to correct location
+            subdevices_p[i] = _device->getSubdevice(i);
+        }
+    }
+
+    void destroy()
+    {
+        // release matrix memory
+        delete[] jointNumbers[0];
+        delete[] values[0];
+        delete[] modes[0];
+
+        // release vector of pointers
+        delete[] jointNumbers;
+        delete[] values;
+        delete[] modes;
+
+        // delete other vectors
+        delete[] subdev_jointsVectorLen;
+        delete[] subdevices_p;
+    }
+};
+
+#endif // YARP_DEV_CONTROLBOARDWRAPPER_MULTIJOINTDATA_H

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -1451,11 +1451,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 rec = true;
                 yCTrace(CONTROLBOARDWRAPPER, "Calling park function");
                 int flag = cmd.get(1).asInt32();
-                if (flag) {
-                    ok = rpc_Icalib->park(true);
-                } else {
-                    ok = rpc_Icalib->park(false);
-                }
+                ok = rpc_Icalib->park(flag ? true : false);
                 ok = true; //client would get stuck if returning false
             } break;
 

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -1501,14 +1501,10 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int* j_tmp = new int[len];
+                    auto* j_tmp = new int[len];
                     auto* pos_tmp = new double[len];
-
                     for (int i = 0; i < len; i++) {
                         j_tmp[i] = jlut->get(i).asInt32();
-                    }
-
-                    for (int i = 0; i < len; i++) {
                         pos_tmp[i] = pos_val->get(i).asFloat64();
                     }
 

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -199,13 +199,13 @@ void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
             yarp::os::Bottle* modeList;
             modeList = cmd.get(3).asList();
 
-            if (modeList->size() != static_cast<size_t>(controlledJoints)) {
+            if (modeList->size() != controlledJoints) {
                 yCError(CONTROLBOARDWRAPPER, "received an invalid setControlMode message. Size of vector doesn´t match the number of controlled joints");
                 *ok = false;
                 break;
             }
             int* modes = new int[controlledJoints];
-            for (int i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 modes[i] = modeList->get(i).asVocab();
             }
             if (rpc_iCtrlMode) {
@@ -320,7 +320,7 @@ void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
         case VOCAB_CM_CONTROL_MODES: {
             yCTrace(CONTROLBOARDWRAPPER, "getControlModes");
             int* p = new int[controlledJoints];
-            for (int i = 0; i < controlledJoints; ++i) {
+            for (size_t i = 0; i < controlledJoints; ++i) {
                 p[i] = -1;
             }
             if (rpc_iCtrlMode) {
@@ -331,8 +331,7 @@ void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
             response.addVocab(VOCAB_CM_CONTROL_MODES);
 
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addVocab(p[i]);
             }
             delete[] p;
@@ -459,11 +458,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
                 break;
             }
 
-            int i;
-            const int njs = b->size();
+            const size_t njs = b->size();
             if (njs == controlledJoints) {
                 auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                for (i = 0; i < njs; i++) {
+                for (size_t i = 0; i < njs; i++) {
                     p[i] = b->get(i).asFloat64();
                 }
                 *ok = rpc_ITorque->setRefTorques(p);
@@ -474,7 +472,7 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
         case VOCAB_TORQUE_MODE: {
             if (rpc_iCtrlMode) {
                 int* modes = new int[controlledJoints];
-                for (int i = 0; i < controlledJoints; i++) {
+                for (size_t i = 0; i < controlledJoints; i++) {
                     modes[i] = VOCAB_CM_TORQUE;
                 }
                 *ok = rpc_iCtrlMode->setControlModes(modes);
@@ -528,11 +526,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
         } break;
 
         case VOCAB_TRQS: {
-            int i = 0;
             auto* p = new double[controlledJoints];
             *ok = rpc_ITorque->getTorques(p);
             Bottle& b = response.addList();
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -543,12 +540,11 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             auto* p2 = new double[controlledJoints];
             *ok = rpc_ITorque->getTorqueRanges(p1, p2);
             Bottle& b1 = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b1.addFloat64(p1[i]);
             }
             Bottle& b2 = response.addList();
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b2.addFloat64(p2[i]);
             }
             delete[] p1;
@@ -564,8 +560,7 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             auto* p = new double[controlledJoints];
             *ok = rpc_ITorque->getRefTorques(p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -608,17 +603,17 @@ void RPCMessagesParser::handleInteractionModeMsg(const yarp::os::Bottle& cmd,
         case VOCAB_INTERACTION_MODE_GROUP: {
             yCTrace(CONTROLBOARDWRAPPER) << "CBW.h set interactionMode GROUP";
 
-            int n_joints = cmd.get(3).asInt32();
+            auto n_joints = static_cast<size_t>(cmd.get(3).asInt32());
             jointList = cmd.get(4).asList();
             modeList = cmd.get(5).asList();
-            if ((jointList->size() != static_cast<size_t>(n_joints)) || (modeList->size() != static_cast<size_t>(n_joints))) {
+            if ((jointList->size() != n_joints) || (modeList->size() != n_joints)) {
                 yCWarning(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vectors doesn´t match");
                 *ok = false;
                 break;
             }
             int* joints = new int[n_joints];
             modes = new yarp::dev::InteractionModeEnum[n_joints];
-            for (int i = 0; i < n_joints; i++) {
+            for (size_t i = 0; i < n_joints; i++) {
                 joints[i] = jointList->get(i).asInt32();
                 modes[i] = static_cast<yarp::dev::InteractionModeEnum>(modeList->get(i).asVocab());
                 yCTrace(CONTROLBOARDWRAPPER) << "CBW.cpp received vocab " << yarp::os::Vocab::decode(modes[i]);
@@ -633,13 +628,13 @@ void RPCMessagesParser::handleInteractionModeMsg(const yarp::os::Bottle& cmd,
             yCTrace(CONTROLBOARDWRAPPER) << "CBW.c set interactionMode ALL";
 
             modeList = cmd.get(3).asList();
-            if (modeList->size() != static_cast<size_t>(controlledJoints)) {
+            if (modeList->size() != controlledJoints) {
                 yCWarning(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vector doesn´t match the number of controlled joints");
                 *ok = false;
                 break;
             }
             modes = new yarp::dev::InteractionModeEnum[controlledJoints];
-            for (int i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 modes[i] = static_cast<yarp::dev::InteractionModeEnum>(modeList->get(i).asVocab());
             }
             *ok = rpc_IInteract->setInteractionModes(modes);
@@ -701,7 +696,7 @@ void RPCMessagesParser::handleInteractionModeMsg(const yarp::os::Bottle& cmd,
             *ok = rpc_IInteract->getInteractionModes(modes);
 
             Bottle& b = response.addList();
-            for (int i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addVocab(modes[i]);
             }
 
@@ -781,8 +776,7 @@ void RPCMessagesParser::handleCurrentMsg(const yarp::os::Bottle& cmd, yarp::os::
             auto* p = new double[controlledJoints];
             *ok = rpc_ICurrent->getRefCurrents(p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -801,11 +795,10 @@ void RPCMessagesParser::handleCurrentMsg(const yarp::os::Bottle& cmd, yarp::os::
             *ok = rpc_ICurrent->getCurrentRanges(p1, p2);
             Bottle& b1 = response.addList();
             Bottle& b2 = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b1.addFloat64(p1[i]);
             }
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b2.addFloat64(p2[i]);
             }
             delete[] p1;
@@ -888,14 +881,13 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
                 break;
             }
 
-            int i;
-            const int njs = b->size();
+            const size_t njs = b->size();
             if (njs == controlledJoints) {
                 Pid* p = new Pid[njs];
 
                 bool allOK = true;
 
-                for (i = 0; i < njs; i++) {
+                for (size_t i = 0; i < njs; i++) {
                     Bottle* c = b->get(i).asList();
                     if (c != nullptr) {
                         p[i].kp = c->get(0).asFloat64();
@@ -933,11 +925,10 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
                 break;
             }
 
-            int i;
-            const int njs = b->size();
+            const size_t njs = b->size();
             if (njs == controlledJoints) {
                 auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                for (i = 0; i < njs; i++) {
+                for (size_t i = 0; i < njs; i++) {
                     p[i] = b->get(i).asFloat64();
                 }
                 *ok = rpc_IPid->setPidReferences(pidtype, p);
@@ -951,16 +942,15 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
 
         case VOCAB_LIMS: {
             Bottle* b = cmd.get(4).asList();
-            int i;
 
             if (b == nullptr) {
                 break;
             }
 
-            const int njs = b->size();
+            const size_t njs = b->size();
             if (njs == controlledJoints) {
                 auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                for (i = 0; i < njs; i++) {
+                for (size_t i = 0; i < njs; i++) {
                     p[i] = b->get(i).asFloat64();
                 }
                 *ok = rpc_IPid->setPidErrorLimits(pidtype, p);
@@ -994,8 +984,7 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPid->getPidErrorLimits(pidtype, p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1016,8 +1005,7 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPid->getPidErrors(pidtype, p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1032,8 +1020,7 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPid->getPidOutputs(pidtype, p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1059,8 +1046,7 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             Pid* p = new Pid[controlledJoints];
             *ok = rpc_IPid->getPids(pidtype, p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 Bottle& c = b.addList();
                 c.addFloat64(p[i].kp);
                 c.addFloat64(p[i].kd);
@@ -1085,8 +1071,7 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPid->getPidReferences(pidtype, p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1160,8 +1145,7 @@ void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPWM->getRefDutyCycles(p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1176,8 +1160,7 @@ void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
             auto* p = new double[controlledJoints];
             *ok = rpc_IPWM->getRefDutyCycles(p);
             Bottle& b = response.addList();
-            int i;
-            for (i = 0; i < controlledJoints; i++) {
+            for (size_t i = 0; i < controlledJoints; i++) {
                 b.addFloat64(p[i]);
             }
             delete[] p;
@@ -1467,16 +1450,15 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     // this operation is also available on "command" port
                 case VOCAB_POSITION_MOVES: {
                     Bottle* b = cmd.get(2).asList();
-                    int i;
                     if (b == nullptr) {
                         break;
                     }
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     tmpVect.resize(njs);
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         tmpVect[i] = b->get(i).asFloat64();
                     }
 
@@ -1486,7 +1468,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 } break;
 
                 case VOCAB_POSITION_MOVE_GROUP: {
-                    int len = cmd.get(2).asInt32();
+                    auto len = static_cast<size_t>(cmd.get(2).asInt32());
                     Bottle* jlut = cmd.get(3).asList();
                     Bottle* pos_val = cmd.get(4).asList();
 
@@ -1497,13 +1479,13 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     if (jlut == nullptr || pos_val == nullptr) {
                         break;
                     }
-                    if (static_cast<size_t>(len) != jlut->size() || static_cast<size_t>(len) != pos_val->size()) {
+                    if (len != jlut->size() || len != pos_val->size()) {
                         break;
                     }
 
                     auto* j_tmp = new int[len];
                     auto* pos_tmp = new double[len];
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         j_tmp[i] = jlut->get(i).asInt32();
                         pos_tmp[i] = pos_val->get(i).asFloat64();
                     }
@@ -1517,16 +1499,15 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     // this operation is also available on "command" port
                 case VOCAB_VELOCITY_MOVES: {
                     Bottle* b = cmd.get(2).asList();
-                    int i;
                     if (b == nullptr) {
                         break;
                     }
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     tmpVect.resize(njs);
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         tmpVect[i] = b->get(i).asFloat64();
                     }
                     if (rpc_IVelCtrl != nullptr) {
@@ -1540,7 +1521,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 } break;
 
                 case VOCAB_RELATIVE_MOVE_GROUP: {
-                    int len = cmd.get(2).asInt32();
+                    auto len = static_cast<size_t>(cmd.get(2).asInt32());
                     Bottle* jBottle_p = cmd.get(3).asList();
                     Bottle* posBottle_p = cmd.get(4).asList();
 
@@ -1551,18 +1532,18 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     if (jBottle_p == nullptr || posBottle_p == nullptr) {
                         break;
                     }
-                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != posBottle_p->size()) {
+                    if (len != jBottle_p->size() || len != posBottle_p->size()) {
                         break;
                     }
 
                     int* j_tmp = new int[len];
                     auto* pos_tmp = new double[len];
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         j_tmp[i] = jBottle_p->get(i).asInt32();
                     }
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         pos_tmp[i] = posBottle_p->get(i).asFloat64();
                     }
 
@@ -1579,13 +1560,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int i;
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         p[i] = b->get(i).asFloat64();
                     }
                     ok = rpc_IPosCtrl->relativeMove(p);
@@ -1597,7 +1577,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 } break;
 
                 case VOCAB_REF_SPEED_GROUP: {
-                    int len = cmd.get(2).asInt32();
+                    auto len = static_cast<size_t>(cmd.get(2).asInt32());
                     Bottle* jBottle_p = cmd.get(3).asList();
                     Bottle* velBottle_p = cmd.get(4).asList();
 
@@ -1608,18 +1588,18 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     if (jBottle_p == nullptr || velBottle_p == nullptr) {
                         break;
                     }
-                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != velBottle_p->size()) {
+                    if (len != jBottle_p->size() || len != velBottle_p->size()) {
                         break;
                     }
 
                     int* j_tmp = new int[len];
                     auto* spds_tmp = new double[len];
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         j_tmp[i] = jBottle_p->get(i).asInt32();
                     }
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         spds_tmp[i] = velBottle_p->get(i).asFloat64();
                     }
 
@@ -1635,13 +1615,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int i;
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         p[i] = b->get(i).asFloat64();
                     }
                     ok = rpc_IPosCtrl->setRefSpeeds(p);
@@ -1653,7 +1632,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 } break;
 
                 case VOCAB_REF_ACCELERATION_GROUP: {
-                    int len = cmd.get(2).asInt32();
+                    auto len = static_cast<size_t>(cmd.get(2).asInt32());
                     Bottle* jBottle_p = cmd.get(3).asList();
                     Bottle* accBottle_p = cmd.get(4).asList();
 
@@ -1664,18 +1643,18 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     if (jBottle_p == nullptr || accBottle_p == nullptr) {
                         break;
                     }
-                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != accBottle_p->size()) {
+                    if (len != jBottle_p->size() || len != accBottle_p->size()) {
                         break;
                     }
 
                     int* j_tmp = new int[len];
                     auto* accs_tmp = new double[len];
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         j_tmp[i] = jBottle_p->get(i).asInt32();
                     }
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         accs_tmp[i] = accBottle_p->get(i).asFloat64();
                     }
 
@@ -1691,13 +1670,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int i;
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         p[i] = b->get(i).asFloat64();
                     }
                     ok = rpc_IPosCtrl->setRefAccelerations(p);
@@ -1709,7 +1687,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                 } break;
 
                 case VOCAB_STOP_GROUP: {
-                    int len = cmd.get(2).asInt32();
+                    auto len = static_cast<size_t>(cmd.get(2).asInt32());
                     Bottle* jBottle_p = cmd.get(3).asList();
 
                     if (rpc_IPosCtrl == nullptr) {
@@ -1719,13 +1697,13 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     if (jBottle_p == nullptr) {
                         break;
                     }
-                    if (static_cast<size_t>(len) != jBottle_p->size()) {
+                    if (len != jBottle_p->size()) {
                         break;
                     }
 
                     int* j_tmp = new int[len];
 
-                    for (int i = 0; i < len; i++) {
+                    for (size_t i = 0; i < len; i++) {
                         j_tmp[i] = jBottle_p->get(i).asInt32();
                     }
 
@@ -1756,13 +1734,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int i;
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         p[i] = b->get(i).asFloat64();
                     }
                     ok = rpc_IEncTimed->setEncoders(p);
@@ -1792,13 +1769,12 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                         break;
                     }
 
-                    int i;
-                    const int njs = b->size();
+                    const size_t njs = b->size();
                     if (njs != controlledJoints) {
                         break;
                     }
                     auto* p = new double[njs]; // LATER: optimize to avoid allocation.
-                    for (i = 0; i < njs; i++) {
+                    for (size_t i = 0; i < njs; i++) {
                         p[i] = b->get(i).asFloat64();
                     }
                     ok = rpc_IMotEnc->setMotorEncoders(p);
@@ -1884,8 +1860,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IMotor->getTemperatures(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -1928,8 +1903,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* refs = new double[controlledJoints];
                     ok = rpc_IPosCtrl->getTargetPositions(refs);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(refs[i]);
                     }
                     delete[] refs;
@@ -1967,8 +1941,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* refs = new double[controlledJoints];
                     ok = rpc_IPosDirect->getRefPositions(refs);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(refs[i]);
                     }
                     delete[] refs;
@@ -2010,8 +1983,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* refs = new double[controlledJoints];
                     ok = rpc_IVelCtrl->getRefVelocities(refs);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(refs[i]);
                     }
                     delete[] refs;
@@ -2087,8 +2059,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IPosCtrl->getRefSpeeds(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2123,8 +2094,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IPosCtrl->getRefAccelerations(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2139,8 +2109,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IEncTimed->getEncoders(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2155,8 +2124,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IEncTimed->getEncoderSpeeds(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2171,8 +2139,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IEncTimed->getEncoderAccelerations(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2192,8 +2159,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IMotEnc->getMotorEncoders(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2208,8 +2174,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IMotEnc->getMotorEncoderSpeeds(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2224,8 +2189,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rpc_IMotEnc->getMotorEncoderAccelerations(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2246,8 +2210,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     auto* p = new double[controlledJoints];
                     ok = rcp_IAmp->getCurrents(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addFloat64(p[i]);
                     }
                     delete[] p;
@@ -2257,8 +2220,7 @@ bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& r
                     int* p = new int[controlledJoints];
                     ok = rcp_IAmp->getAmpStatus(p);
                     Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++) {
+                    for (size_t i = 0; i < controlledJoints; i++) {
                         b.addInt32(p[i]);
                     }
                     delete[] p;
@@ -2364,7 +2326,9 @@ bool RPCMessagesParser::initialize()
 {
     bool ok = false;
     if (rpc_IPosCtrl) {
-        ok = rpc_IPosCtrl->getAxes(&controlledJoints);
+        int tmp_axes;
+        ok = rpc_IPosCtrl->getAxes(&tmp_axes);
+        controlledJoints = static_cast<size_t>(tmp_axes);
     }
 
     DeviceResponder::makeUsage();
@@ -2376,7 +2340,7 @@ bool RPCMessagesParser::initialize()
     addUsage("[get] [enc] $iAxisNumber", "get the encoder value for an axis");
 
     std::string args;
-    for (int i = 0; i < controlledJoints; i++) {
+    for (size_t i = 0; i < controlledJoints; i++) {
         if (i > 0) {
             args += " ";
         }

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -8,11 +8,12 @@
  */
 
 #include "RPCMessagesParser.h"
-#include "ControlBoardWrapper.h"
-#include "ControlBoardWrapperLogComponent.h"
 
-#include <iostream>
 #include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapperCommon.h"
+#include "ControlBoardWrapperLogComponent.h"
+#include <iostream>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -21,22 +22,23 @@ using namespace yarp::sig;
 using namespace std;
 
 
-inline void appendTimeStamp(Bottle &bot, Stamp &st)
+inline void appendTimeStamp(Bottle& bot, Stamp& st)
 {
-    int count=st.getCount();
-    double time=st.getTime();
+    int count = st.getCount();
+    double time = st.getTime();
     bot.addVocab(VOCAB_TIMESTAMP);
     bot.addInt32(count);
     bot.addFloat64(time);
 }
 
 void RPCMessagesParser::handleProtocolVersionRequest(const yarp::os::Bottle& cmd,
-                                           yarp::os::Bottle& response, bool *rec, bool *ok)
+                                                     yarp::os::Bottle& response,
+                                                     bool* rec,
+                                                     bool* ok)
 {
-    if (cmd.get(0).asVocab()!=VOCAB_GET)
-    {
-        *rec=false;
-        *ok=false;
+    if (cmd.get(0).asVocab() != VOCAB_GET) {
+        *rec = false;
+        *ok = false;
         return;
     }
 
@@ -45,815 +47,685 @@ void RPCMessagesParser::handleProtocolVersionRequest(const yarp::os::Bottle& cmd
     response.addInt32(PROTOCOL_VERSION_MINOR);
     response.addInt32(PROTOCOL_VERSION_TWEAK);
 
-    *rec=true;
-    *ok=true;
+    *rec = true;
+    *ok = true;
 }
 
 void RPCMessagesParser::handleImpedanceMsg(const yarp::os::Bottle& cmd,
-                                           yarp::os::Bottle& response, bool *rec, bool *ok)
+                                           yarp::os::Bottle& response,
+                                           bool* rec,
+                                           bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IImpedance message");
-    if (!rpc_IImpedance)
-    {
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IImpedance message");
+    if (!rpc_IImpedance) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid interface");
-        *ok=false;
+        *ok = false;
         return;
     }
 
     int code = cmd.get(0).asVocab();
-    *ok=false;
-    switch(code)
-    {
-        case VOCAB_SET:
-        {
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "handleImpedanceMsg::VOCAB_SET command");
-            switch (cmd.get(2).asVocab())
-            {
-                case VOCAB_IMP_PARAM:
-                {
-                    Bottle *b = cmd.get(4).asList();
-                    if (b!=nullptr)
-                    {
-                        double stiff = b->get(0).asFloat64();
-                        double damp = b->get(1).asFloat64();
-                        *ok = rpc_IImpedance->setImpedance(cmd.get(3).asInt32(),stiff,damp);
-                        *rec=true;
-                    }
-                }
-                break;
-                case VOCAB_IMP_OFFSET:
-                {
-                    Bottle *b = cmd.get(4).asList();
-                    if (b!=nullptr)
-                    {
-                        double offs = b->get(0).asFloat64();
-                        *ok = rpc_IImpedance->setImpedanceOffset(cmd.get(3).asInt32(),offs);
-                        *rec=true;
-                    }
-                }
-                break;
+    *ok = false;
+    switch (code) {
+    case VOCAB_SET: {
+        yCTrace(CONTROLBOARDWRAPPER, "handleImpedanceMsg::VOCAB_SET command");
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_IMP_PARAM: {
+            Bottle* b = cmd.get(4).asList();
+            if (b != nullptr) {
+                double stiff = b->get(0).asFloat64();
+                double damp = b->get(1).asFloat64();
+                *ok = rpc_IImpedance->setImpedance(cmd.get(3).asInt32(), stiff, damp);
+                *rec = true;
             }
+        } break;
+        case VOCAB_IMP_OFFSET: {
+            Bottle* b = cmd.get(4).asList();
+            if (b != nullptr) {
+                double offs = b->get(0).asFloat64();
+                *ok = rpc_IImpedance->setImpedanceOffset(cmd.get(3).asInt32(), offs);
+                *rec = true;
+            }
+        } break;
         }
-        break;
-        case VOCAB_GET:
-        {
-            double stiff = 0;
-            double damp = 0;
-            double offs = 0;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "handleImpedanceMsg::VOCAB_GET command");
+    } break;
+    case VOCAB_GET: {
+        double stiff = 0;
+        double damp = 0;
+        double offs = 0;
+        yCTrace(CONTROLBOARDWRAPPER, "handleImpedanceMsg::VOCAB_GET command");
 
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-            switch (cmd.get(2).asVocab())
-            {
-                case VOCAB_IMP_PARAM:
-                {
-                    *ok = rpc_IImpedance->getImpedance(cmd.get(3).asInt32(),&stiff, &damp);
-                    Bottle& b = response.addList();
-                    b.addFloat64(stiff);
-                    b.addFloat64(damp);
-                    *rec=true;
-                }
-                break;
-                case VOCAB_IMP_OFFSET:
-                {
-                    *ok = rpc_IImpedance->getImpedanceOffset(cmd.get(3).asInt32(),&offs);
-                    Bottle& b = response.addList();
-                    b.addFloat64(offs);
-                    *rec=true;
-                }
-                break;
-                case VOCAB_LIMITS:
-                {
-                    double min_stiff    = 0;
-                    double max_stiff    = 0;
-                    double min_damp     = 0;
-                    double max_damp     = 0;
-                    *ok = rpc_IImpedance->getCurrentImpedanceLimit(cmd.get(3).asInt32(),&min_stiff, &max_stiff, &min_damp, &max_damp);
-                    Bottle& b = response.addList();
-                    b.addFloat64(min_stiff);
-                    b.addFloat64(max_stiff);
-                    b.addFloat64(min_damp);
-                    b.addFloat64(max_damp);
-                    *rec=true;
-                }
-                break;
-            }
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_IMP_PARAM: {
+            *ok = rpc_IImpedance->getImpedance(cmd.get(3).asInt32(), &stiff, &damp);
+            Bottle& b = response.addList();
+            b.addFloat64(stiff);
+            b.addFloat64(damp);
+            *rec = true;
+        } break;
+        case VOCAB_IMP_OFFSET: {
+            *ok = rpc_IImpedance->getImpedanceOffset(cmd.get(3).asInt32(), &offs);
+            Bottle& b = response.addList();
+            b.addFloat64(offs);
+            *rec = true;
+        } break;
+        case VOCAB_LIMITS: {
+            double min_stiff = 0;
+            double max_stiff = 0;
+            double min_damp = 0;
+            double max_damp = 0;
+            *ok = rpc_IImpedance->getCurrentImpedanceLimit(cmd.get(3).asInt32(), &min_stiff, &max_stiff, &min_damp, &max_damp);
+            Bottle& b = response.addList();
+            b.addFloat64(min_stiff);
+            b.addFloat64(max_stiff);
+            b.addFloat64(min_damp);
+            b.addFloat64(max_damp);
+            *rec = true;
+        } break;
         }
-            lastRpcStamp.update();
-            appendTimeStamp(response, lastRpcStamp);
+    }
+        lastRpcStamp.update();
+        appendTimeStamp(response, lastRpcStamp);
         break; // case VOCAB_GET
-        default:
-        {
-            *rec=false;
-        }
-        break;
+    default:
+    {
+        *rec = false;
+    } break;
     }
 }
 
 void RPCMessagesParser::handleControlModeMsg(const yarp::os::Bottle& cmd,
-                                             yarp::os::Bottle& response, bool *rec, bool *ok)
+                                             yarp::os::Bottle& response,
+                                             bool* rec,
+                                             bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IControlMode message");
-    if (! (rpc_iCtrlMode))
-    {
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IControlMode message");
+    if (!(rpc_iCtrlMode)) {
         yCError(CONTROLBOARDWRAPPER, "ControlBoardWrapper: I do not have a valid iControlMode interface");
-        *ok=false;
+        *ok = false;
         return;
     }
 
     //handle here messages about  IControlMode interface
     int code = cmd.get(0).asVocab();
-    *ok=true;
-    *rec=true; //or false
+    *ok = true;
+    *rec = true; //or false
 
-    switch(code)
-    {
-        case VOCAB_SET:
-        {
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "handleControlModeMsg::VOCAB_SET command");
+    switch (code) {
+    case VOCAB_SET: {
+        yCTrace(CONTROLBOARDWRAPPER, "handleControlModeMsg::VOCAB_SET command");
 
-            int method = cmd.get(2).asVocab();
+        int method = cmd.get(2).asVocab();
 
-            switch(method)
-            {
-                case VOCAB_CM_CONTROL_MODE:
-                {
-                    int axis = cmd.get(3).asInt32();
-                    yCTrace(CONTROLBOARDWRAPPER) << "got VOCAB_CM_CONTROL_MODE";
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->setControlMode(axis, cmd.get(4).asVocab());
-                    else
-                    {
-                        yCError(CONTROLBOARDWRAPPER) << "ControlBoardWrapper: Unable to handle setControlMode request! This should not happen!";
-                        *rec = false;
-                    }
-                }
-                break;
-
-                case VOCAB_CM_CONTROL_MODE_GROUP:
-                {
-                    int n_joints = cmd.get(3).asInt32();
-                    Bottle& jList = *(cmd.get(4).asList());
-                    Bottle& modeList= *(cmd.get(5).asList());
-
-                    int *js = new int [n_joints];
-                    int *modes = new int [n_joints];
-
-                    for(int i=0; i<n_joints; i++)
-                    {
-                        js[i] = jList.get(i).asInt32();
-                    }
-
-                    for(int i=0; i<n_joints; i++)
-                    {
-                        modes[i] = modeList.get(i).asVocab();
-                    }
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->setControlModes(n_joints, js, modes);
-                    else
-                    {
-                        *rec = false;
-                        *ok = false;
-                    }
-                    delete [] js;
-                    delete [] modes;
-                }
-                break;
-
-                case VOCAB_CM_CONTROL_MODES:
-                {
-                    yarp::os::Bottle *modeList;
-                    modeList  = cmd.get(3).asList();
-
-                    if(modeList->size() != (size_t) controlledJoints)
-                    {
-                        yCError(CONTROLBOARDWRAPPER, "received an invalid setControlMode message. Size of vector doesn´t match the number of controlled joints");
-                        *ok = false;
-                        break;
-                    }
-                    int *modes  = new int [controlledJoints];
-                    for( int i=0; i<controlledJoints; i++)
-                    {
-                        modes[i] = modeList->get(i).asVocab();
-                    }
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->setControlModes(modes);
-                    else
-                    {
-                        *rec = false;
-                        *ok = false;
-                    }
-                    delete [] modes;
-                }
-                break;
-
-                default:
-                {
-                    // if I´m here, someone is probably sending command using the old interface.
-                    // try to be compatible as much as I can
-
-                    yCError(CONTROLBOARDWRAPPER)  << " Error, received a set control mode message using a legacy version, trying to be handle the message anyway "
-                              << " but please update your client to be compatible with the IControlMode2 interface";
-
-                    yCTrace(CONTROLBOARDWRAPPER) << " cmd.get(4).asVocab() is " << Vocab::decode(cmd.get(4).asVocab());
-                    int axis = cmd.get(3).asInt32();
-
-                    switch (cmd.get(4).asVocab())
-                    {
-                        case VOCAB_CM_POSITION:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_POSITION);
-                        break;
-
-                        case VOCAB_CM_POSITION_DIRECT:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_POSITION_DIRECT);
-                            else
-                            {
-                                *rec = false;
-                                *ok = false;
-                            }
-                        break;
-
-
-                        case VOCAB_CM_VELOCITY:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_VELOCITY);
-                        break;
-
-                        case VOCAB_CM_TORQUE:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_TORQUE);
-                        break;
-
-                        case VOCAB_CM_IMPEDANCE_POS:
-                            yCError(CONTROLBOARDWRAPPER) << "The 'impedancePosition' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_POSITION) instead";
-                        break;
-
-                        case VOCAB_CM_IMPEDANCE_VEL:
-                            yCError(CONTROLBOARDWRAPPER) << "The 'impedanceVelocity' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_VELOCITY) instead";
-                        break;
-
-                        case VOCAB_CM_PWM:
-                            if (rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_PWM);
-                            else
-                            {
-                                *rec = false;
-                                *ok = false;
-                            }
-                            break;
-
-                        case VOCAB_CM_CURRENT:
-                            if (rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_CURRENT);
-                            else
-                            {
-                                *rec = false;
-                                *ok = false;
-                            }
-                            break;
-
-                        case VOCAB_CM_MIXED:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_MIXED);
-                            else
-                            {
-                                *rec = false;
-                                *ok = false;
-                            }
-                        break;
-
-                        case VOCAB_CM_FORCE_IDLE:
-                            if(rpc_iCtrlMode)
-                                *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_FORCE_IDLE);
-                            else
-                            {
-                                *rec = false;
-                                *ok = false;
-                            }
-                        break;
-
-                        default:
-                            //                        if (ControlBoardWrapper_p->verbose())
-                            yCError(CONTROLBOARDWRAPPER, "SET unknown controlMode : %s ", cmd.toString().c_str());
-                            *ok = false;
-                            *rec = false;
-                        break;
-                    }
-                }
-                break;  // close default case
+        switch (method) {
+        case VOCAB_CM_CONTROL_MODE: {
+            int axis = cmd.get(3).asInt32();
+            yCTrace(CONTROLBOARDWRAPPER) << "got VOCAB_CM_CONTROL_MODE";
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->setControlMode(axis, cmd.get(4).asVocab());
+            } else {
+                yCError(CONTROLBOARDWRAPPER) << "ControlBoardWrapper: Unable to handle setControlMode request! This should not happen!";
+                *rec = false;
             }
-        }
-        break;      // close SET case
+        } break;
 
-        case VOCAB_GET:
-        {
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "GET command");
+        case VOCAB_CM_CONTROL_MODE_GROUP: {
+            int n_joints = cmd.get(3).asInt32();
+            Bottle& jList = *(cmd.get(4).asList());
+            Bottle& modeList = *(cmd.get(5).asList());
 
-            int method = cmd.get(2).asVocab();
+            int* js = new int[n_joints];
+            int* modes = new int[n_joints];
 
-            switch(method)
-            {
-                case VOCAB_CM_CONTROL_MODES:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "getControlModes");
-                    int *p = new int[controlledJoints];
-                    for (int i = 0; i < controlledJoints; ++i) {
-                        p[i] = -1;
-                    }
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->getControlModes(p);
+            for (int i = 0; i < n_joints; i++) {
+                js[i] = jList.get(i).asInt32();
+            }
 
-                    response.addVocab(VOCAB_IS);
-                    response.addVocab(VOCAB_CM_CONTROL_MODES);
+            for (int i = 0; i < n_joints; i++) {
+                modes[i] = modeList.get(i).asVocab();
+            }
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->setControlModes(n_joints, js, modes);
+            } else {
+                *rec = false;
+                *ok = false;
+            }
+            delete[] js;
+            delete[] modes;
+        } break;
 
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addVocab(p[i]);
-                    delete[] p;
+        case VOCAB_CM_CONTROL_MODES: {
+            yarp::os::Bottle* modeList;
+            modeList = cmd.get(3).asList();
 
-                    *rec=true;
-                }
-                break;
-
-                case VOCAB_CM_CONTROL_MODE:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "getControlMode");
-
-                    int p=-1;
-                    int axis = cmd.get(3).asInt32();
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->getControlMode(axis, &p);
-
-                    response.addVocab(VOCAB_IS);
-                    response.addInt32(axis);
-                    response.addVocab(p);
-
-                    yCTrace(CONTROLBOARDWRAPPER, "Returning %d", p);
-                    *rec=true;
-                }
-                break;
-
-                case VOCAB_CM_CONTROL_MODE_GROUP:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "getControlMode group");
-
-                    int n_joints = cmd.get(3).asInt32();
-                    Bottle& lIn = *(cmd.get(4).asList());
-
-                    int *js = new int [n_joints];
-                    int *modes = new int [n_joints];
-                    for(int i=0; i<n_joints; i++)
-                    {
-                        js[i] = lIn.get(i).asInt32();
-                        modes[i] = -1;
-                    }
-                    if(rpc_iCtrlMode)
-                        *ok = rpc_iCtrlMode->getControlModes(n_joints, js, modes);
-                    else
-                    {
-                        *rec = false;
-                        *ok = false;
-                    }
-
-                    response.addVocab(VOCAB_IS);
-                    response.addVocab(VOCAB_CM_CONTROL_MODE_GROUP);
-                    Bottle& b = response.addList();
-                    for(int i=0; i<n_joints; i++)
-                    {
-                        b.addVocab(modes[i]);
-                    }
-
-                    delete[] js;
-                    delete[] modes;
-
-                    *rec=true;
-                }
-                break;
-
-                default:
-                    yCError(CONTROLBOARDWRAPPER, "received a GET ICONTROLMODE command not understood");
+            if (modeList->size() != static_cast<size_t>(controlledJoints)) {
+                yCError(CONTROLBOARDWRAPPER, "received an invalid setControlMode message. Size of vector doesn´t match the number of controlled joints");
+                *ok = false;
                 break;
             }
+            int* modes = new int[controlledJoints];
+            for (int i = 0; i < controlledJoints; i++) {
+                modes[i] = modeList->get(i).asVocab();
+            }
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->setControlModes(modes);
+            } else {
+                *rec = false;
+                *ok = false;
+            }
+            delete[] modes;
+        } break;
+
+        default:
+        {
+            // if I´m here, someone is probably sending command using the old interface.
+            // try to be compatible as much as I can
+
+            yCError(CONTROLBOARDWRAPPER) << " Error, received a set control mode message using a legacy version, trying to be handle the message anyway "
+                                         << " but please update your client to be compatible with the IControlMode2 interface";
+
+            yCTrace(CONTROLBOARDWRAPPER) << " cmd.get(4).asVocab() is " << Vocab::decode(cmd.get(4).asVocab());
+            int axis = cmd.get(3).asInt32();
+
+            switch (cmd.get(4).asVocab()) {
+            case VOCAB_CM_POSITION:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_POSITION);
+                }
+                break;
+
+            case VOCAB_CM_POSITION_DIRECT:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_POSITION_DIRECT);
+                } else {
+                    *rec = false;
+                    *ok = false;
+                }
+                break;
+
+
+            case VOCAB_CM_VELOCITY:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_VELOCITY);
+                }
+                break;
+
+            case VOCAB_CM_TORQUE:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_TORQUE);
+                }
+                break;
+
+            case VOCAB_CM_IMPEDANCE_POS:
+                yCError(CONTROLBOARDWRAPPER) << "The 'impedancePosition' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_POSITION) instead";
+                break;
+
+            case VOCAB_CM_IMPEDANCE_VEL:
+                yCError(CONTROLBOARDWRAPPER) << "The 'impedanceVelocity' control mode is deprecated. \nUse setInteractionMode(axis, VOCAB_IM_COMPLIANT) + setControlMode(axis, VOCAB_CM_VELOCITY) instead";
+                break;
+
+            case VOCAB_CM_PWM:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_PWM);
+                } else {
+                    *rec = false;
+                    *ok = false;
+                }
+                break;
+
+            case VOCAB_CM_CURRENT:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_CURRENT);
+                } else {
+                    *rec = false;
+                    *ok = false;
+                }
+                break;
+
+            case VOCAB_CM_MIXED:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_MIXED);
+                } else {
+                    *rec = false;
+                    *ok = false;
+                }
+                break;
+
+            case VOCAB_CM_FORCE_IDLE:
+                if (rpc_iCtrlMode) {
+                    *ok = rpc_iCtrlMode->setControlMode(axis, VOCAB_CM_FORCE_IDLE);
+                } else {
+                    *rec = false;
+                    *ok = false;
+                }
+                break;
+
+            default:
+                yCError(CONTROLBOARDWRAPPER, "SET unknown controlMode : %s ", cmd.toString().c_str());
+                *ok = false;
+                *rec = false;
+                break;
+            }
+        } break; // close default case
         }
+    } break; // close SET case
+
+    case VOCAB_GET: {
+        yCTrace(CONTROLBOARDWRAPPER, "GET command");
+
+        int method = cmd.get(2).asVocab();
+
+        switch (method) {
+        case VOCAB_CM_CONTROL_MODES: {
+            yCTrace(CONTROLBOARDWRAPPER, "getControlModes");
+            int* p = new int[controlledJoints];
+            for (int i = 0; i < controlledJoints; ++i) {
+                p[i] = -1;
+            }
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->getControlModes(p);
+            }
+
+            response.addVocab(VOCAB_IS);
+            response.addVocab(VOCAB_CM_CONTROL_MODES);
+
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addVocab(p[i]);
+            }
+            delete[] p;
+
+            *rec = true;
+        } break;
+
+        case VOCAB_CM_CONTROL_MODE: {
+            yCTrace(CONTROLBOARDWRAPPER, "getControlMode");
+
+            int p = -1;
+            int axis = cmd.get(3).asInt32();
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->getControlMode(axis, &p);
+            }
+
+            response.addVocab(VOCAB_IS);
+            response.addInt32(axis);
+            response.addVocab(p);
+
+            yCTrace(CONTROLBOARDWRAPPER, "Returning %d", p);
+            *rec = true;
+        } break;
+
+        case VOCAB_CM_CONTROL_MODE_GROUP: {
+            yCTrace(CONTROLBOARDWRAPPER, "getControlMode group");
+
+            int n_joints = cmd.get(3).asInt32();
+            Bottle& lIn = *(cmd.get(4).asList());
+
+            int* js = new int[n_joints];
+            int* modes = new int[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                js[i] = lIn.get(i).asInt32();
+                modes[i] = -1;
+            }
+            if (rpc_iCtrlMode) {
+                *ok = rpc_iCtrlMode->getControlModes(n_joints, js, modes);
+            } else {
+                *rec = false;
+                *ok = false;
+            }
+
+            response.addVocab(VOCAB_IS);
+            response.addVocab(VOCAB_CM_CONTROL_MODE_GROUP);
+            Bottle& b = response.addList();
+            for (int i = 0; i < n_joints; i++) {
+                b.addVocab(modes[i]);
+            }
+
+            delete[] js;
+            delete[] modes;
+
+            *rec = true;
+        } break;
+
+        default:
+            yCError(CONTROLBOARDWRAPPER, "received a GET ICONTROLMODE command not understood");
+            break;
+        }
+    }
 
         lastRpcStamp.update();
         appendTimeStamp(response, lastRpcStamp);
         break; // case VOCAB_GET
 
-        default:
-        {
-            *rec=false;
-        }
-        break;
+    default:
+    {
+        *rec = false;
+    } break;
     }
 }
 
 
 void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
-                                        yarp::os::Bottle& response, bool *rec, bool *ok)
+                                        yarp::os::Bottle& response,
+                                        bool* rec,
+                                        bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling ITorqueControl message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling ITorqueControl message");
 
-    if (!rpc_ITorque)
-    {
+    if (!rpc_ITorque) {
         yCError(CONTROLBOARDWRAPPER, "Error, I do not have a valid ITorque interface");
-        *ok=false;
+        *ok = false;
         return;
     }
 
     int code = cmd.get(0).asVocab();
-    switch (code)
-    {
-        case VOCAB_SET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "set command received");
+    switch (code) {
+    case VOCAB_SET: {
+        *rec = true;
+        yCTrace(CONTROLBOARDWRAPPER, "set command received");
 
-            switch(cmd.get(2).asVocab())
-            {
-                case VOCAB_REF:
-                {
-                    *ok = rpc_ITorque->setRefTorque(cmd.get(3).asInt32(), cmd.get(4).asFloat64());
-                }
-                break;
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_REF: {
+            *ok = rpc_ITorque->setRefTorque(cmd.get(3).asInt32(), cmd.get(4).asFloat64());
+        } break;
 
-                case VOCAB_MOTOR_PARAMS:
-                {
-                    yarp::dev::MotorTorqueParameters params;
-                    int joint = cmd.get(3).asInt32();
-                    Bottle *b = cmd.get(4).asList();
+        case VOCAB_MOTOR_PARAMS: {
+            yarp::dev::MotorTorqueParameters params;
+            int joint = cmd.get(3).asInt32();
+            Bottle* b = cmd.get(4).asList();
 
-                    if (b==nullptr)
-                        break;
-
-                    if (b->size() != 4)
-                    {
-                        yCError(CONTROLBOARDWRAPPER, "received a SET VOCAB_MOTOR_PARAMS command not understood, size!=4");
-                        break;
-                    }
-
-                    params.bemf         = b->get(0).asFloat64();
-                    params.bemf_scale   = b->get(1).asFloat64();
-                    params.ktau         = b->get(2).asFloat64();
-                    params.ktau_scale   = b->get(3).asFloat64();
-
-                    *ok = rpc_ITorque->setMotorTorqueParams(joint, params);
-                }
-                break;
-
-                case VOCAB_REFS:
-                {
-                    Bottle *b = cmd.get(3).asList();
-                    if (b==nullptr)
-                        break;
-
-                    int i;
-                    const int njs = b->size();
-                    if (njs==controlledJoints)
-                    {
-                        auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                        for (i = 0; i < njs; i++)
-                            p[i] = b->get(i).asFloat64();
-                        *ok = rpc_ITorque->setRefTorques (p);
-                        delete[] p;
-                    }
-                }
-                break;
-
-                case VOCAB_TORQUE_MODE:
-                {
-                    if(rpc_iCtrlMode)
-                    {
-                        int *modes = new int[controlledJoints];
-                        for(int i=0; i<controlledJoints; i++)
-                            modes[i] = VOCAB_CM_TORQUE;
-                        *ok = rpc_iCtrlMode->setControlModes(modes);
-                        delete [] modes;
-                    }
-                    else
-                    {
-                        *ok = false;
-                    }
-                }
-                break;
-
-            }
-        }
-        break;
-
-        case VOCAB_GET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "get command received");
-            double dtmp  = 0.0;
-            double dtmp2 = 0.0;
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-
-            switch(cmd.get(2).asVocab())
-            {
-                case VOCAB_AXES:
-                {
-                    int tmp;
-                    *ok = rpc_ITorque->getAxes(&tmp);
-                    response.addInt32(tmp);
-                }
-                break;
-
-                case VOCAB_TRQ:
-                {
-                    *ok = rpc_ITorque->getTorque(cmd.get(3).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_MOTOR_PARAMS:
-                {
-                    yarp::dev::MotorTorqueParameters params;
-                    int joint = cmd.get(3).asInt32();
-
-                    // get the data
-                    *ok = rpc_ITorque->getMotorTorqueParams(joint, &params);
-
-                    // convert it back to yarp message
-                    Bottle& b = response.addList();
-
-                    b.addFloat64(params.bemf);
-                    b.addFloat64(params.bemf_scale);
-                    b.addFloat64(params.ktau);
-                    b.addFloat64(params.ktau_scale);
-                }
-                break;
-                case VOCAB_RANGE:
-                {
-                    *ok = rpc_ITorque->getTorqueRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);
-                    response.addFloat64(dtmp);
-                    response.addFloat64(dtmp2);
-                }
-                break;
-
-                case VOCAB_TRQS:
-                {
-                    int i=0;
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_ITorque->getTorques(p);
-                    Bottle& b = response.addList();
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_RANGES:
-                {
-                    auto* p1 = new double[controlledJoints];
-                    auto* p2 = new double[controlledJoints];
-                    *ok = rpc_ITorque->getTorqueRanges(p1,p2);
-                    Bottle& b1 = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b1.addFloat64(p1[i]);
-                    Bottle& b2 = response.addList();
-                    for (i = 0; i < controlledJoints; i++)
-                        b2.addFloat64(p2[i]);
-                    delete[] p1;
-                    delete[] p2;
-                }
-                break;
-
-                case VOCAB_REFERENCE:
-                {
-                    *ok = rpc_ITorque->getRefTorque(cmd.get(3).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_REFERENCES:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_ITorque->getRefTorques(p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
+            if (b == nullptr) {
                 break;
             }
+
+            if (b->size() != 4) {
+                yCError(CONTROLBOARDWRAPPER, "received a SET VOCAB_MOTOR_PARAMS command not understood, size!=4");
+                break;
+            }
+
+            params.bemf = b->get(0).asFloat64();
+            params.bemf_scale = b->get(1).asFloat64();
+            params.ktau = b->get(2).asFloat64();
+            params.ktau_scale = b->get(3).asFloat64();
+
+            *ok = rpc_ITorque->setMotorTorqueParams(joint, params);
+        } break;
+
+        case VOCAB_REFS: {
+            Bottle* b = cmd.get(3).asList();
+            if (b == nullptr) {
+                break;
+            }
+
+            int i;
+            const int njs = b->size();
+            if (njs == controlledJoints) {
+                auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                for (i = 0; i < njs; i++) {
+                    p[i] = b->get(i).asFloat64();
+                }
+                *ok = rpc_ITorque->setRefTorques(p);
+                delete[] p;
+            }
+        } break;
+
+        case VOCAB_TORQUE_MODE: {
+            if (rpc_iCtrlMode) {
+                int* modes = new int[controlledJoints];
+                for (int i = 0; i < controlledJoints; i++) {
+                    modes[i] = VOCAB_CM_TORQUE;
+                }
+                *ok = rpc_iCtrlMode->setControlModes(modes);
+                delete[] modes;
+            } else {
+                *ok = false;
+            }
+        } break;
         }
-            lastRpcStamp.update();
-            appendTimeStamp(response, lastRpcStamp);
+    } break;
+
+    case VOCAB_GET: {
+        *rec = true;
+        yCTrace(CONTROLBOARDWRAPPER, "get command received");
+        double dtmp = 0.0;
+        double dtmp2 = 0.0;
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_AXES: {
+            int tmp;
+            *ok = rpc_ITorque->getAxes(&tmp);
+            response.addInt32(tmp);
+        } break;
+
+        case VOCAB_TRQ: {
+            *ok = rpc_ITorque->getTorque(cmd.get(3).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_MOTOR_PARAMS: {
+            yarp::dev::MotorTorqueParameters params;
+            int joint = cmd.get(3).asInt32();
+
+            // get the data
+            *ok = rpc_ITorque->getMotorTorqueParams(joint, &params);
+
+            // convert it back to yarp message
+            Bottle& b = response.addList();
+
+            b.addFloat64(params.bemf);
+            b.addFloat64(params.bemf_scale);
+            b.addFloat64(params.ktau);
+            b.addFloat64(params.ktau_scale);
+        } break;
+        case VOCAB_RANGE: {
+            *ok = rpc_ITorque->getTorqueRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);
+            response.addFloat64(dtmp);
+            response.addFloat64(dtmp2);
+        } break;
+
+        case VOCAB_TRQS: {
+            int i = 0;
+            auto* p = new double[controlledJoints];
+            *ok = rpc_ITorque->getTorques(p);
+            Bottle& b = response.addList();
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_RANGES: {
+            auto* p1 = new double[controlledJoints];
+            auto* p2 = new double[controlledJoints];
+            *ok = rpc_ITorque->getTorqueRanges(p1, p2);
+            Bottle& b1 = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b1.addFloat64(p1[i]);
+            }
+            Bottle& b2 = response.addList();
+            for (i = 0; i < controlledJoints; i++) {
+                b2.addFloat64(p2[i]);
+            }
+            delete[] p1;
+            delete[] p2;
+        } break;
+
+        case VOCAB_REFERENCE: {
+            *ok = rpc_ITorque->getRefTorque(cmd.get(3).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_REFERENCES: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_ITorque->getRefTorques(p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+        }
+    }
+        lastRpcStamp.update();
+        appendTimeStamp(response, lastRpcStamp);
         break; // case VOCAB_GET
     }
 }
 
 void RPCMessagesParser::handleInteractionModeMsg(const yarp::os::Bottle& cmd,
-                                                 yarp::os::Bottle& response, bool *rec, bool *ok)
+                                                 yarp::os::Bottle& response,
+                                                 bool* rec,
+                                                 bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "\nHandling IInteractionMode message");
-    if (!rpc_IInteract)
-    {
+    yCTrace(CONTROLBOARDWRAPPER, "\nHandling IInteractionMode message");
+    if (!rpc_IInteract) {
         yCError(CONTROLBOARDWRAPPER, "Error I do not have a valid IInteractionMode interface");
-        *ok=false;
+        *ok = false;
         return;
     }
 
-    if (ControlBoardWrapper_p->verbose())
-    {
-        yCDebug(CONTROLBOARDWRAPPER) << "received command: " << cmd.toString();
-    }
+    yCTrace(CONTROLBOARDWRAPPER) << "received command: " << cmd.toString();
 
     int action = cmd.get(0).asVocab();
 
-    switch(action)
-    {
-        case VOCAB_SET:
-        {
-            switch (cmd.get(2).asVocab())
-            {
-                yarp::os::Bottle *jointList;
-                yarp::os::Bottle *modeList;
-                yarp::dev::InteractionModeEnum *modes;
+    switch (action) {
+    case VOCAB_SET: {
+        switch (cmd.get(2).asVocab()) {
+            yarp::os::Bottle* jointList;
+            yarp::os::Bottle* modeList;
+            yarp::dev::InteractionModeEnum* modes;
 
-                case VOCAB_INTERACTION_MODE:
-                {
-                    *ok = rpc_IInteract->setInteractionMode(cmd.get(3).asInt32(), (yarp::dev::InteractionModeEnum) cmd.get(4).asVocab());
-                }
-                break;
+        case VOCAB_INTERACTION_MODE: {
+            *ok = rpc_IInteract->setInteractionMode(cmd.get(3).asInt32(), static_cast<yarp::dev::InteractionModeEnum>(cmd.get(4).asVocab()));
+        } break;
 
-                case VOCAB_INTERACTION_MODE_GROUP:
-                {
-                    yCTrace(CONTROLBOARDWRAPPER) << "CBW.h set interactionMode GROUP";
+        case VOCAB_INTERACTION_MODE_GROUP: {
+            yCTrace(CONTROLBOARDWRAPPER) << "CBW.h set interactionMode GROUP";
 
-                    int n_joints = cmd.get(3).asInt32();
-                    jointList = cmd.get(4).asList();
-                    modeList  = cmd.get(5).asList();
-                    if( (jointList->size() != (size_t) n_joints) || (modeList->size() != (size_t) n_joints) )
-                    {
-                        if (ControlBoardWrapper_p->verbose()) {
-                            yCError(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vectors doesn´t match");
-                        }
-                        *ok = false;
-                        break;
-                    }
-                    int *joints = new int[n_joints];
-                    modes = new yarp::dev::InteractionModeEnum [n_joints];
-                    for( int i=0; i<n_joints; i++)
-                    {
-                        joints[i] = jointList->get(i).asInt32();
-                        modes[i]  = (yarp::dev::InteractionModeEnum) modeList->get(i).asVocab();
-                        yCTrace(CONTROLBOARDWRAPPER)  << "CBW.cpp received vocab " << yarp::os::Vocab::decode(modes[i]);
-                    }
-                    *ok = rpc_IInteract->setInteractionModes(n_joints, joints, modes);
-                    delete [] joints;
-                    delete [] modes;
-
-                }
-                break;
-
-                case VOCAB_INTERACTION_MODES:
-                {
-                    yCTrace(CONTROLBOARDWRAPPER)  << "CBW.c set interactionMode ALL";
-
-                    modeList  = cmd.get(3).asList();
-                    if(modeList->size() != (size_t) controlledJoints)
-                    {
-                        if (ControlBoardWrapper_p->verbose())
-                            yCError(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vector doesn´t match the number of controlled joints");
-                        *ok = false;
-                        break;
-                    }
-                    modes  = new yarp::dev::InteractionModeEnum [controlledJoints];
-                    for( int i=0; i<controlledJoints; i++)
-                    {
-                        modes[i]  = (yarp::dev::InteractionModeEnum) modeList->get(i).asVocab();
-                    }
-                    *ok = rpc_IInteract->setInteractionModes(modes);
-                    delete [] modes;
-                }
-                break;
-
-                default:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCError(CONTROLBOARDWRAPPER, "Error while Handling IInteractionMode message, SET command not understood %s", cmd.get(2).asString().c_str());
-                    *ok = false;
-                }
+            int n_joints = cmd.get(3).asInt32();
+            jointList = cmd.get(4).asList();
+            modeList = cmd.get(5).asList();
+            if ((jointList->size() != static_cast<size_t>(n_joints)) || (modeList->size() != static_cast<size_t>(n_joints))) {
+                yCWarning(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vectors doesn´t match");
+                *ok = false;
                 break;
             }
-            *rec=true; //or false
-        }
-        break;
+            int* joints = new int[n_joints];
+            modes = new yarp::dev::InteractionModeEnum[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                joints[i] = jointList->get(i).asInt32();
+                modes[i] = static_cast<yarp::dev::InteractionModeEnum>(modeList->get(i).asVocab());
+                yCTrace(CONTROLBOARDWRAPPER) << "CBW.cpp received vocab " << yarp::os::Vocab::decode(modes[i]);
+            }
+            *ok = rpc_IInteract->setInteractionModes(n_joints, joints, modes);
+            delete[] joints;
+            delete[] modes;
 
-        case VOCAB_GET:
-        {
-            yarp::os::Bottle *jointList;
+        } break;
 
-            switch (cmd.get(2).asVocab())
-            {
-                case VOCAB_INTERACTION_MODE:
-                {
-                    yarp::dev::InteractionModeEnum mode;
-                    *ok = rpc_IInteract->getInteractionMode(cmd.get(3).asInt32(), &mode);
-                    response.addVocab(mode);
-                    if (ControlBoardWrapper_p->verbose())    yCDebug(CONTROLBOARDWRAPPER)  << " resp is " << response.toString();
-                }
-                break;
+        case VOCAB_INTERACTION_MODES: {
+            yCTrace(CONTROLBOARDWRAPPER) << "CBW.c set interactionMode ALL";
 
-                case VOCAB_INTERACTION_MODE_GROUP:
-                {
-                    yarp::dev::InteractionModeEnum* modes;
-
-                    int n_joints = cmd.get(3).asInt32();
-                    jointList = cmd.get(4).asList();
-                    if(jointList->size() != (size_t) n_joints )
-                    {
-                    yCError(CONTROLBOARDWRAPPER, "Received an invalid getInteractionMode message. Size of vectors doesn´t match");
-                        *ok = false;
-                        break;
-                    }
-                    int *joints = new int[n_joints];
-                    modes       = new yarp::dev::InteractionModeEnum [n_joints];
-                    for( int i=0; i<n_joints; i++)
-                    {
-                        joints[i] = jointList->get(i).asInt32();
-                    }
-                    *ok = rpc_IInteract->getInteractionModes(n_joints, joints, modes);
-
-                    Bottle& c = response.addList();
-                    for( int i=0; i<n_joints; i++)
-                    {
-                        c.addVocab(modes[i]);
-                    }
-
-                    if (ControlBoardWrapper_p->verbose())
-                    {
-                    yCDebug(CONTROLBOARDWRAPPER, "got response bottle");
-                        response.toString();
-                    }
-                    delete [] joints;
-                    delete [] modes;
-                }
-                break;
-
-                case VOCAB_INTERACTION_MODES:
-                {
-                    yarp::dev::InteractionModeEnum* modes;
-                    modes  = new yarp::dev::InteractionModeEnum [controlledJoints];
-
-                    *ok = rpc_IInteract->getInteractionModes(modes);
-
-                    Bottle& b = response.addList();
-                    for( int i=0; i<controlledJoints; i++)
-                    {
-                        b.addVocab(modes[i]);
-                    }
-                    if (ControlBoardWrapper_p->verbose())
-                    {
-                        yCDebug(CONTROLBOARDWRAPPER, "got response bottle");
-                        response.toString();
-                    }
-                    delete [] modes;
-                }
+            modeList = cmd.get(3).asList();
+            if (modeList->size() != static_cast<size_t>(controlledJoints)) {
+                yCWarning(CONTROLBOARDWRAPPER, "Received an invalid setInteractionMode message. Size of vector doesn´t match the number of controlled joints");
+                *ok = false;
                 break;
             }
-            lastRpcStamp.update();
-            appendTimeStamp(response, lastRpcStamp);
-        }
-        break; // case VOCAB_GET
+            modes = new yarp::dev::InteractionModeEnum[controlledJoints];
+            for (int i = 0; i < controlledJoints; i++) {
+                modes[i] = static_cast<yarp::dev::InteractionModeEnum>(modeList->get(i).asVocab());
+            }
+            *ok = rpc_IInteract->setInteractionModes(modes);
+            delete[] modes;
+        } break;
 
         default:
-        yCError(CONTROLBOARDWRAPPER, "Error while Handling IInteractionMode message, command was not SET nor GET");
+        {
+            yCWarning(CONTROLBOARDWRAPPER, "Error while Handling IInteractionMode message, SET command not understood %s", cmd.get(2).asString().c_str());
             *ok = false;
-        break;
+        } break;
+        }
+        *rec = true; //or false
+    } break;
 
+    case VOCAB_GET: {
+        yarp::os::Bottle* jointList;
+
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_INTERACTION_MODE: {
+            yarp::dev::InteractionModeEnum mode;
+            *ok = rpc_IInteract->getInteractionMode(cmd.get(3).asInt32(), &mode);
+            response.addVocab(mode);
+            yCTrace(CONTROLBOARDWRAPPER) << " resp is " << response.toString();
+        } break;
+
+        case VOCAB_INTERACTION_MODE_GROUP: {
+            yarp::dev::InteractionModeEnum* modes;
+
+            int n_joints = cmd.get(3).asInt32();
+            jointList = cmd.get(4).asList();
+            if (jointList->size() != static_cast<size_t>(n_joints)) {
+                yCError(CONTROLBOARDWRAPPER, "Received an invalid getInteractionMode message. Size of vectors doesn´t match");
+                *ok = false;
+                break;
+            }
+            int* joints = new int[n_joints];
+            modes = new yarp::dev::InteractionModeEnum[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                joints[i] = jointList->get(i).asInt32();
+            }
+            *ok = rpc_IInteract->getInteractionModes(n_joints, joints, modes);
+
+            Bottle& c = response.addList();
+            for (int i = 0; i < n_joints; i++) {
+                c.addVocab(modes[i]);
+            }
+
+            yCTrace(CONTROLBOARDWRAPPER, "got response bottle: %s", response.toString().c_str());
+
+            delete[] joints;
+            delete[] modes;
+        } break;
+
+        case VOCAB_INTERACTION_MODES: {
+            yarp::dev::InteractionModeEnum* modes;
+            modes = new yarp::dev::InteractionModeEnum[controlledJoints];
+
+            *ok = rpc_IInteract->getInteractionModes(modes);
+
+            Bottle& b = response.addList();
+            for (int i = 0; i < controlledJoints; i++) {
+                b.addVocab(modes[i]);
+            }
+
+            yCTrace(CONTROLBOARDWRAPPER, "got response bottle: %s", response.toString().c_str());
+
+            delete[] modes;
+        } break;
+        }
+        lastRpcStamp.update();
+        appendTimeStamp(response, lastRpcStamp);
+    } break; // case VOCAB_GET
+
+    default:
+        yCError(CONTROLBOARDWRAPPER, "Error while Handling IInteractionMode message, command was not SET nor GET");
+        *ok = false;
+        break;
     }
 }
 
-void RPCMessagesParser::handleCurrentMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool *rec, bool *ok)
+void RPCMessagesParser::handleCurrentMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling ICurrentControl message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling ICurrentControl message");
 
-    if (!rpc_ICurrent)
-    {
+    if (!rpc_ICurrent) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid ICurrentControl interface");
         *ok = false;
         return;
@@ -864,133 +736,105 @@ void RPCMessagesParser::handleCurrentMsg(const yarp::os::Bottle& cmd, yarp::os::
 
     *ok = false;
     *rec = true;
-    switch (code)
-    {
-    case VOCAB_SET:
-    {
-        switch (action)
+    switch (code) {
+    case VOCAB_SET: {
+        switch (action) {
+        case VOCAB_CURRENT_REF: {
+            yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REF methods is implemented as streaming");
+            *ok = false;
+        } break;
+
+        case VOCAB_CURRENT_REFS: {
+            yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REFS methods is implemented as streaming");
+            *ok = false;
+        } break;
+
+        case VOCAB_CURRENT_REF_GROUP: {
+            yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REF_GROUP methods is implemented as streaming");
+            *ok = false;
+        } break;
+
+        default:
         {
-            case VOCAB_CURRENT_REF:
-            {
-                yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REF methods is implemented as streaming");
-                *ok = false;
-            }
-            break;
-
-            case VOCAB_CURRENT_REFS:
-            {
-                yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REFS methods is implemented as streaming");
-                *ok = false;
-            }
-            break;
-
-            case VOCAB_CURRENT_REF_GROUP:
-            {
-                yCError(CONTROLBOARDWRAPPER, "VOCAB_CURRENT_REF_GROUP methods is implemented as streaming");
-                *ok = false;
-            }
-            break;
-
-            default:
-            {
-                yCError(CONTROLBOARDWRAPPER) << "Unknown handleCurrentMsg message received";
-                *rec = false;
-                *ok = false;
-            }
-            break;
+            yCError(CONTROLBOARDWRAPPER) << "Unknown handleCurrentMsg message received";
+            *rec = false;
+            *ok = false;
+        } break;
         }
-    }
-    break;
+    } break;
 
-    case VOCAB_GET:
-    {
+    case VOCAB_GET: {
         *rec = true;
-        if (ControlBoardWrapper_p->verbose())
-            yCDebug(CONTROLBOARDWRAPPER, "get command received");
+        yCTrace(CONTROLBOARDWRAPPER, "get command received");
         double dtmp = 0.0;
         double dtmp2 = 0.0;
         response.addVocab(VOCAB_IS);
         response.add(cmd.get(1));
 
-        switch (action)
+        switch (action) {
+        case VOCAB_CURRENT_REF: {
+            *ok = rpc_ICurrent->getRefCurrent(cmd.get(3).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_CURRENT_REFS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_ICurrent->getRefCurrents(p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_CURRENT_RANGE: {
+
+            *ok = rpc_ICurrent->getCurrentRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);
+            response.addFloat64(dtmp);
+            response.addFloat64(dtmp2);
+        } break;
+
+        case VOCAB_CURRENT_RANGES: {
+            auto* p1 = new double[controlledJoints];
+            auto* p2 = new double[controlledJoints];
+            *ok = rpc_ICurrent->getCurrentRanges(p1, p2);
+            Bottle& b1 = response.addList();
+            Bottle& b2 = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b1.addFloat64(p1[i]);
+            }
+            for (i = 0; i < controlledJoints; i++) {
+                b2.addFloat64(p2[i]);
+            }
+            delete[] p1;
+            delete[] p2;
+        } break;
+
+        default:
         {
-            case VOCAB_CURRENT_REF:
-            {
-                *ok = rpc_ICurrent->getRefCurrent(cmd.get(3).asInt32(), &dtmp);
-                response.addFloat64(dtmp);
-            }
-            break;
-
-            case VOCAB_CURRENT_REFS:
-            {
-                auto* p = new double[controlledJoints];
-                *ok = rpc_ICurrent->getRefCurrents(p);
-                Bottle& b = response.addList();
-                int i;
-                for (i = 0; i < controlledJoints; i++)
-                    b.addFloat64(p[i]);
-                delete[] p;
-            }
-            break;
-
-            case VOCAB_CURRENT_RANGE:
-            {
-
-                *ok = rpc_ICurrent->getCurrentRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);
-                response.addFloat64(dtmp);
-                response.addFloat64(dtmp2);
-            }
-            break;
-
-            case VOCAB_CURRENT_RANGES:
-            {
-                auto* p1 = new double[controlledJoints];
-                auto* p2 = new double[controlledJoints];
-                *ok = rpc_ICurrent->getCurrentRanges(p1,p2);
-                Bottle& b1 = response.addList();
-                Bottle& b2 = response.addList();
-                int i;
-                for (i = 0; i < controlledJoints; i++)
-                {
-                    b1.addFloat64(p1[i]);
-                }
-                for (i = 0; i < controlledJoints; i++)
-                {
-                    b2.addFloat64(p2[i]);
-                }
-                delete[] p1;
-                delete[] p2;
-            }
-            break;
-
-            default:
-            {
-                yCError(CONTROLBOARDWRAPPER) << "Unknown handleCurrentMsg message received";
-                *rec = false;
-                *ok = false;
-            }
-            break;
+            yCError(CONTROLBOARDWRAPPER) << "Unknown handleCurrentMsg message received";
+            *rec = false;
+            *ok = false;
+        } break;
         }
-    }
-    break;
+    } break;
 
     default:
     {
         yCError(CONTROLBOARDWRAPPER) << "Unknown handleCurrentMsg message received";
         *rec = false;
         *ok = false;
-    }
-    break;
+    } break;
     }
 }
 
-void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool *rec, bool *ok)
+void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IPidControl message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IPidControl message");
 
-    if (!rpc_IPid)
-    {
+    if (!rpc_IPid) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid IPidControl interface");
         *ok = false;
         return;
@@ -1002,324 +846,273 @@ void RPCMessagesParser::handlePidMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
 
     *ok = false;
     *rec = true;
-    switch (code)
+    switch (code) {
+    case VOCAB_SET: {
+        *rec = true;
+        yCTrace(CONTROLBOARDWRAPPER, "set command received");
+
+        switch (action) {
+        case VOCAB_OFFSET: {
+            double v;
+            int j = cmd.get(4).asInt32();
+            v = cmd.get(5).asFloat64();
+            *ok = rpc_IPid->setPidOffset(pidtype, j, v);
+        } break;
+
+        case VOCAB_PID: {
+            Pid p;
+            int j = cmd.get(4).asInt32();
+            Bottle* b = cmd.get(5).asList();
+
+            if (b == nullptr) {
+                break;
+            }
+
+            p.kp = b->get(0).asFloat64();
+            p.kd = b->get(1).asFloat64();
+            p.ki = b->get(2).asFloat64();
+            p.max_int = b->get(3).asFloat64();
+            p.max_output = b->get(4).asFloat64();
+            p.offset = b->get(5).asFloat64();
+            p.scale = b->get(6).asFloat64();
+            p.stiction_up_val = b->get(7).asFloat64();
+            p.stiction_down_val = b->get(8).asFloat64();
+            p.kff = b->get(9).asFloat64();
+            *ok = rpc_IPid->setPid(pidtype, j, p);
+        } break;
+
+        case VOCAB_PIDS: {
+            Bottle* b = cmd.get(4).asList();
+
+            if (b == nullptr) {
+                break;
+            }
+
+            int i;
+            const int njs = b->size();
+            if (njs == controlledJoints) {
+                Pid* p = new Pid[njs];
+
+                bool allOK = true;
+
+                for (i = 0; i < njs; i++) {
+                    Bottle* c = b->get(i).asList();
+                    if (c != nullptr) {
+                        p[i].kp = c->get(0).asFloat64();
+                        p[i].kd = c->get(1).asFloat64();
+                        p[i].ki = c->get(2).asFloat64();
+                        p[i].max_int = c->get(3).asFloat64();
+                        p[i].max_output = c->get(4).asFloat64();
+                        p[i].offset = c->get(5).asFloat64();
+                        p[i].scale = c->get(6).asFloat64();
+                        p[i].stiction_up_val = c->get(7).asFloat64();
+                        p[i].stiction_down_val = c->get(8).asFloat64();
+                        p[i].kff = c->get(9).asFloat64();
+                    } else {
+                        allOK = false;
+                    }
+                }
+                if (allOK) {
+                    *ok = rpc_IPid->setPids(pidtype, p);
+                } else {
+                    *ok = false;
+                }
+
+                delete[] p;
+            }
+        } break;
+
+        case VOCAB_REF: {
+            *ok = rpc_IPid->setPidReference(pidtype, cmd.get(4).asInt32(), cmd.get(5).asFloat64());
+        } break;
+
+        case VOCAB_REFS: {
+            Bottle* b = cmd.get(4).asList();
+
+            if (b == nullptr) {
+                break;
+            }
+
+            int i;
+            const int njs = b->size();
+            if (njs == controlledJoints) {
+                auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                for (i = 0; i < njs; i++) {
+                    p[i] = b->get(i).asFloat64();
+                }
+                *ok = rpc_IPid->setPidReferences(pidtype, p);
+                delete[] p;
+            }
+        } break;
+
+        case VOCAB_LIM: {
+            *ok = rpc_IPid->setPidErrorLimit(pidtype, cmd.get(4).asInt32(), cmd.get(5).asFloat64());
+        } break;
+
+        case VOCAB_LIMS: {
+            Bottle* b = cmd.get(4).asList();
+            int i;
+
+            if (b == nullptr) {
+                break;
+            }
+
+            const int njs = b->size();
+            if (njs == controlledJoints) {
+                auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                for (i = 0; i < njs; i++) {
+                    p[i] = b->get(i).asFloat64();
+                }
+                *ok = rpc_IPid->setPidErrorLimits(pidtype, p);
+                delete[] p;
+            }
+        } break;
+
+        case VOCAB_RESET: {
+            *ok = rpc_IPid->resetPid(pidtype, cmd.get(4).asInt32());
+        } break;
+
+        case VOCAB_DISABLE: {
+            *ok = rpc_IPid->disablePid(pidtype, cmd.get(4).asInt32());
+        } break;
+
+        case VOCAB_ENABLE: {
+            *ok = rpc_IPid->enablePid(pidtype, cmd.get(4).asInt32());
+        } break;
+        }
+    } break;
+
+    case VOCAB_GET: {
+        *rec = true;
+        yCTrace(CONTROLBOARDWRAPPER, "get command received");
+        double dtmp = 0.0;
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+
+        switch (action) {
+        case VOCAB_LIMS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPid->getPidErrorLimits(pidtype, p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_ENABLE: {
+            bool booltmp = false;
+            *ok = rpc_IPid->isPidEnabled(pidtype, cmd.get(4).asInt32(), &booltmp);
+            response.addInt32(booltmp);
+        } break;
+
+        case VOCAB_ERR: {
+            *ok = rpc_IPid->getPidError(pidtype, cmd.get(4).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_ERRS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPid->getPidErrors(pidtype, p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_OUTPUT: {
+            *ok = rpc_IPid->getPidOutput(pidtype, cmd.get(4).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_OUTPUTS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPid->getPidOutputs(pidtype, p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_PID: {
+            Pid p;
+            *ok = rpc_IPid->getPid(pidtype, cmd.get(4).asInt32(), &p);
+            Bottle& b = response.addList();
+            b.addFloat64(p.kp);
+            b.addFloat64(p.kd);
+            b.addFloat64(p.ki);
+            b.addFloat64(p.max_int);
+            b.addFloat64(p.max_output);
+            b.addFloat64(p.offset);
+            b.addFloat64(p.scale);
+            b.addFloat64(p.stiction_up_val);
+            b.addFloat64(p.stiction_down_val);
+            b.addFloat64(p.kff);
+        } break;
+
+        case VOCAB_PIDS: {
+            Pid* p = new Pid[controlledJoints];
+            *ok = rpc_IPid->getPids(pidtype, p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                Bottle& c = b.addList();
+                c.addFloat64(p[i].kp);
+                c.addFloat64(p[i].kd);
+                c.addFloat64(p[i].ki);
+                c.addFloat64(p[i].max_int);
+                c.addFloat64(p[i].max_output);
+                c.addFloat64(p[i].offset);
+                c.addFloat64(p[i].scale);
+                c.addFloat64(p[i].stiction_up_val);
+                c.addFloat64(p[i].stiction_down_val);
+                c.addFloat64(p[i].kff);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_REFERENCE: {
+            *ok = rpc_IPid->getPidReference(pidtype, cmd.get(4).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_REFERENCES: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPid->getPidReferences(pidtype, p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_LIM: {
+            *ok = rpc_IPid->getPidErrorLimit(pidtype, cmd.get(4).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+        }
+    } break;
+
+    default:
     {
-        case VOCAB_SET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "set command received");
-
-            switch(action)
-            {
-                case VOCAB_OFFSET:
-                {
-                    double v;
-                    int j = cmd.get(4).asInt32();
-                    v=cmd.get(5).asFloat64();
-                    *ok = rpc_IPid->setPidOffset(pidtype, j, v);
-                }
-                break;
-
-                case VOCAB_PID:
-                {
-                    Pid p;
-                    int j = cmd.get(4).asInt32();
-                    Bottle *b = cmd.get(5).asList();
-
-                    if (b==nullptr)
-                        break;
-
-                    p.kp = b->get(0).asFloat64();
-                    p.kd = b->get(1).asFloat64();
-                    p.ki = b->get(2).asFloat64();
-                    p.max_int = b->get(3).asFloat64();
-                    p.max_output = b->get(4).asFloat64();
-                    p.offset = b->get(5).asFloat64();
-                    p.scale = b->get(6).asFloat64();
-                    p.stiction_up_val = b->get(7).asFloat64();
-                    p.stiction_down_val = b->get(8).asFloat64();
-                    p.kff = b->get(9).asFloat64();
-                    *ok = rpc_IPid->setPid(pidtype, j, p);
-                }
-                break;
-
-                case VOCAB_PIDS:
-                {
-                    Bottle *b = cmd.get(4).asList();
-
-                    if (b==nullptr)
-                        break;
-
-                    int i;
-                    const int njs = b->size();
-                    if (njs==controlledJoints)
-                    {
-                        Pid *p = new Pid[njs];
-
-                        bool allOK=true;
-
-                        for (i = 0; i < njs; i++)
-                        {
-                            Bottle *c = b->get(i).asList();
-                            if (c!=nullptr)
-                            {
-                                p[i].kp = c->get(0).asFloat64();
-                                p[i].kd = c->get(1).asFloat64();
-                                p[i].ki = c->get(2).asFloat64();
-                                p[i].max_int = c->get(3).asFloat64();
-                                p[i].max_output = c->get(4).asFloat64();
-                                p[i].offset = c->get(5).asFloat64();
-                                p[i].scale = c->get(6).asFloat64();
-                                p[i].stiction_up_val = c->get(7).asFloat64();
-                                p[i].stiction_down_val = c->get(8).asFloat64();
-                                p[i].kff = c->get(9).asFloat64();
-                            }
-                            else
-                            {
-                                allOK=false;
-                            }
-                        }
-                        if (allOK)
-                            *ok = rpc_IPid->setPids(pidtype, p);
-                        else
-                            *ok=false;
-
-                        delete[] p;
-                    }
-                }
-                break;
-
-                case VOCAB_REF:
-                {
-                    *ok = rpc_IPid->setPidReference (pidtype, cmd.get(4).asInt32(), cmd.get(5).asFloat64());
-                }
-                break;
-
-                case VOCAB_REFS:
-                {
-                    Bottle *b = cmd.get(4).asList();
-
-                    if (b==nullptr)
-                        break;
-
-                    int i;
-                    const int njs = b->size();
-                    if (njs==controlledJoints)
-                    {
-                        auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                        for (i = 0; i < njs; i++)
-                            p[i] = b->get(i).asFloat64();
-                        *ok = rpc_IPid->setPidReferences (pidtype, p);
-                        delete[] p;
-                    }
-                }
-                break;
-
-                case VOCAB_LIM:
-                {
-                    *ok = rpc_IPid->setPidErrorLimit (pidtype, cmd.get(4).asInt32(), cmd.get(5).asFloat64());
-                }
-                break;
-
-                case VOCAB_LIMS:
-                {
-                    Bottle *b = cmd.get(4).asList();
-                    int i;
-
-                    if (b==nullptr)
-                        break;
-
-                    const int njs = b->size();
-                    if (njs==controlledJoints)
-                    {
-                        auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                        for (i = 0; i < njs; i++)
-                            p[i] = b->get(i).asFloat64();
-                        *ok = rpc_IPid->setPidErrorLimits (pidtype, p);
-                        delete[] p;
-                    }
-                }
-                break;
-
-                case VOCAB_RESET:
-                {
-                    *ok = rpc_IPid->resetPid (pidtype, cmd.get(4).asInt32());
-                }
-                break;
-
-                case VOCAB_DISABLE:
-                {
-                    *ok = rpc_IPid->disablePid (pidtype, cmd.get(4).asInt32());
-                }
-                break;
-
-                case VOCAB_ENABLE:
-                {
-                    *ok = rpc_IPid->enablePid (pidtype, cmd.get(4).asInt32());
-                }
-                break;
-            }
-        }
-        break;
-
-        case VOCAB_GET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "get command received");
-            double dtmp = 0.0;
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-
-            switch (action)
-            {
-                case VOCAB_LIMS:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPid->getPidErrorLimits(pidtype, p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_ENABLE:
-                {
-                    bool booltmp=false;
-                    *ok = rpc_IPid->isPidEnabled(pidtype, cmd.get(4).asInt32(), &booltmp);
-                    response.addInt32(booltmp);
-                }
-                break;
-
-                case VOCAB_ERR:
-                {
-                    *ok = rpc_IPid->getPidError(pidtype, cmd.get(4).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_ERRS:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPid->getPidErrors(pidtype, p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_OUTPUT:
-                {
-                    *ok = rpc_IPid->getPidOutput(pidtype, cmd.get(4).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_OUTPUTS:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPid->getPidOutputs(pidtype, p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_PID:
-                {
-                    Pid p;
-                    *ok = rpc_IPid->getPid(pidtype, cmd.get(4).asInt32(), &p);
-                    Bottle& b = response.addList();
-                    b.addFloat64(p.kp);
-                    b.addFloat64(p.kd);
-                    b.addFloat64(p.ki);
-                    b.addFloat64(p.max_int);
-                    b.addFloat64(p.max_output);
-                    b.addFloat64(p.offset);
-                    b.addFloat64(p.scale);
-                    b.addFloat64(p.stiction_up_val);
-                    b.addFloat64(p.stiction_down_val);
-                    b.addFloat64(p.kff);
-                }
-                break;
-
-                case VOCAB_PIDS:
-                {
-                    Pid *p = new Pid[controlledJoints];
-                    *ok = rpc_IPid->getPids(pidtype, p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                    {
-                        Bottle& c = b.addList();
-                        c.addFloat64(p[i].kp);
-                        c.addFloat64(p[i].kd);
-                        c.addFloat64(p[i].ki);
-                        c.addFloat64(p[i].max_int);
-                        c.addFloat64(p[i].max_output);
-                        c.addFloat64(p[i].offset);
-                        c.addFloat64(p[i].scale);
-                        c.addFloat64(p[i].stiction_up_val);
-                        c.addFloat64(p[i].stiction_down_val);
-                        c.addFloat64(p[i].kff);
-                    }
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_REFERENCE:
-                {
-                    *ok = rpc_IPid->getPidReference(pidtype, cmd.get(4).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_REFERENCES:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPid->getPidReferences(pidtype, p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_LIM:
-                {
-                    *ok = rpc_IPid->getPidErrorLimit(pidtype, cmd.get(4).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-            }
-        }
-        break;
-
-        default:
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
-            *rec = false;
-            *ok = false;
-        }
-        break;
+        yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
+        *rec = false;
+        *ok = false;
+    } break;
     }
 }
 
-void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool *rec, bool *ok)
+void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IPWMControl message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IPWMControl message");
 
-    if (!rpc_IPWM)
-    {
+    if (!rpc_IPWM) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid IPWMControl interface");
         *ok = false;
         return;
@@ -1330,110 +1123,88 @@ void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
 
     *ok = false;
     *rec = true;
-    switch (code)
-    {
-        case VOCAB_SET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "set command received");
+    switch (code) {
+    case VOCAB_SET: {
+        *rec = true;
+        yCTrace(CONTROLBOARDWRAPPER, "set command received");
 
-            switch (action)
-            {
-                case VOCAB_PWMCONTROL_REF_PWM:
-                {
-                    //handled as streaming!
-                    yCError(CONTROLBOARDWRAPPER) << "VOCAB_PWMCONTROL_REF_PWM handled as straming";
-                    *ok = false;
-                }
-                break;
-
-                default:
-                {
-                    yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
-                    *ok = false;
-                }
-                break;
-            }
-        }
-        break;
-
-        case VOCAB_GET:
-        {
-            *rec = true;
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "get command received");
-            double dtmp = 0.0;
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-
-            switch (action)
-            {
-                case VOCAB_PWMCONTROL_REF_PWM:
-                {
-                    *ok = rpc_IPWM->getRefDutyCycle(cmd.get(3).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_PWMCONTROL_REF_PWMS:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPWM->getRefDutyCycles(p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                case VOCAB_PWMCONTROL_PWM_OUTPUT:
-                {
-                    *ok = rpc_IPWM->getDutyCycle(cmd.get(3).asInt32(), &dtmp);
-                    response.addFloat64(dtmp);
-                }
-                break;
-
-                case VOCAB_PWMCONTROL_PWM_OUTPUTS:
-                {
-                    auto* p = new double[controlledJoints];
-                    *ok = rpc_IPWM->getRefDutyCycles(p);
-                    Bottle& b = response.addList();
-                    int i;
-                    for (i = 0; i < controlledJoints; i++)
-                        b.addFloat64(p[i]);
-                    delete[] p;
-                }
-                break;
-
-                default:
-                {
-                    yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
-                    *ok = false;
-                }
-                break;
-            }
-        }
-        break;
+        switch (action) {
+        case VOCAB_PWMCONTROL_REF_PWM: {
+            //handled as streaming!
+            yCError(CONTROLBOARDWRAPPER) << "VOCAB_PWMCONTROL_REF_PWM handled as straming";
+            *ok = false;
+        } break;
 
         default:
         {
             yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
-            *rec = false;
             *ok = false;
+        } break;
         }
-        break;
+    } break;
+
+    case VOCAB_GET: {
+        yCTrace(CONTROLBOARDWRAPPER, "get command received");
+        *rec = true;
+        double dtmp = 0.0;
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+
+        switch (action) {
+        case VOCAB_PWMCONTROL_REF_PWM: {
+            *ok = rpc_IPWM->getRefDutyCycle(cmd.get(3).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_PWMCONTROL_REF_PWMS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPWM->getRefDutyCycles(p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        case VOCAB_PWMCONTROL_PWM_OUTPUT: {
+            *ok = rpc_IPWM->getDutyCycle(cmd.get(3).asInt32(), &dtmp);
+            response.addFloat64(dtmp);
+        } break;
+
+        case VOCAB_PWMCONTROL_PWM_OUTPUTS: {
+            auto* p = new double[controlledJoints];
+            *ok = rpc_IPWM->getRefDutyCycles(p);
+            Bottle& b = response.addList();
+            int i;
+            for (i = 0; i < controlledJoints; i++) {
+                b.addFloat64(p[i]);
+            }
+            delete[] p;
+        } break;
+
+        default:
+        {
+            yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
+            *ok = false;
+        } break;
+        }
+    } break;
+
+    default:
+    {
+        yCError(CONTROLBOARDWRAPPER) << "Unknown handlePWMMsg message received";
+        *rec = false;
+        *ok = false;
+    } break;
     }
 }
 
-void RPCMessagesParser::handleRemoteVariablesMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool *rec, bool *ok)
+void RPCMessagesParser::handleRemoteVariablesMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IRemoteCalibrator message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IRemoteCalibrator message");
 
-    if (!rpc_IRemoteCalibrator)
-    {
+    if (!rpc_IRemoteCalibrator) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid IRemoteCalibrator interface");
         *ok = false;
         return;
@@ -1444,1348 +1215,1163 @@ void RPCMessagesParser::handleRemoteVariablesMsg(const yarp::os::Bottle& cmd, ya
 
     *ok = false;
     *rec = true;
-    switch (code)
-    {
-        case VOCAB_SET:
+    switch (code) {
+    case VOCAB_SET: {
+        switch (action) {
+        case VOCAB_VARIABLE: {
+            Bottle btail = cmd.tail().tail().tail().tail(); // remove the first four elements
+            string s = btail.toString();
+            *ok = rpc_IVar->setRemoteVariable(cmd.get(3).asString(), btail);
+        } break;
+
+        default:
         {
-            switch (action)
-            {
-                case VOCAB_VARIABLE:
-                {
-                    Bottle btail = cmd.tail().tail().tail().tail(); // remove the first four elements
-                    string s = btail.toString();
-                    *ok = rpc_IVar->setRemoteVariable(cmd.get(3).asString(), btail);
-                }
-                break;
-
-                default:
-                {
-                    *rec = false;
-                    *ok = false;
-                } break;
-             }
+            *rec = false;
+            *ok = false;
+        } break;
         }
-        break;
+    } break;
 
-        case VOCAB_GET:
-        {
-            response.clear();
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-            Bottle btmp;
+    case VOCAB_GET: {
+        yCTrace(CONTROLBOARDWRAPPER, "get command received");
 
-            if (ControlBoardWrapper_p->verbose())
-                yCDebug(CONTROLBOARDWRAPPER, "get command received");
+        response.clear();
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+        Bottle btmp;
 
-            switch (action)
-            {
-                case VOCAB_VARIABLE:
-                {
-                    *ok = rpc_IVar->getRemoteVariable(cmd.get(3).asString(), btmp);
-                    Bottle& b = response.addList();
-                    b = btmp;
-                }
-                break;
+        switch (action) {
+        case VOCAB_VARIABLE: {
+            *ok = rpc_IVar->getRemoteVariable(cmd.get(3).asString(), btmp);
+            Bottle& b = response.addList();
+            b = btmp;
+        } break;
 
-                case VOCAB_LIST_VARIABLES:
-                {
-                    *ok = rpc_IVar->getRemoteVariablesList(&btmp);
-                    Bottle& b = response.addList();
-                    b = btmp;
-                }
-                break;
-            }
+        case VOCAB_LIST_VARIABLES: {
+            *ok = rpc_IVar->getRemoteVariablesList(&btmp);
+            Bottle& b = response.addList();
+            b = btmp;
+        } break;
         }
-    }   //end get/set switch
+    }
+    } //end get/set switch
 }
 
-void RPCMessagesParser::handleRemoteCalibratorMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool *rec, bool *ok)
+void RPCMessagesParser::handleRemoteCalibratorMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    if(ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "Handling IRemoteCalibrator message");
+    yCTrace(CONTROLBOARDWRAPPER, "Handling IRemoteCalibrator message");
 
-    if (!rpc_IRemoteCalibrator)
-    {
+    if (!rpc_IRemoteCalibrator) {
         yCError(CONTROLBOARDWRAPPER, "controlBoardWrapper: I do not have a valid IRemoteCalibrator interface");
-        *ok=false;
+        *ok = false;
         return;
     }
 
-    int code   = cmd.get(0).asVocab();
+    int code = cmd.get(0).asVocab();
     int action = cmd.get(2).asVocab();
 
-    *ok=false;
-    *rec=true;
-    switch(code)
-    {
-        case VOCAB_SET:
+    *ok = false;
+    *rec = true;
+    switch (code) {
+    case VOCAB_SET: {
+        switch (action) {
+        case VOCAB_CALIBRATE_SINGLE_JOINT: {
+            yCDebug(CONTROLBOARDWRAPPER) << "cmd is " << cmd.toString() << " joint is " << cmd.get(3).asInt32();
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
+            *ok = rpc_IRemoteCalibrator->calibrateSingleJoint(cmd.get(3).asInt32());
+        } break;
+
+        case VOCAB_CALIBRATE_WHOLE_PART: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
+            *ok = rpc_IRemoteCalibrator->calibrateWholePart();
+        } break;
+
+        case VOCAB_HOMING_SINGLE_JOINT: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
+            *ok = rpc_IRemoteCalibrator->homingSingleJoint(cmd.get(3).asInt32());
+        } break;
+
+        case VOCAB_HOMING_WHOLE_PART: {
+            yCDebug(CONTROLBOARDWRAPPER) << "Received homing whole part";
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
+            *ok = rpc_IRemoteCalibrator->homingWholePart();
+        } break;
+
+        case VOCAB_PARK_SINGLE_JOINT: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
+            *ok = rpc_IRemoteCalibrator->parkSingleJoint(cmd.get(3).asInt32());
+        } break;
+
+        case VOCAB_PARK_WHOLE_PART: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
+            *ok = rpc_IRemoteCalibrator->parkWholePart();
+        } break;
+
+        case VOCAB_QUIT_CALIBRATE: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling quit calibrate");
+            *ok = rpc_IRemoteCalibrator->quitCalibrate();
+        } break;
+
+        case VOCAB_QUIT_PARK: {
+            yCTrace(CONTROLBOARDWRAPPER, "Calling quit park");
+            *ok = rpc_IRemoteCalibrator->quitPark();
+        } break;
+
+        default:
         {
-            switch(action)
-            {
-                case VOCAB_CALIBRATE_SINGLE_JOINT:
-                {
-                    yCDebug(CONTROLBOARDWRAPPER) << "cmd is " << cmd.toString() << " joint is " << cmd.get(3).asInt32();
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
-                    *ok = rpc_IRemoteCalibrator->calibrateSingleJoint(cmd.get(3).asInt32());
-                } break;
-
-                case VOCAB_CALIBRATE_WHOLE_PART:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
-                    *ok = rpc_IRemoteCalibrator->calibrateWholePart();
-                } break;
-
-                case VOCAB_HOMING_SINGLE_JOINT:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
-                    *ok = rpc_IRemoteCalibrator->homingSingleJoint(cmd.get(3).asInt32());
-                } break;
-
-                case VOCAB_HOMING_WHOLE_PART:
-                {
-                    yCDebug(CONTROLBOARDWRAPPER) << "Received homing whole part";
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
-                    *ok = rpc_IRemoteCalibrator->homingWholePart();
-                } break;
-
-                case VOCAB_PARK_SINGLE_JOINT:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate joint with no parameter");
-                    *ok = rpc_IRemoteCalibrator->parkSingleJoint(cmd.get(3).asInt32());
-                } break;
-
-                case VOCAB_PARK_WHOLE_PART:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate whole part");
-                    *ok = rpc_IRemoteCalibrator->parkWholePart();
-                } break;
-
-                case VOCAB_QUIT_CALIBRATE:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling quit calibrate");
-                    *ok = rpc_IRemoteCalibrator->quitCalibrate();
-                } break;
-
-                case VOCAB_QUIT_PARK:
-                {
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling quit park");
-                    *ok = rpc_IRemoteCalibrator->quitPark();
-                } break;
-
-                default:
-                {
-                    *rec = false;
-                    *ok = false;
-                } break;
-            }
-        }break;
-
-        case VOCAB_GET:
-        {
-            response.clear();
-            response.addVocab(VOCAB_IS);
-            response.add(cmd.get(1));
-
-            switch(action)
-            {
-                case VOCAB_IS_CALIBRATOR_PRESENT:
-                {
-                    bool tmp;
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling VOCAB_IS_CALIBRATOR_PRESENT");
-                    *ok = rpc_IRemoteCalibrator->isCalibratorDevicePresent(&tmp);
-                    response.addInt32(tmp);
-                } break;
-            }
+            *rec = false;
+            *ok = false;
+        } break;
         }
-    }   //end get/set switch
+    } break;
+
+    case VOCAB_GET: {
+        response.clear();
+        response.addVocab(VOCAB_IS);
+        response.add(cmd.get(1));
+
+        switch (action) {
+        case VOCAB_IS_CALIBRATOR_PRESENT: {
+            bool tmp;
+            yCTrace(CONTROLBOARDWRAPPER, "Calling VOCAB_IS_CALIBRATOR_PRESENT");
+            *ok = rpc_IRemoteCalibrator->isCalibratorDevicePresent(&tmp);
+            response.addInt32(tmp);
+        } break;
+        }
+    }
+    } //end get/set switch
 }
 
 
 // rpc callback
 bool RPCMessagesParser::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response)
 {
-    bool ok  = false;
-    bool rec = false;    // Tells if the command is recognized!
+    bool ok = false;
+    bool rec = false; // Tells if the command is recognized!
 
-    if (ControlBoardWrapper_p->verbose())
-        yCDebug(CONTROLBOARDWRAPPER, "command received: %s", cmd.toString().c_str());
+    yCTrace(CONTROLBOARDWRAPPER, "command received: %s", cmd.toString().c_str());
 
     int code = cmd.get(0).asVocab();
 
-    if(cmd.size() < 2)
-    {
+    if (cmd.size() < 2) {
         ok = false;
-    }
-    else
-    {
-        switch (cmd.get(1).asVocab())
-        {
-            case VOCAB_PID:
-                handlePidMsg(cmd, response, &rec, &ok);
+    } else {
+        switch (cmd.get(1).asVocab()) {
+        case VOCAB_PID:
+            handlePidMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_TORQUE:
-                handleTorqueMsg(cmd, response, &rec, &ok);
+        case VOCAB_TORQUE:
+            handleTorqueMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_ICONTROLMODE:
-                handleControlModeMsg(cmd, response, &rec, &ok);
+        case VOCAB_ICONTROLMODE:
+            handleControlModeMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_IMPEDANCE:
-                handleImpedanceMsg(cmd, response, &rec, &ok);
+        case VOCAB_IMPEDANCE:
+            handleImpedanceMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_INTERFACE_INTERACTION_MODE:
-                handleInteractionModeMsg(cmd, response, &rec, &ok);
+        case VOCAB_INTERFACE_INTERACTION_MODE:
+            handleInteractionModeMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_PROTOCOL_VERSION:
-                handleProtocolVersionRequest(cmd, response, &rec, &ok);
+        case VOCAB_PROTOCOL_VERSION:
+            handleProtocolVersionRequest(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_REMOTE_CALIBRATOR_INTERFACE:
-                handleRemoteCalibratorMsg(cmd, response, &rec, &ok);
+        case VOCAB_REMOTE_CALIBRATOR_INTERFACE:
+            handleRemoteCalibratorMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_REMOTE_VARIABILE_INTERFACE:
-                handleRemoteVariablesMsg(cmd, response, &rec, &ok);
+        case VOCAB_REMOTE_VARIABILE_INTERFACE:
+            handleRemoteVariablesMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_CURRENTCONTROL_INTERFACE:
-                handleCurrentMsg(cmd, response, &rec, &ok);
+        case VOCAB_CURRENTCONTROL_INTERFACE:
+            handleCurrentMsg(cmd, response, &rec, &ok);
             break;
 
-            case VOCAB_PWMCONTROL_INTERFACE:
-                handlePWMMsg(cmd, response, &rec, &ok);
-                break;
+        case VOCAB_PWMCONTROL_INTERFACE:
+            handlePWMMsg(cmd, response, &rec, &ok);
+            break;
 
-            default:
-                // fallback for old interfaces with no specific name
-                switch (code)
-                {
-                    case VOCAB_CALIBRATE_JOINT:
-                    {
-                        rec=true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate joint");
+        default:
+            // fallback for old interfaces with no specific name
+            switch (code) {
+            case VOCAB_CALIBRATE_JOINT: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate joint");
 
-                        int j=cmd.get(1).asInt32();
-                        int ui=cmd.get(2).asInt32();
-                        double v1=cmd.get(3).asFloat64();
-                        double v2=cmd.get(4).asFloat64();
-                        double v3=cmd.get(5).asFloat64();
-                        if (rpc_Icalib==nullptr)
-                            yCError(CONTROLBOARDWRAPPER, "Sorry I don't have a IControlCalibration2 interface");
-                        else
-                            ok=rpc_Icalib->calibrateAxisWithParams(j,ui,v1,v2,v3);
+                int j = cmd.get(1).asInt32();
+                int ui = cmd.get(2).asInt32();
+                double v1 = cmd.get(3).asFloat64();
+                double v2 = cmd.get(4).asFloat64();
+                double v3 = cmd.get(5).asFloat64();
+                if (rpc_Icalib == nullptr) {
+                    yCError(CONTROLBOARDWRAPPER, "Sorry I don't have a IControlCalibration2 interface");
+                } else {
+                    ok = rpc_Icalib->calibrateAxisWithParams(j, ui, v1, v2, v3);
+                }
+            } break;
+
+            case VOCAB_CALIBRATE_JOINT_PARAMS: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate joint");
+
+                int j = cmd.get(1).asInt32();
+                CalibrationParameters params;
+                params.type = cmd.get(2).asInt32();
+                params.param1 = cmd.get(3).asFloat64();
+                params.param2 = cmd.get(4).asFloat64();
+                params.param3 = cmd.get(5).asFloat64();
+                params.param4 = cmd.get(6).asFloat64();
+                if (rpc_Icalib == nullptr) {
+                    yCError(CONTROLBOARDWRAPPER, "Sorry I don't have a IControlCalibration2 interface");
+                } else {
+                    ok = rpc_Icalib->setCalibrationParameters(j, params);
+                }
+            } break;
+
+            case VOCAB_CALIBRATE: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate");
+                ok = rpc_Icalib->calibrateRobot();
+            } break;
+
+            case VOCAB_CALIBRATE_DONE: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "Calling calibrate done");
+                int j = cmd.get(1).asInt32();
+                ok = rpc_Icalib->calibrationDone(j);
+            } break;
+
+            case VOCAB_PARK: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "Calling park function");
+                int flag = cmd.get(1).asInt32();
+                if (flag) {
+                    ok = rpc_Icalib->park(true);
+                } else {
+                    ok = rpc_Icalib->park(false);
+                }
+                ok = true; //client would get stuck if returning false
+            } break;
+
+            case VOCAB_SET: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "set command received");
+
+                switch (cmd.get(1).asVocab()) {
+                case VOCAB_POSITION_MOVE: {
+                    ok = rpc_IPosCtrl->positionMove(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                    // this operation is also available on "command" port
+                case VOCAB_POSITION_MOVES: {
+                    Bottle* b = cmd.get(2).asList();
+                    int i;
+                    if (b == nullptr) {
+                        break;
                     }
-                    break;
-
-                    case VOCAB_CALIBRATE_JOINT_PARAMS:
-                    {
-                        rec = true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate joint");
-
-                        int j = cmd.get(1).asInt32();
-                        CalibrationParameters params;
-                        params.type = cmd.get(2).asInt32();
-                        params.param1 = cmd.get(3).asFloat64();
-                        params.param2 = cmd.get(4).asFloat64();
-                        params.param3 = cmd.get(5).asFloat64();
-                        params.param4 = cmd.get(6).asFloat64();
-                        if (rpc_Icalib == nullptr)
-                            yCError(CONTROLBOARDWRAPPER, "Sorry I don't have a IControlCalibration2 interface");
-                        else
-                            ok = rpc_Icalib->setCalibrationParameters(j, params);
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
                     }
-                    break;
-
-                    case VOCAB_CALIBRATE:
-                    {
-                        rec=true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate");
-                        ok=rpc_Icalib->calibrateRobot();
+                    tmpVect.resize(njs);
+                    for (i = 0; i < njs; i++) {
+                        tmpVect[i] = b->get(i).asFloat64();
                     }
-                    break;
 
-                    case VOCAB_CALIBRATE_DONE:
-                    {
-                        rec=true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "Calling calibrate done");
-                        int j=cmd.get(1).asInt32();
-                        ok=rpc_Icalib->calibrationDone(j);
+                    if (rpc_IPosCtrl != nullptr) {
+                        ok = rpc_IPosCtrl->positionMove(&tmpVect[0]);
                     }
-                    break;
+                } break;
 
-                    case VOCAB_PARK:
-                    {
-                        rec=true;
-                    if (ControlBoardWrapper_p->verbose())
-                        yCDebug(CONTROLBOARDWRAPPER, "Calling park function");
-                        int flag=cmd.get(1).asInt32();
-                        if (flag)
-                            ok=rpc_Icalib->park(true);
-                        else
-                            ok=rpc_Icalib->park(false);
-                        ok=true; //client would get stuck if returning false
-                    }
-                    break;
+                case VOCAB_POSITION_MOVE_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle* jlut = cmd.get(3).asList();
+                    Bottle* pos_val = cmd.get(4).asList();
 
-                    case VOCAB_SET:
-                    {
-                        rec = true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "set command received");
-
-                        switch(cmd.get(1).asVocab())
-                        {
-                            case VOCAB_POSITION_MOVE:
-                            {
-                                ok = rpc_IPosCtrl->positionMove(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                                // this operation is also available on "command" port
-                            case VOCAB_POSITION_MOVES:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-                                int i;
-                                if (b==nullptr)
-                                    break;
-                                const int njs = b->size();
-                                if (njs!=controlledJoints)
-                                    break;
-                                tmpVect.resize(njs);
-                                for (i = 0; i < njs; i++)
-                                    tmpVect[i] = b->get(i).asFloat64();
-
-                                if (rpc_IPosCtrl!=nullptr)
-                                    ok = rpc_IPosCtrl->positionMove(&tmpVect[0]);
-                            }
-                            break;
-
-                            case VOCAB_POSITION_MOVE_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle *jlut = cmd.get(3).asList();
-                                Bottle *pos_val= cmd.get(4).asList();
-
-                                if (rpc_IPosCtrl == nullptr)
-                                    break;
-
-                                if (jlut==nullptr || pos_val==nullptr)
-                                    break;
-                                if ((size_t) len!=jlut->size() || (size_t) len!=pos_val->size())
-                                    break;
-
-                                int *j_tmp=new int [len];
-                                auto* pos_tmp=new double [len];
-
-                                for (int i = 0; i < len; i++)
-                                    j_tmp[i] = jlut->get(i).asInt32();
-
-                                for (int i = 0; i < len; i++)
-                                    pos_tmp[i] = pos_val->get(i).asFloat64();
-
-                                ok = rpc_IPosCtrl->positionMove(len, j_tmp, pos_tmp);
-
-                                delete [] j_tmp;
-                                delete [] pos_tmp;
-                            }
-                            break;
-
-                                // this operation is also available on "command" port
-                            case VOCAB_VELOCITY_MOVES:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-                                int i;
-                                if (b==nullptr)
-                                    break;
-                                const int njs = b->size();
-                                if (njs!=controlledJoints)
-                                    break;
-                                tmpVect.resize(njs);
-                                for (i = 0; i < njs; i++)
-                                    tmpVect[i] = b->get(i).asFloat64();
-                                if (rpc_IVelCtrl!=nullptr)
-                                    ok = rpc_IVelCtrl->velocityMove(&tmpVect[0]);
-
-                            }
-                            break;
-
-                            case VOCAB_RELATIVE_MOVE:
-                            {
-                                ok = rpc_IPosCtrl->relativeMove(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_RELATIVE_MOVE_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle *jBottle_p = cmd.get(3).asList();
-                                Bottle *posBottle_p= cmd.get(4).asList();
-
-                                if (rpc_IPosCtrl == nullptr)
-                                    break;
-
-                                if (jBottle_p==nullptr || posBottle_p==nullptr)
-                                    break;
-                                if ((size_t) len!=jBottle_p->size() || (size_t) len!=posBottle_p->size())
-                                    break;
-
-                                int *j_tmp=new int [len];
-                                auto* pos_tmp=new double [len];
-
-                                for (int i = 0; i < len; i++)
-                                    j_tmp[i] = jBottle_p->get(i).asInt32();
-
-                                for (int i = 0; i < len; i++)
-                                    pos_tmp[i] = posBottle_p->get(i).asFloat64();
-
-                                ok = rpc_IPosCtrl->relativeMove(len, j_tmp, pos_tmp);
-
-                                delete [] j_tmp;
-                                delete [] pos_tmp;
-                            }
-                            break;
-
-                            case VOCAB_RELATIVE_MOVES:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-
-                                if (b==nullptr)
-                                    break;
-
-                                int i;
-                                const int njs = b->size();
-                                if(njs!=controlledJoints)
-                                    break;
-                                auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                                for (i = 0; i < njs; i++)
-                                    p[i] = b->get(i).asFloat64();
-                                ok = rpc_IPosCtrl->relativeMove(p);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEED:
-                            {
-                                ok = rpc_IPosCtrl->setRefSpeed(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEED_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle *jBottle_p = cmd.get(3).asList();
-                                Bottle *velBottle_p= cmd.get(4).asList();
-
-                                if (rpc_IPosCtrl == nullptr)
-                                    break;
-
-                                if (jBottle_p==nullptr || velBottle_p==nullptr)
-                                    break;
-                                if ((size_t) len!=jBottle_p->size() || (size_t) len!=velBottle_p->size())
-                                    break;
-
-                                int *j_tmp=new int [len];
-                                auto* spds_tmp=new double [len];
-
-                                for (int i = 0; i < len; i++)
-                                    j_tmp[i] = jBottle_p->get(i).asInt32();
-
-                                for (int i = 0; i < len; i++)
-                                    spds_tmp[i] = velBottle_p->get(i).asFloat64();
-
-                                ok = rpc_IPosCtrl->setRefSpeeds(len, j_tmp, spds_tmp);
-                                delete[] j_tmp;
-                                delete[] spds_tmp;
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEEDS:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-
-                                if (b==nullptr)
-                                    break;
-
-                                int i;
-                                const int njs = b->size();
-                                if (njs!=controlledJoints)
-                                    break;
-                                auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                                for (i = 0; i < njs; i++)
-                                    p[i] = b->get(i).asFloat64();
-                                ok = rpc_IPosCtrl->setRefSpeeds(p);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATION:
-                            {
-                                ok = rpc_IPosCtrl->setRefAcceleration(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATION_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle *jBottle_p = cmd.get(3).asList();
-                                Bottle *accBottle_p = cmd.get(4).asList();
-
-                                if (rpc_IPosCtrl == nullptr)
-                                    break;
-
-                                if (jBottle_p==nullptr || accBottle_p==nullptr)
-                                    break;
-                                if ((size_t) len!=jBottle_p->size() || (size_t) len!=accBottle_p->size())
-                                    break;
-
-                                int *j_tmp = new int [len];
-                                auto* accs_tmp = new double [len];
-
-                                for (int i = 0; i < len; i++)
-                                    j_tmp[i] = jBottle_p->get(i).asInt32();
-
-                                for (int i = 0; i < len; i++)
-                                    accs_tmp[i] = accBottle_p->get(i).asFloat64();
-
-                                ok = rpc_IPosCtrl->setRefAccelerations(len, j_tmp, accs_tmp);
-                                delete[] j_tmp;
-                                delete[] accs_tmp;
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATIONS:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-
-                                if (b==nullptr)
-                                    break;
-
-                                int i;
-                                const int njs = b->size();
-                                if(njs!=controlledJoints)
-                                    break;
-                                auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                                for (i = 0; i < njs; i++)
-                                    p[i] = b->get(i).asFloat64();
-                                ok = rpc_IPosCtrl->setRefAccelerations(p);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_STOP:
-                            {
-                                ok = rpc_IPosCtrl->stop(cmd.get(2).asInt32());
-                            }
-                            break;
-
-                            case VOCAB_STOP_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle *jBottle_p = cmd.get(3).asList();
-
-                                if (rpc_IPosCtrl == nullptr)
-                                    break;
-
-                                if (jBottle_p==nullptr)
-                                    break;
-                                if ((size_t) len!=jBottle_p->size())
-                                    break;
-
-                                int *j_tmp = new int [len];
-
-                                for (int i = 0; i < len; i++)
-                                    j_tmp[i] = jBottle_p->get(i).asInt32();
-
-                                ok = rpc_IPosCtrl->stop(len, j_tmp);
-                                delete[] j_tmp;
-                            }
-                            break;
-
-                            case VOCAB_STOPS:
-                            {
-                                ok = rpc_IPosCtrl->stop();
-                            }
-                            break;
-
-                            case VOCAB_E_RESET:
-                            {
-                                ok = rpc_IEncTimed->resetEncoder(cmd.get(2).asInt32());
-                            }
-                            break;
-
-                            case VOCAB_E_RESETS:
-                            {
-                                ok = rpc_IEncTimed->resetEncoders();
-                            }
-                            break;
-
-                            case VOCAB_ENCODER:
-                            {
-                                ok = rpc_IEncTimed->setEncoder(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_ENCODERS:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-
-                                if (b==nullptr)
-                                    break;
-
-                                int i;
-                                const int njs = b->size();
-                                if (njs!=controlledJoints)
-                                    break;
-                                auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                                for (i = 0; i < njs; i++)
-                                    p[i] = b->get(i).asFloat64();
-                                ok = rpc_IEncTimed->setEncoders(p);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_CPR:
-                            {
-                                ok = rpc_IMotEnc->setMotorEncoderCountsPerRevolution(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_E_RESET:
-                            {
-                                ok = rpc_IMotEnc->resetMotorEncoder(cmd.get(2).asInt32());
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_E_RESETS:
-                            {
-                                ok = rpc_IMotEnc->resetMotorEncoders();
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER:
-                            {
-                                ok = rpc_IMotEnc->setMotorEncoder(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODERS:
-                            {
-                                Bottle *b = cmd.get(2).asList();
-
-                                if (b==nullptr)
-                                    break;
-
-                                int i;
-                                const int njs = b->size();
-                                if (njs!=controlledJoints)
-                                    break;
-                                auto* p = new double[njs];    // LATER: optimize to avoid allocation.
-                                for (i = 0; i < njs; i++)
-                                    p[i] = b->get(i).asFloat64();
-                                ok = rpc_IMotEnc->setMotorEncoders(p);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_AMP_ENABLE:
-                            {
-                                ok = rcp_IAmp->enableAmp(cmd.get(2).asInt32());
-                            }
-                            break;
-
-                            case VOCAB_AMP_DISABLE:
-                            {
-                                ok = rcp_IAmp->disableAmp(cmd.get(2).asInt32());
-                            }
-                            break;
-
-                            case VOCAB_AMP_MAXCURRENT:
-                            {
-                                ok = rcp_IAmp->setMaxCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_AMP_PEAK_CURRENT:
-                            {
-                                ok = rcp_IAmp->setPeakCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_AMP_NOMINAL_CURRENT:
-                            {
-                                ok = rcp_IAmp->setNominalCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_AMP_PWM_LIMIT:
-                            {
-                                ok = rcp_IAmp->setPWMLimit(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_LIMITS:
-                            {
-                                ok = rcp_Ilim->setLimits(cmd.get(2).asInt32(), cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
-                            }
-                            break;
-
-
-                            case VOCAB_TEMPERATURE_LIMIT:
-                            {
-                                ok = rpc_IMotor->setTemperatureLimit(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_GEARBOX_RATIO:
-                            {
-                                ok = rpc_IMotor->setGearboxRatio(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
-                            }
-                            break;
-
-                            case VOCAB_VEL_LIMITS:
-                            {
-                                ok = rcp_Ilim->setVelLimits(cmd.get(2).asInt32(), cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
-                            }
-                            break;
-
-                            default:
-                            {
-                                yCError(CONTROLBOARDWRAPPER, "received an unknown command after a VOCAB_SET (%s)", cmd.toString().c_str());
-                            }
-                            break;
-                        } //switch(cmd.get(1).asVocab()
+                    if (rpc_IPosCtrl == nullptr) {
                         break;
                     }
 
-                    case VOCAB_GET:
-                    {
-                        rec = true;
-                        if (ControlBoardWrapper_p->verbose())
-                            yCDebug(CONTROLBOARDWRAPPER, "get command received");
-
-                        double dtmp = 0.0;
-                        Bottle btmp;
-                        response.addVocab(VOCAB_IS);
-                        response.add(cmd.get(1));
-
-                        switch(cmd.get(1).asVocab())
-                        {
-
-                            case VOCAB_TEMPERATURE_LIMIT:
-                            {
-                                ok = rpc_IMotor->getTemperatureLimit(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_TEMPERATURE:
-                            {
-                                ok = rpc_IMotor->getTemperature(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_GEARBOX_RATIO:
-                            {
-                                ok = rpc_IMotor->getGearboxRatio(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_TEMPERATURES:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IMotor->getTemperatures(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_AMP_MAXCURRENT:
-                            {
-                                ok = rcp_IAmp->getMaxCurrent(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_POSITION_MOVE:
-                            {
-                                if (ControlBoardWrapper_p->verbose())
-                                    yCDebug(CONTROLBOARDWRAPPER, "getTargetPosition");
-
-                                ok = rpc_IPosCtrl->getTargetPosition(cmd.get(2).asInt32(), &dtmp);
-
-                                response.addFloat64(dtmp);
-                                rec=true;
-                            }
-                            break;
-
-                            case VOCAB_POSITION_MOVE_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                auto* refs = new double[len];
-
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                ok = rpc_IPosCtrl->getTargetPositions(len, jointList, refs);
-
-                                Bottle& b = response.addList();
-                                for (int i = 0; i < len; i++)
-                                    b.addFloat64(refs[i]);
-
-                                delete[] jointList;
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_POSITION_MOVES:
-                            {
-                                auto* refs = new double[controlledJoints];
-                                ok = rpc_IPosCtrl->getTargetPositions(refs);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(refs[i]);
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_POSITION_DIRECT:
-                            {
-                                if (ControlBoardWrapper_p->verbose())
-                                    yCDebug(CONTROLBOARDWRAPPER, "getRefPosition");
-
-                                ok = rpc_IPosDirect->getRefPosition(cmd.get(2).asInt32(), &dtmp);
-
-                                response.addFloat64(dtmp);
-                                rec=true;
-                            }
-                            break;
-
-                            case VOCAB_POSITION_DIRECT_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                auto* refs = new double[len];
-
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                ok = rpc_IPosDirect->getRefPositions(len, jointList, refs);
-
-                                Bottle& b = response.addList();
-                                for (int i = 0; i < len; i++)
-                                    b.addFloat64(refs[i]);
-
-                                delete[] jointList;
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_POSITION_DIRECTS:
-                            {
-                                auto* refs = new double[controlledJoints];
-                                ok = rpc_IPosDirect->getRefPositions(refs);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(refs[i]);
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_VELOCITY_MOVE:
-                            {
-                                if (ControlBoardWrapper_p->verbose())
-                                    yCDebug(CONTROLBOARDWRAPPER, "getVelocityMove - cmd: %s", cmd.toString().c_str());
-
-                                ok = rpc_IVelCtrl->getRefVelocity(cmd.get(2).asInt32(), &dtmp);
-
-                                response.addFloat64(dtmp);
-                                rec=true;
-                            }
-                            break;
-
-                            case VOCAB_VELOCITY_MOVE_GROUP:
-                            {
-                                if (ControlBoardWrapper_p->verbose())
-                                    yCDebug(CONTROLBOARDWRAPPER, "getVelocityMove_group - cmd: %s", cmd.toString().c_str());
-
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                auto* refs = new double[len];
-
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                ok = rpc_IVelCtrl->getRefVelocities(len, jointList, refs);
-
-                                Bottle& b = response.addList();
-                                for (int i = 0; i < len; i++)
-                                    b.addFloat64(refs[i]);
-
-                                delete[] jointList;
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_VELOCITY_MOVES:
-                            {
-                                if (ControlBoardWrapper_p->verbose())
-                                    yCDebug(CONTROLBOARDWRAPPER, "getVelocityMoves - cmd: %s", cmd.toString().c_str());
-
-                                auto* refs = new double[controlledJoints];
-                                ok = rpc_IVelCtrl->getRefVelocities(refs);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(refs[i]);
-                                delete[] refs;
-                            }
-                            break;
-
-                            case VOCAB_MOTORS_NUMBER:
-                            {
-                                int tmp;
-                                ok = rpc_IMotor->getNumberOfMotors(&tmp);
-                                response.addInt32(tmp);
-                            }
-                            break;
-
-                            case VOCAB_AXES:
-                            {
-                                int tmp;
-                                ok = rpc_IPosCtrl->getAxes(&tmp);
-                                response.addInt32(tmp);
-                            }
-                            break;
-
-                            case VOCAB_MOTION_DONE:
-                            {
-                                bool x = false;;
-                                ok = rpc_IPosCtrl->checkMotionDone(cmd.get(2).asInt32(), &x);
-                                response.addInt32(x);
-                            }
-                            break;
-
-                            case VOCAB_MOTION_DONE_GROUP:
-                            {
-                                bool x = false;
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                if(rpc_IPosCtrl!=nullptr)
-                                    ok = rpc_IPosCtrl->checkMotionDone(len, jointList, &x);
-                                response.addInt32(x);
-
-                                delete[] jointList;
-                            }
-                            break;
-
-                            case VOCAB_MOTION_DONES:
-                            {
-                                bool x = false;
-                                ok = rpc_IPosCtrl->checkMotionDone(&x);
-                                response.addInt32(x);
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEED:
-                            {
-                                ok = rpc_IPosCtrl->getRefSpeed(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEED_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                auto* speeds = new double[len];
-
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                ok = rpc_IPosCtrl->getRefSpeeds(len, jointList, speeds);
-
-                                Bottle& b = response.addList();
-                                for (int i = 0; i < len; i++)
-                                    b.addFloat64(speeds[i]);
-
-                                delete[] jointList;
-                                delete[] speeds;
-                            }
-                            break;
-
-                            case VOCAB_REF_SPEEDS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IPosCtrl->getRefSpeeds(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATION:
-                            {
-                                ok = rpc_IPosCtrl->getRefAcceleration(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATION_GROUP:
-                            {
-                                int len = cmd.get(2).asInt32();
-                                Bottle& in = *(cmd.get(3).asList());
-                                int *jointList = new int[len];
-                                auto* accs = new double[len];
-
-                                for(int j=0; j<len; j++)
-                                {
-                                    jointList[j] = in.get(j).asInt32();
-                                }
-                                ok = rpc_IPosCtrl->getRefAccelerations(len, jointList, accs);
-
-                                Bottle& b = response.addList();
-                                for (int i = 0; i < len; i++)
-                                    b.addFloat64(accs[i]);
-
-                            delete[] jointList;
-                            delete[] accs;
-                            }
-                            break;
-
-                            case VOCAB_REF_ACCELERATIONS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IPosCtrl->getRefAccelerations(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_ENCODER:
-                            {
-                                ok = rpc_IEncTimed->getEncoder(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_ENCODERS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IEncTimed->getEncoders(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_ENCODER_SPEED:
-                            {
-                                ok = rpc_IEncTimed->getEncoderSpeed(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_ENCODER_SPEEDS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IEncTimed->getEncoderSpeeds(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_ENCODER_ACCELERATION:
-                            {
-                                ok = rpc_IEncTimed->getEncoderAcceleration(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_ENCODER_ACCELERATIONS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IEncTimed->getEncoderAccelerations(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_CPR:
-                            {
-                                ok = rpc_IMotEnc->getMotorEncoderCountsPerRevolution(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER:
-                            {
-                                ok = rpc_IMotEnc->getMotorEncoder(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODERS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IMotEnc->getMotorEncoders(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER_SPEED:
-                            {
-                                ok = rpc_IMotEnc->getMotorEncoderSpeed(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER_SPEEDS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IMotEnc->getMotorEncoderSpeeds(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER_ACCELERATION:
-                            {
-                                ok = rpc_IMotEnc->getMotorEncoderAcceleration(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER_ACCELERATIONS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rpc_IMotEnc->getMotorEncoderAccelerations(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_MOTOR_ENCODER_NUMBER:
-                            {
-                                int num=0;
-                                ok = rpc_IMotEnc->getNumberOfMotorEncoders(&num);
-                                response.addInt32(num);
-                            }
-                            break;
-
-                            case VOCAB_AMP_CURRENT:
-                            {
-                                ok = rcp_IAmp->getCurrent(cmd.get(2).asInt32(), &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_CURRENTS:
-                            {
-                                auto* p = new double[controlledJoints];
-                                ok = rcp_IAmp->getCurrents(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addFloat64(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_AMP_STATUS:
-                            {
-                                int *p = new int[controlledJoints];
-                                ok = rcp_IAmp->getAmpStatus(p);
-                                Bottle& b = response.addList();
-                                int i;
-                                for (i = 0; i < controlledJoints; i++)
-                                    b.addInt32(p[i]);
-                                delete[] p;
-                            }
-                            break;
-
-                            case VOCAB_AMP_STATUS_SINGLE:
-                            {
-                                int j=cmd.get(2).asInt32();
-                                int itmp;
-                                ok = rcp_IAmp->getAmpStatus(j, &itmp);
-                                response.addInt32(itmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_NOMINAL_CURRENT:
-                            {
-                                int m=cmd.get(2).asInt32();
-                                ok = rcp_IAmp->getNominalCurrent(m, &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_PEAK_CURRENT:
-                            {
-                                int m=cmd.get(2).asInt32();
-                                ok = rcp_IAmp->getPeakCurrent(m, &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_PWM:
-                            {
-                                int m=cmd.get(2).asInt32();
-                                ok = rcp_IAmp->getPWM(m, &dtmp);
-                                yCTrace(CONTROLBOARDWRAPPER) << "RPC parser::getPWM: j" << m << " val " << dtmp;
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_PWM_LIMIT:
-                            {
-                                int m=cmd.get(2).asInt32();
-                                ok = rcp_IAmp->getPWMLimit(m, &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_AMP_VOLTAGE_SUPPLY:
-                            {
-                                int m=cmd.get(2).asInt32();
-                                ok = rcp_IAmp->getPowerSupplyVoltage(m, &dtmp);
-                                response.addFloat64(dtmp);
-                            }
-                            break;
-
-                            case VOCAB_LIMITS:
-                            {
-                                double min = 0.0, max = 0.0;
-                                ok = rcp_Ilim->getLimits(cmd.get(2).asInt32(), &min, &max);
-                                response.addFloat64(min);
-                                response.addFloat64(max);
-                            }
-                            break;
-
-                            case VOCAB_VEL_LIMITS:
-                            {
-                                double min = 0.0, max = 0.0;
-                                ok = rcp_Ilim->getVelLimits(cmd.get(2).asInt32(), &min, &max);
-                                response.addFloat64(min);
-                                response.addFloat64(max);
-                            }
-                            break;
-
-                            case VOCAB_INFO_NAME:
-                            {
-                                std::string name = "undocumented";
-                                ok = rpc_AxisInfo->getAxisName(cmd.get(2).asInt32(),name);
-                                response.addString(name.c_str());
-                            }
-                            break;
-
-                            case VOCAB_INFO_TYPE:
-                            {
-                                 yarp::dev::JointTypeEnum type;
-                                 ok = rpc_AxisInfo->getJointType(cmd.get(2).asInt32(), type);
-                                 response.addInt32(type);
-                            }
-                            break;
-
-                            default:
-                            {
-                                 yCError(CONTROLBOARDWRAPPER, "received an unknown request after a VOCAB_GET: %s", yarp::os::Vocab::decode(cmd.get(1).asVocab()).c_str());
-                            }
-                            break;
-                        } //switch cmd.get(1).asVocab())
-
-                        lastRpcStamp.update();
-                        appendTimeStamp(response, lastRpcStamp);
-                    } // case VOCAB_GET
-                    default:
-                    break;
-                } //switch code
-
-                if (!rec)
+                    if (jlut == nullptr || pos_val == nullptr) {
+                        break;
+                    }
+                    if (static_cast<size_t>(len) != jlut->size() || static_cast<size_t>(len) != pos_val->size()) {
+                        break;
+                    }
+
+                    int* j_tmp = new int[len];
+                    auto* pos_tmp = new double[len];
+
+                    for (int i = 0; i < len; i++) {
+                        j_tmp[i] = jlut->get(i).asInt32();
+                    }
+
+                    for (int i = 0; i < len; i++) {
+                        pos_tmp[i] = pos_val->get(i).asFloat64();
+                    }
+
+                    ok = rpc_IPosCtrl->positionMove(len, j_tmp, pos_tmp);
+
+                    delete[] j_tmp;
+                    delete[] pos_tmp;
+                } break;
+
+                    // this operation is also available on "command" port
+                case VOCAB_VELOCITY_MOVES: {
+                    Bottle* b = cmd.get(2).asList();
+                    int i;
+                    if (b == nullptr) {
+                        break;
+                    }
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    tmpVect.resize(njs);
+                    for (i = 0; i < njs; i++) {
+                        tmpVect[i] = b->get(i).asFloat64();
+                    }
+                    if (rpc_IVelCtrl != nullptr) {
+                        ok = rpc_IVelCtrl->velocityMove(&tmpVect[0]);
+                    }
+
+                } break;
+
+                case VOCAB_RELATIVE_MOVE: {
+                    ok = rpc_IPosCtrl->relativeMove(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_RELATIVE_MOVE_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle* jBottle_p = cmd.get(3).asList();
+                    Bottle* posBottle_p = cmd.get(4).asList();
+
+                    if (rpc_IPosCtrl == nullptr) {
+                        break;
+                    }
+
+                    if (jBottle_p == nullptr || posBottle_p == nullptr) {
+                        break;
+                    }
+                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != posBottle_p->size()) {
+                        break;
+                    }
+
+                    int* j_tmp = new int[len];
+                    auto* pos_tmp = new double[len];
+
+                    for (int i = 0; i < len; i++) {
+                        j_tmp[i] = jBottle_p->get(i).asInt32();
+                    }
+
+                    for (int i = 0; i < len; i++) {
+                        pos_tmp[i] = posBottle_p->get(i).asFloat64();
+                    }
+
+                    ok = rpc_IPosCtrl->relativeMove(len, j_tmp, pos_tmp);
+
+                    delete[] j_tmp;
+                    delete[] pos_tmp;
+                } break;
+
+                case VOCAB_RELATIVE_MOVES: {
+                    Bottle* b = cmd.get(2).asList();
+
+                    if (b == nullptr) {
+                        break;
+                    }
+
+                    int i;
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                    for (i = 0; i < njs; i++) {
+                        p[i] = b->get(i).asFloat64();
+                    }
+                    ok = rpc_IPosCtrl->relativeMove(p);
+                    delete[] p;
+                } break;
+
+                case VOCAB_REF_SPEED: {
+                    ok = rpc_IPosCtrl->setRefSpeed(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_REF_SPEED_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle* jBottle_p = cmd.get(3).asList();
+                    Bottle* velBottle_p = cmd.get(4).asList();
+
+                    if (rpc_IPosCtrl == nullptr) {
+                        break;
+                    }
+
+                    if (jBottle_p == nullptr || velBottle_p == nullptr) {
+                        break;
+                    }
+                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != velBottle_p->size()) {
+                        break;
+                    }
+
+                    int* j_tmp = new int[len];
+                    auto* spds_tmp = new double[len];
+
+                    for (int i = 0; i < len; i++) {
+                        j_tmp[i] = jBottle_p->get(i).asInt32();
+                    }
+
+                    for (int i = 0; i < len; i++) {
+                        spds_tmp[i] = velBottle_p->get(i).asFloat64();
+                    }
+
+                    ok = rpc_IPosCtrl->setRefSpeeds(len, j_tmp, spds_tmp);
+                    delete[] j_tmp;
+                    delete[] spds_tmp;
+                } break;
+
+                case VOCAB_REF_SPEEDS: {
+                    Bottle* b = cmd.get(2).asList();
+
+                    if (b == nullptr) {
+                        break;
+                    }
+
+                    int i;
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                    for (i = 0; i < njs; i++) {
+                        p[i] = b->get(i).asFloat64();
+                    }
+                    ok = rpc_IPosCtrl->setRefSpeeds(p);
+                    delete[] p;
+                } break;
+
+                case VOCAB_REF_ACCELERATION: {
+                    ok = rpc_IPosCtrl->setRefAcceleration(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_REF_ACCELERATION_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle* jBottle_p = cmd.get(3).asList();
+                    Bottle* accBottle_p = cmd.get(4).asList();
+
+                    if (rpc_IPosCtrl == nullptr) {
+                        break;
+                    }
+
+                    if (jBottle_p == nullptr || accBottle_p == nullptr) {
+                        break;
+                    }
+                    if (static_cast<size_t>(len) != jBottle_p->size() || static_cast<size_t>(len) != accBottle_p->size()) {
+                        break;
+                    }
+
+                    int* j_tmp = new int[len];
+                    auto* accs_tmp = new double[len];
+
+                    for (int i = 0; i < len; i++) {
+                        j_tmp[i] = jBottle_p->get(i).asInt32();
+                    }
+
+                    for (int i = 0; i < len; i++) {
+                        accs_tmp[i] = accBottle_p->get(i).asFloat64();
+                    }
+
+                    ok = rpc_IPosCtrl->setRefAccelerations(len, j_tmp, accs_tmp);
+                    delete[] j_tmp;
+                    delete[] accs_tmp;
+                } break;
+
+                case VOCAB_REF_ACCELERATIONS: {
+                    Bottle* b = cmd.get(2).asList();
+
+                    if (b == nullptr) {
+                        break;
+                    }
+
+                    int i;
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                    for (i = 0; i < njs; i++) {
+                        p[i] = b->get(i).asFloat64();
+                    }
+                    ok = rpc_IPosCtrl->setRefAccelerations(p);
+                    delete[] p;
+                } break;
+
+                case VOCAB_STOP: {
+                    ok = rpc_IPosCtrl->stop(cmd.get(2).asInt32());
+                } break;
+
+                case VOCAB_STOP_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle* jBottle_p = cmd.get(3).asList();
+
+                    if (rpc_IPosCtrl == nullptr) {
+                        break;
+                    }
+
+                    if (jBottle_p == nullptr) {
+                        break;
+                    }
+                    if (static_cast<size_t>(len) != jBottle_p->size()) {
+                        break;
+                    }
+
+                    int* j_tmp = new int[len];
+
+                    for (int i = 0; i < len; i++) {
+                        j_tmp[i] = jBottle_p->get(i).asInt32();
+                    }
+
+                    ok = rpc_IPosCtrl->stop(len, j_tmp);
+                    delete[] j_tmp;
+                } break;
+
+                case VOCAB_STOPS: {
+                    ok = rpc_IPosCtrl->stop();
+                } break;
+
+                case VOCAB_E_RESET: {
+                    ok = rpc_IEncTimed->resetEncoder(cmd.get(2).asInt32());
+                } break;
+
+                case VOCAB_E_RESETS: {
+                    ok = rpc_IEncTimed->resetEncoders();
+                } break;
+
+                case VOCAB_ENCODER: {
+                    ok = rpc_IEncTimed->setEncoder(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_ENCODERS: {
+                    Bottle* b = cmd.get(2).asList();
+
+                    if (b == nullptr) {
+                        break;
+                    }
+
+                    int i;
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                    for (i = 0; i < njs; i++) {
+                        p[i] = b->get(i).asFloat64();
+                    }
+                    ok = rpc_IEncTimed->setEncoders(p);
+                    delete[] p;
+                } break;
+
+                case VOCAB_MOTOR_CPR: {
+                    ok = rpc_IMotEnc->setMotorEncoderCountsPerRevolution(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_MOTOR_E_RESET: {
+                    ok = rpc_IMotEnc->resetMotorEncoder(cmd.get(2).asInt32());
+                } break;
+
+                case VOCAB_MOTOR_E_RESETS: {
+                    ok = rpc_IMotEnc->resetMotorEncoders();
+                } break;
+
+                case VOCAB_MOTOR_ENCODER: {
+                    ok = rpc_IMotEnc->setMotorEncoder(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_MOTOR_ENCODERS: {
+                    Bottle* b = cmd.get(2).asList();
+
+                    if (b == nullptr) {
+                        break;
+                    }
+
+                    int i;
+                    const int njs = b->size();
+                    if (njs != controlledJoints) {
+                        break;
+                    }
+                    auto* p = new double[njs]; // LATER: optimize to avoid allocation.
+                    for (i = 0; i < njs; i++) {
+                        p[i] = b->get(i).asFloat64();
+                    }
+                    ok = rpc_IMotEnc->setMotorEncoders(p);
+                    delete[] p;
+                } break;
+
+                case VOCAB_AMP_ENABLE: {
+                    ok = rcp_IAmp->enableAmp(cmd.get(2).asInt32());
+                } break;
+
+                case VOCAB_AMP_DISABLE: {
+                    ok = rcp_IAmp->disableAmp(cmd.get(2).asInt32());
+                } break;
+
+                case VOCAB_AMP_MAXCURRENT: {
+                    ok = rcp_IAmp->setMaxCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_AMP_PEAK_CURRENT: {
+                    ok = rcp_IAmp->setPeakCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_AMP_NOMINAL_CURRENT: {
+                    ok = rcp_IAmp->setNominalCurrent(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_AMP_PWM_LIMIT: {
+                    ok = rcp_IAmp->setPWMLimit(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_LIMITS: {
+                    ok = rcp_Ilim->setLimits(cmd.get(2).asInt32(), cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
+                } break;
+
+
+                case VOCAB_TEMPERATURE_LIMIT: {
+                    ok = rpc_IMotor->setTemperatureLimit(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_GEARBOX_RATIO: {
+                    ok = rpc_IMotor->setGearboxRatio(cmd.get(2).asInt32(), cmd.get(3).asFloat64());
+                } break;
+
+                case VOCAB_VEL_LIMITS: {
+                    ok = rcp_Ilim->setVelLimits(cmd.get(2).asInt32(), cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
+                } break;
+
+                default:
                 {
-                    ok = DeviceResponder::respond(cmd,response);
-                }
+                    yCError(CONTROLBOARDWRAPPER, "received an unknown command after a VOCAB_SET (%s)", cmd.toString().c_str());
+                } break;
+                } //switch(cmd.get(1).asVocab()
+                break;
+            }
+
+            case VOCAB_GET: {
+                rec = true;
+                yCTrace(CONTROLBOARDWRAPPER, "get command received");
+
+                double dtmp = 0.0;
+                Bottle btmp;
+                response.addVocab(VOCAB_IS);
+                response.add(cmd.get(1));
+
+                switch (cmd.get(1).asVocab()) {
+
+                case VOCAB_TEMPERATURE_LIMIT: {
+                    ok = rpc_IMotor->getTemperatureLimit(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_TEMPERATURE: {
+                    ok = rpc_IMotor->getTemperature(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_GEARBOX_RATIO: {
+                    ok = rpc_IMotor->getGearboxRatio(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_TEMPERATURES: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IMotor->getTemperatures(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_AMP_MAXCURRENT: {
+                    ok = rcp_IAmp->getMaxCurrent(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_POSITION_MOVE: {
+                    yCTrace(CONTROLBOARDWRAPPER, "getTargetPosition");
+                    ok = rpc_IPosCtrl->getTargetPosition(cmd.get(2).asInt32(), &dtmp);
+
+                    response.addFloat64(dtmp);
+                    rec = true;
+                } break;
+
+                case VOCAB_POSITION_MOVE_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    auto* refs = new double[len];
+
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    ok = rpc_IPosCtrl->getTargetPositions(len, jointList, refs);
+
+                    Bottle& b = response.addList();
+                    for (int i = 0; i < len; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+
+                    delete[] jointList;
+                    delete[] refs;
+                } break;
+
+                case VOCAB_POSITION_MOVES: {
+                    auto* refs = new double[controlledJoints];
+                    ok = rpc_IPosCtrl->getTargetPositions(refs);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+                    delete[] refs;
+                } break;
+
+                case VOCAB_POSITION_DIRECT: {
+                    yCTrace(CONTROLBOARDWRAPPER, "getRefPosition");
+                    ok = rpc_IPosDirect->getRefPosition(cmd.get(2).asInt32(), &dtmp);
+
+                    response.addFloat64(dtmp);
+                    rec = true;
+                } break;
+
+                case VOCAB_POSITION_DIRECT_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    auto* refs = new double[len];
+
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    ok = rpc_IPosDirect->getRefPositions(len, jointList, refs);
+
+                    Bottle& b = response.addList();
+                    for (int i = 0; i < len; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+
+                    delete[] jointList;
+                    delete[] refs;
+                } break;
+
+                case VOCAB_POSITION_DIRECTS: {
+                    auto* refs = new double[controlledJoints];
+                    ok = rpc_IPosDirect->getRefPositions(refs);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+                    delete[] refs;
+                } break;
+
+                case VOCAB_VELOCITY_MOVE: {
+                    yCTrace(CONTROLBOARDWRAPPER, "getVelocityMove - cmd: %s", cmd.toString().c_str());
+                    ok = rpc_IVelCtrl->getRefVelocity(cmd.get(2).asInt32(), &dtmp);
+
+                    response.addFloat64(dtmp);
+                    rec = true;
+                } break;
+
+                case VOCAB_VELOCITY_MOVE_GROUP: {
+                    yCTrace(CONTROLBOARDWRAPPER, "getVelocityMove_group - cmd: %s", cmd.toString().c_str());
+
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    auto* refs = new double[len];
+
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    ok = rpc_IVelCtrl->getRefVelocities(len, jointList, refs);
+
+                    Bottle& b = response.addList();
+                    for (int i = 0; i < len; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+
+                    delete[] jointList;
+                    delete[] refs;
+                } break;
+
+                case VOCAB_VELOCITY_MOVES: {
+                    yCTrace(CONTROLBOARDWRAPPER, "getVelocityMoves - cmd: %s", cmd.toString().c_str());
+
+                    auto* refs = new double[controlledJoints];
+                    ok = rpc_IVelCtrl->getRefVelocities(refs);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(refs[i]);
+                    }
+                    delete[] refs;
+                } break;
+
+                case VOCAB_MOTORS_NUMBER: {
+                    int tmp;
+                    ok = rpc_IMotor->getNumberOfMotors(&tmp);
+                    response.addInt32(tmp);
+                } break;
+
+                case VOCAB_AXES: {
+                    int tmp;
+                    ok = rpc_IPosCtrl->getAxes(&tmp);
+                    response.addInt32(tmp);
+                } break;
+
+                case VOCAB_MOTION_DONE: {
+                    bool x = false;
+                    ;
+                    ok = rpc_IPosCtrl->checkMotionDone(cmd.get(2).asInt32(), &x);
+                    response.addInt32(x);
+                } break;
+
+                case VOCAB_MOTION_DONE_GROUP: {
+                    bool x = false;
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    if (rpc_IPosCtrl != nullptr) {
+                        ok = rpc_IPosCtrl->checkMotionDone(len, jointList, &x);
+                    }
+                    response.addInt32(x);
+
+                    delete[] jointList;
+                } break;
+
+                case VOCAB_MOTION_DONES: {
+                    bool x = false;
+                    ok = rpc_IPosCtrl->checkMotionDone(&x);
+                    response.addInt32(x);
+                } break;
+
+                case VOCAB_REF_SPEED: {
+                    ok = rpc_IPosCtrl->getRefSpeed(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_REF_SPEED_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    auto* speeds = new double[len];
+
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    ok = rpc_IPosCtrl->getRefSpeeds(len, jointList, speeds);
+
+                    Bottle& b = response.addList();
+                    for (int i = 0; i < len; i++) {
+                        b.addFloat64(speeds[i]);
+                    }
+
+                    delete[] jointList;
+                    delete[] speeds;
+                } break;
+
+                case VOCAB_REF_SPEEDS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IPosCtrl->getRefSpeeds(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_REF_ACCELERATION: {
+                    ok = rpc_IPosCtrl->getRefAcceleration(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_REF_ACCELERATION_GROUP: {
+                    int len = cmd.get(2).asInt32();
+                    Bottle& in = *(cmd.get(3).asList());
+                    int* jointList = new int[len];
+                    auto* accs = new double[len];
+
+                    for (int j = 0; j < len; j++) {
+                        jointList[j] = in.get(j).asInt32();
+                    }
+                    ok = rpc_IPosCtrl->getRefAccelerations(len, jointList, accs);
+
+                    Bottle& b = response.addList();
+                    for (int i = 0; i < len; i++) {
+                        b.addFloat64(accs[i]);
+                    }
+
+                    delete[] jointList;
+                    delete[] accs;
+                } break;
+
+                case VOCAB_REF_ACCELERATIONS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IPosCtrl->getRefAccelerations(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_ENCODER: {
+                    ok = rpc_IEncTimed->getEncoder(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_ENCODERS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IEncTimed->getEncoders(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_ENCODER_SPEED: {
+                    ok = rpc_IEncTimed->getEncoderSpeed(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_ENCODER_SPEEDS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IEncTimed->getEncoderSpeeds(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_ENCODER_ACCELERATION: {
+                    ok = rpc_IEncTimed->getEncoderAcceleration(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_ENCODER_ACCELERATIONS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IEncTimed->getEncoderAccelerations(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_MOTOR_CPR: {
+                    ok = rpc_IMotEnc->getMotorEncoderCountsPerRevolution(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_MOTOR_ENCODER: {
+                    ok = rpc_IMotEnc->getMotorEncoder(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_MOTOR_ENCODERS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IMotEnc->getMotorEncoders(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_MOTOR_ENCODER_SPEED: {
+                    ok = rpc_IMotEnc->getMotorEncoderSpeed(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_MOTOR_ENCODER_SPEEDS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IMotEnc->getMotorEncoderSpeeds(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_MOTOR_ENCODER_ACCELERATION: {
+                    ok = rpc_IMotEnc->getMotorEncoderAcceleration(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_MOTOR_ENCODER_ACCELERATIONS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rpc_IMotEnc->getMotorEncoderAccelerations(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_MOTOR_ENCODER_NUMBER: {
+                    int num = 0;
+                    ok = rpc_IMotEnc->getNumberOfMotorEncoders(&num);
+                    response.addInt32(num);
+                } break;
+
+                case VOCAB_AMP_CURRENT: {
+                    ok = rcp_IAmp->getCurrent(cmd.get(2).asInt32(), &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_AMP_CURRENTS: {
+                    auto* p = new double[controlledJoints];
+                    ok = rcp_IAmp->getCurrents(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addFloat64(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_AMP_STATUS: {
+                    int* p = new int[controlledJoints];
+                    ok = rcp_IAmp->getAmpStatus(p);
+                    Bottle& b = response.addList();
+                    int i;
+                    for (i = 0; i < controlledJoints; i++) {
+                        b.addInt32(p[i]);
+                    }
+                    delete[] p;
+                } break;
+
+                case VOCAB_AMP_STATUS_SINGLE: {
+                    int j = cmd.get(2).asInt32();
+                    int itmp;
+                    ok = rcp_IAmp->getAmpStatus(j, &itmp);
+                    response.addInt32(itmp);
+                } break;
+
+                case VOCAB_AMP_NOMINAL_CURRENT: {
+                    int m = cmd.get(2).asInt32();
+                    ok = rcp_IAmp->getNominalCurrent(m, &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_AMP_PEAK_CURRENT: {
+                    int m = cmd.get(2).asInt32();
+                    ok = rcp_IAmp->getPeakCurrent(m, &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_AMP_PWM: {
+                    int m = cmd.get(2).asInt32();
+                    ok = rcp_IAmp->getPWM(m, &dtmp);
+                    yCTrace(CONTROLBOARDWRAPPER) << "RPC parser::getPWM: j" << m << " val " << dtmp;
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_AMP_PWM_LIMIT: {
+                    int m = cmd.get(2).asInt32();
+                    ok = rcp_IAmp->getPWMLimit(m, &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_AMP_VOLTAGE_SUPPLY: {
+                    int m = cmd.get(2).asInt32();
+                    ok = rcp_IAmp->getPowerSupplyVoltage(m, &dtmp);
+                    response.addFloat64(dtmp);
+                } break;
+
+                case VOCAB_LIMITS: {
+                    double min = 0.0;
+                    double max = 0.0;
+                    ok = rcp_Ilim->getLimits(cmd.get(2).asInt32(), &min, &max);
+                    response.addFloat64(min);
+                    response.addFloat64(max);
+                } break;
+
+                case VOCAB_VEL_LIMITS: {
+                    double min = 0.0;
+                    double max = 0.0;
+                    ok = rcp_Ilim->getVelLimits(cmd.get(2).asInt32(), &min, &max);
+                    response.addFloat64(min);
+                    response.addFloat64(max);
+                } break;
+
+                case VOCAB_INFO_NAME: {
+                    std::string name = "undocumented";
+                    ok = rpc_AxisInfo->getAxisName(cmd.get(2).asInt32(), name);
+                    response.addString(name.c_str());
+                } break;
+
+                case VOCAB_INFO_TYPE: {
+                    yarp::dev::JointTypeEnum type;
+                    ok = rpc_AxisInfo->getJointType(cmd.get(2).asInt32(), type);
+                    response.addInt32(type);
+                } break;
+
+                default:
+                {
+                    yCError(CONTROLBOARDWRAPPER, "received an unknown request after a VOCAB_GET: %s", yarp::os::Vocab::decode(cmd.get(1).asVocab()).c_str());
+                } break;
+                } //switch cmd.get(1).asVocab())
+
+                lastRpcStamp.update();
+                appendTimeStamp(response, lastRpcStamp);
+            } // case VOCAB_GET
+            default:
+                break;
+            } //switch code
+
+            if (!rec) {
+                ok = DeviceResponder::respond(cmd, response);
+            }
         }
 
-        if (!ok)
-        {
+        if (!ok) {
             // failed thus send only a VOCAB back.
             response.clear();
             response.addVocab(VOCAB_FAILED);
-        }
-        else
+        } else {
             response.addVocab(VOCAB_OK);
+        }
     }
 
-        return ok;
+    return ok;
 }
 
 bool RPCMessagesParser::initialize()
 {
     bool ok = false;
-    if (rpc_IPosCtrl)
-    {
+    if (rpc_IPosCtrl) {
         ok = rpc_IPosCtrl->getAxes(&controlledJoints);
     }
 
@@ -2798,18 +2384,18 @@ bool RPCMessagesParser::initialize()
     addUsage("[get] [enc] $iAxisNumber", "get the encoder value for an axis");
 
     std::string args;
-    for (int i=0; i<controlledJoints; i++) {
-        if (i>0) {
+    for (int i = 0; i < controlledJoints; i++) {
+        if (i > 0) {
             args += " ";
         }
         // removed dependency from yarp internals
         //args = args + "$f" + yarp::NetType::toString(i);
     }
-    addUsage((std::string("[set] [poss] (")+args+")").c_str(),
+    addUsage((std::string("[set] [poss] (") + args + ")").c_str(),
              "command the position of all axes");
-    addUsage((std::string("[set] [rels] (")+args+")").c_str(),
+    addUsage((std::string("[set] [rels] (") + args + ")").c_str(),
              "command the relative position of all axes");
-    addUsage((std::string("[set] [vmos] (")+args+")").c_str(),
+    addUsage((std::string("[set] [vmos] (") + args + ")").c_str(),
              "command the velocity of all axes");
 
     addUsage("[set] [aen] $iAxisNumber", "enable (amplifier for) the given axis");
@@ -2820,52 +2406,27 @@ bool RPCMessagesParser::initialize()
     return ok;
 }
 
-RPCMessagesParser::RPCMessagesParser() :
-        ControlBoardWrapper_p(nullptr),
-        rpc_IPid(nullptr),
-        rpc_IPosCtrl(nullptr),
-        rpc_IPosDirect(nullptr),
-        rpc_IVelCtrl(nullptr),
-        rpc_IEncTimed(nullptr),
-        rpc_IMotEnc(nullptr),
-        rcp_IAmp(nullptr),
-        rcp_Ilim(nullptr),
-        rpc_ITorque(nullptr),
-        rpc_iCtrlMode(nullptr),
-        rpc_AxisInfo(nullptr),
-        rpc_IRemoteCalibrator(nullptr),
-        rpc_Icalib(nullptr),
-        rpc_IImpedance(nullptr),
-        rpc_IInteract(nullptr),
-        rpc_IMotor(nullptr),
-        rpc_IVar(nullptr),
-        rpc_ICurrent(nullptr),
-        rpc_IPWM(nullptr),
-        controlledJoints(0)
+void RPCMessagesParser::init(yarp::dev::DeviceDriver* x)
 {
-}
-
-void RPCMessagesParser::init(ControlBoardWrapper *x)
-{
-    ControlBoardWrapper_p = x;
-    rpc_IPid              = dynamic_cast<yarp::dev::IPidControl *>          (ControlBoardWrapper_p);
-    rpc_IPosCtrl          = dynamic_cast<yarp::dev::IPositionControl *>     (ControlBoardWrapper_p);
-    rpc_IPosDirect        = dynamic_cast<yarp::dev::IPositionDirect *>      (ControlBoardWrapper_p);
-    rpc_IVelCtrl          = dynamic_cast<yarp::dev::IVelocityControl *>     (ControlBoardWrapper_p);
-    rpc_IEncTimed         = dynamic_cast<yarp::dev::IEncodersTimed *>       (ControlBoardWrapper_p);
-    rpc_IMotEnc           = dynamic_cast<yarp::dev::IMotorEncoders *>       (ControlBoardWrapper_p);
-    rpc_IMotor            = dynamic_cast<yarp::dev::IMotor *>               (ControlBoardWrapper_p);
-    rpc_IVar              = dynamic_cast<yarp::dev::IRemoteVariables *>     (ControlBoardWrapper_p);
-    rcp_IAmp              = dynamic_cast<yarp::dev::IAmplifierControl *>    (ControlBoardWrapper_p);
-    rcp_Ilim              = dynamic_cast<yarp::dev::IControlLimits *>       (ControlBoardWrapper_p);
-    rpc_AxisInfo          = dynamic_cast<yarp::dev::IAxisInfo *>            (ControlBoardWrapper_p);
-    rpc_IRemoteCalibrator = dynamic_cast<yarp::dev::IRemoteCalibrator *>    (ControlBoardWrapper_p);
-    rpc_Icalib            = dynamic_cast<yarp::dev::IControlCalibration *>  (ControlBoardWrapper_p);
-    rpc_IImpedance        = dynamic_cast<yarp::dev::IImpedanceControl *>    (ControlBoardWrapper_p);
-    rpc_ITorque           = dynamic_cast<yarp::dev::ITorqueControl *>       (ControlBoardWrapper_p);
-    rpc_iCtrlMode         = dynamic_cast<yarp::dev::IControlMode *>         (ControlBoardWrapper_p);
-    rpc_IInteract         = dynamic_cast<yarp::dev::IInteractionMode *>     (ControlBoardWrapper_p);
-    rpc_ICurrent          = dynamic_cast<yarp::dev::ICurrentControl *>      (ControlBoardWrapper_p);
-    rpc_IPWM              = dynamic_cast<yarp::dev::IPWMControl *>          (ControlBoardWrapper_p);
-    controlledJoints      = 0;
+    ControlBoardWrapper_p = dynamic_cast<ControlBoardWrapperCommon*>(x);
+    rpc_IPid = dynamic_cast<yarp::dev::IPidControl*>(x);
+    rpc_IPosCtrl = dynamic_cast<yarp::dev::IPositionControl*>(x);
+    rpc_IPosDirect = dynamic_cast<yarp::dev::IPositionDirect*>(x);
+    rpc_IVelCtrl = dynamic_cast<yarp::dev::IVelocityControl*>(x);
+    rpc_IEncTimed = dynamic_cast<yarp::dev::IEncodersTimed*>(x);
+    rpc_IMotEnc = dynamic_cast<yarp::dev::IMotorEncoders*>(x);
+    rpc_IMotor = dynamic_cast<yarp::dev::IMotor*>(x);
+    rpc_IVar = dynamic_cast<yarp::dev::IRemoteVariables*>(x);
+    rcp_IAmp = dynamic_cast<yarp::dev::IAmplifierControl*>(x);
+    rcp_Ilim = dynamic_cast<yarp::dev::IControlLimits*>(x);
+    rpc_AxisInfo = dynamic_cast<yarp::dev::IAxisInfo*>(x);
+    rpc_IRemoteCalibrator = dynamic_cast<yarp::dev::IRemoteCalibrator*>(x);
+    rpc_Icalib = dynamic_cast<yarp::dev::IControlCalibration*>(x);
+    rpc_IImpedance = dynamic_cast<yarp::dev::IImpedanceControl*>(x);
+    rpc_ITorque = dynamic_cast<yarp::dev::ITorqueControl*>(x);
+    rpc_iCtrlMode = dynamic_cast<yarp::dev::IControlMode*>(x);
+    rpc_IInteract = dynamic_cast<yarp::dev::IInteractionMode*>(x);
+    rpc_ICurrent = dynamic_cast<yarp::dev::ICurrentControl*>(x);
+    rpc_IPWM = dynamic_cast<yarp::dev::IPWMControl*>(x);
+    controlledJoints = 0;
 }

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.h
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.h
@@ -80,7 +80,7 @@ protected:
     yarp::sig::Vector tmpVect;
     yarp::os::Stamp lastRpcStamp;
     std::mutex mutex;
-    int controlledJoints {0};
+    size_t controlledJoints {0};
 
 public:
     /**

--- a/src/devices/ControlBoardWrapper/StreamingMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/StreamingMessagesParser.cpp
@@ -8,10 +8,12 @@
  */
 
 #include "StreamingMessagesParser.h"
-#include "ControlBoardWrapper.h"
+
+#include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapperCommon.h"
 #include "ControlBoardWrapperLogComponent.h"
 #include <iostream>
-#include <yarp/os/LogStream.h>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -20,33 +22,24 @@ using namespace yarp::sig;
 using namespace std;
 
 
-StreamingMessagesParser::StreamingMessagesParser() :
-        stream_IPosCtrl(nullptr),
-        stream_IPosDirect(nullptr),
-        stream_IVel(nullptr),
-        stream_ITorque(nullptr),
-        stream_IPWM(nullptr),
-        stream_ICurrent(nullptr),
-        stream_nJoints(0)
+void StreamingMessagesParser::init(yarp::dev::DeviceDriver* x)
 {
-}
-
-void StreamingMessagesParser::init(ControlBoardWrapper *x) {
     stream_nJoints = 0;
-    stream_IPosCtrl  = dynamic_cast<yarp::dev::IPositionControl *> (x);
-    stream_IPosDirect = dynamic_cast<yarp::dev::IPositionDirect *> (x);
-    stream_IVel = dynamic_cast<yarp::dev::IVelocityControl *> (x);
-    stream_ITorque=dynamic_cast<yarp::dev::ITorqueControl *> (x);
-    stream_IPWM = dynamic_cast<yarp::dev::IPWMControl *> (x);
-    stream_ICurrent = dynamic_cast<yarp::dev::ICurrentControl *> (x);
+    stream_IPosCtrl = dynamic_cast<yarp::dev::IPositionControl*>(x);
+    stream_IPosDirect = dynamic_cast<yarp::dev::IPositionDirect*>(x);
+    stream_IVel = dynamic_cast<yarp::dev::IVelocityControl*>(x);
+    stream_ITorque = dynamic_cast<yarp::dev::ITorqueControl*>(x);
+    stream_IPWM = dynamic_cast<yarp::dev::IPWMControl*>(x);
+    stream_ICurrent = dynamic_cast<yarp::dev::ICurrentControl*>(x);
 }
 
 
 bool StreamingMessagesParser::initialize()
 {
-    stream_nJoints=0;
-    if (stream_IPosCtrl)
+    stream_nJoints = 0;
+    if (stream_IPosCtrl) {
         stream_IPosCtrl->getAxes(&stream_nJoints);
+    }
 
     return true;
 }
@@ -61,278 +54,231 @@ void StreamingMessagesParser::onRead(CommandMessage& v)
     yCTrace(CONTROLBOARDWRAPPER, "Received command %s, %s\n", b.toString().c_str(), cmdVector.toString().c_str());
 
     // some consistency checks
-    if ((int)cmdVector.size() > stream_nJoints)
-    {
+    if (static_cast<int>(cmdVector.size()) > stream_nJoints) {
         std::string str = yarp::os::Vocab::decode(b.get(0).asVocab());
-        yCError(CONTROLBOARDWRAPPER, "Received command vector with number of elements bigger than axis controlled by this wrapper (cmd: %s requested jnts: %d received jnts: %d)\n",str.c_str(),stream_nJoints,(int)cmdVector.size());
+        yCError(CONTROLBOARDWRAPPER, "Received command vector with number of elements bigger than axis controlled by this wrapper (cmd: %s requested jnts: %d received jnts: %d)\n", str.c_str(), stream_nJoints, (int)cmdVector.size());
         return;
     }
-    if (cmdVector.data()==nullptr)
-    {
-         yCError(CONTROLBOARDWRAPPER, "Received null command vector");
-         return;
+    if (cmdVector.data() == nullptr) {
+        yCError(CONTROLBOARDWRAPPER, "Received null command vector");
+        return;
     }
 
-    switch (b.get(0).asVocab())
-    {
-        // manage commands with interface name as first
-        case VOCAB_PWMCONTROL_INTERFACE:
-        {
-            switch (b.get(1).asVocab())
-            {
-                case VOCAB_PWMCONTROL_REF_PWM:
-                {
-                    if (stream_IPWM)
-                    {
-                        bool ok = stream_IPWM->setRefDutyCycle(b.get(2).asInt32(), cmdVector[0]);
-                        if (!ok)
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an pwm message");
-                    }
-                    else
-                        yCError(CONTROLBOARDWRAPPER, "PWM interface not valid");
+    switch (b.get(0).asVocab()) {
+    // manage commands with interface name as first
+    case VOCAB_PWMCONTROL_INTERFACE: {
+        switch (b.get(1).asVocab()) {
+        case VOCAB_PWMCONTROL_REF_PWM: {
+            if (stream_IPWM) {
+                bool ok = stream_IPWM->setRefDutyCycle(b.get(2).asInt32(), cmdVector[0]);
+                if (!ok) {
+                    yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an pwm message");
                 }
-                break;
-                case VOCAB_PWMCONTROL_REF_PWMS:
-                {
-                    if (stream_IPWM)
-                    {
-                        bool ok = stream_IPWM->setRefDutyCycles(cmdVector.data());
-                        if (!ok)
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an pwm message");
-                    }
-                    else
-                        yCError(CONTROLBOARDWRAPPER, "PWM interface not valid");
-                }
-                break;
+            } else {
+                yCError(CONTROLBOARDWRAPPER, "PWM interface not valid");
             }
+        } break;
+        case VOCAB_PWMCONTROL_REF_PWMS: {
+            if (stream_IPWM) {
+                bool ok = stream_IPWM->setRefDutyCycles(cmdVector.data());
+                if (!ok) {
+                    yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an pwm message");
+                }
+            } else {
+                yCError(CONTROLBOARDWRAPPER, "PWM interface not valid");
+            }
+        } break;
         }
-        break;
+    } break;
 
-        case VOCAB_CURRENTCONTROL_INTERFACE:
-        {
-            switch (b.get(1).asVocab())
-            {
-                case VOCAB_CURRENT_REF:
-                {
-                    if (stream_ICurrent)
-                    {
-                        bool ok = stream_ICurrent->setRefCurrent(b.get(2).asInt32(), cmdVector[0]);
-                        if (!ok)
-                        {
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming current message on single joint\n");
-                        }
-                    }
+    case VOCAB_CURRENTCONTROL_INTERFACE: {
+        switch (b.get(1).asVocab()) {
+        case VOCAB_CURRENT_REF: {
+            if (stream_ICurrent) {
+                bool ok = stream_ICurrent->setRefCurrent(b.get(2).asInt32(), cmdVector[0]);
+                if (!ok) {
+                    yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming current message on single joint\n");
                 }
-                break;
-                case VOCAB_CURRENT_REFS:
-                {
-                    if (stream_ICurrent)
-                    {
-                        bool ok = stream_ICurrent->setRefCurrents(cmdVector.data());
-                        if (!ok)
-                        {
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming current message on all joints\n");
-                        }
-                    }
+            }
+        } break;
+        case VOCAB_CURRENT_REFS: {
+            if (stream_ICurrent) {
+                bool ok = stream_ICurrent->setRefCurrents(cmdVector.data());
+                if (!ok) {
+                    yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming current message on all joints\n");
                 }
-                break;
-                case VOCAB_CURRENT_REF_GROUP:
-                {
-                    if (stream_ICurrent)
-                    {
-                        int n_joints = b.get(2).asInt32();
-                        Bottle *jlut = b.get(3).asList();
-                        if (((int)jlut->size() != n_joints) && ((int)cmdVector.size() != n_joints))
-                        {
-                            yCError(CONTROLBOARDWRAPPER, "Received VOCAB_CURRENT_REF_GROUP size of joints vector or currents vector does not match the selected joint number\n");
-                        }
-
-                        int *joint_list = new int[n_joints];
-                        for (int i = 0; i < n_joints; i++)
-                            joint_list[i] = jlut->get(i).asInt32();
-
-
-                        bool ok = stream_ICurrent->setRefCurrents(n_joints, joint_list, cmdVector.data());
-                        if (!ok)
-                        {
-                            yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming current message on joint group\n");
-                        }
-
-                        delete[] joint_list;
-                    }
-                }
-                break;
-                default:
-                {
-                    std::string str = yarp::os::Vocab::decode(b.get(0).asVocab());
-                    yCError(CONTROLBOARDWRAPPER, "Unrecognized message while receiving on command port (%s)\n", str.c_str());
-                }
-                break;
             }
-        }
-        break;
-
-        // fallback to commands without interface name
-        case VOCAB_POSITION_MODE:
-            {
-                yCError(CONTROLBOARDWRAPPER, "Received VOCAB_POSITION_MODE this is an send invalid message on streaming port");
-                break;
-            }
-        case VOCAB_POSITION_MOVES:
-            {
-                if (stream_IPosCtrl)
-                    {
-                        bool ok = stream_IPosCtrl->positionMove(cmdVector.data());
-                        if (!ok)
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to start a position move");
-                    }
-
-            }
-            break;
-
-        case VOCAB_VELOCITY_MODE:
-             {
-                yCError(CONTROLBOARDWRAPPER, "Received VOCAB_VELOCITY_MODE this is an send invalid message on streaming port");
-                break;
-            }
-
-        case VOCAB_VELOCITY_MOVE:
-            {
-                stream_IVel->velocityMove(b.get(1).asInt32(), cmdVector[0]);
-            }
-        break;
-
-        case VOCAB_VELOCITY_MOVES:
-            {
-                if (stream_IVel)
-                    {
-                        bool ok = stream_IVel->velocityMove(cmdVector.data());
-                        if (!ok)
-                            yCError(CONTROLBOARDWRAPPER, "Errors while trying to start a velocity move");
-                    }
-            }
-            break;
-
-        case VOCAB_POSITION_DIRECT:
-        {
-            if(stream_IPosDirect)
-            {
-                bool ok = stream_IPosDirect->setPosition(b.get(1).asInt32(), cmdVector[0]); // cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an streaming position direct message on joint %d\n", b.get(1).asInt32() ); }
-            }
-        }
-        break;
-
-        case VOCAB_TORQUES_DIRECT:
-        {
-            if (stream_ITorque)
-            {
-                bool ok = stream_ITorque->setRefTorque(b.get(1).asInt32(), cmdVector[0]);
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming torque direct message on single joint\n"); }
-            }
-        }
-        break;
-
-        case VOCAB_TORQUES_DIRECTS:
-        {
-            if (stream_ITorque)
-            {
-                bool ok = stream_ITorque->setRefTorques(cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming torque direct message on all joints\n"); }
-            }
-        }
-        break;
-
-        case VOCAB_TORQUES_DIRECT_GROUP:
-        {
-            if (stream_ITorque)
-            {
-                int n_joints = b.get(1).asInt32();
-                Bottle *jlut = b.get(2).asList();
-                if( ((int)jlut->size() != n_joints) && ((int)cmdVector.size() != n_joints) )
-                {
-                    yCError(CONTROLBOARDWRAPPER, "Received VOCAB_TORQUES_DIRECT_GROUP size of joints vector or torques vector does not match the selected joint number\n" );
+        } break;
+        case VOCAB_CURRENT_REF_GROUP: {
+            if (stream_ICurrent) {
+                int n_joints = b.get(2).asInt32();
+                Bottle* jlut = b.get(3).asList();
+                if ((static_cast<int>(jlut->size()) != n_joints) && (static_cast<int>(cmdVector.size()) != n_joints)) {
+                    yCError(CONTROLBOARDWRAPPER, "Received VOCAB_CURRENT_REF_GROUP size of joints vector or currents vector does not match the selected joint number\n");
                 }
 
-                int *joint_list = new int[n_joints];
-                for (int i = 0; i < n_joints; i++)
+                int* joint_list = new int[n_joints];
+                for (int i = 0; i < n_joints; i++) {
                     joint_list[i] = jlut->get(i).asInt32();
+                }
 
 
-                bool ok = stream_ITorque->setRefTorques(n_joints, joint_list, cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming toruqe direct message on joint group\n" ); }
+                bool ok = stream_ICurrent->setRefCurrents(n_joints, joint_list, cmdVector.data());
+                if (!ok) {
+                    yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming current message on joint group\n");
+                }
 
                 delete[] joint_list;
             }
-        }
-        break;
-
-        case VOCAB_POSITION_DIRECT_GROUP:
-        {
-            if(stream_IPosDirect)
-            {
-                int n_joints = b.get(1).asInt32();
-                Bottle *jlut = b.get(2).asList();
-                if( ((int)jlut->size() != n_joints) && ((int)cmdVector.size() != n_joints) )
-                {
-                    yCError(CONTROLBOARDWRAPPER, "Received VOCAB_POSITION_DIRECT_GROUP size of joints vector or positions vector does not match the selected joint number\n" );
-                }
-
-                int *joint_list = new int[n_joints];
-                for (int i = 0; i < n_joints; i++)
-                    joint_list[i] = jlut->get(i).asInt32();
-
-
-                bool ok = stream_IPosDirect->setPositions(n_joints, joint_list, cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming position direct message on joint group\n" ); }
-
-                delete[] joint_list;
-            }
-        }
-        break;
-
-        case VOCAB_POSITION_DIRECTS:
-        {
-            if(stream_IPosDirect)
-            {
-                bool ok = stream_IPosDirect->setPositions(cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming position direct message on all joints\n" ); }
-            }
-        }
-        break;
-        case VOCAB_VELOCITY_MOVE_GROUP:
-        {
-            if(stream_IVel)
-            {
-                int n_joints = b.get(1).asInt32();
-                Bottle *jlut = b.get(2).asList();
-                if( ((int)jlut->size() != n_joints) && ((int)cmdVector.size() != n_joints) )
-                    yCError(CONTROLBOARDWRAPPER, "Received VOCAB_VELOCITY_MOVE_GROUP size of joints vector or positions vector does not match the selected joint number\n" );
-
-                int *joint_list = new int[n_joints];
-                for (int i = 0; i < n_joints; i++)
-                    joint_list[i] = jlut->get(i).asInt32();
-
-                bool ok = stream_IVel->velocityMove(n_joints, joint_list, cmdVector.data());
-                if (!ok)
-                {   yCError(CONTROLBOARDWRAPPER, "Error while trying to command a velocity move on joint group\n" ); }
-
-                delete[] joint_list;
-            }
-        }
-        break;
-
+        } break;
         default:
-            {
-                std::string str = yarp::os::Vocab::decode(b.get(0).asVocab());
-                yCError(CONTROLBOARDWRAPPER, "Unrecognized message while receiving on command port (%s)\n",str.c_str());
-            }
-            break;
+        {
+            std::string str = yarp::os::Vocab::decode(b.get(0).asVocab());
+            yCError(CONTROLBOARDWRAPPER, "Unrecognized message while receiving on command port (%s)\n", str.c_str());
+        } break;
         }
+    } break;
+
+    // fallback to commands without interface name
+    case VOCAB_POSITION_MODE: {
+        yCError(CONTROLBOARDWRAPPER, "Received VOCAB_POSITION_MODE this is an send invalid message on streaming port");
+        break;
+    }
+    case VOCAB_POSITION_MOVES: {
+        if (stream_IPosCtrl) {
+            bool ok = stream_IPosCtrl->positionMove(cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Errors while trying to start a position move");
+            }
+        }
+
+    } break;
+
+    case VOCAB_VELOCITY_MODE: {
+        yCError(CONTROLBOARDWRAPPER, "Received VOCAB_VELOCITY_MODE this is an send invalid message on streaming port");
+        break;
+    }
+
+    case VOCAB_VELOCITY_MOVE: {
+        stream_IVel->velocityMove(b.get(1).asInt32(), cmdVector[0]);
+    } break;
+
+    case VOCAB_VELOCITY_MOVES: {
+        if (stream_IVel) {
+            bool ok = stream_IVel->velocityMove(cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Errors while trying to start a velocity move");
+            }
+        }
+    } break;
+
+    case VOCAB_POSITION_DIRECT: {
+        if (stream_IPosDirect) {
+            bool ok = stream_IPosDirect->setPosition(b.get(1).asInt32(), cmdVector[0]); // cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Errors while trying to command an streaming position direct message on joint %d\n", b.get(1).asInt32());
+            }
+        }
+    } break;
+
+    case VOCAB_TORQUES_DIRECT: {
+        if (stream_ITorque) {
+            bool ok = stream_ITorque->setRefTorque(b.get(1).asInt32(), cmdVector[0]);
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming torque direct message on single joint\n");
+            }
+        }
+    } break;
+
+    case VOCAB_TORQUES_DIRECTS: {
+        if (stream_ITorque) {
+            bool ok = stream_ITorque->setRefTorques(cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Errors while trying to command a streaming torque direct message on all joints\n");
+            }
+        }
+    } break;
+
+    case VOCAB_TORQUES_DIRECT_GROUP: {
+        if (stream_ITorque) {
+            int n_joints = b.get(1).asInt32();
+            Bottle* jlut = b.get(2).asList();
+            if ((static_cast<int>(jlut->size()) != n_joints) && (static_cast<int>(cmdVector.size()) != n_joints)) {
+                yCError(CONTROLBOARDWRAPPER, "Received VOCAB_TORQUES_DIRECT_GROUP size of joints vector or torques vector does not match the selected joint number\n");
+            }
+
+            int* joint_list = new int[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                joint_list[i] = jlut->get(i).asInt32();
+            }
+
+
+            bool ok = stream_ITorque->setRefTorques(n_joints, joint_list, cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming toruqe direct message on joint group\n");
+            }
+
+            delete[] joint_list;
+        }
+    } break;
+
+    case VOCAB_POSITION_DIRECT_GROUP: {
+        if (stream_IPosDirect) {
+            int n_joints = b.get(1).asInt32();
+            Bottle* jlut = b.get(2).asList();
+            if ((static_cast<int>(jlut->size()) != n_joints) && (static_cast<int>(cmdVector.size()) != n_joints)) {
+                yCError(CONTROLBOARDWRAPPER, "Received VOCAB_POSITION_DIRECT_GROUP size of joints vector or positions vector does not match the selected joint number\n");
+            }
+
+            int* joint_list = new int[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                joint_list[i] = jlut->get(i).asInt32();
+            }
+
+
+            bool ok = stream_IPosDirect->setPositions(n_joints, joint_list, cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming position direct message on joint group\n");
+            }
+
+            delete[] joint_list;
+        }
+    } break;
+
+    case VOCAB_POSITION_DIRECTS: {
+        if (stream_IPosDirect) {
+            bool ok = stream_IPosDirect->setPositions(cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Error while trying to command a streaming position direct message on all joints\n");
+            }
+        }
+    } break;
+    case VOCAB_VELOCITY_MOVE_GROUP: {
+        if (stream_IVel) {
+            int n_joints = b.get(1).asInt32();
+            Bottle* jlut = b.get(2).asList();
+            if ((static_cast<int>(jlut->size()) != n_joints) && (static_cast<int>(cmdVector.size()) != n_joints)) {
+                yCError(CONTROLBOARDWRAPPER, "Received VOCAB_VELOCITY_MOVE_GROUP size of joints vector or positions vector does not match the selected joint number\n");
+            }
+
+            int* joint_list = new int[n_joints];
+            for (int i = 0; i < n_joints; i++) {
+                joint_list[i] = jlut->get(i).asInt32();
+            }
+
+            bool ok = stream_IVel->velocityMove(n_joints, joint_list, cmdVector.data());
+            if (!ok) {
+                yCError(CONTROLBOARDWRAPPER, "Error while trying to command a velocity move on joint group\n");
+            }
+
+            delete[] joint_list;
+        }
+    } break;
+
+    default:
+    {
+        std::string str = yarp::os::Vocab::decode(b.get(0).asVocab());
+        yCError(CONTROLBOARDWRAPPER, "Unrecognized message while receiving on command port (%s)\n", str.c_str());
+    } break;
+    }
 }

--- a/src/devices/ControlBoardWrapper/StreamingMessagesParser.h
+++ b/src/devices/ControlBoardWrapper/StreamingMessagesParser.h
@@ -13,25 +13,26 @@
 // This file contains helper functions for the ControlBoardWrapper
 
 
-#include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/PortablePair.h>
+#include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
+#include <yarp/os/Time.h>
 #include <yarp/os/Vocab.h>
 
+#include <yarp/sig/Vector.h>
+
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/IPreciselyTimed.h>
-#include <yarp/sig/Vector.h>
-#include <yarp/os/Semaphore.h>
+#include <yarp/dev/PolyDriver.h>
 
 #include <string>
 #include <vector>
 
 #ifdef MSVC
-    #pragma warning(disable:4355)
+#    pragma warning(disable : 4355)
 #endif
 
 /*
@@ -40,8 +41,6 @@
  * (we could also use the actual joint number for each subdevice using a for loop). TODO
  */
 
-class ControlBoardWrapper;
-
 
 /* the control command message type
 * head is a Bottle which contains the specification of the message type
@@ -49,39 +48,37 @@ class ControlBoardWrapper;
 */
 typedef yarp::os::PortablePair<yarp::os::Bottle, yarp::sig::Vector> CommandMessage;
 
-
-
 /**
 * Callback implementation after buffered input.
 */
 class StreamingMessagesParser : public yarp::os::TypedReaderCallback<CommandMessage>
 {
 protected:
-    yarp::dev::IPositionControl     *stream_IPosCtrl;
-    yarp::dev::IPositionDirect      *stream_IPosDirect;
-    yarp::dev::IVelocityControl     *stream_IVel;
-    yarp::dev::ITorqueControl       *stream_ITorque;
-    yarp::dev::IPWMControl          *stream_IPWM;
-    yarp::dev::ICurrentControl      *stream_ICurrent;
-    int                              stream_nJoints;
+    yarp::dev::IPositionControl* stream_IPosCtrl {nullptr};
+    yarp::dev::IPositionDirect* stream_IPosDirect {nullptr};
+    yarp::dev::IVelocityControl* stream_IVel {nullptr};
+    yarp::dev::ITorqueControl* stream_ITorque {nullptr};
+    yarp::dev::IPWMControl* stream_IPWM {nullptr};
+    yarp::dev::ICurrentControl* stream_ICurrent {nullptr};
+    int stream_nJoints {0};
 
 public:
     /**
     * Constructor.
     */
-    StreamingMessagesParser();
+    StreamingMessagesParser() = default;
 
     /**
-    * Initialization.
-    * @param x is the instance of the container class using the callback.
-    */
-    void init(ControlBoardWrapper *x);
+     * Initialization.
+     * @param x is the instance of the container class using the callback.
+     */
+    void init(yarp::dev::DeviceDriver* x);
 
     using yarp::os::TypedReaderCallback<CommandMessage>::onRead;
     /**
-    * Callback function.
-    * @param v is the Vector being received.
-    */
+     * Callback function.
+     * @param v is the Vector being received.
+     */
     void onRead(CommandMessage& v) override;
 
     bool initialize();

--- a/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -24,7 +24,7 @@ using namespace yarp::sig;
 using namespace std;
 
 
-bool SubDevice::configure(int wb, int wt, int b, int t, int n, const std::string& key, ControlBoardWrapper* _parent)
+bool SubDevice::configure(size_t wb, size_t wt, size_t b, size_t t, size_t n, const std::string& key, ControlBoardWrapper* _parent)
 {
     parent = _parent;
     configuredF = false;
@@ -176,7 +176,7 @@ bool SubDevice::attach(yarp::dev::PolyDriver* d, const std::string& k)
         yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iAxisInfo not valid interface.", parentName.c_str());
     }
 
-    int deviceJoints = 0;
+    size_t deviceJoints = 0;
 
     // checking minimum set of intefaces required
     if (!pos) {
@@ -195,28 +195,32 @@ bool SubDevice::attach(yarp::dev::PolyDriver* d, const std::string& k)
     }
 
     if (pos != nullptr) {
-        if (!pos->getAxes(&deviceJoints)) {
+        int tmp_axes;
+        if (!pos->getAxes(&tmp_axes)) {
             yCError(CONTROLBOARDWRAPPER) << "Failed to get axes number for subdevice " << k.c_str();
             return false;
         }
-        if (deviceJoints <= 0) {
-            yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
+        if (tmp_axes <= 0) {
+            yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), tmp_axes);
             return false;
         }
+        deviceJoints = static_cast<size_t>(tmp_axes);
     } else {
-        if (!pos->getAxes(&deviceJoints)) {
+        int tmp_axes;
+        if (!pos->getAxes(&tmp_axes)) {
             yCError(CONTROLBOARDWRAPPER, "Part <%s>: failed to get axes number for subdevice %s.", parentName.c_str(), k.c_str());
             return false;
         }
-        if (deviceJoints <= 0) {
-            yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
+        if (tmp_axes <= 0) {
+            yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), tmp_axes);
             return false;
         }
+        deviceJoints = static_cast<size_t>(tmp_axes);
     }
 
     if (deviceJoints < axes) {
-        yCError(CONTROLBOARDWRAPPER, "Part <%s>: check device configuration, number of joints of attached device '%d' less \
-                than the one specified during configuration '%d' for %s.",
+        yCError(CONTROLBOARDWRAPPER, "Part <%s>: check device configuration, number of joints of attached device '%zu' less \
+                than the one specified during configuration '%zu' for %s.",
                 parentName.c_str(),
                 deviceJoints,
                 axes,

--- a/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -8,13 +8,15 @@
  */
 
 #include "SubDevice.h"
-#include "ControlBoardWrapper.h"
-#include "StreamingMessagesParser.h"
-#include "RPCMessagesParser.h"
-#include "ControlBoardWrapperLogComponent.h"
-#include <iostream>
+
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
+#include "ControlBoardWrapper.h"
+#include "ControlBoardWrapperLogComponent.h"
+#include "RPCMessagesParser.h"
+#include "StreamingMessagesParser.h"
+#include <iostream>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -22,109 +24,76 @@ using namespace yarp::sig;
 using namespace std;
 
 
-SubDevice::SubDevice() :
-    base(-1),
-    top(-1),
-    axes(0),
-    configuredF(false),
-    parent(nullptr),
-    subdevice(nullptr),
-    pid(nullptr),
-    pos(nullptr),
-    vel(nullptr),
-    iJntEnc(nullptr),
-    iMotEnc(nullptr),
-    amp(nullptr),
-    lim(nullptr),
-    calib(nullptr),
-    iTimed(nullptr),
-    iTorque(nullptr),
-    iImpedance(nullptr),
-    iMode(nullptr),
-    info(nullptr),
-    posDir(nullptr),
-    iInteract(nullptr),
-    imotor(nullptr),
-    iVar(nullptr),
-    iPWM(nullptr),
-    iCurr(nullptr),
-    _subDevVerbose(false),
-    attachedF(false)
-{}
-
-bool SubDevice::configure(int wb, int wt, int b, int t, int n, const std::string &key, ControlBoardWrapper *_parent)
+bool SubDevice::configure(int wb, int wt, int b, int t, int n, const std::string& key, ControlBoardWrapper* _parent)
 {
     parent = _parent;
-    configuredF=false;
+    configuredF = false;
 
     wbase = wb;
     wtop = wt;
-    base=b;
-    top=t;
-    axes=n;
-    id=key;
+    base = b;
+    top = t;
+    axes = n;
+    id = key;
 
-    if (top<base)
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Check configuration file top<base.";
-            return false;
-        }
+    if (top < base) {
+        yCError(CONTROLBOARDWRAPPER) << "Check configuration file top<base.";
+        return false;
+    }
 
-    if ((top-base+1)!=axes)
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Check configuration file, number of axes and top/base parameters do not match";
-            return false;
-        }
+    if ((top - base + 1) != axes) {
+        yCError(CONTROLBOARDWRAPPER) << "Check configuration file, number of axes and top/base parameters do not match";
+        return false;
+    }
 
-    if (axes<=0)
-        {
-            yCError(CONTROLBOARDWRAPPER) << "Check number of axes";
-            return false;
-        }
+    if (axes <= 0) {
+        yCError(CONTROLBOARDWRAPPER) << "Check number of axes";
+        return false;
+    }
 
     subDev_joint_encoders.resize(axes);
     jointEncodersTimes.resize(axes);
     subDev_motor_encoders.resize(axes);
     motorEncodersTimes.resize(axes);
 
-    configuredF=true;
+    configuredF = true;
     return true;
 }
 
 void SubDevice::detach()
 {
-    subdevice=nullptr;
+    subdevice = nullptr;
 
-    pid=nullptr;
-    pos=nullptr;
-    posDir=nullptr;
-    vel=nullptr;
+    pid = nullptr;
+    pos = nullptr;
+    posDir = nullptr;
+    vel = nullptr;
     amp = nullptr;
-    iJntEnc=nullptr;
-    iMotEnc=nullptr;
-    lim=nullptr;
-    calib=nullptr;
-    info=nullptr;
-    iTorque=nullptr;
-    iImpedance=nullptr;
-    iMode=nullptr;
-    iTimed=nullptr;
-    iInteract=nullptr;
+    iJntEnc = nullptr;
+    iMotEnc = nullptr;
+    lim = nullptr;
+    calib = nullptr;
+    info = nullptr;
+    iTorque = nullptr;
+    iImpedance = nullptr;
+    iMode = nullptr;
+    iTimed = nullptr;
+    iInteract = nullptr;
     iVar = nullptr;
-    configuredF=false;
-    attachedF=false;
+    configuredF = false;
+    attachedF = false;
 }
 
-bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
+bool SubDevice::attach(yarp::dev::PolyDriver* d, const std::string& k)
 {
     std::string parentName;
-    if(parent) {
+    if (parent) {
         parentName = parent->getId();
     } else {
         parentName = "";
     }
 
-    if (id!=k) {
+    if (id != k) {
         yCError(CONTROLBOARDWRAPPER, "Part <%s>: Wrong or unknown device %s. Cannot attach to it.", parentName.c_str(), k.c_str());
         return false;
     }
@@ -135,12 +104,12 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         return false;
     }
 
-    if (d==nullptr) {
+    if (d == nullptr) {
         yCError(CONTROLBOARDWRAPPER, "Part <%s>: Invalid device (null pointer)", parentName.c_str());
         return false;
     }
 
-    subdevice=d;
+    subdevice = d;
 
     if (subdevice->isValid()) {
         subdevice->view(pid);
@@ -167,110 +136,102 @@ bool SubDevice::attach(yarp::dev::PolyDriver *d, const std::string &k)
         return false;
     }
 
-    if ( ((iMode==nullptr)) && (_subDevVerbose )) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iMode not valid interface.", parentName.c_str());
+    if (!iMode) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iMode not valid interface.", parentName.c_str());
     }
 
-    if ((iTorque==nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iTorque not valid interface.", parentName.c_str());
+    if (!iTorque) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iTorque not valid interface.", parentName.c_str());
     }
 
-    if ((iCurr == nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iCurr not valid interface.", parentName.c_str());
+    if (!iCurr) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iCurr not valid interface.", parentName.c_str());
     }
 
-    if ((iPWM == nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iPWM not valid interface.", parentName.c_str());
+    if (!iPWM) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iPWM not valid interface.", parentName.c_str());
     }
 
-    if ((iImpedance==nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iImpedance not valid interface.", parentName.c_str());
+    if (!iImpedance) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iImpedance not valid interface.", parentName.c_str());
     }
 
-    if ((iInteract==nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iInteractionMode not valid interface.", parentName.c_str());
+    if (!iInteract) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iInteractionMode not valid interface.", parentName.c_str());
     }
 
-    if ((iMotEnc==nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iMotorEncoder not valid interface.", parentName.c_str());
+    if (!iMotEnc) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iMotorEncoder not valid interface.", parentName.c_str());
     }
 
-    if ((imotor==nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iMotor not valid interface.", parentName.c_str());
+    if (!imotor) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iMotor not valid interface.", parentName.c_str());
     }
 
-    if ((iVar == nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iRemoteVariable not valid interface.", parentName.c_str());
+    if (!iVar) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iRemoteVariable not valid interface.", parentName.c_str());
     }
 
-    if ((info == nullptr) && (_subDevVerbose)) {
-        yCWarning(CONTROLBOARDWRAPPER, "Part <%s>: iAxisInfo not valid interface.", parentName.c_str());
+    if (!info) {
+        yCDebug(CONTROLBOARDWRAPPER, "Part <%s>: iAxisInfo not valid interface.", parentName.c_str());
     }
 
-    int deviceJoints=0;
+    int deviceJoints = 0;
 
     // checking minimum set of intefaces required
-    if( ! (pos) )
-    {
-        yCError(CONTROLBOARDWRAPPER, "Neither IPositionControl nor IPositionControl2 interface was not found in subdevice. Quitting");
+    if (!pos) {
+        yCError(CONTROLBOARDWRAPPER, "Part <%s>: IPositionControl interface was not found in subdevice. Quitting", parentName.c_str());
         return false;
     }
 
-    if( ! (vel) )
-    {
-        yCError(CONTROLBOARDWRAPPER, "Neither IVelocityControl nor IVelocityControl2 interface was not found in subdevice. Quitting");
+    if (!vel) {
+        yCError(CONTROLBOARDWRAPPER, "Part <%s>: IVelocityControl nor IVelocityControl2 interface was not found in subdevice. Quitting", parentName.c_str());
         return false;
     }
 
-    if(!iJntEnc)
-    {
+    if (!iJntEnc) {
         yCError(CONTROLBOARDWRAPPER, "Part <%s>: IEncoderTimed interface was not found in subdevice.", parentName.c_str());
         return false;
     }
 
-    if (pos!=nullptr)
-    {
-        if (!pos->getAxes(&deviceJoints))
-        {
+    if (pos != nullptr) {
+        if (!pos->getAxes(&deviceJoints)) {
             yCError(CONTROLBOARDWRAPPER) << "Failed to get axes number for subdevice " << k.c_str();
             return false;
         }
-        if(deviceJoints <= 0)
-        {
+        if (deviceJoints <= 0) {
             yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
             return false;
         }
-    }
-    else
-    {
-        if (!pos->getAxes(&deviceJoints))
-        {
+    } else {
+        if (!pos->getAxes(&deviceJoints)) {
             yCError(CONTROLBOARDWRAPPER, "Part <%s>: failed to get axes number for subdevice %s.", parentName.c_str(), k.c_str());
             return false;
         }
-        if(deviceJoints <=0)
-        {
+        if (deviceJoints <= 0) {
             yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), deviceJoints);
             return false;
         }
     }
 
-    if (deviceJoints<axes)
-    {
+    if (deviceJoints < axes) {
         yCError(CONTROLBOARDWRAPPER, "Part <%s>: check device configuration, number of joints of attached device '%d' less \
-                than the one specified during configuration '%d' for %s.", parentName.c_str(), deviceJoints, axes, k.c_str());
+                than the one specified during configuration '%d' for %s.",
+                parentName.c_str(),
+                deviceJoints,
+                axes,
+                k.c_str());
         return false;
     }
 
     int subdevAxes;
-    if(!pos || !pos->getAxes(&subdevAxes))
-    {
-        yCError(CONTROLBOARDWRAPPER) << "Device <" << parentName << "> attached to subdevice " << k.c_str() << " but it was not ready yet. \n" \
-                 << "Please check the device has been correctly created and all required initialization actions has been performed.";
-                 return false;
+    if (!pos || !pos->getAxes(&subdevAxes)) {
+        yCError(CONTROLBOARDWRAPPER) << "Device <" << parentName << "> attached to subdevice " << k.c_str() << " but it was not ready yet. \n"
+                                     << "Please check the device has been correctly created and all required initialization actions has been performed.";
+        return false;
     }
 
     totalAxis = deviceJoints;
-    attachedF=true;
+    attachedF = true;
     return true;
 }

--- a/src/devices/ControlBoardWrapper/SubDevice.h
+++ b/src/devices/ControlBoardWrapper/SubDevice.h
@@ -55,12 +55,12 @@ class SubDevice
 {
 public:
     std::string id;
-    int base {-1};
-    int top {-1};
-    int wbase;     //wrapper base
-    int wtop;      //wrapper top
-    int axes {0};  //number of used axis of this subdevice
-    int totalAxis; //Numeber of total axis that the subdevice can control
+    size_t base {static_cast<size_t>(-1)};
+    size_t top {static_cast<size_t>(-1)};
+    size_t wbase;     //wrapper base
+    size_t wtop;      //wrapper top
+    size_t axes {0};  //number of used axis of this subdevice
+    size_t totalAxis; //Numeber of total axis that the subdevice can control
 
     bool configuredF {false};
 
@@ -98,7 +98,7 @@ public:
     bool attach(yarp::dev::PolyDriver* d, const std::string& id);
     void detach();
 
-    bool configure(int wbase, int wtop, int base, int top, int axes, const std::string& id, ControlBoardWrapper* _parent);
+    bool configure(size_t wbase, size_t wtop, size_t base, size_t top, size_t axes, const std::string& id, ControlBoardWrapper* _parent);
 
     bool isAttached()
     {
@@ -113,9 +113,9 @@ typedef std::vector<SubDevice> SubDeviceVector;
 
 struct DevicesLutEntry
 {
-    int offset;          //an offset, the device is mapped starting from this joint
-    int deviceEntry;     //index to the joint corresponding subdevice in the list
-    int jointIndexInDev; //the index of joint in the numeration inside the device
+    size_t offset;          //an offset, the device is mapped starting from this joint
+    size_t deviceEntry;     //index to the joint corresponding subdevice in the list
+    size_t jointIndexInDev; //the index of joint in the numeration inside the device
 };
 
 
@@ -124,9 +124,9 @@ class WrappedDevice
 public:
     SubDeviceVector subdevices;
     std::vector<DevicesLutEntry> lut;
-    int maxNumOfJointsInDevices;
+    size_t maxNumOfJointsInDevices;
 
-    inline SubDevice* getSubdevice(unsigned int i)
+    inline SubDevice* getSubdevice(size_t i)
     {
         if (i >= subdevices.size()) {
             return nullptr;

--- a/src/devices/ControlBoardWrapper/SubDevice.h
+++ b/src/devices/ControlBoardWrapper/SubDevice.h
@@ -13,30 +13,29 @@
 // ControlBoardWrapper
 // A modified version of the remote control board class
 // which remaps joints, it can also merge networks into a single part.
-//
 
-#include <yarp/os/PortablePair.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/PortablePair.h>
+#include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
+#include <yarp/os/Time.h>
 #include <yarp/os/Vocab.h>
 
+#include <yarp/sig/Vector.h>
+
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 #include <yarp/dev/IPreciselyTimed.h>
-#include <yarp/sig/Vector.h>
-#include <yarp/os/Semaphore.h>
+#include <yarp/dev/PolyDriver.h>
 
+#include "RPCMessagesParser.h"
+#include "StreamingMessagesParser.h"
 #include <string>
 #include <vector>
 
-#include "StreamingMessagesParser.h"
-#include "RPCMessagesParser.h"
-
 #ifdef MSVC
-    #pragma warning(disable:4355)
+#    pragma warning(disable : 4355)
 #endif
 
 /*
@@ -56,65 +55,66 @@ class SubDevice
 {
 public:
     std::string id;
-    int base;
-    int top;
-    int wbase; //wrapper base
-    int wtop; //wrapper top
-    int axes; //number of used axis of this subdevice
+    int base {-1};
+    int top {-1};
+    int wbase;     //wrapper base
+    int wtop;      //wrapper top
+    int axes {0};  //number of used axis of this subdevice
     int totalAxis; //Numeber of total axis that the subdevice can control
 
-    bool configuredF;
+    bool configuredF {false};
 
-    ControlBoardWrapper *parent;
+    ControlBoardWrapper* parent {nullptr};
 
-    yarp::dev::PolyDriver            *subdevice;
-    yarp::dev::IPidControl           *pid;
-    yarp::dev::IPositionControl      *pos;
-    yarp::dev::IVelocityControl      *vel;
-    yarp::dev::IEncodersTimed        *iJntEnc;
-    yarp::dev::IMotorEncoders        *iMotEnc;
-    yarp::dev::IAmplifierControl     *amp;
-    yarp::dev::IControlLimits        *lim;
-    yarp::dev::IControlCalibration   *calib;
-    yarp::dev::IPreciselyTimed       *iTimed;
-    yarp::dev::ITorqueControl        *iTorque;
-    yarp::dev::IImpedanceControl     *iImpedance;
-    yarp::dev::IControlMode          *iMode;
-    yarp::dev::IAxisInfo             *info;
-    yarp::dev::IPositionDirect       *posDir;
-    yarp::dev::IInteractionMode      *iInteract;
-    yarp::dev::IMotor                *imotor;
-    yarp::dev::IRemoteVariables      *iVar;
-    yarp::dev::IPWMControl           *iPWM;
-    yarp::dev::ICurrentControl       *iCurr;
+    yarp::dev::PolyDriver* subdevice {nullptr};
+    yarp::dev::IPidControl* pid {nullptr};
+    yarp::dev::IPositionControl* pos {nullptr};
+    yarp::dev::IVelocityControl* vel {nullptr};
+    yarp::dev::IEncodersTimed* iJntEnc {nullptr};
+    yarp::dev::IMotorEncoders* iMotEnc {nullptr};
+    yarp::dev::IAmplifierControl* amp {nullptr};
+    yarp::dev::IControlLimits* lim {nullptr};
+    yarp::dev::IControlCalibration* calib {nullptr};
+    yarp::dev::IPreciselyTimed* iTimed {nullptr};
+    yarp::dev::ITorqueControl* iTorque {nullptr};
+    yarp::dev::IImpedanceControl* iImpedance {nullptr};
+    yarp::dev::IControlMode* iMode {nullptr};
+    yarp::dev::IAxisInfo* info {nullptr};
+    yarp::dev::IPositionDirect* posDir {nullptr};
+    yarp::dev::IInteractionMode* iInteract {nullptr};
+    yarp::dev::IMotor* imotor {nullptr};
+    yarp::dev::IRemoteVariables* iVar {nullptr};
+    yarp::dev::IPWMControl* iPWM {nullptr};
+    yarp::dev::ICurrentControl* iCurr {nullptr};
 
     yarp::sig::Vector subDev_joint_encoders;
     yarp::sig::Vector jointEncodersTimes;
     yarp::sig::Vector subDev_motor_encoders;
     yarp::sig::Vector motorEncodersTimes;
 
-    SubDevice();
+    SubDevice() = default;
+    ;
 
-    bool attach(yarp::dev::PolyDriver *d, const std::string &id);
+    bool attach(yarp::dev::PolyDriver* d, const std::string& id);
     void detach();
-    inline void setVerbose(bool _verbose) {_subDevVerbose = _verbose; }
 
-    bool configure(int wbase, int wtop, int base, int top, int axes, const std::string &id, ControlBoardWrapper *_parent);
+    bool configure(int wbase, int wtop, int base, int top, int axes, const std::string& id, ControlBoardWrapper* _parent);
 
     bool isAttached()
-    { return attachedF; }
+    {
+        return attachedF;
+    }
 
 private:
-    bool _subDevVerbose;
-    bool attachedF;
+    bool attachedF {false};
 };
 
 typedef std::vector<SubDevice> SubDeviceVector;
 
 struct DevicesLutEntry
 {
-    int offset; //an offset, the device is mapped starting from this joint
-    int deviceEntry; //index to the joint corresponding subdevice in the list
+    int offset;          //an offset, the device is mapped starting from this joint
+    int deviceEntry;     //index to the joint corresponding subdevice in the list
     int jointIndexInDev; //the index of joint in the numeration inside the device
 };
 
@@ -126,10 +126,11 @@ public:
     std::vector<DevicesLutEntry> lut;
     int maxNumOfJointsInDevices;
 
-    inline SubDevice *getSubdevice(unsigned int i)
+    inline SubDevice* getSubdevice(unsigned int i)
     {
-        if (i>=subdevices.size())
-            return 0;
+        if (i >= subdevices.size()) {
+            return nullptr;
+        }
 
         return &subdevices[i];
     }


### PR DESCRIPTION
* Refactor, splitting interfaces implementation in separate classes.
  Common methods and class members are now in the
  ControlBoardWrapperCommon class, which is virtually inherited by all
  the other classes.
* RPCMessageParser and StreamingMessagesParser now accept a DeviceDriver
  instead of a ControlBoardWrapper in preparation of the YARP/ROS split.
* Cleanup