### PR TITLE
Yarp trafficgen

### DIFF
--- a/doc/release/master/yarp_trafficGen.md
+++ b/doc/release/master/yarp_trafficGen.md
@@ -1,0 +1,9 @@
+yarp_trafficGen {#master}
+-------------------------
+
+## Important Changes
+
+### Yarp companion
+
+#### added command `yarp trafficGen`
+* `yarp trafficGen` sends generated data over a yarp port. The tool allows to test the communication and the available bandwidth over the network.

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(YARP_companion_IMPL_SRCS yarp/companion/impl/Companion.cpp
                              yarp/companion/impl/Companion.cmdSample.cpp
                              yarp/companion/impl/Companion.cmdTerminate.cpp
                              yarp/companion/impl/Companion.cmdTime.cpp
+                             yarp/companion/impl/Companion.cmdTrafficGen.cpp
                              yarp/companion/impl/Companion.cmdTopic.cpp
                              yarp/companion/impl/Companion.cmdVersion.cpp
                              yarp/companion/impl/Companion.cmdWait.cpp

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/companion/impl/Companion.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/PeriodicThread.h>
+
+using yarp::companion::impl::Companion;
+using yarp::os::Bottle;
+using yarp::os::BufferedPort;
+using yarp::os::NetworkBase;
+using yarp::os::Property;
+using namespace std;
+
+class datasender : public yarp::os::PeriodicThread
+{
+private:
+    size_t data_size = 1;
+    char* data_buff =nullptr;
+    std::string portname = "/trafficGen";
+    yarp::os::BufferedPort<yarp::os::Bottle> outport;
+
+public:
+    datasender(double period) : PeriodicThread (period)
+    {
+    }
+
+    bool threadInit()
+    {
+        data_buff = new char[data_size*1000000];
+ 
+        if (!outport.open(portname))
+        {
+            yCError(COMPANION, "Failed to open port: %s", portname);
+            return false;
+        }
+
+        Bottle& pp = outport.prepare();
+        pp.addString(data_buff);
+    }
+
+    void run() override
+    {
+        if (outport.getOutputCount()>0)
+            outport.write();
+    }
+
+    void threadRelease()
+    {
+        outport.interrupt();
+        outport.close();
+    }
+};
+
+int Companion::cmdTrafficGen(int argc, char *argv[])
+{
+    Property options;
+    options.fromCommand(argc, argv, false);
+    if (argc==0 || options.check("help"))
+    {
+        yCInfo(COMPANION, "This is yarp trafficGen. Syntax:");
+        yCInfo(COMPANION, "  yarp trafficGen /port --period [s] --size [MB] --duration [s]");
+        yCInfo(COMPANION, "  yarp trafficGen /port --bandwidth [Mb/s] --duration [s]");
+        return 1;
+    }
+
+    double period = 1;
+    string portname = "/trafficGen";
+    size_t size = 1;
+    double duration = 10;
+
+    datasender pt(period);
+    double start_time = yarp::os::Time::now();
+    if (pt.start() == false)
+    {
+        yCInfo(COMPANION, "Failed to start the main thread");
+        return 0;
+    }
+
+    do
+    {
+        yarp::os::Time::delay(0.1);
+    }   while (yarp::os::Time::now() - start_time < duration);
+    pt.stop();
+    yarp::os::Time::delay(1);
+
+    return 0;
+}

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
@@ -14,6 +14,7 @@
 #include <yarp/os/Property.h>
 #include <yarp/os/PeriodicThread.h>
 #include <limits>
+#include <cstring>
 
 using yarp::companion::impl::Companion;
 using yarp::os::Bottle;

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
@@ -74,18 +74,18 @@ int Companion::cmdTrafficGen(int argc, char *argv[])
     options.fromCommand(argc, argv, false);
     if (argc==0 || options.check("help"))
     {
-        yCInfo(COMPANION, "This is yarp trafficGen. Syntax/available options:");
-        yCInfo(COMPANION, "  yarp trafficGen /port --bandwidth [Mb/s]");
-        yCInfo(COMPANION, "  yarp trafficGen /port --bandwidth [Mb/s] --duration [s]");
-        yCInfo(COMPANION, "  yarp trafficGen /port --period [s] --size [MB]");
-        yCInfo(COMPANION, "  yarp trafficGen /port --period [s] --size [MB] --duration [s]");
+        yCInfo(COMPANION, "This is yarp trafficgen. Syntax/available options:");
+        yCInfo(COMPANION, "  yarp trafficgen /port --bandwidth [Mb/s]");
+        yCInfo(COMPANION, "  yarp trafficgen /port --bandwidth [Mb/s] --duration [s]");
+        yCInfo(COMPANION, "  yarp trafficgen /port --period [s] --size [MB]");
+        yCInfo(COMPANION, "  yarp trafficgen /port --period [s] --size [MB] --duration [s]");
         return 1;
     }
 
     double period;
     double size_MB;
     double duration = options.check("duration", yarp::os::Value(std::numeric_limits<double>::infinity()), "duration (s)").asFloat32();
-    
+
     if (options.check("bandwidth") && !options.check("size") && !options.check("period"))
     {
         double bandwidth_Mbs = options.check("bandwidth", yarp::os::Value(1), "bandwidth (Mb/s)").asFloat32();
@@ -102,15 +102,15 @@ int Companion::cmdTrafficGen(int argc, char *argv[])
         period = 1.0;
         size_MB = 1.0;
     }
-    else 
+    else
     {
-        yCError(COMPANION, "Invalid combination of options. Please check the available options with: yarp trafficGen --help");
+        yCError(COMPANION, "Invalid combination of options. Please check the available options with: yarp trafficgen --help");
         return 0;
     }
 
     string portname = argv[0];
 
-    yCInfo (COMPANION, "Starting trafficGen with the following options: period:%.3f(s), size:%.3f(MB), duration:%.3f(s), bandwidth:%.3f(Mb/s) ", period, size_MB, duration, period* size_MB *8);
+    yCInfo (COMPANION, "Starting trafficgen with the following options: period:%.3f(s), size:%.3f(MB), duration:%.3f(s), bandwidth:%.3f(Mb/s) ", period, size_MB, duration, period* size_MB *8);
 
     datasender pt(period, portname, size_MB);
     double start_time = yarp::os::Time::now();

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
@@ -48,7 +48,7 @@ public:
 
         if (!outport.open(m_portname))
         {
-            yCError(COMPANION, "Failed to open port: %s", m_portname);
+            yCError(COMPANION, "Failed to open port: %s", m_portname.c_str());
             return false;
         }
 

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -163,6 +163,7 @@ Companion::Companion() :
     add("terminate",       &Companion::cmdTerminate,      "terminate a yarp-terminate-aware process by name");
     add("time",            &Companion::cmdTime,           "show the time");
     add("topic",           &Companion::cmdTopic,          "set a topic name");
+    add("trafficGen",      &Companion::cmdTrafficGen,     "generates and streams some test data traffic on a port");
     add("version",         &Companion::cmdVersion,        "get version information");
     add("wait",            &Companion::cmdWait,           "wait for a port to be alive");
     add("where",           &Companion::cmdWhere,          "report where the yarp name server is running");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -163,7 +163,7 @@ Companion::Companion() :
     add("terminate",       &Companion::cmdTerminate,      "terminate a yarp-terminate-aware process by name");
     add("time",            &Companion::cmdTime,           "show the time");
     add("topic",           &Companion::cmdTopic,          "set a topic name");
-    add("trafficGen",      &Companion::cmdTrafficGen,     "generates and streams some test data traffic on a port");
+    add("trafficgen",      &Companion::cmdTrafficGen,     "generates and streams some test data traffic on a port");
     add("version",         &Companion::cmdVersion,        "get version information");
     add("wait",            &Companion::cmdWait,           "wait for a port to be alive");
     add("where",           &Companion::cmdWhere,          "report where the yarp name server is running");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -136,6 +136,9 @@ public:
     // Defined in Companion.cmdTopic.cpp
     int cmdTopic(int argc, char *argv[]);
 
+    // Defined in Companion.cmdTrafficGen.cpp
+    int cmdTrafficGen(int argc, char* argv[]);
+
     // Defined in Companion.cmdVersion.cpp
     static std::string version();
     int cmdVersion(int argc, char *argv[]);


### PR DESCRIPTION
The companion tool `yarp trafficgen` sends generated data over a yarp port. The tool allows to test the communication and the available bandwidth over the network.
E.g.
```
yarp trafficgen /port --bandwidth [Mb/s]
yarp trafficgen /port --bandwidth [Mb/s] --duration [s]
yarp trafficgen /port --period [s] --size [MB]
yarp trafficgen /port --period [s] --size [MB] --duration [s]
```
