### PR TITLE
Print RGBA values as ints in PointCloud data types

### DIFF
--- a/doc/release/yarp_3_4/fix_pcl_toString.md
+++ b/doc/release/yarp_3_4/fix_pcl_toString.md
@@ -1,0 +1,11 @@
+fix_pcl_toString {#yarp_3_4}
+-----------
+
+### Libraries
+
+#### `sig`
+
+##### `PointCloudTypes`
+
+* Fixed logging of RGBA values via `toString()` for types `DataRGBA`,
+  `DataXYZRGBA` and `DataXYZNormalRGBA`.

--- a/src/libYARP_sig/src/yarp/sig/PointCloudTypes.h
+++ b/src/libYARP_sig/src/yarp/sig/PointCloudTypes.h
@@ -251,7 +251,7 @@ struct DataRGBA
         YARP_UNUSED(width);
         std::string ret = "";
         char tmp[128];
-        snprintf(tmp, 128, "%c %c %c %c\t", r, g, b, a);
+        snprintf(tmp, 128, "%d %d %d %d\t", r, g, b, a);
         ret += tmp;
         return ret;
     }
@@ -524,7 +524,7 @@ struct DataXYZRGBA
                                                            width, precision, z);
             ret += tmp;
         }
-        snprintf(tmp, 128, "%c %c %c %c\t", r, g, b, a);
+        snprintf(tmp, 128, "%d %d %d %d\t", r, g, b, a);
         ret += tmp;
         return ret;
     }
@@ -864,7 +864,7 @@ struct DataXYZNormalRGBA
                                                                    width, precision, curvature);
             ret += tmp;
         }
-        snprintf(tmp, 128, "%c %c %c %c\t", r, g, b, a);
+        snprintf(tmp, 128, "%d %d %d %d\t", r, g, b, a);
         ret += tmp;
         return ret;
     }


### PR DESCRIPTION
For instance, `printf("%c", red);` outputs the corresponding ASCII character. We should get numeric values instead.