### PR TITLE
devices/ControlBoardWrapper: Do not get torque data twice

### DIFF
--- a/doc/release/yarp_3_4/cbw_fix_getTorque_twice.md
+++ b/doc/release/yarp_3_4/cbw_fix_getTorque_twice.md
@@ -1,0 +1,8 @@
+cbw_fix_getTorque_twice {#yarp_3_4}
+-----------------------
+
+## Devices
+
+### `controlboardwrapper2`
+
+* `getTorque` is no longer called twice.

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -929,7 +929,6 @@ void ControlBoardWrapper::run()
         yarp_struct.motorPosition_isValid       = getMotorEncoders(yarp_struct.motorPosition.data());
         yarp_struct.motorVelocity_isValid       = getMotorEncoderSpeeds(yarp_struct.motorVelocity.data());
         yarp_struct.motorAcceleration_isValid   = getMotorEncoderAccelerations(yarp_struct.motorAcceleration.data());
-        yarp_struct.torque_isValid              = getTorques(yarp_struct.torque.data());
         yarp_struct.pwmDutycycle_isValid        = getDutyCycles(yarp_struct.pwmDutycycle.data());
         yarp_struct.current_isValid             = getCurrents(yarp_struct.current.data());
         yarp_struct.controlMode_isValid         = getControlModes(yarp_struct.controlMode.data());


### PR DESCRIPTION
## Devices

### `controlboardwrapper2`

* `getTorque` is no longer called twice.

---

See:

https://github.com/robotology/yarp/blob/b9da15361d4d8c18fc1fd8eb1cc5a1fcfe3899ef/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp#L891

and

https://github.com/robotology/yarp/blob/b9da15361d4d8c18fc1fd8eb1cc5a1fcfe3899ef/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp#L924-L925

