### PR TITLE
Properly set dependencies for the  libraries

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -334,6 +334,9 @@ checkandset_dependency(OpenCV)
 set_property(DIRECTORY PROPERTY INCLUDE_DIRECTORIES ${OpenCV24_WORKAROUND_ORIGINAL_INCLUDE_DIRS})
 # End second part of workaround
 
+find_package(PCL COMPONENTS common io QUIET)
+checkandset_dependency(PCL)
+
 find_package(Lua QUIET)
 checkandset_dependency(Lua)
 
@@ -608,6 +611,7 @@ print_dependency(QGVCore)
 print_dependency(Libedit)
 print_dependency(SWIG)
 print_dependency(OpenCV)
+print_dependency(PCL)
 print_dependency(Lua)
 print_dependency(LibOVR)
 print_dependency(GLFW3)

--- a/doc/release/yarp_3_4/fix_interface_lib_deps.md
+++ b/doc/release/yarp_3_4/fix_interface_lib_deps.md
@@ -1,0 +1,9 @@
+fix_interface_lib_deps {#yarp_3_4}
+----------------------
+
+## Build System
+
+* Dependencies for the `INTERFACE` libraries (YARP_cv, YARP_pcl)
+  are now properly set (#2438).
+* PCL is now required to build the YARP_pcl library.
+* OpenCV is now required to build the YARP_cv library.

--- a/src/libYARP_cv/CMakeLists.txt
+++ b/src/libYARP_cv/CMakeLists.txt
@@ -6,6 +6,13 @@
 
 project(YARP_cv)
 
+# OpenCV is required, otherwise the OpenCV_INCLUDE_DIR and OpenCV_LIBRARIES
+# (used in the CMakeLists.txt file in the src direcrory) are not expanded).
+# FIXME Remove this check when OpenCV targets will be used.
+if (NOT YARP_HAS_OpenCV)
+  return()
+endif()
+
 add_subdirectory(src)
 
 include(YarpInstallBasicPackageFiles)

--- a/src/libYARP_cv/src/CMakeLists.txt
+++ b/src/libYARP_cv/src/CMakeLists.txt
@@ -21,8 +21,8 @@ target_compile_features(YARP_conf INTERFACE cxx_std_14)
 target_link_libraries(YARP_cv INTERFACE YARP::YARP_sig)
 list(APPEND YARP_cv_PUBLIC_DEPS YARP_sig)
 
-target_include_directories(YARP_cv SYSTEM INTERFACE ${OPENCV_INCLUDE_DIR})
-target_link_libraries(YARP_cv INTERFACE ${OPENCV_INCLUDE_DIR})
+target_include_directories(YARP_cv SYSTEM INTERFACE ${OpenCV_INCLUDE_DIR})
+target_link_libraries(YARP_cv INTERFACE ${OpenCV_LIBRARIES})
 list(APPEND YARP_cv_PUBLIC_DEPS OpenCV)
 
 # set_property(TARGET YARP_cv PROPERTY PUBLIC_HEADER ${YARP_cv_HDRS})

--- a/src/libYARP_pcl/CMakeLists.txt
+++ b/src/libYARP_pcl/CMakeLists.txt
@@ -6,6 +6,14 @@
 
 project(YARP_pcl)
 
+# PCL is required, otherwise the PCL_<component>_INCLUDE_DIR and
+# PCL_<component>_LIBRARIES
+# (used in the CMakeLists.txt file in the src direcrory) are not expanded).
+# FIXME Remove this check when PCL targets will be used.
+if (NOT YARP_HAS_PCL)
+  return()
+endif()
+
 add_subdirectory(src)
 
 include(YarpInstallBasicPackageFiles)

--- a/src/libYARP_pcl/src/CMakeLists.txt
+++ b/src/libYARP_pcl/src/CMakeLists.txt
@@ -20,9 +20,11 @@ target_compile_features(YARP_pcl INTERFACE cxx_std_14)
 target_link_libraries(YARP_pcl INTERFACE YARP::YARP_sig)
 list(APPEND YARP_pcl_PUBLIC_DEPS YARP_sig)
 
-target_include_directories(YARP_pcl SYSTEM INTERFACE ${PCL_INCLUDE_DIR})
-target_link_libraries(YARP_pcl INTERFACE ${PCL_LIBRARIES})
-list(APPEND YARP_pcl_PUBLIC_DEPS PCL)
+target_include_directories(YARP_pcl SYSTEM INTERFACE ${PCL_COMMON_INCLUDE_DIR}
+                                                     ${PCL_IO_INCLUDE_DIR})
+target_link_libraries(YARP_pcl INTERFACE ${PCL_COMMON_LIBRARIES}
+                                         ${PCL_IO_LIBRARIES})
+list(APPEND YARP_pcl_PUBLIC_DEPS "PCL COMPONENTS common io")
 
 # set_property(TARGET YARP_pcl PROPERTY PUBLIC_HEADER ${YARP_pcl_HDRS})
 # set_property(TARGET YARP_pcl PROPERTY PRIVATE_HEADER ${YARP_pcl_IMPL_HDRS})


### PR DESCRIPTION
## Build System

* Dependencies for the `INTERFACE` libraries (YARP_cv and YARP_pcl)
  are now properly set (#2438).
* PCL is now required to build the YARP_pcl library.
* OpenCV is now required to build the YARP_cv library.

Fixes #2438