### PR TITLE
Deprecate old networks format

### DIFF
--- a/doc/release/yarp_3_4/fix_deprecate-old-networks-format.md
+++ b/doc/release/yarp_3_4/fix_deprecate-old-networks-format.md
@@ -1,0 +1,8 @@
+fix_deprecate-old-networks-format.md {#yarp_3_4}
+---------------
+
+### device
+
+#### `ControlBoardWrapper`
+
+* Deprecated old format of `networks` keyword in the XML files to favor the use of parentheses.

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.h
@@ -170,8 +170,8 @@ public:
  * \code{.xml}
  * <paramlist name="networks">
  *   <!-- elem name hereafter are custom names that live only in this file, they are used in the attach phase -->
- *   <elem name="FirstSetOfJoints">  0  3  0  3  </elem>
- *   <elem name="SecondSetOfJoints"> 4  6  0  2  </elem>
+ *   <elem name="FirstSetOfJoints">  (0  3  0  3)  </elem>
+ *   <elem name="SecondSetOfJoints"> (4  6  0  2)  </elem>
  * </paramlist>
  *
  * <param name="period"> 20                 </param>


### PR DESCRIPTION
This PR addresses the proposal detailed in https://github.com/robotology/robots-configuration/issues/222#issuecomment-744507821 for the official deprecation of the "old" format of the keyword `networks`.

Configuration files have been updated consistently in https://github.com/robotology/robots-configuration/pull/227, thus `yCError` can be adopted gracefully.

cc @traversaro @S-Dafarra 