### PR TITLE
os/impl/PortCore: Refactor state semaphore

### DIFF
--- a/src/libYARP_os/src/yarp/os/Contactable.h
+++ b/src/libYARP_os/src/yarp/os/Contactable.h
@@ -280,6 +280,7 @@ public:
      * @param readOnly set this if you won't be modifying the properties.
      * @return the port properties (or nullptr if readOnly and none have
      *         been set)
+     * @warning Must be called in the same thread as releaseProperties
      */
     virtual Property* acquireProperties(bool readOnly) = 0;
 
@@ -287,6 +288,7 @@ public:
      * End access unstructured port properties.
      *
      * @param prop the port property object provided by acquireProperties()
+     * @warning Must be called in the same thread as acquireProperties
      */
     virtual void releaseProperties(Property* prop) = 0;
 


### PR DESCRIPTION
Replaced by a mutex + a condition_variable + a few atomic variables.

The semaphore was used both for synchronization and for protecting critical sections. It is now clear where the threads are syncronizing, and where the mutex is protecting some data from concurrent access.

(note: better select "Hide whitespace changes" while reviewing the patch)