### PR TITLE
Fix yarpviz grid on export

### DIFF
--- a/doc/release/yarp_3_4/fix_yarpviz_gridOnExport.md
+++ b/doc/release/yarp_3_4/fix_yarpviz_gridOnExport.md
@@ -1,0 +1,12 @@
+fix_yarpviz_gridOnExport {#yarp_3_4}
+-------------------
+
+### Tools + libraries
+
+#### `yarpviz` + `YARP_priv_qgvcore`
+
+* Since, due to how the `QGVScene::drawBackground` function has been reimplemented, everytime a scene is exported as an image from `yarpviz` a white grid is added on top of the background, whether the user likes it or not, I added to `QGVScene` a new **bool** property named `gridNeeded` in order to change this behavior. If the property is *true*, the grid will be drawn as it is now. Otherwise the grid won't be added to the resulting image.
+* The initial value of the property can be passed to the class constructor as a parameter (the default value of this parameter is *true* for backward compatibility sake) and then it can be modified by using `QGVScen::enableBgGrid` and checked via `QGVScene::bgGridEnabled`.
+* In `yarpviz`menu a new voice has been added under `View`-> `Render options`. This checkable option labbelled `Background grid` allows to enabel/disable the background grid menitioned in the previous points.
+
+* **PS:** since the icons resource file for the `Mainwindow` is called `res.qrc` but in the `Mainwindow.ui` file there are multiple references to a non-existent `ress.qrc` file, I changed also those references.

--- a/extern/qgv/qgv/QGVCore/QGVScene.cpp
+++ b/extern/qgv/qgv/QGVCore/QGVScene.cpp
@@ -32,10 +32,11 @@ License along with this library.
 #include <QGraphicsSceneContextMenuEvent>
 #include <iostream>
 
-QGVScene::QGVScene(const QString &name, QObject *parent) : QGraphicsScene(parent)
+QGVScene::QGVScene(const QString &name, QObject *parent, bool gridNeeded) : QGraphicsScene(parent)
 {
     _context = new QGVGvcPrivate(gvContext());
     _graph = new QGVGraphPrivate(agopen(name.toLocal8Bit().data(), Agdirected, NULL));
+    m_gridNeeded = gridNeeded;
     //setGraphAttribute("fontname", QFont().family());
 }
 
@@ -278,22 +279,35 @@ void QGVScene::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *mouseEvent)
 #include <QPainter>
 void QGVScene::drawBackground(QPainter * painter, const QRectF & rect)
 {
-    const int gridSize = 25;
+    if(m_gridNeeded)
+    {
+        const int gridSize = 25;
 
-    const qreal left = int(rect.left()) - (int(rect.left()) % gridSize);
-    const qreal top = int(rect.top()) - (int(rect.top()) % gridSize);
+        const qreal left = int(rect.left()) - (int(rect.left()) % gridSize);
+        const qreal top = int(rect.top()) - (int(rect.top()) % gridSize);
 
-    QVarLengthArray<QLineF, 100> lines;
+        QVarLengthArray<QLineF, 100> lines;
 
-    for (qreal x = left; x < rect.right(); x += gridSize)
-        lines.append(QLineF(x, rect.top(), x, rect.bottom()));
-    for (qreal y = top; y < rect.bottom(); y += gridSize)
-        lines.append(QLineF(rect.left(), y, rect.right(), y));
+        for (qreal x = left; x < rect.right(); x += gridSize)
+            lines.append(QLineF(x, rect.top(), x, rect.bottom()));
+        for (qreal y = top; y < rect.bottom(); y += gridSize)
+            lines.append(QLineF(rect.left(), y, rect.right(), y));
 
-    painter->setRenderHint(QPainter::Antialiasing, false);
+        painter->setRenderHint(QPainter::Antialiasing, false);
 
-    painter->setPen(QColor(Qt::lightGray).lighter(110));
-    painter->drawLines(lines.data(), lines.size());
-    painter->setPen(Qt::black);
+        painter->setPen(QColor(Qt::lightGray).lighter(110));
+        painter->drawLines(lines.data(), lines.size());
+        painter->setPen(Qt::black);
+    }
     //painter->drawRect(sceneRect());
+}
+
+void QGVScene::enableBgGrid(bool enable)
+{
+    m_gridNeeded = enable;
+}
+
+bool QGVScene::bgGridEnabled()
+{
+    return m_gridNeeded;
 }

--- a/extern/qgv/qgv/QGVCore/QGVScene.h
+++ b/extern/qgv/qgv/QGVCore/QGVScene.h
@@ -37,7 +37,7 @@ class QGVCORE_EXPORT QGVScene : public QGraphicsScene
     Q_OBJECT
 public:
 
-    explicit QGVScene(const QString &name, QObject *parent = 0);
+    explicit QGVScene(const QString &name, QObject *parent = 0, bool gridNeeded = true);
     ~QGVScene();
 
     void setGraphAttribute(const QString &name, const QString &value);
@@ -57,6 +57,9 @@ public:
     void loadLayout(const QString &text);
     void applyLayout();
     void clear();
+
+    void enableBgGrid(bool enable);  // Enables or disables the "backgroung grid" added when rendering the scene
+    bool bgGridEnabled();
 
 
 signals:
@@ -89,6 +92,8 @@ private:
     QList<QGVNode*> _nodes;
     QList<QGVEdge*> _edges;
     QList<QGVSubGraph*> _subGraphs;
+
+    bool m_gridNeeded;  // If false, the drawBackground function will not apply the grid to the image background
 };
 
 #endif // QGVSCENE_H

--- a/src/yarpviz/src/MainWindow.cpp
+++ b/src/yarpviz/src/MainWindow.cpp
@@ -83,6 +83,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionUpdateConnectionQosStatus, SIGNAL(triggered()),this,SLOT(onUpdateQosStatus()));
     connect(ui->actionProfilePortsRate, SIGNAL(triggered()),this,SLOT(onProfilePortsRate()));
     connect(ui->actionAbout, SIGNAL(triggered()),this,SLOT(onAbout()));
+    connect(ui->actionBackground_grid, SIGNAL(triggered()),this,SLOT(onBackgroundGrid()));
 
     //progressDlg = new QProgressDialog("...", "Cancel", 0, 100, this);
 
@@ -870,4 +871,9 @@ void MainWindow::onExportScene() {
     this->scene->render( &p );
     p.end();
     */
+}
+
+void MainWindow::onBackgroundGrid()
+{
+    scene->enableBgGrid(ui->actionBackground_grid->isChecked());
 }

--- a/src/yarpviz/src/MainWindow.h
+++ b/src/yarpviz/src/MainWindow.h
@@ -115,6 +115,7 @@ private slots:
     void onProfilePortsRate();
     void onSubGraphContextMenuProcess(QGVSubGraph *node);
     void onAbout();
+    void onBackgroundGrid();
 
 private:
     Ui::MainWindow *ui;

--- a/src/yarpviz/src/MainWindow.ui
+++ b/src/yarpviz/src/MainWindow.ui
@@ -14,7 +14,7 @@
    <string>yarpviz</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ress.qrc">
+   <iconset resource="res.qrc">
     <normaloff>:/icons/resources/profiling.png</normaloff>:/icons/resources/profiling.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -98,7 +98,7 @@
      <x>0</x>
      <y>0</y>
      <width>817</width>
-     <height>19</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -146,8 +146,16 @@
      <addaction name="separator"/>
      <addaction name="actionSubgraph"/>
     </widget>
+    <widget class="QMenu" name="menuRender_options">
+     <property name="title">
+      <string>Render options</string>
+     </property>
+     <addaction name="actionBackground_grid"/>
+    </widget>
     <addaction name="separator"/>
     <addaction name="menuLayout"/>
+    <addaction name="separator"/>
+    <addaction name="menuRender_options"/>
     <addaction name="separator"/>
     <addaction name="actionHidePorts"/>
     <addaction name="actionHideConnectionsLable"/>
@@ -217,7 +225,7 @@
   </action>
   <action name="actionProfile_YARP_network">
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/profiling.png</normaloff>:/icons/resources/profiling.png</iconset>
    </property>
    <property name="text">
@@ -282,7 +290,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/chain.png</normaloff>:/icons/resources/chain.png</iconset>
    </property>
    <property name="text">
@@ -305,7 +313,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/port_hide.svg</normaloff>:/icons/resources/port_hide.svg</iconset>
    </property>
    <property name="text">
@@ -322,7 +330,7 @@
   </action>
   <action name="actionUpdateConnectionQosStatus">
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/qos.png</normaloff>:/icons/resources/qos.png</iconset>
    </property>
    <property name="text">
@@ -331,7 +339,7 @@
   </action>
   <action name="actionProfilePortsRate">
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/profile_rate.png</normaloff>:/icons/resources/profile_rate.png</iconset>
    </property>
    <property name="text">
@@ -361,7 +369,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/debugMode.svg</normaloff>:/icons/resources/debugMode.svg</iconset>
    </property>
    <property name="text">
@@ -376,7 +384,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="ress.qrc">
+    <iconset resource="res.qrc">
      <normaloff>:/icons/resources/atooma.svg</normaloff>:/icons/resources/atooma.svg</iconset>
    </property>
    <property name="text">
@@ -384,6 +392,20 @@
    </property>
    <property name="toolTip">
     <string>Enable the Color Mode</string>
+   </property>
+  </action>
+  <action name="actionBackground_grid">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Background grid</string>
+   </property>
+   <property name="toolTip">
+    <string>Background grid</string>
    </property>
   </action>
  </widget>
@@ -396,7 +418,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="ress.qrc"/>
+  <include location="res.qrc"/>
  </resources>
  <connections>
   <connection>


### PR DESCRIPTION
fix_yarpviz_gridOnExport {#yarp_3_4}
-------------------

### Tools + libraries

#### `yarpviz` + `YARP_priv_qgvcore`

* Since, due to how the `QGVScene::drawBackground` function has been reimplemented, everytime a scene is exported as an image from `yarpviz` a white grid is added on top of the background, whether the user likes it or not, I added to `QGVScene` a new **bool** property named `gridNeeded` in order to change this behavior. If the property is *true*, the grid will be drawn as it is now. Otherwise the grid won't be added to the resulting image.
* The initial value of the property can be passed to the class constructor as a parameter (the default value of this parameter is *true* for backward compatibility sake) and then it can be modified by using `QGVScen::enableBgGrid` and checked via `QGVScene::bgGridEnabled`.
* In `yarpviz`menu a new voice has been added under `View`-> `Render options`. This checkable option labbelled `Background grid` allows to enabel/disable the background grid menitioned in the previous points.

* **PS:** since the icons resource file for the `Mainwindow` is called `res.qrc` but in the `Mainwindow.ui` file there are multiple references to a non-existent `ress.qrc` file, I changed also those references.
