### PR TITLE
carriers/portmonitor: Set the reply handler correctly

### DIFF
--- a/doc/release/master/portmonitor_fix_reply_handler.md
+++ b/doc/release/master/portmonitor_fix_reply_handler.md
@@ -1,0 +1,9 @@
+portmonitor_fix_reply_handler {#master}
+-----------------------------
+
+## Carriers
+
+### `portmonitor`
+
+* The reply handler is now set correctly, it is therefore now possible to
+  monitor RPC connections.

--- a/src/carriers/portmonitor_carrier/PortMonitor.cpp
+++ b/src/carriers/portmonitor_carrier/PortMonitor.cpp
@@ -155,8 +155,12 @@ yarp::os::ConnectionReader& PortMonitor::modifyIncomingData(yarp::os::Connection
     PortMonitor::unlock();
     con.reset();
     if(result.write(con.getWriter())) {
-        con.getReader().setParentConnectionReader(&reader);
-        return con.getReader();
+        auto& cReader = con.getReader(reader.getWriter());
+        cReader.setParentConnectionReader(&reader);
+        if (result.getPortReader() != nullptr) {
+            cReader.getWriter()->setReplyHandler(*result.getPortReader());
+        }
+        return cReader;
     }
     return *localReader;
 }
@@ -193,7 +197,7 @@ bool PortMonitor::acceptIncomingData(yarp::os::ConnectionReader& reader)
         if(thing.hasBeenRead()) {
             con.reset();
             if(thing.write(con.getWriter())) {
-                localReader = &con.getReader();
+                localReader = &con.getReader(reader.getWriter());
             }
         }
     }


### PR DESCRIPTION
## Carriers

### `portmonitor`

* The reply handler is now set correctly, it is therefore now possible to
  monitor RPC connections.

----

This should be a bugfix, but it depends on #2385 therefore it cannot be fixed in the stable branch