### PR TITLE
sig/VectorOf: Do not explicitly implement copy/move ctors and assignment operators

### DIFF
--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -159,41 +159,6 @@ public:
         memcpy(this->data(), p, sizeof(T)*s);
     }
 
-    VectorOf(const VectorOf& r) : VectorBase(), bytes(r.bytes) {
-    }
-
-    /**
-     * Copy operator;
-     */
-    const VectorOf<T> &operator=(const VectorOf<T>& r)
-    {
-
-        if (this == &r) return *this;
-        bytes = r.bytes;
-        return *this;
-    }
-
-    /**
-     * @brief Move constructor.
-     *
-     * @param other the VectorOf to be moved
-     */
-    VectorOf(VectorOf<T>&& other) noexcept : bytes(std::move(other.bytes)) {
-    }
-
-    /**
-     * @brief Move assignment operator.
-     *
-     * @param other the VectorOf to be moved
-     * @return this object
-     */
-    VectorOf& operator=(VectorOf<T>&& other) noexcept
-    {
-        bytes = std::move(other.bytes);
-        return *this;
-    }
-
-
     size_t getElementSize() const override {
         return sizeof(T);
     }

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -159,6 +159,12 @@ public:
         memcpy(this->data(), p, sizeof(T)*s);
     }
 
+    VectorOf(const VectorOf& r) = default;
+    VectorOf<T> &operator=(const VectorOf<T>& r) = default;
+    VectorOf(VectorOf<T>&& other) noexcept = default;
+    VectorOf& operator=(VectorOf<T>&& other) noexcept = default;
+    ~VectorOf() override = default;
+
     size_t getElementSize() const override {
         return sizeof(T);
     }


### PR DESCRIPTION
Default ones are just fine (rule of zero)

CC: @Nicogene
CC-Issue: #2432