### PR TITLE
localization2D_nws

### DIFF
--- a/doc/release/master/localization2D_nws.md
+++ b/doc/release/master/localization2D_nws.md
@@ -1,0 +1,14 @@
+localization2D_nws {#master}
+-------------------------
+
+### Devices
+
+#### `localization2D_nws_yarp`
+
+* This new device implements a new yarp-only wrapper for devices which implement the `ILocalization2D` interface.
+* The implementation is inspired by the original wrapper `localization2DServer`.
+
+#### `localization2D_nws_ros`
+
+* This new device implements a new ros-only wrapper for devices which implement the `ILocalization2D` interface.
+* The implementation is inspired by the original wrapper `localization2DServer`.

--- a/src/devices/localization2DServer/CMakeLists.txt
+++ b/src/devices/localization2DServer/CMakeLists.txt
@@ -49,7 +49,7 @@ yarp_prepare_plugin(localization2D_nws_yarp
                     DEPENDS "TARGET YARP::YARP_math"
                     DEFAULT ON)
 
-if(NOT SKIP_llocalization2D_nws_yarp)
+if(NOT SKIP_localization2D_nws_yarp)
   yarp_add_plugin(yarp_localization2D_nws_yarp)
 
   target_sources(yarp_localization2D_nws_yarp PRIVATE localization2D_nws_yarp.h
@@ -58,13 +58,11 @@ if(NOT SKIP_llocalization2D_nws_yarp)
   target_link_libraries(yarp_localization2D_nws_yarp YARP::YARP_os
                                                   YARP::YARP_sig
                                                   YARP::YARP_dev
-                                                  YARP::YARP_rosmsg
                                                   YARP::YARP_math)
 
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_sig
                                                       YARP_dev
-                                                      YARP_rosmsg
                                                       YARP_math)
 
   yarp_install(TARGETS yarp_localization2D_nws_yarp

--- a/src/devices/localization2DServer/CMakeLists.txt
+++ b/src/devices/localization2DServer/CMakeLists.txt
@@ -40,3 +40,79 @@ if(NOT SKIP_localization2DServer)
 
   set_property(TARGET yarp_localization2DServer PROPERTY FOLDER "Plugins/Device")
 endif()
+
+###########################################################################################################
+yarp_prepare_plugin(localization2D_nws_yarp
+                    CATEGORY device
+                    TYPE Localization2D_nws_yarp
+                    INCLUDE localization2D_nws_yarp.h
+                    DEPENDS "TARGET YARP::YARP_math"
+                    DEFAULT ON)
+
+if(NOT SKIP_llocalization2D_nws_yarp)
+  yarp_add_plugin(yarp_localization2D_nws_yarp)
+
+  target_sources(yarp_localization2D_nws_yarp PRIVATE localization2D_nws_yarp.h
+                                                   localization2D_nws_yarp.cpp)
+
+  target_link_libraries(yarp_localization2D_nws_yarp YARP::YARP_os
+                                                  YARP::YARP_sig
+                                                  YARP::YARP_dev
+                                                  YARP::YARP_rosmsg
+                                                  YARP::YARP_math)
+
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_rosmsg
+                                                      YARP_math)
+
+  yarp_install(TARGETS yarp_localization2D_nws_yarp
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_localization2D_nws_yarp PROPERTY FOLDER "Plugins/Device")
+endif()
+
+###########################################################################################################
+yarp_prepare_plugin(localization2D_nws_ros
+                    CATEGORY device
+                    TYPE Localization2D_nws_ros
+                    INCLUDE localization2D_nws_ros.h
+                    DEPENDS "TARGET YARP::YARP_math"
+                    DEFAULT ON)
+
+if(NOT SKIP_localization2D_nws_ros)
+  yarp_add_plugin(yarp_localization2D_nws_ros)
+
+  target_sources(yarp_localization2D_nws_ros PRIVATE localization2D_nws_ros.h
+                                                   localization2D_nws_ros.cpp)
+
+  target_link_libraries(yarp_localization2D_nws_ros YARP::YARP_os
+                                                  YARP::YARP_sig
+                                                  YARP::YARP_dev
+                                                  YARP::YARP_rosmsg
+                                                  YARP::YARP_math)
+
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig
+                                                      YARP_dev
+                                                      YARP_rosmsg
+                                                      YARP_math)
+
+  yarp_install(TARGETS yarp_localization2D_nws_ros
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_localization2D_nws_ros PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/devices/localization2DServer/localization2D_nws_ros.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_ros.cpp
@@ -33,7 +33,7 @@
 
 #include <cmath>
 
-/*! \file Localization2DServer.cpp */
+/*! \file Localization2D_nws_ros.cpp */
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -47,7 +47,7 @@ using namespace std;
 #endif
 
 namespace {
-YARP_LOG_COMPONENT(LOCALIZATION2DSERVER, "yarp.device.localization2DServer")
+YARP_LOG_COMPONENT(LOCALIZATION2D_NWS_ROS, "yarp.device.localization2D_nws_ros")
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ bool Localization2D_nws_ros::attachAll(const PolyDriverList &device2attach)
 {
     if (device2attach.size() != 1)
     {
-        yCError(LOCALIZATION2DSERVER, "Cannot attach more than one device");
+        yCError(LOCALIZATION2D_NWS_ROS, "Cannot attach more than one device");
         return false;
     }
 
@@ -79,7 +79,7 @@ bool Localization2D_nws_ros::attachAll(const PolyDriverList &device2attach)
 
     if (nullptr == iLoc)
     {
-        yCError(LOCALIZATION2DSERVER, "Subdevice passed to attach method is invalid");
+        yCError(LOCALIZATION2D_NWS_ROS, "Subdevice passed to attach method is invalid");
         return false;
     }
 
@@ -96,7 +96,7 @@ bool Localization2D_nws_ros::attachAll(const PolyDriverList &device2attach)
     }
     else
     {
-        yCWarning(LOCALIZATION2DSERVER) << "Localization data not yet available during server initialization";
+        yCWarning(LOCALIZATION2D_NWS_ROS) << "Localization data not yet available during server initialization";
     }
 
     PeriodicThread::setPeriod(m_period);
@@ -117,50 +117,50 @@ bool Localization2D_nws_ros::open(Searchable& config)
 {
     Property params;
     params.fromString(config.toString().c_str());
-    yCDebug(LOCALIZATION2DSERVER) << "Configuration: \n" << config.toString().c_str();
+    yCDebug(LOCALIZATION2D_NWS_ROS) << "Configuration: \n" << config.toString().c_str();
 
     if (config.check("GENERAL") == false)
     {
-        yCWarning(LOCALIZATION2DSERVER) << "Missing GENERAL group, assuming default options";
+        yCWarning(LOCALIZATION2D_NWS_ROS) << "Missing GENERAL group, assuming default options";
     }
 
     Bottle& general_group = config.findGroup("GENERAL");
     if (!general_group.check("period"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
         m_period = DEFAULT_THREAD_PERIOD;
     }
     else
     {
         m_period = general_group.find("period").asFloat64();
-        yCInfo(LOCALIZATION2DSERVER) << "Period requested: " << m_period;
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Period requested: " << m_period;
     }
 
     if (!general_group.check("retrieve_position_periodically"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
         m_getdata_using_periodic_thread = true;
     }
     else
     {
         m_getdata_using_periodic_thread = general_group.find("retrieve_position_periodically").asBool();
         if (m_getdata_using_periodic_thread)
-            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically requested, Period:" << m_period; }
+            { yCInfo(LOCALIZATION2D_NWS_ROS) << "retrieve_position_periodically requested, Period:" << m_period; }
         else
-            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
+            { yCInfo(LOCALIZATION2D_NWS_ROS) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
     }
 
 
     m_local_name = "/localizationServer";
     if (!general_group.check("name"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'name' parameter. Using default value: /localizationServer";
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Missing 'name' parameter. Using default value: /localizationServer";
     }
     else
     {
         m_local_name = general_group.find("name").asString();
-        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2DSERVER) << "Missing '/' in name parameter" ;  return false; }
-        yCInfo(LOCALIZATION2DSERVER) << "Using local name:" << m_local_name;
+        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2D_NWS_ROS) << "Missing '/' in name parameter" ;  return false; }
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Using local name:" << m_local_name;
     }
 
     m_rpcPortName = m_local_name + "/rpc";
@@ -174,32 +174,32 @@ bool Localization2D_nws_ros::open(Searchable& config)
 
         if (!pLoc.open(p) || !pLoc.isValid())
         {
-            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Failed to open subdevice.. check params";
             return false;
         }
 
         driverlist.push(&pLoc, "1");
         if (!attachAll(driverlist))
         {
-            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Failed to open subdevice.. check params";
             return false;
         }
     }
     else
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Waiting for device to attach";
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Waiting for device to attach";
     }
     m_stats_time_last = yarp::os::Time::now();
 
     if (!initialize_YARP(config))
     {
-        yCError(LOCALIZATION2DSERVER) << "Error initializing YARP ports";
+        yCError(LOCALIZATION2D_NWS_ROS) << "Error initializing YARP ports";
         return false;
     }
 
     if (!initialize_ROS(config))
     {
-        yCError(LOCALIZATION2DSERVER) << "Error initializing ROS system";
+        yCError(LOCALIZATION2D_NWS_ROS) << "Error initializing ROS system";
         return false;
     }
 
@@ -213,7 +213,7 @@ bool Localization2D_nws_ros::initialize_ROS(yarp::os::Searchable& params)
         Bottle& ros_group = params.findGroup("ROS");
         if (!ros_group.check("parent_frame_id"))
         {
-            yCError(LOCALIZATION2DSERVER) << "Missing 'parent_frame_id' parameter";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Missing 'parent_frame_id' parameter";
             //return false;
         }
         else
@@ -222,7 +222,7 @@ bool Localization2D_nws_ros::initialize_ROS(yarp::os::Searchable& params)
         }
         if (!ros_group.check("child_frame_id"))
         {
-            yCError(LOCALIZATION2DSERVER) << "Missing 'child_frame_id' parameter";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Missing 'child_frame_id' parameter";
             //return false;
         }
         else
@@ -233,7 +233,7 @@ bool Localization2D_nws_ros::initialize_ROS(yarp::os::Searchable& params)
     }
     else
     {
-        yCInfo(LOCALIZATION2DSERVER) << "ROS initialization not requested";
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "ROS initialization not requested";
         return true;
     }
 
@@ -243,21 +243,21 @@ bool Localization2D_nws_ros::initialize_ROS(yarp::os::Searchable& params)
         m_ros_node = new yarp::os::Node(m_local_name+"_ROSnode");
         if (m_ros_node == nullptr)
         {
-            yCError(LOCALIZATION2DSERVER) << "Opening " << m_local_name << " Node, check your yarp-ROS network configuration";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Opening " << m_local_name << " Node, check your yarp-ROS network configuration";
         }
 
         string ros_odom_topic = m_local_name + string("/odom");
         b = m_odometry_publisher.topic(ros_odom_topic);
         if (!b)
         {
-            yCError(LOCALIZATION2DSERVER) << "Unable to publish data on" << ros_odom_topic << "topic";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Unable to publish data on" << ros_odom_topic << "topic";
         }
         b = m_tf_publisher.topic("/tf");
         if (!b)
         {
-            yCError(LOCALIZATION2DSERVER) << "Unable to publish data on /tf topic";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Unable to publish data on /tf topic";
         }
-        yCInfo(LOCALIZATION2DSERVER) << "ROS initialized";
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "ROS initialized";
     }
     return true;
 }
@@ -266,7 +266,7 @@ bool Localization2D_nws_ros::initialize_YARP(yarp::os::Searchable &params)
 {
     if (!m_rpcPort.open(m_rpcPortName.c_str()))
     {
-        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_rpcPortName.c_str());
+        yCError(LOCALIZATION2D_NWS_ROS, "Failed to open port %s", m_rpcPortName.c_str());
         return false;
     }
     m_rpcPort.setReader(*this);
@@ -276,7 +276,7 @@ bool Localization2D_nws_ros::initialize_YARP(yarp::os::Searchable &params)
 
 bool Localization2D_nws_ros::close()
 {
-    yCTrace(LOCALIZATION2DSERVER, "Close");
+    yCTrace(LOCALIZATION2D_NWS_ROS, "Close");
     if (PeriodicThread::isRunning())
     {
         PeriodicThread::stop();
@@ -295,7 +295,7 @@ bool Localization2D_nws_ros::close()
         m_ros_node = nullptr;
     }
 
-    yCDebug(LOCALIZATION2DSERVER) << "Execution terminated";
+    yCDebug(LOCALIZATION2D_NWS_ROS) << "Execution terminated";
     return true;
 }
 
@@ -313,29 +313,7 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
         if (command.get(0).asVocab() == VOCAB_INAVIGATION && command.get(1).isVocab())
         {
             int request = command.get(1).asVocab();
-            if (request == VOCAB_NAV_GET_CURRENT_POS)
-            {
-                if (m_getdata_using_periodic_thread)
-                {
-                    //m_current_position is obtained by run()
-                    reply.addVocab(VOCAB_OK);
-                    reply.addString(m_current_position.map_id);
-                    reply.addFloat64(m_current_position.x);
-                    reply.addFloat64(m_current_position.y);
-                    reply.addFloat64(m_current_position.theta);
-                }
-                else
-                {
-                    //m_current_position is obtained by getCurrentPosition()
-                    iLoc->getCurrentPosition(m_current_position);
-                    reply.addVocab(VOCAB_OK);
-                    reply.addString(m_current_position.map_id);
-                    reply.addFloat64(m_current_position.x);
-                    reply.addFloat64(m_current_position.y);
-                    reply.addFloat64(m_current_position.theta);
-                }
-            }
-            else if (request == VOCAB_NAV_SET_INITIAL_POS)
+            if (request == VOCAB_NAV_SET_INITIAL_POS)
             {
                 Map2DLocation init_loc;
                 init_loc.map_id = command.get(2).asString();
@@ -344,19 +322,6 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
                 init_loc.theta = command.get(5).asFloat64();
                 iLoc->setInitialPose(init_loc);
                 reply.addVocab(VOCAB_OK);
-            }
-            else if (request == VOCAB_NAV_GET_CURRENT_POSCOV)
-            {
-                Map2DLocation init_loc;
-                yarp::sig::Matrix cov(3, 3);
-                iLoc->getCurrentPosition(init_loc, cov);
-                reply.addVocab(VOCAB_OK);
-                reply.addString(m_current_position.map_id);
-                reply.addFloat64(m_current_position.x);
-                reply.addFloat64(m_current_position.y);
-                reply.addFloat64(m_current_position.theta);
-                yarp::os::Bottle& mc = reply.addList();
-                for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { mc.addFloat64(cov[i][j]); } }
             }
             else if (request == VOCAB_NAV_SET_INITIAL_POSCOV)
             {
@@ -389,37 +354,6 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
                 iLoc->stopLocalizationService();
                 reply.addVocab(VOCAB_OK);
             }
-            else if (request == VOCAB_NAV_GET_LOCALIZER_STATUS)
-            {
-                if (m_getdata_using_periodic_thread)
-                {
-                    //m_current_status is obtained by run()
-                    reply.addVocab(VOCAB_OK);
-                    reply.addVocab(m_current_status);
-                }
-                else
-                {
-                    //m_current_status is obtained by getLocalizationStatus()
-                    iLoc->getLocalizationStatus(m_current_status);
-                    reply.addVocab(VOCAB_OK);
-                    reply.addVocab(m_current_status);
-                }
-            }
-            else if (request == VOCAB_NAV_GET_LOCALIZER_POSES)
-            {
-                std::vector<Map2DLocation> poses;
-                iLoc->getEstimatedPoses(poses);
-                reply.addVocab(VOCAB_OK);
-                reply.addInt32(poses.size());
-                for (size_t i=0; i<poses.size(); i++)
-                {
-                    Bottle& b = reply.addList();
-                    b.addString(poses[i].map_id);
-                    b.addFloat64(poses[i].x);
-                    b.addFloat64(poses[i].y);
-                    b.addFloat64(poses[i].theta);
-                }
-            }
             else
             {
                 reply.addVocab(VOCAB_ERR);
@@ -427,7 +361,7 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
         }
         else
         {
-            yCError(LOCALIZATION2DSERVER) << "Invalid vocab received";
+            yCError(LOCALIZATION2D_NWS_ROS) << "Invalid vocab received";
             reply.addVocab(VOCAB_ERR);
         }
     }
@@ -458,7 +392,7 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
     }
     else
     {
-        yCError(LOCALIZATION2DSERVER) << "Invalid command type";
+        yCError(LOCALIZATION2D_NWS_ROS) << "Invalid command type";
         reply.addVocab(VOCAB_ERR);
     }
 
@@ -476,7 +410,7 @@ void Localization2D_nws_ros::run()
     double m_stats_time_curr = yarp::os::Time::now();
     if (m_stats_time_curr - m_stats_time_last > 5.0)
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Running";
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "Running";
         m_stats_time_last = yarp::os::Time::now();
     }
 
@@ -485,7 +419,7 @@ void Localization2D_nws_ros::run()
         bool ret = iLoc->getLocalizationStatus(m_current_status);
         if (ret == false)
         {
-            yCError(LOCALIZATION2DSERVER) << "getLocalizationStatus() failed";
+            yCError(LOCALIZATION2D_NWS_ROS) << "getLocalizationStatus() failed";
         }
 
         if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
@@ -496,7 +430,7 @@ void Localization2D_nws_ros::run()
             bool ret2 = iLoc->getCurrentPosition(m_current_position);
             if (ret2 == false)
             {
-                yCError(LOCALIZATION2DSERVER) << "getCurrentPosition() failed";
+                yCError(LOCALIZATION2D_NWS_ROS) << "getCurrentPosition() failed";
             }
             else
             {
@@ -505,7 +439,7 @@ void Localization2D_nws_ros::run()
             bool ret3 = iLoc->getEstimatedOdometry(m_current_odometry);
             if (ret3 == false)
             {
-                //yCError(LOCALIZATION2DSERVER) << "getEstimatedOdometry() failed";
+                //yCError(LOCALIZATION2D_NWS_ROS) << "getEstimatedOdometry() failed";
             }
             else
             {
@@ -514,7 +448,7 @@ void Localization2D_nws_ros::run()
         }
         else
         {
-            yCWarning(LOCALIZATION2DSERVER, "The system is not properly localized!");
+            yCWarning(LOCALIZATION2D_NWS_ROS, "The system is not properly localized!");
         }
     }
 

--- a/src/devices/localization2DServer/localization2D_nws_ros.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_ros.cpp
@@ -132,6 +132,17 @@ bool Localization2D_nws_ros::open(Searchable& config)
         yCInfo(LOCALIZATION2D_NWS_ROS) << "Period requested: " << m_period;
     }
 
+    if (!general_group.check("publish_odometry"))
+    {
+        m_enable_publish_odometry_topic = general_group.find("publish_odometry").asBool();
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "publish_odometry=" << m_enable_publish_odometry_topic;
+    }
+    if (!general_group.check("publish_tf"))
+    {
+        m_enable_publish_odometry_tf = general_group.find("publish_tf").asBool();
+        yCInfo(LOCALIZATION2D_NWS_ROS) << "publish_tf=" << m_enable_publish_odometry_tf;
+    }
+
     if (!general_group.check("name"))
     {
         yCInfo(LOCALIZATION2D_NWS_ROS) << "Missing 'name' parameter. Using default value: " << m_local_name;

--- a/src/devices/localization2DServer/localization2D_nws_ros.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_ros.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#define _USE_MATH_DEFINES
+
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
@@ -41,10 +43,6 @@ using namespace yarp::dev::Nav2D;
 using namespace std;
 
 #define DEFAULT_THREAD_PERIOD 0.01
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 
 namespace {
 YARP_LOG_COMPONENT(LOCALIZATION2D_NWS_ROS, "yarp.device.localization2D_nws_ros")

--- a/src/devices/localization2DServer/localization2D_nws_ros.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_ros.cpp
@@ -1,0 +1,592 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <yarp/os/Network.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/Port.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/dev/IMap2D.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IFrameTransform.h>
+#include <yarp/math/Math.h>
+#include "Localization2D_nws_ros.h"
+
+#include <cmath>
+
+/*! \file Localization2DServer.cpp */
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::dev::Nav2D;
+using namespace std;
+
+#define DEFAULT_THREAD_PERIOD 0.01
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace {
+YARP_LOG_COMPONENT(LOCALIZATION2DSERVER, "yarp.device.localization2DServer")
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+
+Localization2D_nws_ros::Localization2D_nws_ros() : PeriodicThread(DEFAULT_THREAD_PERIOD)
+{
+    m_ros_node = nullptr;
+    m_current_status = yarp::dev::Nav2D::LocalizationStatusEnum::localization_status_not_yet_localized;
+    m_period = DEFAULT_THREAD_PERIOD;
+    m_stats_time_last = yarp::os::Time::now();
+    iLoc = nullptr;
+    m_getdata_using_periodic_thread = true;
+}
+
+bool Localization2D_nws_ros::attachAll(const PolyDriverList &device2attach)
+{
+    if (device2attach.size() != 1)
+    {
+        yCError(LOCALIZATION2DSERVER, "Cannot attach more than one device");
+        return false;
+    }
+
+    yarp::dev::PolyDriver * Idevice2attach = device2attach[0]->poly;
+
+    if (Idevice2attach->isValid())
+    {
+        Idevice2attach->view(iLoc);
+    }
+
+    if (nullptr == iLoc)
+    {
+        yCError(LOCALIZATION2DSERVER, "Subdevice passed to attach method is invalid");
+        return false;
+    }
+
+    //initialize m_current_position and m_current_status, if available
+    bool ret = true;
+    yarp::dev::Nav2D::LocalizationStatusEnum status;
+    Map2DLocation loc;
+    ret &= iLoc->getLocalizationStatus(status);
+    ret &= iLoc->getCurrentPosition(loc);
+    if (ret)
+    {
+        m_current_status = status;
+        m_current_position = loc;
+    }
+    else
+    {
+        yCWarning(LOCALIZATION2DSERVER) << "Localization data not yet available during server initialization";
+    }
+
+    PeriodicThread::setPeriod(m_period);
+    return PeriodicThread::start();
+}
+
+bool Localization2D_nws_ros::detachAll()
+{
+    if (PeriodicThread::isRunning())
+    {
+        PeriodicThread::stop();
+    }
+    iLoc = nullptr;
+    return true;
+}
+
+bool Localization2D_nws_ros::open(Searchable& config)
+{
+    Property params;
+    params.fromString(config.toString().c_str());
+    yCDebug(LOCALIZATION2DSERVER) << "Configuration: \n" << config.toString().c_str();
+
+    if (config.check("GENERAL") == false)
+    {
+        yCWarning(LOCALIZATION2DSERVER) << "Missing GENERAL group, assuming default options";
+    }
+
+    Bottle& general_group = config.findGroup("GENERAL");
+    if (!general_group.check("period"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
+        m_period = DEFAULT_THREAD_PERIOD;
+    }
+    else
+    {
+        m_period = general_group.find("period").asFloat64();
+        yCInfo(LOCALIZATION2DSERVER) << "Period requested: " << m_period;
+    }
+
+    if (!general_group.check("retrieve_position_periodically"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
+        m_getdata_using_periodic_thread = true;
+    }
+    else
+    {
+        m_getdata_using_periodic_thread = general_group.find("retrieve_position_periodically").asBool();
+        if (m_getdata_using_periodic_thread)
+            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically requested, Period:" << m_period; }
+        else
+            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
+    }
+
+
+    m_local_name = "/localizationServer";
+    if (!general_group.check("name"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'name' parameter. Using default value: /localizationServer";
+    }
+    else
+    {
+        m_local_name = general_group.find("name").asString();
+        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2DSERVER) << "Missing '/' in name parameter" ;  return false; }
+        yCInfo(LOCALIZATION2DSERVER) << "Using local name:" << m_local_name;
+    }
+
+    m_rpcPortName = m_local_name + "/rpc";
+
+    if (config.check("subdevice"))
+    {
+        Property       p;
+        PolyDriverList driverlist;
+        p.fromString(config.toString(), false);
+        p.put("device", config.find("subdevice").asString());
+
+        if (!pLoc.open(p) || !pLoc.isValid())
+        {
+            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            return false;
+        }
+
+        driverlist.push(&pLoc, "1");
+        if (!attachAll(driverlist))
+        {
+            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            return false;
+        }
+    }
+    else
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Waiting for device to attach";
+    }
+    m_stats_time_last = yarp::os::Time::now();
+
+    if (!initialize_YARP(config))
+    {
+        yCError(LOCALIZATION2DSERVER) << "Error initializing YARP ports";
+        return false;
+    }
+
+    if (!initialize_ROS(config))
+    {
+        yCError(LOCALIZATION2DSERVER) << "Error initializing ROS system";
+        return false;
+    }
+
+    return true;
+}
+
+bool Localization2D_nws_ros::initialize_ROS(yarp::os::Searchable& params)
+{
+    if (params.check("ROS"))
+    {
+        Bottle& ros_group = params.findGroup("ROS");
+        if (!ros_group.check("parent_frame_id"))
+        {
+            yCError(LOCALIZATION2DSERVER) << "Missing 'parent_frame_id' parameter";
+            //return false;
+        }
+        else
+        {
+            m_parent_frame_id = ros_group.find("parent_frame_id").asString();
+        }
+        if (!ros_group.check("child_frame_id"))
+        {
+            yCError(LOCALIZATION2DSERVER) << "Missing 'child_frame_id' parameter";
+            //return false;
+        }
+        else
+        {
+            m_child_frame_id = ros_group.find("child_frame_id").asString();
+        }
+
+    }
+    else
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "ROS initialization not requested";
+        return true;
+    }
+
+    if (m_ros_node == nullptr)
+    {
+        bool b= false;
+        m_ros_node = new yarp::os::Node(m_local_name+"_ROSnode");
+        if (m_ros_node == nullptr)
+        {
+            yCError(LOCALIZATION2DSERVER) << "Opening " << m_local_name << " Node, check your yarp-ROS network configuration";
+        }
+
+        string ros_odom_topic = m_local_name + string("/odom");
+        b = m_odometry_publisher.topic(ros_odom_topic);
+        if (!b)
+        {
+            yCError(LOCALIZATION2DSERVER) << "Unable to publish data on" << ros_odom_topic << "topic";
+        }
+        b = m_tf_publisher.topic("/tf");
+        if (!b)
+        {
+            yCError(LOCALIZATION2DSERVER) << "Unable to publish data on /tf topic";
+        }
+        yCInfo(LOCALIZATION2DSERVER) << "ROS initialized";
+    }
+    return true;
+}
+
+bool Localization2D_nws_ros::initialize_YARP(yarp::os::Searchable &params)
+{
+    if (!m_rpcPort.open(m_rpcPortName.c_str()))
+    {
+        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_rpcPortName.c_str());
+        return false;
+    }
+    m_rpcPort.setReader(*this);
+
+    return true;
+}
+
+bool Localization2D_nws_ros::close()
+{
+    yCTrace(LOCALIZATION2DSERVER, "Close");
+    if (PeriodicThread::isRunning())
+    {
+        PeriodicThread::stop();
+    }
+
+    detachAll();
+
+    m_rpcPort.interrupt();
+    m_rpcPort.close();
+
+    if (m_ros_node)
+    {
+        m_tf_publisher.close();
+        m_odometry_publisher.close();
+        delete m_ros_node;
+        m_ros_node = nullptr;
+    }
+
+    yCDebug(LOCALIZATION2DSERVER) << "Execution terminated";
+    return true;
+}
+
+bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::Bottle command;
+    yarp::os::Bottle reply;
+    bool ok = command.read(connection);
+    if (!ok) return false;
+
+    reply.clear();
+
+    if (command.get(0).isVocab())
+    {
+        if (command.get(0).asVocab() == VOCAB_INAVIGATION && command.get(1).isVocab())
+        {
+            int request = command.get(1).asVocab();
+            if (request == VOCAB_NAV_GET_CURRENT_POS)
+            {
+                if (m_getdata_using_periodic_thread)
+                {
+                    //m_current_position is obtained by run()
+                    reply.addVocab(VOCAB_OK);
+                    reply.addString(m_current_position.map_id);
+                    reply.addFloat64(m_current_position.x);
+                    reply.addFloat64(m_current_position.y);
+                    reply.addFloat64(m_current_position.theta);
+                }
+                else
+                {
+                    //m_current_position is obtained by getCurrentPosition()
+                    iLoc->getCurrentPosition(m_current_position);
+                    reply.addVocab(VOCAB_OK);
+                    reply.addString(m_current_position.map_id);
+                    reply.addFloat64(m_current_position.x);
+                    reply.addFloat64(m_current_position.y);
+                    reply.addFloat64(m_current_position.theta);
+                }
+            }
+            else if (request == VOCAB_NAV_SET_INITIAL_POS)
+            {
+                Map2DLocation init_loc;
+                init_loc.map_id = command.get(2).asString();
+                init_loc.x = command.get(3).asFloat64();
+                init_loc.y = command.get(4).asFloat64();
+                init_loc.theta = command.get(5).asFloat64();
+                iLoc->setInitialPose(init_loc);
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_GET_CURRENT_POSCOV)
+            {
+                Map2DLocation init_loc;
+                yarp::sig::Matrix cov(3, 3);
+                iLoc->getCurrentPosition(init_loc, cov);
+                reply.addVocab(VOCAB_OK);
+                reply.addString(m_current_position.map_id);
+                reply.addFloat64(m_current_position.x);
+                reply.addFloat64(m_current_position.y);
+                reply.addFloat64(m_current_position.theta);
+                yarp::os::Bottle& mc = reply.addList();
+                for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { mc.addFloat64(cov[i][j]); } }
+            }
+            else if (request == VOCAB_NAV_SET_INITIAL_POSCOV)
+            {
+                Map2DLocation init_loc;
+                yarp::sig::Matrix cov(3,3);
+                init_loc.map_id = command.get(2).asString();
+                init_loc.x = command.get(3).asFloat64();
+                init_loc.y = command.get(4).asFloat64();
+                init_loc.theta = command.get(5).asFloat64();
+                Bottle* mc = command.get(6).asList();
+                if (mc!=nullptr && mc->size() == 9)
+                {
+                    for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { cov[i][j] = mc->get(i * 3 + j).asFloat64(); } }
+                    bool ret = iLoc->setInitialPose(init_loc, cov);
+                    if (ret) { reply.addVocab(VOCAB_OK); }
+                    else     { reply.addVocab(VOCAB_ERR); }
+                }
+                else
+                {
+                    reply.addVocab(VOCAB_ERR);
+                }
+            }
+            else if (request == VOCAB_NAV_LOCALIZATION_START)
+            {
+                iLoc->startLocalizationService();
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_LOCALIZATION_STOP)
+            {
+                iLoc->stopLocalizationService();
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_GET_LOCALIZER_STATUS)
+            {
+                if (m_getdata_using_periodic_thread)
+                {
+                    //m_current_status is obtained by run()
+                    reply.addVocab(VOCAB_OK);
+                    reply.addVocab(m_current_status);
+                }
+                else
+                {
+                    //m_current_status is obtained by getLocalizationStatus()
+                    iLoc->getLocalizationStatus(m_current_status);
+                    reply.addVocab(VOCAB_OK);
+                    reply.addVocab(m_current_status);
+                }
+            }
+            else if (request == VOCAB_NAV_GET_LOCALIZER_POSES)
+            {
+                std::vector<Map2DLocation> poses;
+                iLoc->getEstimatedPoses(poses);
+                reply.addVocab(VOCAB_OK);
+                reply.addInt32(poses.size());
+                for (size_t i=0; i<poses.size(); i++)
+                {
+                    Bottle& b = reply.addList();
+                    b.addString(poses[i].map_id);
+                    b.addFloat64(poses[i].x);
+                    b.addFloat64(poses[i].y);
+                    b.addFloat64(poses[i].theta);
+                }
+            }
+            else
+            {
+                reply.addVocab(VOCAB_ERR);
+            }
+        }
+        else
+        {
+            yCError(LOCALIZATION2DSERVER) << "Invalid vocab received";
+            reply.addVocab(VOCAB_ERR);
+        }
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "help")
+    {
+        reply.addVocab(Vocab::encode("many"));
+        reply.addString("Available commands are:");
+        reply.addString("getLoc");
+        reply.addString("initLoc <map_name> <x> <y> <angle in degrees>");
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "getLoc")
+    {
+        Map2DLocation curr_loc;
+        iLoc->getCurrentPosition(curr_loc);
+        std::string s = std::string("Current Location is: ") + curr_loc.toString();
+        reply.addString(s);
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "initLoc")
+    {
+        Map2DLocation init_loc;
+        init_loc.map_id = command.get(1).asString();
+        init_loc.x = command.get(2).asFloat64();
+        init_loc.y = command.get(3).asFloat64();
+        init_loc.theta = command.get(4).asFloat64();
+        iLoc->setInitialPose(init_loc);
+        std::string s = std::string("Localization initialized to: ") + init_loc.toString();
+        reply.addString(s);
+    }
+    else
+    {
+        yCError(LOCALIZATION2DSERVER) << "Invalid command type";
+        reply.addVocab(VOCAB_ERR);
+    }
+
+    yarp::os::ConnectionWriter *returnToSender = connection.getWriter();
+    if (returnToSender != nullptr)
+    {
+        reply.write(*returnToSender);
+    }
+
+    return true;
+}
+
+void Localization2D_nws_ros::run()
+{
+    double m_stats_time_curr = yarp::os::Time::now();
+    if (m_stats_time_curr - m_stats_time_last > 5.0)
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Running";
+        m_stats_time_last = yarp::os::Time::now();
+    }
+
+    if (m_getdata_using_periodic_thread)
+    {
+        bool ret = iLoc->getLocalizationStatus(m_current_status);
+        if (ret == false)
+        {
+            yCError(LOCALIZATION2DSERVER) << "getLocalizationStatus() failed";
+        }
+
+        if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
+        {
+            //update the stamp
+
+
+            bool ret2 = iLoc->getCurrentPosition(m_current_position);
+            if (ret2 == false)
+            {
+                yCError(LOCALIZATION2DSERVER) << "getCurrentPosition() failed";
+            }
+            else
+            {
+                m_loc_stamp.update();
+            }
+            bool ret3 = iLoc->getEstimatedOdometry(m_current_odometry);
+            if (ret3 == false)
+            {
+                //yCError(LOCALIZATION2DSERVER) << "getEstimatedOdometry() failed";
+            }
+            else
+            {
+                m_odom_stamp.update();
+            }
+        }
+        else
+        {
+            yCWarning(LOCALIZATION2DSERVER, "The system is not properly localized!");
+        }
+    }
+
+    if (1) publish_odometry_on_ROS_topic();
+    if (1) publish_odometry_on_TF_topic();
+
+}
+
+void Localization2D_nws_ros::publish_odometry_on_TF_topic()
+{
+    yarp::rosmsg::tf2_msgs::TFMessage& rosData = m_tf_publisher.prepare();
+    yarp::rosmsg::geometry_msgs::TransformStamped transform;
+    transform.child_frame_id = m_child_frame_id;
+    transform.header.frame_id = m_parent_frame_id;
+    transform.header.seq = m_odom_stamp.getCount();
+    transform.header.stamp = m_odom_stamp.getTime();
+    double halfYaw = m_current_odometry.odom_theta / 180.0 * M_PI * 0.5;
+    double cosYaw = cos(halfYaw);
+    double sinYaw = sin(halfYaw);
+    transform.transform.rotation.x = 0;
+    transform.transform.rotation.y = 0;
+    transform.transform.rotation.z = sinYaw;
+    transform.transform.rotation.w = cosYaw;
+    transform.transform.translation.x = m_current_odometry.odom_x;
+    transform.transform.translation.y = m_current_odometry.odom_y;
+    transform.transform.translation.z = 0;
+    if (rosData.transforms.size() == 0)
+    {
+        rosData.transforms.push_back(transform);
+    }
+    else
+    {
+        rosData.transforms[0] = transform;
+    }
+
+    m_tf_publisher.write();
+}
+
+void Localization2D_nws_ros::publish_odometry_on_ROS_topic()
+{
+    if (m_ros_node && m_odometry_publisher.asPort().getOutputCount() > 0)
+    {
+        yarp::rosmsg::nav_msgs::Odometry& odom = m_odometry_publisher.prepare();
+        odom.clear();
+        odom.header.frame_id = m_fixed_frame;
+        odom.header.seq = m_odom_stamp.getCount();
+        odom.header.stamp = m_odom_stamp.getTime();
+        odom.child_frame_id = m_robot_frame;
+
+        odom.pose.pose.position.x = m_current_odometry.odom_x;
+        odom.pose.pose.position.y = m_current_odometry.odom_y;
+        odom.pose.pose.position.z = 0;
+        yarp::sig::Vector vecrpy(3);
+        vecrpy[0] = 0;
+        vecrpy[1] = 0;
+        vecrpy[2] = m_current_odometry.odom_theta;
+        yarp::sig::Matrix matrix = yarp::math::rpy2dcm(vecrpy);
+        yarp::math::Quaternion q; q.fromRotationMatrix(matrix);
+        odom.pose.pose.orientation.x = q.x();
+        odom.pose.pose.orientation.y = q.y();
+        odom.pose.pose.orientation.z = q.z();
+        odom.pose.pose.orientation.w = q.w();
+        //odom.pose.covariance = 0;
+
+        odom.twist.twist.linear.x = m_current_odometry.base_vel_x;
+        odom.twist.twist.linear.y = m_current_odometry.base_vel_y;
+        odom.twist.twist.linear.z = 0;
+        odom.twist.twist.angular.x = 0;
+        odom.twist.twist.angular.y = 0;
+        odom.twist.twist.angular.z = m_current_odometry.base_vel_theta;
+        //odom.twist.covariance = 0;
+
+        m_odometry_publisher.write();
+    }
+}

--- a/src/devices/localization2DServer/localization2D_nws_ros.h
+++ b/src/devices/localization2DServer/localization2D_nws_ros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef YARP_DEV_LOCALIZATION2DSERVER_H
-#define YARP_DEV_LOCALIZATION2DSERVER_H
+#ifndef YARP_DEV_LOCALIZATION2D_NWS_ROS_H
+#define YARP_DEV_LOCALIZATION2D_NWS_ROS_H
 
 
 #include <yarp/os/Network.h>
@@ -41,9 +41,9 @@
  /**
  * @ingroup dev_impl_network_wrapper dev_impl_navigation
  *
- * \section Localization2DServer
+ * \section Localization2D_nws_ros
  *
- * \brief `localization2DServer`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
+ * \brief `Localization2D_nws_ros`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
  *
  *
  *  Parameters required by this device are:
@@ -53,10 +53,8 @@
  * | GENERAL        |  retrieve_position_periodically     | bool  | -  | true         | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
  * | GENERAL        |  name          | string  |  -             | /localizationServer | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /localizationServer/rpc and /localizationServer/streaming:o     |
  * | subdevice      |  -             | string  |  -             |  -                  | Yes          | The name of the of Localization device to be used                 | -     |
- * | ROS            |  publish_tf    | bool    |  -             |  false              | No           | If true, odometry data will be published on global ROS /tf topic      | -     |
- * | ROS            |  publish_odom  | bool    |  -             |  false              | No           | If true, odometry data will be published on a user-defined ROS topic  | The default name of the topic is built as: name+"/odom"     |
  */
-class Localization2DServer :
+class Localization2D_nws_ros :
         public yarp::dev::DeviceDriver,
         public yarp::os::PeriodicThread,
         public yarp::dev::IMultipleWrapper,
@@ -64,18 +62,10 @@ class Localization2DServer :
 {
 protected:
 
-    //general options
-    bool m_ros_publish_odometry_on_topic;
-    bool m_ros_publish_odometry_on_tf;
-
     //yarp
     std::string                               m_local_name;
     yarp::os::Port                            m_rpcPort;
     std::string                               m_rpcPortName;
-    yarp::os::BufferedPort<yarp::dev::Nav2D::Map2DLocation>  m_2DLocationPort;
-    std::string                               m_2DLocationPortName;
-    yarp::os::BufferedPort<yarp::dev::OdometryData>  m_odometryPort;
-    std::string                               m_odometryPortName;
     std::string                               m_robot_frame;
     std::string                               m_fixed_frame;
 
@@ -101,13 +91,11 @@ protected:
     yarp::dev::Nav2D::LocalizationStatusEnum    m_current_status;
 
 private:
-    void publish_2DLocation_on_yarp_port();
-    void publish_odometry_on_yarp_port();
     void publish_odometry_on_ROS_topic();
     void publish_odometry_on_TF_topic();
 
 public:
-    Localization2DServer();
+    Localization2D_nws_ros();
 
 public:
     virtual bool open(yarp::os::Searchable& prop) override;
@@ -121,4 +109,4 @@ public:
     virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
-#endif // YARP_DEV_LOCALIZATION2DSERVER_H
+#endif // YARP_DEV_LOCALIZATION2D_NWS_ROS

--- a/src/devices/localization2DServer/localization2D_nws_ros.h
+++ b/src/devices/localization2DServer/localization2D_nws_ros.h
@@ -51,11 +51,13 @@
  * |:----------------:|:----------------:|:-------:|:--------------:|:------------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | GENERAL          |  period          | double  | s              | 0.01                     | No           | The period of the working thread                                  |       |
  * | GENERAL          |  name            | string  |  -             | /localization2D_nws_ros  | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are: /xxx/rpc |
- * | subdevice        |  -               | string  |  -             |  -                       | Yes          | The name of the of Localization device to be used                 | -     |
+ * | GENERAL          |  publish_odometry | bool   |  -             | true                     | No           | Periodically publish odometry data over the network               | -     |
+ * | GENERAL          |  publish_tf       | bool   |  -             | true                     | No           | Periodically publish tf data over the network                     | -     |
  * | ROS              | parent_frame_id  | string  |  -             | odom                     | No           | The name of the of the parent frame published in the /tf topic    | -     |
  * | ROS              | child_frame_id   | string  |  -             | base_link                | No           | The name of the of the child frame published in the /tf topic     | -     |
  * | ROS              | odometry_topic   | string  |  -             | GENERAL::name+"/odom"    | No           | The name of the of the odometry topic                             | -     |
  * | ROS              | node_name        | string  |  -             | GENERAL::name+"_ROSnode" | No           | The name of the of the ROS node                                   | -     |
+ * | subdevice        |  -               | string  |  -             |  -                       | Yes          | The name of the of Localization device to be used                 | -     |
  */
 class Localization2D_nws_ros :
         public yarp::dev::DeviceDriver,

--- a/src/devices/localization2DServer/localization2D_nws_ros.h
+++ b/src/devices/localization2DServer/localization2D_nws_ros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -50,7 +50,6 @@
  * | Parameter name | SubParameter   | Type    | Units          | Default Value       | Required     | Description                                                       | Notes |
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | GENERAL        |  period        | double  | s              | 0.01                | No           | The period of the working thread                                  |       |
- * | GENERAL        |  retrieve_position_periodically     | bool  | -  | true         | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
  * | GENERAL        |  name          | string  |  -             | /localizationServer | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /localizationServer/rpc and /localizationServer/streaming:o     |
  * | subdevice      |  -             | string  |  -             |  -                  | Yes          | The name of the of Localization device to be used                 | -     |
  */
@@ -68,27 +67,28 @@ protected:
     std::string                               m_rpcPortName;
     std::string                               m_robot_frame;
     std::string                               m_fixed_frame;
+    bool                                      m_enable_publish_odometry_topic = true;
+    bool                                      m_enable_publish_odometry_tf = true;
 
     //ROS
     std::string                                           m_child_frame_id;
     std::string                                           m_parent_frame_id;
-    yarp::os::Node*                                       m_ros_node;
+    yarp::os::Node*                                       m_ros_node = nullptr;
     yarp::os::Publisher<yarp::rosmsg::nav_msgs::Odometry> m_odometry_publisher;
     yarp::os::Publisher<yarp::rosmsg::tf2_msgs::TFMessage>  m_tf_publisher;
 
     //drivers and interfaces
     yarp::dev::PolyDriver                   pLoc;
-    yarp::dev::Nav2D::ILocalization2D*      iLoc;
+    yarp::dev::Nav2D::ILocalization2D*      iLoc = nullptr;
 
     double                                  m_stats_time_last;
     double                                  m_period;
     yarp::os::Stamp                         m_loc_stamp;
     yarp::os::Stamp                         m_odom_stamp;
-    bool                                    m_getdata_using_periodic_thread;
 
     yarp::dev::OdometryData                     m_current_odometry;
     yarp::dev::Nav2D::Map2DLocation             m_current_position;
-    yarp::dev::Nav2D::LocalizationStatusEnum    m_current_status;
+    yarp::dev::Nav2D::LocalizationStatusEnum    m_current_status = yarp::dev::Nav2D::LocalizationStatusEnum::localization_status_not_yet_localized;
 
 private:
     void publish_odometry_on_ROS_topic();

--- a/src/devices/localization2DServer/localization2D_nws_ros.h
+++ b/src/devices/localization2DServer/localization2D_nws_ros.h
@@ -47,11 +47,15 @@
  *
  *
  *  Parameters required by this device are:
- * | Parameter name | SubParameter   | Type    | Units          | Default Value       | Required     | Description                                                       | Notes |
- * |:--------------:|:--------------:|:-------:|:--------------:|:-------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
- * | GENERAL        |  period        | double  | s              | 0.01                | No           | The period of the working thread                                  |       |
- * | GENERAL        |  name          | string  |  -             | /localizationServer | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /localizationServer/rpc and /localizationServer/streaming:o     |
- * | subdevice      |  -             | string  |  -             |  -                  | Yes          | The name of the of Localization device to be used                 | -     |
+ * | Parameter name   | SubParameter     | Type    | Units          | Default Value            | Required     | Description                                                       | Notes |
+ * |:----------------:|:----------------:|:-------:|:--------------:|:------------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+ * | GENERAL          |  period          | double  | s              | 0.01                     | No           | The period of the working thread                                  |       |
+ * | GENERAL          |  name            | string  |  -             | /localization2D_nws_ros  | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are: /xxx/rpc |
+ * | subdevice        |  -               | string  |  -             |  -                       | Yes          | The name of the of Localization device to be used                 | -     |
+ * | ROS              | parent_frame_id  | string  |  -             | odom                     | No           | The name of the of the parent frame published in the /tf topic    | -     |
+ * | ROS              | child_frame_id   | string  |  -             | base_link                | No           | The name of the of the child frame published in the /tf topic     | -     |
+ * | ROS              | odometry_topic   | string  |  -             | GENERAL::name+"/odom"    | No           | The name of the of the odometry topic                             | -     |
+ * | ROS              | node_name        | string  |  -             | GENERAL::name+"_ROSnode" | No           | The name of the of the ROS node                                   | -     |
  */
 class Localization2D_nws_ros :
         public yarp::dev::DeviceDriver,
@@ -62,7 +66,7 @@ class Localization2D_nws_ros :
 protected:
 
     //yarp
-    std::string                               m_local_name;
+    std::string                               m_local_name = "/localization2D_nws_ros";
     yarp::os::Port                            m_rpcPort;
     std::string                               m_rpcPortName;
     std::string                               m_robot_frame;
@@ -71,9 +75,11 @@ protected:
     bool                                      m_enable_publish_odometry_tf = true;
 
     //ROS
-    std::string                                           m_child_frame_id;
-    std::string                                           m_parent_frame_id;
+    std::string                                           m_child_frame_id = "base_link";
+    std::string                                           m_parent_frame_id = "odom";
+    std::string                                           m_ros_node_name;
     yarp::os::Node*                                       m_ros_node = nullptr;
+    std::string                                           m_odom_topic_name;
     yarp::os::Publisher<yarp::rosmsg::nav_msgs::Odometry> m_odometry_publisher;
     yarp::os::Publisher<yarp::rosmsg::tf2_msgs::TFMessage>  m_tf_publisher;
 

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -269,9 +269,18 @@ bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
             int request = command.get(1).asVocab();
             if (request == VOCAB_NAV_GET_CURRENT_POS)
             {
+                bool b = true;
                 if (m_getdata_using_periodic_thread)
                 {
                     //m_current_position is obtained by run()
+                }
+                else
+                {
+                    //m_current_position is obtained by getCurrentPosition()
+                    b = iLoc->getCurrentPosition(m_current_position);
+                }
+                if (b)
+                {
                     reply.addVocab(VOCAB_OK);
                     reply.addString(m_current_position.map_id);
                     reply.addFloat64(m_current_position.x);
@@ -280,13 +289,37 @@ bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
                 }
                 else
                 {
+                    reply.addVocab(VOCAB_ERR);
+                }
+            }
+            else if (request == VOCAB_NAV_GET_ESTIMATED_ODOM)
+            {
+                bool b = true;
+                if (m_getdata_using_periodic_thread)
+                {
+                    //m_current_position is obtained by run()
+                }
+                else
+                {
                     //m_current_position is obtained by getCurrentPosition()
-                    iLoc->getCurrentPosition(m_current_position);
+                    b = iLoc->getEstimatedOdometry(m_current_odometry);
+                }
+                if (b)
+                {
                     reply.addVocab(VOCAB_OK);
-                    reply.addString(m_current_position.map_id);
-                    reply.addFloat64(m_current_position.x);
-                    reply.addFloat64(m_current_position.y);
-                    reply.addFloat64(m_current_position.theta);
+                    reply.addFloat64(m_current_odometry.odom_x);
+                    reply.addFloat64(m_current_odometry.odom_y);
+                    reply.addFloat64(m_current_odometry.odom_theta);
+                    reply.addFloat64(m_current_odometry.base_vel_x);
+                    reply.addFloat64(m_current_odometry.base_vel_y);
+                    reply.addFloat64(m_current_odometry.base_vel_theta);
+                    reply.addFloat64(m_current_odometry.odom_vel_x);
+                    reply.addFloat64(m_current_odometry.odom_vel_y);
+                    reply.addFloat64(m_current_odometry.odom_vel_theta);
+                }
+                else
+                {
+                    reply.addVocab(VOCAB_ERR);
                 }
             }
             else if (request == VOCAB_NAV_SET_INITIAL_POS)

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#define _USE_MATH_DEFINES
+
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
@@ -41,10 +43,6 @@ using namespace yarp::dev::Nav2D;
 using namespace std;
 
 #define DEFAULT_THREAD_PERIOD 0.01
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 
 namespace
 {

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -1,0 +1,508 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <yarp/os/Network.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/Port.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/dev/IMap2D.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IFrameTransform.h>
+#include <yarp/math/Math.h>
+#include "Localization2D_nws_yarp.h"
+
+#include <cmath>
+
+/*! \file Localization2DServer.cpp */
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::dev::Nav2D;
+using namespace std;
+
+#define DEFAULT_THREAD_PERIOD 0.01
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace {
+YARP_LOG_COMPONENT(LOCALIZATION2DSERVER, "yarp.device.localization2DServer")
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+
+Localization2D_nws_yarp::Localization2D_nws_yarp() : PeriodicThread(DEFAULT_THREAD_PERIOD)
+{
+    m_current_status = yarp::dev::Nav2D::LocalizationStatusEnum::localization_status_not_yet_localized;
+    m_period = DEFAULT_THREAD_PERIOD;
+    m_stats_time_last = yarp::os::Time::now();
+    iLoc = nullptr;
+    m_getdata_using_periodic_thread = true;
+}
+
+bool Localization2D_nws_yarp::attachAll(const PolyDriverList &device2attach)
+{
+    if (device2attach.size() != 1)
+    {
+        yCError(LOCALIZATION2DSERVER, "Cannot attach more than one device");
+        return false;
+    }
+
+    yarp::dev::PolyDriver * Idevice2attach = device2attach[0]->poly;
+
+    if (Idevice2attach->isValid())
+    {
+        Idevice2attach->view(iLoc);
+    }
+
+    if (nullptr == iLoc)
+    {
+        yCError(LOCALIZATION2DSERVER, "Subdevice passed to attach method is invalid");
+        return false;
+    }
+
+    //initialize m_current_position and m_current_status, if available
+    bool ret = true;
+    yarp::dev::Nav2D::LocalizationStatusEnum status;
+    Map2DLocation loc;
+    ret &= iLoc->getLocalizationStatus(status);
+    ret &= iLoc->getCurrentPosition(loc);
+    if (ret)
+    {
+        m_current_status = status;
+        m_current_position = loc;
+    }
+    else
+    {
+        yCWarning(LOCALIZATION2DSERVER) << "Localization data not yet available during server initialization";
+    }
+
+    PeriodicThread::setPeriod(m_period);
+    return PeriodicThread::start();
+}
+
+bool Localization2D_nws_yarp::detachAll()
+{
+    if (PeriodicThread::isRunning())
+    {
+        PeriodicThread::stop();
+    }
+    iLoc = nullptr;
+    return true;
+}
+
+bool Localization2D_nws_yarp::open(Searchable& config)
+{
+    Property params;
+    params.fromString(config.toString().c_str());
+    yCDebug(LOCALIZATION2DSERVER) << "Configuration: \n" << config.toString().c_str();
+
+    if (config.check("GENERAL") == false)
+    {
+        yCWarning(LOCALIZATION2DSERVER) << "Missing GENERAL group, assuming default options";
+    }
+
+    Bottle& general_group = config.findGroup("GENERAL");
+    if (!general_group.check("period"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
+        m_period = DEFAULT_THREAD_PERIOD;
+    }
+    else
+    {
+        m_period = general_group.find("period").asFloat64();
+        yCInfo(LOCALIZATION2DSERVER) << "Period requested: " << m_period;
+    }
+
+    if (!general_group.check("retrieve_position_periodically"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
+        m_getdata_using_periodic_thread = true;
+    }
+    else
+    {
+        m_getdata_using_periodic_thread = general_group.find("retrieve_position_periodically").asBool();
+        if (m_getdata_using_periodic_thread)
+            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically requested, Period:" << m_period; }
+        else
+            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
+    }
+
+
+    m_local_name = "/localizationServer";
+    if (!general_group.check("name"))
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Missing 'name' parameter. Using default value: /localizationServer";
+    }
+    else
+    {
+        m_local_name = general_group.find("name").asString();
+        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2DSERVER) << "Missing '/' in name parameter" ;  return false; }
+        yCInfo(LOCALIZATION2DSERVER) << "Using local name:" << m_local_name;
+    }
+
+    m_rpcPortName = m_local_name + "/rpc";
+    m_2DLocationPortName = m_local_name + "/streaming:o";
+    m_odometryPortName = m_local_name + "/odometry:o";
+
+    if (config.check("subdevice"))
+    {
+        Property       p;
+        PolyDriverList driverlist;
+        p.fromString(config.toString(), false);
+        p.put("device", config.find("subdevice").asString());
+
+        if (!pLoc.open(p) || !pLoc.isValid())
+        {
+            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            return false;
+        }
+
+        driverlist.push(&pLoc, "1");
+        if (!attachAll(driverlist))
+        {
+            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            return false;
+        }
+    }
+    else
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Waiting for device to attach";
+    }
+    m_stats_time_last = yarp::os::Time::now();
+
+    if (!initialize_YARP(config))
+    {
+        yCError(LOCALIZATION2DSERVER) << "Error initializing YARP ports";
+        return false;
+    }
+
+    return true;
+}
+
+bool Localization2D_nws_yarp::initialize_YARP(yarp::os::Searchable &params)
+{
+    if (!m_2DLocationPort.open(m_2DLocationPortName.c_str()))
+    {
+        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_2DLocationPortName.c_str());
+        return false;
+    }
+
+    if (!m_odometryPort.open(m_odometryPortName.c_str()))
+    {
+        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_odometryPortName.c_str());
+        return false;
+    }
+
+    if (!m_rpcPort.open(m_rpcPortName.c_str()))
+    {
+        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_rpcPortName.c_str());
+        return false;
+    }
+    m_rpcPort.setReader(*this);
+
+    return true;
+}
+
+bool Localization2D_nws_yarp::close()
+{
+    yCTrace(LOCALIZATION2DSERVER, "Close");
+    if (PeriodicThread::isRunning())
+    {
+        PeriodicThread::stop();
+    }
+
+    detachAll();
+
+    m_2DLocationPort.interrupt();
+    m_2DLocationPort.close();
+    m_odometryPort.interrupt();
+    m_odometryPort.close();
+    m_rpcPort.interrupt();
+    m_rpcPort.close();
+
+    yCDebug(LOCALIZATION2DSERVER) << "Execution terminated";
+    return true;
+}
+
+bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::Bottle command;
+    yarp::os::Bottle reply;
+    bool ok = command.read(connection);
+    if (!ok) return false;
+
+    reply.clear();
+
+    if (command.get(0).isVocab())
+    {
+        if (command.get(0).asVocab() == VOCAB_INAVIGATION && command.get(1).isVocab())
+        {
+            int request = command.get(1).asVocab();
+            if (request == VOCAB_NAV_GET_CURRENT_POS)
+            {
+                if (m_getdata_using_periodic_thread)
+                {
+                    //m_current_position is obtained by run()
+                    reply.addVocab(VOCAB_OK);
+                    reply.addString(m_current_position.map_id);
+                    reply.addFloat64(m_current_position.x);
+                    reply.addFloat64(m_current_position.y);
+                    reply.addFloat64(m_current_position.theta);
+                }
+                else
+                {
+                    //m_current_position is obtained by getCurrentPosition()
+                    iLoc->getCurrentPosition(m_current_position);
+                    reply.addVocab(VOCAB_OK);
+                    reply.addString(m_current_position.map_id);
+                    reply.addFloat64(m_current_position.x);
+                    reply.addFloat64(m_current_position.y);
+                    reply.addFloat64(m_current_position.theta);
+                }
+            }
+            else if (request == VOCAB_NAV_SET_INITIAL_POS)
+            {
+                Map2DLocation init_loc;
+                init_loc.map_id = command.get(2).asString();
+                init_loc.x = command.get(3).asFloat64();
+                init_loc.y = command.get(4).asFloat64();
+                init_loc.theta = command.get(5).asFloat64();
+                iLoc->setInitialPose(init_loc);
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_GET_CURRENT_POSCOV)
+            {
+                Map2DLocation init_loc;
+                yarp::sig::Matrix cov(3, 3);
+                iLoc->getCurrentPosition(init_loc, cov);
+                reply.addVocab(VOCAB_OK);
+                reply.addString(m_current_position.map_id);
+                reply.addFloat64(m_current_position.x);
+                reply.addFloat64(m_current_position.y);
+                reply.addFloat64(m_current_position.theta);
+                yarp::os::Bottle& mc = reply.addList();
+                for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { mc.addFloat64(cov[i][j]); } }
+            }
+            else if (request == VOCAB_NAV_SET_INITIAL_POSCOV)
+            {
+                Map2DLocation init_loc;
+                yarp::sig::Matrix cov(3,3);
+                init_loc.map_id = command.get(2).asString();
+                init_loc.x = command.get(3).asFloat64();
+                init_loc.y = command.get(4).asFloat64();
+                init_loc.theta = command.get(5).asFloat64();
+                Bottle* mc = command.get(6).asList();
+                if (mc!=nullptr && mc->size() == 9)
+                {
+                    for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { cov[i][j] = mc->get(i * 3 + j).asFloat64(); } }
+                    bool ret = iLoc->setInitialPose(init_loc, cov);
+                    if (ret) { reply.addVocab(VOCAB_OK); }
+                    else     { reply.addVocab(VOCAB_ERR); }
+                }
+                else
+                {
+                    reply.addVocab(VOCAB_ERR);
+                }
+            }
+            else if (request == VOCAB_NAV_LOCALIZATION_START)
+            {
+                iLoc->startLocalizationService();
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_LOCALIZATION_STOP)
+            {
+                iLoc->stopLocalizationService();
+                reply.addVocab(VOCAB_OK);
+            }
+            else if (request == VOCAB_NAV_GET_LOCALIZER_STATUS)
+            {
+                if (m_getdata_using_periodic_thread)
+                {
+                    //m_current_status is obtained by run()
+                    reply.addVocab(VOCAB_OK);
+                    reply.addVocab(m_current_status);
+                }
+                else
+                {
+                    //m_current_status is obtained by getLocalizationStatus()
+                    iLoc->getLocalizationStatus(m_current_status);
+                    reply.addVocab(VOCAB_OK);
+                    reply.addVocab(m_current_status);
+                }
+            }
+            else if (request == VOCAB_NAV_GET_LOCALIZER_POSES)
+            {
+                std::vector<Map2DLocation> poses;
+                iLoc->getEstimatedPoses(poses);
+                reply.addVocab(VOCAB_OK);
+                reply.addInt32(poses.size());
+                for (size_t i=0; i<poses.size(); i++)
+                {
+                    Bottle& b = reply.addList();
+                    b.addString(poses[i].map_id);
+                    b.addFloat64(poses[i].x);
+                    b.addFloat64(poses[i].y);
+                    b.addFloat64(poses[i].theta);
+                }
+            }
+            else
+            {
+                reply.addVocab(VOCAB_ERR);
+            }
+        }
+        else
+        {
+            yCError(LOCALIZATION2DSERVER) << "Invalid vocab received";
+            reply.addVocab(VOCAB_ERR);
+        }
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "help")
+    {
+        reply.addVocab(Vocab::encode("many"));
+        reply.addString("Available commands are:");
+        reply.addString("getLoc");
+        reply.addString("initLoc <map_name> <x> <y> <angle in degrees>");
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "getLoc")
+    {
+        Map2DLocation curr_loc;
+        iLoc->getCurrentPosition(curr_loc);
+        std::string s = std::string("Current Location is: ") + curr_loc.toString();
+        reply.addString(s);
+    }
+    else if (command.get(0).isString() && command.get(0).asString() == "initLoc")
+    {
+        Map2DLocation init_loc;
+        init_loc.map_id = command.get(1).asString();
+        init_loc.x = command.get(2).asFloat64();
+        init_loc.y = command.get(3).asFloat64();
+        init_loc.theta = command.get(4).asFloat64();
+        iLoc->setInitialPose(init_loc);
+        std::string s = std::string("Localization initialized to: ") + init_loc.toString();
+        reply.addString(s);
+    }
+    else
+    {
+        yCError(LOCALIZATION2DSERVER) << "Invalid command type";
+        reply.addVocab(VOCAB_ERR);
+    }
+
+    yarp::os::ConnectionWriter *returnToSender = connection.getWriter();
+    if (returnToSender != nullptr)
+    {
+        reply.write(*returnToSender);
+    }
+
+    return true;
+}
+
+void Localization2D_nws_yarp::run()
+{
+    double m_stats_time_curr = yarp::os::Time::now();
+    if (m_stats_time_curr - m_stats_time_last > 5.0)
+    {
+        yCInfo(LOCALIZATION2DSERVER) << "Running";
+        m_stats_time_last = yarp::os::Time::now();
+    }
+
+    if (m_getdata_using_periodic_thread)
+    {
+        bool ret = iLoc->getLocalizationStatus(m_current_status);
+        if (ret == false)
+        {
+            yCError(LOCALIZATION2DSERVER) << "getLocalizationStatus() failed";
+        }
+
+        if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
+        {
+            //update the stamp
+
+
+            bool ret2 = iLoc->getCurrentPosition(m_current_position);
+            if (ret2 == false)
+            {
+                yCError(LOCALIZATION2DSERVER) << "getCurrentPosition() failed";
+            }
+            else
+            {
+                m_loc_stamp.update();
+            }
+            bool ret3 = iLoc->getEstimatedOdometry(m_current_odometry);
+            if (ret3 == false)
+            {
+                //yCError(LOCALIZATION2DSERVER) << "getEstimatedOdometry() failed";
+            }
+            else
+            {
+                m_odom_stamp.update();
+            }
+        }
+        else
+        {
+            yCWarning(LOCALIZATION2DSERVER, "The system is not properly localized!");
+        }
+    }
+
+    if (1) publish_odometry_on_yarp_port();
+    if (1) publish_2DLocation_on_yarp_port();
+
+}
+
+void Localization2D_nws_yarp::publish_odometry_on_yarp_port()
+{
+    if (m_odometryPort.getOutputCount() > 0)
+    {
+        yarp::dev::OdometryData& odom = m_odometryPort.prepare();
+        odom = m_current_odometry;
+
+        //send data to port
+        m_odometryPort.setEnvelope(m_odom_stamp);
+        m_odometryPort.write();
+    }
+}
+
+void Localization2D_nws_yarp::publish_2DLocation_on_yarp_port()
+{
+    if (m_2DLocationPort.getOutputCount() > 0)
+    {
+        Nav2D::Map2DLocation& loc = m_2DLocationPort.prepare();
+        if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
+        {
+            loc = m_current_position;
+        }
+        else
+        {
+            Map2DLocation temp_loc;
+            temp_loc.x = std::nan("");
+            temp_loc.y = std::nan("");
+            temp_loc.theta = std::nan("");
+            loc = temp_loc;
+        }
+
+        //send data to port
+        m_2DLocationPort.setEnvelope(m_loc_stamp);
+        m_2DLocationPort.write();
+    }
+}

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,7 +29,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IFrameTransform.h>
 #include <yarp/math/Math.h>
-#include "Localization2D_nws_yarp.h"
+#include "localization2D_nws_yarp.h"
 
 #include <cmath>
 
@@ -46,19 +46,17 @@ using namespace std;
 #define M_PI 3.14159265358979323846
 #endif
 
-namespace {
-YARP_LOG_COMPONENT(LOCALIZATION2D_NWS_YARP, "yarp.device.localization2D_nws_yarp")
+namespace
+{
+    YARP_LOG_COMPONENT(LOCALIZATION2D_NWS_YARP, "yarp.device.localization2D_nws_yarp")
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-Localization2D_nws_yarp::Localization2D_nws_yarp() : PeriodicThread(DEFAULT_THREAD_PERIOD)
+Localization2D_nws_yarp::Localization2D_nws_yarp() : PeriodicThread(DEFAULT_THREAD_PERIOD),
+                                                     m_period(DEFAULT_THREAD_PERIOD)
 {
-    m_current_status = yarp::dev::Nav2D::LocalizationStatusEnum::localization_status_not_yet_localized;
-    m_period = DEFAULT_THREAD_PERIOD;
     m_stats_time_last = yarp::os::Time::now();
-    iLoc = nullptr;
-    m_getdata_using_periodic_thread = true;
 }
 
 bool Localization2D_nws_yarp::attachAll(const PolyDriverList &device2attach)
@@ -437,9 +435,6 @@ void Localization2D_nws_yarp::run()
 
         if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
         {
-            //update the stamp
-
-
             bool ret2 = iLoc->getCurrentPosition(m_current_position);
             if (ret2 == false)
             {
@@ -465,9 +460,8 @@ void Localization2D_nws_yarp::run()
         }
     }
 
-    if (1) publish_odometry_on_yarp_port();
-    if (1) publish_2DLocation_on_yarp_port();
-
+    if (m_enable_publish_odometry) publish_odometry_on_yarp_port();
+    if (m_enable_publish_location) publish_2DLocation_on_yarp_port();
 }
 
 void Localization2D_nws_yarp::publish_odometry_on_yarp_port()

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -133,6 +133,17 @@ bool Localization2D_nws_yarp::open(Searchable& config)
         yCInfo(LOCALIZATION2D_NWS_YARP) << "Period requested: " << m_period;
     }
 
+    if (!general_group.check("publish_odometry"))
+    {
+        m_enable_publish_odometry = general_group.find("publish_odometry").asBool();
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "publish_odometry=" << m_enable_publish_odometry;
+    }
+    if (!general_group.check("publish_location"))
+    {
+        m_enable_publish_location = general_group.find("publish_location").asBool();
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "publish_location=" << m_enable_publish_location;
+    }
+
     if (!general_group.check("retrieve_position_periodically"))
     {
         yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -33,7 +33,7 @@
 
 #include <cmath>
 
-/*! \file Localization2DServer.cpp */
+/*! \file Localization2D_nws_yarp.cpp */
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -47,7 +47,7 @@ using namespace std;
 #endif
 
 namespace {
-YARP_LOG_COMPONENT(LOCALIZATION2DSERVER, "yarp.device.localization2DServer")
+YARP_LOG_COMPONENT(LOCALIZATION2D_NWS_YARP, "yarp.device.localization2D_nws_yarp")
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ bool Localization2D_nws_yarp::attachAll(const PolyDriverList &device2attach)
 {
     if (device2attach.size() != 1)
     {
-        yCError(LOCALIZATION2DSERVER, "Cannot attach more than one device");
+        yCError(LOCALIZATION2D_NWS_YARP, "Cannot attach more than one device");
         return false;
     }
 
@@ -78,7 +78,7 @@ bool Localization2D_nws_yarp::attachAll(const PolyDriverList &device2attach)
 
     if (nullptr == iLoc)
     {
-        yCError(LOCALIZATION2DSERVER, "Subdevice passed to attach method is invalid");
+        yCError(LOCALIZATION2D_NWS_YARP, "Subdevice passed to attach method is invalid");
         return false;
     }
 
@@ -95,7 +95,7 @@ bool Localization2D_nws_yarp::attachAll(const PolyDriverList &device2attach)
     }
     else
     {
-        yCWarning(LOCALIZATION2DSERVER) << "Localization data not yet available during server initialization";
+        yCWarning(LOCALIZATION2D_NWS_YARP) << "Localization data not yet available during server initialization";
     }
 
     PeriodicThread::setPeriod(m_period);
@@ -116,50 +116,50 @@ bool Localization2D_nws_yarp::open(Searchable& config)
 {
     Property params;
     params.fromString(config.toString().c_str());
-    yCDebug(LOCALIZATION2DSERVER) << "Configuration: \n" << config.toString().c_str();
+    yCDebug(LOCALIZATION2D_NWS_YARP) << "Configuration: \n" << config.toString().c_str();
 
     if (config.check("GENERAL") == false)
     {
-        yCWarning(LOCALIZATION2DSERVER) << "Missing GENERAL group, assuming default options";
+        yCWarning(LOCALIZATION2D_NWS_YARP) << "Missing GENERAL group, assuming default options";
     }
 
     Bottle& general_group = config.findGroup("GENERAL");
     if (!general_group.check("period"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'period' parameter. Using default value: " << DEFAULT_THREAD_PERIOD;
         m_period = DEFAULT_THREAD_PERIOD;
     }
     else
     {
         m_period = general_group.find("period").asFloat64();
-        yCInfo(LOCALIZATION2DSERVER) << "Period requested: " << m_period;
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Period requested: " << m_period;
     }
 
     if (!general_group.check("retrieve_position_periodically"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'retrieve_position_periodically' parameter. Using default value: true. Period:" << m_period ;
         m_getdata_using_periodic_thread = true;
     }
     else
     {
         m_getdata_using_periodic_thread = general_group.find("retrieve_position_periodically").asBool();
         if (m_getdata_using_periodic_thread)
-            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically requested, Period:" << m_period; }
+            { yCInfo(LOCALIZATION2D_NWS_YARP) << "retrieve_position_periodically requested, Period:" << m_period; }
         else
-            { yCInfo(LOCALIZATION2DSERVER) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
+            { yCInfo(LOCALIZATION2D_NWS_YARP) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
     }
 
 
     m_local_name = "/localizationServer";
     if (!general_group.check("name"))
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Missing 'name' parameter. Using default value: /localizationServer";
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'name' parameter. Using default value: /localizationServer";
     }
     else
     {
         m_local_name = general_group.find("name").asString();
-        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2DSERVER) << "Missing '/' in name parameter" ;  return false; }
-        yCInfo(LOCALIZATION2DSERVER) << "Using local name:" << m_local_name;
+        if (m_local_name.c_str()[0] != '/') { yCError(LOCALIZATION2D_NWS_YARP) << "Missing '/' in name parameter" ;  return false; }
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Using local name:" << m_local_name;
     }
 
     m_rpcPortName = m_local_name + "/rpc";
@@ -175,26 +175,26 @@ bool Localization2D_nws_yarp::open(Searchable& config)
 
         if (!pLoc.open(p) || !pLoc.isValid())
         {
-            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            yCError(LOCALIZATION2D_NWS_YARP) << "Failed to open subdevice.. check params";
             return false;
         }
 
         driverlist.push(&pLoc, "1");
         if (!attachAll(driverlist))
         {
-            yCError(LOCALIZATION2DSERVER) << "Failed to open subdevice.. check params";
+            yCError(LOCALIZATION2D_NWS_YARP) << "Failed to open subdevice.. check params";
             return false;
         }
     }
     else
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Waiting for device to attach";
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Waiting for device to attach";
     }
     m_stats_time_last = yarp::os::Time::now();
 
     if (!initialize_YARP(config))
     {
-        yCError(LOCALIZATION2DSERVER) << "Error initializing YARP ports";
+        yCError(LOCALIZATION2D_NWS_YARP) << "Error initializing YARP ports";
         return false;
     }
 
@@ -205,19 +205,19 @@ bool Localization2D_nws_yarp::initialize_YARP(yarp::os::Searchable &params)
 {
     if (!m_2DLocationPort.open(m_2DLocationPortName.c_str()))
     {
-        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_2DLocationPortName.c_str());
+        yCError(LOCALIZATION2D_NWS_YARP, "Failed to open port %s", m_2DLocationPortName.c_str());
         return false;
     }
 
     if (!m_odometryPort.open(m_odometryPortName.c_str()))
     {
-        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_odometryPortName.c_str());
+        yCError(LOCALIZATION2D_NWS_YARP, "Failed to open port %s", m_odometryPortName.c_str());
         return false;
     }
 
     if (!m_rpcPort.open(m_rpcPortName.c_str()))
     {
-        yCError(LOCALIZATION2DSERVER, "Failed to open port %s", m_rpcPortName.c_str());
+        yCError(LOCALIZATION2D_NWS_YARP, "Failed to open port %s", m_rpcPortName.c_str());
         return false;
     }
     m_rpcPort.setReader(*this);
@@ -227,7 +227,7 @@ bool Localization2D_nws_yarp::initialize_YARP(yarp::os::Searchable &params)
 
 bool Localization2D_nws_yarp::close()
 {
-    yCTrace(LOCALIZATION2DSERVER, "Close");
+    yCTrace(LOCALIZATION2D_NWS_YARP, "Close");
     if (PeriodicThread::isRunning())
     {
         PeriodicThread::stop();
@@ -242,7 +242,7 @@ bool Localization2D_nws_yarp::close()
     m_rpcPort.interrupt();
     m_rpcPort.close();
 
-    yCDebug(LOCALIZATION2DSERVER) << "Execution terminated";
+    yCDebug(LOCALIZATION2D_NWS_YARP) << "Execution terminated";
     return true;
 }
 
@@ -374,7 +374,7 @@ bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
         }
         else
         {
-            yCError(LOCALIZATION2DSERVER) << "Invalid vocab received";
+            yCError(LOCALIZATION2D_NWS_YARP) << "Invalid vocab received";
             reply.addVocab(VOCAB_ERR);
         }
     }
@@ -405,7 +405,7 @@ bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
     }
     else
     {
-        yCError(LOCALIZATION2DSERVER) << "Invalid command type";
+        yCError(LOCALIZATION2D_NWS_YARP) << "Invalid command type";
         reply.addVocab(VOCAB_ERR);
     }
 
@@ -423,7 +423,7 @@ void Localization2D_nws_yarp::run()
     double m_stats_time_curr = yarp::os::Time::now();
     if (m_stats_time_curr - m_stats_time_last > 5.0)
     {
-        yCInfo(LOCALIZATION2DSERVER) << "Running";
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Running";
         m_stats_time_last = yarp::os::Time::now();
     }
 
@@ -432,7 +432,7 @@ void Localization2D_nws_yarp::run()
         bool ret = iLoc->getLocalizationStatus(m_current_status);
         if (ret == false)
         {
-            yCError(LOCALIZATION2DSERVER) << "getLocalizationStatus() failed";
+            yCError(LOCALIZATION2D_NWS_YARP) << "getLocalizationStatus() failed";
         }
 
         if (m_current_status == LocalizationStatusEnum::localization_status_localized_ok)
@@ -443,7 +443,7 @@ void Localization2D_nws_yarp::run()
             bool ret2 = iLoc->getCurrentPosition(m_current_position);
             if (ret2 == false)
             {
-                yCError(LOCALIZATION2DSERVER) << "getCurrentPosition() failed";
+                yCError(LOCALIZATION2D_NWS_YARP) << "getCurrentPosition() failed";
             }
             else
             {
@@ -452,7 +452,7 @@ void Localization2D_nws_yarp::run()
             bool ret3 = iLoc->getEstimatedOdometry(m_current_odometry);
             if (ret3 == false)
             {
-                //yCError(LOCALIZATION2DSERVER) << "getEstimatedOdometry() failed";
+                //yCError(LOCALIZATION2D_NWS_YARP) << "getEstimatedOdometry() failed";
             }
             else
             {
@@ -461,7 +461,7 @@ void Localization2D_nws_yarp::run()
         }
         else
         {
-            yCWarning(LOCALIZATION2DSERVER, "The system is not properly localized!");
+            yCWarning(LOCALIZATION2D_NWS_YARP, "The system is not properly localized!");
         }
     }
 

--- a/src/devices/localization2DServer/localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.cpp
@@ -147,11 +147,9 @@ bool Localization2D_nws_yarp::open(Searchable& config)
             { yCInfo(LOCALIZATION2D_NWS_YARP) << "retrieve_position_periodically NOT requested. Localization data obtained asynchronously."; }
     }
 
-
-    m_local_name = "/localizationServer";
     if (!general_group.check("name"))
     {
-        yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'name' parameter. Using default value: /localizationServer";
+        yCInfo(LOCALIZATION2D_NWS_YARP) << "Missing 'name' parameter. Using default value:" << m_local_name;
     }
     else
     {

--- a/src/devices/localization2DServer/localization2D_nws_yarp.h
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef YARP_DEV_LOCALIZATION2DSERVER_H
-#define YARP_DEV_LOCALIZATION2DSERVER_H
+#ifndef YARP_DEV_LOCALIZATION2D_NWS_YARP_H
+#define YARP_DEV_LOCALIZATION2D_NWS_YARP_H
 
 
 #include <yarp/os/Network.h>
@@ -41,9 +41,9 @@
  /**
  * @ingroup dev_impl_network_wrapper dev_impl_navigation
  *
- * \section Localization2DServer
+ * \section Localization2D_nws_yarp
  *
- * \brief `localization2DServer`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
+ * \brief `Localization2D_nws_yarp`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
  *
  *
  *  Parameters required by this device are:
@@ -53,20 +53,14 @@
  * | GENERAL        |  retrieve_position_periodically     | bool  | -  | true         | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
  * | GENERAL        |  name          | string  |  -             | /localizationServer | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /localizationServer/rpc and /localizationServer/streaming:o     |
  * | subdevice      |  -             | string  |  -             |  -                  | Yes          | The name of the of Localization device to be used                 | -     |
- * | ROS            |  publish_tf    | bool    |  -             |  false              | No           | If true, odometry data will be published on global ROS /tf topic      | -     |
- * | ROS            |  publish_odom  | bool    |  -             |  false              | No           | If true, odometry data will be published on a user-defined ROS topic  | The default name of the topic is built as: name+"/odom"     |
  */
-class Localization2DServer :
+class Localization2D_nws_yarp :
         public yarp::dev::DeviceDriver,
         public yarp::os::PeriodicThread,
         public yarp::dev::IMultipleWrapper,
         public yarp::os::PortReader
 {
 protected:
-
-    //general options
-    bool m_ros_publish_odometry_on_topic;
-    bool m_ros_publish_odometry_on_tf;
 
     //yarp
     std::string                               m_local_name;
@@ -78,13 +72,6 @@ protected:
     std::string                               m_odometryPortName;
     std::string                               m_robot_frame;
     std::string                               m_fixed_frame;
-
-    //ROS
-    std::string                                           m_child_frame_id;
-    std::string                                           m_parent_frame_id;
-    yarp::os::Node*                                       m_ros_node;
-    yarp::os::Publisher<yarp::rosmsg::nav_msgs::Odometry> m_odometry_publisher;
-    yarp::os::Publisher<yarp::rosmsg::tf2_msgs::TFMessage>  m_tf_publisher;
 
     //drivers and interfaces
     yarp::dev::PolyDriver                   pLoc;
@@ -103,11 +90,9 @@ protected:
 private:
     void publish_2DLocation_on_yarp_port();
     void publish_odometry_on_yarp_port();
-    void publish_odometry_on_ROS_topic();
-    void publish_odometry_on_TF_topic();
 
 public:
-    Localization2DServer();
+    Localization2D_nws_yarp();
 
 public:
     virtual bool open(yarp::os::Searchable& prop) override;
@@ -117,8 +102,7 @@ public:
     virtual void run() override;
 
     bool initialize_YARP(yarp::os::Searchable &config);
-    bool initialize_ROS(yarp::os::Searchable& config);
     virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
-#endif // YARP_DEV_LOCALIZATION2DSERVER_H
+#endif // YARP_DEV_LOCALIZATION2D_NWS_YARP_H

--- a/src/devices/localization2DServer/localization2D_nws_yarp.h
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,8 +34,6 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ILocalization2D.h>
 #include <yarp/dev/OdometryData.h>
-#include <yarp/rosmsg/nav_msgs/Odometry.h>
-#include <yarp/rosmsg/tf2_msgs/TFMessage.h>
 #include <math.h>
 
  /**
@@ -72,20 +70,22 @@ protected:
     std::string                               m_odometryPortName;
     std::string                               m_robot_frame;
     std::string                               m_fixed_frame;
+    bool                                      m_enable_publish_odometry=true;
+    bool                                      m_enable_publish_location=true;
 
     //drivers and interfaces
     yarp::dev::PolyDriver                   pLoc;
-    yarp::dev::Nav2D::ILocalization2D*      iLoc;
+    yarp::dev::Nav2D::ILocalization2D*      iLoc = nullptr;
 
     double                                  m_stats_time_last;
     double                                  m_period;
     yarp::os::Stamp                         m_loc_stamp;
     yarp::os::Stamp                         m_odom_stamp;
-    bool                                    m_getdata_using_periodic_thread;
+    bool                                    m_getdata_using_periodic_thread = true;
 
     yarp::dev::OdometryData                     m_current_odometry;
     yarp::dev::Nav2D::Map2DLocation             m_current_position;
-    yarp::dev::Nav2D::LocalizationStatusEnum    m_current_status;
+    yarp::dev::Nav2D::LocalizationStatusEnum    m_current_status = yarp::dev::Nav2D::LocalizationStatusEnum::localization_status_not_yet_localized;
 
 private:
     void publish_2DLocation_on_yarp_port();

--- a/src/devices/localization2DServer/localization2D_nws_yarp.h
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.h
@@ -50,6 +50,8 @@
  * | GENERAL        |  period        | double  | s                  | 0.01                     | No           | The period of the working thread                                  |       |
  * | GENERAL        |  retrieve_position_periodically  | bool  | -  | true                     | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
  * | GENERAL        |  name          | string  |  -                 | /localization2D_nws_yarp | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /xxx/rpc and /xxx/streaming:o     |
+ * | GENERAL        |  publish_odometry | bool |  -                 | true                     | No           | Periodically publish odometry data over the network               | -     |
+ * | GENERAL        |  publish_location | bool |  -                 | true                     | No           | PEriodically publish location data over the network               | -     |
  * | subdevice      |  -             | string  |  -                 |  -                       | Yes          | The name of the of Localization device to be used                 | -     |
  */
 class Localization2D_nws_yarp :
@@ -61,7 +63,7 @@ class Localization2D_nws_yarp :
 protected:
 
     //yarp
-    std::string                               m_local_name = "/localizationServer";
+    std::string                               m_local_name = "/localization2D_nws_yarp";
     yarp::os::Port                            m_rpcPort;
     std::string                               m_rpcPortName;
     yarp::os::BufferedPort<yarp::dev::Nav2D::Map2DLocation>  m_2DLocationPort;

--- a/src/devices/localization2DServer/localization2D_nws_yarp.h
+++ b/src/devices/localization2DServer/localization2D_nws_yarp.h
@@ -45,12 +45,12 @@
  *
  *
  *  Parameters required by this device are:
- * | Parameter name | SubParameter   | Type    | Units          | Default Value       | Required     | Description                                                       | Notes |
- * |:--------------:|:--------------:|:-------:|:--------------:|:-------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
- * | GENERAL        |  period        | double  | s              | 0.01                | No           | The period of the working thread                                  |       |
- * | GENERAL        |  retrieve_position_periodically     | bool  | -  | true         | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
- * | GENERAL        |  name          | string  |  -             | /localizationServer | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /localizationServer/rpc and /localizationServer/streaming:o     |
- * | subdevice      |  -             | string  |  -             |  -                  | Yes          | The name of the of Localization device to be used                 | -     |
+ * | Parameter name | SubParameter   | Type    | Units              | Default Value            | Required     | Description                                                       | Notes |
+ * |:--------------:|:--------------:|:-------:|:------------------:|:------------------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+ * | GENERAL        |  period        | double  | s                  | 0.01                     | No           | The period of the working thread                                  |       |
+ * | GENERAL        |  retrieve_position_periodically  | bool  | -  | true                     | No           | If true, the subdevice is asked periodically to retrieve the current location. Otherwise the current location is obtained asynchronously when a getCurrentPosition() command is issued.     | -     |
+ * | GENERAL        |  name          | string  |  -                 | /localization2D_nws_yarp | No           | The name of the server, used as a prefix for the opened ports     | By default ports opened are /xxx/rpc and /xxx/streaming:o     |
+ * | subdevice      |  -             | string  |  -                 |  -                       | Yes          | The name of the of Localization device to be used                 | -     |
  */
 class Localization2D_nws_yarp :
         public yarp::dev::DeviceDriver,
@@ -61,7 +61,7 @@ class Localization2D_nws_yarp :
 protected:
 
     //yarp
-    std::string                               m_local_name;
+    std::string                               m_local_name = "/localizationServer";
     yarp::os::Port                            m_rpcPort;
     std::string                               m_rpcPortName;
     yarp::os::BufferedPort<yarp::dev::Nav2D::Map2DLocation>  m_2DLocationPort;


### PR DESCRIPTION
In this PR the following new devices have been implemented:

* `localization2D_nws_yarp`
* `localization2D_nws_ros`

These devices replace the old all-in-one device `localization2DServer`, in order to provide grater flexibility and decouple the logic from the wrapper(s)