### PR TITLE
Fix ROI clipping in yarp::sig::utils::depthToPC()

### DIFF
--- a/doc/release/yarp_3_4/fix_depthToPC_ROI.md
+++ b/doc/release/yarp_3_4/fix_depthToPC_ROI.md
@@ -1,0 +1,10 @@
+fix_depthToPC_ROI {#yarp_3_4}
+-----------
+
+### Libraries
+
+#### `sig`
+
+##### `utils`
+
+* Fixed ROI bug in `depthToPC()`, values are now correctly clipped.

--- a/src/libYARP_sig/src/yarp/sig/PointCloudUtils.cpp
+++ b/src/libYARP_sig/src/yarp/sig/PointCloudUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <yarp/sig/PointCloudUtils.h>
+#include <cmath>
 #include <cstring>
 
 using namespace yarp::sig;
@@ -48,22 +49,21 @@ PointCloud<DataXYZ> utils::depthToPC(const yarp::sig::ImageOf<PixelFloat>& depth
     yCAssert(POINTCLOUDUTILS, depth.width() != 0);
     yCAssert(POINTCLOUDUTILS, depth.height() != 0);
 
-    size_t max_x = 0;
-    size_t max_y = 0;
-    if (roi.max_x == 0) max_x = depth.width();
-    if (roi.max_y == 0) max_y = depth.height();
-    max_x = max_x < depth.width()  ? max_x : depth.width();
-    max_y = max_y < depth.height() ? max_y : depth.height();
+    size_t max_x = roi.max_x == 0 ? depth.width()  : std::min(roi.max_x, depth.width());
+    size_t max_y = roi.max_y == 0 ? depth.height() : std::min(roi.max_y, depth.height());
+    size_t min_x = std::min(roi.min_x, max_x);
+    size_t min_y = std::min(roi.min_y, max_y);
+    // avoid step larger than ROI and division by zero
+    step_x = std::max<size_t>(std::min(step_x, max_x - min_x), 1);
+    step_y = std::max<size_t>(std::min(step_y, max_y - min_y), 1);
 
     PointCloud<DataXYZ> pointCloud;
-    size_t size_x = (max_x-roi.min_x)/step_x;
-    size_t size_y = (max_y-roi.min_y)/step_y;
-    pointCloud.resize(size_x,size_y);
+    size_t size_x = (max_x - min_x) / step_x;
+    size_t size_y = (max_y - min_y) / step_y;
+    pointCloud.resize(size_x, size_y);
 
-    size_t i=0;
-    for (    size_t u = roi.min_x; u < max_x; u += step_x) {
-        size_t j=0;
-        for (size_t v = roi.min_y; v < max_y; v += step_y) {
+    for (size_t i = 0, u = min_x; u < max_x; i++, u += step_x) {
+        for (size_t j = 0, v = min_y; v < max_y; j++, v += step_y) {
             // De-projection equation (pinhole model):
             //                          x = (u - ppx)/ fx * z
             //                          y = (v - ppy)/ fy * z
@@ -71,9 +71,7 @@ PointCloud<DataXYZ> utils::depthToPC(const yarp::sig::ImageOf<PixelFloat>& depth
             pointCloud(i, j).x = (u - intrinsic.principalPointX) / intrinsic.focalLengthX * depth.pixel(u, v);
             pointCloud(i, j).y = (v - intrinsic.principalPointY) / intrinsic.focalLengthY * depth.pixel(u, v);
             pointCloud(i, j).z = depth.pixel(u, v);
-            j++;
         }
-        i++;
     }
     return pointCloud;
 }

--- a/tests/libYARP_sig/PointCloudTest.cpp
+++ b/tests/libYARP_sig/PointCloudTest.cpp
@@ -950,6 +950,22 @@ TEST_CASE("sig::PointCloudTest", "[yarp::sig]")
         CHECK(pcCol.height() == depth.height()); // Checking PC height
     }
 
+    SECTION("Testing depthToPC with ROI")
+    {
+        ImageOf<PixelFloat> depth;
+        size_t width{320};
+        size_t height{240};
+        depth.resize(width, height);
+        IntrinsicParams intp;
+        utils::PCL_ROI roi {100, 300, 150, 200}; // {min_x, max_x, min_y, max_y}
+        size_t step_x = 2; // (300 - 100) / 2 = 100 pixels wide
+        size_t step_y = 5; // (200 - 150) / 5 = 10 pixels high
+
+        auto pc = utils::depthToPC(depth, intp, roi, step_x, step_y);
+        CHECK(pc.width() == (roi.max_x - roi.min_x) / step_x); // Checking PC width
+        CHECK(pc.height() == (roi.max_y - roi.min_y) / step_y); // Checking PC height
+    }
+
     SECTION("Testing move semantics")
     {
         INFO("Testing the copy constructor with PC of the same type");


### PR DESCRIPTION
Max and min values of both ROI and decimation steps are now clipped within reasonable limits.