### PR TITLE
yarp repeat

### DIFF
--- a/doc/release/master/yarp_repeat.md
+++ b/doc/release/master/yarp_repeat.md
@@ -1,0 +1,9 @@
+yarp_repeat {#master}
+-------------------------
+
+## Important Changes
+
+### Yarp companion
+
+#### added command `yarp repeat`
+* `yarp repeat` repeats in an output port all data received in an input port. The command is useful to control stream flows on a wifi/mobile connection.

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(YARP_companion_IMPL_SRCS yarp/companion/impl/Companion.cpp
                              yarp/companion/impl/Companion.cmdResource.cpp
                              yarp/companion/impl/Companion.cmdRead.cpp
                              yarp/companion/impl/Companion.cmdReadWrite.cpp
+                             yarp/companion/impl/Companion.cmdRepeat.cpp
                              yarp/companion/impl/Companion.cmdRpc.cpp
                              yarp/companion/impl/Companion.cmdRpcServer.cpp
                              yarp/companion/impl/Companion.cmdSample.cpp

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/companion/impl/Companion.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+
+using yarp::companion::impl::Companion;
+using yarp::os::Bottle;
+using yarp::os::BufferedPort;
+using yarp::os::NetworkBase;
+using yarp::os::Property;
+
+int Companion::cmdRepeat(int argc, char *argv[])
+{
+    BufferedPort<Bottle> port;
+
+    Property options;
+    options.fromCommand(argc, argv, false);
+    if (argc==0 || !(options.check("output")))
+    {
+        yCInfo(COMPANION, "This is yarp repeat. Syntax:");
+        yCInfo(COMPANION, "  yarp sample --output /port");
+        yCInfo(COMPANION, "Data is read from the input port and repeated on the output port");
+        return 1;
+    }
+
+    if (!port.open(options.find("output").asString()))
+    {
+        yCError(COMPANION, "Failed to open output port");
+        return 1;
+    }
+
+    if (options.check("input"))
+    {
+        std::string input = options.find("input").asString();
+        std::string carrier = options.find("carrier").asString();
+        if (carrier!="")
+        {
+            NetworkBase::connect(input.c_str(), port.getName().c_str(), carrier.c_str());
+        }
+        else
+        {
+            NetworkBase::connect(input, port.getName());
+        }
+    }
+
+    while (true)
+    {
+        Bottle *bot = port.read();
+        if (!bot) continue;
+        if (port.getOutputCount()>0)
+        {
+            port.prepare() = *bot;
+            port.write();
+        }
+    }
+
+    return 0;
+}

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
@@ -25,32 +25,26 @@ int Companion::cmdRepeat(int argc, char *argv[])
 
     Property options;
     options.fromCommand(argc, argv, false);
-    if (argc==0 || !(options.check("output")))
+    if (argc==0 || options.check("help"))
     {
         yCInfo(COMPANION, "This is yarp repeat. Syntax:");
-        yCInfo(COMPANION, "  yarp sample --output /port");
-        yCInfo(COMPANION, "Data is read from the input port and repeated on the output port");
+        yCInfo(COMPANION, "  yarp repeat /port");
+        yCInfo(COMPANION, "/port is both the input port and the output port which repeats data");
         return 1;
     }
 
-    if (!port.open(options.find("output").asString()))
+    if (argc==1)
     {
-        yCError(COMPANION, "Failed to open output port");
-        return 1;
+        if (!port.open(argv[0]))
+        {
+            yCError(COMPANION, "Failed to open port: %s", argv[0]);
+            return 1;
+        }
     }
-
-    if (options.check("input"))
+    else
     {
-        std::string input = options.find("input").asString();
-        std::string carrier = options.find("carrier").asString();
-        if (carrier!="")
-        {
-            NetworkBase::connect(input.c_str(), port.getName().c_str(), carrier.c_str());
-        }
-        else
-        {
-            NetworkBase::connect(input, port.getName());
-        }
+        yCError(COMPANION, "Invalid command syntax");
+        return 1;
     }
 
     while (true)

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -154,6 +154,7 @@ Companion::Companion() :
     add("priority-qos",    &Companion::cmdPriorityQos,    "set/get the packet priority for a given connection");
     add("read",            &Companion::cmdRead,           "read from the network and print to standard output");
     add("readwrite",       &Companion::cmdReadWrite,      "read from the network and print to standard output, write to the network from standard input");
+    add("repeat",          &Companion::cmdRepeat,         "repeats on the output port the same data received in the input port");
     add("resource",        &Companion::cmdResource,       "locates resource files (see ResourceFinder class)");
     add("rpc",             &Companion::cmdRpc,            "write commands to a port, and read replies");
     add("rpcserver",       &Companion::cmdRpcServer,      "make a test RPC server to receive and reply to Bottle-format messages");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -110,6 +110,9 @@ public:
     // Defined in Companion.cmdReadWrite.cpp
     int cmdReadWrite(int argc, char *argv[]);
 
+    // Defined in Companion.cmdRepeat.cpp
+    int cmdRepeat(int argc, char* argv[]);
+
     // Defined in Companion.cmdResource.cpp
     int cmdResource(int argc, char *argv[]);
 


### PR DESCRIPTION
Added new yarp companion command `yarp repeat`.

**Usage example:**
The picture below shows two machines connected through a wireless network. This network topology is **BAD** because each module uses its own connection, streaming data over the wireless twice.
 
![Screenshot from 2020-12-16 19-34-32 (2)](https://user-images.githubusercontent.com/2869969/102485259-a640b600-4067-11eb-8771-1707c2ef855f.png)

Instead you can use the **yarp repeat** on the receiver side:
```
yarp repeat /repeater
yarp connect /grabber /repeater
yarp connect /repeater /port1 unix_stream
yarp connect /repeater /port2 unix_stream
```
![Screenshot from 2020-12-16 19-33-21 (2)](https://user-images.githubusercontent.com/2869969/102485054-637ede00-4067-11eb-8c5d-52d38f3a9c21.png)
In this way only one connection is used over the wifi. The two receiver modules run on the same machine, so they can use a `unix_stream` connection to efficiently receive data from the `/repeater` port.
