### PR TITLE
Fix wrong include in PointCloudUtils.cpp

### DIFF
--- a/src/libYARP_sig/src/yarp/sig/PointCloudUtils.cpp
+++ b/src/libYARP_sig/src/yarp/sig/PointCloudUtils.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <yarp/sig/PointCloudUtils.h>
-#include <cmath>
+#include <algorithm>
 #include <cstring>
 
 using namespace yarp::sig;


### PR DESCRIPTION
https://github.com/robotology/yarp/pull/2425 added the use of std::max and std::min, but adding as include cmath instead of algorithm . Without this change, I am experiencing compilation errors on Windows.