### PR TITLE
Fix handling of attach action for IWrapper devices

### DIFF
--- a/doc/release/yarp_3_4/robotinterface_attach.md
+++ b/doc/release/yarp_3_4/robotinterface_attach.md
@@ -1,0 +1,8 @@
+robotinterface_attach {#yarp_3_4}
+---------------------
+
+### Libraries
+
+#### `robotinterface`
+
+* Fixed handling of `attach` action for `IWrapper` devices.


### PR DESCRIPTION
### Libraries

#### `robotinterface`

* Fixed handling of `attach` action for `IWrapper` devices.