### PR TITLE
[virtualanalogwrapper] update conf files parsing to the use of parentheses

### DIFF
--- a/doc/release/yarp_3_4/fix_virtualanalogwrapper_parser.md
+++ b/doc/release/yarp_3_4/fix_virtualanalogwrapper_parser.md
@@ -1,0 +1,9 @@
+fix_virtualanalogwrapper {#master}
+----------------------------------
+
+## device
+
+### `virtualAnalogWrapper`
+
+* Fixed: favor the use of parentheses with the keyword `networks` in the XML files; old style deprecated but still accepted.
+  This is a fix in the sense that `virtualAnalogWrapper` was behaving differently from `ControlBoardWrapper`.


### PR DESCRIPTION
Following up on #2446, this PR upgrades the parsing of conf files for the `virtualAnalogWrapper` device in order to make it behave as `ControlBoardWrapper`.

Essentially, the use of parentheses is enforced and the old way is now deprecated although still accepted.

This PR fixes the problem spotted in https://github.com/robotology/robots-configuration/issues/233.

cc @xEnVrE 