### PR TITLE
Fix clang-tidy readability-braces-around-statements warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       timestamp: ${{ steps.select.outputs.timestamp }}
+      repository_owner: ${{ steps.select.outputs.repository_owner }}
+      repository_name: ${{ steps.select.outputs.repository_name }}
       repository: ${{ steps.select.outputs.repository }}
       ref: ${{ steps.select.outputs.ref }}
       environment: ${{ steps.select.outputs.environment }}
@@ -33,11 +35,13 @@ jobs:
       run: |
         echo "::set-output name=timestamp::$(/bin/date -u +%Y%m%d-%H%M%S)"
 
+        echo "::set-output name=repository_owner::${{ github.repository_owner }}
+        echo "::set-output name=repository_name::$(cat $GITHUB_EVENT_PATH | jq -r .repository.name)
         echo "::set-output name=repository::${{ github.repository }}"
 
         if [[ "$GITHUB_EVENT_NAME" = "pull_request_target" ]]; then
           echo "::set-output name=environment::code-analysis_unsafe"
-          echo "::set-output name=ref::refs/pull/$(cat $GITHUB_EVENT_PATH | jq .number)/merge"
+          echo "::set-output name=ref::refs/pull/$(cat $GITHUB_EVENT_PATH | jq -r .number)/merge"
         else
           echo "::set-output name=environment::code-analysis"
           echo "::set-output name=ref::${{ github.ref }}"
@@ -46,7 +50,7 @@ jobs:
           echo "::set-output name=sha::${{ github.event.pull_request.head.sha }}"
           echo "::set-output name=head_ref::${GITHUB_HEAD_REF}"
           echo "::set-output name=base_ref::${GITHUB_BASE_REF}"
-          echo "::set-output name=pr_number::$(cat $GITHUB_EVENT_PATH | jq .number)"
+          echo "::set-output name=pr_number::$(cat $GITHUB_EVENT_PATH | jq -r .number)"
         else
           echo "::set-output name=sha::${{ github.sha }}"
         fi
@@ -59,6 +63,8 @@ jobs:
     - name: 'Debug output variables'
       env:
         TIMESTAMP: ${{ steps.select.outputs.timestamp }}
+        REPOSITORY_OWNER: ${{ steps.select.outputs.repository_owner }}
+        REPOSITORY_NAME: ${{ steps.select.outputs.repository_name }}
         REPOSITORY: ${{ steps.select.outputs.repository }}
         REF: ${{ steps.select.outputs.ref }}
         ENVIRONMENT: ${{ steps.select.outputs.environment }}
@@ -69,6 +75,8 @@ jobs:
         YARP_VERSION: ${{ steps.select.outputs.yarp_version }}
       run: |
         echo "TIMESTAMP = ${TIMESTAMP}"
+        echo "REPOSITORY_OWNER = ${REPOSITORY_OWNER}"
+        echo "REPOSITORY_NAME = ${REPOSITORY_NAME}"
         echo "REPOSITORY = ${REPOSITORY}"
         echo "REF = ${REF}"
         echo "ENVIRONMENT = ${ENVIRONMENT}"
@@ -1630,9 +1638,9 @@ jobs:
     - name: Get Sonar and Prepare Environment
       id: get_sonar
       env:
-        SONAR_ORGANIZATION: 'robotology'
-        SONAR_PROJECT_KEY: 'robotology_yarp'
-        SONAR_PROJECT_NAME: 'yarp'
+        SONAR_ORGANIZATION: ${{ needs.select_environment.outputs.repository_owner }}
+        SONAR_PROJECT_KEY: ${{ needs.select_environment.outputs.repository_owner }}_${{ needs.select_environment.outputs.repository_name }}
+        SONAR_PROJECT_NAME: ${{ needs.select_environment.outputs.repository_name }}
         SONAR_PROJECT_DESCRIPTION: 'Yet Another Robot Platform'
         SONAR_PROJECT_VERSION: ${{ needs.select_environment.outputs.yarp_version }}
         SONAR_LINKS_HOMEPAGE: 'https://www.yarp.it/'

--- a/src/carriers/bayer_carrier/BayerCarrier.h
+++ b/src/carriers/bayer_carrier/BayerCarrier.h
@@ -74,7 +74,9 @@ public:
     {}
 
     ~BayerCarrier() {
-        if (local) delete local;
+        if (local) {
+            delete local;
+        }
     }
 
     Carrier *create() const override {

--- a/src/carriers/h264_carrier/H264Decoder.cpp
+++ b/src/carriers/h264_carrier/H264Decoder.cpp
@@ -228,8 +228,9 @@ GstFlowReturn new_sample(GstAppSink *appsink, gpointer user_data)
     gst_buffer_unmap(buffer, &map);
 
     gst_sample_unref(sample);
-    if(dec_data->isReq)
+    if (dec_data->isReq) {
         dec_data->s->post();
+    }
 
 
 #ifdef debug_time

--- a/src/carriers/human_carrier/HumanCarrier.cpp
+++ b/src/carriers/human_carrier/HumanCarrier.cpp
@@ -12,7 +12,9 @@ bool HumanCarrier::sendHeader(ConnectionState& proto) {
     ManagedBytes header(8);
     getHeader(header.bytes());
     proto.os().write(header.bytes());
-    if (!proto.os().isOk()) return false;
+    if (!proto.os().isOk()) {
+        return false;
+    }
 
     // Now we can do whatever we want, as long as somehow
     // we also send the name of the originating port

--- a/src/carriers/human_carrier/HumanCarrier.h
+++ b/src/carriers/human_carrier/HumanCarrier.h
@@ -131,7 +131,9 @@ public:
 
     bool write(ConnectionState& proto, SizedWriter& writer) override {
         bool ok = sendIndex(proto,writer);
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
         writer.write(proto.os());
         return proto.os().isOk();
     }
@@ -149,7 +151,9 @@ public:
         Bytes b2((char*)prefix.c_str(),prefix.length());
         proto.is().read(b2);
         bool ok = proto.is().isOk() && (prefix==compare);
-        if (!ok) std::cout << "YOU DID NOT SAY 'human says '" << std::endl;
+        if (!ok) {
+            std::cout << "YOU DID NOT SAY 'human says '" << std::endl;
+        }
         return ok;
     }
 
@@ -168,7 +172,9 @@ public:
         Bytes b2((char*)prefix.c_str(),prefix.length());
         proto.is().read(b2);
         bool ok = proto.is().isOk() && (prefix==compare);
-        if (!ok) std::cout << "YOU DID NOT SAY 'computers rule!'" << std::endl;
+        if (!ok) {
+            std::cout << "YOU DID NOT SAY 'computers rule!'" << std::endl;
+        }
         return ok;
     }
 

--- a/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
+++ b/src/carriers/mjpeg_carrier/MjpegCarrier.cpp
@@ -158,7 +158,9 @@ bool MjpegCarrier::write(ConnectionState& proto, SizedWriter& writer) {
     WireImage rep;
     FlexImage *img = rep.checkForImage(writer);
 
-    if (img==nullptr) return false;
+    if (img == nullptr) {
+        return false;
+    }
     int w = img->width();
     int h = img->height();
     int row_stride = img->getRowSize();

--- a/src/carriers/mpi_carrier/MpiBcastCarrier.cpp
+++ b/src/carriers/mpi_carrier/MpiBcastCarrier.cpp
@@ -39,8 +39,9 @@ void MpiBcastCarrier::createStream(bool sender) {
         }
         stream = new MpiBcastStream(name+"->bcast", comm);
         auto* mpiStream = dynamic_cast<MpiBcastStream*> (stream);
-        if(mpiStream)
+        if (mpiStream) {
             mpiStream->startJoin();
+        }
         getCaster().add(name, this);
         electionMember = true;
     } else {

--- a/src/carriers/mpi_carrier/MpiBcastCarrier.h
+++ b/src/carriers/mpi_carrier/MpiBcastCarrier.h
@@ -64,8 +64,9 @@ public:
     bool expectReplyToHeader(yarp::os::ConnectionState&  proto) override {
         bool ok = MpiCarrier::expectReplyToHeader(proto);
         MpiBcastStream *mpiStream = dynamic_cast<MpiBcastStream*> (stream);
-        if(mpiStream)
+        if (mpiStream) {
             mpiStream->post();
+        }
         return ok;
     }
 

--- a/src/carriers/mpi_carrier/MpiCarrier.cpp
+++ b/src/carriers/mpi_carrier/MpiCarrier.cpp
@@ -41,7 +41,9 @@ bool MpiCarrier::sendHeader(ConnectionState& proto) {
     ManagedBytes header(8);
     getHeader(header.bytes());
     proto.os().write(header.bytes());
-    if (!proto.os().isOk()) return false;
+    if (!proto.os().isOk()) {
+        return false;
+    }
 
     // Now we can do whatever we want, as long as somehow
     // we also send the name of the originating port
@@ -58,9 +60,12 @@ bool MpiCarrier::sendHeader(ConnectionState& proto) {
 
     createStream(true);
 
-    if (!MpiControl) return false;
-    if (! MpiControl->isRunning())
+    if (!MpiControl) {
         return false;
+    }
+    if (!MpiControl->isRunning()) {
+        return false;
+    }
     comm->openPort();
     char* port = comm->port_name;
     char* uid = comm->unique_id;
@@ -100,9 +105,12 @@ bool MpiCarrier::expectSenderSpecifier(ConnectionState& proto) {
     route = name + "<-" + other;
 
     createStream(false);
-    if (!MpiControl) return false;
-    if (! MpiControl->isRunning())
+    if (!MpiControl) {
         return false;
+    }
+    if (!MpiControl->isRunning()) {
+        return false;
+    }
 
     std::string other_id = proto.is().readLine();
     bool notLocal = comm->notLocal(other_id);

--- a/src/carriers/mpi_carrier/MpiP2PStream.cpp
+++ b/src/carriers/mpi_carrier/MpiP2PStream.cpp
@@ -22,12 +22,14 @@ ssize_t MpiP2PStream::read(Bytes& b) {
         int rank = comm->rank();
         MPI_Status status;
         while (true) {
-            if (terminate)
+            if (terminate) {
                 return -1;
+            }
             // Check for a message
             MPI_Iprobe(!rank, tag, comm->comm, &available, &status);
-            if (available)
+            if (available) {
                 break;
+            }
             // Prevent the busy polling which hurts
             // performance in the oversubscription scenario
             Time::yield();
@@ -84,8 +86,9 @@ void MpiP2PStream::write(const Bytes& b) {
         */
         // Check if message has been received
         MPI_Test(&request, &flag, &status);
-        if (flag)
+        if (flag) {
             break;
+        }
         // Prevent the busy polling which hurts
         // performance in the oversubscription scenario
         Time::yield();

--- a/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.cpp
+++ b/src/carriers/portmonitor_carrier/dll/MonitorSharedLib.cpp
@@ -30,8 +30,9 @@ MonitorSharedLib::MonitorSharedLib()
 
 MonitorSharedLib::~MonitorSharedLib()
 {
-    if(monitor.isValid())
+    if (monitor.isValid()) {
         monitor->destroy();
+    }
     monitor.close();
 }
 
@@ -97,8 +98,9 @@ bool MonitorSharedLib::peerTrigged()
 
 bool MonitorSharedLib::canAccept()
 {
-    if(constraint == "")
+    if (constraint == "") {
         return true;
+    }
      //TODO: constraint checking should be implemented here!
      return true;
 }

--- a/src/carriers/portmonitor_carrier/lua/MonitorLua.cpp
+++ b/src/carriers/portmonitor_carrier/lua/MonitorLua.cpp
@@ -48,8 +48,9 @@ MonitorLua::~MonitorLua()
         //  call PortMonitor.destroy if exists
         if(getLocalFunction("destroy"))
         {
-            if(lua_pcall(L, 0, 0, 0) != 0)
+            if (lua_pcall(L, 0, 0, 0) != 0) {
                 yCError(PORTMONITORCARRIER, "%s", lua_tostring(L, -1));
+            }
         }
         // closing lua state handler
         lua_close(L);
@@ -119,9 +120,9 @@ bool MonitorLua::load(const Property &options)
             L = nullptr;
             luaMutex.unlock();
             return false;
-        }
-        else
+        } else {
             result = lua_toboolean(L, -1);
+        }
     }
     lua_pop(L,1);
 
@@ -400,8 +401,9 @@ bool MonitorLua::registerExtraFunctions()
 
 bool MonitorLua::canAccept()
 {
-    if(constraint == "")
+    if (constraint == "") {
         return true;
+    }
 
     MonitorEventRecord& record = MonitorEventRecord::getInstance();
 
@@ -473,20 +475,24 @@ inline void MonitorLua::trimString(string& str)
   if(pos != string::npos) {
     str.erase(pos + 1);
     pos = str.find_first_not_of(' ');
-    if(pos != string::npos) str.erase(0, pos);
+    if (pos != string::npos) {
+        str.erase(0, pos);
+    }
+  } else {
+      str.erase(str.begin(), str.end());
   }
-  else str.erase(str.begin(), str.end());
 }
 
 inline bool MonitorLua::isKeyword(const char* str)
 {
-    if(!str)
+    if (!str) {
         return false;
+    }
 
     string token = str;
-    if((token == "true") || (token == "false") ||
-       (token == "and") || (token == "or") || (token == "not") )
-       return true;
+    if ((token == "true") || (token == "false") || (token == "and") || (token == "or") || (token == "not")) {
+        return true;
+    }
     return false;
 }
 
@@ -540,10 +546,9 @@ int MonitorLua::setEvent(lua_State* L)
         // check if the event's lifetime is given as argument
         if(n_args > 1)
         {
-            if(lua_isnumber(L,2))
+            if (lua_isnumber(L, 2)) {
                 lifetime = (double) luaL_checknumber(L,2);
-            else
-            {
+            } else {
                 yCError(PORTMONITORCARRIER, "The second arguemnt of setEvent() must be number");
                 return 0;
             }
@@ -557,8 +562,9 @@ int MonitorLua::setEvent(lua_State* L)
         }
         auto* owner = static_cast<MonitorLua*>(lua_touserdata(L, -1));
         yCAssert(PORTMONITORCARRIER, owner);
-        if(owner->isKeyword(event_name))
+        if (owner->isKeyword(event_name)) {
             return 0;
+        }
         MonitorEventRecord& record = MonitorEventRecord::getInstance();
         record.lock();
         record.setEvent(event_name, owner, lifetime);
@@ -580,8 +586,9 @@ int MonitorLua::unsetEvent(lua_State* L)
         }
         auto* owner = static_cast<MonitorLua*>(lua_touserdata(L, -1));
         yCAssert(PORTMONITORCARRIER, owner);
-        if(owner->isKeyword(event_name))
+        if (owner->isKeyword(event_name)) {
             return 0;
+        }
         MonitorEventRecord& record = MonitorEventRecord::getInstance();
         record.lock();
         record.unsetEvent(event_name, owner);
@@ -595,9 +602,9 @@ int MonitorLua::setTrigInterval(lua_State* L)
     double period = 0.0;
     int n_args =  lua_gettop(L);
     if(n_args > 0) {
-        if(lua_isnumber(L, 1))
+        if (lua_isnumber(L, 1)) {
             period = (double) luaL_checknumber(L,1);
-        else {
+        } else {
             yCError(PORTMONITORCARRIER, "The arguemnt of setTrigInterval() must be number");
             return 0;
         }

--- a/src/carriers/priority_carrier/PriorityCarrier.cpp
+++ b/src/carriers/priority_carrier/PriorityCarrier.cpp
@@ -61,7 +61,9 @@ bool PriorityCarrier::configure(yarp::os::ConnectionState& proto) {
     portName = proto.getRoute().getToName();
     sourceName = proto.getRoute().getFromName();
     group = getPeers().add(portName,this);
-    if (!group) return false;
+    if (!group) {
+        return false;
+    }
 
     Property options;
     options.fromString(proto.getSenderSpecifier());
@@ -70,8 +72,9 @@ bool PriorityCarrier::configure(yarp::os::ConnectionState& proto) {
     timeResting = fabs(options.check("tr",Value(0.0)).asFloat64());
     stimulation = fabs(options.check("st",Value(STIMUL_THRESHOLD*10)).asFloat64());
     // Zero stimulation is undefined and will be interpreted as S=Thresould.
-    if(stimulation == 0)
-        stimulation = STIMUL_THRESHOLD*10;
+    if (stimulation == 0) {
+        stimulation = STIMUL_THRESHOLD * 10;
+    }
     stimulation /= 10.0;
 
     bias = options.check("bs",Value(STIMUL_THRESHOLD*10)).asFloat64();
@@ -155,42 +158,43 @@ double PriorityCarrier::getActualStimulation(double t)
     double dt = t - timeArrival;
     // Temporal priority is inverted if this is a neuron model and the temporal
     // stimulation has already reached to STIMUL_THRESHOLD and waited for Tc.
-    if((timeResting > 0)
-       && (dt >= fabs(timeConstant))
-       && (temporalStimulation >= STIMUL_THRESHOLD))
-       temporalStimulation = -temporalStimulation;
+    if ((timeResting > 0)
+        && (dt >= fabs(timeConstant))
+        && (temporalStimulation >= STIMUL_THRESHOLD)) {
+        temporalStimulation = -temporalStimulation;
+    }
 
     double actualStimulation;
     if(!isResting(temporalStimulation)) // behavior is in stimulation state
     {
         // After a gap bigger than Tc, the
         // priority is set to zero to avoid redundant calculation.
-        if(dt > fabs(timeConstant))
+        if (dt > fabs(timeConstant)) {
             actualStimulation = 0;
-        else
-            actualStimulation = temporalStimulation *
-                (1.0 - exp((dt-timeConstant)/timeConstant*5.0) + exp(-5.0));
+        } else {
+            actualStimulation = temporalStimulation * (1.0 - exp((dt - timeConstant) / timeConstant * 5.0) + exp(-5.0));
+        }
     }
     else // behavior is in resting state
     {
         // it is in waiting state for Tc
-        if(temporalStimulation > 0)
+        if (temporalStimulation > 0) {
             actualStimulation = temporalStimulation;
-        else
-        {
+        } else {
             dt -= fabs(timeConstant);
             // After a gap bigger than Tr, the
             // priority is set to zero to avoid redundant calculation.
-            if(dt > fabs(timeResting))
+            if (dt > fabs(timeResting)) {
                 actualStimulation = 0;
-            else
-                actualStimulation = temporalStimulation *
-                    (1.0 - exp((dt-timeResting)/timeResting*5.0) + exp(-5.0));
+            } else {
+                actualStimulation = temporalStimulation * (1.0 - exp((dt - timeResting) / timeResting * 5.0) + exp(-5.0));
+            }
         }
     }
 
-    if(actualStimulation <= 0)
+    if (actualStimulation <= 0) {
         isActive = false;
+    }
 
     return actualStimulation;
 }
@@ -198,8 +202,9 @@ double PriorityCarrier::getActualStimulation(double t)
 double PriorityCarrier::getActualInput(double t)
 {
     // calculating E(t) = Sum(e.I(t)) + b
-    if(!isActive)
+    if (!isActive) {
         return 0.0;
+    }
 
     double E = 0;
     for (auto& it : group->peerSet)
@@ -214,8 +219,9 @@ double PriorityCarrier::getActualInput(double t)
                 {
                     Bottle* b = v.asList();
                     // an exitatory to this priority carrier
-                    if(sourceName == b->get(0).asString())
-                        E += peer->getActualInput(t) * (b->get(1).asFloat64()/10.0);
+                    if (sourceName == b->get(0).asString()) {
+                        E += peer->getActualInput(t) * (b->get(1).asFloat64() / 10.0);
+                    }
                 }
             }
 
@@ -235,8 +241,9 @@ bool PriorityGroup::recalculate(double t)
 {
     //TODO: find the correct way to get the size of peerSet
     int nConnections = 0;
-    for(auto it=peerSet.begin(); it!=peerSet.end(); it++)
+    for (auto it = peerSet.begin(); it != peerSet.end(); it++) {
         nConnections++;
+    }
 
     // calculate matrices X, B, InvA and Y
     X.resize(nConnections, 1);
@@ -266,8 +273,9 @@ bool PriorityGroup::recalculate(double t)
                 {
                     Bottle* b = v.asList();
                     // an exitatory link to this connection
-                    if(peer->sourceName == b->get(0).asString())
-                        InvA(row,col) = -(b->get(1).asFloat64()/10.0)*xi;
+                    if (peer->sourceName == b->get(0).asString()) {
+                        InvA(row, col) = -(b->get(1).asFloat64() / 10.0) * xi;
+                    }
                 }
             }
             col++;
@@ -305,8 +313,9 @@ bool PriorityGroup::acceptIncomingData(yarp::os::ConnectionReader& reader,
     double tNow = yarp::os::Time::now();
     source->stimulate(tNow);
 
-    if(!recalculate(tNow))
+    if (!recalculate(tNow)) {
         return false;
+    }
 
     int row = 0;
     PriorityCarrier *maxPeer = nullptr;
@@ -331,8 +340,9 @@ bool PriorityGroup::acceptIncomingData(yarp::os::ConnectionReader& reader,
 
     // a virtual message will never be delivered. It will be only
     // used for the coordination
-    if(source->isVirtual)
+    if (source->isVirtual) {
         accept = false;
+    }
 
     return accept;
 }
@@ -351,7 +361,9 @@ PriorityDebugThread::PriorityDebugThread(PriorityCarrier* carrier) : PeriodicThr
 
 PriorityDebugThread::~PriorityDebugThread()
 {
-    if(isRunning()) stop();
+    if (isRunning()) {
+        stop();
+    }
 }
 
 void PriorityDebugThread::run()

--- a/src/carriers/shmem_carrier/ShmemInputStream.cpp
+++ b/src/carriers/shmem_carrier/ShmemInputStream.cpp
@@ -163,8 +163,9 @@ int ShmemInputStreamImpl::read(char* data, int len)
         return -1;
     }
 
-    while (m_pHeader->resize)
+    while (m_pHeader->resize) {
         Resize();
+    }
 
     if (m_pHeader->avail < len) {
         ++m_pHeader->waiting;
@@ -229,8 +230,9 @@ yarp::conf::ssize_t ShmemInputStreamImpl::read(yarp::os::Bytes& b)
 
 void ShmemInputStreamImpl::close()
 {
-    if (!m_bOpen)
+    if (!m_bOpen) {
         return;
+    }
 
     m_bOpen = false;
 

--- a/src/carriers/shmem_carrier/ShmemOutputStream.cpp
+++ b/src/carriers/shmem_carrier/ShmemOutputStream.cpp
@@ -228,8 +228,9 @@ bool ShmemOutputStreamImpl::write(const yarp::os::Bytes& b)
 
 void ShmemOutputStreamImpl::close()
 {
-    if (!m_bOpen)
+    if (!m_bOpen) {
         return;
+    }
 
     m_bOpen = false;
 

--- a/src/carriers/tcpros_carrier/RosSlave.h
+++ b/src/carriers/tcpros_carrier/RosSlave.h
@@ -65,7 +65,9 @@ public:
     bool read(yarp::os::ConnectionReader& reader) override {
         yarp::os::Bottle cmd, reply;
         bool ok = cmd.read(reader);
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
         yCDebug(TCPROSCARRIER, "slave got request %s", cmd.toString().c_str());
         reply.addInt32(1);
         reply.addString("");

--- a/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
+++ b/src/carriers/tcpros_carrier/TcpRosCarrier.cpp
@@ -60,7 +60,9 @@ std::string TcpRosCarrier::getRosType(ConnectionState& proto) {
             rtyp = "";
         } else if (typ=="yarp/bottle") {
             rtyp = proto.getContactable()->getType().getNameOnWire();
-            if (rtyp=="yarp/image") rtyp = "sensor_msgs/Image";
+            if (rtyp == "yarp/image") {
+                rtyp = "sensor_msgs/Image";
+            }
             wire_type = rtyp;
         } else if (typ!="") {
             rtyp = typ;
@@ -461,7 +463,9 @@ int TcpRosCarrier::connect(const yarp::os::Contact& src,
         break;
     }
 
-    if (!reversed) return -1;
+    if (!reversed) {
+        return -1;
+    }
 
     Contact fullDest = dest;
     if (fullDest.getPort()<=0) {

--- a/src/carriers/tcpros_carrier/TcpRosStream.cpp
+++ b/src/carriers/tcpros_carrier/TcpRosStream.cpp
@@ -30,7 +30,9 @@ yarp::conf::ssize_t TcpRosStream::read(Bytes& b) {
       return twiddlerReader.read(b);
     }
 
-    if (phase==-1) return -1;
+    if (phase == -1) {
+        return -1;
+    }
     if (remaining==0) {
         if (phase==1) {
             phase = 2;
@@ -68,7 +70,9 @@ yarp::conf::ssize_t TcpRosStream::read(Bytes& b) {
         yCTrace(TCPROSCARRIER, "Unit length %d\n", len);
 
         // inhibit type scanning for now, it is unreliable
-        if (raw==-1) raw = 2;
+        if (raw == -1) {
+            raw = 2;
+        }
         if (raw==-2) {
             scan.allocate(len);
             int res = delegate->getInputStream().readFull(scan.bytes());
@@ -172,7 +176,9 @@ std::map<std::string, std::string> TcpRosStream::rosToKind() {
 }
 
 std::string TcpRosStream::rosToKind(const char *rosname) {
-    if (std::string(rosname)=="") return {};
+    if (std::string(rosname) == "") {
+        return {};
+    };
     std::map<std::string, std::string> kinds = rosToKind();
 
     if (kinds.find(rosname)!=kinds.end()) {
@@ -187,7 +193,9 @@ std::string TcpRosStream::rosToKind(const char *rosname) {
         port.write(cmd,resp);
         yCTrace(TCPROSCARRIER, "GOT yarpidl_rosmsg %s\n", resp.toString().c_str());
         std::string txt = resp.get(0).asString();
-        if (txt!="?") return txt;
+        if (txt != "?") {
+            return txt;
+        }
     }
     port.close();
     if (std::string(rosname)!="") {

--- a/src/carriers/tcpros_carrier/yarpros.cpp
+++ b/src/carriers/tcpros_carrier/yarpros.cpp
@@ -71,15 +71,21 @@ string addPart(string t, string name, int code, Value *val, string orig, string 
             r += '\''; r += char1; r += "\'*256^3";
         }
         if (char2!=0) {
-            if (r!="") r += "+";
+            if (r != "") {
+                r += "+";
+            }
             r += '\''; r += char2; r += "\'*256^2";
         }
         if (char3!=0) {
-            if (r!="") r += "+";
+            if (r != "") {
+                r += "+";
+            }
             r += '\''; r += char3; r += "\'*256";
         }
         if (char4!=0) {
-            if (r!="") r += "+";
+            if (r != "") {
+                r += "+";
+            }
             r += '\''; r += char4; r += '\'';
         }
         if (r.length()==0) {
@@ -355,11 +361,15 @@ int main(int argc, char *argv[]) {
         RosLookup lookup;
         yCDebug(YARPROS, "  * looking up ros node %s", ros_port.c_str());
         bool ok = lookup.lookupCore(ros_port);
-        if (!ok) return 1;
+        if (!ok) {
+            return 1;
+        }
         yCDebug(YARPROS, "  * found ros node %s", ros_port.c_str());
         yCDebug(YARPROS, "  * looking up topic %s", topic.c_str());
         ok = lookup.lookupTopic(topic);
-        if (!ok) return 1;
+        if (!ok) {
+            return 1;
+        }
         yCDebug(YARPROS, "  * found topic %s", topic.c_str());
         string carrier = "tcpros+role.pub+topic.";
         if (service) {
@@ -391,7 +401,9 @@ int main(int argc, char *argv[]) {
         RosLookup lookup;
         yCDebug(YARPROS, "  * looking up ros node %s", ros_port.c_str());
         bool ok = lookup.lookupCore(ros_port);
-        if (!ok) return 1;
+        if (!ok) {
+            return 1;
+        }
         yCDebug(YARPROS, "  * found ros node %s", ros_port.c_str());
         ok = register_port(yarp_port.c_str(),
                       (string("tcpros+role.sub+topic.")+topic).c_str(),
@@ -410,19 +422,27 @@ int main(int argc, char *argv[]) {
         }
         std::string dir = cmd.get(1).asString();
         bool in = false;
-        if (dir=="in") in = true;
-        else if (dir=="out") in = false;
-        else {
+        if (dir == "in") {
+            in = true;
+        } else if (dir == "out") {
+            in = false;
+        } else {
             yCError(YARPROS, "Please specify one of 'in' or 'out'.");
             return 1;
         }
         std::string pname = cmd.get(2).asString();
         Port p;
-        if (!p.open("...")) return 1;
+        if (!p.open("...")) {
+            return 1;
+        }
         if (in) {
-            if (!Network::connect(pname,p.getName(),"tcp+log.in")) return 1;
+            if (!Network::connect(pname, p.getName(), "tcp+log.in")) {
+                return 1;
+            }
         } else {
-            if (!Network::connect(pname,p.getName())) return 1;
+            if (!Network::connect(pname, p.getName())) {
+                return 1;
+            }
         }
         Bottle b;
         p.read(b);

--- a/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
+++ b/src/devices/AnalogSensorClient/AnalogSensorClient.cpp
@@ -55,10 +55,12 @@ void InputPortProcessor::onRead(yarp::sig::Vector &v)
     {
         double tmpDT=now-prev;
         deltaT+=tmpDT;
-        if (tmpDT>deltaTMax)
-            deltaTMax=tmpDT;
-        if (tmpDT<deltaTMin)
-            deltaTMin=tmpDT;
+        if (tmpDT > deltaTMax) {
+            deltaTMax = tmpDT;
+        }
+        if (tmpDT < deltaTMin) {
+            deltaTMin = tmpDT;
+        }
 
         //compare network time
         if (tmpDT*1000<ANALOG_TIMEOUT)
@@ -175,9 +177,9 @@ void  AnalogSensorClient::removeLeadingTrailingSlashesOnly(std::string &name)
         {
             done = false;       // we could have both leading and trailing, so let's check again
             name.erase(found,1);
+        } else {
+            done = true; // there is some '/', but their are in the middle and they are allowed
         }
-        else
-            done = true;        // there is some '/', but their are in the middle and they are allowed
     }
 
     yCDebug(ANALOGSENSORCLIENT) << name;
@@ -281,8 +283,9 @@ int AnalogSensorClient::calibrateSensor(const yarp::sig::Vector& value)
     cmd.addVocab32(VOCAB_IANALOG);
     cmd.addVocab32(VOCAB_CALIBRATE);
     Bottle& l = cmd.addList();
-    for (int i = 0; i < this->getChannels(); i++)
-         l.addFloat64(value[i]);
+    for (int i = 0; i < this->getChannels(); i++) {
+        l.addFloat64(value[i]);
+    }
     bool ok = rpcPort.write(cmd, response);
     return checkResponse(ok, response);
 }

--- a/src/devices/AnalogWrapper/AnalogWrapper.cpp
+++ b/src/devices/AnalogWrapper/AnalogWrapper.cpp
@@ -82,8 +82,9 @@ void AnalogServerHandler::setInterface(yarp::dev::IAnalogSensor *is)
 
 bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle &reply)
 {
-    if (is==nullptr)
-      return false;
+    if (is == nullptr) {
+        return false;
+    }
 
     const size_t msgsize=cmd.size();
     int ret=IAnalogSensor::AS_ERROR;
@@ -92,18 +93,16 @@ bool AnalogServerHandler::_handleIAnalog(yarp::os::Bottle &cmd, yarp::os::Bottle
     switch (code)
     {
     case VOCAB_CALIBRATE:
-      if (msgsize==2)
-        ret=is->calibrateSensor();
-      else if (msgsize>2)
-      {
-        size_t offset=2;
-        Vector v(msgsize-offset);
-        for (unsigned int i=0; i<v.size(); i++)
-        {
-          v[i]=cmd.get(i+offset).asFloat64();
+        if (msgsize == 2) {
+            ret = is->calibrateSensor();
+        } else if (msgsize > 2) {
+            size_t offset = 2;
+            Vector v(msgsize - offset);
+            for (unsigned int i = 0; i < v.size(); i++) {
+                v[i] = cmd.get(i + offset).asFloat64();
+            }
+            ret = is->calibrateSensor(v);
         }
-        ret=is->calibrateSensor(v);
-      }
       break;
     case VOCAB_CALIBRATE_CHANNEL:
       if (msgsize==3)
@@ -131,7 +130,9 @@ bool AnalogServerHandler::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok=in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     // parse in, prepare out
     int code = in.get(0).asVocab32();
@@ -299,8 +300,9 @@ bool AnalogWrapper::openAndAttachSubDevice(Searchable &prop)
 bool AnalogWrapper::openDeferredAttach(yarp::os::Searchable &prop)
 {
     // nothing to do here?
-    if( (subDeviceOwned != nullptr) || (ownDevices == true) )
+    if ((subDeviceOwned != nullptr) || (ownDevices == true)) {
         yCError(ANALOGWRAPPER) << "AnalogWrapper: something wrong with the initialization.";
+    }
     return true;
 }
 
@@ -312,8 +314,9 @@ bool AnalogWrapper::openDeferredAttach(yarp::os::Searchable &prop)
 bool AnalogWrapper::attachAll(const PolyDriverList &analog2attach)
 {
     //check if we already instantiated a subdevice previously
-    if (ownDevices)
+    if (ownDevices) {
         return false;
+    }
 
     if (analog2attach.size() != 1)
     {
@@ -341,14 +344,16 @@ bool AnalogWrapper::attachAll(const PolyDriverList &analog2attach)
 bool AnalogWrapper::detachAll()
 {
     //check if we already instantiated a subdevice previously
-    if (ownDevices)
+    if (ownDevices) {
         return false;
+    }
 
     analogSensor_p = nullptr;
     for(unsigned int i=0; i<analogPorts.size(); i++)
     {
-        if(handlers[i] != nullptr)
+        if (handlers[i] != nullptr) {
             handlers[i]->setInterface(analogSensor_p);
+        }
     }
     return true;
 }
@@ -763,8 +768,9 @@ bool AnalogWrapper::open(yarp::os::Searchable &config)
     else
     {
         ownDevices=false;
-        if(!openDeferredAttach(config))
+        if (!openDeferredAttach(config)) {
             return false;
+        }
     }
 
     return true;
@@ -794,8 +800,9 @@ bool AnalogWrapper::initialize_YARP(yarp::os::Searchable &params)
                 }
                 createPort((streamingPortName ).c_str(), _rate );
                 // since createPort always return true, check the port is really been opened is done here
-                if(! Network::exists(streamingPortName + "/rpc:i"))
+                if (!Network::exists(streamingPortName + "/rpc:i")) {
                     return false;
+                }
             }
             else
             {
@@ -895,10 +902,11 @@ void AnalogWrapper::run()
                     {
                         yarp::sig::Vector &pv = analogPort.port.prepare();
                         first = analogPort.offset;
-                        if(analogPort.length == -1)   // read the max length available
+                        if (analogPort.length == -1) { // read the max length available
                             last = lastDataRead.size()-1;
-                        else
+                        } else {
                             last = analogPort.offset + analogPort.length - 1;
+                        }
 
                         // check vector limit
                         if(last>=(int)lastDataRead.size()){

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -464,8 +464,9 @@ bool ControlBoardRemapper::detachAll()
 {
     //check if we already instantiated a subdevice previously
     int devices=remappedControlBoards.getNrOfSubControlBoards();
-    for(int k=0;k<devices;k++)
+    for (int k = 0; k < devices; k++) {
         remappedControlBoards.getSubControlBoard(k)->detach();
+    }
 
     IRemoteCalibrator::releaseCalibratorDevice();
     return true;
@@ -2351,15 +2352,16 @@ bool ControlBoardRemapper::getMotorEncoders(double *encs)
         size_t subIndex=remappedControlBoards.lut[l].subControlBoardIndex;
 
         RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
-        if (!p)
+        if (!p) {
             return false;
+        }
 
         if (p->iMotEnc)
         {
             ret=ret&&p->iMotEnc->getMotorEncoder(off, encs+l);
+        } else {
+            ret = false;
         }
-        else
-            ret=false;
     }
     return ret;
 }
@@ -3550,8 +3552,9 @@ bool ControlBoardRemapper::getControlMode(int j, int *mode)
     size_t subIndex=remappedControlBoards.lut[j].subControlBoardIndex;
 
     RemappedSubControlBoard *p=remappedControlBoards.getSubControlBoard(subIndex);
-    if (!p)
+    if (!p) {
         return false;
+    }
 
     return p->iMode->getControlMode(off, mode);
 

--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
@@ -158,12 +158,15 @@ bool DynamixelAX12FtdiDriver::open(yarp::os::Searchable& config) {
 
     // We have an open device and it is accessible, so set parameters
 
-    if ((retCode = ftdi_set_baudrate(&ftdic, ftdiSetting.baudrate)) != 0)
+    if ((retCode = ftdi_set_baudrate(&ftdic, ftdiSetting.baudrate)) != 0) {
         yCError(DYNAMIXELAX12FTDIDRIVER, "Error setting baudrate, ret=%d", retCode);
-    if (ftdi_set_line_property(&ftdic, BITS_8, STOP_BIT_1, NONE) == -1)
+    }
+    if (ftdi_set_line_property(&ftdic, BITS_8, STOP_BIT_1, NONE) == -1) {
         yCError(DYNAMIXELAX12FTDIDRIVER, "Error setting connection properties");
-    if (ftdi_setflowctrl(&ftdic, SIO_DISABLE_FLOW_CTRL) == -1)
+    }
+    if (ftdi_setflowctrl(&ftdic, SIO_DISABLE_FLOW_CTRL) == -1) {
         yCError(DYNAMIXELAX12FTDIDRIVER, "Error setting flow control");
+    }
 
     // Set chunk sizes for in and out
     ftdi_write_data_set_chunksize(&ftdic, ftdiSetting.write_chunksize);
@@ -287,7 +290,9 @@ int DynamixelAX12FtdiDriver::sendCommand(unsigned char id, unsigned char inst[],
                 } else {
                     //check checksum
                     chksum = 0;
-                    for (i = 0; i < retCode - 1; i++) chksum += body[i];
+                    for (i = 0; i < retCode - 1; i++) {
+                        chksum += body[i];
+                    }
                     if (body[retCode - 1] != (unsigned char) ~(chksum + header[2] + header[3])) {
                         badAnswer = true;
                         yCInfo(DYNAMIXELAX12FTDIDRIVER, "Received data with wrong checksum (%X != %X): ", body[retCode - 1], (unsigned char) ~(chksum + header[2] + header[3]));
@@ -411,8 +416,9 @@ bool DynamixelAX12FtdiDriver::positionMove(int j, double ref) {
 bool DynamixelAX12FtdiDriver::positionMove(const double *refs) {
     bool t = true;
     for (int k = 0; k < numOfAxes; k++) {
-        if (!this->positionMove(k, refs[k]))
+        if (!this->positionMove(k, refs[k])) {
             t = false;
+        }
     }
     return t;
 }
@@ -421,15 +427,17 @@ bool DynamixelAX12FtdiDriver::relativeMove(int j, double delta) {
     double v = positions[j];
     if (getEncoder(j, &v)) {
         return this->positionMove(j, v + delta);
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DynamixelAX12FtdiDriver::relativeMove(const double *deltas) {
     bool t = true;
     for (int k = 0; k < numOfAxes; k++) {
-        if (!this->positionMove(k, positions[k] + deltas[k]))
+        if (!this->positionMove(k, positions[k] + deltas[k])) {
             t = false;
+        }
     }
     return t;
 }
@@ -448,8 +456,9 @@ bool DynamixelAX12FtdiDriver::checkMotionDone(bool *flag) {
     bool tmp_done(false), all_done(true);
     for (int k = 0; k < numOfAxes; k++)
     {
-        if (!this->checkMotionDone(k, &tmp_done))
+        if (!this->checkMotionDone(k, &tmp_done)) {
             t = false;
+        }
         all_done &= tmp_done;
     }
     *flag = all_done;
@@ -474,8 +483,9 @@ bool DynamixelAX12FtdiDriver::setRefSpeed(int j, double sp) {
 bool DynamixelAX12FtdiDriver::setRefSpeeds(const double *spds) {
     bool t = true;
     for (int k = 0; k < numOfAxes; k++) {
-        if (!setRefSpeed(k, spds[k]))
+        if (!setRefSpeed(k, spds[k])) {
             t = false;
+        }
     }
     return t;
 }
@@ -526,8 +536,9 @@ bool DynamixelAX12FtdiDriver::stop(int j) {
 
 bool DynamixelAX12FtdiDriver::stop() {
     for (int i = 0; i < numOfAxes; i++) {
-        if (!stop(i))
+        if (!stop(i)) {
             return false;
+        }
     }
     return true;
 }
@@ -574,8 +585,9 @@ bool DynamixelAX12FtdiDriver::getRefTorque(int j, double *t) {
 bool DynamixelAX12FtdiDriver::setTorques(const double *t) {
     bool tt = true;
     for (int k = 0; k < numOfAxes; k++) {
-        if (!this->setTorque(k, t[k]))
+        if (!this->setTorque(k, t[k])) {
             tt = false;
+        }
     }
     return tt;
 }
@@ -636,8 +648,9 @@ bool DynamixelAX12FtdiDriver::getTorques(double *t) {
     int k = 0;
     bool tt = true;
     for (k = 0; k < numOfAxes; k++) {
-        if (!getTorque(k, &t[k]))
+        if (!getTorque(k, &t[k])) {
             tt = false;
+        }
     }
     return tt;
 }
@@ -783,9 +796,10 @@ bool DynamixelAX12FtdiDriver::getEncoder(int j, double *v) {
             return false;
         }
 
-    }        // pos = (blankReturn[1]&0b00000011)*0x100 + blankReturn[0];
-    else
+    } // pos = (blankReturn[1]&0b00000011)*0x100 + blankReturn[0];
+    else {
         return false;
+    }
 }
 
 bool DynamixelAX12FtdiDriver::getEncoders(double *encs) {
@@ -831,8 +845,9 @@ bool DynamixelAX12FtdiDriver::getEncoderSpeeds(double *spds) {
     int k = 0;
     bool tt = true;
     for (k = 0; k < numOfAxes; k++) {
-        if (!getEncoderSpeed(k, &spds[k]))
+        if (!getEncoderSpeed(k, &spds[k])) {
             tt = false;
+        }
     }
     return tt;
 }

--- a/src/devices/JoypadControlClient/JoypadControlClient.cpp
+++ b/src/devices/JoypadControlClient/JoypadControlClient.cpp
@@ -46,7 +46,9 @@ bool JoypadControlClient::getJoypadInfo()
 
     for(auto vocab_port : vocabs_ports)
     {
-        if(!getCount(get<0>(vocab_port), count)) return false;
+        if (!getCount(get<0>(vocab_port), count)) {
+            return false;
+        }
         if(count)
         {
             string source;

--- a/src/devices/JoypadControlServer/JoypadControlServer.cpp
+++ b/src/devices/JoypadControlServer/JoypadControlServer.cpp
@@ -340,8 +340,9 @@ bool JoypadControlServer::openAndAttachSubDevice(Searchable& prop)
         return false;
     }
     m_isSubdeviceOwned = true;
-    if(!attach(m_subDeviceOwned))
+    if (!attach(m_subDeviceOwned)) {
         return false;
+    }
 
     if(!m_parser.configure(m_device) )
     {
@@ -356,8 +357,9 @@ bool JoypadControlServer::openAndAttachSubDevice(Searchable& prop)
 
 bool JoypadControlServer::attach(PolyDriver* poly)
 {
-    if(poly)
+    if (poly) {
         poly->view(m_device);
+    }
 
     if(m_device == nullptr)
     {
@@ -663,7 +665,9 @@ void JoypadControlServer::run()
                 }
                 b.push_back(v);
             }
-            if(write)m_portButtons.write();
+            if (write) {
+                m_portButtons.write();
+            }
         }
 
         if (m_portHats.valid)
@@ -683,7 +687,9 @@ void JoypadControlServer::run()
                 }
                 b.push_back(v);
             }
-            if(write)m_portHats.write();
+            if (write) {
+                m_portHats.write();
+            }
         }
 
         if (m_portAxis.valid)
@@ -704,7 +710,9 @@ void JoypadControlServer::run()
                 }
                 b.push_back(v);
             }
-            if(write)m_portAxis.write();
+            if (write) {
+                m_portAxis.write();
+            }
         }
 
         if (m_portTrackball.valid)
@@ -725,7 +733,9 @@ void JoypadControlServer::run()
                 }
                 cat(b, v);
             }
-            if(write)m_portTrackball.write();
+            if (write) {
+                m_portTrackball.write();
+            }
         }
 
         if (m_portStick.valid)
@@ -745,7 +755,9 @@ void JoypadControlServer::run()
                 }
                 cat(b, v);
             }
-            if(write)m_portStick.write();
+            if (write) {
+                m_portStick.write();
+            }
         }
 
         if (m_portTouch.valid)
@@ -765,7 +777,9 @@ void JoypadControlServer::run()
                 cat(b, v);
             }
 
-            if(write)m_portTouch.write();
+            if (write) {
+                m_portTouch.write();
+            }
         }
     }
     else
@@ -807,12 +821,14 @@ bool JoypadControlServer::attachAll(const PolyDriverList& p)
     }
 
     Idevice2attach->view(m_device);
-    if(!attach(m_device))
+    if (!attach(m_device)) {
         return false;
+    }
 
     PeriodicThread::setPeriod(m_period);
-    if (!PeriodicThread::start())
+    if (!PeriodicThread::start()) {
         return false;
+    }
 
     openPorts();
     return true;
@@ -820,12 +836,14 @@ bool JoypadControlServer::attachAll(const PolyDriverList& p)
 
 bool JoypadControlServer::detachAll()
 {
-    if (yarp::os::PeriodicThread::isRunning())
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
+    }
 
     //check if we already instantiated a subdevice previously
-    if (m_isSubdeviceOwned)
+    if (m_isSubdeviceOwned) {
         return false;
+    }
 
     m_device = nullptr;
     return true;
@@ -838,7 +856,9 @@ bool JoypadControlServer::close()
     // close subdevice if it was created inside the open (--subdevice option)
     if(m_isSubdeviceOwned)
     {
-        if(m_subDeviceOwned)m_subDeviceOwned->close();
+        if (m_subDeviceOwned) {
+            m_subDeviceOwned->close();
+        }
 
         m_subDeviceOwned   = nullptr;
         m_device           = nullptr;

--- a/src/devices/RGBDRosConversionUtils/rosPixelCode.cpp
+++ b/src/devices/RGBDRosConversionUtils/rosPixelCode.cpp
@@ -50,36 +50,37 @@ std::string yarp2RosPixelCode(int code)
 
 int Ros2YarpPixelCode(const std::string& roscode)
 {
-    if (roscode == BGR8)
+    if (roscode == BGR8) {
         return VOCAB_PIXEL_BGR;
-    else if (roscode == BGRA8)
+    } else if (roscode == BGRA8) {
         return VOCAB_PIXEL_BGRA;
-    else if (roscode == BAYER_BGGR8)
+    } else if (roscode == BAYER_BGGR8) {
         return VOCAB_PIXEL_ENCODING_BAYER_BGGR8;
-    else if (roscode == BAYER_GBRG16)
+    } else if (roscode == BAYER_GBRG16) {
         return VOCAB_PIXEL_ENCODING_BAYER_GBRG16;
-    else if (roscode == BAYER_GBRG8)
+    } else if (roscode == BAYER_GBRG8) {
         return VOCAB_PIXEL_ENCODING_BAYER_GBRG8;
-    else if (roscode == BAYER_GRBG16)
+    } else if (roscode == BAYER_GRBG16) {
         return VOCAB_PIXEL_ENCODING_BAYER_GRBG16;
-    else if (roscode == BAYER_GRBG8)
+    } else if (roscode == BAYER_GRBG8) {
         return VOCAB_PIXEL_ENCODING_BAYER_GRBG8;
-    else if (roscode == BAYER_RGGB16)
+    } else if (roscode == BAYER_RGGB16) {
         return VOCAB_PIXEL_ENCODING_BAYER_RGGB16;
-    else if (roscode == BAYER_RGGB8)
+    } else if (roscode == BAYER_RGGB8) {
         return VOCAB_PIXEL_ENCODING_BAYER_RGGB8;
-    else if (roscode == MONO8)
+    } else if (roscode == MONO8) {
         return VOCAB_PIXEL_MONO;
-    else if (roscode == MONO16)
+    } else if (roscode == MONO16) {
         return VOCAB_PIXEL_MONO16;
-    else if (roscode == RGB8)
+    } else if (roscode == RGB8) {
         return VOCAB_PIXEL_RGB;
-    else if (roscode == RGBA8)
+    } else if (roscode == RGBA8) {
         return VOCAB_PIXEL_RGBA;
-    else if (roscode == TYPE_32FC1)
+    } else if (roscode == TYPE_32FC1) {
         return VOCAB_PIXEL_MONO_FLOAT;
-    else
+    } else {
         return VOCAB_PIXEL_INVALID;
+    }
 }
 
 }}}

--- a/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -102,9 +102,9 @@ bool RGBDSensorParser::respond(const Bottle& cmd, Bottle& response)
                                 response.addVocab32(VOCAB_IS);
                                 ret &= Property::copyPortable(params, params_b);  // will it really work??
                                 response.append(params_b);
-                            }
-                            else
+                            } else {
                                 response.addVocab32(VOCAB_FAILED);
+                            }
                         }
                         break;
 
@@ -204,8 +204,10 @@ bool RGBDSensorWrapper::open(yarp::os::Searchable &config)
 //     addUsage("[set] [expo] $fExposure", "set exposure");
 //
     m_conf.fromString(config.toString());
-    if(verbose >= 5)
-        yCTrace(RGBDSENSORWRAPPER) << "\nParameters are: \n" << config.toString();
+    if (verbose >= 5) {
+        yCTrace(RGBDSENSORWRAPPER) << "\nParameters are: \n"
+                                   << config.toString();
+    }
 
     if(!fromConfig(config))
     {
@@ -239,8 +241,9 @@ bool RGBDSensorWrapper::open(yarp::os::Searchable &config)
     }
     else
     {
-        if(!openDeferredAttach(config))
+        if (!openDeferredAttach(config)) {
             return false;
+        }
     }
 
     return true;
@@ -250,17 +253,19 @@ bool RGBDSensorWrapper::fromConfig(yarp::os::Searchable &config)
 {
     if (!config.check("period", "refresh period of the broadcasted values in ms"))
     {
-        if(verbose >= 3)
+        if (verbose >= 3) {
             yCInfo(RGBDSENSORWRAPPER) << "Using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "s";
-    }
-    else
+        }
+    } else {
         period = config.find("period").asInt32() / 1000.0;
+    }
 
     Bottle &rosGroup = config.findGroup("ROS");
     if(rosGroup.isNull())
     {
-        if(verbose >= 3)
+        if (verbose >= 3) {
             yCInfo(RGBDSENSORWRAPPER) << "ROS configuration parameters are not set, skipping ROS topic initialization.";
+        }
         use_ROS  = false;
         use_YARP = true;
     }
@@ -534,8 +539,9 @@ bool RGBDSensorWrapper::attachAll(const PolyDriverList &device2attach)
 
     Idevice2attach->view(sensor_p);
     Idevice2attach->view(fgCtrl);
-    if(!attach(sensor_p))
+    if (!attach(sensor_p)) {
         return false;
+    }
 
     PeriodicThread::setPeriod(period);
     return PeriodicThread::start();
@@ -543,12 +549,14 @@ bool RGBDSensorWrapper::attachAll(const PolyDriverList &device2attach)
 
 bool RGBDSensorWrapper::detachAll()
 {
-    if (yarp::os::PeriodicThread::isRunning())
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
+    }
 
     //check if we already instantiated a subdevice previously
-    if (isSubdeviceOwned)
+    if (isSubdeviceOwned) {
         return false;
+    }
 
     sensor_p = nullptr;
     return true;

--- a/src/devices/RGBDSensorWrapper/RgbdSensor_nws_ros.cpp
+++ b/src/devices/RGBDSensorWrapper/RgbdSensor_nws_ros.cpp
@@ -56,8 +56,9 @@ bool RgbdSensor_nws_ros::open(yarp::os::Searchable &config)
     }
     if (!config.check("period", "refresh period of the broadcasted values in ms"))
     {
-        if(verbose >= 3)
+        if (verbose >= 3) {
             yCInfo(RGBDSENSORNWSROS) << "Using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "s";
+        }
     }
     else
     {
@@ -96,8 +97,9 @@ bool RgbdSensor_nws_ros::open(yarp::os::Searchable &config)
     }
     else
     {
-        if(!openDeferredAttach(config))
+        if (!openDeferredAttach(config)) {
             return false;
+        }
     }
 
     return true;
@@ -262,12 +264,14 @@ std::string RgbdSensor_nws_ros::getId()
 
 bool RgbdSensor_nws_ros::detach()
 {
-    if (yarp::os::PeriodicThread::isRunning())
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
+    }
 
     //check if we already instantiated a subdevice previously
-    if (isSubdeviceOwned)
+    if (isSubdeviceOwned) {
         return false;
+    }
 
     sensor_p = nullptr;
     return true;

--- a/src/devices/RGBDSensorWrapper/RgbdSensor_nws_yarp.cpp
+++ b/src/devices/RGBDSensorWrapper/RgbdSensor_nws_yarp.cpp
@@ -101,9 +101,9 @@ bool RGBDSensorParser::respond(const Bottle& cmd, Bottle& response)
                                 response.addVocab32(VOCAB_IS);
                                 ret &= Property::copyPortable(params, params_b);  // will it really work??
                                 response.append(params_b);
-                            }
-                            else
+                            } else {
                                 response.addVocab32(VOCAB_FAILED);
+                            }
                         }
                         break;
 
@@ -194,8 +194,10 @@ bool RgbdSensor_nws_yarp::open(yarp::os::Searchable &config)
 //     addUsage("[set] [expo] $fExposure", "set exposure");
 //
     m_conf.fromString(config.toString());
-    if(verbose >= 5)
-        yCTrace(RGBDSENSORNWSYARP) << "\nParameters are: \n" << config.toString();
+    if (verbose >= 5) {
+        yCTrace(RGBDSENSORNWSYARP) << "\nParameters are: \n"
+                                   << config.toString();
+    }
 
     if(!fromConfig(config))
     {
@@ -223,8 +225,9 @@ bool RgbdSensor_nws_yarp::open(yarp::os::Searchable &config)
     }
     else
     {
-        if(!openDeferredAttach(config))
+        if (!openDeferredAttach(config)) {
             return false;
+        }
     }
 
     return true;
@@ -234,11 +237,12 @@ bool RgbdSensor_nws_yarp::fromConfig(yarp::os::Searchable &config)
 {
     if (!config.check("period", "refresh period of the broadcasted values in s"))
     {
-        if(verbose >= 3)
+        if (verbose >= 3) {
             yCInfo(RGBDSENSORNWSYARP) << "Using default 'period' parameter of " << DEFAULT_THREAD_PERIOD << "s";
-    }
-    else
+        }
+    } else {
         period = config.find("period").asFloat64();
+    }
 
     std::string rootName;
     rootName = config.check("name",Value("/"), "starting '/' if needed.").asString();
@@ -372,12 +376,14 @@ std::string RgbdSensor_nws_yarp::getId()
 
 bool RgbdSensor_nws_yarp::detach()
 {
-    if (yarp::os::PeriodicThread::isRunning())
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
+    }
 
     //check if we already instantiated a subdevice previously
-    if (isSubdeviceOwned)
+    if (isSubdeviceOwned) {
         return false;
+    }
 
     sensor_p = nullptr;
     return true;

--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
@@ -57,10 +57,12 @@ void Rangefinder2DInputPortProcessor::onRead(yarp::dev::LaserScan2D&b)
     {
         double tmpDT=now-prev;
         deltaT+=tmpDT;
-        if (tmpDT>deltaTMax)
-            deltaTMax=tmpDT;
-        if (tmpDT<deltaTMin)
-            deltaTMin=tmpDT;
+        if (tmpDT > deltaTMax) {
+            deltaTMax = tmpDT;
+        }
+        if (tmpDT < deltaTMin) {
+            deltaTMin = tmpDT;
+        }
 
         //compare network time
         if (tmpDT*1000<LASER_TIMEOUT)

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -261,7 +261,9 @@ bool Rangefinder2DWrapper::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     // parse in, prepare out
     int action = in.get(0).asVocab32();
@@ -470,9 +472,9 @@ bool Rangefinder2DWrapper::open(yarp::os::Searchable &config)
     {
         yCError(RANGEFINDER2DWRAPPER) << "Rangefinder2DWrapper: missing 'period' parameter. Check you configuration file\n";
         return false;
-    }
-    else
+    } else {
         _period = config.find("period").asInt32() / 1000.0;
+    }
 
     if (!config.check("name"))
     {
@@ -565,10 +567,11 @@ void Rangefinder2DWrapper::run()
 
         if (ret)
         {
-            if(iTimed)
+            if (iTimed) {
                 lastStateStamp = iTimed->getLastInputStamp();
-            else
+            } else {
                 lastStateStamp.update(yarp::os::Time::now());
+            }
 
             int ranges_size = ranges.size();
 

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.cpp
@@ -223,10 +223,11 @@ void Rangefinder2D_nws_ros::run()
 
         if (ret)
         {
-            if(iTimed)
+            if (iTimed) {
                 lastStateStamp = iTimed->getLastInputStamp();
-            else
+            } else {
                 lastStateStamp.update(yarp::os::Time::now());
+            }
 
             int ranges_size = ranges.size();
 

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.cpp
@@ -105,7 +105,9 @@ bool Rangefinder2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     // parse in, prepare out
     int action = in.get(0).asVocab32();
@@ -299,9 +301,9 @@ bool Rangefinder2D_nws_yarp::open(yarp::os::Searchable &config)
     {
         yCError(RANGEFINDER2D_NWS_YARP) << "missing 'period' parameter. Check you configuration file\n";
         return false;
-    }
-    else
+    } else {
         _period = config.find("period").asFloat64();
+    }
 
     if (!config.check("name"))
     {
@@ -384,10 +386,11 @@ void Rangefinder2D_nws_yarp::run()
 
         if (ret)
         {
-            if(iTimed)
+            if (iTimed) {
                 lastStateStamp = iTimed->getLastInputStamp();
-            else
+            } else {
                 lastStateStamp.update(yarp::os::Time::now());
+            }
 
             int ranges_size = ranges.size();
             YARP_UNUSED(ranges_size);

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -123,11 +123,13 @@ bool RemoteControlBoard::checkProtocolVersion(bool ignore)
     rpc_p.write(cmd, reply);
 
     // check size and format of messages, expected [prot] int int int [ok]
-    if (reply.size()!=5)
-       error=true;
+    if (reply.size() != 5) {
+        error = true;
+    }
 
-    if (reply.get(0).asVocab32()!=VOCAB_PROTOCOL_VERSION)
-       error=true;
+    if (reply.get(0).asVocab32() != VOCAB_PROTOCOL_VERSION) {
+        error = true;
+    }
 
     if (!error)
     {
@@ -136,15 +138,18 @@ bool RemoteControlBoard::checkProtocolVersion(bool ignore)
         protocolVersion.tweak=reply.get(3).asInt32();
 
         //verify protocol
-        if (protocolVersion.major!=PROTOCOL_VERSION_MAJOR)
-            error=true;
+        if (protocolVersion.major != PROTOCOL_VERSION_MAJOR) {
+            error = true;
+        }
 
-        if (protocolVersion.minor!=PROTOCOL_VERSION_MINOR)
-            error=true;
+        if (protocolVersion.minor != PROTOCOL_VERSION_MINOR) {
+            error = true;
+        }
     }
 
-    if (!error)
+    if (!error) {
         return true;
+    }
 
     // protocol did not match
     yCError(REMOTECONTROLBOARD,
@@ -184,23 +189,29 @@ bool RemoteControlBoard::open(Searchable& config)
     yarp::os::QosStyle localQos;
     if (config.check("local_qos")) {
         Bottle& qos = config.findGroup("local_qos");
-        if(qos.check("thread_priority"))
+        if (qos.check("thread_priority")) {
             localQos.setThreadPriority(qos.find("thread_priority").asInt32());
-        if(qos.check("thread_policy"))
+        }
+        if (qos.check("thread_policy")) {
             localQos.setThreadPolicy(qos.find("thread_policy").asInt32());
-        if(qos.check("packet_priority"))
+        }
+        if (qos.check("packet_priority")) {
             localQos.setPacketPriority(qos.find("packet_priority").asString());
+        }
     }
 
     yarp::os::QosStyle remoteQos;
     if (config.check("remote_qos")) {
         Bottle& qos = config.findGroup("remote_qos");
-        if(qos.check("thread_priority"))
+        if (qos.check("thread_priority")) {
             remoteQos.setThreadPriority(qos.find("thread_priority").asInt32());
-        if(qos.check("thread_policy"))
+        }
+        if (qos.check("thread_policy")) {
             remoteQos.setThreadPolicy(qos.find("thread_policy").asInt32());
-        if(qos.check("packet_priority"))
+        }
+        if (qos.check("packet_priority")) {
             remoteQos.setPacketPriority(qos.find("packet_priority").asString());
+        }
     }
 
     bool writeStrict_isFound = config.check("writeStrict");
@@ -218,9 +229,9 @@ bool RemoteControlBoard::open(Searchable& config)
             writeStrict_singleJoint = false;
             writeStrict_moreJoints  = false;
             yCInfo(REMOTECONTROLBOARD, "RemoteControlBoard is DISABLING the writeStrict opition for all commands");
-        }
-        else
+        } else {
             yCError(REMOTECONTROLBOARD, "Found writeStrict opition with wrong value. Accepted options are 'on' or 'off'");
+        }
     }
 
     if (local=="") {
@@ -284,8 +295,9 @@ bool RemoteControlBoard::open(Searchable& config)
             connectionProblem = true;
         }
         // set the QoS preferences for the 'command' port
-        if (config.check("local_qos") || config.check("remote_qos"))
+        if (config.check("local_qos") || config.check("remote_qos")) {
             NetworkBase::setConnectionQos(command_p.getName(), s1, localQos, remoteQos, false);
+        }
 
         s1 = remote;
         s1 += "/stateExt:o";
@@ -296,8 +308,9 @@ bool RemoteControlBoard::open(Searchable& config)
         if (ok)
         {
             // set the QoS preferences for the 'state' port
-            if (config.check("local_qos") || config.check("remote_qos"))
+            if (config.check("local_qos") || config.check("remote_qos")) {
                 NetworkBase::setConnectionQos(s1, extendedIntputStatePort.getName(), remoteQos, localQos, false);
+            }
         }
         else
         {
@@ -343,9 +356,9 @@ bool RemoteControlBoard::open(Searchable& config)
         diagnosticThread = new DiagnosticThread(DIAGNOSTIC_THREAD_PERIOD);
         diagnosticThread->setOwner(&extendedIntputStatePort);
         diagnosticThread->start();
+    } else {
+        diagnosticThread = nullptr;
     }
-    else
-        diagnosticThread=nullptr;
 
     // allocate memory for helper struct
     // single joint
@@ -558,62 +571,76 @@ bool RemoteControlBoard::set1V1I2D(int code, int j, double val1, double val2)
 
 bool RemoteControlBoard::set1VDA(int v, const double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(v);
     Bottle& l = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l.addFloat64(val[i]);
+    }
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
 
 bool RemoteControlBoard::set2V1DA(int v1, int v2, const double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(v1);
     cmd.addVocab32(v2);
     Bottle& l = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l.addFloat64(val[i]);
+    }
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
 
 bool RemoteControlBoard::set2V2DA(int v1, int v2, const double *val1, const double *val2)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(v1);
     cmd.addVocab32(v2);
     Bottle& l1 = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l1.addFloat64(val1[i]);
+    }
     Bottle& l2 = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l2.addFloat64(val2[i]);
+    }
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
 
 bool RemoteControlBoard::set1V1I1IA1DA(int v, const int len, const int *val1, const double *val2)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(v);
     cmd.addInt32(len);
     int i;
     Bottle& l1 = cmd.addList();
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
         l1.addInt32(val1[i]);
+    }
     Bottle& l2 = cmd.addList();
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
         l2.addFloat64(val2[i]);
+    }
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
@@ -632,7 +659,9 @@ bool RemoteControlBoard::set2V1I1D(int v1, int v2, int axis, double val)
 
 bool RemoteControlBoard::setValWithPidType(int voc, PidControlTypeEnum type, int axis, double val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
@@ -646,15 +675,18 @@ bool RemoteControlBoard::setValWithPidType(int voc, PidControlTypeEnum type, int
 
 bool RemoteControlBoard::setValWithPidType(int voc, PidControlTypeEnum type, const double* val_arr)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
     cmd.addVocab32(voc);
     cmd.addVocab32(type);
     Bottle& l = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l.addFloat64(val_arr[i]);
+    }
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
@@ -680,7 +712,9 @@ bool RemoteControlBoard::getValWithPidType(int voc, PidControlTypeEnum type, int
 
 bool RemoteControlBoard::getValWithPidType(int voc, PidControlTypeEnum type, double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(VOCAB_PID);
@@ -690,12 +724,14 @@ bool RemoteControlBoard::getValWithPidType(int voc, PidControlTypeEnum type, dou
     if (CHECK_FAIL(ok, response))
     {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
-        for (size_t i = 0; i < nj; i++)
+        for (size_t i = 0; i < nj; i++) {
             val[i] = l.get(i).asFloat64();
+        }
         getTimeStamp(response, lastStamp);
         return true;
     }
@@ -825,8 +861,9 @@ bool RemoteControlBoard::get1V1I1IA1B(int v,  const int len, const int *val1, bo
     cmd.addVocab32(v);
     cmd.addInt32(len);
     Bottle& l1 = cmd.addList();
-    for (int i = 0; i < len; i++)
+    for (int i = 0; i < len; i++) {
         l1.addInt32(val1[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
 
@@ -841,7 +878,9 @@ bool RemoteControlBoard::get1V1I1IA1B(int v,  const int len, const int *val1, bo
 bool RemoteControlBoard::get2V1I1IA1DA(int v1, int v2, const int n_joints, const int *joints, double *retVals, std::string functionName)
 {
     Bottle cmd, response;
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
 
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v1);
@@ -849,8 +888,9 @@ bool RemoteControlBoard::get2V1I1IA1DA(int v1, int v2, const int n_joints, const
     cmd.addInt32(n_joints);
 
     Bottle& l1 = cmd.addList();
-    for (int i = 0; i < n_joints; i++)
+    for (int i = 0; i < n_joints; i++) {
         l1.addInt32(joints[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
 
@@ -897,19 +937,23 @@ bool RemoteControlBoard::get1V1B(int v, bool &val)
 
 bool RemoteControlBoard::get1VIA(int v, int *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v);
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
-        for (size_t i = 0; i < nj; i++)
+        for (size_t i = 0; i < nj; i++) {
             val[i] = l.get(i).asInt32();
+        }
 
         getTimeStamp(response, lastStamp);
 
@@ -920,19 +964,23 @@ bool RemoteControlBoard::get1VIA(int v, int *val)
 
 bool RemoteControlBoard::get1VDA(int v, double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v);
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
-        for (size_t i = 0; i < nj; i++)
+        for (size_t i = 0; i < nj; i++) {
             val[i] = l.get(i).asFloat64();
+        }
 
         getTimeStamp(response, lastStamp);
 
@@ -943,7 +991,9 @@ bool RemoteControlBoard::get1VDA(int v, double *val)
 
 bool RemoteControlBoard::get1V1DA(int v1, double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v1);
@@ -951,12 +1001,14 @@ bool RemoteControlBoard::get1V1DA(int v1, double *val)
 
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
-        for (size_t i = 0; i < nj; i++)
+        for (size_t i = 0; i < nj; i++) {
             val[i] = l.get(i).asFloat64();
+        }
 
         getTimeStamp(response, lastStamp);
         return true;
@@ -966,7 +1018,9 @@ bool RemoteControlBoard::get1V1DA(int v1, double *val)
 
 bool RemoteControlBoard::get2V1DA(int v1, int v2, double *val)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v1);
@@ -975,12 +1029,14 @@ bool RemoteControlBoard::get2V1DA(int v1, int v2, double *val)
 
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
-        for (size_t i = 0; i < nj; i++)
+        for (size_t i = 0; i < nj; i++) {
             val[i] = l.get(i).asFloat64();
+        }
 
         getTimeStamp(response, lastStamp);
         return true;
@@ -990,7 +1046,9 @@ bool RemoteControlBoard::get2V1DA(int v1, int v2, double *val)
 
 bool RemoteControlBoard::get2V2DA(int v1, int v2, double *val1, double *val2)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v1);
@@ -998,12 +1056,14 @@ bool RemoteControlBoard::get2V2DA(int v1, int v2, double *val1, double *val2)
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp1 = response.get(2).asList();
-        if (lp1 == nullptr)
+        if (lp1 == nullptr) {
             return false;
+        }
         Bottle& l1 = *lp1;
         Bottle* lp2 = response.get(3).asList();
-        if (lp2 == nullptr)
+        if (lp2 == nullptr) {
             return false;
+        }
         Bottle& l2 = *lp2;
 
         size_t nj1 = l1.size();
@@ -1011,10 +1071,12 @@ bool RemoteControlBoard::get2V2DA(int v1, int v2, double *val1, double *val2)
        // yCAssert(REMOTECONTROLBOARD, nj == nj1);
        // yCAssert(REMOTECONTROLBOARD, nj == nj2);
 
-        for (size_t i = 0; i < nj1; i++)
+        for (size_t i = 0; i < nj1; i++) {
             val1[i] = l1.get(i).asFloat64();
-        for (size_t i = 0; i < nj2; i++)
+        }
+        for (size_t i = 0; i < nj2; i++) {
             val2[i] = l2.get(i).asFloat64();
+        }
 
         getTimeStamp(response, lastStamp);
         return true;
@@ -1040,22 +1102,26 @@ bool RemoteControlBoard::get1V1I1S(int code, int j, std::string &name)
 
 bool RemoteControlBoard::get1V1I1IA1DA(int v, const int len, const int *val1, double *val2)
 {
-    if(!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
 
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(v);
     cmd.addInt32(len);
     Bottle &l1 = cmd.addList();
-    for(int i = 0; i < len; i++)
+    for (int i = 0; i < len; i++) {
         l1.addInt32(val1[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
 
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp2 = response.get(2).asList();
-        if (lp2 == nullptr)
+        if (lp2 == nullptr) {
             return false;
+        }
         Bottle& l2 = *lp2;
 
         size_t nj2 = l2.size();
@@ -1064,8 +1130,9 @@ bool RemoteControlBoard::get1V1I1IA1DA(int v, const int len, const int *val1, do
             yCError(REMOTECONTROLBOARD, "received an answer with an unexpected number of entries!");
             return false;
         }
-        for (size_t i = 0; i < nj2; i++)
+        for (size_t i = 0; i < nj2; i++) {
             val2[i] = l2.get(i).asFloat64();
+        }
 
         getTimeStamp(response, lastStamp);
         return true;
@@ -1107,7 +1174,9 @@ bool RemoteControlBoard::setPid(const PidControlTypeEnum& pidtype, int j, const 
 
 bool RemoteControlBoard::setPids(const PidControlTypeEnum& pidtype, const Pid *pids)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
@@ -1173,8 +1242,9 @@ bool RemoteControlBoard::getPid(const PidControlTypeEnum& pidtype, int j, Pid *p
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         pid->kp = l.get(0).asFloat64();
         pid->kd = l.get(1).asFloat64();
@@ -1193,7 +1263,9 @@ bool RemoteControlBoard::getPid(const PidControlTypeEnum& pidtype, int j, Pid *p
 
 bool RemoteControlBoard::getPids(const PidControlTypeEnum& pidtype, Pid *pids)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_GET);
     cmd.addVocab32(VOCAB_PID);
@@ -1203,15 +1275,17 @@ bool RemoteControlBoard::getPids(const PidControlTypeEnum& pidtype, Pid *pids)
     if (CHECK_FAIL(ok, response))
     {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         yCAssert(REMOTECONTROLBOARD, nj == l.size());
         for (size_t i = 0; i < nj; i++)
         {
             Bottle* mp = l.get(i).asList();
-            if (mp == nullptr)
+            if (mp == nullptr) {
                 return false;
+            }
             pids[i].kp = mp->get(0).asFloat64();
             pids[i].kd = mp->get(1).asFloat64();
             pids[i].ki = mp->get(2).asFloat64();
@@ -1250,7 +1324,9 @@ bool RemoteControlBoard::getPidErrorLimits(const PidControlTypeEnum& pidtype, do
 
 bool RemoteControlBoard::resetPid(const PidControlTypeEnum& pidtype, int j)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
@@ -1263,7 +1339,9 @@ bool RemoteControlBoard::resetPid(const PidControlTypeEnum& pidtype, int j)
 
 bool RemoteControlBoard::disablePid(const PidControlTypeEnum& pidtype, int j)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
@@ -1276,7 +1354,9 @@ bool RemoteControlBoard::disablePid(const PidControlTypeEnum& pidtype, int j)
 
 bool RemoteControlBoard::enablePid(const PidControlTypeEnum& pidtype, int j)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_PID);
@@ -1781,15 +1861,18 @@ bool RemoteControlBoard::stop(int j)
 
 bool RemoteControlBoard::stop(const int len, const int *val1)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_STOP_GROUP);
     cmd.addInt32(len);
     int i;
     Bottle& l1 = cmd.addList();
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
         l1.addInt32(val1[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
@@ -1807,7 +1890,9 @@ bool RemoteControlBoard::stop()
 bool RemoteControlBoard::velocityMove(int j, double v)
 {
  //   return set1V1I1D(VOCAB_VELOCITY_MOVE, j, v);
-    if (!isLive()) return false;
+ if (!isLive()) {
+     return false;
+ }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_VELOCITY_MOVE);
@@ -1820,7 +1905,9 @@ bool RemoteControlBoard::velocityMove(int j, double v)
 
 bool RemoteControlBoard::velocityMove(const double *v)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_VELOCITY_MOVES);
@@ -2031,7 +2118,9 @@ bool RemoteControlBoard::setRefTorques(const double *t)
 {
     //Now we use streaming instead of rpc
     //return set2V1DA(VOCAB_TORQUE, VOCAB_REFS, t);
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_TORQUES_DIRECTS);
@@ -2048,7 +2137,9 @@ bool RemoteControlBoard::setRefTorque(int j, double v)
 {
     //return set2V1I1D(VOCAB_TORQUE, VOCAB_REF, j, v);
     // use the streaming port!
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     // in streaming port only SET command can be sent, so it is implicit
@@ -2066,15 +2157,18 @@ bool RemoteControlBoard::setRefTorques(const int n_joint, const int *joints, con
 {
     //return set2V1I1D(VOCAB_TORQUE, VOCAB_REF, j, v);
     // use the streaming port!
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     // in streaming port only SET command can be sent, so it is implicit
     c.head.addVocab32(VOCAB_TORQUES_DIRECT_GROUP);
     c.head.addInt32(n_joint);
     Bottle &jointList = c.head.addList();
-    for (int i = 0; i < n_joint; i++)
+    for (int i = 0; i < n_joint; i++) {
         jointList.addInt32(joints[i]);
+    }
     c.body.resize(n_joint);
     memcpy(&(c.body[0]), t, sizeof(double)*n_joint);
     command_buffer.write(writeStrict_moreJoints);
@@ -2107,8 +2201,9 @@ bool RemoteControlBoard::getMotorTorqueParams(int j, MotorTorqueParameters *para
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         if (l.size() != 4)
         {
@@ -2166,8 +2261,9 @@ bool RemoteControlBoard::getImpedance(int j, double *stiffness, double *damping)
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         *stiffness = l.get(0).asFloat64();
         *damping   = l.get(1).asFloat64();
@@ -2186,8 +2282,9 @@ bool RemoteControlBoard::getImpedanceOffset(int j, double *offset)
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         *offset    = l.get(0).asFloat64();
         return true;
@@ -2236,8 +2333,9 @@ bool RemoteControlBoard::getCurrentImpedanceLimit(int j, double *min_stiff, doub
     bool ok = rpc_p.write(cmd, response);
     if (CHECK_FAIL(ok, response)) {
         Bottle* lp = response.get(2).asList();
-        if (lp == nullptr)
+        if (lp == nullptr) {
             return false;
+        }
         Bottle& l = *lp;
         *min_stiff    = l.get(0).asFloat64();
         *max_stiff    = l.get(1).asFloat64();
@@ -2278,11 +2376,12 @@ bool RemoteControlBoard::getControlModes(const int n_joint, const int *joints, i
     bool ret = extendedIntputStatePort.getLastVector(VOCAB_CM_CONTROL_MODES, last_wholePart.controlMode.data(), lastStamp, localArrivalTime);
     if(ret)
     {
-        for (int i = 0; i < n_joint; i++)
+        for (int i = 0; i < n_joint; i++) {
             modes[i] = last_wholePart.controlMode[joints[i]];
-    }
-    else
+        }
+    } else {
         ret = false;
+    }
 
     extendedPortMutex.unlock();
     return ret;
@@ -2290,7 +2389,9 @@ bool RemoteControlBoard::getControlModes(const int n_joint, const int *joints, i
 
 bool RemoteControlBoard::setControlMode(const int j, const int mode)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_ICONTROLMODE);
@@ -2304,7 +2405,9 @@ bool RemoteControlBoard::setControlMode(const int j, const int mode)
 
 bool RemoteControlBoard::setControlModes(const int n_joint, const int *joints, int *modes)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_ICONTROLMODE);
@@ -2312,12 +2415,14 @@ bool RemoteControlBoard::setControlModes(const int n_joint, const int *joints, i
     cmd.addInt32(n_joint);
     int i;
     Bottle& l1 = cmd.addList();
-    for (i = 0; i < n_joint; i++)
+    for (i = 0; i < n_joint; i++) {
         l1.addInt32(joints[i]);
+    }
 
     Bottle& l2 = cmd.addList();
-    for (i = 0; i < n_joint; i++)
+    for (i = 0; i < n_joint; i++) {
         l2.addVocab32(modes[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
@@ -2325,15 +2430,18 @@ bool RemoteControlBoard::setControlModes(const int n_joint, const int *joints, i
 
 bool RemoteControlBoard::setControlModes(int *modes)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     Bottle cmd, response;
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_ICONTROLMODE);
     cmd.addVocab32(VOCAB_CM_CONTROL_MODES);
 
     Bottle& l2 = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l2.addVocab32(modes[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
@@ -2345,7 +2453,9 @@ bool RemoteControlBoard::setControlModes(int *modes)
 
 bool RemoteControlBoard::setPosition(int j, double ref)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_POSITION_DIRECT);
@@ -2358,14 +2468,17 @@ bool RemoteControlBoard::setPosition(int j, double ref)
 
 bool RemoteControlBoard::setPositions(const int n_joint, const int *joints, const double *refs)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_POSITION_DIRECT_GROUP);
     c.head.addInt32(n_joint);
     Bottle &jointList = c.head.addList();
-    for (int i = 0; i < n_joint; i++)
+    for (int i = 0; i < n_joint; i++) {
         jointList.addInt32(joints[i]);
+    }
     c.body.resize(n_joint);
     memcpy(&(c.body[0]), refs, sizeof(double)*n_joint);
     command_buffer.write(writeStrict_moreJoints);
@@ -2374,7 +2487,9 @@ bool RemoteControlBoard::setPositions(const int n_joint, const int *joints, cons
 
 bool RemoteControlBoard::setPositions(const double *refs)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_POSITION_DIRECTS);
@@ -2406,15 +2521,17 @@ bool RemoteControlBoard::getRefPositions(const int n_joint, const int* joints, d
 bool RemoteControlBoard::velocityMove(const int n_joint, const int *joints, const double *spds)
 {
     // streaming port
-    if (!isLive())
+    if (!isLive()) {
         return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_VELOCITY_MOVE_GROUP);
     c.head.addInt32(n_joint);
     Bottle &jointList = c.head.addList();
-    for (int i = 0; i < n_joint; i++)
+    for (int i = 0; i < n_joint; i++) {
         jointList.addInt32(joints[i]);
+    }
     c.body.resize(n_joint);
     memcpy(&(c.body[0]), spds, sizeof(double)*n_joint);
     command_buffer.write(writeStrict_moreJoints);
@@ -2457,11 +2574,12 @@ bool RemoteControlBoard::getInteractionModes(int n_joints, int *joints, yarp::de
     bool ret = extendedIntputStatePort.getLastVector(VOCAB_INTERACTION_MODES, last_wholePart.interactionMode.data(), lastStamp, localArrivalTime);
     if(ret)
     {
-        for (int i = 0; i < n_joints; i++)
+        for (int i = 0; i < n_joints; i++) {
             modes[i] = (yarp::dev::InteractionModeEnum)last_wholePart.interactionMode[joints[i]];
-    }
-    else
+        }
+    } else {
         ret = false;
+    }
 
     extendedPortMutex.unlock();
     return ret;
@@ -2479,7 +2597,9 @@ bool RemoteControlBoard::getInteractionModes(yarp::dev::InteractionModeEnum* mod
 bool RemoteControlBoard::setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode)
 {
     Bottle cmd, response;
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
 
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_INTERFACE_INTERACTION_MODE);
@@ -2494,7 +2614,9 @@ bool RemoteControlBoard::setInteractionMode(int axis, yarp::dev::InteractionMode
 bool RemoteControlBoard::setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
     Bottle cmd, response;
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
 
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_INTERFACE_INTERACTION_MODE);
@@ -2502,8 +2624,9 @@ bool RemoteControlBoard::setInteractionModes(int n_joints, int *joints, yarp::de
     cmd.addInt32(n_joints);
 
     Bottle& l1 = cmd.addList();
-    for (int i = 0; i < n_joints; i++)
+    for (int i = 0; i < n_joints; i++) {
         l1.addInt32(joints[i]);
+    }
 
     Bottle& l2 = cmd.addList();
     for (int i = 0; i < n_joints; i++)
@@ -2517,15 +2640,18 @@ bool RemoteControlBoard::setInteractionModes(int n_joints, int *joints, yarp::de
 bool RemoteControlBoard::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
     Bottle cmd, response;
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
 
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_INTERFACE_INTERACTION_MODE);
     cmd.addVocab32(VOCAB_INTERACTION_MODES);
 
     Bottle& l1 = cmd.addList();
-    for (size_t i = 0; i < nj; i++)
+    for (size_t i = 0; i < nj; i++) {
         l1.addVocab32(modes[i]);
+    }
 
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
@@ -2632,7 +2758,9 @@ bool RemoteControlBoard::getRefCurrent(int j, double *t)
 
 bool RemoteControlBoard::setRefCurrents(const double *refs)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_CURRENTCONTROL_INTERFACE);
@@ -2645,7 +2773,9 @@ bool RemoteControlBoard::setRefCurrents(const double *refs)
 
 bool RemoteControlBoard::setRefCurrent(int j, double ref)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_CURRENTCONTROL_INTERFACE);
@@ -2659,15 +2789,18 @@ bool RemoteControlBoard::setRefCurrent(int j, double ref)
 
 bool RemoteControlBoard::setRefCurrents(const int n_joint, const int *joints, const double *refs)
 {
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_CURRENTCONTROL_INTERFACE);
     c.head.addVocab32(VOCAB_CURRENT_REF_GROUP);
     c.head.addInt32(n_joint);
     Bottle &jointList = c.head.addList();
-    for (int i = 0; i < n_joint; i++)
+    for (int i = 0; i < n_joint; i++) {
         jointList.addInt32(joints[i]);
+    }
     c.body.resize(n_joint);
     memcpy(&(c.body[0]), refs, sizeof(double)*n_joint);
     command_buffer.write(writeStrict_moreJoints);
@@ -2708,7 +2841,9 @@ bool RemoteControlBoard::getCurrentRanges(double *min, double *max)
 bool RemoteControlBoard::setRefDutyCycle(int j, double v)
 {
     // using the streaming port
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     // in streaming port only SET command can be sent, so it is implicit
@@ -2726,7 +2861,9 @@ bool RemoteControlBoard::setRefDutyCycle(int j, double v)
 bool RemoteControlBoard::setRefDutyCycles(const double *v)
 {
     // using the streaming port
-    if (!isLive()) return false;
+    if (!isLive()) {
+        return false;
+    }
     CommandMessage& c = command_buffer.get();
     c.head.clear();
     c.head.addVocab32(VOCAB_PWMCONTROL_INTERFACE);
@@ -2759,9 +2896,9 @@ bool RemoteControlBoard::getRefDutyCycle(int j, double *ref)
 
         getTimeStamp(response, lastStamp);
         return true;
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 bool RemoteControlBoard::getRefDutyCycles(double *refs)

--- a/src/devices/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/devices/RemoteControlBoard/stateExtendedReader.cpp
@@ -76,10 +76,12 @@ void StateExtendedInputPort::onRead(yarp::dev::impl::jointData &v)
     {
         double tmpDT=now-prev;
         deltaT+=tmpDT;
-        if (tmpDT>deltaTMax)
-            deltaTMax=tmpDT;
-        if (tmpDT<deltaTMin)
-            deltaTMin=tmpDT;
+        if (tmpDT > deltaTMax) {
+            deltaTMax = tmpDT;
+        }
+        if (tmpDT < deltaTMin) {
+            deltaTMin = tmpDT;
+        }
     }
 
     prev=now;
@@ -89,8 +91,9 @@ void StateExtendedInputPort::onRead(yarp::dev::impl::jointData &v)
     last=v;
     getEnvelope(lastStamp);
     //check that timestamp are available
-    if (!lastStamp.isValid())
+    if (!lastStamp.isValid()) {
         lastStamp.update(now);
+    }
     mutex.unlock();
 }
 
@@ -158,8 +161,9 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
+        if (ret && ((Time::now() - localArrivalTime) > timeout)) {
             ret = false;
+        }
     }
     mutex.unlock();
 
@@ -190,9 +194,9 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, int *data, Stamp &s
         }
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
+        if (ret && ((Time::now() - localArrivalTime) > timeout)) {
             ret = false;
-
+        }
     }
     mutex.unlock();
     return ret;
@@ -258,8 +262,9 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
 
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
+        if (ret && ((Time::now() - localArrivalTime) > timeout)) {
             ret = false;
+        }
     }
     mutex.unlock();
 
@@ -290,8 +295,9 @@ bool StateExtendedInputPort::getLastVector(int field, int* data, Stamp& stamp, d
         }
         localArrivalTime=now;
         stamp = lastStamp;
-        if (ret && ( (Time::now()-localArrivalTime) > timeout) )
+        if (ret && ((Time::now() - localArrivalTime) > timeout)) {
             ret = false;
+        }
     }
     mutex.unlock();
     return ret;

--- a/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.h
+++ b/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.h
@@ -96,8 +96,9 @@ public:
         image.resize(response.get(2).asInt32(), response.get(3).asInt32());
         unsigned char *pixelOut    = image.getRawImage();
 
-        if(response.get(4).asBlob())
-            memcpy(pixelOut, response.get(4).asBlob(), (size_t) image.getRawImageSize());
+        if (response.get(4).asBlob()) {
+            memcpy(pixelOut, response.get(4).asBlob(), (size_t)image.getRawImageSize());
+        }
 
         return true;
     }
@@ -142,11 +143,12 @@ public:
             if(!config.check("no_stream") )
             {
                 no_stream = false;
-                if(!yarp::os::Network::connect(remote,local,carrier))
-                    yCError(REMOTEFRAMEGRABBER) << "cannot connect "  << local << " to " << remote;
-            }
-            else
+                if (!yarp::os::Network::connect(remote, local, carrier)) {
+                    yCError(REMOTEFRAMEGRABBER) << "cannot connect " << local << " to " << remote;
+                }
+            } else {
                 no_stream = true;
+            }
 
             // reverse connection for RPC
             // could choose to do this only on need

--- a/src/devices/RobotDescriptionServer/RobotDescriptionServer.cpp
+++ b/src/devices/RobotDescriptionServer/RobotDescriptionServer.cpp
@@ -117,7 +117,9 @@ bool RobotDescriptionServer::read(yarp::os::ConnectionReader& connection)
     int              code;
 
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     // parse in, prepare out
     code = in.get(0).asVocab32();

--- a/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
+++ b/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
@@ -95,8 +95,9 @@ bool ServerFrameGrabber::open(yarp::os::Searchable& config)
             poly.view(fgAv);
         }
         poly.view(fgCtrl);
-        if(fgCtrl)
+        if (fgCtrl) {
             ifgCtrl_Responder.configure(fgCtrl);
+        }
         poly.view(fgTimed);
         poly.view(rgbVis_p);
 

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
@@ -57,9 +57,9 @@ bool ServerGrabberResponder::respond(const yarp::os::Bottle &command, yarp::os::
         {
             return DeviceResponder::respond(command, reply);
         }
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 // **********ServerGrabber**********
@@ -71,8 +71,9 @@ ServerGrabber::ServerGrabber() :
 
 ServerGrabber::~ServerGrabber()
 {
-    if(param.active)
+    if (param.active) {
         close();
+    }
 }
 
 bool ServerGrabber::close() {
@@ -166,8 +167,9 @@ bool ServerGrabber::open(yarp::os::Searchable& config) {
     else
     {
         yCInfo(SERVERGRABBER) << "Running, waiting for attach...";
-        if(!openDeferredAttach(config))
-        return false;
+        if (!openDeferredAttach(config)) {
+            return false;
+        }
     }
 
 
@@ -205,33 +207,38 @@ bool ServerGrabber::open(yarp::os::Searchable& config) {
 
 bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
 {
-    if(config.check("period","refresh period(in ms) of the broadcasted values through yarp ports")
-            && config.find("period").isInt32())
+    if (config.check("period", "refresh period(in ms) of the broadcasted values through yarp ports")
+        && config.find("period").isInt32()) {
         period = config.find("period").asInt32() / 1000.0;
-    else
-        yCInfo(SERVERGRABBER) << "Period parameter not found, using default of"<< DEFAULT_THREAD_PERIOD << "s";
+    } else {
+        yCInfo(SERVERGRABBER) << "Period parameter not found, using default of" << DEFAULT_THREAD_PERIOD << "s";
+    }
     if((config.check("subdevice")) && (config.check("left_config") || config.check("right_config")))
     {
         yCError(SERVERGRABBER) << "Found both 'subdevice' and 'left_config/right_config' parameters...";
         return false;
     }
-    if(!config.check("subdevice", "name of the subdevice to use as a data source")
-            && config.check("left_config","name of the ini file containing the configuration of one of two subdevices to use as a data source")
-            && config.check("right_config" , "name of the ini file containing the configuration of one of two subdevices to use as a data source"))
-        param.twoCameras=true;
-    if(config.check("twoCameras", "if true ServerGrabber will open and handle two devices, if false only one"))//extra conf parameter for the yarprobotinterface
-        param.twoCameras=config.find("twoCameras").asBool();
-    if(config.check("split", "set 'true' to split the streaming on two different ports"))
-        param.split=config.find("split").asBool();
+    if (!config.check("subdevice", "name of the subdevice to use as a data source")
+        && config.check("left_config", "name of the ini file containing the configuration of one of two subdevices to use as a data source")
+        && config.check("right_config", "name of the ini file containing the configuration of one of two subdevices to use as a data source")) {
+        param.twoCameras = true;
+    }
+    if (config.check("twoCameras", "if true ServerGrabber will open and handle two devices, if false only one")) { //extra conf parameter for the yarprobotinterface
+        param.twoCameras = config.find("twoCameras").asBool();
+    }
+    if (config.check("split", "set 'true' to split the streaming on two different ports")) {
+        param.split = config.find("split").asBool();
+    }
     if(config.check("capabilities","two capabilities supported, COLOR and RAW respectively for rgb and raw streaming"))
     {
-        if(config.find("capabilities").asString()=="COLOR")
+        if (config.find("capabilities").asString() == "COLOR") {
             param.cap=COLOR;
-        else if(config.find("capabilities").asString()=="RAW")
-            param.cap=RAW;
-    }
-    else
+        } else if (config.find("capabilities").asString() == "RAW") {
+            param.cap = RAW;
+        }
+    } else {
         yCWarning(SERVERGRABBER) << "'capabilities' parameter not found or misspelled, the option available are COLOR(default) and RAW, using default";
+    }
     param.canDrop = !config.check("no_drop","if present, use strict policy for sending data");
     param.addStamp = config.check("stamp","if present, add timestamps to data");
 
@@ -242,17 +249,20 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
     std::string rootName;
     rootName = config.check("name",Value("/grabber"),
                             "name of port to send data on").asString();
-    if(!param.twoCameras && param.split)
+    if (!param.twoCameras && param.split) {
         param.splitterMode = true;
+    }
 
     responder = new ServerGrabberResponder(true);
-    if(!responder->configure(this))
+    if (!responder->configure(this)) {
         return false;
+    }
     if(param.twoCameras)
     {
         responder2 = new ServerGrabberResponder(false);
-        if(!responder2->configure(this))
+        if (!responder2->configure(this)) {
             return false;
+        }
 
         rpcPort_Name  = rootName + "/left/rpc";
         rpcPort2_Name  = rootName + "/right/rpc";
@@ -260,9 +270,9 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
         {
             pImg_Name = rootName + "/left";
             pImg2_Name = rootName + "/right";
-        }
-        else
+        } else {
             pImg_Name = rootName;
+        }
 
         // check if we need to create subdevice or if they are
         // passed later on thorugh attachAll()
@@ -280,8 +290,9 @@ bool ServerGrabber::fromConfig(yarp::os::Searchable &config)
         if(param.split)
         {
             responder2 = new ServerGrabberResponder(false);
-            if(!responder2->configure(this))
+            if (!responder2->configure(this)) {
                 return false;
+            }
             pImg_Name = rootName + "/left";
             pImg2_Name = rootName + "/right";
         }
@@ -530,9 +541,9 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
                 }
             }
             return ret;
-        }
-        else
+        } else {
             return ifgCtrl_Responder.respond(cmd, response);
+        }
     } break;
 
     case VOCAB_RGB_VISUAL_PARAMS:
@@ -570,9 +581,9 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
             }
 
             return ret;
+        } else {
+            return rgbParser.respond(cmd, response);
         }
-        else
-            return rgbParser.respond(cmd,response);
     } break;
         //////////////////
         // DC1394 COMMANDS
@@ -607,9 +618,9 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
                 }
             }
             return ret;
-        }
-        else
+        } else {
             return ifgCtrl_DC1394_Responder.respond(cmd, response);
+        }
     } break;
     }
     yCError(SERVERGRABBER) << "Command not recognized" << cmd.toString();
@@ -789,16 +800,18 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
 bool ServerGrabber::detachAll()
 {
     //check if we already instantiated a subdevice previously
-    if (isSubdeviceOwned)
+    if (isSubdeviceOwned) {
         return false;
+    }
     stopThread();
     return true;
 
 }
 void ServerGrabber::stopThread()
 {
-    if (yarp::os::PeriodicThread::isRunning())
+    if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
+    }
 
     rgbVis_p       = nullptr;
     rgbVis_p2      = nullptr;
@@ -913,8 +926,9 @@ bool ServerGrabber::openAndAttachSubDevice(Searchable &prop){
         plist.push(pd);
         plist.push(pd2);
         //The thread is started by attachAll()
-        if(!attachAll(plist))
+        if (!attachAll(plist)) {
             return false;
+        }
     }
     else
     {
@@ -943,8 +957,9 @@ bool ServerGrabber::openAndAttachSubDevice(Searchable &prop){
         PolyDriverDescriptor pd(poly,"poly");
         plist.push(pd);
         //The thread is started by attachAll()
-        if(!attachAll(plist))
+        if (!attachAll(plist)) {
             return false;
+        }
     }
     isSubdeviceOwned = true;
     return true;
@@ -1027,10 +1042,9 @@ void ServerGrabber::run()
                     setupFlexImage(*img,flex_i);
                     fgImage2->getImage(*img2);
                     setupFlexImage(*img2,flex_i2);
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
-
+                }
             }
             if(param.cap==RAW)
             {
@@ -1040,10 +1054,9 @@ void ServerGrabber::run()
                     setupFlexImage(*img_Raw,flex_i);
                     fgImageRaw2->getImage(*img2_Raw);
                     setupFlexImage(*img2_Raw,flex_i2);
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
-
+                }
             }
             Stamp s = Stamp(count,Time::now());
             pImg.setStrict(!param.canDrop);
@@ -1075,10 +1088,9 @@ void ServerGrabber::run()
                         yCError(SERVERGRABBER) << "Failed to concatenate images";
                         return;
                     }
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
-
+                }
             }
             if(param.cap==RAW)
             {
@@ -1094,10 +1106,9 @@ void ServerGrabber::run()
                         yCError(SERVERGRABBER) << "Failed to concatenate images";
                         return;
                     }
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
-
+                }
             }
 
             Stamp s = Stamp(count,Time::now());
@@ -1130,9 +1141,9 @@ void ServerGrabber::run()
 
                     setupFlexImage(*img,flex_i);
                     setupFlexImage(*img2,flex_i2);
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
+                }
             }
             if(param.cap==RAW)
             {
@@ -1151,9 +1162,9 @@ void ServerGrabber::run()
                     setupFlexImage(*img_Raw,flex_i);
                     setupFlexImage(*img2_Raw,flex_i2);
 
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
+                }
             }
             Stamp s = Stamp(count,Time::now());
             pImg.setStrict(!param.canDrop);
@@ -1176,9 +1187,9 @@ void ServerGrabber::run()
                 {
                     fgImage->getImage(*img);
                     setupFlexImage(*img,flex_i);
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
+                }
             }
             if(param.cap==RAW)
             {
@@ -1186,9 +1197,9 @@ void ServerGrabber::run()
                 {
                     fgImageRaw->getImage(*img_Raw);
                     setupFlexImage(*img_Raw,flex_i);
-                }
-                else
+                } else {
                     yCError(SERVERGRABBER) << "Image not captured.. check hardware configuration";
+                }
             }
             Stamp s = Stamp(count,Time::now());
             pImg.setStrict(!param.canDrop);

--- a/src/devices/ServerInertial/ServerInertial.cpp
+++ b/src/devices/ServerInertial/ServerInertial.cpp
@@ -77,7 +77,9 @@ ServerInertial::ServerInertial() :
 
 ServerInertial::~ServerInertial()
 {
-    if (IMU != nullptr) close();
+    if (IMU != nullptr) {
+        close();
+    }
 }
 
 
@@ -234,9 +236,9 @@ bool ServerInertial::openAndAttachSubDevice(yarp::os::Property& prop)
         p.fromString(prop.toString());
         p.put("device",subdevice.toString());
         IMU_polydriver->open(p);
-    }
-    else
+    } else {
         IMU_polydriver->open(subdevice);
+    }
 
     if (!IMU_polydriver->isValid())
     {
@@ -297,8 +299,9 @@ bool ServerInertial::open(yarp::os::Searchable& config)
     else
     {
         ownDevices=false;
-        if(!openDeferredAttach(prop))
+        if (!openDeferredAttach(prop)) {
             return false;
+        }
     }
 
 
@@ -310,10 +313,9 @@ bool ServerInertial::open(yarp::os::Searchable& config)
     std::string portName;
     if(useROS != ROS_only)
     {
-        if (config.check("name"))
+        if (config.check("name")) {
             portName = config.find("name").asString();
-        else
-        {
+        } else {
             yCInfo(SERVERINERTIAL) << "Using default values for port name, you can change it by using '--name /myPortName' parameter";
             portName = "/inertial";
         }
@@ -380,8 +382,9 @@ bool ServerInertial::getInertial(yarp::os::Bottle &bot)
             bot.clear();
 
             // Euler+accel+gyro+magn orientation values
-            for (int i = 0; i < nchannels; i++)
-                bot.addFloat64 (indata[i]);
+            for (int i = 0; i < nchannels; i++) {
+                bot.addFloat64(indata[i]);
+            }
         }
         else
         {
@@ -412,10 +415,11 @@ void ServerInertial::run()
                 if (res)
                 {
                     static yarp::os::Stamp ts;
-                    if (iTimed)
+                    if (iTimed) {
                         ts=iTimed->getLastInputStamp();
-                    else
+                    } else {
                         ts.update();
+                    }
 
 
                     curr_timestamp_counter = ts.getCount();
@@ -531,8 +535,9 @@ bool ServerInertial::attach(PolyDriver* poly)
 
     if(IMU != nullptr)
     {
-        if(!Thread::isRunning())
+        if (!Thread::isRunning()) {
             start();
+        }
     }
     else
     {

--- a/src/devices/ServerSerial/ServerSerial.cpp
+++ b/src/devices/ServerSerial/ServerSerial.cpp
@@ -21,26 +21,28 @@ ServerSerial::~ServerSerial()
 
 bool ServerSerial::send(const Bottle& msg)
 {
-    if(verb)
+    if (verb) {
         yCDebug(SERVERSERIAL, "std::string to send : %s", msg.toString().c_str());
+    }
     if(serial != nullptr) {
         serial->send(msg);
         return true;
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 bool ServerSerial::send(char *msg, size_t size)
 {
-    if(verb)
+    if (verb) {
         yCDebug(SERVERSERIAL, "std::string to send : %s", msg);
+    }
     if(serial != nullptr) {
         serial->send(msg, size);
         return true;
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 bool ServerSerial::receive(Bottle& msg)
@@ -48,54 +50,54 @@ bool ServerSerial::receive(Bottle& msg)
     if(serial != nullptr) {
         serial->receive(msg);
         return true;
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 int ServerSerial::receiveChar(char& c)
 {
     if(serial != nullptr) {
         return serial->receiveChar(c);
-    }
-    else
+    } else {
         return -1;
+    }
 }
 
 int ServerSerial::flush()
 {
     if(serial != nullptr) {
         return serial->flush();
-    }
-    else
+    } else {
         return -1;
+    }
 }
 
 bool ServerSerial::setDTR(bool enable)
 {
     if (serial != nullptr) {
         return serial->setDTR(enable);
-    }
-    else
+    } else {
         return false;
+    }
 }
 
 int ServerSerial::receiveLine(char* line, const int MaxLineLength)
 {
     if(serial != nullptr) {
         return serial->receiveLine(line, MaxLineLength);
-    }
-    else
+    } else {
         return -1;
+    }
 }
 
 int ServerSerial::receiveBytes(unsigned char* bytes, const int size)
 {
     if (serial != nullptr) {
         return serial->receiveBytes(bytes, size);
-    }
-    else
+    } else {
         return -1;
+    }
 }
 
 bool ServerSerial::open()  {
@@ -109,8 +111,9 @@ bool ServerSerial::close() {
 bool ServerSerial::open(Searchable& prop)
 {
     verb = (prop.check("verbose",Value(0),"Specifies if the device is in verbose mode (0/1).").asInt32())>0;
-    if (verb)
+    if (verb) {
         yCInfo(SERVERSERIAL, "running with verbose output");
+    }
 
     Value *name;
     if (prop.check("subdevice",name,"name of specific control device to wrap")) {
@@ -152,9 +155,9 @@ bool ServerSerial::open(Searchable& prop)
     fromDevice.open(rootName+"/out");
 
 
-
-    if (poly.isValid())
+    if (poly.isValid()) {
         poly.view(serial);
+    }
 
     if(serial != nullptr) {
         start();
@@ -203,7 +206,8 @@ void ImplementCallbackHelper2::onRead(Bottle &b)
 {
     if (ser) {
         bool ok = ser->send(b);
-        if (!ok)
+        if (!ok) {
             yCError(SERVERSERIAL, "Problems while trying to send data");
+        }
     }
 }

--- a/src/devices/ServerSoundGrabber/ServerSoundGrabber.cpp
+++ b/src/devices/ServerSoundGrabber/ServerSoundGrabber.cpp
@@ -163,8 +163,9 @@ bool ServerSoundGrabber::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok)
+    if (!ok) {
         return false;
+    }
     reply.clear();
 
     if (command.get(0).asString() == "start") {

--- a/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.cpp
+++ b/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.cpp
@@ -110,7 +110,9 @@ bool VirtualAnalogWrapper::open(Searchable& config)
 
     mIsVerbose = (config.check("verbose","if present, give detailed output"));
 
-    if (mIsVerbose) yCDebug(VIRTUALANALOGSERVER) << "Running with verbose output\n";
+    if (mIsVerbose) {
+        yCDebug(VIRTUALANALOGSERVER) << "Running with verbose output\n";
+    }
 
     //thus thread period is useful for output port... this input port has callback so maybe can skip it (?)
     //thread_period = prop.check("threadrate", 20, "thread rate in ms. for streaming encoder data").asInt32();
@@ -296,7 +298,9 @@ bool VirtualAnalogWrapper::detachAll()
 
 bool VirtualAnalogWrapper::perform_first_check(int elems)
 {
-    if (first_check) return true;
+    if (first_check) {
+        return true;
+    }
 
     for (int i=0; i<elems; i++)
     {
@@ -331,7 +335,9 @@ void VirtualAnalogWrapper::run()
             switch (pTorques->get(0).asInt32())
             {
                 case 1: //arm torque message
-                    if (perform_first_check(6)==false) break;
+                    if (perform_first_check(6) == false) {
+                        break;
+                    }
                     mSubdevices[mChan2Board[0]].setTorque(mChan2BAddr[0],pTorques->get(1).asFloat64()); //shoulder 1 pitch      (0)
                     mSubdevices[mChan2Board[1]].setTorque(mChan2BAddr[1],pTorques->get(2).asFloat64()); //shoulder 2 roll       (1)
                     mSubdevices[mChan2Board[2]].setTorque(mChan2BAddr[2],pTorques->get(3).asFloat64()); //shoulder 3 yaw        (2)
@@ -341,7 +347,9 @@ void VirtualAnalogWrapper::run()
                 break;
 
                 case 2: //legs torque message
-                    if (perform_first_check(6)==false) break;
+                    if (perform_first_check(6) == false) {
+                        break;
+                    }
                     mSubdevices[mChan2Board[0]].setTorque(mChan2BAddr[0],pTorques->get(1).asFloat64()); //hip pitch
                     mSubdevices[mChan2Board[1]].setTorque(mChan2BAddr[1],pTorques->get(2).asFloat64()); //hip roll
                     mSubdevices[mChan2Board[2]].setTorque(mChan2BAddr[2],pTorques->get(3).asFloat64()); //hip yaw
@@ -351,7 +359,9 @@ void VirtualAnalogWrapper::run()
                 break;
 
                 case 3: //wrist torque message
-                    if (perform_first_check(6)==false) break;
+                    if (perform_first_check(6) == false) {
+                        break;
+                    }
                     mSubdevices[mChan2Board[0]].setTorque(mChan2BAddr[0],pTorques->get(6).asFloat64()); //wrist yaw   (6)
                     mSubdevices[mChan2Board[1]].setTorque(mChan2BAddr[1],pTorques->get(7).asFloat64()); //wrist pitch (7)
                     mSubdevices[mChan2Board[2]].setTorque(mChan2BAddr[2],0.0);
@@ -361,7 +371,9 @@ void VirtualAnalogWrapper::run()
                 break;
 
                 case 4: // torso
-                    if (perform_first_check(3)==false) break;
+                    if (perform_first_check(3) == false) {
+                        break;
+                    }
                     mSubdevices[mChan2Board[0]].setTorque(mChan2BAddr[0],pTorques->get(1).asFloat64()); //torso yaw (respect gravity)
                     mSubdevices[mChan2Board[1]].setTorque(mChan2BAddr[1],pTorques->get(2).asFloat64()); //torso roll (lateral movement)
                     mSubdevices[mChan2Board[2]].setTorque(mChan2BAddr[2],pTorques->get(3).asFloat64()); //torso pitch (front-back movement)

--- a/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
+++ b/src/devices/VirtualAnalogWrapper/VirtualAnalogWrapper.h
@@ -122,7 +122,9 @@ public:
 
     void setTorque(int joint,double torque)
     {
-        if (joint<mMap0 || mMap1<joint) return;
+        if (joint < mMap0 || mMap1 < joint) {
+            return;
+        }
 
         mTorques[joint-mMap0]=torque;
     }
@@ -134,7 +136,9 @@ public:
 
     void flushTorques()
     {
-        if (mpSensor) mpSensor->updateVirtualAnalogSensorMeasure(mTorques);
+        if (mpSensor) {
+            mpSensor->updateVirtualAnalogSensorMeasure(mTorques);
+        }
     }
 
     const std::string& getKey(){ return mKey; }

--- a/src/devices/audioRecorderWrapper/AudioRecorderWrapper.cpp
+++ b/src/devices/audioRecorderWrapper/AudioRecorderWrapper.cpp
@@ -159,7 +159,9 @@ bool AudioRecorderWrapper::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     reply.clear();
 
     if (command.get(0).asString()=="start")

--- a/src/devices/audioToFileDevice/audioToFileDevice.cpp
+++ b/src/devices/audioToFileDevice/audioToFileDevice.cpp
@@ -73,7 +73,9 @@ bool audioToFileDevice::open(yarp::os::Searchable &config)
 void audioToFileDevice::save_to_file()
 {
     //of the buffer is empty, there is nothing to save
-    if (m_sounds.size() == 0) return;
+    if (m_sounds.size() == 0) {
+        return;
+    }
 
     //we need to set the number of channels and the frequency before calling the
     //concatenation operator

--- a/src/devices/batteryClient/BatteryClient.cpp
+++ b/src/devices/batteryClient/BatteryClient.cpp
@@ -46,10 +46,12 @@ void BatteryInputPortProcessor::onRead(yarp::os::Bottle &b)
     {
         double tmpDT=now-prev;
         deltaT+=tmpDT;
-        if (tmpDT>deltaTMax)
-            deltaTMax=tmpDT;
-        if (tmpDT<deltaTMin)
-            deltaTMin=tmpDT;
+        if (tmpDT > deltaTMax) {
+            deltaTMax = tmpDT;
+        }
+        if (tmpDT < deltaTMin) {
+            deltaTMin = tmpDT;
+        }
 
         //compare network time
         if (tmpDT*1000<BATTERY_TIMEOUT)

--- a/src/devices/batteryWrapper/BatteryWrapper.cpp
+++ b/src/devices/batteryWrapper/BatteryWrapper.cpp
@@ -90,7 +90,9 @@ bool BatteryWrapper::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     // parse in, prepare out
     int code = in.get(0).asVocab32();
@@ -247,27 +249,37 @@ void BatteryWrapper::run()
         {
             double tmp;
             ret_chg = m_ibattery_p->getBatteryCharge(tmp);
-            if (ret_chg) m_battery_charge = tmp;
+            if (ret_chg) {
+                m_battery_charge = tmp;
+            }
         }
         {
             double tmp;
             ret_vlt = m_ibattery_p->getBatteryVoltage(tmp);
-            if (ret_vlt) m_battery_voltage = tmp;
+            if (ret_vlt) {
+                m_battery_voltage = tmp;
+            }
         }
         {
             double tmp;
             ret_cur = m_ibattery_p->getBatteryCurrent(tmp);
-            if (ret_cur) m_battery_current = tmp;
+            if (ret_cur) {
+                m_battery_current = tmp;
+            }
         }
         {
             double tmp;
             ret_tmp = m_ibattery_p->getBatteryTemperature(tmp);
-            if (ret_tmp) m_battery_temperature = tmp;
+            if (ret_tmp) {
+                m_battery_temperature = tmp;
+            }
         }
         {
             IBattery::Battery_status tmp;
             ret_sts = m_ibattery_p->getBatteryStatus(tmp);
-            if (ret_sts) m_battery_status = tmp;
+            if (ret_sts) {
+                m_battery_status = tmp;
+            }
         }
 
         if (ret_sts)
@@ -284,7 +296,9 @@ void BatteryWrapper::run()
             m_streamingPort.write();
 
             // if the battery is not charging, checks its status of charge
-            if (m_battery_status >0.4) check_battery_status(m_battery_charge);
+            if (m_battery_status > 0.4) {
+                check_battery_status(m_battery_charge);
+            }
 
             // save data to file
             if (m_enable_log)

--- a/src/devices/depthCamera/depthCameraDriver.cpp
+++ b/src/devices/depthCamera/depthCameraDriver.cpp
@@ -150,12 +150,15 @@ depthCameraDriver::depthCameraDriver() : m_depthFrame(nullptr), m_imageFrame(nul
 depthCameraDriver::~depthCameraDriver()
 {
     close();
-    if (m_depthFrame)
+    if (m_depthFrame) {
         delete m_depthFrame;
-    if (m_imageFrame)
+    }
+    if (m_imageFrame) {
         delete m_imageFrame;
-    if (m_paramParser)
+    }
+    if (m_paramParser) {
         delete m_paramParser;
+    }
 }
 
 bool depthCameraDriver::initializeOpeNIDevice()
@@ -252,24 +255,29 @@ bool depthCameraDriver::setParams()
     //ACCURACY
     if (params_map[accuracy].isSetting && ret)
     {
-        if (!params_map[accuracy].val[0].isFloat64() )
+        if (!params_map[accuracy].val[0].isFloat64()) {
             settingErrorMsg("Param " + params_map[accuracy].name + " is not a double as it should be.", ret);
+        }
 
-        if (! setDepthAccuracy(params_map[accuracy].val[0].asFloat64() ) )
+        if (!setDepthAccuracy(params_map[accuracy].val[0].asFloat64())) {
             settingErrorMsg("Setting param " + params_map[accuracy].name + " failed... quitting.", ret);
+        }
     }
 
     //CLIP_PLANES
     if (params_map[clipPlanes].isSetting && ret)
     {
-        if (!params_map[clipPlanes].val[0].isFloat64() )
+        if (!params_map[clipPlanes].val[0].isFloat64()) {
             settingErrorMsg("Param " + params_map[clipPlanes].name + " is not a double as it should be.", ret);
+        }
 
-        if (!params_map[clipPlanes].val[1].isFloat64() )
+        if (!params_map[clipPlanes].val[1].isFloat64()) {
             settingErrorMsg("Param " + params_map[clipPlanes].name + " is not a double as it should be.", ret);
+        }
 
-        if (! setDepthClipPlanes(params_map[clipPlanes].val[0].asFloat64(), params_map[clipPlanes].val[1].asFloat64() ) )
+        if (!setDepthClipPlanes(params_map[clipPlanes].val[0].asFloat64(), params_map[clipPlanes].val[1].asFloat64())) {
             settingErrorMsg("Setting param " + params_map[clipPlanes].name + " failed... quitting.", ret);
+        }
     }
 
     //DEPTH_FOV
@@ -279,11 +287,13 @@ bool depthCameraDriver::setParams()
         p1 = params_map[depth_Fov].val[0];
         p2 = params_map[depth_Fov].val[1];
 
-        if (!p1.isFloat64() || !p2.isFloat64() )
+        if (!p1.isFloat64() || !p2.isFloat64()) {
             settingErrorMsg("Param " + params_map[depth_Fov].name + " is not a double as it should be.", ret);
+        }
 
-        if (! setDepthFOV(p1.asFloat64(), p2.asFloat64() ) )
+        if (!setDepthFOV(p1.asFloat64(), p2.asFloat64())) {
             settingErrorMsg("Setting param " + params_map[depth_Fov].name + " failed... quitting.", ret);
+        }
     }
 
 

--- a/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
+++ b/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
@@ -142,10 +142,11 @@ void FakeAnalogSensor::run()
     double timeNow = yarp::os::Time::now();
 
     //if 100ms have passed since the last received message
-    if (timeNow > timeStamp+10)
+    if (timeNow > timeStamp + 10) {
         status = IAnalogSensor::AS_TIMEOUT;
-    else
+    } else {
         status = IAnalogSensor::AS_OK;
+    }
 
     timeStamp = timeNow;
     mutex.unlock();

--- a/src/devices/fakeDepthCamera/fakeDepthCameraDriver.cpp
+++ b/src/devices/fakeDepthCamera/fakeDepthCameraDriver.cpp
@@ -251,7 +251,9 @@ bool fakeDepthCameraDriver::getRgbImage(FlexImage& rgbImage, Stamp* timeStamp)
     rgbImage.setPixelCode(VOCAB_PIXEL_RGB);
     rgbImage.resize(imageof);
     memcpy((void*)rgbImage.getRawImage(), (void*)imageof.getRawImage(), imageof.getRawImageSize());
-    if(timeStamp) timeStamp->update(yarp::os::Time::now());
+    if (timeStamp) {
+        timeStamp->update(yarp::os::Time::now());
+    }
     return true;
 }
 
@@ -267,8 +269,9 @@ bool fakeDepthCameraDriver::getDepthImage(ImageOf<PixelFloat>& depthImage, Stamp
             *(PixelFloat*)depthImage.getPixelAddress(i, j) = (float(pix.b) / 255.0)/3.0 + (float(pix.g) / 255.0) / 3.0 + (float(pix.r) / 255.0) / 3.0;
         }
     }
-    if(timeStamp)
+    if (timeStamp) {
         timeStamp->update(yarp::os::Time::now());
+    }
     return true;
 }
 

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -126,7 +126,9 @@ bool FakeFrameGrabber::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     reply.clear();
 
     if (command.get(0).asString()=="help")
@@ -617,7 +619,7 @@ void FakeFrameGrabber::printTime(unsigned char* pixbuf, size_t pixbuf_w, size_t 
             default: num_p = num[10]; break;
         }
 
-        for (size_t yi = 0; yi < num_height; yi++)
+        for (size_t yi = 0; yi < num_height; yi++) {
             for (size_t xi = 0; xi < num_width; xi++) {
                 size_t ii = yi * num_width + xi;
                 if (num_p[ii] == '*') {
@@ -638,6 +640,7 @@ void FakeFrameGrabber::printTime(unsigned char* pixbuf, size_t pixbuf_w, size_t 
                     }
                 }
             }
+        }
     }
 }
 

--- a/src/devices/fakeIMU/fakeIMU.cpp
+++ b/src/devices/fakeIMU/fakeIMU.cpp
@@ -77,8 +77,9 @@ bool fakeIMU::close()
 
 bool fakeIMU::read(Vector &out)
 {
-    if(out.size() != nchannels)
+    if (out.size() != nchannels) {
         out.resize(nchannels);
+    }
 
     out.zero();
 
@@ -146,8 +147,9 @@ void fakeIMU::run()
         count++;
     }
 
-    if(count >= 360)
+    if (count >= 360) {
         count = 0;
+    }
 }
 
 yarp::os::Stamp fakeIMU::getLastInputStamp()

--- a/src/devices/fakeLocalizerDevice/fakeLocalizerDev.cpp
+++ b/src/devices/fakeLocalizerDevice/fakeLocalizerDev.cpp
@@ -150,8 +150,11 @@ void fakeLocalizerThread::run()
 
         m_current_loc.theta = m_current_odom.theta                   - m_initial_odom.theta + m_initial_loc.theta;
 
-        if      (m_current_loc.theta >= +360) m_current_loc.theta -= 360;
-        else if (m_current_loc.theta <= -360) m_current_loc.theta += 360;
+        if (m_current_loc.theta >= +360) {
+            m_current_loc.theta -= 360;
+        } else if (m_current_loc.theta <= -360) {
+            m_current_loc.theta += 360;
+        }
     }
     if (current_time - m_last_locdata_received > 0.1)
     {

--- a/src/devices/fakeMicrophone/fakeMicrophone.cpp
+++ b/src/devices/fakeMicrophone/fakeMicrophone.cpp
@@ -168,7 +168,9 @@ void fakeMicrophone::run()
                 double elem1 = double(m_wave_amplitude * sin(double(m_counter[i]) / m_max_count[i] * 2 * M_PI));
                 m_inputBuffer->write(elem1 * m_hw_gain);
                 m_counter[i]++;
-                if (m_counter[i] >= m_max_count[i]) m_counter[i] = 0;
+                if (m_counter[i] >= m_max_count[i]) {
+                    m_counter[i] = 0;
+                }
             }
         }
         else if(m_waveform == waveform_t::sawtooth)
@@ -179,7 +181,9 @@ void fakeMicrophone::run()
                 double elem1 = m_wave_amplitude * 2 * (double(m_counter[i])/ m_max_count[i]) - m_wave_amplitude;
                 m_inputBuffer->write(elem1 * m_hw_gain);
                 m_counter[i]++;
-                if (m_counter[i] >= m_max_count[i]) m_counter[i] = 0;
+                if (m_counter[i] >= m_max_count[i]) {
+                    m_counter[i] = 0;
+                }
             }
         }
         else if (m_waveform == waveform_t::square)
@@ -190,7 +194,9 @@ void fakeMicrophone::run()
                 double elem1 = m_counter[i] < m_max_count[i]/2  ? m_wave_amplitude : 0;
                 m_inputBuffer->write(elem1 * m_hw_gain);
                 m_counter[i]++;
-                if (m_counter[i] >= m_max_count[i]) m_counter[i] = 0;
+                if (m_counter[i] >= m_max_count[i]) {
+                    m_counter[i] = 0;
+                }
             }
         }
         else if (m_waveform == waveform_t::constant)
@@ -199,7 +205,9 @@ void fakeMicrophone::run()
             {
                 m_inputBuffer->write(m_wave_amplitude * m_hw_gain / double(i + 1));
                 m_counter[i]++;
-                if (m_counter[i] >= m_max_count[i]) m_counter[i] = 0;
+                if (m_counter[i] >= m_max_count[i]) {
+                    m_counter[i] = 0;
+                }
             }
         }
         else

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -540,8 +540,9 @@ bool FakeMotionControl::open(yarp::os::Searchable &config)
     }
 
     // Default value
-    for(int i=0; i<_njoints; i++)
+    for (int i = 0; i < _njoints; i++) {
         _newtonsToSensor[i] = 1;
+    }
 
     if(!fromConfig(config))
     {
@@ -721,8 +722,9 @@ bool FakeMotionControl::parsePositionPidsGroup(Bottle& pidsGroup, Pid myPid[])
         }
 
         yCInfo(FAKEMOTIONCONTROL) << "Using LIMITED PWM!!";
-        for (j=0; j<_njoints; j++)
-            myPid[j].max_output = xtmp.get(j+1).asFloat64();
+        for (j = 0; j < _njoints; j++) {
+            myPid[j].max_output = xtmp.get(j + 1).asFloat64();
+        }
     }
 
     return true;
@@ -843,7 +845,9 @@ bool FakeMotionControl::parseTorquePidsGroup(Bottle& pidsGroup, Pid myPid[], dou
         }
 
         yCInfo(FAKEMOTIONCONTROL) << "Using LIMITED PWM!!";
-        for (j=0; j<_njoints; j++) myPid[j].max_output = xtmp.get(j+1).asFloat64();
+        for (j = 0; j < _njoints; j++) {
+            myPid[j].max_output = xtmp.get(j + 1).asFloat64();
+        }
     }
 
     return true;
@@ -860,17 +864,19 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
     {
         if(extractGroup(general, xtmp, "AxisMap", "a list of reordered indices for the axes", _njoints))
         {
-            for (i = 1; (size_t) i < xtmp.size(); i++)
+            for (i = 1; (size_t)i < xtmp.size(); i++) {
                 _axisMap[i - 1] = xtmp.get(i).asInt32();
-        }
-        else
+            }
+        } else {
             return false;
+        }
     }
     else
     {
         yCInfo(FAKEMOTIONCONTROL) << "Using default AxisMap";
-        for (i = 0; i < _njoints; i++)
+        for (i = 0; i < _njoints; i++) {
             _axisMap[i] = i;
+        }
     }
 
     if(general.check("AxisName"))
@@ -882,9 +888,9 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
             {
                 _axisName[_axisMap[i - 1]] = xtmp.get(i).asString();
             }
-        }
-        else
+        } else {
             return false;
+        }
     }
     else
     {
@@ -902,18 +908,19 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
             for (i = 1; (size_t) i < xtmp.size(); i++)
             {
                 string typeString = xtmp.get(i).asString();
-                if (typeString == "revolute")  _jointType[_axisMap[i - 1]] = VOCAB_JOINTTYPE_REVOLUTE;
-                else if (typeString == "prismatic")  _jointType[_axisMap[i - 1]] = VOCAB_JOINTTYPE_PRISMATIC;
-                else
-                {
+                if (typeString == "revolute") {
+                    _jointType[_axisMap[i - 1]] = VOCAB_JOINTTYPE_REVOLUTE;
+                } else if (typeString == "prismatic") {
+                    _jointType[_axisMap[i - 1]] = VOCAB_JOINTTYPE_PRISMATIC;
+                } else {
                     yCError(FAKEMOTIONCONTROL, "Unknown AxisType value %s!", typeString.c_str());
                     _jointType[_axisMap[i - 1]] = VOCAB_JOINTTYPE_UNKNOWN;
                     return false;
                 }
             }
-        }
-        else
+        } else {
             return false;
+        }
     }
     else
     {
@@ -936,9 +943,9 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
                     _ampsToSensor[i - 1] = xtmp.get(i).asFloat64();
                 }
             }
-        }
-        else
+        } else {
             return false;
+        }
     }
     else
     {
@@ -961,15 +968,16 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
                     _dutycycleToPWM[i - 1] = xtmp.get(i).asFloat64() / 100.0;
                 }
             }
-        }
-        else
+        } else {
             return false;
+        }
     }
     else
     {
         yCInfo(FAKEMOTIONCONTROL) << "Using default dutycycleToPWM=1.0";
-        for (i = 0; i < _njoints; i++)
+        for (i = 0; i < _njoints; i++) {
             _dutycycleToPWM[i] = 1.0;
+        }
     }
 
 //     double tmp_A2E;
@@ -982,15 +990,16 @@ bool FakeMotionControl::fromConfig(yarp::os::Searchable &config)
             {
                 _angleToEncoder[i-1] = xtmp.get(i).asFloat64();
             }
-        }
-        else
+        } else {
             return false;
+        }
     }
     else
     {
         yCInfo(FAKEMOTIONCONTROL) << "Using default Encoder";
-        for (i = 0; i < _njoints; i++)
+        for (i = 0; i < _njoints; i++) {
             _angleToEncoder[i] = 1;
+        }
     }
 
     // Joint encoder resolution
@@ -1842,8 +1851,9 @@ bool FakeMotionControl::velocityMoveRaw(const double *sp)
 {
     yCTrace(FAKEMOTIONCONTROL);
     bool ret = true;
-    for(int i=0; i<_njoints; i++)
+    for (int i = 0; i < _njoints; i++) {
         ret &= velocityMoveRaw(i, sp[i]);
+    }
     return ret;
 }
 
@@ -1884,8 +1894,9 @@ bool FakeMotionControl::getAxes(int *ax)
 
 bool FakeMotionControl::positionMoveRaw(int j, double ref)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j " << j << " ref " << ref;
+    }
 
 //     if (yarp::os::Time::now()-_last_position_move_time[j]<MAX_POSITION_MOVE_INTERVAL)
 //     {
@@ -1908,8 +1919,9 @@ bool FakeMotionControl::positionMoveRaw(int j, double ref)
 
 bool FakeMotionControl::positionMoveRaw(const double *refs)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL);
+    }
 
     bool ret = true;
     for(int j=0, index=0; j< _njoints; j++, index++)
@@ -1921,8 +1933,9 @@ bool FakeMotionControl::positionMoveRaw(const double *refs)
 
 bool FakeMotionControl::relativeMoveRaw(int j, double delta)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j " << j << " ref " << delta;
+    }
 //     if (yarp::os::Time::now()-_last_position_move_time[j]<MAX_POSITION_MOVE_INTERVAL)
 //     {
 //         yCWarning(FAKEMOTIONCONTROL) << "Performance warning: You are using positionMove commands at high rate (<"<< MAX_POSITION_MOVE_INTERVAL*1000.0 <<" ms). Probably position control mode is not the right control mode to use.";
@@ -1944,8 +1957,9 @@ bool FakeMotionControl::relativeMoveRaw(int j, double delta)
 
 bool FakeMotionControl::relativeMoveRaw(const double *deltas)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL);
+    }
 
     bool ret = true;
     for(int j=0, index=0; j< _njoints; j++, index++)
@@ -1958,8 +1972,9 @@ bool FakeMotionControl::relativeMoveRaw(const double *deltas)
 
 bool FakeMotionControl::checkMotionDoneRaw(int j, bool *flag)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j ";
+    }
 
     *flag = false;
     return false;
@@ -1967,8 +1982,9 @@ bool FakeMotionControl::checkMotionDoneRaw(int j, bool *flag)
 
 bool FakeMotionControl::checkMotionDoneRaw(bool *flag)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL);
+    }
 
     bool ret = true;
     bool val, tot_res = true;
@@ -2091,8 +2107,9 @@ bool FakeMotionControl::stopRaw()
 
 bool FakeMotionControl::positionMoveRaw(const int n_joint, const int *joints, const double *refs)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << " -> n_joint " << n_joint;
+    }
 
     for(int j=0; j<n_joint; j++)
     {
@@ -2109,8 +2126,9 @@ bool FakeMotionControl::positionMoveRaw(const int n_joint, const int *joints, co
 
 bool FakeMotionControl::relativeMoveRaw(const int n_joint, const int *joints, const double *deltas)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2122,8 +2140,9 @@ bool FakeMotionControl::relativeMoveRaw(const int n_joint, const int *joints, co
 
 bool FakeMotionControl::checkMotionDoneRaw(const int n_joint, const int *joints, bool *flag)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     bool val = true;
@@ -2140,8 +2159,9 @@ bool FakeMotionControl::checkMotionDoneRaw(const int n_joint, const int *joints,
 
 bool FakeMotionControl::setRefSpeedsRaw(const int n_joint, const int *joints, const double *spds)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2153,8 +2173,9 @@ bool FakeMotionControl::setRefSpeedsRaw(const int n_joint, const int *joints, co
 
 bool FakeMotionControl::setRefAccelerationsRaw(const int n_joint, const int *joints, const double *accs)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2166,8 +2187,9 @@ bool FakeMotionControl::setRefAccelerationsRaw(const int n_joint, const int *joi
 
 bool FakeMotionControl::getRefSpeedsRaw(const int n_joint, const int *joints, double *spds)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2179,8 +2201,9 @@ bool FakeMotionControl::getRefSpeedsRaw(const int n_joint, const int *joints, do
 
 bool FakeMotionControl::getRefAccelerationsRaw(const int n_joint, const int *joints, double *accs)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2192,8 +2215,9 @@ bool FakeMotionControl::getRefAccelerationsRaw(const int n_joint, const int *joi
 
 bool FakeMotionControl::stopRaw(const int n_joint, const int *joints)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joint " << _njoints;
+    }
 
     bool ret = true;
     for(int j=0; j<n_joint; j++)
@@ -2210,8 +2234,9 @@ bool FakeMotionControl::stopRaw(const int n_joint, const int *joints)
 // puo' essere richiesto con get
 bool FakeMotionControl::getControlModeRaw(int j, int *v)
 {
-    if(verbose > VERY_VERY_VERBOSE)
+    if (verbose > VERY_VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j: " << j;
+    }
 
     *v = _controlModes[j];
     return true;
@@ -2245,8 +2270,9 @@ bool FakeMotionControl::getControlModesRaw(const int n_joint, const int *joints,
 // con il control mode il can ora lo fa ma e' giusto? era cosi' anche in passato?
 bool FakeMotionControl::setControlModeRaw(const int j, const int _mode)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j: " << j << " mode: " << yarp::os::Vocab32::decode(_mode);
+    }
 
     if (_mode==VOCAB_CM_FORCE_IDLE)
     {
@@ -2263,8 +2289,9 @@ bool FakeMotionControl::setControlModeRaw(const int j, const int _mode)
 
 bool FakeMotionControl::setControlModesRaw(const int n_joint, const int *joints, int *modes)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "n_joints: " << n_joint;
+    }
 
     bool ret = true;
     for(int i=0; i<n_joint; i++)
@@ -2276,8 +2303,9 @@ bool FakeMotionControl::setControlModesRaw(const int n_joint, const int *joints,
 
 bool FakeMotionControl::setControlModesRaw(int *modes)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL);
+    }
 
     bool ret = true;
     for(int i=0; i<_njoints; i++)
@@ -2374,8 +2402,9 @@ bool FakeMotionControl::getEncodersTimedRaw(double *encs, double *stamps)
 {
     bool ret = getEncodersRaw(encs);
     _mutex.lock();
-    for(int i=0; i<_njoints; i++)
+    for (int i = 0; i < _njoints; i++) {
         stamps[i] = _encodersStamp[i];
+    }
     _mutex.unlock();
     return ret;
 }
@@ -2481,8 +2510,9 @@ bool FakeMotionControl::getMotorEncodersTimedRaw(double *encs, double *stamps)
 {
     bool ret = getMotorEncodersRaw(encs);
     _mutex.lock();
-    for(int i=0; i<_njoints; i++)
+    for (int i = 0; i < _njoints; i++) {
         stamps[i] = _encodersStamp[i];
+    }
     _mutex.unlock();
 
     return ret;
@@ -2754,8 +2784,9 @@ bool FakeMotionControl::getTorqueRangesRaw(double *min, double *max)
 bool FakeMotionControl::setRefTorquesRaw(const double *t)
 {
     bool ret = true;
-    for(int j=0; j<_njoints && ret; j++)
+    for (int j = 0; j < _njoints && ret; j++) {
         ret &= setRefTorqueRaw(j, t[j]);
+    }
     return ret;
 }
 
@@ -2863,8 +2894,9 @@ bool FakeMotionControl::setPositionsRaw(const double *refs)
 
 bool FakeMotionControl::getTargetPositionRaw(int axis, double *ref)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j " << axis << " ref " << _posCtrl_references[axis];
+    }
 
     int mode = 0;
     getControlModeRaw(axis, &mode);
@@ -2882,8 +2914,9 @@ bool FakeMotionControl::getTargetPositionRaw(int axis, double *ref)
 bool FakeMotionControl::getTargetPositionsRaw(double *refs)
 {
     bool ret = true;
-    for(int i=0; i<_njoints; i++)
+    for (int i = 0; i < _njoints; i++) {
         ret &= getTargetPositionRaw(i, &refs[i]);
+    }
     return ret;
 }
 
@@ -2965,8 +2998,9 @@ bool FakeMotionControl::getRefPositionsRaw(int nj, const int * jnts, double *ref
 // InteractionMode
 bool FakeMotionControl::getInteractionModeRaw(int j, yarp::dev::InteractionModeEnum* _mode)
 {
-    if(verbose > VERY_VERY_VERBOSE)
+    if (verbose > VERY_VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j: " << j;
+    }
 
     *_mode = (yarp::dev::InteractionModeEnum)_interactMode[j];
     return true;}
@@ -2985,8 +3019,9 @@ bool FakeMotionControl::getInteractionModesRaw(int n_joints, int *joints, yarp::
 bool FakeMotionControl::getInteractionModesRaw(yarp::dev::InteractionModeEnum* modes)
 {
     bool ret = true;
-    for(int j=0; j<_njoints; j++)
+    for (int j = 0; j < _njoints; j++) {
         ret = ret && getInteractionModeRaw(j, &modes[j]);
+    }
     return ret;
 }
 
@@ -2995,8 +3030,9 @@ bool FakeMotionControl::getInteractionModesRaw(yarp::dev::InteractionModeEnum* m
 // con il interaction mode il can ora non lo fa. mentre lo fa per il control mode. perche' diverso?
 bool FakeMotionControl::setInteractionModeRaw(int j, yarp::dev::InteractionModeEnum _mode)
 {
-    if(verbose >= VERY_VERBOSE)
+    if (verbose >= VERY_VERBOSE) {
         yCTrace(FAKEMOTIONCONTROL) << "j: " << j << " interaction mode: " << yarp::os::Vocab32::decode(_mode);
+    }
 
     _interactMode[j] = _mode;
 

--- a/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
+++ b/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
@@ -31,8 +31,12 @@ bool fakeNavigation :: open(yarp::os::Searchable& config)
     std::string context_name = "robotGoto";
     std::string file_name = "robotGoto_cer.ini";
 
-    if (config.check("context"))   context_name = config.find("context").asString();
-    if (config.check("from")) file_name    = config.find("from").asString();
+    if (config.check("context")) {
+        context_name = config.find("context").asString();
+    }
+    if (config.check("from")) {
+        file_name = config.find("from").asString();
+    }
 
     yarp::os::ResourceFinder rf;
     rf.setDefaultContext(context_name.c_str());
@@ -40,7 +44,9 @@ bool fakeNavigation :: open(yarp::os::Searchable& config)
 
     yarp::os::Property p;
     std::string configFile = rf.findFile("from");
-    if (configFile != "") p.fromConfigFile(configFile.c_str());
+    if (configFile != "") {
+        p.fromConfigFile(configFile.c_str());
+    }
     yCDebug(FAKENAVIGATION) << "robotGotoDev configuration: \n" << p.toString().c_str();
 
 #else

--- a/src/devices/fakebot/FakeBot.cpp
+++ b/src/devices/fakebot/FakeBot.cpp
@@ -76,8 +76,12 @@ void scramble(unsigned char& ch, float f) {
     //x += (int)(Random::normal(0,x*f));
     x += (int)(rnds[idx]*f);
     idx = (idx+17)%MAXRND;
-    if (x<0) x = 0;
-    if (x>255) x = 255;
+    if (x < 0) {
+        x = 0;
+    }
+    if (x > 255) {
+        x = 255;
+    }
     ch = (unsigned char) x;
 }
 

--- a/src/devices/ffmpeg/FfmpegGrabber.cpp
+++ b/src/devices/ffmpeg/FfmpegGrabber.cpp
@@ -317,7 +317,9 @@ public:
 
 const char *xstrdup(const char *str)
 {
-    if (str[0]=='-') return nullptr;
+    if (str[0] == '-') {
+        return nullptr;
+    }
     return strdup(str);
 }
 
@@ -568,7 +570,9 @@ bool FfmpegGrabber::open(yarp::os::Searchable & config)
     if (_hasAudio) {
         ok = ok && audioDecoder.getCodec(pAudioFormatCtx);
     }
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     if (_hasVideo) {
         ok = ok && videoDecoder.allocateImage();
@@ -576,7 +580,9 @@ bool FfmpegGrabber::open(yarp::os::Searchable & config)
     if (_hasAudio) {
         ok = ok && audioDecoder.allocateSound();
     }
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     if (_hasVideo) {
         m_w = videoDecoder.getWidth();

--- a/src/devices/ffmpeg/FfmpegWriter.cpp
+++ b/src/devices/ffmpeg/FfmpegWriter.cpp
@@ -170,8 +170,9 @@ static void get_audio_frame(int16_t *samples, int frame_size, int nb_channels)
     q = samples;
     for(j=0;j<frame_size;j++) {
         v = (int)(sin(t) * 10000);
-        for(i = 0; i < nb_channels; i++)
+        for (i = 0; i < nb_channels; i++) {
             *q++ = v;
+        }
         t += tincr;
         tincr += tincr2;
     }
@@ -372,8 +373,9 @@ static AVStream *add_video_stream(AVFormatContext *oc, AVCodecID codec_id,
         c->mb_decision=2;
     }
     // some formats want stream headers to be separate
-    if(!strcmp(oc->oformat->name, "mp4") || !strcmp(oc->oformat->name, "mov") || !strcmp(oc->oformat->name, "3gp"))
+    if (!strcmp(oc->oformat->name, "mp4") || !strcmp(oc->oformat->name, "mov") || !strcmp(oc->oformat->name, "3gp")) {
         c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    }
 
 
     return st;
@@ -386,8 +388,9 @@ static AVFrame *alloc_picture(int pix_fmt, int width, int height)
     int size;
 
     picture = av_frame_alloc();
-    if (!picture)
+    if (!picture) {
         return nullptr;
+    }
     size = avpicture_get_size((AVPixelFormat)pix_fmt, width, height);
     picture_buf = (uint8_t*)av_malloc(size);
     if (!picture_buf) {
@@ -499,8 +502,9 @@ void FfmpegWriter::write_video_frame(AVFormatContext *oc, AVStream *st,
         av_init_packet(&pkt);
 
         pkt.pts= av_rescale_q(c->coded_frame->pts, c->time_base, st->time_base);
-        if(c->coded_frame->key_frame)
+        if (c->coded_frame->key_frame) {
             pkt.flags |= AV_PKT_FLAG_KEY;
+        }
         pkt.stream_index= st->index;
         pkt.data= video_outbuf;
         pkt.size= out_size;
@@ -669,10 +673,12 @@ bool FfmpegWriter::close() {
     if (!isOk()) { return false; }
 
     /* close each codec */
-    if (video_st)
+    if (video_st) {
         close_video(oc, video_st);
-    if (audio_st)
+    }
+    if (audio_st) {
         close_audio(oc, audio_st);
+    }
 
     /* write the trailer, if any */
     av_write_trailer(oc);
@@ -704,18 +710,21 @@ bool FfmpegWriter::putImage(yarp::sig::ImageOf<yarp::sig::PixelRgb> & image) {
     if (!isOk()) { return false; }
 
     /* compute current audio and video time */
-    if (audio_st)
+    if (audio_st) {
         audio_pts = (double)av_stream_get_end_pts(audio_st) * audio_st->time_base.num / audio_st->time_base.den;
-    else
+    } else {
         audio_pts = 0.0;
+    }
 
-    if (video_st)
+    if (video_st) {
         video_pts = (double)av_stream_get_end_pts(video_st) * video_st->time_base.num / video_st->time_base.den;
-    else
+    } else {
         video_pts = 0.0;
+    }
 
-    if (!(audio_st||video_st))
+    if (!(audio_st || video_st)) {
         return false;
+    }
 
     /* write interleaved audio and video frames */
     if (!video_st || (video_st && audio_st && audio_pts < video_pts)) {

--- a/src/devices/frameTransformClient/FrameTransformClient.cpp
+++ b/src/devices/frameTransformClient/FrameTransformClient.cpp
@@ -36,7 +36,9 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     string request = in.get(0).asString();
     if (request == "help")
@@ -111,7 +113,9 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
         if (format_s == "matrix") {eformat = broadcast_port_t::format_t::matrix;}
         else {yCError(FRAMETRANSFORMCLIENT) << "Invalid format" << format_s << "using format `matrix`. Only `matrix` is currently supported."; }
 
-        if (port_name[0] == '/')  port_name.erase(port_name.begin());
+        if (port_name[0] == '/') {
+            port_name.erase(port_name.begin());
+        }
         std::string full_port_name = m_local_name + "/" + port_name;
 
         //print a warning if the frames do not exists yet
@@ -153,7 +157,9 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
             {
                 out.addString("Operation complete. Port " + full_port_name + " opened.");
                 m_array_of_ports.push_back(b);
-                if (m_array_of_ports.size()==1) this->start();
+                if (m_array_of_ports.size() == 1) {
+                    this->start();
+                }
             }
             else
             {
@@ -175,14 +181,18 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
             m_array_of_port=nullptr;
         }
         m_array_of_ports.clear();
-        if (m_array_of_ports.size()==0) this->askToStop();
+        if (m_array_of_ports.size() == 0) {
+            this->askToStop();
+        }
         out.addString("Operation complete");
     }
     else if (request == "unpublish_transform")
     {
         bool ret = false;
         string port_name = in.get(1).asString();
-        if (port_name[0]=='/')  port_name.erase(port_name.begin());
+        if (port_name[0] == '/') {
+            port_name.erase(port_name.begin());
+        }
         string full_port_name = m_local_name + "/" + port_name;
         for (auto it = m_array_of_ports.begin(); it != m_array_of_ports.end(); it++)
         {
@@ -204,7 +214,9 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
         {
             out.addString("Port " + full_port_name + " was not found.");
         }
-        if (m_array_of_ports.size()==0) this->askToStop();
+        if (m_array_of_ports.size() == 0) {
+            this->askToStop();
+        }
     }
     else if (request == "set_static_transform_rad" ||
              request == "set_static_transform_deg")
@@ -243,9 +255,13 @@ bool FrameTransformClient::read(yarp::os::ConnectionReader& connection)
     else if (request == "generate_view")
     {
         m_show_transforms_in_diagram = show_transforms_in_diagram_t::do_not_show;
-        if (in.get(1).asString() == "show_quaternion") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_quaternion;
-        else if (in.get(1).asString() == "show_matrix") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_matrix;
-        else if (in.get(1).asString() == "show_rpy") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_rpy;
+        if (in.get(1).asString() == "show_quaternion") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_quaternion;
+        } else if (in.get(1).asString() == "show_matrix") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_matrix;
+        } else if (in.get(1).asString() == "show_rpy") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_rpy;
+        }
         priv_generate_view();
         out.addString("ok");
     }
@@ -361,8 +377,9 @@ bool FrameTransformClient::allFramesAsString(string &all_frames)
     bool br = m_ift_util->getInternalContainer(p_cont);
     if (br && p_cont)
     {
-        for (auto it = p_cont->begin(); it != p_cont->end(); it++)
-        all_frames += it->toString() + " ";
+        for (auto it = p_cont->begin(); it != p_cont->end(); it++) {
+            all_frames += it->toString() + " ";
+        }
         return true;
     }
     return false;
@@ -468,7 +485,9 @@ bool FrameTransformClient::getAllFrameIds(std::vector< string > &ids)
         {
             if (it->src_frame_id == id) { found = true; break; }
         }
-        if (found == false) ids.push_back(it->src_frame_id);
+        if (found == false) {
+            ids.push_back(it->src_frame_id);
+        }
     }
 
     for (auto it = p_cont->begin(); it != p_cont->end(); it++)
@@ -478,7 +497,9 @@ bool FrameTransformClient::getAllFrameIds(std::vector< string > &ids)
         {
             if (it->dst_frame_id == id) { found = true; break; }
         }
-        if (found == false) ids.push_back(it->dst_frame_id);
+        if (found == false) {
+            ids.push_back(it->dst_frame_id);
+        }
     }
 
     return true;
@@ -799,7 +820,9 @@ void     FrameTransformClient::run()
 
 string FrameTransformClient::priv_get_matrix_as_text(FrameTransform* t)
 {
-    if (t==nullptr) return "";
+    if (t == nullptr) {
+        return "";
+    }
 
     if (m_show_transforms_in_diagram == do_not_show)
     {

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.cpp
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.cpp
@@ -51,9 +51,15 @@ bool FrameTransformGet_nwc_ros::open(yarp::os::Searchable& config)
     {
         yCInfo(FRAMETRANSFORGETNWCROS, "Configuring ROS params");
         Bottle ROS_config = config.findGroup("ROS");
-        if(ROS_config.check("ft_topic")) m_topic = ROS_config.find("ft_topic").asString();
-        if(ROS_config.check("ft_topic_static")) m_topic_static = ROS_config.find("ft_topic_static").asString();
-        if(ROS_config.check("ft_node")) m_nodeName = ROS_config.find("ft_node").asString();
+        if (ROS_config.check("ft_topic")) {
+            m_topic = ROS_config.find("ft_topic").asString();
+        }
+        if (ROS_config.check("ft_topic_static")) {
+            m_topic_static = ROS_config.find("ft_topic_static").asString();
+        }
+        if (ROS_config.check("ft_node")) {
+            m_nodeName = ROS_config.find("ft_node").asString();
+        }
 
         //open ros publisher
         if (m_rosNode == nullptr)

--- a/src/devices/frameTransformServer/FrameTransformServer.cpp
+++ b/src/devices/frameTransformServer/FrameTransformServer.cpp
@@ -33,7 +33,9 @@ bool FrameTransformServer::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     string request = in.get(0).asString();
     if (request == "help")

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.cpp
@@ -52,9 +52,15 @@ bool FrameTransformSet_nwc_ros::open(yarp::os::Searchable& config)
     {
         yCInfo(FRAMETRANSFORSETNWCROS, "Configuring ROS params");
         Bottle ROS_config = config.findGroup("ROS");
-        if(ROS_config.check("ft_topic")) m_topic = ROS_config.find("ft_topic").asString();
-        if(ROS_config.check("ft_topic_static")) m_topic_static = ROS_config.find("ft_topic_static").asString();
-        if(ROS_config.check("ft_node")) m_nodeName = ROS_config.find("ft_node").asString();
+        if (ROS_config.check("ft_topic")) {
+            m_topic = ROS_config.find("ft_topic").asString();
+        }
+        if (ROS_config.check("ft_topic_static")) {
+            m_topic_static = ROS_config.find("ft_topic_static").asString();
+        }
+        if (ROS_config.check("ft_node")) {
+            m_nodeName = ROS_config.find("ft_node").asString();
+        }
 
         //open ros publisher
         if (m_rosNode == nullptr)

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -66,7 +66,9 @@ void FrameTransformStorage::run()
     // get new transforms
     std::vector<yarp::math::FrameTransform> tfs;
     bool b=iGetIf->getTransforms(tfs);
-    if (b) this->setTransforms(tfs);
+    if (b) {
+        this->setTransforms(tfs);
+    }
 }
 
 bool FrameTransformStorage::detach()

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -333,8 +333,9 @@ bool BoschIMU::sendWriteCommandSer(unsigned char register_add, int len, unsigned
     command[1]= WRITE_CMD;      // read operation
     command[2]= register_add;   // operation mode register
     command[3]= (unsigned char) len;     // length 1 byte
-    for(int i=0; i<len; i++)
-        command[4+i] = cmd[i];  // data
+    for (int i = 0; i < len; i++) {
+        command[4 + i] = cmd[i]; // data
+    }
 
 //     yCTrace(IMUBOSCH_BNO055, "> WRITE_COMMAND:  %s ... ", comment.c_str());
 //     yCTrace(IMUBOSCH_BNO055, "Command is:");
@@ -371,8 +372,9 @@ int BoschIMU::readBytes(unsigned char* buffer, int bytes)
     do
     {
         r = ::read(fd, (void*)&buffer[bytesRead], 1);
-        if(r > 0)
+        if (r > 0) {
             bytesRead += r;
+        }
     }
     while(r!=0 && bytesRead < bytes);
 
@@ -391,16 +393,18 @@ void BoschIMU::dropGarbage()
 
 void BoschIMU::printBuffer(unsigned char* buffer, int length)
 {
-    for(int i=0; i< length; i++)
+    for (int i = 0; i < length; i++) {
         printf("\t0x%02X ", buffer[i]);
+    }
     printf("\n");
 }
 
 void BoschIMU::readSysError()
 {
     // avoid recursive error check
-    if(checkError)
+    if (checkError) {
         return;
+    }
 
     checkError = true;
     yarp::os::SystemClock::delaySystem(0.002);
@@ -589,10 +593,11 @@ bool BoschIMU::threadInit()
     {
         // read data from IMU
         run();
-        if(dataIsValid)
+        if (dataIsValid) {
             break;
-        else
+        } else {
             yarp::os::SystemClock::delaySystem(0.01);
+        }
     }
 
     if(!dataIsValid)

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -90,8 +90,9 @@ bool LaserFromDepth::close()
 {
     PeriodicThread::stop();
 
-    if(driver.isValid())
+    if (driver.isValid()) {
         driver.close();
+    }
 
     yCInfo(LASER_FROM_DEPTH) << "closed";
     return true;

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
@@ -60,8 +60,9 @@ yarpdev --device Rangefinder2DWrapper --subdevice laserFromExternalPort \
 double constrainAngle(double x)
 {
     x = fmod(x, 360);
-    if (x < 0)
+    if (x < 0) {
         x += 360;
+    }
     return x;
 }
 
@@ -119,8 +120,9 @@ bool LaserFromExternalPort::open(yarp::os::Searchable& config)
         yarp::os::Bottle* portlist = general_config.find("input_ports_name").asList();
         if (portlist)
         {
-            for (size_t i = 0; i < portlist->size(); i++)
+            for (size_t i = 0; i < portlist->size(); i++) {
                 m_port_names.push_back(portlist->get(i).asString());
+            }
         }
         else
         {
@@ -150,15 +152,21 @@ bool LaserFromExternalPort::open(yarp::os::Searchable& config)
     m_empty_laser_data = m_laser_data;
     if (m_base_type == base_enum::BASE_IS_INF)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = std::numeric_limits<double>::infinity();
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = std::numeric_limits<double>::infinity();
+        }
     }
     else if (m_base_type == base_enum::BASE_IS_NAN)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = std::nanf("");
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = std::nanf("");
+        }
     }
     else if (m_base_type == base_enum::BASE_IS_ZERO)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = 0;
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = 0;
+        }
     }
     else
     {
@@ -403,7 +411,9 @@ bool LaserFromExternalPort::acquireDataFromHW()
             m_max_distance = m_last_scan_data[0].range_max;
             m_min_distance = m_last_scan_data[0].range_min;
             m_resolution = received_scans / (m_max_angle - m_min_angle);
-            if (m_laser_data.size() != m_sensorsNum) m_laser_data.resize(m_sensorsNum);
+            if (m_laser_data.size() != m_sensorsNum) {
+                m_laser_data.resize(m_sensorsNum);
+            }
         }
 
         if (m_iTc == nullptr)

--- a/src/devices/laserFromPointCloud/laserFromPointCloud.cpp
+++ b/src/devices/laserFromPointCloud/laserFromPointCloud.cpp
@@ -137,7 +137,9 @@ void ros_compute_and_send_pc(const yarp::sig::PointCloud<yarp::sig::DataXYZ>& pc
     }
    //yCDebug(LASER_FROM_POINTCLOUD)<<elem <<yelem;
 
-    if (pointCloud_outTopic) pointCloud_outTopic->write(rosPC_data);
+    if (pointCloud_outTopic) {
+        pointCloud_outTopic->write(rosPC_data);
+    }
 }
 
 //-------------------------------------------------------------------------------------
@@ -281,11 +283,13 @@ bool LaserFromPointCloud::close()
 {
     PeriodicThread::stop();
 
-    if(m_rgbd_driver.isValid())
+    if (m_rgbd_driver.isValid()) {
         m_rgbd_driver.close();
+    }
 
-    if(m_tc_driver.isValid())
+    if (m_tc_driver.isValid()) {
         m_tc_driver.close();
+    }
 
     yCInfo(LASER_FROM_POINTCLOUD) << "closed";
     return true;
@@ -445,16 +449,18 @@ bool LaserFromPointCloud::acquireDataFromHW()
     {
         left_theta += 360;
         left_elem_neg = 1;
+    } else if (left_theta > 360) {
+        left_theta -= 360;
     }
-    else if (left_theta > 360) left_theta -= 360;
     size_t left_elem = left_theta / m_resolution;
 
     if (right_theta < 0)
     {
         right_theta += 360;
         right_elem_neg = 1;
+    } else if (right_theta > 360) {
+        right_theta -= 360;
     }
-    else if (right_theta > 360) right_theta -= 360;
     size_t right_elem = right_theta / m_resolution;
 
     //enter critical section and protect m_laser_data
@@ -517,8 +523,11 @@ bool LaserFromPointCloud::acquireDataFromHW()
 
             //compute the right element of the vector where to put distance data. This is done by clusterizing angles, depending on the laser resolution.
             theta = theta * 180 / M_PI;
-            if (theta < 0)   theta += 360;
-            else if (theta > 360) theta -= 360;
+            if (theta < 0) {
+                theta += 360;
+            } else if (theta > 360) {
+                theta -= 360;
+            }
             size_t elem = theta / m_resolution;
             if (elem >= m_laser_data.size())
             {

--- a/src/devices/laserFromRosTopic/LaserFromRosTopic.cpp
+++ b/src/devices/laserFromRosTopic/LaserFromRosTopic.cpp
@@ -66,8 +66,9 @@ yarpdev --device Rangefinder2DWrapper --subdevice laserFromRosTopic \
 double constrainAngle(double x)
 {
     x = fmod(x, 360);
-    if (x < 0)
+    if (x < 0) {
         x += 360;
+    }
     return x;
 }
 
@@ -137,8 +138,9 @@ bool LaserFromRosTopic::open(yarp::os::Searchable& config)
         yarp::os::Bottle* portlist = general_config.find("input_topics_name").asList();
         if (portlist)
         {
-            for (size_t i = 0; i < portlist->size(); i++)
+            for (size_t i = 0; i < portlist->size(); i++) {
                 m_port_names.push_back(portlist->get(i).asString());
+            }
         }
         else
         {
@@ -168,15 +170,21 @@ bool LaserFromRosTopic::open(yarp::os::Searchable& config)
     m_empty_laser_data = m_laser_data;
     if (m_base_type == base_enum::BASE_IS_INF)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = std::numeric_limits<double>::infinity();
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = std::numeric_limits<double>::infinity();
+        }
     }
     else if (m_base_type == base_enum::BASE_IS_NAN)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = std::nanf("");
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = std::nanf("");
+        }
     }
     else if (m_base_type == base_enum::BASE_IS_ZERO)
     {
-        for (size_t i = 0; i < m_empty_laser_data.size(); i++) m_empty_laser_data[i] = 0;
+        for (size_t i = 0; i < m_empty_laser_data.size(); i++) {
+            m_empty_laser_data[i] = 0;
+        }
     }
     else
     {
@@ -425,7 +433,9 @@ bool LaserFromRosTopic::acquireDataFromHW()
             m_max_distance = m_last_scan_data[0].range_max;
             m_min_distance = m_last_scan_data[0].range_min;
             m_resolution = received_scans / (m_max_angle - m_min_angle);
-            if (m_laser_data.size() != m_sensorsNum) m_laser_data.resize(m_sensorsNum);
+            if (m_laser_data.size() != m_sensorsNum) {
+                m_laser_data.resize(m_sensorsNum);
+            }
         }
 
         if (m_iTc == nullptr)

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -185,21 +185,37 @@ bool laserHokuyo::open(yarp::os::Searchable& config)
     //parsing the answer
     size_t found;
     found = ans.find("MODL");
-    if (found!=string::npos) sensor_properties.MODL = string(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.MODL = string(ans.c_str() + found + 5);
+    }
     found = ans.find("DMIN");
-    if (found!=string::npos) sensor_properties.DMIN = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.DMIN = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("DMAX");
-    if (found!=string::npos) sensor_properties.DMAX = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.DMAX = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("ARES");
-    if (found!=string::npos) sensor_properties.ARES = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.ARES = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("AMIN");
-    if (found!=string::npos) sensor_properties.AMIN = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.AMIN = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("AMAX");
-    if (found!=string::npos) sensor_properties.AMAX = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.AMAX = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("AFRT");
-    if (found!=string::npos) sensor_properties.AFRT = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.AFRT = atoi(ans.c_str() + found + 5);
+    }
     found = ans.find("SCAN");
-    if (found!=string::npos) sensor_properties.SCAN = atoi(ans.c_str()+found+5);
+    if (found != string::npos) {
+        sensor_properties.SCAN = atoi(ans.c_str() + found + 5);
+    }
     b.clear();
     b_ans.clear();
 
@@ -440,9 +456,9 @@ int laserHokuyo::readData(const Laser_mode_type laser_mode, const char* text_dat
             {
                 yCTrace(LASERHOKUYO, "Invalid answer to a MD command: %s", text_data);
                 return HOKUYO_STATUS_ERROR_INVALID_COMMAND;
-            }
-            else
-                return  HOKUYO_STATUS_OK;
+        } else {
+            return HOKUYO_STATUS_OK;
+        }
     }
 
     // check in the second line if the status of the sensor is ok
@@ -453,9 +469,9 @@ int laserHokuyo::readData(const Laser_mode_type laser_mode, const char* text_dat
             {
                 yCTrace(LASERHOKUYO, "Invalid sensor status: %s", text_data);
                 return HOKUYO_STATUS_ERROR_BUSY;
-            }
-            else
-                return HOKUYO_STATUS_OK;
+        } else {
+            return HOKUYO_STATUS_OK;
+        }
     }
 
     // verify the checksum for all the following lines
@@ -523,7 +539,9 @@ void laserHokuyo::run()
             rx_completed = true;
         }
         t2 = yarp::os::SystemClock::nowSystem();
-        if (t2-t1>maxtime) timeout = true;
+        if (t2 - t1 > maxtime) {
+            timeout = true;
+        }
     }
     while (rx_completed == false && timeout == false && error == false);
 

--- a/src/devices/localization2DClient/Localization2DClient.cpp
+++ b/src/devices/localization2DClient/Localization2DClient.cpp
@@ -245,7 +245,9 @@ bool  Localization2DClient::getCurrentPosition(Map2DLocation& loc, yarp::sig::Ma
             loc.y = resp.get(3).asFloat64();
             loc.theta = resp.get(4).asFloat64();
             Bottle* mc = resp.get(5).asList();
-            if (mc == nullptr) return false;
+            if (mc == nullptr) {
+                return false;
+            }
             for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { cov[i][j] = mc->get(i*3+j).asFloat64(); } }
             return true;
         }

--- a/src/devices/localization2DServer/Localization2DServer.cpp
+++ b/src/devices/localization2DServer/Localization2DServer.cpp
@@ -324,7 +324,9 @@ bool Localization2DServer::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     reply.clear();
 
@@ -571,11 +573,18 @@ void Localization2DServer::run()
         }
     }
 
-    if (1) publish_odometry_on_yarp_port();
-    if (1) publish_2DLocation_on_yarp_port();
-    if (m_ros_publish_odometry_on_topic) publish_odometry_on_ROS_topic();
-    if (m_ros_publish_odometry_on_tf) publish_odometry_on_TF_topic();
-
+    if (1) {
+        publish_odometry_on_yarp_port();
+    }
+    if (1) {
+        publish_2DLocation_on_yarp_port();
+    }
+    if (m_ros_publish_odometry_on_topic) {
+        publish_odometry_on_ROS_topic();
+    }
+    if (m_ros_publish_odometry_on_tf) {
+        publish_odometry_on_TF_topic();
+    }
 }
 
 void Localization2DServer::publish_odometry_on_yarp_port()

--- a/src/devices/localization2DServer/Localization2D_nws_ros.cpp
+++ b/src/devices/localization2DServer/Localization2D_nws_ros.cpp
@@ -261,7 +261,9 @@ bool Localization2D_nws_ros::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     reply.clear();
 
@@ -326,9 +328,12 @@ void Localization2D_nws_ros::run()
         yCWarning(LOCALIZATION2D_NWS_ROS, "The system is not properly localized!");
     }
 
-    if (m_enable_publish_odometry_topic) publish_odometry_on_ROS_topic();
-    if (m_enable_publish_odometry_tf)    publish_odometry_on_TF_topic();
-
+    if (m_enable_publish_odometry_topic) {
+        publish_odometry_on_ROS_topic();
+    }
+    if (m_enable_publish_odometry_tf) {
+        publish_odometry_on_TF_topic();
+    }
 }
 
 void Localization2D_nws_ros::publish_odometry_on_TF_topic()

--- a/src/devices/localization2DServer/Localization2D_nws_yarp.cpp
+++ b/src/devices/localization2DServer/Localization2D_nws_yarp.cpp
@@ -237,7 +237,9 @@ bool Localization2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     reply.clear();
 
@@ -481,8 +483,12 @@ void Localization2D_nws_yarp::run()
         }
     }
 
-    if (m_enable_publish_odometry) publish_odometry_on_yarp_port();
-    if (m_enable_publish_location) publish_2DLocation_on_yarp_port();
+    if (m_enable_publish_odometry) {
+        publish_odometry_on_yarp_port();
+    }
+    if (m_enable_publish_location) {
+        publish_2DLocation_on_yarp_port();
+    }
 }
 
 void Localization2D_nws_yarp::publish_odometry_on_yarp_port()

--- a/src/devices/map2DServer/Map2DServer.cpp
+++ b/src/devices/map2DServer/Map2DServer.cpp
@@ -790,7 +790,9 @@ bool Map2DServer::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     //parse string command
     if(in.get(0).isString())
@@ -859,7 +861,9 @@ bool Map2DServer::loadMaps(std::string mapsfile)
         std::getline(file, buffer);
         std::istringstream iss(buffer);
         iss >> dummy;
-        if (dummy == "") break;
+        if (dummy == "") {
+            break;
+        }
         if (dummy == "mapfile:")
         {
             string mapfilename;
@@ -875,8 +879,9 @@ bool Map2DServer::loadMaps(std::string mapsfile)
                 auto p = m_maps_storage.find(map_name);
                 if (p == m_maps_storage.end())
                 {
-                    if (option == "crop")
-                        map.crop(-1,-1,-1,-1);
+                    if (option == "crop") {
+                        map.crop(-1, -1, -1, -1);
+                    }
                     m_maps_storage[map_name] = map;
                 }
                 else
@@ -1092,17 +1097,22 @@ bool Map2DServer::open(yarp::os::Searchable &config)
         yarp::sig::Vector vec=yarp::math::dcm2rpy(mat);
         double orig_angle = vec[2];
         map.setOrigin(map_ros->info.origin.position.x,map_ros->info.origin.position.y,orig_angle);
-        for (size_t y=0; y< map_ros->info.height; y++)
+        for (size_t y = 0; y < map_ros->info.height; y++) {
             for (size_t x=0; x< map_ros->info.width; x++)
             {
                XYCell cell(x,map_ros->info.height-1-y);
                double occ = map_ros->data[x+y*map_ros->info.width];
                map.setOccupancyData(cell,occ);
 
-               if      (occ >= 0   && occ <= 70)  map.setMapFlag(cell, MapGrid2D::MAP_CELL_FREE);
-               else if (occ >= 71 && occ <= 100)  map.setMapFlag(cell, MapGrid2D::MAP_CELL_WALL);
-               else                               map.setMapFlag(cell, MapGrid2D::MAP_CELL_UNKNOWN);
+               if (occ >= 0 && occ <= 70) {
+                   map.setMapFlag(cell, MapGrid2D::MAP_CELL_FREE);
+               } else if (occ >= 71 && occ <= 100) {
+                   map.setMapFlag(cell, MapGrid2D::MAP_CELL_WALL);
+               } else {
+                   map.setMapFlag(cell, MapGrid2D::MAP_CELL_UNKNOWN);
+               }
             }
+        }
         auto p = m_maps_storage.find(map_name);
         if (p == m_maps_storage.end())
         {
@@ -1146,7 +1156,9 @@ bool Map2DServer::priv_load_locations_and_areas_v1(std::ifstream& file)
     while (1)
     {
         std::getline(file, buffer);
-        if (buffer == "Areas:") break;
+        if (buffer == "Areas:") {
+            break;
+        }
         if (file.eof())
         {
             yCError(MAP2DSERVER) << "Unexpected End Of File";
@@ -1179,7 +1191,9 @@ bool Map2DServer::priv_load_locations_and_areas_v1(std::ifstream& file)
     {
         Map2DArea       area;
         std::getline(file, buffer);
-        if (file.eof()) break;
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);
@@ -1216,7 +1230,9 @@ bool Map2DServer::priv_load_locations_and_areas_v2(std::ifstream& file)
     while (1)
     {
         std::getline(file, buffer);
-        if (buffer == "Areas:") break;
+        if (buffer == "Areas:") {
+            break;
+        }
         if (file.eof())
         {
             yCError(MAP2DSERVER) << "Unexpected End Of File";
@@ -1249,8 +1265,12 @@ bool Map2DServer::priv_load_locations_and_areas_v2(std::ifstream& file)
     {
         Map2DArea       area;
         std::getline(file, buffer);
-        if (buffer == "Paths:") break;
-        if (file.eof()) break;
+        if (buffer == "Paths:") {
+            break;
+        }
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);
@@ -1282,7 +1302,9 @@ bool Map2DServer::priv_load_locations_and_areas_v2(std::ifstream& file)
     {
         Map2DPath       path;
         std::getline(file, buffer);
-        if (file.eof()) break;
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);

--- a/src/devices/map2DServer/Map2D_nws_ros.cpp
+++ b/src/devices/map2DServer/Map2D_nws_ros.cpp
@@ -62,7 +62,9 @@ bool Map2D_nws_ros::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     reply.clear();
 
@@ -232,12 +234,13 @@ bool Map2D_nws_ros::publishMapToRos(string map_name)
     ogrid.data.resize(current_map.width() * current_map.height());
     int index = 0;
     yarp::dev::Nav2D::XYCell cell;
-    for (cell.y = current_map.height(); cell.y-- > 0;)
+    for (cell.y = current_map.height(); cell.y-- > 0;) {
         for (cell.x = 0; cell.x < current_map.width(); cell.x++)
         {
             current_map.getOccupancyData(cell, tmp);
             ogrid.data[index++] = (int)tmp;
         }
+    }
 
     m_publisherPort_map.write();
 
@@ -280,9 +283,13 @@ bool Map2D_nws_ros::subscribeMapFromRos(string map_name)
                 double occ = map_ros->data[x + y * map_ros->info.width];
                 map.setOccupancyData(cell,occ);
 
-                if (occ >= 0 && occ <= 70)  map.setMapFlag(cell, MapGrid2D::MAP_CELL_FREE);
-                else if (occ >= 71 && occ <= 100)  map.setMapFlag(cell, MapGrid2D::MAP_CELL_WALL);
-                else                               map.setMapFlag(cell, MapGrid2D::MAP_CELL_UNKNOWN);
+                if (occ >= 0 && occ <= 70) {
+                    map.setMapFlag(cell, MapGrid2D::MAP_CELL_FREE);
+                } else if (occ >= 71 && occ <= 100) {
+                    map.setMapFlag(cell, MapGrid2D::MAP_CELL_WALL);
+                } else {
+                    map.setMapFlag(cell, MapGrid2D::MAP_CELL_UNKNOWN);
+                }
             }
         }
         if (m_iMap2D->store_map(map))

--- a/src/devices/map2DServer/Map2D_nws_yarp.cpp
+++ b/src/devices/map2DServer/Map2D_nws_yarp.cpp
@@ -706,7 +706,9 @@ bool Map2D_nws_yarp::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     //parse string command
     if(in.get(0).isString())

--- a/src/devices/map2DStorage/map2DStorage.cpp
+++ b/src/devices/map2DStorage/map2DStorage.cpp
@@ -90,7 +90,9 @@ bool Map2DStorage::loadMapsCollection(std::string mapsfile)
         std::getline(file, buffer);
         std::istringstream iss(buffer);
         iss >> dummy;
-        if (dummy == "") break;
+        if (dummy == "") {
+            break;
+        }
         if (dummy == "mapfile:")
         {
             string mapfilename;
@@ -108,8 +110,9 @@ bool Map2DStorage::loadMapsCollection(std::string mapsfile)
                 auto p = m_maps_storage.find(map_name);
                 if (p == m_maps_storage.end())
                 {
-                    if (option == "crop")
-                        map.crop(-1,-1,-1,-1);
+                    if (option == "crop") {
+                        map.crop(-1, -1, -1, -1);
+                    }
                     m_maps_storage[map_name] = map;
                 }
                 else
@@ -256,7 +259,9 @@ bool Map2DStorage::priv_load_locations_and_areas_v1(std::ifstream& file)
     while (1)
     {
         std::getline(file, buffer);
-        if (buffer == "Areas:") break;
+        if (buffer == "Areas:") {
+            break;
+        }
         if (file.eof())
         {
             yCError(MAP2DSTORAGE) << "Unexpected End Of File";
@@ -289,7 +294,9 @@ bool Map2DStorage::priv_load_locations_and_areas_v1(std::ifstream& file)
     {
         Map2DArea       area;
         std::getline(file, buffer);
-        if (file.eof()) break;
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);
@@ -326,7 +333,9 @@ bool Map2DStorage::priv_load_locations_and_areas_v2(std::ifstream& file)
     while (1)
     {
         std::getline(file, buffer);
-        if (buffer == "Areas:") break;
+        if (buffer == "Areas:") {
+            break;
+        }
         if (file.eof())
         {
             yCError(MAP2DSTORAGE) << "Unexpected End Of File";
@@ -359,8 +368,12 @@ bool Map2DStorage::priv_load_locations_and_areas_v2(std::ifstream& file)
     {
         Map2DArea       area;
         std::getline(file, buffer);
-        if (buffer == "Paths:") break;
-        if (file.eof()) break;
+        if (buffer == "Paths:") {
+            break;
+        }
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);
@@ -392,7 +405,9 @@ bool Map2DStorage::priv_load_locations_and_areas_v2(std::ifstream& file)
     {
         Map2DPath       path;
         std::getline(file, buffer);
-        if (file.eof()) break;
+        if (file.eof()) {
+            break;
+        }
 
         Bottle b;
         b.fromString(buffer);
@@ -836,7 +851,9 @@ bool Map2DStorage::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     //parse string command
     if (in.get(0).isString())

--- a/src/devices/multipleAnalogSensorsRosPublishers/IMURosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/IMURosPublisher.cpp
@@ -19,7 +19,9 @@ bool IMURosPublisher::viewInterfaces()
     ok &= m_poly->view(m_iThreeAxisLinearAccelerometers);
     ok &= m_poly->view(m_iThreeAxisMagnetometers);
     ok &= m_poly->view(m_iOrientationSensors);
-    if (m_iThreeAxisGyroscopes) m_iThreeAxisGyroscopes->getThreeAxisGyroscopeFrameName(m_sens_index, m_framename);
+    if (m_iThreeAxisGyroscopes) {
+        m_iThreeAxisGyroscopes->getThreeAxisGyroscopeFrameName(m_sens_index, m_framename);
+    }
     return ok;
 }
 

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -250,8 +250,9 @@ bool MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMeta
         return false;
     }
 
-    if (!m_externalConnection)
+    if (!m_externalConnection) {
         assert(metadataVector.size() == measurementsVector.measurements.size());
+    }
 
     timestamp = measurementsVector.measurements[sens_index].timestamp;
     out = measurementsVector.measurements[sens_index].measurement;

--- a/src/devices/navigation2DClient/Navigation2DClient.cpp
+++ b/src/devices/navigation2DClient/Navigation2DClient.cpp
@@ -328,8 +328,9 @@ bool Navigation2DClient::parse_respond_string(const yarp::os::Bottle& command, y
                 yarp::sig::Matrix cov(3,3);
                 for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { cov[i][j] = b->get(i * 3 + j).asFloat64(); } }
                 ret = this->setInitialPose(init_loc, cov);
+            } else {
+                ret = false;
             }
-            else ret = false;
         }
 
         if (ret)
@@ -439,8 +440,9 @@ bool Navigation2DClient::parse_respond_string(const yarp::os::Bottle& command, y
     else if (command.get(0).asString() == "pause_nav")
     {
         double time = -1;
-        if (command.size() > 1)
+        if (command.size() > 1) {
             time = command.get(1).asFloat64();
+        }
         this->suspendNavigation(time);
         reply.addString("Pausing.");
     }
@@ -467,7 +469,9 @@ bool Navigation2DClient::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     reply.clear();
 
     if (command.get(0).isString())
@@ -850,7 +854,9 @@ bool  Navigation2DClient::getCurrentPosition(Map2DLocation& loc, yarp::sig::Matr
             loc.y = resp.get(3).asFloat64();
             loc.theta = resp.get(4).asFloat64();
             Bottle* mc = resp.get(5).asList();
-            if (mc == nullptr) return false;
+            if (mc == nullptr) {
+                return false;
+            }
             for (size_t i = 0; i < 3; i++) { for (size_t j = 0; j < 3; j++) { cov[i][j] = mc->get(i * 3 + j).asFloat64(); } }
             return true;
         }

--- a/src/devices/navigation2DServer/navigation2DServer.cpp
+++ b/src/devices/navigation2DServer/navigation2DServer.cpp
@@ -493,7 +493,9 @@ bool navigation2DServer::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle command;
     yarp::os::Bottle reply;
     bool ok = command.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     reply.clear();
 
     //^^^^^^^^^^^^^^^^^ STRING SECTION
@@ -542,16 +544,27 @@ void navigation2DServer::run()
 
 std::string navigation2DServer::getStatusAsString(NavigationStatusEnum status)
 {
-    if (status == navigation_status_idle) return std::string("navigation_status_idle");
-    else if (status == navigation_status_moving) return std::string("navigation_status_moving");
-    else if (status == navigation_status_waiting_obstacle) return std::string("navigation_status_waiting_obstacle");
-    else if (status == navigation_status_goal_reached) return std::string("navigation_status_goal_reached");
-    else if (status == navigation_status_aborted) return std::string("navigation_status_aborted");
-    else if (status == navigation_status_failing) return std::string("navigation_status_failing");
-    else if (status == navigation_status_paused) return std::string("navigation_status_paused");
-    else if (status == navigation_status_preparing_before_move) return std::string("navigation_status_preparing_before_move");
-    else if (status == navigation_status_thinking) return std::string("navigation_status_thinking");
-    else if (status == navigation_status_error) return std::string("navigation_status_error");
+    if (status == navigation_status_idle) {
+        return std::string("navigation_status_idle");
+    } else if (status == navigation_status_moving) {
+        return std::string("navigation_status_moving");
+    } else if (status == navigation_status_waiting_obstacle) {
+        return std::string("navigation_status_waiting_obstacle");
+    } else if (status == navigation_status_goal_reached) {
+        return std::string("navigation_status_goal_reached");
+    } else if (status == navigation_status_aborted) {
+        return std::string("navigation_status_aborted");
+    } else if (status == navigation_status_failing) {
+        return std::string("navigation_status_failing");
+    } else if (status == navigation_status_paused) {
+        return std::string("navigation_status_paused");
+    } else if (status == navigation_status_preparing_before_move) {
+        return std::string("navigation_status_preparing_before_move");
+    } else if (status == navigation_status_thinking) {
+        return std::string("navigation_status_thinking");
+    } else if (status == navigation_status_error) {
+        return std::string("navigation_status_error");
+    }
     return std::string("navigation_status_error");
 }
 

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -100,9 +100,15 @@ bool OpenCVGrabber::open(Searchable & config) {
             m_cap.set(cv::VideoCaptureProperties::CAP_PROP_FPS, m_fps);
         }
 
-        if (config.check("flip_x", "if present, flip the image along the x-axis"))         m_flip_x = true;
-        if (config.check("flip_y", "if present, flip the image along the y-axis"))         m_flip_y = true;
-        if (config.check("transpose", "if present, rotate the image along of 90 degrees")) m_transpose = true;
+        if (config.check("flip_x", "if present, flip the image along the x-axis")) {
+            m_flip_x = true;
+        }
+        if (config.check("flip_y", "if present, flip the image along the y-axis")) {
+            m_flip_y = true;
+        }
+        if (config.check("transpose", "if present, rotate the image along of 90 degrees")) {
+            m_transpose = true;
+        }
     }
 
 
@@ -224,7 +230,9 @@ bool OpenCVGrabber::getImage(ImageOf<PixelRgb> & image) {
 
     if (frame.empty() && m_loop) {
         bool ok = open(m_config);
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
         m_cap.read(frame);
     }
 

--- a/src/devices/portaudio/PortAudioDeviceDriver.cpp
+++ b/src/devices/portaudio/PortAudioDeviceDriver.cpp
@@ -99,7 +99,9 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesToCalc; i++ )
             {
                 recdata->write(0); // left
-                if(num_rec_channels == 2 ) recdata->write(0);  // right
+                if (num_rec_channels == 2) {
+                    recdata->write(0); // right
+                }
             }
         }
         else
@@ -108,7 +110,9 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesToCalc; i++ )
             {
                 recdata->write(*rptr++);  // left
-                if(num_rec_channels == 2 ) recdata->write(*rptr++);  // right
+                if (num_rec_channels == 2) {
+                    recdata->write(*rptr++); // right
+                }
             }
         }
         //note: you can record or play but not simultaneously (for now)
@@ -133,13 +137,19 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesLeft/ num_play_channels; i++ )
             {
                 *wptr++ = playdata->read();  // left
-                if( num_play_channels == 2 ) *wptr++ = playdata->read();  // right
-                for (int chs=2; chs<num_play_channels; chs++) playdata->read(); //remove all additional channels > 2
+                if (num_play_channels == 2) {
+                    *wptr++ = playdata->read(); // right
+                }
+                for (int chs = 2; chs < num_play_channels; chs++) {
+                    playdata->read(); //remove all additional channels > 2
+                }
             }
             for( ; i<framesPerBuffer; i++ )
             {
                 *wptr++ = 0;  // left
-                if(num_play_channels == 2 ) *wptr++ = 0;  // right
+                if (num_play_channels == 2) {
+                    *wptr++ = 0; // right
+                }
             }
 #ifdef STOP_PLAY_ON_EMPTY_BUFFER
             //if we return paComplete, then the callback is not called anymore.
@@ -158,8 +168,12 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesPerBuffer; i++ )
             {
                 *wptr++ = playdata->read();  // left
-                if( num_play_channels == 2 ) *wptr++ = playdata->read();  // right
-                for (int chs=2; chs<num_play_channels; chs++) playdata->read(); //remove all additional channels > 2
+                if (num_play_channels == 2) {
+                    *wptr++ = playdata->read(); // right
+                }
+                for (int chs = 2; chs < num_play_channels; chs++) {
+                    playdata->read(); //remove all additional channels > 2
+                }
             }
             //if we return paContinue, then the callback will be invoked again later
             //method Pa_IsStreamActive() will return 0
@@ -240,18 +254,25 @@ bool PortAudioDeviceDriver::open(PortAudioDeviceDriverSettings& config)
     bool wantWrite = config.wantWrite;
     int deviceNumber = config.deviceNumber;
 
-    if (playChannels==0) playChannels = DEFAULT_NUM_CHANNELS;
-    if (recChannels == 0) recChannels = DEFAULT_NUM_CHANNELS;
+    if (playChannels == 0) {
+        playChannels = DEFAULT_NUM_CHANNELS;
+    }
+    if (recChannels == 0) {
+        recChannels = DEFAULT_NUM_CHANNELS;
+    }
     m_numPlaybackChannels = playChannels;
     m_numRecordChannels = recChannels;
 
-    if (rate==0) rate = DEFAULT_SAMPLE_RATE;
+    if (rate == 0) {
+        rate = DEFAULT_SAMPLE_RATE;
+    }
     m_frequency = rate;
 
-    if (samples==0)
+    if (samples == 0) {
         numSamples = m_frequency; //  by default let's stream chunks of 1 second
-    else
+    } else {
         numSamples = samples;
+    }
 
 //     size_t numPlayBytes = numSamples * sizeof(SAMPLE) * m_numPlaybackChannels;
 //     size_t numRecBytes = numSamples * sizeof(SAMPLE) * m_numRecordChannels;
@@ -260,12 +281,18 @@ bool PortAudioDeviceDriver::open(PortAudioDeviceDriverSettings& config)
     AudioBufferSize rec_buffer_size (numSamples, m_numRecordChannels, sizeof(SAMPLE));
     dataBuffers.numPlayChannels = m_numPlaybackChannels;
     dataBuffers.numRecChannels = m_numRecordChannels;
-    if (dataBuffers.playData==nullptr)
+    if (dataBuffers.playData == nullptr) {
         dataBuffers.playData = new CircularAudioBuffer_16t("portatudio_play", playback_buffer_size);
-    if (dataBuffers.recData==nullptr)
+    }
+    if (dataBuffers.recData == nullptr) {
         dataBuffers.recData = new CircularAudioBuffer_16t("portatudio_rec", rec_buffer_size);
-    if (wantRead) dataBuffers.canRec = true;
-    if (wantWrite) dataBuffers.canPlay = true;
+    }
+    if (wantRead) {
+        dataBuffers.canRec = true;
+    }
+    if (wantWrite) {
+        dataBuffers.canPlay = true;
+    }
 
     err = Pa_Initialize();
     if( err != paNoError )
@@ -424,12 +451,13 @@ bool PortAudioDeviceDriver::getSound(yarp::sig::Sound& sound, size_t min_number_
     }
     sound.setFrequency(this->m_frequency);
 
-    for (size_t i=0; i<this->numSamples; i++)
+    for (size_t i = 0; i < this->numSamples; i++) {
         for (size_t j=0; j<this->m_numRecordChannels; j++)
         {
             SAMPLE s = dataBuffers.recData->read();
             sound.set(s,i,j);
         }
+    }
     return true;
 }
 
@@ -527,9 +555,11 @@ bool PortAudioDeviceDriver::immediateSound(const yarp::sig::Sound& sound)
     size_t num_channels = sound.getChannels();
     size_t num_samples = sound.getSamples();
 
-    for (size_t i=0; i<num_samples; i++)
-        for (size_t j=0; j<num_channels; j++)
-            dataBuffers.playData->write (sound.get(i,j));
+    for (size_t i = 0; i < num_samples; i++) {
+        for (size_t j = 0; j < num_channels; j++) {
+            dataBuffers.playData->write(sound.get(i, j));
+        }
+    }
 
     pThread.something_to_play = true;
     return true;
@@ -563,10 +593,11 @@ bool PortAudioDeviceDriver::renderSound(const yarp::sig::Sound& sound)
         }
     }
 
-    if (renderMode == RENDER_IMMEDIATE)
+    if (renderMode == RENDER_IMMEDIATE) {
         return immediateSound(sound);
-    else if (renderMode == RENDER_APPEND)
+    } else if (renderMode == RENDER_APPEND) {
         return appendSound(sound);
+    }
 
     return false;
 }
@@ -577,9 +608,11 @@ bool PortAudioDeviceDriver::appendSound(const yarp::sig::Sound& sound)
     size_t num_channels = sound.getChannels();
     size_t num_samples = sound.getSamples();
 
-    for (size_t i=0; i<num_samples; i++)
-        for (size_t j=0; j<num_channels; j++)
-            dataBuffers.playData->write (sound.get(i,j));
+    for (size_t i = 0; i < num_samples; i++) {
+        for (size_t j = 0; j < num_channels; j++) {
+            dataBuffers.playData->write(sound.get(i, j));
+        }
+    }
 
     pThread.something_to_play = true;
     return true;

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
@@ -79,13 +79,19 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesLeft/ num_play_channels; i++ )
             {
                 *wptr++ = playdata->read();  // left
-                if( num_play_channels == 2 ) *wptr++ = playdata->read();  // right
-                for (size_t chs=2; chs<num_play_channels; chs++) playdata->read(); //remove all additional channels > 2
+                if (num_play_channels == 2) {
+                    *wptr++ = playdata->read(); // right
+                }
+                for (size_t chs = 2; chs < num_play_channels; chs++) {
+                    playdata->read(); //remove all additional channels > 2
+                }
             }
             for( ; i<framesPerBuffer; i++ )
             {
                 *wptr++ = 0;  // left
-                if(num_play_channels == 2 ) *wptr++ = 0;  // right
+                if (num_play_channels == 2) {
+                    *wptr++ = 0; // right
+                }
             }
 #ifdef STOP_PLAY_ON_EMPTY_BUFFER
             //if we return paComplete, then the callback is not called anymore.
@@ -104,8 +110,12 @@ static int bufferIOCallback( const void *inputBuffer, void *outputBuffer,
             for( i=0; i<framesPerBuffer; i++ )
             {
                 *wptr++ = playdata->read();  // left
-                if( num_play_channels == 2 ) *wptr++ = playdata->read();  // right
-                for (size_t chs=2; chs<num_play_channels; chs++) playdata->read(); //remove all additional channels > 2
+                if (num_play_channels == 2) {
+                    *wptr++ = playdata->read(); // right
+                }
+                for (size_t chs = 2; chs < num_play_channels; chs++) {
+                    playdata->read(); //remove all additional channels > 2
+                }
             }
             //if we return paContinue, then the callback will be invoked again later
             //method Pa_IsStreamActive() will return 0
@@ -197,8 +207,9 @@ bool PortAudioPlayerDeviceDriver::interruptDeviceAndClose()
 bool PortAudioPlayerDeviceDriver::configureDeviceAndStart()
 {
     AudioBufferSize playback_buffer_size(m_audioplayer_cfg.numSamples, m_audioplayer_cfg.numChannels, m_audioplayer_cfg.bytesPerSample);
-    if (m_outputBuffer == nullptr)
+    if (m_outputBuffer == nullptr) {
         m_outputBuffer = new CircularAudioBuffer_16t("portatudio_play", playback_buffer_size);
+    }
 
     m_err = Pa_Initialize();
     if (m_err != paNoError)
@@ -251,7 +262,9 @@ bool PortAudioPlayerDeviceDriver::open(yarp::os::Searchable& config)
 
     m_device_id = config.check("id", Value(-1), "which portaudio index to use (-1=automatic)").asInt32();
     m_driver_frame_size = config.check("driver_frame_size", Value(0), "").asInt32();
-    if (m_driver_frame_size == 0)  m_driver_frame_size = DEFAULT_FRAMES_PER_BUFFER;
+    if (m_driver_frame_size == 0) {
+        m_driver_frame_size = DEFAULT_FRAMES_PER_BUFFER;
+    }
 
     b = configureDeviceAndStart();
     return (m_err==paNoError);
@@ -303,7 +316,9 @@ void PortAudioPlayerDeviceDriver::waitUntilPlaybackStreamIsComplete()
     {
         yarp::os::Time::delay(SLEEP_TIME);
         size_t tmp = m_outputBuffer->size().getSamples();
-        if (tmp == 0) break;
+        if (tmp == 0) {
+            break;
+        }
     }
 }
 

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
@@ -146,7 +146,9 @@ bool PortAudioRecorderDeviceDriver::open(yarp::os::Searchable& config)
 
     m_device_id = config.check("id", Value(-1), "which portaudio index to use (-1=automatic)").asInt32();
     m_driver_frame_size = config.check("driver_frame_size", Value(0), "").asInt32();
-    if (m_driver_frame_size == 0)  m_driver_frame_size = DEFAULT_FRAMES_PER_BUFFER;
+    if (m_driver_frame_size == 0) {
+        m_driver_frame_size = DEFAULT_FRAMES_PER_BUFFER;
+    }
 
     m_err = Pa_Initialize();
     if(m_err != paNoError )

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -200,8 +200,9 @@ bool RpLidar::close()
         HW_reset();
     }
 
-    if(driver.isValid())
+    if (driver.isValid()) {
         driver.close();
+    }
 
     yCInfo(RPLIDAR) << "rpLidar closed";
     return true;
@@ -625,7 +626,9 @@ void RpLidar::run()
         double distance = i_distance / 4.0 / 1000; //m
         double angle = i_angle / 64.0; //deg
         angle = (360 - angle) + 90;
-        if (angle >= 360) angle -= 360;
+        if (angle >= 360) {
+            angle -= 360;
+        }
 
         if (i_distance == 0)
         {
@@ -643,8 +646,9 @@ void RpLidar::run()
 
         if (clip_min_enable)
         {
-            if (distance < min_distance)
+            if (distance < min_distance) {
                 distance = max_distance;
+            }
         }
         if (clip_max_enable)
         {

--- a/src/devices/rpLidar/rpLidar.h
+++ b/src/devices/rpLidar/rpLidar.h
@@ -69,7 +69,9 @@ public:
     {
         for (int i = 0; i < size; i++)
         {
-            if (write_elem(elems[i]) == false) return false;
+            if (write_elem(elems[i]) == false) {
+                return false;
+            }
         }
         return true;
     }
@@ -77,12 +79,13 @@ public:
     inline int size()
     {
         int i;
-        if (end>start)
+        if (end > start) {
             i = end - start;
-        else if (end == start)
+        } else if (end == start) {
             i = 0;
-        else
+        } else {
             i = maxsize - start + end;
+        }
         return i;
     }
 
@@ -125,7 +128,9 @@ public:
     {
         for (int i = 0; i < size; i++)
         {
-            if (read_elem(&elems[i]) == false) return false;
+            if (read_elem(&elems[i]) == false) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/devices/serialport/SerialDeviceDriver.cpp
+++ b/src/devices/serialport/SerialDeviceDriver.cpp
@@ -88,11 +88,13 @@ bool SerialDeviceDriver::open(yarp::os::Searchable& config) {
     config2.SerialParams.databits = config.check("databits",Value(7),"Data bits. Valid values 5, 6, 7 and 8 data bits. Additionally Win32 supports 4 data bits.").asInt32();
     config2.SerialParams.stopbits = config.check("stopbits",Value(1),"Stop bits. Valid values are 1 and 2.").asInt32();
 
-    if (config.check("line_terminator_char1", "line terminator character for receiveLine(), default '\r'"))
+    if (config.check("line_terminator_char1", "line terminator character for receiveLine(), default '\r'")) {
         line_terminator_char1 = config.find("line_terminator_char1").asInt32();
+    }
 
-    if (config.check("line_terminator_char2", "line terminator character for receiveLine(), default '\n'"))
+    if (config.check("line_terminator_char2", "line terminator character for receiveLine(), default '\n'")) {
         line_terminator_char2 = config.find("line_terminator_char2").asInt32();
+    }
 
     return open(config2);
 }
@@ -105,10 +107,14 @@ bool SerialDeviceDriver::close() {
 bool SerialDeviceDriver::setDTR(bool value) {
     ACE_TTY_IO::Serial_Params arg;
     int ret = _serial_dev.control(_serial_dev.GETPARAMS, &arg);
-    if (ret == -1) return false;
+    if (ret == -1) {
+        return false;
+    }
     arg.dtrdisable = !value;
     ret = _serial_dev.control(_serial_dev.SETPARAMS, &arg);
-    if (ret == -1) return false;
+    if (ret == -1) {
+        return false;
+    }
     return true;
 }
 
@@ -136,13 +142,17 @@ bool SerialDeviceDriver::send(const Bottle& msg)
         }
         else
         {
-           if (verbose) yCDebug(SERIALPORT, "The input command bottle contains an empty string.");
+            if (verbose) {
+                yCDebug(SERIALPORT, "The input command bottle contains an empty string.");
+            }
            return false;
         }
     }
     else
     {
-        if (verbose) yCDebug(SERIALPORT, "The input command bottle is empty. \n");
+        if (verbose) {
+            yCDebug(SERIALPORT, "The input command bottle is empty. \n");
+        }
         return false;
     }
 
@@ -169,7 +179,9 @@ bool SerialDeviceDriver::send(char *msg, size_t size)
     }
     else
     {
-        if (verbose) yCDebug(SERIALPORT, "The input message is empty. \n");
+        if (verbose) {
+            yCDebug(SERIALPORT, "The input message is empty. \n");
+        }
         return false;
     }
 
@@ -207,7 +219,9 @@ int  SerialDeviceDriver::flush()
     {
         bytes_read = _serial_dev.recv((void *) &chr, 100);
         count+=bytes_read;
-        if (count > MAX_FLUSHED_BYTES) break; //to prevent endless loop
+        if (count > MAX_FLUSHED_BYTES) {
+            break; //to prevent endless loop
+        }
     }
     while (bytes_read>0);
     return count;
@@ -276,8 +290,9 @@ bool SerialDeviceDriver::receive(Bottle& msg)
         return false;
     }
 
-    if (bytes_read == 0)  //nothing there
+    if (bytes_read == 0) { //nothing there
         return true;
+    }
 
     message[bytes_read] = 0;
 

--- a/src/devices/transformClient/transformClient.cpp
+++ b/src/devices/transformClient/transformClient.cpp
@@ -38,10 +38,12 @@ void Transforms_client_storage::onRead(yarp::os::Bottle &b)
     {
         double tmpDT = m_now - m_prev;
         m_deltaT += tmpDT;
-        if (tmpDT>m_deltaTMax)
+        if (tmpDT > m_deltaTMax) {
             m_deltaTMax = tmpDT;
-        if (tmpDT<m_deltaTMin)
+        }
+        if (tmpDT < m_deltaTMin) {
             m_deltaTMin = tmpDT;
+        }
 
         //compare network time
         /*if (tmpDT*1000<TRANSFORM_TIMEOUT)
@@ -189,7 +191,9 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     std::string request = in.get(0).asString();
     if (request == "help")
@@ -275,7 +279,9 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
         std::string format = "matrix";
         if (in.size() > 4)
             {format= in.get(4).asString();}
-        if (port_name[0]=='/')  port_name.erase(port_name.begin());
+        if (port_name[0] == '/') {
+            port_name.erase(port_name.begin());
+        }
         std::string full_port_name = m_local_name + "/" + port_name;
         bool ret = true;
         for (auto& m_array_of_port : m_array_of_ports)
@@ -307,7 +313,9 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
             {
                 out.addString("Operation complete. Port " + full_port_name + " opened.");
                 m_array_of_ports.push_back(b);
-                if (m_array_of_ports.size()==1) this->start();
+                if (m_array_of_ports.size() == 1) {
+                    this->start();
+                }
             }
             else
             {
@@ -329,14 +337,18 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
             m_array_of_port=nullptr;
         }
         m_array_of_ports.clear();
-        if (m_array_of_ports.size()==0) this->askToStop();
+        if (m_array_of_ports.size() == 0) {
+            this->askToStop();
+        }
         out.addString("Operation complete");
     }
     else if (request == "unpublish_transform")
     {
         bool ret = false;
         std::string port_name = in.get(1).asString();
-        if (port_name[0]=='/')  port_name.erase(port_name.begin());
+        if (port_name[0] == '/') {
+            port_name.erase(port_name.begin());
+        }
         std::string full_port_name = m_local_name + "/" + port_name;
         for (auto it = m_array_of_ports.begin(); it != m_array_of_ports.end(); it++)
         {
@@ -358,7 +370,9 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
         {
             out.addString("Port " + full_port_name + " was not found.");
         }
-        if (m_array_of_ports.size()==0) this->askToStop();
+        if (m_array_of_ports.size() == 0) {
+            this->askToStop();
+        }
     }
     else
     {
@@ -575,7 +589,9 @@ bool TransformClient::getAllFrameIds(std::vector< std::string > &ids)
         {
             if (((*m_transform_storage)[i].src_frame_id) == id) { found = true; break; }
         }
-        if (found == false) ids.push_back((*m_transform_storage)[i].src_frame_id);
+        if (found == false) {
+            ids.push_back((*m_transform_storage)[i].src_frame_id);
+        }
     }
 
     for (size_t i = 0; i < m_transform_storage->size(); i++)
@@ -585,7 +601,9 @@ bool TransformClient::getAllFrameIds(std::vector< std::string > &ids)
         {
             if (((*m_transform_storage)[i].dst_frame_id) == id) { found = true; break; }
         }
-        if (found == false) ids.push_back((*m_transform_storage)[i].dst_frame_id);
+        if (found == false) {
+            ids.push_back((*m_transform_storage)[i].dst_frame_id);
+        }
     }
 
     return true;
@@ -955,10 +973,14 @@ void     TransformClient::run()
 bool     TransformClient::isConnectedWithServer()
 {
     bool ok1 = Network::isConnected(m_local_rpcServer.c_str(), m_remote_rpc.c_str());
-    if (!ok1) yCInfo(TRANSFORMCLIENT) << m_local_rpcServer << "is not connected to: " << m_remote_rpc;
+    if (!ok1) {
+        yCInfo(TRANSFORMCLIENT) << m_local_rpcServer << "is not connected to: " << m_remote_rpc;
+    }
 
     bool ok2 = Network::isConnected(m_remote_streaming_name.c_str(), m_local_streaming_name.c_str(),m_streaming_connection_type.c_str());
-    if (!ok2) yCInfo(TRANSFORMCLIENT) << m_remote_streaming_name << "is not connected to: " << m_local_streaming_name;
+    if (!ok2) {
+        yCInfo(TRANSFORMCLIENT) << m_remote_streaming_name << "is not connected to: " << m_local_streaming_name;
+    }
 
     return ok1 && ok2;
 }

--- a/src/devices/transformServer/transformServer.cpp
+++ b/src/devices/transformServer/transformServer.cpp
@@ -332,7 +332,9 @@ bool TransformServer::read(yarp::os::ConnectionReader& connection)
     yarp::os::Bottle in;
     yarp::os::Bottle out;
     bool ok = in.read(connection);
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     string request = in.get(0).asString();
 
@@ -480,9 +482,13 @@ bool TransformServer::read(yarp::os::ConnectionReader& connection)
     else if (request == "generate_view")
     {
         m_show_transforms_in_diagram  = show_transforms_in_diagram_t::do_not_show;
-        if      (in.get(1).asString() == "show_quaternion") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_quaternion;
-        else if (in.get(1).asString() == "show_matrix") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_matrix;
-        else if (in.get(1).asString() == "show_rpy") m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_rpy;
+        if (in.get(1).asString() == "show_quaternion") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_quaternion;
+        } else if (in.get(1).asString() == "show_matrix") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_matrix;
+        } else if (in.get(1).asString() == "show_rpy") {
+            m_show_transforms_in_diagram = show_transforms_in_diagram_t::show_rpy;
+        }
         generate_view();
         out.addString("ok");
     }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdClock.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdClock.cpp
@@ -116,9 +116,9 @@ int Companion::cmdClock(int argc, char *argv[])
                 std::fflush(stdout);
             }
             done = true;
-        }
-        else
+        } else {
             done = false;
+        }
 
         clock.delay(period);
     }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdDetect.cpp
@@ -57,7 +57,9 @@ int Companion::detectRos(bool write)
     yCError(COMPANION, "Trying ROS_MASTER_URI=%s...", uri.c_str());
     OutputProtocol *out = Carriers::connect(root);
     bool ok = (out != nullptr);
-    if (ok) delete out;
+    if (ok) {
+        delete out;
+    }
     if (!ok) {
         yCError(COMPANION, "Could not reach server.");
         return 1;
@@ -110,7 +112,9 @@ int Companion::cmdDetect(int argc, char *argv[])
     }
     OutputProtocol *out = Carriers::connect(addr);
     bool ok = (out != nullptr);
-    if (ok) delete out;
+    if (ok) {
+        delete out;
+    }
     if (ok) {
         yCInfo(COMPANION);
         yCInfo(COMPANION, "=========================================================");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdLatencyTest.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdLatencyTest.cpp
@@ -60,7 +60,9 @@ int Companion::cmdLatencyTest(int argc, char* argv[])
     }
 
     bool verbose = false;
-    if (p.check("details")) verbose=true;
+    if (p.check("details")) {
+        verbose = true;
+    }
 
     if (p.check("server"))
     {
@@ -81,12 +83,18 @@ int Companion::cmdLatencyTest(int argc, char* argv[])
         int frames = p.find("nframes").asInt32();
 
         double client_wait = 0;
-        if (p.check("client_wait")) client_wait = p.find("client_wait").asFloat64();
+        if (p.check("client_wait")) {
+            client_wait = p.find("client_wait").asFloat64();
+        }
 
         string logfilename = "log_";
-        if (p.check("logfile")) logfilename = p.find("logfile").asString();
+        if (p.check("logfile")) {
+            logfilename = p.find("logfile").asString();
+        }
 
-        if (p.check("protocol")) proto = p.find("protocol").asString();
+        if (p.check("protocol")) {
+            proto = p.find("protocol").asString();
+        }
 
         bool no_reply = p.check("no-reply");
 
@@ -116,7 +124,9 @@ int Companion::cmdLatencyTest(int argc, char* argv[])
                     for (size_t id=0 ; id<4; id++)
                     {
                         //yCInfo(COMPANION) << val;
-                        if (val>=min && val<=max) psizes.push_back(val);
+                        if (val >= min && val <= max) {
+                            psizes.push_back(val);
+                        }
                         val*=2;
                     }
                     val=val-val%(int(pow(10,pot)));
@@ -212,8 +222,11 @@ server_return_code_t server(double server_wait, bool verbose)
         {
             yCInfo(COMPANION, "Received: \"%s\"", b.toString().c_str());
         }
-        if      (b.get(0).asString() == "stop") break;
-        else if (b.get(0).asString() == "quit") return SERVER_QUIT;
+        if (b.get(0).asString() == "stop") {
+            break;
+        } else if (b.get(0).asString() == "quit") {
+            return SERVER_QUIT;
+        }
         double tt1 = yarp::os::Time::now();
         b.append(payloadbottle);
         double tt2 = yarp::os::Time::now();
@@ -235,7 +248,9 @@ server_return_code_t server(double server_wait, bool verbose)
         }
 
         //Give the CPU some idle time
-        if (server_wait > 0) Time::delay(server_wait);
+        if (server_wait > 0) {
+            Time::delay(server_wait);
+        }
         serverframecounter++;
     }
 
@@ -332,8 +347,12 @@ client_return_code_t client(int nframes, int payload_size, string proto, double 
         double latency_ms = (finaltime - time - copytime) * 1000;
         test_data[clientframecounter].latency = latency_ms;
         test_data[clientframecounter].copytime = copytime;
-        if (latency_ms>latency_max) latency_max = latency_ms;
-        if (latency_ms<latency_min) latency_min = latency_ms;
+        if (latency_ms > latency_max) {
+            latency_max = latency_ms;
+        }
+        if (latency_ms < latency_min) {
+            latency_min = latency_ms;
+        }
 
         if (verbose)
         {

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdMerge.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdMerge.cpp
@@ -119,7 +119,9 @@ int Companion::cmdMerge(int argc, char *argv[])
     yCInfo(COMPANION, "Ready. Output goes to %s", outPort.getName().c_str());
     while(true) {
         product.wait();
-        while (product.check()) product.wait();
+        while (product.check()) {
+            product.wait();
+        }
 
         //write
         outStamp.update();

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdPray.cpp
@@ -37,20 +37,24 @@ int Companion::cmdPray(int argc, char *argv[])
 #if defined(__unix__)
         char buf = 0;
         struct termios old;
-        if (tcgetattr(0, &old) < 0)
-                perror("tcsetattr()");
+        if (tcgetattr(0, &old) < 0) {
+            perror("tcsetattr()");
+        }
         old.c_lflag &= ~ICANON;
         old.c_lflag &= ~ECHO;
         old.c_cc[VMIN] = 1;
         old.c_cc[VTIME] = 0;
-        if (tcsetattr(0, TCSANOW, &old) < 0)
-                perror("tcsetattr ICANON");
-        if (::read(0, &buf, 1) < 0)
-                perror ("read()");
+        if (tcsetattr(0, TCSANOW, &old) < 0) {
+            perror("tcsetattr ICANON");
+        }
+        if (::read(0, &buf, 1) < 0) {
+            perror("read()");
+        }
         old.c_lflag |= ICANON;
         old.c_lflag |= ECHO;
-        if (tcsetattr(0, TCSADRAIN, &old) < 0)
-                perror ("tcsetattr ~ICANON");
+        if (tcsetattr(0, TCSADRAIN, &old) < 0) {
+            perror("tcsetattr ~ICANON");
+        }
         return (buf);
 #elif defined(_MSC_VER)
         return static_cast<char>(_getch());

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRepeat.cpp
@@ -47,7 +47,9 @@ int Companion::cmdRepeat(int argc, char *argv[])
     while (true)
     {
         Bottle *bot = port.read();
-        if (!bot) continue;
+        if (!bot) {
+            continue;
+        }
         if (port.getOutputCount()>0)
         {
             port.prepare() = *bot;

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRpc.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRpc.cpp
@@ -69,21 +69,23 @@ char* command_generator (const char* text, int state)
         yarp::os::Bottle helpCommand, helpBottle;
         helpCommand.addString("help");
         bool helpOk=false;
-        if (rpcHelpPort)
+        if (rpcHelpPort) {
             helpOk = rpcHelpPort->write(helpCommand, helpBottle);
+        }
         if (helpOk)
         {
             yarp::os::Bottle* cmdList = nullptr;
             if (helpBottle.get(0).isVocab32() && helpBottle.get(0).asVocab32()==yarp::os::createVocab32('m', 'a', 'n', 'y') )
             {
                 cmdList=helpBottle.get(1).asList();
+            } else {
+                cmdList = helpBottle.get(0).asList();
             }
-            else
-                cmdList=helpBottle.get(0).asList();
             if (cmdList && cmdList->get(0).asString() == "*** Available commands:")
             {
-                for (size_t i=1; i<cmdList->size(); ++i)
+                for (size_t i = 1; i < cmdList->size(); ++i) {
                     commands.push_back(cmdList->get(i).asString());
+                }
             }
         }
         commands.emplace_back(" ");
@@ -92,8 +94,9 @@ char* command_generator (const char* text, int state)
     while ((list_index<commands.size()) && (name = (char*)commands[list_index].c_str()))
         {
         list_index++;
-        if (strncmp (name, text, len) == 0)
+        if (strncmp(name, text, len) == 0) {
             return (dupstr(name));
+        }
         }
 
     /* if no names matched, then return null. */
@@ -113,12 +116,13 @@ char ** my_completion (const char* text, int start, int end)
     /* If this word is at the start of the line, then it is a command
        to complete. If we are completing after "help ", it is a command again.
        Otherwise, stop completing. */
-    if (start == 0)
+    if (start == 0) {
         matches = rl_completion_matches(text, &command_generator);
-    else if (start == 5 && strncmp (text, "help ", 5) != 0)
+    } else if (start == 5 && strncmp(text, "help ", 5) != 0) {
         matches = rl_completion_matches(text, &command_generator);
-    else
-        rl_attempted_completion_over=1;
+    } else {
+        rl_attempted_completion_over = 1;
+    }
 
     return (matches);
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRpcServer.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRpcServer.cpp
@@ -72,6 +72,8 @@ int Companion::cmdRpcServer(int argc, char *argv[])
         } else {
             port.reply(response);
         }
-        if (stop) return 0;
+        if (stop) {
+            return 0;
+        }
     }
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdSample.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdSample.cpp
@@ -57,7 +57,9 @@ int Companion::cmdSample(int argc, char *argv[]) {
     bool show = options.check("show");
     while (true) {
         Bottle *bot = port.read();
-        if (!bot) continue;
+        if (!bot) {
+            continue;
+        }
         if (show) {
             yCInfo(COMPANION, "%s", bot->toString().c_str());
         }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdTrafficGen.cpp
@@ -54,8 +54,9 @@ public:
 
     void run() override
     {
-        if (outport.getOutputCount()>0)
+        if (outport.getOutputCount() > 0) {
             outport.write(pp);
+        }
     }
 
     void threadRelease() override

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdWrite.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdWrite.cpp
@@ -52,9 +52,9 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
         hist_file += temp;
         read_history(hist_file.c_str());
         disable_file_history=false;
+    } else {
+        disable_file_history = true;
     }
-    else
-        disable_file_history=true;
 #endif
     if (Companion::getActivePort() == nullptr) {
         Companion::installHandler();
@@ -103,13 +103,16 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
                 while (port.getOutputCount()<1) {
                     SystemClock::delaySystem(delay);
                     delay *= 2;
-                    if (delay>4) delay = 4;
+                    if (delay > 4) {
+                        delay = 4;
+                    }
                 }
             }
             port.write(bot);
 #ifdef YARP_HAS_Libedit
-            if (!disable_file_history)
+            if (!disable_file_history) {
                 write_history(hist_file.c_str());
+            }
 #endif
         }
     }
@@ -119,7 +122,9 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
         while (port.isWriting()) {
             SystemClock::delaySystem(delay);
             delay *= 2;
-            if (delay>4) delay = 4;
+            if (delay > 4) {
+                delay = 4;
+            }
         }
     }
 

--- a/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.cpp
@@ -112,9 +112,11 @@ bool AudioPlayerDeviceBase::appendSound(const yarp::sig::Sound& sound)
     size_t num_channels = sound.getChannels();
     size_t num_samples = sound.getSamples();
 
-    for (size_t i = 0; i < num_samples; i++)
-        for (size_t j = 0; j < num_channels; j++)
+    for (size_t i = 0; i < num_samples; i++) {
+        for (size_t j = 0; j < num_channels; j++) {
             m_outputBuffer->write(sound.get(i, j));
+        }
+    }
 
     return true;
 }
@@ -127,9 +129,11 @@ bool AudioPlayerDeviceBase::immediateSound(const yarp::sig::Sound& sound)
     size_t num_channels = sound.getChannels();
     size_t num_samples = sound.getSamples();
 
-    for (size_t i = 0; i < num_samples; i++)
-        for (size_t j = 0; j < num_channels; j++)
+    for (size_t i = 0; i < num_samples; i++) {
+        for (size_t j = 0; j < num_channels; j++) {
             m_outputBuffer->write(sound.get(i, j));
+        }
+    }
 
     return true;
 }
@@ -190,10 +194,11 @@ bool AudioPlayerDeviceBase::renderSound(const yarp::sig::Sound& sound)
         }
     }
 
-    if (m_renderMode == RENDER_IMMEDIATE)
+    if (m_renderMode == RENDER_IMMEDIATE) {
         return immediateSound(procsound);
-    else if (m_renderMode == RENDER_APPEND)
+    } else if (m_renderMode == RENDER_APPEND) {
         return appendSound(procsound);
+    }
 
     return false;
 }
@@ -204,9 +209,15 @@ bool AudioPlayerDeviceBase::configurePlayerAudioDevice(yarp::os::Searchable& con
     m_audioplayer_cfg.numSamples = config.check("samples", Value(0), "number of samples per network packet (0=automatic). For chunks of 1 second of recording set samples=rate. Channels number is handled internally.").asInt32();
     m_audioplayer_cfg.numChannels = config.check("channels", Value(0), "number of audio channels (0=automatic, max is 2)").asInt32();
 
-    if (m_audioplayer_cfg.numChannels == 0)  m_audioplayer_cfg.numChannels = DEFAULT_NUM_CHANNELS;
-    if (m_audioplayer_cfg.frequency == 0)  m_audioplayer_cfg.frequency = DEFAULT_SAMPLE_RATE;
-    if (m_audioplayer_cfg.numSamples == 0) m_audioplayer_cfg.numSamples = m_audioplayer_cfg.frequency; //  by default let's use chunks of 1 second
+    if (m_audioplayer_cfg.numChannels == 0) {
+        m_audioplayer_cfg.numChannels = DEFAULT_NUM_CHANNELS;
+    }
+    if (m_audioplayer_cfg.frequency == 0) {
+        m_audioplayer_cfg.frequency = DEFAULT_SAMPLE_RATE;
+    }
+    if (m_audioplayer_cfg.numSamples == 0) {
+        m_audioplayer_cfg.numSamples = m_audioplayer_cfg.frequency; //  by default let's use chunks of 1 second
+    }
 
     if (config.check("render_mode_append"))
     {

--- a/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.cpp
@@ -85,7 +85,9 @@ bool AudioRecorderDeviceBase::getSound(yarp::sig::Sound& sound, size_t min_numbe
 
     //prepare the sound data struct
     size_t samples_to_be_copied = buff_size;
-    if (samples_to_be_copied > max_number_of_samples) samples_to_be_copied = max_number_of_samples;
+    if (samples_to_be_copied > max_number_of_samples) {
+        samples_to_be_copied = max_number_of_samples;
+    }
     if (sound.getChannels() != this->m_audiorecorder_cfg.numChannels && sound.getSamples() != samples_to_be_copied)
     {
         sound.resize(samples_to_be_copied, this->m_audiorecorder_cfg.numChannels);
@@ -213,9 +215,15 @@ bool AudioRecorderDeviceBase::configureRecorderAudioDevice(yarp::os::Searchable&
     m_audiorecorder_cfg.numSamples = config.check("samples", Value(0), "number of samples per network packet (0=automatic). For chunks of 1 second of recording set samples=rate. Channels number is handled internally.").asInt32();
     m_audiorecorder_cfg.numChannels = config.check("channels", Value(0), "number of audio channels (0=automatic, max is 2)").asInt32();
 
-    if (m_audiorecorder_cfg.frequency == 0)  m_audiorecorder_cfg.frequency = DEFAULT_SAMPLE_RATE;
-    if (m_audiorecorder_cfg.numChannels == 0)  m_audiorecorder_cfg.numChannels = DEFAULT_NUM_CHANNELS;
-    if (m_audiorecorder_cfg.numSamples == 0) m_audiorecorder_cfg.numSamples = m_audiorecorder_cfg.frequency; //  by default let's use chunks of 1 second
+    if (m_audiorecorder_cfg.frequency == 0) {
+        m_audiorecorder_cfg.frequency = DEFAULT_SAMPLE_RATE;
+    }
+    if (m_audiorecorder_cfg.numChannels == 0) {
+        m_audiorecorder_cfg.numChannels = DEFAULT_NUM_CHANNELS;
+    }
+    if (m_audiorecorder_cfg.numSamples == 0) {
+        m_audiorecorder_cfg.numSamples = m_audiorecorder_cfg.frequency; //  by default let's use chunks of 1 second
+    }
 
     yCInfo(AUDIORECORDER_BASE) << "Device configured with the following options:";
     yCInfo(AUDIORECORDER_BASE) << "Frequency:"<< m_audiorecorder_cfg.frequency;

--- a/src/libYARP_dev/src/yarp/dev/CircularAudioBuffer.h
+++ b/src/libYARP_dev/src/yarp/dev/CircularAudioBuffer.h
@@ -56,12 +56,13 @@ class CircularAudioBuffer
     AudioBufferSize size()
     {
         size_t i;
-        if (end>start)
+        if (end > start) {
             i = end-start;
-        else if (end==start)
+        } else if (end == start) {
             i = 0;
-        else
+        } else {
             i = maxsize.size - start + end;
+        }
         return AudioBufferSize(i/maxsize.m_channels, maxsize.m_channels, sizeof(SAMPLE));
     }
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -166,14 +166,30 @@ ControlBoardHelper::ControlBoardHelper(int n, const int *aMap, const double *ang
 
     memcpy(mPriv->axisMap, aMap, sizeof(int)*n);
 
-    if (zs!=nullptr)           memcpy(mPriv->position_zeros, zs, sizeof(double)*n);
-    if (angToEncs!=nullptr)    memcpy(mPriv->angleToEncoders, angToEncs, sizeof(double)*n);
-    if (newtons!=nullptr)      memcpy(mPriv->newtonsToSensors, newtons, sizeof(double)*n);
-    if (amps!=nullptr)         memcpy(mPriv->ampereToSensors, amps, sizeof(double)*n);
-    if (volts!=nullptr)        memcpy(mPriv->voltToSensors, volts, sizeof(double)*n);
-    if (dutycycles != nullptr) memcpy(mPriv->dutycycleToPWMs, dutycycles, sizeof(double)*n);
-    if (kbemf != nullptr)      memcpy(mPriv->bemfToRaws, kbemf, sizeof(double)*n);
-    if (ktau != nullptr)       memcpy(mPriv->ktauToRaws, ktau, sizeof(double)*n);
+    if (zs != nullptr) {
+        memcpy(mPriv->position_zeros, zs, sizeof(double) * n);
+    }
+    if (angToEncs != nullptr) {
+        memcpy(mPriv->angleToEncoders, angToEncs, sizeof(double) * n);
+    }
+    if (newtons != nullptr) {
+        memcpy(mPriv->newtonsToSensors, newtons, sizeof(double) * n);
+    }
+    if (amps != nullptr) {
+        memcpy(mPriv->ampereToSensors, amps, sizeof(double) * n);
+    }
+    if (volts != nullptr) {
+        memcpy(mPriv->voltToSensors, volts, sizeof(double) * n);
+    }
+    if (dutycycles != nullptr) {
+        memcpy(mPriv->dutycycleToPWMs, dutycycles, sizeof(double) * n);
+    }
+    if (kbemf != nullptr) {
+        memcpy(mPriv->bemfToRaws, kbemf, sizeof(double) * n);
+    }
+    if (ktau != nullptr) {
+        memcpy(mPriv->ktauToRaws, ktau, sizeof(double) * n);
+    }
 
     // invert the axis map
     memset (mPriv->invAxisMap, 0, sizeof(int) * n);
@@ -222,16 +238,18 @@ bool ControlBoardHelper::checkAxesIds(const int n_axes, const int* axesList)
 {
     if(n_axes > mPriv->nj)
     {
-        if(mPriv->verbose)
+        if (mPriv->verbose) {
             yError("checkAxesIds: num of axes is too big");
+        }
         return false;
     }
     for(int idx = 0; idx<n_axes; idx++)
     {
         if( (axesList[idx]<0) || (axesList[idx]>= mPriv->nj) )
         {
-            if(mPriv->verbose)
+            if (mPriv->verbose) {
                 yError("checkAxesIds: joint id out of bound");
+            }
 
             return false;
         }
@@ -248,29 +266,33 @@ int ControlBoardHelper::toUser(int axis)
 //map a vector, no conversion
     void ControlBoardHelper::toUser(const double *hwData, double *user)
 {
-    for (int k=0;k<mPriv->nj;k++)
-        user[toUser(k)]=hwData[k];
+    for (int k = 0; k < mPriv->nj; k++) {
+        user[toUser(k)] = hwData[k];
+    }
 }
 
 //map a vector, no conversion
 void ControlBoardHelper::ControlBoardHelper::toUser(const int *hwData, int *user)
 {
-    for (int k=0;k<mPriv->nj;k++)
-        user[toUser(k)]=hwData[k];
+    for (int k = 0; k < mPriv->nj; k++) {
+        user[toUser(k)] = hwData[k];
+    }
 }
 
 //map a vector, no conversion
     void ControlBoardHelper::toHw(const double *usr, double *hwData)
 {
-    for (int k=0;k<mPriv->nj;k++)
-        hwData[toHw(k)]=usr[k];
+    for (int k = 0; k < mPriv->nj; k++) {
+        hwData[toHw(k)] = usr[k];
+    }
 }
 
 //map a vector, no conversion
 void ControlBoardHelper::toHw(const int *usr, int *hwData)
 {
-    for (int k=0;k<mPriv->nj;k++)
-        hwData[toHw(k)]=usr[k];
+    for (int k = 0; k < mPriv->nj; k++) {
+        hwData[toHw(k)] = usr[k];
+    }
 }
 
 void ControlBoardHelper::posA2E(double ang, int j, double &enc, int &k)

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfacesImpl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfacesImpl.cpp
@@ -12,10 +12,11 @@ using namespace yarp::dev;
 
 bool StubImplEncodersRaw::NOT_YET_IMPLEMENTED(const char *func)
 {
-    if (func)
+    if (func) {
         yError("%s: not yet implemented\n", func);
-    else
+    } else {
         yError("Function not yet implemented\n");
+    }
 
     return false;
 }

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardPid.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardPid.cpp
@@ -106,35 +106,45 @@ void Pid::setKff(double ff)
 bool Pid::operator==(const yarp::dev::Pid &p) const
 {
 
-    if(kp != p.kp)
+    if (kp != p.kp) {
         return false;
+    }
 
-    if(ki != p.ki)
+    if (ki != p.ki) {
         return false;
+    }
 
-    if(kd != p.kd)
+    if (kd != p.kd) {
         return false;
+    }
 
-    if(max_output != p.max_output)
+    if (max_output != p.max_output) {
         return false;
+    }
 
-    if(max_int != p.max_int)
+    if (max_int != p.max_int) {
         return false;
+    }
 
-    if(kff != p.kff)
+    if (kff != p.kff) {
         return false;
+    }
 
-    if(offset != p.offset)
+    if (offset != p.offset) {
         return false;
+    }
 
-    if(scale != p.scale)
+    if (scale != p.scale) {
         return false;
+    }
 
-    if(stiction_down_val !=  p.stiction_down_val)
+    if (stiction_down_val != p.stiction_down_val) {
         return false;
+    }
 
-    if(stiction_up_val != p.stiction_up_val)
+    if (stiction_up_val != p.stiction_up_val) {
         return false;
+    }
 
     return true;
 

--- a/src/libYARP_dev/src/yarp/dev/DataSource.h
+++ b/src/libYARP_dev/src/yarp/dev/DataSource.h
@@ -107,10 +107,12 @@ public:
         {
             deltaT=now-timePrevious;
             cumulativeT+=deltaT;
-            if (deltaT>maxT)
-               maxT=deltaT;
-            if (deltaT<minT)
-               minT=deltaT;
+            if (deltaT > maxT) {
+                maxT = deltaT;
+            }
+            if (deltaT < minT) {
+                minT = deltaT;
+            }
             timePrevious=now;
         }
 

--- a/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
@@ -43,7 +43,9 @@ bool isEqual(const double& a, const double& b, const double& tolerance)
 
 bool isEqual(const yarp::sig::Vector& a, const yarp::sig::Vector& b, const double& tolerance)
 {
-    if (a.size() != b.size()) return false;
+    if (a.size() != b.size()) {
+        return false;
+    }
 
     for (size_t i = 0; i < a.size(); i++)
     {

--- a/src/libYARP_dev/src/yarp/dev/INavigation2D.cpp
+++ b/src/libYARP_dev/src/yarp/dev/INavigation2D.cpp
@@ -7,34 +7,54 @@
 
 std::string yarp::dev::Nav2D::INavigation2DHelpers::statusToString(yarp::dev::Nav2D::NavigationStatusEnum status)
 {
-    if (status == navigation_status_idle) return std::string("navigation_status_idle");
-    else if (status == navigation_status_moving) return std::string("navigation_status_moving");
-    else if (status == navigation_status_waiting_obstacle) return std::string("navigation_status_waiting_obstacle");
-    else if (status == navigation_status_goal_reached) return std::string("navigation_status_goal_reached");
-    else if (status == navigation_status_aborted) return std::string("navigation_status_aborted");
-    else if (status == navigation_status_failing) return std::string("navigation_status_failing");
-    else if (status == navigation_status_paused) return std::string("navigation_status_paused");
-    else if (status == navigation_status_preparing_before_move) return std::string("navigation_status_preparing_before_move");
-    else if (status == navigation_status_thinking) return std::string("navigation_status_thinking");
-    else if (status == navigation_status_error) return std::string("navigation_status_error");
+    if (status == navigation_status_idle) {
+        return std::string("navigation_status_idle");
+    } else if (status == navigation_status_moving) {
+        return std::string("navigation_status_moving");
+    } else if (status == navigation_status_waiting_obstacle) {
+        return std::string("navigation_status_waiting_obstacle");
+    } else if (status == navigation_status_goal_reached) {
+        return std::string("navigation_status_goal_reached");
+    } else if (status == navigation_status_aborted) {
+        return std::string("navigation_status_aborted");
+    } else if (status == navigation_status_failing) {
+        return std::string("navigation_status_failing");
+    } else if (status == navigation_status_paused) {
+        return std::string("navigation_status_paused");
+    } else if (status == navigation_status_preparing_before_move) {
+        return std::string("navigation_status_preparing_before_move");
+    } else if (status == navigation_status_thinking) {
+        return std::string("navigation_status_thinking");
+    } else if (status == navigation_status_error) {
+        return std::string("navigation_status_error");
+    }
     return std::string("navigation_status_error");
 }
 
 yarp::dev::Nav2D::NavigationStatusEnum yarp::dev::Nav2D::INavigation2DHelpers::stringToStatus(std::string s)
 {
     yarp::dev::Nav2D::NavigationStatusEnum status;
-    if (s == "navigation_status_idle")     status = navigation_status_idle;
-    else if (s == "navigation_status_moving")   status = navigation_status_moving;
-    else if (s == "navigation_status_waiting_obstacle")  status = navigation_status_waiting_obstacle;
-    else if (s == "navigation_status_goal_reached")  status = navigation_status_goal_reached;
-    else if (s == "navigation_status_aborted")  status = navigation_status_aborted;
-    else if (s == "navigation_status_failing")  status = navigation_status_failing;
-    else if (s == "navigation_status_paused")   status = navigation_status_paused;
-    else if (s == "navigation_status_preparing_before_move")   status = navigation_status_preparing_before_move;
-    else if (s == "navigation_status_thinking") status = navigation_status_thinking;
-    else if (s == "navigation_status_error") status = navigation_status_error;
-    else
-    {
+    if (s == "navigation_status_idle") {
+        status = navigation_status_idle;
+    } else if (s == "navigation_status_moving") {
+        status = navigation_status_moving;
+    } else if (s == "navigation_status_waiting_obstacle") {
+        status = navigation_status_waiting_obstacle;
+    } else if (s == "navigation_status_goal_reached") {
+        status = navigation_status_goal_reached;
+    } else if (s == "navigation_status_aborted") {
+        status = navigation_status_aborted;
+    } else if (s == "navigation_status_failing") {
+        status = navigation_status_failing;
+    } else if (s == "navigation_status_paused") {
+        status = navigation_status_paused;
+    } else if (s == "navigation_status_preparing_before_move") {
+        status = navigation_status_preparing_before_move;
+    } else if (s == "navigation_status_thinking") {
+        status = navigation_status_thinking;
+    } else if (s == "navigation_status_error") {
+        status = navigation_status_error;
+    } else {
         status = navigation_status_error;
     }
     return status;

--- a/src/libYARP_dev/src/yarp/dev/ImplementAmplifierControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementAmplifierControl.cpp
@@ -30,8 +30,9 @@ ImplementAmplifierControl::~ImplementAmplifierControl()
 
 bool ImplementAmplifierControl:: initialize (int size, const int *amap, const double *enc, const double *zos, const double *ampereFactor, const double *voltFactor)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos,nullptr, ampereFactor, voltFactor));
     yAssert (helper != nullptr);
@@ -49,8 +50,9 @@ bool ImplementAmplifierControl:: initialize (int size, const int *amap, const do
 */
 bool ImplementAmplifierControl::uninitialize ()
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         delete castToMapper(helper);
+    }
 
     delete [] dTemp;
     delete [] iTemp;

--- a/src/libYARP_dev/src/yarp/dev/ImplementAxisInfo.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementAxisInfo.cpp
@@ -24,8 +24,9 @@ ImplementAxisInfo::~ImplementAxisInfo()
 
 bool ImplementAxisInfo::initialize(int size, const int *amap)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementControlCalibration.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementControlCalibration.cpp
@@ -36,9 +36,9 @@ bool IControlCalibration::calibrateRobot()
     {
         yDebug("Going to call calibrator\n");
         ret=calibrator->calibrate(dynamic_cast<DeviceDriver *>(this));
-    }
-    else
+    } else {
         yWarning("Warning called calibrate but no calibrator was set\n");
+    }
 
     return ret;
 }
@@ -46,16 +46,18 @@ bool IControlCalibration::calibrateRobot()
 bool IControlCalibration::abortCalibration()
 {
     bool ret=false;
-    if (calibrator!=nullptr)
-        ret=calibrator->quitCalibrate();
+    if (calibrator != nullptr) {
+        ret = calibrator->quitCalibrate();
+    }
     return ret;
 }
 
 bool IControlCalibration::abortPark()
 {
     bool ret=false;
-    if (calibrator!=nullptr)
-        ret=calibrator->quitPark();
+    if (calibrator != nullptr) {
+        ret = calibrator->quitPark();
+    }
     return ret;
 }
 
@@ -66,9 +68,9 @@ bool IControlCalibration::park(bool wait)
     {
         yDebug("Going to call calibrator\n");
         ret=calibrator->park(dynamic_cast<DeviceDriver *>(this), wait);
-    }
-    else
+    } else {
         yWarning("Warning called park but no calibrator was set\n");
+    }
 
     return ret;
 }
@@ -89,8 +91,9 @@ ImplementControlCalibration::~ImplementControlCalibration()
 
 bool ImplementControlCalibration::initialize(int size, const int *amap, const double *enc, const double *zos)
 {
-    if (helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper = (void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementControlLimits.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementControlLimits.cpp
@@ -38,8 +38,9 @@ bool ImplementControlLimits::uninitialize()
 
 bool ImplementControlLimits::initialize(int size, const int *amap, const double *enc, const double *zos)
 {
-    if(helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementControlLimits.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementControlLimits.h
@@ -88,10 +88,11 @@ private:
      */
     bool NOT_YET_IMPLEMENTED(const char *func=0)
     {
-        if (func)
+        if (func) {
             yError("%s: not yet implemented\n", func);
-        else
+        } else {
             yError("Function not yet implemented\n");
+        }
 
         return false;
     }

--- a/src/libYARP_dev/src/yarp/dev/ImplementControlMode.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementControlMode.cpp
@@ -21,8 +21,9 @@ ImplementControlMode::ImplementControlMode(IControlModeRaw *r):
 
 bool ImplementControlMode::initialize(int size, const int *amap)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);
@@ -73,8 +74,9 @@ bool ImplementControlMode::getControlModes(int *modes)
 
 bool ImplementControlMode::getControlModes(const int n_joint, const int *joints, int *modes)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffValues = buffManager->getBuffer();
 
@@ -97,8 +99,9 @@ bool ImplementControlMode::setControlMode(const int j, const int mode)
 
 bool ImplementControlMode::setControlModes(const int n_joint, const int *joints, int *modes)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffValues  = buffManager->getBuffer();
 

--- a/src/libYARP_dev/src/yarp/dev/ImplementCurrentControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementCurrentControl.cpp
@@ -27,8 +27,9 @@ ImplementCurrentControl::~ImplementCurrentControl()
 
 bool ImplementCurrentControl::initialize(int size, const int *amap, const double* ampsToSens)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     intBuffManager = new yarp::dev::impl::FixedSizeBuffersManager<int> (size);
     yAssert (intBuffManager != nullptr);
@@ -120,8 +121,9 @@ bool ImplementCurrentControl::getCurrents(double *t)
 
 bool ImplementCurrentControl::setRefCurrents(const int n_joint, const int *joints, const double *t)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();

--- a/src/libYARP_dev/src/yarp/dev/ImplementEncoders.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementEncoders.cpp
@@ -31,8 +31,9 @@ ImplementEncoders::~ImplementEncoders()
 
 bool ImplementEncoders:: initialize (int size, const int *amap, const double *enc, const double *zos)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementEncodersTimed.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementEncodersTimed.cpp
@@ -27,8 +27,9 @@ ImplementEncodersTimed::~ImplementEncodersTimed()
 
 bool ImplementEncodersTimed:: initialize (int size, const int *amap, const double *enc, const double *zos)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementImpedanceControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementImpedanceControl.cpp
@@ -23,8 +23,9 @@ ImplementImpedanceControl::ImplementImpedanceControl(IImpedanceControlRaw *r)
 
 bool ImplementImpedanceControl::initialize(int size, const int *amap, const double *enc, const double *zos, const double *nw)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos, nw));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementInteractionMode.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementInteractionMode.cpp
@@ -40,8 +40,9 @@ bool ImplementInteractionMode::initialize(int size, const int *amap)
 
 bool ImplementInteractionMode::initialize(int size, const int *amap, const double *enc, const double *zos)
 {
-    if(helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
@@ -89,8 +90,9 @@ bool ImplementInteractionMode::getInteractionMode(int axis, yarp::dev::Interacti
 
 bool ImplementInteractionMode::getInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joints, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joints, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
 
@@ -129,8 +131,9 @@ bool ImplementInteractionMode::setInteractionMode(int axis, yarp::dev::Interacti
 
 bool ImplementInteractionMode::setInteractionModes(int n_joints, int *joints, yarp::dev::InteractionModeEnum* modes)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joints, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joints, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
 

--- a/src/libYARP_dev/src/yarp/dev/ImplementInteractionMode.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementInteractionMode.h
@@ -116,10 +116,11 @@ protected:
      */
     bool NOT_YET_IMPLEMENTED(const char *func = 0)
     {
-        if (func)
+        if (func) {
             yError("%s: not yet implemented\n", func);
-        else
+        } else {
             yError("Function not yet implemented\n");
+        }
 
         return false;
     }

--- a/src/libYARP_dev/src/yarp/dev/ImplementMotor.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementMotor.cpp
@@ -27,8 +27,9 @@ ImplementMotor::~ImplementMotor()
 
 bool ImplementMotor:: initialize (int size, const int *amap)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementMotorEncoders.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementMotorEncoders.cpp
@@ -28,8 +28,9 @@ ImplementMotorEncoders::~ImplementMotorEncoders()
 
 bool ImplementMotorEncoders:: initialize (int size, const int *amap, const double *enc, const double *zos)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementPWMControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementPWMControl.cpp
@@ -23,8 +23,9 @@ ImplementPWMControl::ImplementPWMControl(IPWMControlRaw *r) :
 
 bool ImplementPWMControl::initialize(int size, const int *amap, const double* dutyToPWM)
 {
-    if (helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper = (void *)(new ControlBoardHelper(size, amap, nullptr, nullptr, nullptr, nullptr, nullptr, dutyToPWM));
     yAssert(helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementPidControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementPidControl.cpp
@@ -30,8 +30,9 @@ ImplementPidControl::~ImplementPidControl()
 
 bool ImplementPidControl:: initialize (int size, const int *amap, const double *enc, const double *zos, const double* newtons, const double* amps, const double* dutys)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos,newtons,amps,nullptr,dutys));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementPositionControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementPositionControl.cpp
@@ -38,8 +38,9 @@ ImplementPositionControl::~ImplementPositionControl()
  */
 bool ImplementPositionControl::initialize(int size, const int *amap, const double *enc, const double *zos)
 {
-    if(helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
@@ -99,8 +100,9 @@ bool ImplementPositionControl::positionMove(int j, double ang)
 
 bool ImplementPositionControl::positionMove(const int n_joint, const int *joints, const double *refs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
@@ -139,8 +141,9 @@ bool ImplementPositionControl::relativeMove(int j, double delta)
 
 bool ImplementPositionControl::relativeMove(const int n_joint, const int *joints, const double *deltas)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
@@ -174,8 +177,9 @@ bool ImplementPositionControl::checkMotionDone(int j, bool *flag)
 
 bool ImplementPositionControl::checkMotionDone(const int n_joint, const int *joints, bool *flags)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)
@@ -203,8 +207,9 @@ bool ImplementPositionControl::setRefSpeed(int j, double sp)
 
 bool ImplementPositionControl::setRefSpeeds(const int n_joint, const int *joints, const double *spds)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)
@@ -238,8 +243,9 @@ bool ImplementPositionControl::setRefAcceleration(int j, double acc)
 
 bool ImplementPositionControl::setRefAccelerations(const int n_joint, const int *joints, const double *accs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
@@ -280,8 +286,9 @@ bool ImplementPositionControl::getRefSpeed(int j, double *ref)
 
 bool ImplementPositionControl::getRefSpeeds(const int n_joint, const int *joints, double *spds)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)
@@ -321,8 +328,9 @@ bool ImplementPositionControl::getRefAccelerations(double *accs)
 
 bool ImplementPositionControl::getRefAccelerations(const int n_joint, const int *joints, double *accs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)
@@ -392,8 +400,9 @@ bool ImplementPositionControl::getAxes(int *axis)
 
 bool ImplementPositionControl::getTargetPosition(const int joint, double* ref)
 {
-    if(!castToMapper(helper)->checkAxisId(joint))
+    if (!castToMapper(helper)->checkAxisId(joint)) {
         return false;
+    }
     int k;
     double enc;
     k=castToMapper(helper)->toHw(joint);
@@ -415,8 +424,9 @@ bool ImplementPositionControl::getTargetPositions(double* refs)
 
 bool ImplementPositionControl::getTargetPositions(const int n_joint, const int* joints, double* refs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)
@@ -442,10 +452,11 @@ bool ImplementPositionControl::getTargetPositions(const int n_joint, const int* 
 
 bool StubImplPositionControlRaw::NOT_YET_IMPLEMENTED(const char *func)
 {
-    if (func)
+    if (func) {
         yError("%s: not yet implemented\n", func);
-    else
+    } else {
         yError("Function not yet implemented\n");
+    }
 
     return false;
 }

--- a/src/libYARP_dev/src/yarp/dev/ImplementPositionDirect.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementPositionDirect.cpp
@@ -30,8 +30,9 @@ ImplementPositionDirect::~ImplementPositionDirect()
 
 bool ImplementPositionDirect::initialize(int size, const int *amap, const double *enc, const double *zos)
 {
-    if(helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos));
     yAssert(helper != nullptr);
@@ -85,14 +86,16 @@ bool ImplementPositionDirect::setPosition(int j, double ref)
 
 bool ImplementPositionDirect::setPositions(const int n_joint, const int *joints, const double *refs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
 
-    if(n_joint > (int)intBuffManager->getBufferSize())
+    if (n_joint > (int)intBuffManager->getBufferSize()) {
         return false;
+    }
 
     for(int idx=0; idx<n_joint; idx++)
     {
@@ -132,8 +135,9 @@ bool ImplementPositionDirect::getRefPosition(const int j, double* ref)
 
 bool ImplementPositionDirect::getRefPositions(const int n_joint, const int* joints, double* refs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
 
@@ -170,10 +174,11 @@ bool ImplementPositionDirect::getRefPositions(double* refs)
 
 bool StubImplPositionDirectRaw::NOT_YET_IMPLEMENTED(const char *func)
 {
-    if (func)
+    if (func) {
         yError("%s: not yet implemented\n", func);
-    else
+    } else {
         yError("Function not yet implemented\n");
+    }
 
     return false;
 }

--- a/src/libYARP_dev/src/yarp/dev/ImplementRemoteVariables.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementRemoteVariables.cpp
@@ -26,8 +26,9 @@ ImplementRemoteVariables::~ImplementRemoteVariables()
 
 bool ImplementRemoteVariables::initialize(int size, const int *amap)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -27,8 +27,9 @@ ImplementTorqueControl::~ImplementTorqueControl()
 
 bool ImplementTorqueControl::initialize(int size, const int *amap, const double *enc, const double *zos, const double *nw, const double* amps, const double* dutys, const double* bemfs, const double* ktaus)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, enc, zos, nw, amps, nullptr, dutys,bemfs,ktaus));
     yAssert (helper != nullptr);
@@ -154,8 +155,9 @@ bool ImplementTorqueControl::getTorques(double *t)
 
 bool ImplementTorqueControl::setRefTorques(const int n_joint, const int *joints, const double *t)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();

--- a/src/libYARP_dev/src/yarp/dev/ImplementVelocityControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementVelocityControl.cpp
@@ -28,8 +28,9 @@ ImplementVelocityControl::~ImplementVelocityControl()
 
 bool ImplementVelocityControl::initialize(int size, const int *axis_map, const double *enc, const double *zeros)
 {
-    if (helper != nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, axis_map, enc, zeros));
     yAssert (helper != nullptr);
@@ -83,8 +84,9 @@ bool ImplementVelocityControl::velocityMove(int j, double sp)
 
 bool ImplementVelocityControl::velocityMove(const int n_joint, const int *joints, const double *spds)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
@@ -132,8 +134,9 @@ bool ImplementVelocityControl::getRefVelocities(double *vels)
 
 bool ImplementVelocityControl::getRefVelocities(const int n_joint, const int *joints, double *vels)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints = intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
@@ -166,8 +169,9 @@ bool ImplementVelocityControl::setRefAcceleration(int j, double acc)
 
 bool ImplementVelocityControl::setRefAccelerations(const int n_joint, const int *joints, const double *accs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
@@ -206,8 +210,9 @@ bool ImplementVelocityControl::getRefAcceleration(int j, double *acc)
 
 bool ImplementVelocityControl::getRefAccelerations(const int n_joint, const int *joints, double *accs)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
     yarp::dev::impl::Buffer<double> buffValues = doubleBuffManager->getBuffer();
@@ -251,8 +256,9 @@ bool ImplementVelocityControl::stop(int j)
 
 bool ImplementVelocityControl::stop(const int n_joint, const int *joints)
 {
-    if(!castToMapper(helper)->checkAxesIds(n_joint, joints))
+    if (!castToMapper(helper)->checkAxesIds(n_joint, joints)) {
         return false;
+    }
 
     yarp::dev::impl::Buffer<int> buffJoints =  intBuffManager->getBuffer();
     for(int idx=0; idx<n_joint; idx++)

--- a/src/libYARP_dev/src/yarp/dev/ImplementVelocityControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementVelocityControl.h
@@ -111,10 +111,11 @@ private:
      */
     bool NOT_YET_IMPLEMENTED(const char *func = 0)
     {
-        if (func)
+        if (func) {
             yError("%s: not yet implemented\n", func);
-        else
+        } else {
             yError("Function not yet implemented\n");
+        }
 
         return false;
     }

--- a/src/libYARP_dev/src/yarp/dev/ImplementVirtualAnalogSensor.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementVirtualAnalogSensor.cpp
@@ -24,8 +24,9 @@ ImplementVirtualAnalogSensor::~ImplementVirtualAnalogSensor()
 
 bool ImplementVirtualAnalogSensor::initialize(int size, const int *amap, const double *userToRaw)
 {
-    if (helper!=nullptr)
+    if (helper != nullptr) {
         return false;
+    }
 
     helper=(void *)(new ControlBoardHelper(size, amap, nullptr, nullptr, nullptr, nullptr, userToRaw, nullptr));
     yAssert (helper != nullptr);

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
@@ -199,8 +199,9 @@ bool Lidar2DDeviceBase::parseConfiguration(yarp::os::Searchable& config)
     yCInfo(LASER_BASE) << "allow_infinity:" << (m_do_not_clip_and_allow_infinity_enable ==true);
     if (m_range_skip_vector.size() >0)
     {
-        for (size_t i=0; i< m_range_skip_vector.size(); i++)
-        yCInfo(LASER_BASE) << "skip area:" << m_range_skip_vector[i].min << "->" << m_range_skip_vector[i].max;
+        for (size_t i = 0; i < m_range_skip_vector.size(); i++) {
+            yCInfo(LASER_BASE) << "skip area:" << m_range_skip_vector[i].min << "->" << m_range_skip_vector[i].max;
+        }
     }
     return true;
 }
@@ -227,8 +228,12 @@ bool Lidar2DDeviceBase::applyLimitsOnLaserData()
         double& distance = m_laser_data[i];
         double  angle = i * m_resolution;
 
-        if (std::isnan(distance)) continue;
-        if (checkSkipAngle(angle, distance)) continue;
+        if (std::isnan(distance)) {
+            continue;
+        }
+        if (checkSkipAngle(angle, distance)) {
+            continue;
+        }
 
         if (m_clip_min_enable)
         {
@@ -269,9 +274,13 @@ bool Lidar2DDeviceBase::updateLidarData()
 {
     bool b = true;
     b &= acquireDataFromHW();
-    if (!b) return false;
+    if (!b) {
+        return false;
+    }
     b &= applyLimitsOnLaserData();
-    if (!b) return false;
+    if (!b) {
+        return false;
+    }
     b &= updateTimestamp();
     return b;
 }

--- a/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
@@ -146,9 +146,15 @@ std::string Map2DArea::toString() const
 
 bool Map2DArea::checkLocationInsideArea(Map2DLocation loc)
 {
-    if (loc.map_id != this->map_id) return false;
-    if (points.size() < 3) return false;
-    if (pnpoly(points, loc.x, loc.y) > 0) return true;
+    if (loc.map_id != this->map_id) {
+        return false;
+    }
+    if (points.size() < 3) {
+        return false;
+    }
+    if (pnpoly(points, loc.x, loc.y) > 0) {
+        return true;
+    }
     return false;
 }
 
@@ -178,8 +184,12 @@ bool Map2DArea::operator==(const Map2DArea& r) const
 
 bool Map2DArea::isValid() const
 {
-    if (points.size() < 3) return false;
-    if (map_id == "") return false;
+    if (points.size() < 3) {
+        return false;
+    }
+    if (map_id == "") {
+        return false;
+    }
     return true;
 }
 
@@ -188,7 +198,9 @@ bool  Map2DArea::findAreaBounds(Map2DLocation& lt, Map2DLocation& rb)
     lt.map_id = rb.map_id = this->map_id;
     lt.x = lt.y = std::numeric_limits<double>::max();
     rb.x = rb.y = std::numeric_limits<double>::min();
-    if (isValid() == false) return false;
+    if (isValid() == false) {
+        return false;
+    }
     for (auto it = points.begin(); it != points.end(); it++)
     {
         if (it->x > rb.x) { rb.x = it->x; }
@@ -203,8 +215,9 @@ bool  Map2DArea::getRandomLocation(Map2DLocation& loc)
 {
     Map2DLocation lt;
     Map2DLocation rb;
-    if (findAreaBounds(lt, rb) == false)
+    if (findAreaBounds(lt, rb) == false) {
         return false;
+    }
 
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -222,7 +235,9 @@ bool  Map2DArea::getRandomLocation(Map2DLocation& loc)
         loc.y = rnd_y;
         loc.theta = 0;
         count_trials++;
-        if (this->checkLocationInsideArea(loc)) break;
+        if (this->checkLocationInsideArea(loc)) {
+            break;
+        }
     } while (count_trials < 20);
 
     if (count_trials >= 20)

--- a/src/libYARP_dev/src/yarp/dev/Map2DLocation.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DLocation.cpp
@@ -15,8 +15,12 @@ YARP_LOG_COMPONENT(MAP2DLOCATION, "yarp.Map2DLocation")
 
 bool Map2DLocation::is_near_to(const Map2DLocation& other_loc, double linear_tolerance, double angular_tolerance) const
 {
-    if (linear_tolerance < 0) return false;
-    if (angular_tolerance < 0) return false;
+    if (linear_tolerance < 0) {
+        return false;
+    }
+    if (angular_tolerance < 0) {
+        return false;
+    }
     yCAssert(MAP2DLOCATION, linear_tolerance >= 0);
     yCAssert(MAP2DLOCATION, angular_tolerance >= 0);
 

--- a/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
@@ -22,21 +22,21 @@ using namespace std;
 
 bool Map2DPath::operator!=(const Map2DPath& r) const
 {
-    for (size_t i = 0; i < waypoints.size(); i++)
-        if (this->waypoints[i].map_id == r.waypoints[i].map_id ||
-            this->waypoints[i].x == r.waypoints[i].x ||
-            this->waypoints[i].y == r.waypoints[i].y ||
-            this->waypoints[i].theta == r.waypoints[i].theta) return false;
+    for (size_t i = 0; i < waypoints.size(); i++) {
+        if (this->waypoints[i].map_id == r.waypoints[i].map_id || this->waypoints[i].x == r.waypoints[i].x || this->waypoints[i].y == r.waypoints[i].y || this->waypoints[i].theta == r.waypoints[i].theta) {
+            return false;
+        }
+    }
     return true;
 }
 
 bool Map2DPath::operator==(const Map2DPath& r) const
 {
-    for (size_t i = 0; i < waypoints.size(); i++)
-        if (this->waypoints[i].map_id != r.waypoints[i].map_id ||
-            this->waypoints[i].x != r.waypoints[i].x ||
-            this->waypoints[i].y != r.waypoints[i].y ||
-            this->waypoints[i].theta != r.waypoints[i].theta) return false;
+    for (size_t i = 0; i < waypoints.size(); i++) {
+        if (this->waypoints[i].map_id != r.waypoints[i].map_id || this->waypoints[i].x != r.waypoints[i].x || this->waypoints[i].y != r.waypoints[i].y || this->waypoints[i].theta != r.waypoints[i].theta) {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -91,11 +91,15 @@ double Map2DPath::getLength() const
 
 bool Map2DPath::isOnSingleMap() const
 {
-    if (waypoints.size() == 0) return true;
+    if (waypoints.size() == 0) {
+        return true;
+    }
     string mapname = waypoints[0].map_id;
     for (auto it = waypoints.begin(); it != waypoints.end(); it++)
     {
-        if (it->map_id != mapname) return false;
+        if (it->map_id != mapname) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/libYARP_dev/src/yarp/dev/MapGrid2D.cpp
+++ b/src/libYARP_dev/src/yarp/dev/MapGrid2D.cpp
@@ -41,9 +41,13 @@ static string extractPathFromFile(string full_filename)
 {
     size_t found;
     found = full_filename.find_last_of('/');
-    if (found != string::npos) return full_filename.substr(0, found)+"/";
+    if (found != string::npos) {
+        return full_filename.substr(0, found) + "/";
+    }
     found = full_filename.find_last_of('\\');
-    if (found != string::npos) return full_filename.substr(0, found)+"\\";
+    if (found != string::npos) {
+        return full_filename.substr(0, found) + "\\";
+    }
     return full_filename;
 }
 
@@ -56,15 +60,35 @@ static string extractExtensionFromFile(string full_filename)
 
 bool MapGrid2D::isIdenticalTo(const MapGrid2D& other) const
 {
-    if (m_map_name != other.m_map_name) return false;
-    if (m_origin != other.m_origin) return false;
-    if (m_resolution != other.m_resolution) return false;
-    if (m_width != other.width()) return false;
-    if (m_height != other.height()) return false;
-    for (size_t y = 0; y < m_height; y++) for (size_t x = 0; x < m_width;  x++)
-        if (m_map_occupancy.safePixel(x, y) != other.m_map_occupancy.safePixel(x, y)) return false;
-    for (size_t y = 0; y < m_height; y++) for (size_t x = 0; x < m_width; x++)
-        if (m_map_flags.safePixel(x, y) != other.m_map_flags.safePixel(x, y)) return false;
+    if (m_map_name != other.m_map_name) {
+        return false;
+    }
+    if (m_origin != other.m_origin) {
+        return false;
+    }
+    if (m_resolution != other.m_resolution) {
+        return false;
+    }
+    if (m_width != other.width()) {
+        return false;
+    }
+    if (m_height != other.height()) {
+        return false;
+    }
+    for (size_t y = 0; y < m_height; y++) {
+        for (size_t x = 0; x < m_width; x++) {
+            if (m_map_occupancy.safePixel(x, y) != other.m_map_occupancy.safePixel(x, y)) {
+                return false;
+            }
+        }
+    }
+    for (size_t y = 0; y < m_height; y++) {
+        for (size_t x = 0; x < m_width; x++) {
+            if (m_map_flags.safePixel(x, y) != other.m_map_flags.safePixel(x, y)) {
+                return false;
+            }
+        }
+    }
     return true;
 }
 
@@ -100,10 +124,18 @@ bool MapGrid2D::isNotFree(XYCell cell) const
 {
     if (isInsideMap(cell))
     {
-        if (m_map_occupancy.safePixel(cell.x, cell.y) != 0) return true;
-        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_KEEP_OUT) return true;
-        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_TEMPORARY_OBSTACLE) return true;
-        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_ENLARGED_OBSTACLE) return true;
+        if (m_map_occupancy.safePixel(cell.x, cell.y) != 0) {
+            return true;
+        }
+        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_KEEP_OUT) {
+            return true;
+        }
+        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_TEMPORARY_OBSTACLE) {
+            return true;
+        }
+        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_ENLARGED_OBSTACLE) {
+            return true;
+        }
     }
     return false;
 }
@@ -112,9 +144,9 @@ bool MapGrid2D::isFree(XYCell cell) const
 {
     if (isInsideMap(cell))
     {
-        if (m_map_occupancy.safePixel(cell.x, cell.y) == 0 &&
-            m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_FREE)
+        if (m_map_occupancy.safePixel(cell.x, cell.y) == 0 && m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_FREE) {
             return true;
+        }
     }
     return false;
 }
@@ -123,8 +155,9 @@ bool MapGrid2D::isKeepOut(XYCell cell) const
 {
     if (isInsideMap(cell))
     {
-        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_KEEP_OUT)
+        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_KEEP_OUT) {
             return true;
+        }
     }
     return false;
 }
@@ -135,8 +168,9 @@ bool MapGrid2D::isWall(XYCell cell) const
     {
        // if (m_map_occupancy.safePixel(cell.x, cell.y) == 0)
        //     return true;
-        if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_WALL)
-            return true;
+       if (m_map_flags.safePixel(cell.x, cell.y) == MapGrid2D::map_flags::MAP_CELL_WALL) {
+           return true;
+       }
     }
     return false;
 }
@@ -239,14 +273,30 @@ void MapGrid2D::enlargeCell(XYCell cell)
     size_t ju = cell.y > 1 ? cell.y - 1 : 0;
     size_t jd = cell.y + 1 < (m_height)-1 ? cell.y + 1 : (m_height)-1;
 
-    if (m_map_flags.pixel(il, j) == MAP_CELL_FREE) m_map_flags.pixel(il, j) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(ir, j) == MAP_CELL_FREE) m_map_flags.pixel(ir, j) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(i, ju) == MAP_CELL_FREE) m_map_flags.pixel(i, ju) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(i, jd) == MAP_CELL_FREE) m_map_flags.pixel(i, jd) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(il, ju) == MAP_CELL_FREE) m_map_flags.pixel(il, ju) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(il, jd) == MAP_CELL_FREE) m_map_flags.pixel(il, jd) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(ir, ju) == MAP_CELL_FREE) m_map_flags.pixel(ir, ju) = MAP_CELL_ENLARGED_OBSTACLE;
-    if (m_map_flags.pixel(ir, jd) == MAP_CELL_FREE) m_map_flags.pixel(ir, jd) = MAP_CELL_ENLARGED_OBSTACLE;
+    if (m_map_flags.pixel(il, j) == MAP_CELL_FREE) {
+        m_map_flags.pixel(il, j) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(ir, j) == MAP_CELL_FREE) {
+        m_map_flags.pixel(ir, j) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(i, ju) == MAP_CELL_FREE) {
+        m_map_flags.pixel(i, ju) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(i, jd) == MAP_CELL_FREE) {
+        m_map_flags.pixel(i, jd) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(il, ju) == MAP_CELL_FREE) {
+        m_map_flags.pixel(il, ju) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(il, jd) == MAP_CELL_FREE) {
+        m_map_flags.pixel(il, jd) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(ir, ju) == MAP_CELL_FREE) {
+        m_map_flags.pixel(ir, ju) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
+    if (m_map_flags.pixel(ir, jd) == MAP_CELL_FREE) {
+        m_map_flags.pixel(ir, jd) = MAP_CELL_ENLARGED_OBSTACLE;
+    }
 }
 
 bool MapGrid2D::loadROSParams(string ros_yaml_filename, string& pgm_occ_filename, double& resolution, double& orig_x, double& orig_y, double& orig_t )
@@ -459,13 +509,21 @@ bool MapGrid2D::loadMapYarpOnly(string yarp_filename)
         {
             yarp::sig::PixelMono pix_flg = m_map_flags.safePixel(x, y);
 
-            if      (pix_flg == MAP_CELL_FREE) m_map_occupancy.safePixel(x, y) = 0;//@@@SET HERE
-            else if (pix_flg == MAP_CELL_KEEP_OUT) m_map_occupancy.safePixel(x, y) = 0;//@@@SET HERE
-            else if (pix_flg == MAP_CELL_TEMPORARY_OBSTACLE) m_map_occupancy.safePixel(x, y) = 0;//@@@SET HERE
-            else if (pix_flg == MAP_CELL_ENLARGED_OBSTACLE) m_map_occupancy.safePixel(x, y) = 0;//@@@SET HERE
-            else if (pix_flg == MAP_CELL_WALL) m_map_occupancy.safePixel(x, y) = 100;//@@@SET HERE
-            else if (pix_flg == MAP_CELL_UNKNOWN) m_map_occupancy.safePixel(x, y) = 255;//@@@SET HERE
-            else m_map_occupancy.safePixel(x, y) = 255;//@@@SET HERE
+            if (pix_flg == MAP_CELL_FREE) {
+                m_map_occupancy.safePixel(x, y) = 0; //@@@SET HERE
+            } else if (pix_flg == MAP_CELL_KEEP_OUT) {
+                m_map_occupancy.safePixel(x, y) = 0; //@@@SET HERE
+            } else if (pix_flg == MAP_CELL_TEMPORARY_OBSTACLE) {
+                m_map_occupancy.safePixel(x, y) = 0; //@@@SET HERE
+            } else if (pix_flg == MAP_CELL_ENLARGED_OBSTACLE) {
+                m_map_occupancy.safePixel(x, y) = 0; //@@@SET HERE
+            } else if (pix_flg == MAP_CELL_WALL) {
+                m_map_occupancy.safePixel(x, y) = 100; //@@@SET HERE
+            } else if (pix_flg == MAP_CELL_UNKNOWN) {
+                m_map_occupancy.safePixel(x, y) = 255; //@@@SET HERE
+            } else {
+                m_map_occupancy.safePixel(x, y) = 255; //@@@SET HERE
+            }
         }
     }
     m_occupied_thresh = 0.80; //@@@SET HERE
@@ -574,10 +632,15 @@ bool  MapGrid2D::loadFromFile(std::string map_file_with_path)
 
 MapGrid2D::CellFlagData MapGrid2D::PixelToCellFlagData(const yarp::sig::PixelRgb& pixin) const
 {
-    if (pixin.r == 0 && pixin.g == 0 && pixin.b == 0)   return MAP_CELL_WALL;
-    else if (pixin.r == 205 && pixin.g == 205 && pixin.b == 205) return  MAP_CELL_UNKNOWN;
-    else if (pixin.r == 254 && pixin.g == 254 && pixin.b == 254) return  MAP_CELL_FREE;
-    else if (pixin.r == 255 && pixin.g == 0 && pixin.b == 0) return  MAP_CELL_KEEP_OUT;
+    if (pixin.r == 0 && pixin.g == 0 && pixin.b == 0) {
+        return MAP_CELL_WALL;
+    } else if (pixin.r == 205 && pixin.g == 205 && pixin.b == 205) {
+        return MAP_CELL_UNKNOWN;
+    } else if (pixin.r == 254 && pixin.g == 254 && pixin.b == 254) {
+        return MAP_CELL_FREE;
+    } else if (pixin.r == 255 && pixin.g == 0 && pixin.b == 0) {
+        return MAP_CELL_KEEP_OUT;
+    }
     return  MAP_CELL_UNKNOWN;
 }
 
@@ -704,10 +767,18 @@ bool  MapGrid2D::crop (int left, int top, int right, int bottom)
     }
     rightFound:
 
-    if (left   > (int)this->width()) return false;
-    if (right  > (int)this->width()) return false;
-    if (top    > (int)this->height()) return false;
-    if (bottom > (int)this->height()) return false;
+        if (left > (int)this->width()) {
+            return false;
+        }
+        if (right > (int)this->width()) {
+            return false;
+        }
+        if (top > (int)this->height()) {
+            return false;
+        }
+        if (bottom > (int)this->height()) {
+            return false;
+        }
 
     yarp::sig::ImageOf<CellOccupancyData> new_map_occupancy;
     yarp::sig::ImageOf<CellFlagData> new_map_flags;
@@ -720,12 +791,13 @@ bool  MapGrid2D::crop (int left, int top, int right, int bottom)
 //     size_t original_width = m_map_occupancy.width();
     size_t original_height = m_map_occupancy.height();
 
-    for (int j=top, y=0; j<bottom; j++, y++)
+    for (int j = top, y = 0; j < bottom; j++, y++) {
         for (int i=left, x=0; i<right; i++, x++)
         {
             new_map_occupancy.safePixel(x,y) = m_map_occupancy.safePixel(i,j);
             new_map_flags.safePixel(x,y)     = m_map_flags.safePixel(i,j);
         }
+    }
     m_map_occupancy.copy(new_map_occupancy);
     m_map_flags.copy(new_map_flags);
     this->m_width=m_map_occupancy.width();
@@ -871,7 +943,9 @@ bool MapGrid2D::read(yarp::os::ConnectionReader& connection)
             unsigned char* mem = m_map_flags.getRawImage();
             ok &= connection.expectBlock((char*)mem, memsize);
         }
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
     }
     return !connection.isError();
 }

--- a/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.cpp
+++ b/src/libYARP_dev/src/yarp/dev/MapGrid2DInfo.cpp
@@ -42,9 +42,15 @@ MapGrid2DOrigin::MapGrid2DOrigin(double x_init, double y_init, double t_init)
 
 bool MapGrid2DOrigin::operator != (const MapGrid2DOrigin& other) const
 {
-    if (x != other.x) return true;
-    if (y != other.y) return true;
-    if (theta != other.theta) return true; //should I check for 360 wrap?
+    if (x != other.x) {
+        return true;
+    }
+    if (y != other.y) {
+        return true;
+    }
+    if (theta != other.theta) {
+        return true; //should I check for 360 wrap?
+    }
     return false;
 }
 
@@ -117,10 +123,12 @@ bool MapGrid2DInfo::isInsideMap(XYCell cell) const
 {
     //if (cell.x < 0) return false;
     //if (cell.y < 0) return false;
-    if (cell.x >= m_width)
+    if (cell.x >= m_width) {
         return false;
-    if (cell.y >= m_height)
+    }
+    if (cell.y >= m_height) {
         return false;
+    }
     return true;
 }
 

--- a/src/libYARP_dev/src/yarp/dev/PolyDriver.cpp
+++ b/src/libYARP_dev/src/yarp/dev/PolyDriver.cpp
@@ -200,8 +200,12 @@ bool PolyDriver::isValid() const
 
 bool PolyDriver::link(PolyDriver& alt)
 {
-    if (!alt.isValid()) return false;
-    if (isValid()) return false;
+    if (!alt.isValid()) {
+        return false;
+    }
+    if (isValid()) {
+        return false;
+    }
     dd = alt.dd;
     if (mPriv!=nullptr) {
         int ct = mPriv->removeRef();

--- a/src/libYARP_init/src/yarp/os/Network.CustomInit.cpp
+++ b/src/libYARP_init/src/yarp/os/Network.CustomInit.cpp
@@ -83,5 +83,7 @@ void yarp::os::Network::fini() {
         yarpCustomFini();
         finiMinimum();
     }
-    if (__custom_yarp_is_initialized>0) __custom_yarp_is_initialized--;
+    if (__custom_yarp_is_initialized > 0) {
+        __custom_yarp_is_initialized--;
+    }
 }

--- a/src/libYARP_logger/src/yarp/logger/YarpLogger.cpp
+++ b/src/libYARP_logger/src/yarp/logger/YarpLogger.cpp
@@ -83,13 +83,22 @@ void LogEntryInfo::clearLastError()
 
 void LogEntryInfo::setNewError(LogLevel level)
 {
-    if      (level==LOGLEVEL_TRACE)   number_of_traces++;
-    else if (level==LOGLEVEL_DEBUG)   number_of_debugs++;
-    else if (level==LOGLEVEL_INFO)    number_of_infos++;
-    else if (level==LOGLEVEL_WARNING) number_of_warnings++;
-    else if (level==LOGLEVEL_ERROR)   number_of_errors++;
-    else if (level==LOGLEVEL_FATAL)   number_of_fatals++;
-    if (level>highest_error) highest_error=level;
+    if (level == LOGLEVEL_TRACE) {
+        number_of_traces++;
+    } else if (level == LOGLEVEL_DEBUG) {
+        number_of_debugs++;
+    } else if (level == LOGLEVEL_INFO) {
+        number_of_infos++;
+    } else if (level == LOGLEVEL_WARNING) {
+        number_of_warnings++;
+    } else if (level == LOGLEVEL_ERROR) {
+        number_of_errors++;
+    } else if (level == LOGLEVEL_FATAL) {
+        number_of_fatals++;
+    }
+    if (level > highest_error) {
+        highest_error = level;
+    }
 }
 
 void LoggerEngine::discover  (std::list<std::string>& ports)
@@ -405,12 +414,19 @@ void LoggerEngine::logger_thread::run()
                 {
                     std::string level = s.substr(str,end+1);
                     body.level = LOGLEVEL_UNDEFINED;
-                    if      (level.find("TRACE")!=std::string::npos)   body.level = LOGLEVEL_TRACE;
-                    else if (level.find("DEBUG")!=std::string::npos)   body.level = LOGLEVEL_DEBUG;
-                    else if (level.find("INFO")!=std::string::npos)    body.level = LOGLEVEL_INFO;
-                    else if (level.find("WARNING")!=std::string::npos) body.level = LOGLEVEL_WARNING;
-                    else if (level.find("ERROR")!=std::string::npos)   body.level = LOGLEVEL_ERROR;
-                    else if (level.find("FATAL")!=std::string::npos)   body.level = LOGLEVEL_FATAL;
+                    if (level.find("TRACE") != std::string::npos) {
+                        body.level = LOGLEVEL_TRACE;
+                    } else if (level.find("DEBUG") != std::string::npos) {
+                        body.level = LOGLEVEL_DEBUG;
+                    } else if (level.find("INFO") != std::string::npos) {
+                        body.level = LOGLEVEL_INFO;
+                    } else if (level.find("WARNING") != std::string::npos) {
+                        body.level = LOGLEVEL_WARNING;
+                    } else if (level.find("ERROR") != std::string::npos) {
+                        body.level = LOGLEVEL_ERROR;
+                    } else if (level.find("FATAL") != std::string::npos) {
+                        body.level = LOGLEVEL_FATAL;
+                    }
                     body.text = s.substr(end+1);
                 }
                 else
@@ -439,8 +455,12 @@ void LoggerEngine::logger_thread::run()
             getline(iss, token, '/'); entry.logInfo.port_prefix  = "/"+ token;
             getline(iss, token, '/'); entry.logInfo.process_name = token;
             getline(iss, token, '/'); entry.logInfo.process_pid  = token.erase(token.size()-1);
-            if (entry.logInfo.port_system == "log" && listen_to_YARP_MESSAGES==false)    continue;
-            if (entry.logInfo.port_system == "yarprunlog" && listen_to_YARPRUN_MESSAGES==false) continue;
+            if (entry.logInfo.port_system == "log" && listen_to_YARP_MESSAGES == false) {
+                continue;
+            }
+            if (entry.logInfo.port_system == "yarprunlog" && listen_to_YARPRUN_MESSAGES == false) {
+                continue;
+            }
 
             std::list<LogEntry>::iterator it;
             for (it = log_list.begin(); it != log_list.end(); it++)
@@ -529,16 +549,22 @@ void LoggerEngine::logger_thread::threadRelease()
 
 bool LoggerEngine::stop_logging()
 {
-    if (log_updater == nullptr) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
 
     logging=false;
-    if (log_updater->isRunning()==true) log_updater->stop();
+    if (log_updater->isRunning() == true) {
+        log_updater->stop();
+    }
     return true;
 }
 
 void LoggerEngine::start_discover()
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->start();
     discovering=true;
@@ -568,14 +594,18 @@ LoggerEngine::~LoggerEngine()
 
 int  LoggerEngine::get_num_of_processes()
 {
-    if (log_updater == nullptr) return 0;
+    if (log_updater == nullptr) {
+        return 0;
+    }
 
     return log_updater->logger_port.getInputCount();
 }
 
 void LoggerEngine::get_infos (std::list<LogEntryInfo>& infos)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -588,7 +618,9 @@ void LoggerEngine::get_infos (std::list<LogEntryInfo>& infos)
 
 void LoggerEngine::get_messages (std::list<MessageEntry>& messages)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -601,7 +633,9 @@ void LoggerEngine::get_messages (std::list<MessageEntry>& messages)
 
 void LoggerEngine::get_messages_by_port_prefix    (std::string  port,  std::list<MessageEntry>& messages,  bool from_beginning)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -632,7 +666,9 @@ void LoggerEngine::get_messages_by_port_prefix    (std::string  port,  std::list
 
 void LoggerEngine::clear_messages_by_port_complete    (std::string  port)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -649,7 +685,9 @@ void LoggerEngine::clear_messages_by_port_complete    (std::string  port)
 
 void LoggerEngine::get_messages_by_port_complete    (std::string  port,  std::list<MessageEntry>& messages,  bool from_beginning)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -681,7 +719,9 @@ void LoggerEngine::get_messages_by_port_complete    (std::string  port,  std::li
 
 void LoggerEngine::get_messages_by_process (std::string  process,  std::list<MessageEntry>& messages,  bool from_beginning)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -712,7 +752,9 @@ void LoggerEngine::get_messages_by_process (std::string  process,  std::list<Mes
 
 void LoggerEngine::get_messages_by_pid     (std::string pid, std::list<MessageEntry>& messages,  bool from_beginning)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -748,15 +790,18 @@ const std::list<MessageEntry> filter_by_level (int level, const std::list<Messag
     for (it = messages.begin(); it != messages.end(); it++)
     {
         LogLevel llevel = it->level;
-        if (llevel.toInt() == level)
+        if (llevel.toInt() == level) {
             ret.push_back(*it);
+        }
     }
     return ret;
 }
 
 void LoggerEngine::set_listen_option               (LogLevel logLevel, bool enable)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
     if      (logLevel == LOGLEVEL_UNDEFINED)  {log_updater->listen_to_LOGLEVEL_UNDEFINED=enable;}
     else if (logLevel == LOGLEVEL_TRACE)      {log_updater->listen_to_LOGLEVEL_TRACE=enable;}
@@ -770,7 +815,9 @@ void LoggerEngine::set_listen_option               (LogLevel logLevel, bool enab
 
 bool LoggerEngine::get_listen_option               (LogLevel logLevel)
 {
-    if (log_updater == nullptr) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
     if (logLevel == LOGLEVEL_UNDEFINED) {return log_updater->listen_to_LOGLEVEL_UNDEFINED;}
     if (logLevel == LOGLEVEL_TRACE)     {return log_updater->listen_to_LOGLEVEL_TRACE;}
     if (logLevel == LOGLEVEL_DEBUG)     {return log_updater->listen_to_LOGLEVEL_DEBUG;}
@@ -783,7 +830,9 @@ bool LoggerEngine::get_listen_option               (LogLevel logLevel)
 
 void LoggerEngine::set_listen_option               (std::string   option, bool enable)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
     log_updater->mutex.unlock();
 }
@@ -795,7 +844,9 @@ bool LoggerEngine::get_listen_option               (std::string   option)
 
 void LoggerEngine::set_listen_option               (LogSystemEnum   logSystem, bool enable)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
     if      (logSystem == LOGSYSTEM_YARP)         {log_updater->listen_to_YARP_MESSAGES=enable;}
     else if (logSystem == LOGSYSTEM_YARPRUN)      {log_updater->listen_to_YARPRUN_MESSAGES=enable;}
@@ -804,7 +855,9 @@ void LoggerEngine::set_listen_option               (LogSystemEnum   logSystem, b
 
 bool LoggerEngine::get_listen_option               (LogSystemEnum   logSystem)
 {
-    if (log_updater == nullptr) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
     if (logSystem == LOGSYSTEM_YARP)        {return log_updater->listen_to_YARP_MESSAGES;}
     if (logSystem == LOGSYSTEM_YARPRUN)     {return log_updater->listen_to_YARPRUN_MESSAGES;}
     return false;
@@ -812,8 +865,12 @@ bool LoggerEngine::get_listen_option               (LogSystemEnum   logSystem)
 
 bool LoggerEngine::export_log_to_text_file   (std::string  filename, std::string portname)
 {
-    if (log_updater == nullptr) return false;
-    if (filename.size() == 0) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
+    if (filename.size() == 0) {
+        return false;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -841,17 +898,25 @@ bool LoggerEngine::save_all_logs_to_file   (std::string  filename)
     string start_string ="<#STRING_START#>";
     string end_string ="<#STRING_END#>";
 
-    if (log_updater == nullptr) return false;
-    if (filename.size() == 0) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
+    if (filename.size() == 0) {
+        return false;
+    }
 
     const int      LOGFILE_VERSION = 1;
 
     ofstream file1;
     file1.open(filename.c_str());
-    if (file1.is_open() == false) return false;
+    if (file1.is_open() == false) {
+        return false;
+    }
 
     bool wasRunning = log_updater->isRunning();
-    if (wasRunning) log_updater->stop();
+    if (wasRunning) {
+        log_updater->stop();
+    }
     std::list<LogEntry>::iterator it;
     file1 << LOGFILE_VERSION << std::endl;
     file1 << log_updater->log_list.size() << std::endl;
@@ -878,12 +943,16 @@ bool LoggerEngine::save_all_logs_to_file   (std::string  filename)
             file1 << it1->local_timestamp << std::endl;
             file1 << it1->level.toInt() << std::endl;
             file1 << start_string;
-            for (char s : it1->text) file1.put(s);
+            for (char s : it1->text) {
+                file1.put(s);
+            }
             file1 << end_string <<endl;
         }
     }
     file1.close();
-    if (wasRunning) log_updater->start();
+    if (wasRunning) {
+        log_updater->start();
+    }
     return true;
 }
 
@@ -892,7 +961,9 @@ std::streamoff get_tag(ifstream& file, const char* tag)
     std::streamoff pos=file.tellg();
     int tag_size=strlen(tag);
     char* buff = new char[tag_size+2];
-    for(int i=0; i<tag_size+2;i++) buff[i]=0;
+    for (int i = 0; i < tag_size + 2; i++) {
+        buff[i] = 0;
+    }
     std::streamoff off=0;
     for (; ;off++)
     {
@@ -903,7 +974,9 @@ std::streamoff get_tag(ifstream& file, const char* tag)
             delete [] buff;
             return -1;
         }
-        if (strcmp(buff,tag)==0) break;
+        if (strcmp(buff, tag) == 0) {
+            break;
+        }
     }
     delete [] buff;
     return pos+off;
@@ -916,18 +989,26 @@ bool LoggerEngine::load_all_logs_from_file   (std::string  filename)
     string end_string ="<#STRING_END#>";
     int end_string_size=strlen(end_string.c_str());
 
-    if (log_updater == nullptr) return false;
-    if (filename.size() == 0) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
+    if (filename.size() == 0) {
+        return false;
+    }
 
     const int      LOGFILE_VERSION = 1;
 
     ifstream file1;
     file1.open(filename.c_str(),std::ifstream::binary);
-    if (file1.is_open() == false) return false;
+    if (file1.is_open() == false) {
+        return false;
+    }
 
     int log_file_version;
     bool wasRunning = log_updater->isRunning();
-    if (wasRunning) log_updater->stop();
+    if (wasRunning) {
+        log_updater->stop();
+    }
     file1 >> log_file_version;
     if (log_file_version == LOGFILE_VERSION)
     {
@@ -964,7 +1045,9 @@ bool LoggerEngine::load_all_logs_from_file   (std::string  filename)
                 std::streamoff start_p = get_tag(file1, start_string.c_str());
                 std::streamoff end_p = get_tag(file1, end_string.c_str());
                 //validity check
-                if (start_p<0 || end_p<0 || end_p-start_p+start_string_size<=0) return false;
+                if (start_p < 0 || end_p < 0 || end_p - start_p + start_string_size <= 0) {
+                    return false;
+                }
                 char *buff = new char[(unsigned int)(end_p-start_p+start_string_size)];
                 //memset(buff,0,end_p-start_p+start_string_size);
                 file1.seekg(start_p+start_string_size);
@@ -985,13 +1068,17 @@ bool LoggerEngine::load_all_logs_from_file   (std::string  filename)
         }
     }
     file1.close();
-    if (wasRunning) log_updater->start();
+    if (wasRunning) {
+        log_updater->start();
+    }
     return true;
 }
 
 void LoggerEngine::set_log_lines_max_size (bool  enabled,  int new_size)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
 
     std::list<LogEntry>::iterator it;
@@ -1007,7 +1094,9 @@ void LoggerEngine::set_log_lines_max_size (bool  enabled,  int new_size)
 
 void LoggerEngine::set_log_list_max_size           (bool  enabled,  int new_size)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
     log_updater->log_list_max_size_enabled = enabled;
     log_updater->log_list_max_size = new_size;
@@ -1016,8 +1105,12 @@ void LoggerEngine::set_log_list_max_size           (bool  enabled,  int new_size
 
 void LoggerEngine::get_log_lines_max_size          (bool& enabled, int& current_size)
 {
-    if (log_updater == nullptr) return;
-    if (log_updater->log_list.empty() == true) return;
+    if (log_updater == nullptr) {
+        return;
+    }
+    if (log_updater->log_list.empty() == true) {
+        return;
+    }
     log_updater->mutex.lock();
     auto it = log_updater->log_list.begin();
     current_size = it->getLogEntryMaxSize();
@@ -1027,7 +1120,9 @@ void LoggerEngine::get_log_lines_max_size          (bool& enabled, int& current_
 
 void LoggerEngine::get_log_list_max_size           (bool& enabled, int& current_size)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
     log_updater->mutex.lock();
     enabled=log_updater->log_list_max_size_enabled;
     current_size=log_updater->log_list_max_size;
@@ -1036,7 +1131,9 @@ void LoggerEngine::get_log_list_max_size           (bool& enabled, int& current_
 
 bool LoggerEngine::clear()
 {
-    if (log_updater == nullptr) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
     log_updater->mutex.lock();
     log_updater->log_list.clear();
     log_updater->mutex.unlock();
@@ -1045,7 +1142,9 @@ bool LoggerEngine::clear()
 
 void LoggerEngine::set_log_enable_by_port_complete (std::string  port, bool enable)
 {
-    if (log_updater == nullptr) return;
+    if (log_updater == nullptr) {
+        return;
+    }
 
     log_updater->mutex.lock();
     std::list<LogEntry>::iterator it;
@@ -1062,7 +1161,9 @@ void LoggerEngine::set_log_enable_by_port_complete (std::string  port, bool enab
 
 bool  LoggerEngine::get_log_enable_by_port_complete (std::string  port)
 {
-    if (log_updater == nullptr) return false;
+    if (log_updater == nullptr) {
+        return false;
+    }
 
     bool enabled=false;
     log_updater->mutex.lock();

--- a/src/libYARP_manager/src/yarp/manager/application.cpp
+++ b/src/libYARP_manager/src/yarp/manager/application.cpp
@@ -15,8 +15,9 @@ ModuleInterface::ModuleInterface(Module* module) :
     waitStart(0.0),
     waitStop(0.0)
 {
-    if(!module)
+    if (!module) {
         return;
+    }
 
     strName = module->strName;
     strHost = module->strHost;
@@ -31,10 +32,11 @@ ModuleInterface::ModuleInterface(Module* module) :
     strDisplay = module->getDisplay();
     waitStart = module->getPostExecWait();
     waitStop = module->getPostStopWait();
-    if(module->getModel())
+    if (module->getModel()) {
         modelBase = *module->getModel();
-    else
+    } else {
         modelBase = module->getModelBase();
+    }
 
    //TODO: resources should be added too
 }
@@ -49,8 +51,9 @@ bool ModuleInterface::addPortmap(Portmap &portmap)
 bool ModuleInterface::removePortmap(Portmap& portmap)
 {
     auto itr = findPortmap(portmap);
-    if(itr == portmaps.end())
+    if (itr == portmaps.end()) {
         return true;
+    }
     portmaps.erase(itr);
     return true;
 }
@@ -59,9 +62,11 @@ bool ModuleInterface::removePortmap(Portmap& portmap)
 PortmapIterator ModuleInterface::findPortmap(Portmap& portmap)
 {
     PortmapIterator itr;
-    for(itr=portmaps.begin(); itr<portmaps.end(); itr++)
-        if ((*itr) == portmap)
+    for (itr = portmaps.begin(); itr < portmaps.end(); itr++) {
+        if ((*itr) == portmap) {
             return itr;
+        }
+    }
     return portmaps.end();
 }
 
@@ -120,8 +125,9 @@ bool Application::addImodule(ModuleInterface &imod)
 bool Application::removeImodule(ModuleInterface& imod)
 {
     auto itr = findImodule(imod);
-    if(itr == Imodules.end())
+    if (itr == Imodules.end()) {
         return true;
+    }
     Imodules.erase(itr);
     return true;
 }
@@ -138,8 +144,9 @@ Connection& Application::addConnection(Connection &cnn)
 bool Application::removeConnection(Connection& cnn)
 {
     auto itr = findConnection(cnn);
-    if(itr == connections.end())
+    if (itr == connections.end()) {
         return true;
+    }
     connections.erase(itr);
     return true;
 
@@ -155,8 +162,9 @@ Arbitrator& Application::addArbitrator(Arbitrator &arb)
 bool Application::removeArbitrator(Arbitrator& arb)
 {
     auto itr = findArbitrator(arb);
-    if(itr == arbitrators.end())
+    if (itr == arbitrators.end()) {
         return true;
+    }
     arbitrators.erase(itr);
     return true;
 }
@@ -194,8 +202,9 @@ bool Application::addIapplication(ApplicationInterface &iapp)
 bool Application::removeIapplication(ApplicationInterface& iapp)
 {
     auto itr = findIapplication(iapp);
-    if(itr == Iapplications.end())
+    if (itr == Iapplications.end()) {
         return true;
+    }
     Iapplications.erase(itr);
     return true;
 }
@@ -210,8 +219,9 @@ bool Application::addResource(ResYarpPort &res)
 bool Application::removeResource(ResYarpPort& res)
 {
     auto itr = findResource(res);
-    if(itr == resources.end())
+    if (itr == resources.end()) {
         return true;
+    }
     resources.erase(itr);
     return true;
 }
@@ -219,12 +229,13 @@ bool Application::removeResource(ResYarpPort& res)
 bool Application::removeAuthor(Author& author)
 {
     AuthorIterator itr;
-    for(itr=authors.begin(); itr<authors.end(); itr++)
+    for (itr = authors.begin(); itr < authors.end(); itr++) {
         if((*itr) == author)
         {
             authors.erase(itr);
             return true;
         }
+    }
     return true;
 }
 
@@ -232,9 +243,11 @@ bool Application::removeAuthor(Author& author)
 IModuleIterator Application::findImodule(ModuleInterface& imod)
 {
     IModuleIterator itr;
-    for(itr=Imodules.begin(); itr<Imodules.end(); itr++)
-        if ((*itr) == imod)
+    for (itr = Imodules.begin(); itr < Imodules.end(); itr++) {
+        if ((*itr) == imod) {
             return itr;
+        }
+    }
     return Imodules.end();
 }
 
@@ -242,18 +255,22 @@ IModuleIterator Application::findImodule(ModuleInterface& imod)
 CnnIterator Application::findConnection(Connection& cnn)
 {
     CnnIterator itr;
-    for(itr=connections.begin(); itr<connections.end(); itr++)
-        if ((*itr) == cnn)
+    for (itr = connections.begin(); itr < connections.end(); itr++) {
+        if ((*itr) == cnn) {
             return itr;
+        }
+    }
     return connections.end();
 }
 
 ArbIterator Application::findArbitrator(Arbitrator& arb)
 {
     ArbIterator itr;
-    for(itr=arbitrators.begin(); itr<arbitrators.end(); itr++)
-        if ((*itr) == arb)
+    for (itr = arbitrators.begin(); itr < arbitrators.end(); itr++) {
+        if ((*itr) == arb) {
             return itr;
+        }
+    }
     return arbitrators.end();
 }
 
@@ -261,17 +278,21 @@ ArbIterator Application::findArbitrator(Arbitrator& arb)
 IApplicationIterator Application::findIapplication(ApplicationInterface& iapp)
 {
     IApplicationIterator itr;
-    for(itr=Iapplications.begin(); itr<Iapplications.end(); itr++)
-        if ((*itr) == iapp)
+    for (itr = Iapplications.begin(); itr < Iapplications.end(); itr++) {
+        if ((*itr) == iapp) {
             return itr;
+        }
+    }
     return Iapplications.end();
 }
 
 ResourceIterator Application::findResource(ResYarpPort& res)
 {
     ResourceIterator itr;
-    for(itr=resources.begin(); itr<resources.end(); itr++)
-        if ((*itr) == res)
+    for (itr = resources.begin(); itr < resources.end(); itr++) {
+        if ((*itr) == res) {
             return itr;
+        }
+    }
     return resources.end();
 }

--- a/src/libYARP_manager/src/yarp/manager/arbitrator.cpp
+++ b/src/libYARP_manager/src/yarp/manager/arbitrator.cpp
@@ -76,13 +76,15 @@ bool Arbitrator::trainWeights(const char* opnd)
 
     BinaryExpParser parser;
     std::map<string, string>::iterator itr;
-    for(itr=rules.begin(); itr!=rules.end(); itr++)
+    for (itr = rules.begin(); itr != rules.end(); itr++) {
         parser.addRestrictedOperand((itr->first).c_str());
+    }
 
     // parsing the compact logic
     rule = string(opnd) + " : " + rule;
-    if(!parser.parse(rule))
+    if (!parser.parse(rule)) {
         return false;
+    }
 
     // trining the weights
     LinkTrainer trainer;
@@ -118,8 +120,9 @@ bool Arbitrator::trainWeights()
     alphas.clear();
     bool bAllOk = true;
     std::map<string, string>::iterator itr;
-    for(itr=rules.begin(); itr!=rules.end(); itr++)
+    for (itr = rules.begin(); itr != rules.end(); itr++) {
         bAllOk &= trainWeights((itr->first).c_str());
+    }
 
     return bAllOk;
 }
@@ -128,14 +131,16 @@ bool Arbitrator::validate()
 {
     ErrorLogger* logger  = ErrorLogger::Instance();
 
-    if(!trainWeights())
+    if (!trainWeights()) {
         return false;
+    }
 
 #ifdef WITH_YARPMATH
 //#if (GSL_MAJOR_VERSION >= 2 || (GSL_MAJOR_VERSION >= 1 && GSL_MINOR_VERSION >= 14))
     int n = alphas.size();
-    if(n == 0)
+    if (n == 0) {
         return true;
+    }
 
     yarp::sig::Matrix A(n, n);
     std::map<std::string, std::map<std::string, double> >::iterator itr;    // iterating over rows
@@ -149,10 +154,11 @@ bool Arbitrator::validate()
         for(jtr=alphas.begin(); jtr!=alphas.end(); jtr++)
         {
             std::string opnd = jtr->first;
-            if(w.find(opnd) != w.end())
+            if (w.find(opnd) != w.end()) {
                 A(row,col) = w[opnd];
-            else
-                A(row,col) = 0.0;
+            } else {
+                A(row, col) = 0.0;
+            }
             col++;
         }
         row++;

--- a/src/libYARP_manager/src/yarp/manager/binexparser.cpp
+++ b/src/libYARP_manager/src/yarp/manager/binexparser.cpp
@@ -37,8 +37,9 @@ bool BinaryExpParser::parse(string _exp)
 {
     expression = _exp;
     string strexp = expression;
-    if(!checkExpression(strexp))
+    if (!checkExpression(strexp)) {
         return false;
+    }
 
     binTree.clear();
     operands.clear();
@@ -55,8 +56,9 @@ bool BinaryExpParser::parse(string _exp)
     {
         ErrorLogger* logger = ErrorLogger::Instance();
         string msg = "Invalid operands";
-        for(const auto& invalidOperand : invalidOperands)
+        for (const auto& invalidOperand : invalidOperands) {
             msg += " '" + invalidOperand + "'";
+        }
         logger->addError(msg);
         return false;
     }
@@ -67,8 +69,9 @@ bool BinaryExpParser::parse(string _exp)
     for(int x = 0; x < (1 << (n-1)); ++x)
     {
         auto itr = operands.begin();
-        for(int y = 0; y < (n-1); ++y)
+        for (int y = 0; y < (n - 1); ++y) {
             (*itr++).second = (truthTable[y][x] != 0);
+        }
         truthTable[n-1][x] = evalTree(root, operands);
     }
     //printTruthTable(leftOpr);
@@ -79,8 +82,9 @@ bool BinaryExpParser::exportDotGraph(const char* szFileName)
 {
     ofstream dot;
     dot.open(szFileName);
-    if(!dot.is_open())
+    if (!dot.is_open()) {
         return false;
+    }
 
     dot<<"digraph G {"<<endl;
     for(GraphIterator itr=binTree.begin(); itr!=binTree.end(); itr++)
@@ -217,8 +221,9 @@ bool BinaryExpParser::checkExpression(std::string& strexp)
             bError |= (dummy[n+1] == EXPAND);        // operator & after ~
             bError |= (dummy[n+1] == EXPOR);         // operand | after ~
         }
-        if(n != 0)
-            bError |= (dummy[n-1] != EXPAND) && (dummy[n-1] != EXPOR);  // an operand before ~
+        if (n != 0) {
+            bError |= (dummy[n - 1] != EXPAND) && (dummy[n - 1] != EXPOR); // an operand before ~
+        }
         if(bError)
         {
             msg<<"Incorrect expression format of '~' at "<<(int)n;
@@ -281,8 +286,9 @@ void BinaryExpParser::parseExpression(std::string &strexp, BinaryNodePtr& node)
 void BinaryExpParser::parseNot(std::string &strexp, BinaryNodePtr& node) {
     string op;
     BinaryNodePtr rightNode;
-    if(*strexp.begin() != EXPNOT)
+    if (*strexp.begin() != EXPNOT) {
         parseFactor(strexp, node);
+    }
     while(!strexp.empty() &&
           (*strexp.begin() == EXPNOT))
     {
@@ -303,9 +309,12 @@ void BinaryExpParser::parseFactor(std::string &strexp, BinaryNodePtr& node) {
         operands[op] = false;
         if(validOperands.size())
         {
-            if(std::find(validOperands.begin(),
-                         validOperands.end(), op) == validOperands.end())
+            if (std::find(validOperands.begin(),
+                          validOperands.end(),
+                          op)
+                == validOperands.end()) {
                 invalidOperands.push_back(op);
+            }
         }
     }
     else
@@ -320,27 +329,27 @@ void BinaryExpParser::parseFactor(std::string &strexp, BinaryNodePtr& node) {
 std::string BinaryExpParser::getNextOperand(std::string &strexp) {
         string token;
         std::string::iterator it;
-        for (it=strexp.begin(); it!=strexp.end(); ++it)
-            if((*it != EXPAND) && (*it != EXPOR) && (*it != EXPNOT) &&
-               (*it != ')') && (*it != '('))
+        for (it = strexp.begin(); it != strexp.end(); ++it) {
+            if ((*it != EXPAND) && (*it != EXPOR) && (*it != EXPNOT) && (*it != ')') && (*it != '(')) {
                 token.push_back(*it);
-            else
+            } else {
                 break;
+            }
+        }
         return token;
 }
 
 std::string BinaryExpParser::popNextOperand(std::string &strexp) {
         string token;
         std::string::iterator it;
-       for (it=strexp.begin(); it!=strexp.end(); ++it)
-            if((*it != EXPAND) && (*it != EXPOR) && (*it != EXPNOT) &&
-               (*it != ')') && (*it != '('))
+        for (it = strexp.begin(); it != strexp.end(); ++it) {
+            if ((*it != EXPAND) && (*it != EXPOR) && (*it != EXPNOT) && (*it != ')') && (*it != '(')) {
                 token.push_back(*it);
-            else
-            {
+            } else {
                 strexp.erase(strexp.begin(), it);
                 break;
             }
+        }
         return token;
 }
 
@@ -353,8 +362,9 @@ void BinaryExpParser::createTruthTable(const int n)
     truthTable.clear();
     // n input + one output
     truthTable.resize(n+1);
-    for(int i=0; i<n+1; i++)
+    for (int i = 0; i < n + 1; i++) {
         truthTable[i].resize(1 << n);
+    }
     int num_to_fill = 1 << (n - 1);
     for(int col = 0; col < n; ++col, num_to_fill >>= 1)
     {
@@ -374,17 +384,20 @@ void BinaryExpParser::printTruthTable(std::string lopr)
     yAssert(1 <= (INT_MAX >> (n-1)));
 
     map<string, bool>::iterator itr;
-    for(itr=operands.begin(); itr!=operands.end(); itr++)
-       cout<<(*itr).first<<"\t";
+    for (itr = operands.begin(); itr != operands.end(); itr++) {
+        cout << (*itr).first << "\t";
+    }
     cout<<lopr<<endl;
-    for(int i=0; i<(int)operands.size()*8+1; i++)
-        cout<<"-";
+    for (int i = 0; i < (int)operands.size() * 8 + 1; i++) {
+        cout << "-";
+    }
     cout<<endl;
 
     for(int x = 0; x < (1<<(n-1)); ++x)
     {
-        for(int y = 0; y < n; ++y)
-            std::cout<< truthTable[y][x] << "\t";
+        for (int y = 0; y < n; ++y) {
+            std::cout << truthTable[y][x] << "\t";
+        }
         std::cout<<std::endl;
     }
 }
@@ -409,15 +422,17 @@ bool LinkTrainer::train(const std::vector<std::vector<int> >&  truthTable)
             // computing output of one set
             double P = truthTable[n-1][x];
             double out = bias;
-            for(int y = 0; y < n-1; ++y)
+            for (int y = 0; y < n - 1; ++y) {
                 out = out + ((double)truthTable[y][x] * alphas[y]);
+            }
             out = (out>0) ? 1 : 0;
             double err = P - out;
             sumerr += fabs(err);
             //cout<<P<<"\t"<<out<<"\terr:"<<err<<endl;
             bias = bias + trainRate * err;
-            for(int y = 0; y < (n-1); ++y)
+            for (int y = 0; y < (n - 1); ++y) {
                 alphas[y] = alphas[y] + (trainRate * err * (double)truthTable[y][x]);
+            }
         }
         errors.push_back(sumerr);
     }

--- a/src/libYARP_manager/src/yarp/manager/execstate.cpp
+++ b/src/libYARP_manager/src/yarp/manager/execstate.cpp
@@ -75,9 +75,9 @@ void Suspended::refresh()
     {
         executable->getEvent()->onExecutableStart(executable);
         castEvent(EventFactory::recoverEvent);
-    }
-    else if(ret == -1)
+    } else if (ret == -1) {
         logger->addError(executable->getBroker()->error());
+    }
 }
 
 
@@ -100,9 +100,10 @@ bool Ready::checkPriorityPorts()
     for(itr=executable->getConnections().begin();
         itr!=executable->getConnections().end(); itr++)
     {
-        if((*itr).withPriority()
-            && !executable->getBroker()->exists((*itr).from()))
+        if ((*itr).withPriority()
+            && !executable->getBroker()->exists((*itr).from())) {
             return false;
+        }
     }
     return true;
 }
@@ -116,9 +117,9 @@ bool Ready::checkResources(bool silent)
     {
         if(!executable->getBroker()->exists((*itr).getPort())) {
             allOK = false;
-            if(silent)
-               return false;
-            else {
+            if (silent) {
+                return false;
+            } else {
                 OSTRINGSTREAM msg;
                 msg<<(*itr).getPort()<<" does not exist";
                 ErrorLogger::Instance()->addError(msg);
@@ -135,10 +136,11 @@ bool Ready::checkResources(bool silent)
                 OSTRINGSTREAM msg;
                 msg<<"cannot request resource "<<(*itr).getPort()<<" for "<<(*itr).getRequest();
                 ErrorLogger::Instance()->addError(msg);
-                if(silent)
-                   return false;
-                else
+                if (silent) {
+                    return false;
+                } else {
                     continue;
+                }
             }
 
             if(!compareString(reply, (*itr).getReply())) {
@@ -148,10 +150,11 @@ bool Ready::checkResources(bool silent)
                 msg<<" for request "<<(*itr).getRequest();
                 msg<<". (expected="<<(*itr).getReply()<<", received="<<reply<<")";
                 ErrorLogger::Instance()->addWarning(msg);
-                if(silent)
-                   return false;
-                else
+                if (silent) {
+                    return false;
+                } else {
                     continue;
+                }
             }
         }
     }
@@ -161,8 +164,9 @@ bool Ready::checkResources(bool silent)
 bool Ready::timeout(double base, double timeout)
 {
     yarp::os::SystemClock::delaySystem(1.0);
-    if((yarp::os::SystemClock::nowSystem()-base) > timeout)
+    if ((yarp::os::SystemClock::nowSystem() - base) > timeout) {
         return true;
+    }
     return false;
 }
 
@@ -178,7 +182,9 @@ void Ready::startModule()
         while(!checkPriorityPorts())
         {
             yarp::os::SystemClock::delaySystem(1.0);
-            if(bAborted) return;
+            if (bAborted) {
+                return;
+            }
         }
     }
 
@@ -188,14 +194,17 @@ void Ready::startModule()
     for(itr=executable->getResources().begin();
         itr!=executable->getResources().end(); itr++)
     {
-        if((*itr).getTimeout() > maxTimeout)
+        if ((*itr).getTimeout() > maxTimeout) {
             maxTimeout = (*itr).getTimeout();
+        }
     }
 
     // waiting for resources
     double base = yarp::os::SystemClock::nowSystem();
     while(!checkResources()) {
-        if(bAborted) return;
+        if (bAborted) {
+            return;
+        }
 
         if(timeout(base, maxTimeout)) {
             // give it the last try and collect the error messages
@@ -221,8 +230,9 @@ void Ready::startModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot run "<<executable->getCommand()<<" on "<<executable->getHost();
-        if(executable->getBroker()->error())
-            msg<<" : "<<executable->getBroker()->error();
+        if (executable->getBroker()->error()) {
+            msg << " : " << executable->getBroker()->error();
+        }
         logger->addError(msg);
 
         castEvent(EventFactory::startModuleEventFailed);
@@ -262,9 +272,9 @@ bool Connecting::checkNormalPorts()
     for(itr=executable->getConnections().begin();
         itr!=executable->getConnections().end(); itr++)
     {
-        if(!executable->getBroker()->exists((*itr).to()) ||
-            !executable->getBroker()->exists((*itr).from()))
+        if (!executable->getBroker()->exists((*itr).to()) || !executable->getBroker()->exists((*itr).from())) {
             return false;
+        }
     }
     return true;
 }
@@ -282,7 +292,9 @@ void Connecting::connectAllPorts()
         while(!checkNormalPorts())
         {
             yarp::os::SystemClock::delaySystem(1.0);
-            if(bAborted) return;
+            if (bAborted) {
+                return;
+            }
         }
 
         CnnIterator itr;
@@ -294,12 +306,13 @@ void Connecting::connectAllPorts()
             {
                 OSTRINGSTREAM msg;
                 msg<<"cannot connect "<<(*itr).from() <<" to "<<(*itr).to();
-                if(executable->getBroker()->error())
-                    msg<<" : "<<executable->getBroker()->error();
+                if (executable->getBroker()->error()) {
+                    msg << " : " << executable->getBroker()->error();
+                }
                 logger->addError(msg);
-            }
-            else
+            } else {
                 executable->getEvent()->onCnnStablished(&(*itr));
+            }
         }
     }
 
@@ -310,10 +323,11 @@ void Connecting::refresh()
 {
     ErrorLogger* logger = ErrorLogger::Instance();
     int ret = executable->getBroker()->running();
-    if(ret == 0)
+    if (ret == 0) {
         Connecting::moduleFailed();
-    else if(ret == -1)
+    } else if (ret == -1) {
         logger->addError(executable->getBroker()->error());
+    }
 }
 
 void Connecting::kill()
@@ -346,11 +360,11 @@ void Running::refresh()
 {
     ErrorLogger* logger = ErrorLogger::Instance();
     int ret = executable->getBroker()->running();
-    if(ret == 0)
+    if (ret == 0) {
         Running::moduleFailed();
-    else if(ret == -1)
+    } else if (ret == -1) {
         logger->addError(executable->getBroker()->error());
-
+    }
 }
 
 void Running::start()
@@ -405,8 +419,9 @@ void Dying::stopModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot stop "<<executable->getCommand()<<" on "<<executable->getHost();
-        if(executable->getBroker()->error())
-            msg<<" : "<<executable->getBroker()->error();
+        if (executable->getBroker()->error()) {
+            msg << " : " << executable->getBroker()->error();
+        }
         logger->addError(msg);
         executable->getEvent()->onError(executable);
         castEvent(EventFactory::stopModuleEventFailed);
@@ -425,8 +440,9 @@ void Dying::killModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot kill "<<executable->getCommand()<<" on "<<executable->getHost();
-        if(executable->getBroker()->error())
-            msg<<" : "<<executable->getBroker()->error();
+        if (executable->getBroker()->error()) {
+            msg << " : " << executable->getBroker()->error();
+        }
         logger->addError(msg);
         executable->getEvent()->onError(executable);
         castEvent(EventFactory::killModuleEventFailed);
@@ -452,12 +468,13 @@ void Dying::disconnectAllPorts()
             {
                 OSTRINGSTREAM msg;
                 msg<<"cannot disconnect "<<(*itr).from() <<" to "<<(*itr).to();
-                if(executable->getBroker()->error())
-                    msg<<" : "<<executable->getBroker()->error();
+                if (executable->getBroker()->error()) {
+                    msg << " : " << executable->getBroker()->error();
+                }
                 logger->addError(msg);
-            }
-            else
+            } else {
                 executable->getEvent()->onCnnReleased(&(*itr));
+            }
         }
     }
     // We do not need to handle event disconnectAllPortsEventOk
@@ -467,11 +484,11 @@ void Dying::refresh()
 {
     ErrorLogger* logger = ErrorLogger::Instance();
     int ret = executable->getBroker()->running();
-    if(ret == 0)
+    if (ret == 0) {
         Dying::moduleFailed();
-    else if(ret == -1)
+    } else if (ret == -1) {
         logger->addError(executable->getBroker()->error());
-
+    }
 }
 
 void Dying::kill() { /* do nothing */ }
@@ -525,9 +542,9 @@ void Dead::refresh()
     {
         executable->getEvent()->onExecutableStart(executable);
         castEvent(EventFactory::recoverEvent);
-    }
-    else if(ret == -1)
+    } else if (ret == -1) {
         logger->addError(executable->getBroker()->error());
+    }
 }
 
 

--- a/src/libYARP_manager/src/yarp/manager/executable.cpp
+++ b/src/libYARP_manager/src/yarp/manager/executable.cpp
@@ -28,16 +28,18 @@ Executable::Executable(Broker* _broker, MEvent* _event, Module *module,
     killWrapper = new ConcurentWrapper(this, &Executable::killImplement);
     theID = -1;
 
-    if(bWatchDog)
+    if (bWatchDog) {
         watchdogWrapper = new ConcurentRateWrapper(this, &Executable::watchdogImplement);
-    else
+    } else {
         watchdogWrapper = nullptr;
+    }
 }
 
 Executable::~Executable()
 {
-    if(watchdogWrapper)
+    if (watchdogWrapper) {
         delete watchdogWrapper;
+    }
     delete startWrapper;
     delete stopWrapper;
     delete killWrapper;
@@ -63,8 +65,9 @@ bool Executable::initialize()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot initialize broker. : ";
-        if(broker->error())
-            msg<<broker->error();
+        if (broker->error()) {
+            msg << broker->error();
+        }
         logger->addError(msg);
         event->onExecutableDied(this);
         return false;
@@ -98,8 +101,9 @@ void Executable::startImplement()
 
 void Executable::stop()
 {
-    if(!broker->initialized())
+    if (!broker->initialized()) {
         initialize();
+    }
 
     if(!stopWrapper->isRunning()) {
         stopWatchDog();
@@ -118,8 +122,9 @@ void Executable::stopImplement()
 
 void Executable::kill()
 {
-    if(!broker->initialized())
+    if (!broker->initialized()) {
         initialize();
+    }
 
     // Notice that kill can be called from multiple threads
     stopWatchDog();
@@ -136,8 +141,9 @@ void Executable::killImplement()
 RSTATE Executable::state()
 {
 
-    if(!broker->initialized())
+    if (!broker->initialized()) {
         initialize();
+    }
 
     // Updating real module state on demand
     // Notice that this is a blocking method
@@ -145,18 +151,24 @@ RSTATE Executable::state()
 
     const char* strState = execMachine->currentState()->getName();
 
-    if(compareString(strState, "SUSPENDED"))
+    if (compareString(strState, "SUSPENDED")) {
         return SUSPENDED;
-    if(compareString(strState, "READY"))
+    }
+    if (compareString(strState, "READY")) {
         return READY;
-    if(compareString(strState, "CONNECTING"))
+    }
+    if (compareString(strState, "CONNECTING")) {
         return CONNECTING;
-    if(compareString(strState, "RUNNING"))
+    }
+    if (compareString(strState, "RUNNING")) {
         return RUNNING;
-    if(compareString(strState, "DEAD"))
+    }
+    if (compareString(strState, "DEAD")) {
         return DEAD;
-    if(compareString(strState, "DYING"))
+    }
+    if (compareString(strState, "DYING")) {
         return DYING;
+    }
 
     std::cerr<<"Unknown state!"<<std::endl;
     return STUNKNOWN;
@@ -205,16 +217,19 @@ void Executable::setAndInitializeBroker(Broker *_broker)
 }
 
 bool Executable::startWatchDog() {
-    if(watchdogWrapper == nullptr)
+    if (watchdogWrapper == nullptr) {
         return false;
-    if(!watchdogWrapper->isRunning())
+    }
+    if (!watchdogWrapper->isRunning()) {
         watchdogWrapper->start();
+    }
     return true;
 }
 
 void Executable::stopWatchDog() {
-    if(watchdogWrapper && watchdogWrapper->isRunning())
+    if (watchdogWrapper && watchdogWrapper->isRunning()) {
         watchdogWrapper->stop();
+    }
 }
 
 void Executable::onBrokerStdout(const char* msg)
@@ -225,14 +240,17 @@ void Executable::onBrokerStdout(const char* msg)
 
 void Executable::watchdogImplement()
 {
-    if(!broker->running())
-            execMachine->moduleFailed();
+    if (!broker->running()) {
+        execMachine->moduleFailed();
+    }
 
     if(bAutoConnect)
     {
         CnnIterator itr;
-        for(itr=connections.begin(); itr!=connections.end(); itr++)
-            if( !broker->connected((*itr).from(), (*itr).to(), (*itr).carrier()) )
+        for (itr = connections.begin(); itr != connections.end(); itr++) {
+            if (!broker->connected((*itr).from(), (*itr).to(), (*itr).carrier())) {
                 execMachine->connectionFailed(&(*itr));
+            }
+        }
     }
 }

--- a/src/libYARP_manager/src/yarp/manager/graph.cpp
+++ b/src/libYARP_manager/src/yarp/manager/graph.cpp
@@ -17,10 +17,12 @@ Graph::~Graph()
 Node* Graph::addNode(Node* _node)
 {
     //__CHECK_NULLPTR(_node);
-    if(!_node)
+    if (!_node) {
         return nullptr;
-    if(hasNode(_node))
+    }
+    if (hasNode(_node)) {
         return nullptr;
+    }
 
     Node* node = _node->clone();
     nodes[node->getLabel()] = node;
@@ -32,8 +34,9 @@ bool Graph::removeNode(Node* node)
     __CHECK_NULLPTR(node);
 
     auto itr = nodes.find(node->getLabel());
-    if(itr == nodes.end())
+    if (itr == nodes.end()) {
         return true;
+    }
     delete (*itr).second;
     nodes.erase(itr);
     return true;
@@ -43,8 +46,9 @@ bool Graph::removeNode(Node* node)
 bool Graph::removeNode(const char* szLabel)
 {
     auto itr = nodes.find(szLabel);
-    if(itr == nodes.end())
+    if (itr == nodes.end()) {
         return true;
+    }
     delete (*itr).second;
     nodes.erase(itr);
     return true;
@@ -53,30 +57,34 @@ bool Graph::removeNode(const char* szLabel)
 void Graph::clear()
 {
     NodePIterator itr;
-    for(itr=nodes.begin(); itr!=nodes.end(); itr++)
+    for (itr = nodes.begin(); itr != nodes.end(); itr++) {
         delete ((*itr).second);
+    }
     nodes.clear();
 }
 
 void Graph::setSatisfied(bool sat)
 {
     NodePIterator itr;
-    for(itr=nodes.begin(); itr!=nodes.end(); itr++)
+    for (itr = nodes.begin(); itr != nodes.end(); itr++) {
         ((*itr).second)->setSatisfied(sat);
+    }
 }
 
 void Graph::setVisited(bool vis)
 {
     NodePIterator itr;
-    for(itr=nodes.begin(); itr!=nodes.end(); itr++)
+    for (itr = nodes.begin(); itr != nodes.end(); itr++) {
         ((*itr).second)->setVisited(vis);
+    }
 }
 
 Node* Graph::getNode( const char* szLabel)
 {
     auto itr = nodes.find(szLabel);
-    if(itr != nodes.end())
+    if (itr != nodes.end()) {
         return (*itr).second;
+    }
     return nullptr;
 }
 
@@ -129,15 +137,17 @@ bool Graph::hasNode(Node* node)
     __CHECK_NULLPTR(node);
 
     auto itr = nodes.find(node->getLabel());
-    if(itr == nodes.end())
+    if (itr == nodes.end()) {
         return false;
+    }
     return true;
 }
 
 bool Graph::hasNode(const char* szLabel)
 {
-    if(getNode(szLabel))
+    if (getNode(szLabel)) {
         return true;
+    }
     return false;
 }
 
@@ -145,8 +155,9 @@ bool Graph::hasNode(const char* szLabel)
 Node* Graph::getNodeAt(int index)
 {
     auto itr = nodes.begin();
-    for(int i=0; i<index; i++)
+    for (int i = 0; i < index; i++) {
         itr++;
+    }
     return (*itr).second;
 }
 
@@ -168,8 +179,10 @@ GraphIterator Graph::end()
 NodePIterator Graph::findNode(Node* node)
 {
     NodePIterator itr;
-    for(itr=nodes.begin(); itr!=nodes.end(); itr++)
-        if ((*itr).second == node)
+    for (itr = nodes.begin(); itr != nodes.end(); itr++) {
+        if ((*itr).second == node) {
             return itr;
+        }
+    }
     return nodes.end();
 }

--- a/src/libYARP_manager/src/yarp/manager/impl/textparser.h
+++ b/src/libYARP_manager/src/yarp/manager/impl/textparser.h
@@ -32,7 +32,9 @@ public:
         if (key.empty())
         {
             war << "TextParser: empty key on variable setting..";
-            if (logger) logger->addWarning(war);
+            if (logger) {
+                logger->addWarning(war);
+            }
             return false;
         }
         variables[key] = parseText(value.c_str());
@@ -85,7 +87,9 @@ public:
             if(badSymbol)
             {
                 war << "use of symbol '$' detected but no keyword understood.. possible use: ${foo} for internal variable or $ENV{foo} for environment variable";
-                if (logger) logger->addWarning(war);
+                if (logger) {
+                    logger->addWarning(war);
+                }
             }
         }
 

--- a/src/libYARP_manager/src/yarp/manager/kbase.cpp
+++ b/src/libYARP_manager/src/yarp/manager/kbase.cpp
@@ -41,8 +41,9 @@ bool KnowledgeBase::createFrom(ModuleLoader* _mloader,
     {
         GenericResource* resource;
         resloader->reset();
-        while((resource=resloader->getNextResource()))
+        while ((resource = resloader->getNextResource())) {
             addResource(resource);
+        }
     }
 
     /**
@@ -52,8 +53,9 @@ bool KnowledgeBase::createFrom(ModuleLoader* _mloader,
     {
         Module* module;
         modloader->reset();
-        while((module=modloader->getNextModule()))
+        while ((module = modloader->getNextModule())) {
             addModule(module);
+        }
     }
 
     /**
@@ -63,8 +65,9 @@ bool KnowledgeBase::createFrom(ModuleLoader* _mloader,
     {
         Application* application;
         apploader->reset();
-        while((application = apploader->getNextApplication()))
+        while ((application = apploader->getNextApplication())) {
             addApplication(application);
+        }
     }
 
     return true;
@@ -79,10 +82,11 @@ bool KnowledgeBase::addApplication(Application* app, char** szAppName_, bool mod
     app->setLabel(app->getName());
     if(kbGraph.hasNode(app))
     {
-        if(mapId.find(string(app->getName()))==mapId.end())
+        if (mapId.find(string(app->getName())) == mapId.end()) {
             mapId[app->getName()] = 1;
-        else
+        } else {
             mapId[app->getName()] = mapId[app->getName()] + 1;
+        }
         OSTRINGSTREAM newlable;
         newlable<<app->getLabel()<<"("<<mapId[app->getName()]<<")";
         OSTRINGSTREAM msg;
@@ -190,8 +194,9 @@ const ApplicaitonPContainer& KnowledgeBase::getApplications(Application* parent)
         for(GraphIterator itr=tmpGraph.begin(); itr!=tmpGraph.end(); itr++)
         {
             auto* app = dynamic_cast<Application*>(*itr);
-            if(app && (app->owner() == parent))
-                    dummyApplications.push_back(app);
+            if (app && (app->owner() == parent)) {
+                dummyApplications.push_back(app);
+            }
         }
     }
     else
@@ -199,8 +204,9 @@ const ApplicaitonPContainer& KnowledgeBase::getApplications(Application* parent)
         for(GraphIterator itr=kbGraph.begin(); itr!=kbGraph.end(); itr++)
         {
             auto* app = dynamic_cast<Application*>(*itr);
-            if(app)
-                    dummyApplications.push_back(app);
+            if (app) {
+                dummyApplications.push_back(app);
+            }
         }
     }
 
@@ -217,8 +223,9 @@ const ModulePContainer& KnowledgeBase::getModules(Application* parent)
         for(GraphIterator itr=tmpGraph.begin(); itr!=tmpGraph.end(); itr++)
         {
             auto* mod = dynamic_cast<Module*>(*itr);
-            if(mod && (mod->owner() == parent))
+            if (mod && (mod->owner() == parent)) {
                 dummyModules.push_back(mod);
+            }
         }
     }
     else
@@ -226,8 +233,9 @@ const ModulePContainer& KnowledgeBase::getModules(Application* parent)
         for(GraphIterator itr=kbGraph.begin(); itr!=kbGraph.end(); itr++)
         {
             auto* mod = dynamic_cast<Module*>(*itr);
-            if(mod)
+            if (mod) {
                 dummyModules.push_back(mod);
+            }
         }
     }
     sort(dummyModules.begin(), dummyModules.end(), sortModules());
@@ -241,11 +249,12 @@ const CnnContainer& KnowledgeBase::getConnections(Application* parent)
     dummyConnections.clear();
     if(parent)
     {
-        for(int i=0; i<parent->connectionCount(); i++)
+        for (int i = 0; i < parent->connectionCount(); i++) {
             dummyConnections.push_back(parent->getConnectionAt(i));
-    }
-    else
+        }
+    } else {
         dummyConnections = selconnections;
+    }
     //sort(dummyConnections.begin(), dummyConnections.end(), sortConnections());
     return dummyConnections;
 }
@@ -259,14 +268,16 @@ const ResourcePContainer& KnowledgeBase::getResources(Application* parent)
         if(res)
         {
             bool bHas = false;
-            for(auto& dummyResource : dummyResources)
+            for (auto& dummyResource : dummyResources) {
                 if(string(dummyResource->getName()) == string(res->getName()))
                 {
                     bHas = true;
                     break;
                 }
-            if(!bHas)
+            }
+            if (!bHas) {
                 dummyResources.push_back(res);
+            }
         }
     }
 
@@ -276,14 +287,16 @@ const ResourcePContainer& KnowledgeBase::getResources(Application* parent)
         if(res)
         {
             bool bHas = false;
-            for(auto& dummyResource : dummyResources)
+            for (auto& dummyResource : dummyResources) {
                 if(string(dummyResource->getName()) == string(res->getName()))
                 {
                     bHas = true;
                     break;
                 }
-            if(!bHas)
+            }
+            if (!bHas) {
                 dummyResources.push_back(res);
+            }
         }
     }
     sort(dummyResources.begin(), dummyResources.end(), sortResources());
@@ -295,8 +308,9 @@ const ArbContainer& KnowledgeBase::getArbitrators(Application* parent)
     dummyArbitrators.clear();
     if(parent)
     {
-        for(int i=0; i<parent->arbitratorCount(); i++)
+        for (int i = 0; i < parent->arbitratorCount(); i++) {
             dummyArbitrators.push_back(parent->getArbitratorAt(i));
+        }
     }
     return dummyArbitrators;
 }
@@ -306,10 +320,11 @@ const InputContainer& KnowledgeBase::getInputCandidates(OutputData* output)
 {
     static InputContainer inputs;
     inputs.clear();
-    for(GraphIterator itr=kbGraph.begin(); itr!=kbGraph.end(); itr++)
-        if((*itr)->getType() == INPUTD &&
-            (*itr)->hasSuc(output))
+    for (GraphIterator itr = kbGraph.begin(); itr != kbGraph.end(); itr++) {
+        if ((*itr)->getType() == INPUTD && (*itr)->hasSuc(output)) {
             inputs.push_back(*((InputData*)(*itr)));
+        }
+    }
     return inputs;
 }
 
@@ -318,8 +333,9 @@ const OutputContainer& KnowledgeBase::getOutputCandidates(InputData* input)
 {
     static OutputContainer outputs;
     outputs.clear();
-    for(int i=0; i<input->sucCount(); i++)
+    for (int i = 0; i < input->sucCount(); i++) {
         outputs.push_back(*((OutputData*)input->getLinkAt(i).to()));
+    }
     return outputs;
 }
 
@@ -330,8 +346,9 @@ const OutputContainer& KnowledgeBase::getOutputCandidates(InputData* input)
 bool KnowledgeBase::makeupApplication(Application* application)
 {
     ErrorLogger* logger  = ErrorLogger::Instance();
-    if(!application)
+    if (!application) {
         return false;
+    }
     /**
      * we need to load all child  applications first
      */
@@ -356,8 +373,9 @@ bool KnowledgeBase::makeupApplication(Application* application)
             else
             {
 
-                if(appList.find(string(interfaceApp.getName()))==appList.end())
+                if (appList.find(string(interfaceApp.getName())) == appList.end()) {
                     appList[interfaceApp.getName()] = 1;
+                }
                 OSTRINGSTREAM newname;
                 newname<<application->getName()<<":";
                 newname<<interfaceApp.getName()<<":"<<appList[interfaceApp.getName()];
@@ -437,8 +455,9 @@ bool KnowledgeBase::makeupApplication(Application* application)
         mres.setLabel(strLabel.str().c_str());
         mres.setName("MultipleResource");
         mres.setOwner(application);
-        for(int i=0; i<application->resourcesCount(); i++)
-             mres.addResource(application->getResourceAt(i));
+        for (int i = 0; i < application->resourcesCount(); i++) {
+            mres.addResource(application->getResourceAt(i));
+        }
         Node* node = tmpGraph.addNode(&mres);
         tmpGraph.addLink(application, node, 0);
     }
@@ -452,8 +471,9 @@ bool KnowledgeBase::setModulePrefix(Module* module, const char* szPrefix, bool u
     __CHECK_NULLPTR(szPrefix);
 
     module->setPrefix(szPrefix);
-    if(updateBasePrefix)
+    if (updateBasePrefix) {
         module->setBasePrefix(szPrefix);
+    }
 
     // updating port's prefix
     // TODO: check if this is required anymore
@@ -491,8 +511,9 @@ bool KnowledgeBase::setApplicationPrefix(Application* application, const char* s
     __CHECK_NULLPTR(szPrefix);
 
     application->setPrefix(szPrefix);
-    if(updateBasePrefix)
+    if (updateBasePrefix) {
         application->setBasePrefix(szPrefix);
+    }
 
     /**
      * updating nested application's and module's prefixs
@@ -629,8 +650,9 @@ bool KnowledgeBase::removeConnectionFromApplication(Application* application, Co
 
 const std::string KnowledgeBase::getUniqueAppID(Application* parent, const char* szAppName)
 {
-    if(appList.find(string(szAppName)) == appList.end())
+    if (appList.find(string(szAppName)) == appList.end()) {
         appList[szAppName] = 1;
+    }
     OSTRINGSTREAM newname;
     newname<<parent->getName()<<":";
     newname<<szAppName<<":"<<appList[szAppName];
@@ -662,8 +684,9 @@ Application* KnowledgeBase::addIApplicationToApplication(Application* applicatio
         }
         else
         {
-            if(appList.find(string(interfaceApp.getName()))==appList.end())
+            if (appList.find(string(interfaceApp.getName())) == appList.end()) {
                 appList[interfaceApp.getName()] = 1;
+            }
             OSTRINGSTREAM newname;
             newname<<application->getName()<<":";
             newname<<interfaceApp.getName()<<":"<<appList[interfaceApp.getName()];
@@ -701,16 +724,16 @@ Module* KnowledgeBase::addIModuleToApplication(Application* application,
 
     Module* module;
 
-    if(application->modList.find(string(mod.getName()))==application->modList.end())
+    if (application->modList.find(string(mod.getName())) == application->modList.end()) {
         application->modList[mod.getName()] = 1;
+    }
     OSTRINGSTREAM newname;
     newname<<application->getLabel()<<":"<<mod.getName()<<":"<<application->modList[mod.getName()];
 
     auto* repmod = dynamic_cast<Module*>(kbGraph.getNode(mod.getName()));
-    if(repmod)
+    if (repmod) {
         module = replicateModule(tmpGraph, repmod, newname.str().c_str());
-    else
-    {
+    } else {
         Module newmod(mod.getName());
         newmod.setLabel(newname.str().c_str());
         module = addModuleToGraph(tmpGraph, &newmod);
@@ -746,8 +769,9 @@ Module* KnowledgeBase::addIModuleToApplication(Application* application,
     tmpGraph.addLink(application, module, 0, false);
     module->setOwner(application);
 
-    if(isNew)
+    if (isNew) {
         application->addImodule(mod);
+    }
     return module;
 }
 
@@ -758,8 +782,9 @@ bool KnowledgeBase::removeIModuleFromApplication(Application* application, const
     __CHECK_NULLPTR(application);
 
     auto* module = dynamic_cast<Module*>(tmpGraph.getNode(szModTag));
-    if(module)
+    if (module) {
         removeModuleFromGraph(tmpGraph, module);
+    }
     for(int i=0; i<application->imoduleCount(); i++)
     {
         if(strcmp(application->getImoduleAt(i).getTag(), szModTag) == 0)
@@ -777,24 +802,25 @@ bool KnowledgeBase::removeIApplicationFromApplication(Application* application, 
 {
     __CHECK_NULLPTR(application);
     auto* app = dynamic_cast<Application*>(tmpGraph.getNode(szAppTag));
-    if(!app)
+    if (!app) {
         return false;
+    }
 
     // removing all nested applications recursively
     for(GraphIterator itr=tmpGraph.begin(); itr!=tmpGraph.end(); itr++)
     {
         auto* nestedApp = dynamic_cast<Application*>(*itr);
-        if(nestedApp && (nestedApp->owner() == app))
+        if (nestedApp && (nestedApp->owner() == app)) {
             removeIApplicationFromApplication(app, nestedApp->getLabel());
+        }
     }
 
     for(GraphIterator itr=tmpGraph.begin(); itr!=tmpGraph.end(); itr++)
     {
         auto* mod = dynamic_cast<Module*>(*itr);
-        if(mod && (mod->owner() == app))
+        if (mod && (mod->owner() == app)) {
             removeModuleFromGraph(tmpGraph, mod);
-        else
-        {
+        } else {
             auto* res = dynamic_cast<MultiResource*>(*itr);
             if(res && (res->owner() == app))
             {
@@ -825,9 +851,11 @@ GenericResource* KnowledgeBase::findResByName(Graph& graph, const char* szName)
     for(GraphIterator itr=graph.begin(); itr!=graph.end(); itr++)
     {
         auto* res = dynamic_cast<GenericResource*>(*itr);
-        if(res)
-            if(string(res->getName()) == string(szName))
+        if (res) {
+            if (string(res->getName()) == string(szName)) {
                 return res;
+            }
+        }
     }
     return nullptr;
 }
@@ -840,8 +868,9 @@ InputData* KnowledgeBase::findInputByPort(Graph& graph, const char* szPort)
         if((*itr)->getType() == INPUTD )
         {
             auto* input = (InputData*)(*itr);
-            if(compareString(input->getPort(), szPort))
+            if (compareString(input->getPort(), szPort)) {
                 return input;
+            }
         }
     }
     return nullptr;
@@ -855,8 +884,9 @@ OutputData* KnowledgeBase::findOutputByPort(Graph& graph, const char* szPort)
         if((*itr)->getType() == OUTPUTD)
         {
             auto* output = (OutputData*)(*itr);
-            if(compareString(output->getPort(), szPort))
+            if (compareString(output->getPort(), szPort)) {
                 return output;
+            }
         }
     }
     return nullptr;
@@ -910,15 +940,17 @@ bool KnowledgeBase::reasolveDependency(Application* app,
 
     // Adding all resources which are providers to tmpGraph
     // providers are those with no owner.
-    for(GraphIterator itr=kbGraph.begin(); itr!=kbGraph.end(); itr++)
+    for (GraphIterator itr = kbGraph.begin(); itr != kbGraph.end(); itr++) {
         if(dynamic_cast<GenericResource*>(*itr))
         {
 
-            if(!dynamic_cast<GenericResource*>(*itr)->owner())
+            if (!dynamic_cast<GenericResource*>(*itr)->owner()) {
                 replicateResource(tmpGraph,
                                   (GenericResource*)(*itr),
                                   (*itr)->getLabel());
+            }
         }
+    }
 
     // make resources links
     makeResourceLinks(tmpGraph);
@@ -946,9 +978,9 @@ bool KnowledgeBase::reasolveDependency(Application* app,
            for(int i=0; i<mres->resourceCount(); i++)
            {
                 auto* yres = dynamic_cast<ResYarpPort*>(&mres->getResourceAt(i));
-                if(yres && (find(selresources.begin(), selresources.end(), yres)
-                    == selresources.end()))
+                if (yres && (find(selresources.begin(), selresources.end(), yres) == selresources.end())) {
                     selresources.push_back(yres);
+                }
 
                 // adding ResYarpPort from modules dependencies
                 /*
@@ -968,24 +1000,27 @@ bool KnowledgeBase::reasolveDependency(Application* app,
        }
        else
        {
-            if(find(selresources.begin(), selresources.end(), resource)
-                == selresources.end())
-                selresources.push_back(resource);
+           if (find(selresources.begin(), selresources.end(), resource)
+               == selresources.end()) {
+               selresources.push_back(resource);
+           }
        }
     }
 
     for(auto& module : modules)
     {
-       if(find(selmodules.begin(), selmodules.end(), module)
-          == selmodules.end())
+        if (find(selmodules.begin(), selmodules.end(), module)
+            == selmodules.end()) {
             selmodules.push_back(module);
+        }
     }
 
     for(auto& application : applications)
     {
-       if(find(selapplications.begin(), selapplications.end(), application)
-          == selapplications.end())
+        if (find(selapplications.begin(), selapplications.end(), application)
+            == selapplications.end()) {
             selapplications.push_back(application);
+        }
     }
 
 
@@ -1085,8 +1120,9 @@ bool KnowledgeBase::updateApplication(Application* app,
     __CHECK_NULLPTR(app);
     __CHECK_NULLPTR(iapp);
 
-    if(strlen(iapp->getPrefix()))
+    if (strlen(iapp->getPrefix())) {
         app->setPrefix(iapp->getPrefix());
+    }
     app->setModelBase(iapp->getModelBase());
     return true;
 }
@@ -1102,28 +1138,36 @@ bool KnowledgeBase::updateModule(Module* module, ModuleInterface* imod )
         module->setForced(true);
     }
 
-    if(strlen(imod->getParam()))
+    if (strlen(imod->getParam())) {
         module->setParam(imod->getParam());
-    if(imod->getRank()>0)
+    }
+    if (imod->getRank() > 0) {
         module->setRank(imod->getRank());
-    if(strlen(imod->getBroker()))
+    }
+    if (strlen(imod->getBroker())) {
         module->setBroker(imod->getBroker());
-    if(strlen(imod->getStdio()))
+    }
+    if (strlen(imod->getStdio())) {
         module->setStdio(imod->getStdio());
-    if(strlen(imod->getWorkDir()))
+    }
+    if (strlen(imod->getWorkDir())) {
         module->setWorkDir(imod->getWorkDir());
-    if(strlen(imod->getDisplay()))
+    }
+    if (strlen(imod->getDisplay())) {
         module->setDisplay(imod->getDisplay());
-    if(strlen(imod->getEnvironment()))
+    }
+    if (strlen(imod->getEnvironment())) {
         module->setEnvironment(imod->getEnvironment());
+    }
     module->setPostExecWait(imod->getPostExecWait());
     module->setPostStopWait(imod->getPostStopWait());
     module->setModelBase(imod->getModelBase());
 
 
     // updating module prefix
-    if(strlen(imod->getPrefix()))
+    if (strlen(imod->getPrefix())) {
         setModulePrefix(module, imod->getPrefix(), false);
+    }
     return true;
 }
 
@@ -1188,12 +1232,14 @@ Module* KnowledgeBase::addModuleToGraph(Graph& graph, Module* module)
 {
     ErrorLogger* logger  = ErrorLogger::Instance();
 
-    if(!moduleCompleteness(module))
+    if (!moduleCompleteness(module)) {
         return nullptr;
+    }
 
     /*Adding module to the graph */
-    if(!(module = (Module*)graph.addNode(module)))
+    if (!(module = (Module*)graph.addNode(module))) {
         return nullptr;
+    }
 
     /* Adding inputs nodes to the graph*/
     for(int i=0; i<module->inputCount(); i++)
@@ -1202,11 +1248,10 @@ Module* KnowledgeBase::addModuleToGraph(Graph& graph, Module* module)
         input->setLabel(createDataLabel(module->getLabel(),
                                         input->getPort(), ":I"));
         input->setOwner(module);
-        if((input=(InputData*)graph.addNode(input)))
+        if ((input = (InputData*)graph.addNode(input))) {
             graph.addLink(module, input, 0,
                         !(input->isRequired()));
-        else
-        {
+        } else {
             input = &(module->getInputAt(i));
             module->removeInput(*input);
             OSTRINGSTREAM msg;
@@ -1225,10 +1270,9 @@ Module* KnowledgeBase::addModuleToGraph(Graph& graph, Module* module)
         output->setLabel(createDataLabel(module->getLabel(),
                                         output->getPort(), ":O"));
         output->setOwner(module);
-        if((output=(OutputData*)graph.addNode(output)))
+        if ((output = (OutputData*)graph.addNode(output))) {
             graph.addLink(output, module, 0);
-        else
-        {
+        } else {
             output = &(module->getOutputAt(i));
             module->removeOutput(*output);
             OSTRINGSTREAM msg;
@@ -1249,8 +1293,9 @@ Module* KnowledgeBase::addModuleToGraph(Graph& graph, Module* module)
     mres.setLabel(strLabel.str().c_str());
     mres.setName("MultipleResource");
     mres.setOwner(module);
-    for(int i=0; i<module->resourceCount(); i++)
+    for (int i = 0; i < module->resourceCount(); i++) {
         mres.addResource(module->getResourceAt(i));
+    }
     Node* node = graph.addNode(&mres);
     graph.addLink(module, node, 0);
 
@@ -1268,10 +1313,11 @@ bool KnowledgeBase::saveApplication(AppSaver* appSaver, Application* application
         {
             ApplicationInterface iapp(embApp->getName());
             iapp.setPrefix(embApp->getBasePrefix());
-            if(embApp->getModel())
+            if (embApp->getModel()) {
                 iapp.setModelBase(*embApp->getModel());
-            else
+            } else {
                 iapp.setModelBase(embApp->getModelBase());
+            }
             application->addIapplication(iapp);
         }
     }
@@ -1293,16 +1339,18 @@ bool KnowledgeBase::saveApplication(AppSaver* appSaver, Application* application
     for(int i=0; i<application->connectionCount(); i++)
     {
         Connection* pcon = &application->getConnectionAt(i);
-        if(pcon->getModel())
+        if (pcon->getModel()) {
             pcon->setModelBase(*pcon->getModel());
+        }
     }
 
     // updating arbitrators modelBase with Model if exists
     for(int i=0; i<application->arbitratorCount(); i++)
     {
         Arbitrator* parb = &application->getArbitratorAt(i);
-        if(parb->getModel())
+        if (parb->getModel()) {
             parb->setModelBase(*parb->getModel());
+        }
     }
 
     return appSaver->save(application);
@@ -1337,9 +1385,9 @@ bool KnowledgeBase::removeModuleFromGraph(Graph& graph, Module* mod)
                     {
                          graph.removeNode(res);
                          itr=graph.begin();
-                    }
-                    else
+                    } else {
                         itr++;
+                    }
                 }
             }
             //itr++;
@@ -1366,10 +1414,12 @@ bool KnowledgeBase::moduleCompleteness(Module* module)
     {
         const char* szType = module->getInputAt(i).getName();
         const char* szPort = module->getInputAt(i).getPort();
-        if(!strlen(szType))
+        if (!strlen(szType)) {
             logger->addWarning(string(module->getName()) + string(" has an input with no type."));
-        if(!strlen(szPort))
+        }
+        if (!strlen(szPort)) {
             logger->addWarning(string(module->getName()) + string(" has an input with no port."));
+        }
     }
 
     /* Checking outputs name and port */
@@ -1377,10 +1427,12 @@ bool KnowledgeBase::moduleCompleteness(Module* module)
     {
         const char* szType = module->getOutputAt(i).getName();
         const char* szPort = module->getOutputAt(i).getPort();
-        if(!strlen(szType))
+        if (!strlen(szType)) {
             logger->addWarning(string(module->getName()) + string(" has an output with no type."));
-        if(!strlen(szPort))
+        }
+        if (!strlen(szPort)) {
             logger->addWarning(string(module->getName()) + string(" has an output with no port."));
+        }
     }
     return true;
 }
@@ -1396,8 +1448,9 @@ Module* KnowledgeBase::findOwner(Graph& graph, InputData* input)
             for(int i=0; i<module->sucCount(); i++)
             {
                 Link l = module->getLinkAt(i);
-                if((InputData*)l.to() == input)
+                if ((InputData*)l.to() == input) {
                     return module;
+                }
             }
         }
     }
@@ -1450,16 +1503,18 @@ void KnowledgeBase::updateNodesLink(Graph& graph, int level)
                 if((*itr2)->getType() == RESOURCE)
                 {
                     auto* res = (ResYarpPort*)(*itr2);
-                    if(compareString(res->getName(), input->getName()))
+                    if (compareString(res->getName(), input->getName())) {
                         graph.addLink(input, res, 0.0, false);
+                    }
                 }
             }
 
             /**
              * adding relevant outputs to inputs
              */
-            if(level==NODELINK_DEEP)
+            if (level == NODELINK_DEEP) {
                 linkToOutputs(graph, input);
+            }
         }
     }
 }
@@ -1469,9 +1524,11 @@ void KnowledgeBase::updateResourceWeight(Graph& graph,
 {
     for(GraphIterator itr=graph.begin(); itr!=graph.end(); itr++)
     {
-        for(int i=0; i<(*itr)->sucCount(); i++)
-            if((*itr)->getLinkAt(i).to() == resource)
+        for (int i = 0; i < (*itr)->sucCount(); i++) {
+            if ((*itr)->getLinkAt(i).to() == resource) {
                 (*itr)->getLinkAt(i).setWeight(weight);
+            }
+        }
     }
 
 }
@@ -1501,8 +1558,9 @@ void KnowledgeBase::makeResourceLinks(Graph& graph)
                     provider = (GenericResource*) graph.addNode(&comp);
                 }
                 float w = 0.0;
-                if(dynamic_cast<Computer*>(provider))
+                if (dynamic_cast<Computer*>(provider)) {
                     w = calculateLoad((Computer*)provider);
+                }
                 graph.addLink(resource, provider, w, false);
             }
             else if((module && !module->getForced()))
@@ -1511,14 +1569,16 @@ void KnowledgeBase::makeResourceLinks(Graph& graph)
                 for(GraphIterator itr2=graph.begin(); itr2!=graph.end(); itr2++)
                 {
                     auto* provider = dynamic_cast<GenericResource*>(*itr2);
-                    if(provider && !provider->owner())
+                    if (provider && !provider->owner()) {
                         if(provider->satisfy(resource))
                         {
                             float w = 0.0;
-                            if(dynamic_cast<Computer*>(provider))
+                            if (dynamic_cast<Computer*>(provider)) {
                                 w = calculateLoad((Computer*)provider);
+                            }
                             graph.addLink(resource, provider, w, false);
                         }
+                    }
                 }
             }
         }
@@ -1530,7 +1590,9 @@ float KnowledgeBase::calculateLoad(Computer* comp)
 {
     LoadAvg load = comp->getProcessor().getCPULoad();
     int siblings = comp->getProcessor().getSiblings();
-    if(siblings == 0) siblings = 1;
+    if (siblings == 0) {
+        siblings = 1;
+    }
     //cout<<comp->getName()<<": "<<load.loadAverage1<<", "<<load.loadAverage5<<", "<<load.loadAverage15;
     //cout<<" ("<<siblings<<")"<<endl;
     auto lavg = (float)((load.loadAverage1*15.0 +
@@ -1548,11 +1610,10 @@ void KnowledgeBase::linkToOutputs(Graph& graph, InputData* input)
         {
             auto* output = (OutputData*)(*itr);
             auto* producer = (Module*)output->getLinkAt(0).to();
-            if(compareString(output->getName(), input->getName())
-               &&(producer != findOwner(graph, input)))
-                graph.addLink(input, output,
-                             (float)getProducerRank(graph, output),
-                             !input->isRequired());
+            if (compareString(output->getName(), input->getName())
+                && (producer != findOwner(graph, input))) {
+                graph.addLink(input, output, (float)getProducerRank(graph, output), !input->isRequired());
+            }
         }
     }
 }
@@ -1668,24 +1729,27 @@ bool KnowledgeBase::reason(Graph* graph, Node* initial,
     {
         /* if it's a resource dependency */
         auto* resource = dynamic_cast<GenericResource*>(initial);
-        if(resource && resource->owner())
+        if (resource && resource->owner()) {
             resources.push_back(resource);
+        }
         return false;
     }
 
     if(initial->isLeaf())
     {
         // adding resource
-        if(dynamic_cast<GenericResource*>(initial))
+        if (dynamic_cast<GenericResource*>(initial)) {
             resources.push_back(dynamic_cast<GenericResource*>(initial));
+        }
 
         // adding connections
         auto* application = dynamic_cast<Application*>(initial);
         if(application)
         {
             applications.push_back(application);
-            for(int i=0; i<application->connectionCount(); i++)
+            for (int i = 0; i < application->connectionCount(); i++) {
                 connections.push_back(application->getConnectionAt(i));
+            }
         }
         initial->setSatisfied(true);
         initial->setVisited(false);
@@ -1716,11 +1780,11 @@ bool KnowledgeBase::reason(Graph* graph, Node* initial,
             bool ret = reason(graph, current,
                               subApplications, subModules, subResources, subConnections,
                               bAutoDependancy, bSilent);
-            if(ret)
+            if (ret) {
                 bPathFound = true;
-            else if(dynamic_cast<Application*>(initial) ||
-                    dynamic_cast<Module*>(initial))
-                    bPathFound = false;
+            } else if (dynamic_cast<Application*>(initial) || dynamic_cast<Module*>(initial)) {
+                bPathFound = false;
+            }
 
             /* we meet a conjunctive node and we need to copy all the
              *  selected successors
@@ -1764,8 +1828,9 @@ bool KnowledgeBase::reason(Graph* graph, Node* initial,
             // It will help for better load distribution among nodes
             auto* comp = dynamic_cast<Computer*>(provider);
             float default_tunning = 0.1F;
-            if(comp && (comp->getProcessor().getSiblings() > 0))
+            if (comp && (comp->getProcessor().getSiblings() > 0)) {
                 default_tunning = 1.0F / (float)comp->getProcessor().getSiblings();
+            }
             float tunner = (module->getRank()<10)? default_tunning : (float)module->getRank()/100.0F;
             updateResourceWeight(*graph, provider, candidateLink->weight()+tunner);
         }
@@ -1773,16 +1838,18 @@ bool KnowledgeBase::reason(Graph* graph, Node* initial,
     }
 
     /* adding current module to the modules list.*/
-    if(dynamic_cast<Module*>(initial))
+    if (dynamic_cast<Module*>(initial)) {
         modules.push_back(dynamic_cast<Module*>(initial));
+    }
 
     /* we should add all the connections */
     auto* application = dynamic_cast<Application*>(initial);
     if(application)
     {
         applications.push_back(dynamic_cast<Application*>(initial));
-        for(int i=0; i<application->connectionCount(); i++)
+        for (int i = 0; i < application->connectionCount(); i++) {
             connections.push_back(application->getConnectionAt(i));
+        }
     }
     initial->setSatisfied(bPathFound);
     initial->setVisited(false);
@@ -1797,7 +1864,8 @@ const char* KnowledgeBase::createDataLabel(const char* modlabel,
     static string name;
     name.clear();
     name = string(modlabel) + string(port);
-    if(postfix)
+    if (postfix) {
         name += string(postfix);
+    }
     return name.c_str();
 }

--- a/src/libYARP_manager/src/yarp/manager/localbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/localbroker.cpp
@@ -154,8 +154,9 @@ LocalBroker::~LocalBroker()
 
 void LocalBroker::fini()
 {
-    if(Thread::isRunning())
+    if (Thread::isRunning()) {
         Thread::stop();
+    }
 }
 
 bool LocalBroker::init()
@@ -191,24 +192,29 @@ bool LocalBroker::init(const char* szcmd, const char* szparam,
         return false;
     }
     strCmd = szcmd;
-    if(szparam && strlen(szparam))
+    if (szparam && strlen(szparam)) {
         strParam = szparam;
+    }
 
-    if(szhost && strlen(szhost))
+    if (szhost && strlen(szhost)) {
         strHost = szhost;
-    if(szworkdir && strlen(szworkdir))
+    }
+    if (szworkdir && strlen(szworkdir)) {
         strWorkdir = szworkdir;
+    }
 
     if(szstdio && strlen(szstdio))
     {
-        if(szstdio[0] != '/')
+        if (szstdio[0] != '/') {
             strStdio = string("/") + string(szstdio);
-        else
+        } else {
             strStdio = szstdio;
+        }
     }
 
-    if(szenv && strlen(szenv))
+    if (szenv && strlen(szenv)) {
         strEnv = szenv;
+    }
 
     /*
     OSTRINGSTREAM sstrID;
@@ -243,16 +249,22 @@ bool LocalBroker::init(const char* szcmd, const char* szparam,
 
 bool LocalBroker::start()
 {
-    if(!bInitialized) return false;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return false;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
-    if(running())
+    if (running()) {
         return true;
+    }
 
     strError.clear();
     ID = ExecuteCmd();
-    if(!ID)
+    if (!ID) {
         return false;
+    }
 
    if(running())
    {
@@ -263,8 +275,12 @@ bool LocalBroker::start()
 
 bool LocalBroker::stop()
 {
-    if(!bInitialized) return true;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return true;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
     strError.clear();
 #if defined(_WIN32)
@@ -278,8 +294,9 @@ bool LocalBroker::stop()
     double base = SystemClock::nowSystem();
     while(!timeout(base, STOP_TIMEOUT))
     {
-        if(!running())
+        if (!running()) {
             return true;
+        }
     }
 
     strError = "Timeout! cannot stop ";
@@ -291,8 +308,12 @@ bool LocalBroker::stop()
 
 bool LocalBroker::kill()
 {
-    if(!bInitialized) return true;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return true;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
     strError.clear();
 
@@ -307,8 +328,9 @@ bool LocalBroker::kill()
     double base = SystemClock::nowSystem();
     while(!timeout(base, KILL_TIMEOUT))
     {
-        if(!running())
+        if (!running()) {
             return true;
+        }
     }
 
     strError = "Timeout! cannot kill ";
@@ -321,8 +343,12 @@ bool LocalBroker::kill()
 
 int LocalBroker::running()
 {
-    if(!bInitialized) return 0;
-    if(bOnlyConnector) return 0;
+    if (!bInitialized) {
+        return 0;
+    }
+    if (bOnlyConnector) {
+        return 0;
+    }
     return (psCmd(ID))?1:0;
 }
 
@@ -399,8 +425,9 @@ bool LocalBroker::disconnect(const char* from, const char* to, const char *carri
         return true;
     }
 
-    if(!connected(from, to, carrier))
+    if (!connected(from, to, carrier)) {
         return true;
+    }
 
     if(!NetworkBase::disconnect(from, to))
     {
@@ -421,17 +448,20 @@ bool LocalBroker::exists(const char* port)
 
 const char* LocalBroker::requestRpc(const char* szport, const char* request, double timeout)
 {
-    if((szport==nullptr) || (request==nullptr))
+    if ((szport == nullptr) || (request == nullptr)) {
         return nullptr;
+    }
 
-    if(!exists(szport))
+    if (!exists(szport)) {
         return nullptr;
+    }
 
     // opening the port
     yarp::os::Port port;
     port.setTimeout((float)((timeout>0.0) ? timeout : CONNECTION_TIMEOUT));
-    if(!port.open("..."))
+    if (!port.open("...")) {
         return nullptr;
+    }
 
     ContactStyle style;
     style.quiet = true;
@@ -439,7 +469,9 @@ const char* LocalBroker::requestRpc(const char* szport, const char* request, dou
     bool ret;
     for(int i=0; i<10; i++) {
         ret = NetworkBase::connect(port.getName(), szport, style);
-        if(ret) break;
+        if (ret) {
+            break;
+        }
         SystemClock::delaySystem(1.0);
     }
 
@@ -463,8 +495,9 @@ const char* LocalBroker::requestRpc(const char* szport, const char* request, dou
 
 bool LocalBroker::connected(const char* from, const char* to, const char* carrier)
 {
-    if(!exists(from) || !exists(to))
+    if (!exists(from) || !exists(to)) {
         return false;
+    }
     return NetworkBase::isConnected(from, to);
 }
 
@@ -476,8 +509,9 @@ const char* LocalBroker::error()
 
 bool LocalBroker::attachStdout()
 {
-    if(Thread::isRunning())
+    if (Thread::isRunning()) {
         return true;
+    }
     if(!running())
     {
         strError = "Module is not running";
@@ -495,8 +529,9 @@ void LocalBroker::detachStdout()
 bool LocalBroker::timeout(double base, double timeout)
 {
     SystemClock::delaySystem(1.0);
-    if((SystemClock::nowSystem()-base) > timeout)
+    if ((SystemClock::nowSystem() - base) > timeout) {
         return true;
+    }
     return false;
 }
 
@@ -533,10 +568,12 @@ void LocalBroker::run()
            {
                 string strmsg;
                 char buff[1024];
-                while(fgets(buff, 1024, fd_stdout))
+                while (fgets(buff, 1024, fd_stdout)) {
                     strmsg += string(buff);
-                if(eventSink && strmsg.size())
+                }
+                if (eventSink && strmsg.size()) {
                     eventSink->onBrokerStdout(strmsg.c_str());
+                }
                 yarp::os::SystemClock::delaySystem(0.5); // this prevents event flooding
            }
         }
@@ -754,24 +791,27 @@ bool LocalBroker::stopCmd(int pid)
 
 bool LocalBroker::psCmd(int pid)
 {
-    if(!pid)
+    if (!pid) {
         return false;
+    }
     return !::kill(pid, 0);
 }
 
 
 bool LocalBroker::killCmd(int pid)
 {
-    if(!pid)
+    if (!pid) {
         return false;
+    }
     return !::kill(pid, SIGKILL);
 }
 
 
 bool LocalBroker::stopCmd(int pid)
 {
-    if(!pid)
+    if (!pid) {
         return false;
+    }
    return !::kill(pid, SIGTERM);
 }
 
@@ -816,8 +856,9 @@ int LocalBroker::waitPipeSignal(int pipe_fd)
         return PIPE_EVENT;
 #endif
 */
-    if(pselect(pipe_fd + 1, &fd, nullptr, nullptr, &timeout, nullptr))
+    if (pselect(pipe_fd + 1, &fd, nullptr, nullptr, &timeout, nullptr)) {
         return PIPE_EVENT;
+    }
     return PIPE_TIMEOUT;
 }
 
@@ -846,8 +887,9 @@ bool LocalBroker::startStdout()
 void LocalBroker::stopStdout()
 {
     Thread::stop();
-    if(fd_stdout)
+    if (fd_stdout) {
         fclose(fd_stdout);
+    }
     fd_stdout = nullptr;
 }
 
@@ -938,7 +980,9 @@ int LocalBroker::ExecuteCmd()
         if (currWorkDir)
         {
             char **cwd_szarg=new char*[nargs+1];
-            for (int i=1; i<nargs; ++i) cwd_szarg[i]=szarg[i];
+            for (int i = 1; i < nargs; ++i) {
+                cwd_szarg[i] = szarg[i];
+            }
             cwd_szarg[nargs]=nullptr;
             cwd_szarg[0]=new char[strlen(currWorkDir)+strlen(szarg[0])+16];
 
@@ -984,8 +1028,9 @@ int LocalBroker::ExecuteCmd()
         string retError;
         waitPipe(pipe_child_to_parent[READ_FROM_PIPE]);
 
-        for (char buff[1024]; fgets(buff,1024,in_from_child);)
+        for (char buff[1024]; fgets(buff, 1024, in_from_child);) {
             retError += string(buff);
+        }
         fclose(in_from_child);
 
         if(retError.size())

--- a/src/libYARP_manager/src/yarp/manager/logicresource.cpp
+++ b/src/libYARP_manager/src/yarp/manager/logicresource.cpp
@@ -32,12 +32,14 @@ Node* Platform::clone()
 
 bool Platform::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* os = dynamic_cast<Platform*>(resource);
-    if(os)
+    if (os) {
         return satisfy_platform(os);
+    }
 
     return false;
 }
@@ -77,12 +79,14 @@ Node* ResYarpPort::clone()
 
 bool ResYarpPort::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* resport = dynamic_cast<ResYarpPort*>(resource);
-    if(!resport)
+    if (!resport) {
         return false;
+    }
     return (strPort == string(resport->getPort()) ||
             strPort == string(resport->getName()) );
 }

--- a/src/libYARP_manager/src/yarp/manager/manager.cpp
+++ b/src/libYARP_manager/src/yarp/manager/manager.cpp
@@ -60,18 +60,21 @@ Manager::Manager(const char* szModPath, const char* szAppPath,
 
     XmlModLoader modload(szModPath, nullptr);
     XmlModLoader* pModLoad = &modload;
-    if(!modload.init())
+    if (!modload.init()) {
         pModLoad = nullptr;
+    }
 
     XmlAppLoader appload(szAppPath, nullptr);
     XmlAppLoader* pAppLoad = &appload;
-    if(!appload.init())
+    if (!appload.init()) {
         pAppLoad = nullptr;
+    }
 
     XmlResLoader resload(szResPath, nullptr);
     XmlResLoader* pResLoad = &resload;
-    if(!resload.init())
+    if (!resload.init()) {
         pResLoad = nullptr;
+    }
 
     knowledge.createFrom(pModLoad, pAppLoad, pResLoad);
     connector.init();
@@ -87,16 +90,19 @@ Manager::~Manager()
 
 bool Manager::addApplication(const char* szFileName, char** szAppName_, bool modifyName)
 {
-    if(find(listOfXml.begin(), listOfXml.end(),szFileName) == listOfXml.end())
+    if (find(listOfXml.begin(), listOfXml.end(), szFileName) == listOfXml.end()) {
         listOfXml.emplace_back(szFileName);
-    else
-        return true;//it means that the app exist already so it is safe to return true
+    } else {
+        return true; //it means that the app exist already so it is safe to return true
+    }
     XmlAppLoader appload(szFileName);
-    if(!appload.init())
+    if (!appload.init()) {
         return false;
+    }
     Application* application = appload.getNextApplication();
-    if(!application)
+    if (!application) {
         return false;
+    }
 
     return knowledge.addApplication(application, szAppName_, modifyName);
 }
@@ -105,8 +111,9 @@ bool Manager::addApplication(const char* szFileName, char** szAppName_, bool mod
 bool Manager::addApplications(const char* szPath)
 {
     XmlAppLoader appload(szPath, nullptr);
-    if(!appload.init())
+    if (!appload.init()) {
         return false;
+    }
     Application* application;
     while((application = appload.getNextApplication()))
     {
@@ -121,11 +128,13 @@ bool Manager::addApplications(const char* szPath)
 bool Manager::addModule(const char* szFileName)
 {
     XmlModLoader modload(szFileName);
-    if(!modload.init())
+    if (!modload.init()) {
         return false;
+    }
     Module* module = modload.getNextModule();
-    if(!module)
+    if (!module) {
         return false;
+    }
     return knowledge.addModule(module);
 }
 
@@ -133,11 +142,13 @@ bool Manager::addModule(const char* szFileName)
 bool Manager::addModules(const char* szPath)
 {
     XmlModLoader modload(szPath, nullptr);
-    if(!modload.init())
+    if (!modload.init()) {
         return false;
+    }
     Module* module;
-    while((module = modload.getNextModule()))
+    while ((module = modload.getNextModule())) {
         knowledge.addModule(module);
+    }
     return true;
 }
 
@@ -145,12 +156,14 @@ bool Manager::addModules(const char* szPath)
 bool Manager::addResource(const char* szFileName)
 {
     XmlResLoader resload(szFileName);
-    if(!resload.init())
+    if (!resload.init()) {
         return false;
+    }
     GenericResource* resource;
     bool bloaded = false;
-    while((resource = resload.getNextResource()))
-           bloaded |= knowledge.addResource(resource);
+    while ((resource = resload.getNextResource())) {
+        bloaded |= knowledge.addResource(resource);
+    }
     return bloaded;
 }
 
@@ -158,11 +171,13 @@ bool Manager::addResource(const char* szFileName)
 bool Manager::addResources(const char* szPath)
 {
     XmlResLoader resload(szPath, nullptr);
-    if(!resload.init())
+    if (!resload.init()) {
         return false;
+    }
     GenericResource* resource;
-    while((resource = resload.getNextResource()))
+    while ((resource = resload.getNextResource())) {
         knowledge.addResource(resource);
+    }
     return true;
 }
 
@@ -178,8 +193,9 @@ bool Manager::removeApplication(const char *szFileName, const char* szAppName)
     }
     listOfXml.erase(std::remove(listOfXml.begin(), listOfXml.end(), szFileName), listOfXml.end());
     Application* app = knowledge.getApplication(szAppName);
-    if(!app)
+    if (!app) {
         return false;
+    }
     return knowledge.removeApplication(app);
 }
 
@@ -195,8 +211,9 @@ bool Manager::removeModule(const char* szModName)
     }
 
     Module* mod = knowledge.getModule(szModName);
-    if(!mod)
+    if (!mod) {
         return false;
+    }
 
     return knowledge.removeModule(mod);
 }
@@ -212,8 +229,9 @@ bool Manager::removeResource(const char* szResName)
     }
 
     GenericResource* res = knowledge.getResource(szResName);
-    if(!res)
+    if (!res) {
         return false;
+    }
 
     return knowledge.removeResource(res);
 }
@@ -237,8 +255,9 @@ bool Manager::loadApplication(const char* szAppName)
     for(auto& allresource : allresources)
     {
         auto* comp = dynamic_cast<Computer*>(allresource);
-        if(comp)
+        if (comp) {
             comp->setAvailability(false);
+        }
     }
 
     return prepare(true);
@@ -334,10 +353,12 @@ bool Manager::prepare(bool silent)
         exe->setOriginalPostExecWait((*itr)->getPostExecWait());
         exe->setOriginalPostStopWait((*itr)->getPostStopWait());
         string env;
-        if ((*itr)->getPrefix() && strlen((*itr)->getPrefix()))
+        if ((*itr)->getPrefix() && strlen((*itr)->getPrefix())) {
             env = string("YARP_PORT_PREFIX=") + string((*itr)->getPrefix());
-        if((*itr)->getEnvironment() && strlen((*itr)->getEnvironment()))
+        }
+        if ((*itr)->getEnvironment() && strlen((*itr)->getEnvironment())) {
             env += (env.length()) ? (string(";") + (*itr)->getEnvironment()) : (*itr)->getEnvironment();
+        }
         exe->setEnv(env.c_str());
 
         /**
@@ -356,8 +377,9 @@ bool Manager::prepare(bool silent)
         for(auto& resource : resources)
         {
             auto* res = dynamic_cast<ResYarpPort*>(resource);
-            if(res && (res->owner() == (*itr)))
+            if (res && (res->owner() == (*itr))) {
                 exe->addResource(*res);
+            }
         }
 
         runnables.push_back(exe);
@@ -370,20 +392,22 @@ Broker* Manager::createBroker(Module* module)
 {
     if(strlen(module->getBroker()) == 0)
     {
-        if(compareString(module->getHost(), "localhost"))
+        if (compareString(module->getHost(), "localhost")) {
             return (new LocalBroker());
-        else
+        } else {
             return (new YarpBroker());
+        }
     }
     else if(compareString(module->getBroker(), BROKER_YARPDEV))
     {
-        if(compareString(module->getHost(), "localhost"))
-           return (new YarpdevLocalBroker());
-        else
+        if (compareString(module->getHost(), "localhost")) {
+            return (new YarpdevLocalBroker());
+        } else {
             return (new YarpdevYarprunBroker());
-    }
-    else if(compareString(module->getHost(), "localhost"))
+        }
+    } else if (compareString(module->getHost(), "localhost")) {
         return (new ScriptLocalBroker(module->getBroker()));
+    }
 
     return (new ScriptYarprunBroker(module->getBroker()));
 }
@@ -472,8 +496,9 @@ bool Manager::exist(unsigned int id)
     }
 
     GenericResource* res = resources[id];
-    if(compareString(res->getName(), "localhost"))
+    if (compareString(res->getName(), "localhost")) {
         return true;
+    }
 
     if(dynamic_cast<Computer*>(res) || dynamic_cast<ResYarpPort*>(res))
     {
@@ -482,8 +507,9 @@ bool Manager::exist(unsigned int id)
             //YarpBroker broker;
             //broker.init();
             string strPort = res->getName();
-            if(strPort[0] != '/')
+            if (strPort[0] != '/') {
                 strPort = string("/") + strPort;
+            }
             if(dynamic_cast<ResYarpPort*>(res))
             {
                 res->setAvailability(connector.exists(strPort.c_str()));
@@ -544,8 +570,9 @@ bool Manager::updateResources()
             for(int i=0; i<comp->peripheralCount(); i++)
             {
                 auto* res = dynamic_cast<ResYarpPort*>(&comp->getPeripheralAt(i));
-                if(res)
+                if (res) {
                     res->setAvailability(false);
+                }
             }
 
             // adding all available yarp ports as peripherals
@@ -566,8 +593,9 @@ bool Manager::updateResources()
                         break;
                     }
                 }
-                if(!bfound)
+                if (!bfound) {
                     comp->addPeripheral(resport);
+                }
             }
         }
     } // end of for
@@ -579,8 +607,9 @@ bool Manager::updateResources()
 bool Manager::updateResource(const char* szName)
 {
     GenericResource* res = knowledge.getResource(szName);
-    if(!res)
+    if (!res) {
         return false;
+    }
     return updateResource(res);
 }
 
@@ -590,16 +619,19 @@ bool Manager::updateResource(GenericResource* resource)
     broker.init();
 
     auto* comp = dynamic_cast<Computer*>(resource);
-    if(!comp || !strlen(comp->getName()))
+    if (!comp || !strlen(comp->getName())) {
         return false;
+    }
 
-    if(compareString(comp->getName(), "localhost"))
+    if (compareString(comp->getName(), "localhost")) {
         return false;
+    }
 
     yarp::os::SystemInfoSerializer info;
     string strServer = comp->getName();
-    if(strServer[0] != '/')
+    if (strServer[0] != '/') {
         strServer = string("/") + strServer;
+    }
     if(!broker.getSystemInfo(strServer.c_str(), info))
     {
         logger->addError(broker.error());
@@ -643,8 +675,11 @@ bool Manager::waitingModuleRun(unsigned int id)
 {
     double base = yarp::os::Time::now();
     double wait = runnables[id]->getPostExecWait() + RUN_TIMEOUT;
-    while(!timeout(base, wait))
-        if(running(id)) return true;
+    while (!timeout(base, wait)) {
+        if (running(id)) {
+            return true;
+        }
+    }
 
     OSTRINGSTREAM msg;
     msg<<"Failed to run "<<runnables[id]->getCommand();
@@ -659,8 +694,11 @@ bool Manager::waitingModuleRun(unsigned int id)
 bool Manager::waitingModuleStop(unsigned int id)
 {
     double base = yarp::os::Time::now();
-    while(!timeout(base, STOP_TIMEOUT))
-        if(!running(id)) return true;
+    while (!timeout(base, STOP_TIMEOUT)) {
+        if (!running(id)) {
+            return true;
+        }
+    }
 
     OSTRINGSTREAM msg;
     msg<<"Failed to stop "<<runnables[id]->getCommand();
@@ -674,8 +712,11 @@ bool Manager::waitingModuleStop(unsigned int id)
 bool Manager::waitingModuleKill(unsigned int id)
 {
     double base = yarp::os::Time::now();
-    while(!timeout(base, KILL_TIMEOUT))
-        if(!running(id)) return true;
+    while (!timeout(base, KILL_TIMEOUT)) {
+        if (!running(id)) {
+            return true;
+        }
+    }
 
     OSTRINGSTREAM msg;
     msg<<"Failed to kill "<<runnables[id]->getCommand();
@@ -770,8 +811,9 @@ bool Manager::run(unsigned int id, bool async)
         yarp::os::SystemClock::delaySystem(1.0);
         runnables[id]->startWatchDog();
     }
-    if(async)
+    if (async) {
         return true;
+    }
 
     // waiting for running
     return waitingModuleRun(id);
@@ -791,19 +833,20 @@ bool Manager::run()
         {
             logger->addError("Some of external ports dependency are not satisfied.");
             return false;
-        }
-        else
+        } else {
             logger->addWarning("Some of external ports dependency are not satisfied.");
+        }
     }
 
     ExecutablePIterator itr;
     double wait = 0.0;
     for(itr=runnables.begin(); itr!=runnables.end(); itr++)
     {
-        if(bAutoConnect)
+        if (bAutoConnect) {
             (*itr)->enableAutoConnect();
-        else
+        } else {
             (*itr)->disableAutoConnect();
+        }
         (*itr)->start();
         yarp::os::SystemClock::delaySystem(0.2);
         wait = (wait > (*itr)->getPostExecWait()) ? wait : (*itr)->getPostExecWait();
@@ -811,19 +854,23 @@ bool Manager::run()
 
     // waiting for running
     double base = yarp::os::SystemClock::nowSystem();
-    while(!timeout(base, wait + RUN_TIMEOUT))
-        if(allRunning()) break;
+    while (!timeout(base, wait + RUN_TIMEOUT)) {
+        if (allRunning()) {
+            break;
+        }
+    }
 
     // starting the watchdog if needed
     if(bWithWatchDog) {
-        for(itr=runnables.begin(); itr!=runnables.end(); itr++)
+        for (itr = runnables.begin(); itr != runnables.end(); itr++) {
             (*itr)->startWatchDog();
+        }
     }
 
     if(!allRunning())
     {
         ExecutablePIterator itr;
-        for(itr=runnables.begin(); itr!=runnables.end(); itr++)
+        for (itr = runnables.begin(); itr != runnables.end(); itr++) {
             if((*itr)->state() != RUNNING)
             {
                 OSTRINGSTREAM msg;
@@ -833,6 +880,7 @@ bool Manager::run()
                 msg<<", parameter: "<<(*itr)->getParam()<<")";
                 logger->addError(msg);
             }
+        }
 
         if(bRestricted)
         {
@@ -842,13 +890,15 @@ bool Manager::run()
     }
 
     /* connecting extra ports*/
-    if(bAutoConnect)
+    if (bAutoConnect) {
         if(!connectExtraPorts())
         {
             logger->addError("Failed to stablish some of connections.");
-            if(bRestricted)
+            if (bRestricted) {
                 return false;
+            }
         }
+    }
 
     return true;
 }
@@ -869,8 +919,9 @@ bool Manager::stop(unsigned int id, bool async)
 
     runnables[id]->stop();
 
-    if(async)
+    if (async) {
         return true;
+    }
 
     // waiting for stop
     return waitingModuleStop(id);
@@ -879,8 +930,9 @@ bool Manager::stop(unsigned int id, bool async)
 
 bool Manager::stop()
 {
-    if(runnables.empty())
+    if (runnables.empty()) {
         return true;
+    }
 
     ExecutablePIterator itr;
     for(itr=runnables.begin(); itr!=runnables.end(); itr++)
@@ -890,13 +942,16 @@ bool Manager::stop()
     }
 
     double base = yarp::os::SystemClock::nowSystem();
-    while(!timeout(base, STOP_TIMEOUT))
-        if(allStopped()) break;
+    while (!timeout(base, STOP_TIMEOUT)) {
+        if (allStopped()) {
+            break;
+        }
+    }
 
     if(!allStopped())
     {
         ExecutablePIterator itr;
-        for(itr=runnables.begin(); itr!=runnables.end(); itr++)
+        for (itr = runnables.begin(); itr != runnables.end(); itr++) {
             if( ((*itr)->state() != SUSPENDED) &&
                 ((*itr)->state() != DEAD))
             {
@@ -907,6 +962,7 @@ bool Manager::stop()
                 msg<<", paramete: "<<(*itr)->getParam()<<")";
                 logger->addError(msg);
             }
+        }
         return false;
     }
 
@@ -929,16 +985,18 @@ bool Manager::kill(unsigned int id, bool async)
 
     runnables[id]->kill();
 
-    if(async)
+    if (async) {
         return true;
+    }
     return waitingModuleKill(id);
 }
 
 
 bool Manager::kill()
 {
-    if(runnables.empty())
+    if (runnables.empty()) {
         return true;
+    }
 
     ExecutablePIterator itr;
     for(itr=runnables.begin(); itr!=runnables.end(); itr++)
@@ -948,13 +1006,16 @@ bool Manager::kill()
     }
 
     double base = yarp::os::SystemClock::nowSystem();
-    while(!timeout(base, KILL_TIMEOUT))
-        if(allStopped()) break;
+    while (!timeout(base, KILL_TIMEOUT)) {
+        if (allStopped()) {
+            break;
+        }
+    }
 
     if(!allStopped())
     {
         ExecutablePIterator itr;
-        for(itr=runnables.begin(); itr!=runnables.end(); itr++)
+        for (itr = runnables.begin(); itr != runnables.end(); itr++) {
             if( ((*itr)->state() != SUSPENDED) &&
                 ((*itr)->state() != DEAD))
             {
@@ -965,6 +1026,7 @@ bool Manager::kill()
                 msg<<", paramete: "<<(*itr)->getParam()<<")";
                 logger->addError(msg);
             }
+        }
         return false;
     }
 
@@ -1025,15 +1087,17 @@ bool Manager::connect()
             {
                 logger->addError(connector.error());
                 //cout<<connector.error()<<endl;
-                if(bRestricted)
+                if (bRestricted) {
                     return false;
+                }
             }
 
         // setting the connection Qos if specified
         if(! connector.setQos((*cnn).from(), (*cnn).to(),
                          (*cnn).qosFrom(), (*cnn).qosTo())) {
-            if(bRestricted)
+            if (bRestricted) {
                 return false;
+            }
         }
     }
     return true;
@@ -1067,13 +1131,14 @@ bool Manager::disconnect()
     //YarpBroker connector;
     //connector.init();
     CnnIterator cnn;
-    for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
+    for (cnn = connections.begin(); cnn != connections.end(); cnn++) {
         if( !connector.disconnect((*cnn).from(), (*cnn).to(), (*cnn).carrier()) )
             {
                 logger->addError(connector.error());
                 //cout<<connector.error()<<endl;
                 return false;
-            }
+        }
+    }
     return true;
 }
 
@@ -1100,12 +1165,13 @@ bool Manager::rmconnect(unsigned int id)
 bool Manager::rmconnect()
 {
     CnnIterator cnn;
-    for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
+    for (cnn = connections.begin(); cnn != connections.end(); cnn++) {
         if( !connector.rmconnect((*cnn).from(), (*cnn).to()) )
             {
                 logger->addError(connector.error());
                 return false;
-            }
+        }
+    }
     return true;
 }
 
@@ -1132,11 +1198,11 @@ bool Manager::connected()
     //connector.init();
     CnnIterator cnn;
     bool bConnected = true;
-    for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
-        if( !(*cnn).getFromExists() ||
-            !(*cnn).getToExists() ||
-            !connector.connected((*cnn).from(), (*cnn).to(), (*cnn).carrier()) )
+    for (cnn = connections.begin(); cnn != connections.end(); cnn++) {
+        if (!(*cnn).getFromExists() || !(*cnn).getToExists() || !connector.connected((*cnn).from(), (*cnn).to(), (*cnn).carrier())) {
             bConnected = false;
+        }
+    }
     return bConnected;
 }
 
@@ -1147,9 +1213,9 @@ bool Manager::checkPortsAvailable(Broker* broker)
     {
        //if(!(*itr).owner() )
        // {
-            if(!broker->exists((*itr).to()) ||
-                !broker->exists((*itr).from()))
-                    return false;
+       if (!broker->exists((*itr).to()) || !broker->exists((*itr).from())) {
+           return false;
+       }
        // }
     }
     return true;
@@ -1162,9 +1228,11 @@ bool Manager::connectExtraPorts()
     //connector.init();
 
     double base = yarp::os::SystemClock::nowSystem();
-    while(!timeout(base, 10.0))
-        if(checkPortsAvailable(&connector))
+    while (!timeout(base, 10.0)) {
+        if (checkPortsAvailable(&connector)) {
             break;
+        }
+    }
 
     CnnIterator cnn;
     for(cnn=connections.begin(); cnn!=connections.end(); cnn++)
@@ -1192,22 +1260,25 @@ bool Manager::running(unsigned int id)
     }
 
     RSTATE st = runnables[id]->state();
-    if((st == RUNNING) || (st == CONNECTING) || (st == DYING))
-            return true;
+    if ((st == RUNNING) || (st == CONNECTING) || (st == DYING)) {
+        return true;
+    }
     return false;
 }
 
 
 bool Manager::allRunning()
 {
-    if(!runnables.size())
+    if (!runnables.size()) {
         return false;
+    }
     ExecutablePIterator itr;
     for(itr=runnables.begin(); itr!=runnables.end(); itr++)
     {
         RSTATE st = (*itr)->state();
-        if((st != RUNNING) && (st != CONNECTING) && (st != DYING))
+        if ((st != RUNNING) && (st != CONNECTING) && (st != DYING)) {
             return false;
+        }
     }
     return true;
 }
@@ -1221,22 +1292,25 @@ bool Manager::suspended(unsigned int id)
         return false;
     }
     RSTATE st = runnables[id]->state();
-    if((st == SUSPENDED) || (st == DEAD))
-            return true;
+    if ((st == SUSPENDED) || (st == DEAD)) {
+        return true;
+    }
     return false;
 }
 
 
 bool Manager::allStopped()
 {
-    if(!runnables.size())
+    if (!runnables.size()) {
         return true;
+    }
     ExecutablePIterator itr;
     for(itr=runnables.begin(); itr!=runnables.end(); itr++)
     {
         RSTATE st = (*itr)->state();
-        if( (st != SUSPENDED) && (st != DEAD))
+        if ((st != SUSPENDED) && (st != DEAD)) {
             return false;
+        }
     }
     return true;
 }
@@ -1278,8 +1352,9 @@ bool Manager::detachStdout(unsigned int id)
 bool Manager::timeout(double base, double t)
 {
     yarp::os::SystemClock::delaySystem(1.0);
-    if((yarp::os::SystemClock::nowSystem()-base) > t)
+    if ((yarp::os::SystemClock::nowSystem() - base) > t) {
         return true;
+    }
     return false;
 }
 

--- a/src/libYARP_manager/src/yarp/manager/module.cpp
+++ b/src/libYARP_manager/src/yarp/manager/module.cpp
@@ -64,8 +64,9 @@ void Module::swap(const Module &mod)
     waitStart = mod.waitStart;
     waitStop = mod.waitStop;
     // deep copy
-    for(int i=0; i<mod.resourceCount(); i++)
+    for (int i = 0; i < mod.resourceCount(); i++) {
         addResource(mod.getResourceAt(i));
+    }
 }
 
 
@@ -89,8 +90,9 @@ bool Module::addArgument(Argument &argument)
 bool Module::removeArgument(Argument& argument)
 {
     auto itr = findArgument(argument);
-    if(itr == arguments.end())
+    if (itr == arguments.end()) {
         return true;
+    }
     arguments.erase(itr);
     return true;
 }
@@ -109,8 +111,9 @@ bool Module::removeOutput(OutputData& output)
     //__CHECK_NULLPTR(output);
 
     auto itr = findOutput(output);
-    if(itr == outputs.end())
+    if (itr == outputs.end()) {
         return true;
+    }
     outputs.erase(itr);
     return true;
 }
@@ -129,8 +132,9 @@ bool Module::removeInput(InputData& input)
     //__CHECK_NULLPTR(input);
 
     auto itr = findInput(input);
-    if(itr == inputs.end())
+    if (itr == inputs.end()) {
         return true;
+    }
     inputs.erase(itr);
     return true;
 }
@@ -148,8 +152,9 @@ bool Module::addResource(GenericResource& res)
 bool Module::removeResource(GenericResource& res)
 {
     auto itr = findResource(res);
-    if(itr == resources.end())
+    if (itr == resources.end()) {
         return true;
+    }
     resources.erase(itr);
     delete (*itr);
     return true;
@@ -158,12 +163,13 @@ bool Module::removeResource(GenericResource& res)
 bool Module::removeAuthor(Author& author)
 {
     AuthorIterator itr;
-    for(itr=authors.begin(); itr<authors.end(); itr++)
+    for (itr = authors.begin(); itr < authors.end(); itr++) {
         if((*itr) == author)
         {
             authors.erase(itr);
             return true;
         }
+    }
     return true;
 }
 
@@ -171,9 +177,11 @@ bool Module::removeAuthor(Author& author)
 ArgumentIterator Module::findArgument(Argument& argument)
 {
     ArgumentIterator itr;
-    for(itr=arguments.begin(); itr<arguments.end(); itr++)
-        if ((*itr) == argument)
+    for (itr = arguments.begin(); itr < arguments.end(); itr++) {
+        if ((*itr) == argument) {
             return itr;
+        }
+    }
     return arguments.end();
 }
 
@@ -181,9 +189,11 @@ ArgumentIterator Module::findArgument(Argument& argument)
 InputIterator Module::findInput(InputData& input)
 {
     InputIterator itr;
-    for(itr=inputs.begin(); itr<inputs.end(); itr++)
-        if ((*itr) == input)
+    for (itr = inputs.begin(); itr < inputs.end(); itr++) {
+        if ((*itr) == input) {
             return itr;
+        }
+    }
     return inputs.end();
 }
 
@@ -191,18 +201,22 @@ InputIterator Module::findInput(InputData& input)
 OutputIterator Module::findOutput(OutputData& output)
 {
     OutputIterator itr;
-    for(itr=outputs.begin(); itr<outputs.end(); itr++)
-        if ((*itr) == output)
+    for (itr = outputs.begin(); itr < outputs.end(); itr++) {
+        if ((*itr) == output) {
             return itr;
+        }
+    }
     return outputs.end();
 }
 
 ResourcePIterator Module::findResource(GenericResource& res)
 {
     ResourcePIterator itr;
-    for(itr=resources.begin(); itr<resources.end(); itr++)
-        if (*(*itr) == res)
+    for (itr = resources.begin(); itr < resources.end(); itr++) {
+        if (*(*itr) == res) {
             return itr;
+        }
+    }
     return resources.end();
 }
 
@@ -260,12 +274,12 @@ bool Module::setParam(const char* szParam)
         }
         else
         {
-            if((*itr).isSwitch())
+            if ((*itr).isSwitch()) {
                 (*itr).setValue(strVal.c_str());
-            else
-            {
-                if(strVal != "off")
+            } else {
+                if (strVal != "off") {
                     (*itr).setValue(strVal.c_str());
+                }
             }
         }
     }
@@ -274,8 +288,9 @@ bool Module::setParam(const char* szParam)
 
 bool Module::getParamValue(const char* key, bool bSwitch, std::string &param)
 {
-    if(!key)
+    if (!key) {
         return false;
+    }
 
     //printf("\n\nparsing '%s' for %s (switch:%d)\n", strParam.c_str(), key, bSwitch);
     string strKey = string("--") + string(key);
@@ -294,20 +309,23 @@ bool Module::getParamValue(const char* key, bool bSwitch, std::string &param)
     //printf("%s %d \n", __FILE__, __LINE__);
 
     pos += strKey.size();
-    if((pos >= strParam.length()) || (strParam.at(pos) != ' '))
+    if ((pos >= strParam.length()) || (strParam.at(pos) != ' ')) {
         return false;
+    }
 
     // skip all spaces
     while(strParam.at(pos++) == ' ')
     {
-        if(pos >= strParam.length())
+        if (pos >= strParam.length()) {
             return false;
+        }
     }
     pos--;
 
     size_t pos2 = pos;
-    while((pos2 < strParam.length()) && (strParam.at(pos2) != ' '))
+    while ((pos2 < strParam.length()) && (strParam.at(pos2) != ' ')) {
         pos2++;
+    }
     param = strParam.substr(pos, pos2-pos);
     return true;
 }

--- a/src/libYARP_manager/src/yarp/manager/node.cpp
+++ b/src/libYARP_manager/src/yarp/manager/node.cpp
@@ -30,8 +30,9 @@ bool Node::removeSuc(Node* node)
     __CHECK_NULLPTR(node);
 
     auto it = findSuc(node);
-    if(it != sucessors.end())
+    if (it != sucessors.end()) {
         sucessors.erase(it);
+    }
     return true;
 }
 
@@ -46,8 +47,9 @@ void Node::removeAllSuc()
 bool Node::hasSuc(Node* node)
 {
     auto it = findSuc(node);
-    if(it == sucessors.end())
+    if (it == sucessors.end()) {
         return false;
+    }
     return true;
 }
 
@@ -56,8 +58,10 @@ bool Node::hasSuc(Node* node)
 LinkIterator Node::findSuc(Node* node)
 {
     LinkIterator itr;
-    for(itr=sucessors.begin(); itr<sucessors.end(); itr++)
-        if ((*itr).to() == node)
+    for (itr = sucessors.begin(); itr < sucessors.end(); itr++) {
+        if ((*itr).to() == node) {
             return itr;
+        }
+    }
     return sucessors.end();
 }

--- a/src/libYARP_manager/src/yarp/manager/physicresource.cpp
+++ b/src/libYARP_manager/src/yarp/manager/physicresource.cpp
@@ -65,12 +65,14 @@ Node* GPU::clone()
 
 bool GPU::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     GPU* gpu = dynamic_cast<GPU*>(resource);
-    if(!gpu)
+    if (!gpu) {
         return false;
+    }
     bool ret = (!strlen(gpu->getCompCompatibility()))? true : (compCompatibility == string(gpu->getCompCompatibility()));
     ret &= (cores >= gpu->getCores());
     ret &= (frequency >= gpu->getFrequency());

--- a/src/libYARP_manager/src/yarp/manager/primresource.cpp
+++ b/src/libYARP_manager/src/yarp/manager/primresource.cpp
@@ -30,12 +30,14 @@ Memory::Memory(const char* szName) : GenericResource("Memory")
 
 bool Memory::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* mem = dynamic_cast<Memory*>(resource);
-    if(!mem)
+    if (!mem) {
         return false;
+    }
     return ( (freeSpace >= mem->getFreeSpace()) &&
              (totalSpace >= mem->getTotalSpace()) );
 }
@@ -70,12 +72,14 @@ Storage::Storage(const char* szName) : GenericResource("Storage")
 
 bool Storage::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* mem = dynamic_cast<Storage*>(resource);
-    if(!mem)
+    if (!mem) {
         return false;
+    }
     return ( (freeSpace >= mem->getFreeSpace()) &&
              (totalSpace >= mem->getTotalSpace()) );
 }
@@ -106,12 +110,14 @@ Network::Network(const char* szName) : GenericResource("Network")
 
 bool Network::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* net = dynamic_cast<Network*>(resource);
-    if(!net)
+    if (!net) {
         return false;
+    }
     bool ret = (!strlen(net->getIP4()))? true : (strIP4 == string(net->getIP4()));
     ret &= (!strlen(net->getIP6()))? true : (strIP6 == string(net->getIP6()));
     ret &= (!strlen(net->getMAC()))? true : (strMAC == string(net->getMAC()));
@@ -158,12 +164,14 @@ Processor::Processor(const char* szName) : GenericResource("Processor")
 
 bool Processor::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* proc = dynamic_cast<Processor*>(resource);
-    if(!proc)
+    if (!proc) {
         return false;
+    }
 
     bool ret = (!strlen(proc->getArchitecture()))? true : (strArchitecure == string(proc->getArchitecture()));
     ret &= (!strlen(proc->getModel()))? true : (strModel == string(proc->getModel()));
@@ -225,28 +233,32 @@ bool Computer::addPeripheral(GenericResource& res)
 
 bool Computer::satisfy(GenericResource* resource)
 {
-    if(!getAvailability() || getDisable())
+    if (!getAvailability() || getDisable()) {
         return false;
+    }
 
     auto* mres = dynamic_cast<MultiResource*>(resource);
     if(mres)
     {
-        if(!mres->resourceCount())
+        if (!mres->resourceCount()) {
             return true;
+        }
         for(int i=0; i<mres->resourceCount(); i++)
         {
             auto* comp = dynamic_cast<Computer*>(&mres->getResourceAt(i));
-            if(comp &&satisfyComputer(comp))
+            if (comp && satisfyComputer(comp)) {
                 return true;
-            else if(satisfyComputerResource(&mres->getResourceAt(i)))
-                    return true;
+            } else if (satisfyComputerResource(&mres->getResourceAt(i))) {
+                return true;
+            }
         }
         return false;
     }
 
     auto* comp = dynamic_cast<Computer*>(resource);
-    if(comp)
+    if (comp) {
         return satisfyComputer(comp);
+    }
 
     return satisfyComputerResource(resource);
 }
@@ -259,29 +271,37 @@ bool Computer::satisfyComputer(Computer* comp)
     ret &= satisfyComputerResource(&comp->getProcessor());
     ret &= satisfyComputerResource(&comp->getNetwork());
     ret &= satisfyComputerResource(&comp->getPlatform());
-    for(int i=0; i<comp->peripheralCount(); i++)
+    for (int i = 0; i < comp->peripheralCount(); i++) {
         ret &= satisfyComputerResource(&comp->getPeripheralAt(i));
+    }
     return ret;
 }
 
 
 bool Computer::satisfyComputerResource(GenericResource* resource)
 {
-    if(memory.satisfy(resource))
+    if (memory.satisfy(resource)) {
         return true;
-    if(storage.satisfy(resource))
+    }
+    if (storage.satisfy(resource)) {
         return true;
-    if(network.satisfy(resource))
+    }
+    if (network.satisfy(resource)) {
         return true;
-    if(processor.satisfy(resource))
+    }
+    if (processor.satisfy(resource)) {
         return true;
-    if(platform.satisfy(resource))
+    }
+    if (platform.satisfy(resource)) {
         return true;
+    }
 
     ResourcePIterator itr;
-    for(itr=peripheralResources.begin(); itr!=peripheralResources.end(); itr++)
-        if((*itr)->satisfy(resource))
+    for (itr = peripheralResources.begin(); itr != peripheralResources.end(); itr++) {
+        if ((*itr)->satisfy(resource)) {
             return true;
+        }
+    }
     return false;
 }
 
@@ -301,8 +321,9 @@ void Computer::swap(const Computer &comp)
     platform = comp.platform;
     processes = comp.processes;
     // deep copy
-    for(int i=0; i<comp.peripheralCount(); i++)
+    for (int i = 0; i < comp.peripheralCount(); i++) {
         addPeripheral(comp.getPeripheralAt(i));
+    }
 }
 
 void Computer::clear()

--- a/src/libYARP_manager/src/yarp/manager/primresource.h
+++ b/src/libYARP_manager/src/yarp/manager/primresource.h
@@ -78,9 +78,21 @@ public:
     Node* clone() override;
     bool satisfy(GenericResource* resource) override;
 
-    void setIP4(const char* ip) { if(ip) strIP4 = ip; }
-    void setIP6(const char* ip) { if(ip) strIP6 = ip; }
-    void setMAC(const char* mac) { if(mac) strMAC = mac; }
+    void setIP4(const char* ip) {
+        if (ip) {
+            strIP4 = ip;
+        }
+    }
+    void setIP6(const char* ip) {
+        if (ip) {
+            strIP6 = ip;
+        }
+    }
+    void setMAC(const char* mac) {
+        if (mac) {
+            strMAC = mac;
+        }
+    }
     const char* getIP4() { return strIP4.c_str(); }
     const char* getIP6() { return strIP6.c_str(); }
     const char* getMAC() { return strMAC.c_str(); }
@@ -113,8 +125,16 @@ public:
     Node* clone() override;
     bool satisfy(GenericResource* resource) override;
 
-    void setArchitecture(const char* arch) {if(arch) strArchitecure = arch; }
-    void setModel(const char* model) {if(model) strModel = model; }
+    void setArchitecture(const char* arch) {
+        if (arch) {
+            strArchitecure = arch;
+        }
+    }
+    void setModel(const char* model) {
+        if (model) {
+            strModel = model;
+        }
+    }
     void setCores(size_t n) { cores = n; }
     void setSiblings(size_t n) { siblings = n; }
     void setFrequency(double f) { frequency = f; }

--- a/src/libYARP_manager/src/yarp/manager/resource.cpp
+++ b/src/libYARP_manager/src/yarp/manager/resource.cpp
@@ -17,8 +17,9 @@ GenericResource::GenericResource(const char* szTypeName) : Node(RESOURCE)
     modOwner = nullptr;
     bAvailable = true;
     bDisabled = false;
-    if(szTypeName)
+    if (szTypeName) {
         strTypeName = szTypeName;
+    }
 }
 
 GenericResource::~GenericResource() = default;
@@ -80,8 +81,9 @@ void MultiResource::swap(const MultiResource &res)
 {
     clear();
     // deep copy
-    for(int i=0; i<res.resourceCount(); i++)
+    for (int i = 0; i < res.resourceCount(); i++) {
         addResource(res.getResourceAt(i));
+    }
 }
 
 void MultiResource::clear()

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
@@ -50,10 +50,9 @@ static Bottle parsePaths(const std::string& txt) {
 static bool fileExists(const char *fname) {
         FILE *fp=nullptr;
         fp = fopen(fname,"r");
-        if(fp == nullptr)
+        if (fp == nullptr) {
             return false;
-        else
-        {
+        } else {
             fclose(fp);
             return true;
         }
@@ -87,9 +86,12 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
         }
 
     }
-    if(strCmd=="")
+    if (strCmd == "") {
         return false;
-    if(szparam) strParam = szparam;
+    }
+    if (szparam) {
+        strParam = szparam;
+    }
     strDevParam<<strCmd<<" "<<strParam;
     return LocalBroker::init(script.c_str(), strDevParam.str().c_str(),
                                 szhost, szstdio, szworkdir, szenv);
@@ -98,8 +100,9 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
 
 bool ScriptYarprunBroker::whichFile(const char* server, const char* filename, std::string& filenameWithPath)
 {
-    if(!strlen(server))
+    if (!strlen(server)) {
         return false;
+    }
 
     yarp::os::Bottle msg, grp;
     grp.clear();
@@ -144,13 +147,16 @@ bool ScriptYarprunBroker::init(const char* szcmd, const char* szparam,
     if(szcmd)
     {
         std::string strHost;
-        if(szhost[0] != '/')
+        if (szhost[0] != '/') {
             strHost = string("/") + string(szhost);
-        else
+        } else {
             strHost = szhost;
+        }
         whichFile(strHost.c_str(), szcmd, strCmd);
     }
-    if(szparam) strParam = szparam;
+    if (szparam) {
+        strParam = szparam;
+    }
     strDevParam<<strCmd<<" "<<strParam;
     return YarpBroker::init(script.c_str(), strDevParam.str().c_str(),
                                 szhost, szstdio, szworkdir, szenv);

--- a/src/libYARP_manager/src/yarp/manager/singleapploader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/singleapploader.cpp
@@ -13,8 +13,12 @@ using namespace yarp::manager;
 
 SingleAppLoader::SingleAppLoader(const char* szModule, const char* szHost)
 {
-    if(szModule) strModule = szModule;
-    if(szHost) strHost = szHost;
+    if (szModule) {
+        strModule = szModule;
+    }
+    if (szHost) {
+        strHost = szHost;
+    }
 }
 
 

--- a/src/libYARP_manager/src/yarp/manager/utility.cpp
+++ b/src/libYARP_manager/src/yarp/manager/utility.cpp
@@ -103,8 +103,9 @@ ErrorLogger* ErrorLogger::Instance()
 }
 
 void ErrorLogger::addWarning(const char* szWarning) {
-    if(szWarning)
+    if (szWarning) {
         warnings.emplace_back(szWarning);
+    }
 }
 
 void ErrorLogger::addWarning(const string &str) {
@@ -116,8 +117,9 @@ void ErrorLogger::addWarning(OSTRINGSTREAM &stream) {
 }
 
 void ErrorLogger::addError(const char* szError) {
-    if(szError)
+    if (szError) {
         errors.emplace_back(szError);
+    }
 }
 
 void ErrorLogger::addError(const string &str) {
@@ -129,8 +131,9 @@ void ErrorLogger::addError(OSTRINGSTREAM &stream) {
 }
 
 const char* ErrorLogger::getLastError() {
-    if(errors.empty())
+    if (errors.empty()) {
         return nullptr;
+    }
     static string msg;
     msg = errors.back();
     errors.pop_back();
@@ -140,14 +143,16 @@ const char* ErrorLogger::getLastError() {
 const char* ErrorLogger::getFormatedErrorString() {
     static string msgs;
     char* err;
-    while((err=(char*)getLastError()) != nullptr)
+    while ((err = (char*)getLastError()) != nullptr) {
         msgs += string(err) + " ";
+    }
     return msgs.c_str();
 }
 
 const char* ErrorLogger::getLastWarning() {
-    if(warnings.empty())
+    if (warnings.empty()) {
         return nullptr;
+    }
     static string msg;
     msg = warnings.back();
     warnings.pop_back();
@@ -157,8 +162,9 @@ const char* ErrorLogger::getLastWarning() {
 const char* ErrorLogger::getFormatedWarningString() {
     static string msgs;
     char* err;
-    while((err=(char*)getLastWarning()) != nullptr)
+    while ((err = (char*)getLastWarning()) != nullptr) {
         msgs += string(err) + " ";
+    }
     return msgs.c_str();
 }
 
@@ -288,12 +294,15 @@ OS yarp::manager::strToOS(const char* szOS)
 {
     if(szOS)
     {
-        if(compareString(szOS, "LINUX"))
+        if (compareString(szOS, "LINUX")) {
             return LINUX;
-        if (compareString(szOS, "WINDOWS"))
+        }
+        if (compareString(szOS, "WINDOWS")) {
             return WINDOWS;
-        if (compareString(szOS, "MAC"))
+        }
+        if (compareString(szOS, "MAC")) {
             return MAC;
+        }
     }
     return OTHER;
 }
@@ -301,10 +310,12 @@ OS yarp::manager::strToOS(const char* szOS)
 
 bool yarp::manager::compareString(const char* szFirst, const char* szSecond)
 {
-    if(!szFirst && !szSecond)
+    if (!szFirst && !szSecond) {
         return true;
-    if( !szFirst || !szSecond)
+    }
+    if (!szFirst || !szSecond) {
         return false;
+    }
 
     string strFirst(szFirst);
     string strSecond(szSecond);
@@ -312,8 +323,9 @@ bool yarp::manager::compareString(const char* szFirst, const char* szSecond)
               (int(*)(int))toupper);
     transform(strSecond.begin(), strSecond.end(), strSecond.begin(),
               (int(*)(int))toupper);
-    if(strFirst == strSecond)
+    if (strFirst == strSecond) {
         return true;
+    }
     return false;
 }
 
@@ -324,10 +336,12 @@ void yarp::manager::trimString(string& str)
     {
         str.erase(pos + 1);
         pos = str.find_first_not_of(' ');
-        if(pos != string::npos)
+        if (pos != string::npos) {
             str.erase(0, pos);
+        }
+    } else {
+        str.erase(str.begin(), str.end());
     }
-    else str.erase(str.begin(), str.end());
 }
 
 
@@ -335,8 +349,9 @@ bool yarp::manager::exportDotGraph(Graph& graph, const char* szFileName)
 {
     ofstream dot;
     dot.open(szFileName);
-    if(!dot.is_open())
+    if (!dot.is_open()) {
         return false;
+    }
 
     dot<<"digraph G {"<<endl;
     dot<<"rankdir=LR;"<<endl;
@@ -357,11 +372,11 @@ bool yarp::manager::exportDotGraph(Graph& graph, const char* szFileName)
                         auto* in = (InputData*)l.to();
                         dot<<"\""<<mod->getLabel()<<"\" -> ";
                         dot<<"\""<<in->getLabel()<<"\"";
-                        if(!l.isVirtual())
+                        if (!l.isVirtual()) {
                             dot<<" [label=\"\"];"<<endl;
-                        else
-                            dot<<" [label=\"\" style=dashed];"<<endl;
-
+                        } else {
+                            dot << " [label=\"\" style=dashed];" << endl;
+                        }
                     }
 
                     break;
@@ -385,10 +400,11 @@ bool yarp::manager::exportDotGraph(Graph& graph, const char* szFileName)
                         auto* out = (OutputData*)l.to();
                         dot<<"\""<<in->getLabel()<<"\" -> ";
                         dot<<"\""<<out->getLabel()<<"\"";
-                        if(!l.isVirtual())
+                        if (!l.isVirtual()) {
                             dot<<" [label=\""<<l.weight()<<"\"];"<<endl;
-                        else
-                            dot<<" [label=\""<<l.weight()<<"\" style=dashed];"<<endl;
+                        } else {
+                            dot << " [label=\"" << l.weight() << "\" style=dashed];" << endl;
+                        }
                     }
 
                     break;
@@ -421,10 +437,11 @@ bool yarp::manager::exportDotGraph(Graph& graph, const char* szFileName)
                         auto* mod = (Module*)l.to();
                         dot<<"\""<<app->getLabel()<<"\" -> ";
                         dot<<"\""<<mod->getLabel()<<"\"";
-                        if(!l.isVirtual())
+                        if (!l.isVirtual()) {
                             dot<<" [label=\"\"];"<<endl;
-                        else
-                            dot<<" [label=\"\" style=dashed];"<<endl;
+                        } else {
+                            dot << " [label=\"\" style=dashed];" << endl;
+                        }
                     }
                     break;
             }
@@ -432,10 +449,11 @@ bool yarp::manager::exportDotGraph(Graph& graph, const char* szFileName)
             case RESOURCE:{
                     auto* res = (GenericResource*)(*itr);
                     dot<<"\""<<res->getLabel()<<"\"";
-                    if(res->owner())
+                    if (res->owner()) {
                         dot<<" [shape=rect, color=black, fillcolor=salmon, peripheries=1, style=filled ";
-                    else
-                        dot<<" [shape=house, color=maroon, fillcolor=indianred, peripheries=1, style=filled, penwidth=2";
+                    } else {
+                        dot << " [shape=house, color=maroon, fillcolor=indianred, peripheries=1, style=filled, penwidth=2";
+                    }
                     dot<<" label=\""<<res->getName()<<"\""<<"];"<<endl;
                     for(int i=0; i<res->sucCount(); i++)
                     {

--- a/src/libYARP_manager/src/yarp/manager/xmlapploader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlapploader.cpp
@@ -34,16 +34,17 @@ XmlAppLoader::XmlAppLoader(const char* szPath, const char* szAppName)
 {
     parser = new(TextParser);
     app.clear();
-    if(szAppName)
+    if (szAppName) {
         strAppName = szAppName;
+    }
 
     if(strlen(szPath))
     {
         const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
-        if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+        if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
             strPath = strPath + string(directorySeparator);
+        }
     }
 }
 
@@ -54,8 +55,9 @@ XmlAppLoader::XmlAppLoader(const char* szFileName)
 {
     parser = new(TextParser);
     app.clear();
-    if(szFileName)
+    if (szFileName) {
         strFileName = szFileName;
+    }
 }
 
 
@@ -106,8 +108,9 @@ bool XmlAppLoader::init()
         if(name.size() > 3)
         {
             string ext = name.substr(name.size()-3,3);
-            if(compareString(ext.c_str(), "xml"))
-                fileNames.push_back(strPath+name);
+            if (compareString(ext.c_str(), "xml")) {
+                fileNames.push_back(strPath + name);
+            }
         }
     }
     closedir(dir);
@@ -144,8 +147,9 @@ Application* XmlAppLoader::getNextApplication()
         Application* app = nullptr;
         while(!app)
         {
-            if(fileNames.empty())
+            if (fileNames.empty()) {
                 return nullptr;
+            }
             string fname = fileNames.back();
             fileNames.pop_back();
             app = parsXml(fname.c_str());
@@ -158,8 +162,9 @@ Application* XmlAppLoader::getNextApplication()
         for(itr=fileNames.begin(); itr<fileNames.end(); itr++)
         {
          Application* app = parsXml((*itr).c_str());
-         if(app && (string(app->getName())==strAppName))
-            return app;
+         if (app && (string(app->getName()) == strAppName)) {
+             return app;
+         }
         }
     }
  return nullptr;
@@ -224,21 +229,25 @@ Application* XmlAppLoader::parsXml(const char* szFile)
     if(name)
     {
         string strname = parser->parseText(name->GetText());
-        for(char& i : strname)
-            if(i == ' ')
+        for (char& i : strname) {
+            if (i == ' ') {
                 i = '_';
+            }
+        }
         app.setName(strname.c_str());
     }
 
     /* retrieving description */
     TiXmlElement* desc;
-    if((desc = (TiXmlElement*) root->FirstChild("description")))
+    if ((desc = (TiXmlElement*)root->FirstChild("description"))) {
         app.setDescription(parser->parseText(desc->GetText()).c_str());
+    }
 
     /* retrieving version */
     TiXmlElement* ver;
-    if((ver = (TiXmlElement*) root->FirstChild("version")))
+    if ((ver = (TiXmlElement*)root->FirstChild("version"))) {
         app.setVersion(parser->parseText(ver->GetText()).c_str());
+    }
 
     /*
      * TODO: setting prefix of the main application is inactivated.
@@ -253,17 +262,19 @@ Application* XmlAppLoader::parsXml(const char* szFile)
 
     /* retrieving authors information*/
     TiXmlElement* authors;
-    if((authors = (TiXmlElement*) root->FirstChild("authors")))
+    if ((authors = (TiXmlElement*)root->FirstChild("authors"))) {
         for(TiXmlElement* ath = authors->FirstChildElement(); ath;
                 ath = ath->NextSiblingElement())
         {
             if(compareString(ath->Value(), "author"))
             {
                 Author author;
-                if(ath->GetText())
+                if (ath->GetText()) {
                     author.setName(parser->parseText(ath->GetText()).c_str());
-                if(ath->Attribute("email"))
+                }
+                if (ath->Attribute("email")) {
                     author.setEmail(ath->Attribute("email"));
+                }
                 app.addAuthor(author);
             }
             else
@@ -274,10 +285,11 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                 logger->addWarning(war);
             }
         }
+    }
 
     /* retrieving resources information*/
     TiXmlElement* resources;
-    if((resources = (TiXmlElement*) root->FirstChild("dependencies")))
+    if ((resources = (TiXmlElement*)root->FirstChild("dependencies"))) {
         for(TiXmlElement* res = resources->FirstChildElement(); res;
                 res = res->NextSiblingElement())
         {
@@ -298,6 +310,7 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                 logger->addWarning(war);
             }
         }
+    }
 
     /* retrieving modules information*/
     using setter = void (ModuleInterface::*)(const char*);
@@ -388,12 +401,15 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                             {
                                 ResYarpPort resource(parser->parseText(res->GetText()).c_str());
                                 resource.setPort(parser->parseText(res->GetText()).c_str());
-                                if(res->Attribute("timeout"))
+                                if (res->Attribute("timeout")) {
                                     resource.setTimeout(atof(res->Attribute("timeout")));
-                                if(res->Attribute("request"))
+                                }
+                                if (res->Attribute("request")) {
                                     resource.setRequest(res->Attribute("request"));
-                                if(res->Attribute("reply"))
+                                }
+                                if (res->Attribute("reply")) {
                                     resource.setReply(res->Attribute("reply"));
+                                }
                                 module.addResource(resource);
                             }
                         }
@@ -417,12 +433,14 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                         if(compareString(res->Value(), "wait"))
                         {
                             if (res->Attribute("when") && compareString(res->Attribute("when"), "start")) {
-                                if(parser->parseText(res->GetText()).c_str())
+                                if (parser->parseText(res->GetText()).c_str()) {
                                     module.setPostExecWait(atof(parser->parseText(res->GetText()).c_str()));
+                                }
                             }
                             else if (res->Attribute("when") && compareString(res->Attribute("when"), "stop")) {
-                                if(parser->parseText(res->GetText()).c_str())
+                                if (parser->parseText(res->GetText()).c_str()) {
                                     module.setPostStopWait(atof(parser->parseText(res->GetText()).c_str()));
+                                }
                             }
                             else if (res->Attribute("when") && strlen(res->Attribute("when"))) {
                                 OSTRINGSTREAM war;
@@ -430,8 +448,9 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                                 logger->addWarning(war);
                             }
                             else {  // if "when" has not been specified, use setPostExecWait!
-                                if(parser->parseText(res->GetText()).c_str())
+                                if (parser->parseText(res->GetText()).c_str()) {
                                     module.setPostExecWait(atof(parser->parseText(res->GetText()).c_str()));
+                                }
                             }
                         }
                         else
@@ -444,8 +463,8 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                     }
                 }
                 /* retrieving portmaps */
-                for(TiXmlElement* map = mod->FirstChildElement(); map;
-                            map = map->NextSiblingElement())
+                for (TiXmlElement* map = mod->FirstChildElement(); map;
+                     map = map->NextSiblingElement()) {
                     if(compareString(map->Value(), "portmap"))
                     {
                         TiXmlElement* first;
@@ -457,6 +476,7 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                             module.addPortmap(portmap);
                         }
                     }
+                }
 
                 app.addImodule(module);
             }
@@ -482,8 +502,9 @@ Application* XmlAppLoader::parsXml(const char* szFile)
             if((name=(TiXmlElement*) embApp->FirstChild("name")))
             {
                 ApplicationInterface IApp(parser->parseText(name->GetText()).c_str());
-                if((prefix=(TiXmlElement*) embApp->FirstChild("prefix")))
+                if ((prefix = (TiXmlElement*)embApp->FirstChild("prefix"))) {
                     IApp.setPrefix(parser->parseText(prefix->GetText()).c_str());
+                }
 #ifdef WITH_GEOMETRY
                 auto* element = (TiXmlElement*) embApp->FirstChild("geometry");
                 if(element && element->GetText())
@@ -530,8 +551,9 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                 {
                     if(compareString(rule->Value(), "rule"))
                     {
-                        if(rule->Attribute("connection"))
+                        if (rule->Attribute("connection")) {
                             arbitrator.addRule(rule->Attribute("connection"), parser->parseText(rule->GetText()).c_str());
+                        }
                     }
                 }
 #ifdef WITH_GEOMETRY
@@ -575,18 +597,20 @@ Application* XmlAppLoader::parsXml(const char* szFile)
             auto* from = (TiXmlElement*) cnn->FirstChild("from");
             auto* to = (TiXmlElement*) cnn->FirstChild("to");
 
-            if(!from)
-                from = (TiXmlElement*) cnn->FirstChild("output");
-            if(!to)
-                to = (TiXmlElement*) cnn->FirstChild("input");
+            if (!from) {
+                from = (TiXmlElement*)cnn->FirstChild("output");
+            }
+            if (!to) {
+                to = (TiXmlElement*)cnn->FirstChild("input");
+            }
 
             TiXmlElement* protocol;
             if(from && to)
             {
                 string strCarrier;
-                if((protocol=(TiXmlElement*) cnn->FirstChild("protocol")) &&
-                    protocol->GetText())
+                if ((protocol = (TiXmlElement*)cnn->FirstChild("protocol")) && protocol->GetText()) {
                     strCarrier = parser->parseText(protocol->GetText());
+                }
                 Connection connection(parser->parseText(from->GetText()).c_str(),
                                     parser->parseText(to->GetText()).c_str(),
                                     strCarrier.c_str());
@@ -608,8 +632,9 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                         app.addResource(resource);
                     }
                 }
-                if(from->Attribute("qos"))
+                if (from->Attribute("qos")) {
                     connection.setQosFrom(from->Attribute("qos"));
+                }
                 if(to->Attribute("external") &&
                     compareString(to->Attribute("external"), "true"))
                 {
@@ -621,26 +646,30 @@ Application* XmlAppLoader::parsXml(const char* szFile)
                         app.addResource(resource);
                     }
                 }
-                if(to->Attribute("qos"))
+                if (to->Attribute("qos")) {
                     connection.setQosTo(to->Attribute("qos"));
+                }
 
                 //Connections which have the same port name in Port Resources
                 // should also be set as external
                 for(int i=0; i<app.resourcesCount(); i++)
                 {
                     ResYarpPort res = app.getResourceAt(i);
-                    if(compareString(res.getPort(), connection.from()))
+                    if (compareString(res.getPort(), connection.from())) {
                         connection.setFromExternal(true);
-                    if(compareString(res.getPort(), connection.to()))
+                    }
+                    if (compareString(res.getPort(), connection.to())) {
                         connection.setToExternal(true);
+                    }
                 }
 
-                if(cnn->Attribute("id"))
+                if (cnn->Attribute("id")) {
                     connection.setId(cnn->Attribute("id"));
+                }
 
-                if(cnn->Attribute("persist") &&
-                        compareString(cnn->Attribute("persist"), "true"))
+                if (cnn->Attribute("persist") && compareString(cnn->Attribute("persist"), "true")) {
                     connection.setPersistent(true);
+                }
 
 #ifdef WITH_GEOMETRY
                 auto* geometry = (TiXmlElement*) cnn->FirstChild("geometry");

--- a/src/libYARP_manager/src/yarp/manager/xmlappsaver.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlappsaver.cpp
@@ -21,13 +21,16 @@ using namespace yarp::manager;
 
 XmlAppSaver::XmlAppSaver(const char* szFileName)
 {
-    if(szFileName) strFileName = szFileName;
+    if (szFileName) {
+        strFileName = szFileName;
+    }
 }
 
 bool XmlAppSaver::save(Application* application)
 {
-    if(!strFileName.size())
-         return serialXml(application, application->getXmlFile());
+    if (!strFileName.size()) {
+        return serialXml(application, application->getXmlFile());
+    }
 
     return serialXml(application, strFileName.c_str());
 }
@@ -201,21 +204,25 @@ bool XmlAppSaver::serialXml(Application* app, const char* szFile)
             auto* newConn=new TiXmlElement("connection");
             Connection curConn=app->getConnectionAt(connCt);
 
-            if(strlen(curConn.getId()))
+            if (strlen(curConn.getId())) {
                 newConn->SetAttribute("id", curConn.getId());
+            }
 
-            if(curConn.isPersistent())
+            if (curConn.isPersistent()) {
                 newConn->SetAttribute("persist", "true");
+            }
 
             auto* from = new TiXmlElement("from");
-            if (curConn.isExternalFrom())
+            if (curConn.isExternalFrom()) {
                 from->SetAttribute("external", "true");
+            }
             from->LinkEndChild(new TiXmlText(curConn.from()));
             newConn->LinkEndChild(from);
 
             auto* to = new TiXmlElement("to");
-            if (curConn.isExternalTo())
+            if (curConn.isExternalTo()) {
                 to->SetAttribute("external", "true");
+            }
             to->LinkEndChild(new TiXmlText(curConn.to()));
             newConn->LinkEndChild(to);
 
@@ -228,8 +235,10 @@ bool XmlAppSaver::serialXml(Application* app, const char* szFile)
             if(model.points.size()>0)
             {
                 txt<<"(Pos ";
-                for(auto& point : model.points)
-                    txt<<"((x "<<point.x<<") "<<"(y "<<point.y<<")) ";
+                for (auto& point : model.points) {
+                    txt << "((x " << point.x << ") "
+                        << "(y " << point.y << ")) ";
+                }
                 txt<<" )";
                 auto* geometry=new TiXmlElement("geometry");
                 geometry->LinkEndChild(new TiXmlText(txt.str().c_str()));
@@ -265,8 +274,10 @@ bool XmlAppSaver::serialXml(Application* app, const char* szFile)
             if(model.points.size()>0)
             {
                 txt<<"(Pos ";
-                for(auto& point : model.points)
-                    txt<<"((x "<<point.x<<") "<<"(y "<<point.y<<")) ";
+                for (auto& point : model.points) {
+                    txt << "((x " << point.x << ") "
+                        << "(y " << point.y << ")) ";
+                }
                 txt<<" )";
                 auto* geometry=new TiXmlElement("geometry");
                 geometry->LinkEndChild(new TiXmlText(txt.str().c_str()));
@@ -282,12 +293,13 @@ bool XmlAppSaver::serialXml(Application* app, const char* szFile)
 
         OSTRINGSTREAM err;
         err<<"tinyXml error for file " << app->getXmlFile();
-        if (doc.Error())
-            err <<" at line " << doc.ErrorRow() << ", column " << doc.ErrorCol() << ": " << doc.ErrorDesc();
+        if (doc.Error()) {
+            err << " at line " << doc.ErrorRow() << ", column " << doc.ErrorCol() << ": " << doc.ErrorDesc();
+        }
         logger->addError(err);
         err <<"\n";
         return false;
+    } else {
+        return true;
     }
-    else return true;
-
 }

--- a/src/libYARP_manager/src/yarp/manager/xmlmodloader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlmodloader.cpp
@@ -33,13 +33,14 @@ XmlModLoader::XmlModLoader(const char* szPath, const char* szName)
     {
         const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
-        if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+        if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
             strPath = strPath + string(directorySeparator);
+        }
     }
 
-    if(szName)
+    if (szName) {
         strName = szName;
+    }
 }
 
 /**
@@ -49,8 +50,9 @@ XmlModLoader::XmlModLoader(const char* szFileName)
 {
     parser = new(TextParser);
     module.clear();
-    if(szFileName)
+    if (szFileName) {
         strFileName = szFileName;
+    }
 }
 
 
@@ -102,8 +104,9 @@ bool XmlModLoader::init()
         if(name.size() > 3)
         {
             string ext = name.substr(name.size()-3,3);
-            if(compareString(ext.c_str(), "xml"))
-                fileNames.push_back(strPath+name);
+            if (compareString(ext.c_str(), "xml")) {
+                fileNames.push_back(strPath + name);
+            }
         }
     }
     closedir(dir);
@@ -142,8 +145,9 @@ Module* XmlModLoader::getNextModule()
         Module* mod = nullptr;
         while(!mod)
         {
-            if(fileNames.empty())
+            if (fileNames.empty()) {
                 return nullptr;
+            }
 
             string fname = fileNames.back();
             fileNames.pop_back();
@@ -160,8 +164,9 @@ Module* XmlModLoader::getNextModule()
          for(itr=fileNames.begin(); itr<fileNames.end(); itr++)
          {
              Module* mod = parsXml((*itr).c_str());
-             if(mod && (string(mod->getName())==strName))
-                return mod;
+             if (mod && (string(mod->getName()) == strName)) {
+                 return mod;
+             }
          }
     }
     return nullptr;
@@ -226,23 +231,26 @@ Module* XmlModLoader::parsXml(const char* szFile)
 
     module.setXmlFile(szFile);
 
-    if(name)
+    if (name) {
         module.setName(parser->parseText(name->GetText()).c_str());
+    }
 
     /* retrieving description */
     TiXmlElement* desc;
-    if((desc = (TiXmlElement*) root->FirstChild("description")))
+    if ((desc = (TiXmlElement*)root->FirstChild("description"))) {
         module.setDescription(parser->parseText(desc->GetText()).c_str());
+    }
 
     /* retrieving version */
     TiXmlElement* ver;
-    if((ver = (TiXmlElement*) root->FirstChild("version")))
+    if ((ver = (TiXmlElement*)root->FirstChild("version"))) {
         module.setVersion(parser->parseText(ver->GetText()).c_str());
+    }
 
 
     /* retrieving parameter */
     TiXmlElement* arguments;
-    if((arguments = (TiXmlElement*) root->FirstChild("arguments")))
+    if ((arguments = (TiXmlElement*)root->FirstChild("arguments"))) {
         for(TiXmlElement* param = arguments->FirstChildElement(); param;
                 param = param->NextSiblingElement())
         {
@@ -251,8 +259,9 @@ Module* XmlModLoader::parsXml(const char* szFile)
                 if(param->GetText())
                 {
                     bool brequired = false;
-                    if(compareString(param->Attribute("required"), "yes"))
+                    if (compareString(param->Attribute("required"), "yes")) {
                         brequired = true;
+                    }
                     Argument arg(parser->parseText(param->GetText()).c_str(),
                                  brequired,
                                  param->Attribute("desc"));
@@ -266,8 +275,9 @@ Module* XmlModLoader::parsXml(const char* szFile)
                 if(param->GetText())
                 {
                     bool brequired = false;
-                    if(compareString(param->Attribute("required"), "yes"))
+                    if (compareString(param->Attribute("required"), "yes")) {
                         brequired = true;
+                    }
                     Argument arg(parser->parseText(param->GetText()).c_str(),
                                  brequired,
                                  param->Attribute("desc"), true);
@@ -282,30 +292,32 @@ Module* XmlModLoader::parsXml(const char* szFile)
                    <<param->Row()<<".";
                 logger->addWarning(war);
             }
-
         }
+    }
 
 
     /* retrieving rank */
     TiXmlElement* rank;
-    if((rank = (TiXmlElement*) root->FirstChild("rank")) &&
-        rank->GetText())
+    if ((rank = (TiXmlElement*)root->FirstChild("rank")) && rank->GetText()) {
         module.setRank(atoi(parser->parseText(rank->GetText()).c_str()));
+    }
 
 
     /* retrieving authors information*/
     TiXmlElement* authors;
-    if((authors = (TiXmlElement*) root->FirstChild("authors")))
+    if ((authors = (TiXmlElement*)root->FirstChild("authors"))) {
         for(TiXmlElement* ath = authors->FirstChildElement(); ath;
                 ath = ath->NextSiblingElement())
         {
             if(compareString(ath->Value(), "author"))
             {
                 Author author;
-                if(ath->GetText())
+                if (ath->GetText()) {
                     author.setName(parser->parseText(ath->GetText()).c_str());
-                if(ath->Attribute("email"))
+                }
+                if (ath->Attribute("email")) {
                     author.setEmail(ath->Attribute("email"));
+                }
                 module.addAuthor(author);
             }
             else
@@ -315,12 +327,12 @@ Module* XmlModLoader::parsXml(const char* szFile)
                    <<ath->Row()<<".";
                 logger->addWarning(war);
             }
-
         }
+    }
 
 
    /* retrieving data */
-    if(root->FirstChild("data"))
+    if (root->FirstChild("data")) {
         for(TiXmlElement* data = root->FirstChild("data")->FirstChildElement();
             data; data = data->NextSiblingElement())
         {
@@ -329,14 +341,13 @@ Module* XmlModLoader::parsXml(const char* szFile)
             {
                 OutputData output;
 
-                if(compareString(data->Attribute("port_type"), "stream") || !data->Attribute("port_type"))
+                if (compareString(data->Attribute("port_type"), "stream") || !data->Attribute("port_type")) {
                     output.setPortType(STREAM_PORT);
-                else if(compareString(data->Attribute("port_type"), "event"))
+                } else if (compareString(data->Attribute("port_type"), "event")) {
                     output.setPortType(EVENT_PORT);
-                else if(compareString(data->Attribute("port_type"), "service"))
+                } else if (compareString(data->Attribute("port_type"), "service")) {
                     output.setPortType(SERVICE_PORT);
-                else
-                {
+                } else {
                     OSTRINGSTREAM war;
                     war<<"Unknown port type \'"<<data->Attribute("port_type")<<"\' from "<<szFile<<" at line "\
                        <<data->Row()<<". Available types : stream, event, service";
@@ -347,18 +358,17 @@ Module* XmlModLoader::parsXml(const char* szFile)
                 TiXmlElement* element;
                 if(output.getPortType() != SERVICE_PORT )
                 {
-                    if((element = (TiXmlElement*) data->FirstChild("type")))
+                    if ((element = (TiXmlElement*)data->FirstChild("type"))) {
                         output.setName(parser->parseText(element->GetText()).c_str());
-                    else
-                    {
+                    } else {
                         OSTRINGSTREAM war;
                         war<<"Output data from "<<szFile<<" at line "\
                            <<data->Row()<<" has no type.";
                         logger->addWarning(war);
                     }
-                }
-                else
+                } else {
                     output.setName("*");
+                }
 
                 if((element = (TiXmlElement*) data->FirstChild("port")))
                 {
@@ -373,8 +383,9 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     logger->addWarning(war);
                 }
 
-                if((element = (TiXmlElement*) data->FirstChild("description")))
+                if ((element = (TiXmlElement*)data->FirstChild("description"))) {
                     output.setDescription(parser->parseText(element->GetText()).c_str());
+                }
 
                 module.addOutput(output);
             } // end of output data
@@ -384,14 +395,13 @@ Module* XmlModLoader::parsXml(const char* szFile)
             {
                 InputData input;
 
-                if(compareString(data->Attribute("port_type"), "stream") || !data->Attribute("port_type"))
+                if (compareString(data->Attribute("port_type"), "stream") || !data->Attribute("port_type")) {
                     input.setPortType(STREAM_PORT);
-                else if(compareString(data->Attribute("port_type"), "event"))
+                } else if (compareString(data->Attribute("port_type"), "event")) {
                     input.setPortType(EVENT_PORT);
-                else if(compareString(data->Attribute("port_type"), "service"))
+                } else if (compareString(data->Attribute("port_type"), "service")) {
                     input.setPortType(SERVICE_PORT);
-                else
-                {
+                } else {
                     OSTRINGSTREAM war;
                     war<<"Unknown port type \'"<<data->Attribute("port_type")<<"\' from "<<szFile<<" at line "\
                        <<data->Row()<<". Available types : stream, event, service";
@@ -402,18 +412,17 @@ Module* XmlModLoader::parsXml(const char* szFile)
                 if(input.getPortType() != SERVICE_PORT )
                 {
 
-                    if((element = (TiXmlElement*) data->FirstChild("type")))
+                    if ((element = (TiXmlElement*)data->FirstChild("type"))) {
                         input.setName(parser->parseText(element->GetText()).c_str());
-                    else
-                    {
+                    } else {
                         OSTRINGSTREAM war;
                         war<<"Input data from "<<szFile<<" at line "\
                            <<data->Row()<<" has no type.";
                         logger->addWarning(war);
                     }
-                }
-                else
+                } else {
                     input.setName("rpc");
+                }
 
                 if((element = (TiXmlElement*) data->FirstChild("port")))
                 {
@@ -428,21 +437,26 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     logger->addWarning(war);
                 }
 
-                if((element = (TiXmlElement*) data->FirstChild("description")))
+                if ((element = (TiXmlElement*)data->FirstChild("description"))) {
                     input.setDescription(parser->parseText(element->GetText()).c_str());
+                }
 
-                if((element = (TiXmlElement*) data->FirstChild("required")))
-                    if(compareString(parser->parseText(element->GetText()).c_str(), "yes"))
+                if ((element = (TiXmlElement*)data->FirstChild("required"))) {
+                    if (compareString(parser->parseText(element->GetText()).c_str(), "yes")) {
                         input.setRequired(true);
+                    }
+                }
 
-                if((element = (TiXmlElement*) data->FirstChild("priority")))
-                    if(compareString(parser->parseText(element->GetText()).c_str(), "yes"))
+                if ((element = (TiXmlElement*)data->FirstChild("priority"))) {
+                    if (compareString(parser->parseText(element->GetText()).c_str(), "yes")) {
                         input.setPriority(true);
+                    }
+                }
 
                 module.addInput(input);
             } // end of input data
-
         }
+    }
 
     if(root->FirstChild("services")) {
         for(TiXmlElement* services = root->FirstChild("services")->FirstChildElement();
@@ -458,12 +472,14 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     input.setPort(parser->parseText(element->GetText()).c_str());
                     input.setCarrier("tcp");
                 }
-                if((element = (TiXmlElement*) services->FirstChild("description")))
+                if ((element = (TiXmlElement*)services->FirstChild("description"))) {
                     input.setDescription(parser->parseText(element->GetText()).c_str());
-                if((element = (TiXmlElement*) services->FirstChild("type")))
+                }
+                if ((element = (TiXmlElement*)services->FirstChild("type"))) {
                     input.setName(parser->parseText(element->GetText()).c_str());
-                else
+                } else {
                     input.setName("rpc");
+                }
                 module.addInput(input);
             }
             /* client */
@@ -476,12 +492,14 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     output.setPort(parser->parseText(element->GetText()).c_str());
                     output.setCarrier("tcp");
                 }
-                if((element = (TiXmlElement*) services->FirstChild("description")))
+                if ((element = (TiXmlElement*)services->FirstChild("description"))) {
                     output.setDescription(parser->parseText(element->GetText()).c_str());
-                if((element = (TiXmlElement*) services->FirstChild("type")))
+                }
+                if ((element = (TiXmlElement*)services->FirstChild("type"))) {
                     output.setName(parser->parseText(element->GetText()).c_str());
-                else
+                } else {
                     output.setName("rpc");
+                }
                 module.addOutput(output);
             }
         }
@@ -497,7 +515,7 @@ Module* XmlModLoader::parsXml(const char* szFile)
     }
 
     /* retrieving dependencies*/
-    if(root->FirstChild("dependencies"))
+    if (root->FirstChild("dependencies")) {
         for(TiXmlElement* restag = root->FirstChild("dependencies")->FirstChildElement();
             restag; restag = restag->NextSiblingElement())
         {
@@ -510,24 +528,29 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     comptag; comptag = comptag->NextSiblingElement())
                 {
                      /* retrieving name */
-                    if(compareString(comptag->Value(), "name"))
-                        computer.setName(parser->parseText(comptag->GetText()).c_str());
+                     if (compareString(comptag->Value(), "name")) {
+                         computer.setName(parser->parseText(comptag->GetText()).c_str());
+                     }
 
                     /* retrieving description */
-                     if(compareString(comptag->Value(), "description"))
-                        computer.setDescription(parser->parseText(comptag->GetText()).c_str());
+                     if (compareString(comptag->Value(), "description")) {
+                         computer.setDescription(parser->parseText(comptag->GetText()).c_str());
+                     }
 
                     // platform
                     if(compareString(comptag->Value(), "platform"))
                     {
                         Platform os;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("name")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("name"))) {
                             os.setName(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("distribution")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("distribution"))) {
                             os.setDistribution(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("release")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("release"))) {
                             os.setRelease(parser->parseText(element->GetText()).c_str());
+                        }
                         computer.setPlatform(os);
                     } // end of platform tag
 
@@ -562,10 +585,12 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     {
                         Memory mem;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("total_space")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("total_space"))) {
                             mem.setTotalSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("free_space")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("free_space"))) {
                             mem.setFreeSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                        }
                         computer.setMemory(mem);
                     } // end of memory tag
 
@@ -574,10 +599,12 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     {
                         Storage stg;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("total_space")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("total_space"))) {
                             stg.setTotalSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("free_space")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("free_space"))) {
                             stg.setFreeSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                        }
                         computer.setStorage(stg);
                     } // end of storage tag
 
@@ -586,16 +613,21 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     {
                         Processor proc;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("architecture")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("architecture"))) {
                             proc.setArchitecture(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("model")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("model"))) {
                             proc.setModel(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("cores")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("cores"))) {
                             proc.setCores((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("siblings")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("siblings"))) {
                             proc.setSiblings((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("frequency")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("frequency"))) {
                             proc.setFrequency(atof(parser->parseText(element->GetText()).c_str()));
+                        }
                         computer.setProcessor(proc);
                     } // end of processor tag
 
@@ -604,12 +636,15 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     {
                         Network net;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("ip4")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("ip4"))) {
                             net.setIP4(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("ip6")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("ip6"))) {
                             net.setIP6(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("mac")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("mac"))) {
                             net.setMAC(parser->parseText(element->GetText()).c_str());
+                        }
                         module.addResource(net);
                         computer.setNetwork(net);
                     } // end of network tag
@@ -638,24 +673,31 @@ Module* XmlModLoader::parsXml(const char* szFile)
                     {
                         GPU gpu;
                         TiXmlElement* element;
-                        if((element = (TiXmlElement*) comptag->FirstChild("name")))
+                        if ((element = (TiXmlElement*)comptag->FirstChild("name"))) {
                             gpu.setName(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("capability")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("capability"))) {
                             gpu.setCompCompatibility(parser->parseText(element->GetText()).c_str());
-                        if((element = (TiXmlElement*) comptag->FirstChild("cores")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("cores"))) {
                             gpu.setCores((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("frequency")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("frequency"))) {
                             gpu.setFrequency(atof(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("register_block")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("register_block"))) {
                             gpu.setResgisterPerBlock((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                        if((element = (TiXmlElement*) comptag->FirstChild("thread_block")))
+                        }
+                        if ((element = (TiXmlElement*)comptag->FirstChild("thread_block"))) {
                             gpu.setThreadPerBlock((size_t)atoi(parser->parseText(element->GetText()).c_str()));
+                        }
                         if((element = (TiXmlElement*) comptag->FirstChild("overlap")))
                         {
-                            if(compareString(parser->parseText(element->GetText()).c_str(), "yes"))
+                            if (compareString(parser->parseText(element->GetText()).c_str(), "yes")) {
                                 gpu.setOverlap(true);
-                            else
+                            } else {
                                 gpu.setOverlap(false);
+                            }
                         }
 
 
@@ -664,8 +706,9 @@ Module* XmlModLoader::parsXml(const char* szFile)
                         {
                             TiXmlElement* element;
                             element = (TiXmlElement*) comptag->FirstChild("global_memory");
-                            if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                            if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                                 gpu.setGlobalMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                            }
                         } // end of global memory tag
 
                         // shared memory
@@ -673,8 +716,9 @@ Module* XmlModLoader::parsXml(const char* szFile)
                         {
                             TiXmlElement* element;
                             element = (TiXmlElement*) comptag->FirstChild("shared_memory");
-                            if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                            if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                                 gpu.setSharedMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                            }
                         } // end of shared memory tag
 
                         // constant memory
@@ -682,15 +726,17 @@ Module* XmlModLoader::parsXml(const char* szFile)
                         {
                             TiXmlElement* element;
                             element = (TiXmlElement*) comptag->FirstChild("constant_memory");
-                            if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                            if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                                 gpu.setConstantMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                            }
                         } // end of shared memory tag
                         computer.addPeripheral(gpu);
                     } // end of gpu tag
                 } // end of computer tag loop
                 module.addResource(computer);
             } //end of if computer tag
-        }// end of dependecnies tag
+        }     // end of dependecnies tag
+    }
 
     return &module;
 }

--- a/src/libYARP_manager/src/yarp/manager/xmlresloader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmlresloader.cpp
@@ -29,13 +29,14 @@ XmlResLoader::XmlResLoader(const char* szPath, const char* szName)
     {
         const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
-        if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+        if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
             strPath = strPath + string(directorySeparator);
+        }
     }
 
-    if(szName)
+    if (szName) {
         strName = szName;
+    }
 }
 
 /**
@@ -44,8 +45,9 @@ XmlResLoader::XmlResLoader(const char* szPath, const char* szName)
 XmlResLoader::XmlResLoader(const char* szFileName)
 {
     parser = new(TextParser);
-    if(szFileName)
+    if (szFileName) {
         strFileName = szFileName;
+    }
 }
 
 
@@ -96,8 +98,9 @@ bool XmlResLoader::init()
         if(name.size() > 3)
         {
             string ext = name.substr(name.size()-3,3);
-            if(compareString(ext.c_str(), "xml"))
-                fileNames.push_back(strPath+name);
+            if (compareString(ext.c_str(), "xml")) {
+                fileNames.push_back(strPath + name);
+            }
         }
     }
     closedir(dir);
@@ -143,8 +146,9 @@ GenericResource* XmlResLoader::getNextResource()
             bool ret = false;
             do
             {
-                if(fileNames.empty())
+                if (fileNames.empty()) {
                     return nullptr;
+                }
 
                 string fname = fileNames.back();
                 fileNames.pop_back();
@@ -166,9 +170,11 @@ GenericResource* XmlResLoader::getNextResource()
          {
              if(parsXml((*itr).c_str()))
              {
-                for(auto& computer : computers)
-                if(string(computer.getName()) == strName)
-                    return &computer;
+                 for (auto& computer : computers) {
+                     if (string(computer.getName()) == strName) {
+                         return &computer;
+                     }
+                 }
              }
          }
     }
@@ -238,18 +244,21 @@ bool XmlResLoader::parsXml(const char* szFile)
                 comptag; comptag = comptag->NextSiblingElement())
             {
                  /* retrieving name */
-                if(compareString(comptag->Value(), "name"))
-                    computer.setName(parser->parseText(comptag->GetText()).c_str());
+                 if (compareString(comptag->Value(), "name")) {
+                     computer.setName(parser->parseText(comptag->GetText()).c_str());
+                 }
 
                 /* retrieving description */
-                 if(compareString(comptag->Value(), "description"))
-                    computer.setDescription(parser->parseText(comptag->GetText()).c_str());
+                 if (compareString(comptag->Value(), "description")) {
+                     computer.setDescription(parser->parseText(comptag->GetText()).c_str());
+                 }
 
                 /* retrieving disablility */
                 if(compareString(comptag->Value(), "disable"))
                 {
-                    if(compareString(parser->parseText(comptag->GetText()).c_str(), "yes"))
+                    if (compareString(parser->parseText(comptag->GetText()).c_str(), "yes")) {
                         computer.setDisable(true);
+                    }
                 }
 
                 // platform
@@ -257,21 +266,22 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     Platform os;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("name")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("name"))) {
                         os.setName(parser->parseText(element->GetText()).c_str());
-                    else
-                    {
+                    } else {
                         OSTRINGSTREAM war;
                         war<<"Platform from "<<szFile<<" at line "\
                            <<comptag->Row()<<" has no name.";
                         logger->addWarning(war);
                     }
 
-                    if((element = (TiXmlElement*) comptag->FirstChild("distribution")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("distribution"))) {
                         os.setDistribution(parser->parseText(element->GetText()).c_str());
+                    }
 
-                    if((element = (TiXmlElement*) comptag->FirstChild("release")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("release"))) {
                         os.setRelease(parser->parseText(element->GetText()).c_str());
+                    }
 
                     computer.setPlatform(os);
                 } // end of platform tag
@@ -281,8 +291,9 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     Memory mem;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("total_space")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("total_space"))) {
                         mem.setTotalSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                    }
                    computer.setMemory(mem);
                 } // end of memory tag
 
@@ -291,8 +302,9 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     Storage stg;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("total_space")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("total_space"))) {
                         stg.setTotalSpace((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                    }
                    computer.setStorage(stg);
                 } // end of storage tag
 
@@ -301,14 +313,18 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     Processor proc;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("architecture")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("architecture"))) {
                         proc.setArchitecture(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("model")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("model"))) {
                         proc.setModel(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("cores")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("cores"))) {
                         proc.setCores((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                    if((element = (TiXmlElement*) comptag->FirstChild("frequency")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("frequency"))) {
                         proc.setFrequency(atof(parser->parseText(element->GetText()).c_str()));
+                    }
                    computer.setProcessor(proc);
                 } // end of processor tag
 
@@ -317,12 +333,15 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     Network net;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("ip4")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("ip4"))) {
                         net.setIP4(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("ip6")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("ip6"))) {
                         net.setIP6(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("mac")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("mac"))) {
                         net.setMAC(parser->parseText(element->GetText()).c_str());
+                    }
                     computer.setNetwork(net);
                 } // end of network tag
 
@@ -332,24 +351,31 @@ bool XmlResLoader::parsXml(const char* szFile)
                 {
                     GPU gpu;
                     TiXmlElement* element;
-                    if((element = (TiXmlElement*) comptag->FirstChild("name")))
+                    if ((element = (TiXmlElement*)comptag->FirstChild("name"))) {
                         gpu.setName(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("capability")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("capability"))) {
                         gpu.setCompCompatibility(parser->parseText(element->GetText()).c_str());
-                    if((element = (TiXmlElement*) comptag->FirstChild("cores")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("cores"))) {
                         gpu.setCores((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                    if((element = (TiXmlElement*) comptag->FirstChild("frequency")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("frequency"))) {
                         gpu.setFrequency(atof(parser->parseText(element->GetText()).c_str()));
-                    if((element = (TiXmlElement*) comptag->FirstChild("register_block")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("register_block"))) {
                         gpu.setResgisterPerBlock((size_t)atoi(parser->parseText(element->GetText()).c_str()));
-                    if((element = (TiXmlElement*) comptag->FirstChild("thread_block")))
+                    }
+                    if ((element = (TiXmlElement*)comptag->FirstChild("thread_block"))) {
                         gpu.setThreadPerBlock((size_t)atoi(parser->parseText(element->GetText()).c_str()));
+                    }
                     if((element = (TiXmlElement*) comptag->FirstChild("overlap")))
                     {
-                        if(compareString(parser->parseText(element->GetText()).c_str(), "yes"))
+                        if (compareString(parser->parseText(element->GetText()).c_str(), "yes")) {
                             gpu.setOverlap(true);
-                        else
+                        } else {
                             gpu.setOverlap(false);
+                        }
                     }
 
                     // global memory
@@ -357,8 +383,9 @@ bool XmlResLoader::parsXml(const char* szFile)
                     {
                         TiXmlElement* element;
                         element = (TiXmlElement*) comptag->FirstChild("global_memory");
-                        if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                        if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                             gpu.setGlobalMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                        }
                     } // end of global memory tag
 
                     // shared memory
@@ -366,8 +393,9 @@ bool XmlResLoader::parsXml(const char* szFile)
                     {
                         TiXmlElement* element;
                         element = (TiXmlElement*) comptag->FirstChild("shared_memory");
-                        if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                        if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                             gpu.setSharedMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                        }
                     } // end of shared memory tag
 
                     // constant memory
@@ -375,8 +403,9 @@ bool XmlResLoader::parsXml(const char* szFile)
                     {
                         TiXmlElement* element;
                         element = (TiXmlElement*) comptag->FirstChild("constant_memory");
-                        if((element = (TiXmlElement*) element->FirstChild("total_space")))
+                        if ((element = (TiXmlElement*)element->FirstChild("total_space"))) {
                             gpu.setConstantMemory((Capacity)atol(parser->parseText(element->GetText()).c_str()));
+                        }
                     } // end of shared memory tag
 
                    computer.addPeripheral(gpu);

--- a/src/libYARP_manager/src/yarp/manager/xmltemploader.cpp
+++ b/src/libYARP_manager/src/yarp/manager/xmltemploader.cpp
@@ -27,16 +27,17 @@ using namespace yarp::manager;
  */
 XmlTempLoader::XmlTempLoader(const char* szPath, const char* szAppName)
 {
-    if(szAppName)
+    if (szAppName) {
         strAppName = szAppName;
+    }
 
     if(strlen(szPath))
     {
         const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
         strPath = szPath;
-        if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+        if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
             strPath = strPath + string(directorySeparator);
+        }
     }
 }
 
@@ -45,8 +46,9 @@ XmlTempLoader::XmlTempLoader(const char* szPath, const char* szAppName)
  */
 XmlTempLoader::XmlTempLoader(const char* szFileName)
 {
-    if(szFileName)
+    if (szFileName) {
         strFileName = szFileName;
+    }
 }
 
 
@@ -90,8 +92,9 @@ bool XmlTempLoader::init()
         if(name.size() > 12)
         {
             string ext = name.substr(name.size()-12,12);
-            if(compareString(ext.c_str(), "xml.template"))
-                fileNames.push_back(strPath+name);
+            if (compareString(ext.c_str(), "xml.template")) {
+                fileNames.push_back(strPath + name);
+            }
         }
     }
     closedir(dir);
@@ -118,8 +121,9 @@ AppTemplate* XmlTempLoader::getNextAppTemplate()
         AppTemplate* app = nullptr;
         while(!app)
         {
-            if(fileNames.empty())
+            if (fileNames.empty()) {
                 return nullptr;
+            }
             string fname = fileNames.back();
             fileNames.pop_back();
             app = parsXml(fname.c_str());
@@ -132,8 +136,9 @@ AppTemplate* XmlTempLoader::getNextAppTemplate()
         for(itr=fileNames.begin(); itr<fileNames.end(); itr++)
         {
          AppTemplate* app = parsXml((*itr).c_str());
-         if(app && (app->name==strAppName))
-            return app;
+         if (app && (app->name == strAppName)) {
+             return app;
+         }
         }
     }
  return nullptr;
@@ -189,9 +194,11 @@ AppTemplate* XmlTempLoader::parsXml(const char* szFile)
     else
     {
         string strname = name->GetText();
-        for(char& i : strname)
-            if(i == ' ')
+        for (char& i : strname) {
+            if (i == ' ') {
                 i = '_';
+            }
+        }
         app.name = strname;
     }
 

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
@@ -53,8 +53,9 @@ YarpBroker::~YarpBroker()
 
 void YarpBroker::fini()
 {
-    if(PeriodicThread::isRunning())
+    if (PeriodicThread::isRunning()) {
         PeriodicThread::stop();
+    }
     //port.close();
 }
 
@@ -113,35 +114,42 @@ bool YarpBroker::init(const char* szcmd, const char* szparam,
         return false;
     }
 
-    if(szhost[0] != '/')
+    if (szhost[0] != '/') {
         strHost = string("/") + string(szhost);
-    else
+    } else {
         strHost = szhost;
+    }
 
     strCmd = szcmd;
-    if(strlen(szparam))
+    if (strlen(szparam)) {
         strParam = szparam;
-    if(strlen(szworkdir))
+    }
+    if (strlen(szworkdir)) {
         strWorkdir = szworkdir;
+    }
 
     if(strlen(szstdio))
     {
-        if(szstdio[0] != '/')
+        if (szstdio[0] != '/') {
             strStdio = string("/") + string(szstdio);
-        else
+        } else {
             strStdio = szstdio;
+        }
     }
 
-    if(strlen(szenv))
+    if (strlen(szenv)) {
         strEnv = szenv;
+    }
 
     OSTRINGSTREAM sstrID;
     sstrID<<(int)ID;
     strTag = strHost + strCmd + strParam + strEnv + sstrID.str();
     string::iterator itr;
-    for(itr=strTag.begin(); itr!=strTag.end(); itr++)
-        if(((*itr) == ' ') || ((*itr) == '/') )
+    for (itr = strTag.begin(); itr != strTag.end(); itr++) {
+        if (((*itr) == ' ') || ((*itr) == '/')) {
             (*itr) = ':';
+        }
+    }
 
    __trace_message = "(init) checking yarp network";
     if(!NetworkBase::checkNetwork(5.0))
@@ -177,8 +185,12 @@ bool YarpBroker::init(const char* szcmd, const char* szparam,
 
 bool YarpBroker::start()
 {
-    if(!bInitialized) return false;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return false;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
     strError.clear();
     int ret = requestServer(runProperty());
@@ -189,8 +201,9 @@ bool YarpBroker::start()
         strError += " to run ";
         strError += strCmd;
         strError += yarprun_err_msg[ret];
-        if(ret == YARPRUN_SEMAPHORE_PARAM)
+        if (ret == YARPRUN_SEMAPHORE_PARAM) {
             strError += string(" due to " + __trace_message);
+        }
         return false;
     }
 
@@ -201,8 +214,9 @@ bool YarpBroker::start()
         {
             if(strStdioUUID.size())
             {
-                if(PeriodicThread::isRunning())
+                if (PeriodicThread::isRunning()) {
                     PeriodicThread::stop();
+                }
                 PeriodicThread::start();
             }
             return true;
@@ -218,8 +232,12 @@ bool YarpBroker::start()
 
 bool YarpBroker::stop()
 {
-    if(!bInitialized) return true;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return true;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
     strError.clear();
     yarp::os::Bottle msg,grp,response;
@@ -240,8 +258,9 @@ bool YarpBroker::stop()
         strError += " to stop ";
         strError += strCmd;
         strError += yarprun_err_msg[ret];
-        if(ret == YARPRUN_SEMAPHORE_PARAM)
+        if (ret == YARPRUN_SEMAPHORE_PARAM) {
             strError += string(" due to " + __trace_message);
+        }
         return false;
     }
 
@@ -265,8 +284,12 @@ bool YarpBroker::stop()
 
 bool YarpBroker::kill()
 {
-    if(!bInitialized) return true;
-    if(bOnlyConnector) return false;
+    if (!bInitialized) {
+        return true;
+    }
+    if (bOnlyConnector) {
+        return false;
+    }
 
     strError.clear();
 
@@ -288,8 +311,9 @@ bool YarpBroker::kill()
         strError += " to kill ";
         strError += strCmd;
         strError += yarprun_err_msg[ret];
-        if(ret == YARPRUN_SEMAPHORE_PARAM)
+        if (ret == YARPRUN_SEMAPHORE_PARAM) {
             strError += string(" due to " + __trace_message);
+        }
         return false;
     }
 
@@ -314,8 +338,12 @@ bool YarpBroker::kill()
 
 int YarpBroker::running()
 {
-    if(!bInitialized) return -1;
-    if(bOnlyConnector) return -1;
+    if (!bInitialized) {
+        return -1;
+    }
+    if (bOnlyConnector) {
+        return -1;
+    }
 
     strError.clear();
     yarp::os::Bottle msg,grp,response;
@@ -338,8 +366,9 @@ int YarpBroker::running()
         strError += " to check for status of ";
         strError += strCmd;
         strError += yarprun_err_msg[ret];
-        if(ret == YARPRUN_SEMAPHORE_PARAM)
+        if (ret == YARPRUN_SEMAPHORE_PARAM) {
             strError += string(" due to " + __trace_message);
+        }
         return -1;
     }
     return ((response.get(0).asString() == "running")?1:0);
@@ -363,12 +392,15 @@ Property& YarpBroker::runProperty()
     command.put("cmd", cmd);
     command.put("on", strHost);
     command.put("as", strTag);
-    if(!strWorkdir.empty())
+    if (!strWorkdir.empty()) {
         command.put("workdir", strWorkdir);
-    if(!strStdio.empty())
+    }
+    if (!strStdio.empty()) {
         command.put("stdio", strStdio);
-    if(!strEnv.empty())
+    }
+    if (!strEnv.empty()) {
         command.put("env", strEnv);
+    }
     //command.put("hold", "hold");
     return command;
 }
@@ -407,8 +439,9 @@ bool YarpBroker::connect(const char* from, const char* to,
         bool needDisconnect = strCarrier.find("udp") == (size_t)0;
         needDisconnect |= strCarrier.find("mcast") == (size_t)0;
         if(needDisconnect == false) {
-            if(NetworkBase::isConnected(from, to, style))
+            if (NetworkBase::isConnected(from, to, style)) {
                 return true;
+            }
         }
 
         NetworkBase::connect(from, to, style);
@@ -470,8 +503,9 @@ bool YarpBroker::disconnect(const char* from, const char* to, const char* carrie
     }
     */
 
-    if(!connected(from, to, carrier))
+    if (!connected(from, to, carrier)) {
         return true;
+    }
 
     ContactStyle style;
     style.quiet = true;
@@ -498,17 +532,20 @@ bool YarpBroker::exists(const char* szport)
 
 const char* YarpBroker::requestRpc(const char* szport, const char* request, double timeout)
 {
-    if((szport==nullptr) || (request==nullptr))
+    if ((szport == nullptr) || (request == nullptr)) {
         return nullptr;
+    }
 
-    if(!exists(szport))
+    if (!exists(szport)) {
         return nullptr;
+    }
 
     // opening the port
     yarp::os::Port port;
     port.setTimeout((float)((timeout>0.0) ? timeout : CONNECTION_TIMEOUT));
-    if(!port.open("..."))
+    if (!port.open("...")) {
         return nullptr;
+    }
 
     ContactStyle style;
     style.quiet = true;
@@ -516,7 +553,9 @@ const char* YarpBroker::requestRpc(const char* szport, const char* request, doub
     bool ret;
     for(int i=0; i<10; i++) {
         ret = NetworkBase::connect(port.getName(), szport, style);
-        if(ret) break;
+        if (ret) {
+            break;
+        }
         SystemClock::delaySystem(1.0);
     }
 
@@ -540,8 +579,9 @@ const char* YarpBroker::requestRpc(const char* szport, const char* request, doub
 
 bool YarpBroker::connected(const char* from, const char* to, const char* carrier)
 {
-    if(!exists(from) || !exists(to))
+    if (!exists(from) || !exists(to)) {
         return false;
+    }
     ContactStyle style;
     style.quiet = true;
     style.timeout = CONNECTION_TIMEOUT;
@@ -551,10 +591,12 @@ bool YarpBroker::connected(const char* from, const char* to, const char* carrier
 
 bool YarpBroker::getSystemInfo(const char* server, SystemInfoSerializer& info)
 {
-    if(!strlen(server))
+    if (!strlen(server)) {
         return false;
-    if(!semParam.check())
+    }
+    if (!semParam.check()) {
         return false;
+    }
 
     yarp::os::Port port;
     // opening the port
@@ -622,8 +664,9 @@ bool YarpBroker::getAllPorts(vector<string> &ports)
         return false;
     }
 
-    if((reply.size()!=1) || (!reply.get(0).isString()))
+    if ((reply.size() != 1) || (!reply.get(0).isString())) {
         return false;
+    }
 
     std::string str = reply.get(0).asString();
     const char* delm = "registration name ";
@@ -631,8 +674,9 @@ bool YarpBroker::getAllPorts(vector<string> &ports)
     while((pos1 = str.find(delm)) != std::string::npos)
     {
         str = str.substr(pos1+strlen(delm));
-        if((pos2 = str.find(' ')) != std::string::npos)
+        if ((pos2 = str.find(' ')) != std::string::npos) {
             ports.push_back(str.substr(0, pos2));
+        }
     }
 
     return true;
@@ -641,8 +685,9 @@ bool YarpBroker::getAllPorts(vector<string> &ports)
 bool YarpBroker::getAllProcesses(const char* server,
                                  ProcessContainer& processes)
 {
-    if(!strlen(server))
+    if (!strlen(server)) {
         return false;
+    }
 
     processes.clear();
     strError.clear();
@@ -659,13 +704,15 @@ bool YarpBroker::getAllProcesses(const char* server,
         {
             Process proc;
             std::string sprc;
-            if(response.get(i).check("pid"))
+            if (response.get(i).check("pid")) {
                 proc.pid = response.get(i).find("pid").asInt32();
-            if(response.get(i).check("cmd"))
-               sprc = response.get(i).find("cmd").asString();
-            if(response.get(i).check("env") &&
-               response.get(i).find("env").asString().length())
-               sprc.append("; ").append(response.get(i).find("env").asString());
+            }
+            if (response.get(i).check("cmd")) {
+                sprc = response.get(i).find("cmd").asString();
+            }
+            if (response.get(i).check("env") && response.get(i).find("env").asString().length()) {
+                sprc.append("; ").append(response.get(i).find("env").asString());
+            }
             proc.command = sprc;
             processes.push_back(proc);
         }
@@ -676,8 +723,9 @@ bool YarpBroker::getAllProcesses(const char* server,
     strError += server;
     strError += " to give the list of running processes.";
     strError += yarprun_err_msg[ret];
-    if(ret == YARPRUN_SEMAPHORE_PARAM)
+    if (ret == YARPRUN_SEMAPHORE_PARAM) {
         strError += string(" due to " + __trace_message);
+    }
     return false;
 }
 
@@ -700,8 +748,9 @@ bool YarpBroker::setQos(const char* from, const char *to,
                         const char *qosFrom, const char *qosTo) {
     strError.clear();
 
-    if(qosFrom && qosTo && !strlen(qosFrom) && !strlen(qosTo))
+    if (qosFrom && qosTo && !strlen(qosFrom) && !strlen(qosTo)) {
         return true;
+    }
 
     QosStyle styleFrom;
     QosStyle styleTo;
@@ -711,11 +760,12 @@ bool YarpBroker::setQos(const char* from, const char *to,
             return false;
         }
     }
-    if(qosTo != nullptr && strlen(qosTo))
+    if (qosTo != nullptr && strlen(qosTo)) {
         if(!getQosFromString(qosTo, styleTo)) {
             strError = "Error in parsing Qos properties of " + string(to);
             return false;
         }
+    }
     return NetworkBase::setConnectionQos(from, to, styleFrom, styleTo, true);
 }
 
@@ -735,8 +785,9 @@ bool YarpBroker::getQosFromString(const char* qos, yarp::os::QosStyle& style) {
             string value = prop.substr(p+1);
             if (key.length() > 0 && value.length() > 0) {
                 if (key == "LEVEL" || key=="DSCP" || key == "TOS") {
-                    if(!style.setPacketPriority(prop))
+                    if (!style.setPacketPriority(prop)) {
                         return false;
+                    }
                 }
                 else if (key == "PRIORITY") {
                     char* p;
@@ -763,15 +814,17 @@ const char* YarpBroker::error()
 bool YarpBroker::timeout(double base, double timeout)
 {
     SystemClock::delaySystem(1.0);
-    if((SystemClock::nowSystem()-base) > timeout)
+    if ((SystemClock::nowSystem() - base) > timeout) {
         return true;
+    }
     return false;
 }
 
 bool YarpBroker::threadInit()
 {
-    if(!strStdioUUID.size())
+    if (!strStdioUUID.size()) {
         return false;
+    }
 
     string strStdioPort = strStdioUUID + "/stdout";
     stdioPort.open("...");
@@ -782,8 +835,9 @@ bool YarpBroker::threadInit()
     style.timeout = CONNECTION_TIMEOUT;
     while(!timeout(base, 5.0))
     {
-        if(NetworkBase::connect(strStdioPort, stdioPort.getName(), style))
+        if (NetworkBase::connect(strStdioPort, stdioPort.getName(), style)) {
             return true;
+        }
     }
 
     strError = "Cannot connect to stdio port ";
@@ -798,8 +852,9 @@ void YarpBroker::run()
     Bottle *input;
     if( (input=stdioPort.read(false)) && eventSink)
     {
-        for (size_t i=0; i<input->size(); i++)
+        for (size_t i = 0; i < input->size(); i++) {
             eventSink->onBrokerStdout(input->get(i).asString().c_str());
+        }
     }
 }
 
@@ -813,11 +868,13 @@ void YarpBroker::threadRelease()
 
 int YarpBroker::SendMsg(Bottle& msg, std::string target, Bottle& response, float fTimeout)
 {
-    if(!exists(target.c_str()))
+    if (!exists(target.c_str())) {
         return YARPRUN_NOCONNECTION;
+    }
 
-    if(!semParam.check())
+    if (!semParam.check()) {
         return YARPRUN_SEMAPHORE_PARAM;
+    }
 
     // opening the port
     yarp::os::Port port;
@@ -838,7 +895,9 @@ int YarpBroker::SendMsg(Bottle& msg, std::string target, Bottle& response, float
     for(int i=0; i<10; i++)
     {
         ret = NetworkBase::connect(port.getName(), target, style);
-        if(ret) break;
+        if (ret) {
+            break;
+        }
         SystemClock::delaySystem(1.0);
     }
 
@@ -888,19 +947,29 @@ int YarpBroker::requestServer(Property& config)
         msg.addList()=config.findGroup("as");
         msg.addList()=config.findGroup("on");
 
-        if (config.check("workdir")) msg.addList()=config.findGroup("workdir");
-        if (config.check("geometry")) msg.addList()=config.findGroup("geometry");
-        if (config.check("hold")) msg.addList()=config.findGroup("hold");
-        if (config.check("env")) msg.addList()=config.findGroup("env");
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("geometry")) {
+            msg.addList() = config.findGroup("geometry");
+        }
+        if (config.check("hold")) {
+            msg.addList() = config.findGroup("hold");
+        }
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
 
         Bottle response;
         int ret = SendMsg(msg, config.find("stdio").asString(),
                           response, CONNECTION_TIMEOUT);
-        if (ret != YARPRUN_OK)
+        if (ret != YARPRUN_OK) {
             return ret;
+        }
 
-        if(response.size() > 2)
+        if (response.size() > 2) {
             strStdioUUID = response.get(2).asString();
+        }
 
         return ((response.get(0).asInt32()>0)?YARPRUN_OK:YARPRUN_UNDEF);
     }
@@ -918,14 +987,19 @@ int YarpBroker::requestServer(Property& config)
         msg.addList()=config.findGroup("cmd");
         msg.addList()=config.findGroup("as");
 
-        if (config.check("workdir")) msg.addList()=config.findGroup("workdir");
-        if (config.check("env")) msg.addList()=config.findGroup("env");
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
 
         Bottle response;
         int ret = SendMsg(msg, config.find("on").asString(),
                           response, CONNECTION_TIMEOUT);
-        if (ret != YARPRUN_OK)
+        if (ret != YARPRUN_OK) {
             return ret;
+        }
 
         return ((response.get(0).asInt32()>0)?YARPRUN_OK:YARPRUN_UNDEF);
     }

--- a/src/libYARP_manager/src/yarp/manager/yarpdevbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/yarpdevbroker.h
@@ -29,8 +29,12 @@ public:
             OSTRINGSTREAM strDevParam;
             std::string strParam;
             std::string strCmd;
-            if(szcmd) strCmd = szcmd;
-            if(szparam) strParam = szparam;
+            if (szcmd) {
+                strCmd = szcmd;
+            }
+            if (szparam) {
+                strParam = szparam;
+            }
             strDevParam<<"--device "<<strCmd<<" "<<strParam;
             return LocalBroker::init("yarpdev", strDevParam.str().c_str(),
                                      szhost, szstdio, szworkdir, szenv);
@@ -52,8 +56,12 @@ public:
             OSTRINGSTREAM strDevParam;
             std::string strParam;
             std::string strCmd;
-            if(szcmd) strCmd = szcmd;
-            if(szparam) strParam = szparam;
+            if (szcmd) {
+                strCmd = szcmd;
+            }
+            if (szparam) {
+                strParam = szparam;
+            }
             strDevParam<<"--device "<<strCmd<<" "<<strParam;
             return YarpBroker::init("yarpdev", strDevParam.str().c_str(),
                                      szhost, szstdio, szworkdir, szenv);

--- a/src/libYARP_math/src/yarp/math/NormRand.cpp
+++ b/src/libYARP_math/src/yarp/math/NormRand.cpp
@@ -42,11 +42,12 @@ yarp::sig::Vector NormRand::vector(const yarp::sig::Vector &u, const yarp::sig::
 yarp::sig::Matrix NormRand::matrix(int rows, int cols, double u, double sigma)
 {
     yarp::sig::Matrix ret(rows,cols);
-    for(int r=0;r<rows;r++)
+    for (int r = 0; r < rows; r++) {
         for(int c=0;c<cols;c++)
         {
             ret[r][c]=theRandnScalar.get(u, sigma);
         }
+    }
     return ret;
 }
 

--- a/src/libYARP_math/src/yarp/math/Quaternion.cpp
+++ b/src/libYARP_math/src/yarp/math/Quaternion.cpp
@@ -110,7 +110,9 @@ bool Quaternion::read(yarp::os::ConnectionReader& connection)
     connection.convertTextMode();
     QuaternionPortContentHeader header;
     bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
 
     if (header.listLen == 4 &&  header.listTag == (BOTTLE_TAG_LIST | BOTTLE_TAG_FLOAT64))
     {
@@ -172,8 +174,9 @@ void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
         double sqdip1 = sqrt(R(1, 1) - R(0, 0) - R(2, 2) + 1.0);
         internal_data[2] = 0.5*sqdip1;
 
-        if (sqdip1>0.0)
+        if (sqdip1 > 0.0) {
             sqdip1 = 0.5 / sqdip1;
+        }
 
         internal_data[0] = (R(0, 2) - R(2, 0))*sqdip1;
         internal_data[1] = (R(1, 0) + R(0, 1))*sqdip1;
@@ -184,8 +187,9 @@ void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
         double sqdip1 = sqrt(R(2, 2) - R(0, 0) - R(1, 1) + 1.0);
         internal_data[3] = 0.5*sqdip1;
 
-        if (sqdip1>0.0)
+        if (sqdip1 > 0.0) {
             sqdip1 = 0.5 / sqdip1;
+        }
 
         internal_data[0] = (R(1, 0) - R(0, 1))*sqdip1;
         internal_data[1] = (R(0, 2) + R(2, 0))*sqdip1;
@@ -196,8 +200,9 @@ void Quaternion::fromRotationMatrix(const yarp::sig::Matrix &R)
         double sqdip1 = sqrt(R(0, 0) - R(1, 1) - R(2, 2) + 1.0);
         internal_data[1] = 0.5*sqdip1;
 
-        if (sqdip1>0.0)
+        if (sqdip1 > 0.0) {
             sqdip1 = 0.5 / sqdip1;
+        }
 
         internal_data[0] = (R(2, 1) - R(1, 2))*sqdip1;
         internal_data[2] = (R(1, 0) + R(0, 1))*sqdip1;

--- a/src/libYARP_math/src/yarp/math/Rand.cpp
+++ b/src/libYARP_math/src/yarp/math/Rand.cpp
@@ -102,11 +102,12 @@ Vector Rand::vector(const Vector &min, const Vector &max)
 Matrix Rand::matrix(int rows, int cols)
 {
     yarp::sig::Matrix ret(rows,cols);
-    for(int r=0;r<rows;r++)
+    for (int r = 0; r < rows; r++) {
         for(int c=0;c<cols;c++)
         {
             ret[r][c]=theRandScalar.get();
         }
+    }
 
     return ret;
 }

--- a/src/libYARP_math/src/yarp/math/SVD.cpp
+++ b/src/libYARP_math/src/yarp/math/SVD.cpp
@@ -52,9 +52,11 @@ Matrix yarp::math::pinv(const Matrix &in, double tol)
     yarp::math::SVD(in, U, Sdiag, V);
 
     Matrix Spinv = zeros(k,k);
-    for (int c=0;c<k; c++)
-        if ( Sdiag(c)> tol)
-            Spinv(c,c) = 1/Sdiag(c);
+    for (int c = 0; c < k; c++) {
+        if (Sdiag(c) > tol) {
+            Spinv(c, c) = 1 / Sdiag(c);
+        }
+    }
     return V*Spinv*U.transposed();
 }
 
@@ -67,9 +69,11 @@ void yarp::math::pinv(const Matrix &in, Matrix &out, double tol)
     yarp::math::SVD(in, U, Sdiag, V);
 
     Matrix Spinv = zeros(k,k);
-    for (int c=0;c<k; c++)
-        if ( Sdiag(c)> tol)
-            Spinv(c,c) = 1/Sdiag(c);
+    for (int c = 0; c < k; c++) {
+        if (Sdiag(c) > tol) {
+            Spinv(c, c) = 1 / Sdiag(c);
+        }
+    }
     out = V*Spinv*U.transposed();
 }
 
@@ -77,15 +81,18 @@ Matrix yarp::math::pinv(const Matrix &in, Vector &sv, double tol)
 {
     int m = in.rows(), n = in.cols(), k = m<n?m:n;
     Matrix U(m,k), V(n,k);
-    if((int)sv.size()!=k)
+    if ((int)sv.size() != k) {
         sv.resize(k);
+    }
 
     yarp::math::SVD(in, U, sv, V);
 
     Matrix Spinv = zeros(k,k);
-    for (int c=0;c<k; c++)
-        if ( sv(c)> tol)
-            Spinv(c,c) = 1/sv(c);
+    for (int c = 0; c < k; c++) {
+        if (sv(c) > tol) {
+            Spinv(c, c) = 1 / sv(c);
+        }
+    }
 
     return V*Spinv*U.transposed();
 }
@@ -94,15 +101,18 @@ void yarp::math::pinv(const Matrix &in, Matrix &out, Vector &sv, double tol)
 {
     int m = in.rows(), n = in.cols(), k = m<n?m:n;
     Matrix U(m,k), V(n,k);
-    if((int)sv.size()!=k)
+    if ((int)sv.size() != k) {
         sv.resize(k);
+    }
 
     yarp::math::SVD(in, U, sv, V);
 
     Matrix Spinv = zeros(k,k);
-    for (int c=0;c<k; c++)
-        if ( sv(c)> tol)
-            Spinv(c,c) = 1/sv(c);
+    for (int c = 0; c < k; c++) {
+        if (sv(c) > tol) {
+            Spinv(c, c) = 1 / sv(c);
+        }
+    }
 
     out = V*Spinv*U.transposed();
 }
@@ -134,15 +144,17 @@ void yarp::math::pinvDamped(const Matrix &in, Matrix &out, Vector &sv, double da
 {
     int m = in.rows(), n = in.cols(), k = m<n?m:n;
     Matrix U(m,k), V(n,k);
-    if((int)sv.size()!=k)
+    if ((int)sv.size() != k) {
         sv.resize(k);
+    }
 
     yarp::math::SVD(in, U, sv, V);
 
     Matrix Spinv = zeros(k,k);
     double damp2 = damp*damp;
-    for (int c=0;c<k; c++)
-        Spinv(c,c) = sv(c) / (sv(c)*sv(c) + damp2);
+    for (int c = 0; c < k; c++) {
+        Spinv(c, c) = sv(c) / (sv(c) * sv(c) + damp2);
+    }
 
     out = V*Spinv*U.transposed();
 }

--- a/src/libYARP_math/src/yarp/math/math.cpp
+++ b/src/libYARP_math/src/yarp/math/math.cpp
@@ -38,8 +38,9 @@ Vector operator+(const double &s, const Vector &a)
 Vector& operator+=(Vector &a, const double &s)
 {
     size_t l = a.size();
-    for(size_t i=0; i<l; i++)
+    for (size_t i = 0; i < l; i++) {
         a[i] += s;
+    }
     return a;
 }
 
@@ -53,8 +54,9 @@ Vector& operator+=(Vector &a, const Vector &b)
 {
     size_t s=a.size();
     yCAssert(MATH, s==b.size());
-    for (size_t k=0; k<s;k++)
-        a[k]+=b[k];
+    for (size_t k = 0; k < s; k++) {
+        a[k] += b[k];
+    }
     return a;
 }
 
@@ -69,9 +71,11 @@ Matrix& operator+=(Matrix &a, const Matrix &b)
     size_t n=a.cols();
     size_t m=a.rows();
     yCAssert(MATH, m==b.rows() && n==b.cols());
-    for (size_t r=0; r<m;r++)
-        for (size_t c=0; c<n;c++)
-            a(r,c)+=b(r,c);
+    for (size_t r = 0; r < m; r++) {
+        for (size_t c = 0; c < n; c++) {
+            a(r, c) += b(r, c);
+        }
+    }
     return a;
 }
 
@@ -85,16 +89,18 @@ Vector operator-(const double &s, const Vector &a)
 {
     size_t l = a.size();
     Vector ret(l);
-    for(size_t i=0; i<l; i++)
-        ret[i] = s-a[i];
+    for (size_t i = 0; i < l; i++) {
+        ret[i] = s - a[i];
+    }
     return ret;
 }
 
 Vector& operator-=(Vector &a, const double &s)
 {
     size_t l = a.size();
-    for(size_t i=0; i<l; i++)
+    for (size_t i = 0; i < l; i++) {
         a[i] -= s;
+    }
     return a;
 }
 
@@ -108,8 +114,9 @@ Vector& operator-=(Vector &a, const Vector &b)
 {
     size_t s=a.size();
     yCAssert(MATH, s==b.size());
-    for (size_t k=0; k<s;k++)
-        a[k]-=b[k];
+    for (size_t k = 0; k < s; k++) {
+        a[k] -= b[k];
+    }
     return a;
 }
 
@@ -125,9 +132,11 @@ Matrix& operator-=(Matrix &a, const Matrix &b)
     size_t m=a.rows();
     yCAssert(MATH, m==b.rows());
     yCAssert(MATH, n==b.cols());
-    for (size_t r=0; r<m;r++)
-        for (size_t c=0; c<n;c++)
-            a(r,c)-=b(r,c);
+    for (size_t r = 0; r < m; r++) {
+        for (size_t c = 0; c < n; c++) {
+            a(r, c) -= b(r, c);
+        }
+    }
     return a;
 }
 
@@ -145,8 +154,9 @@ Vector operator*(const Vector &a, double k)
 Vector& operator*=(Vector &a, double k)
 {
     size_t size=a.size();
-    for (size_t i = 0; i < size; i++)
-        a[i]*=k;
+    for (size_t i = 0; i < size; i++) {
+        a[i] *= k;
+    }
     return a;
 }
 
@@ -215,9 +225,11 @@ Matrix operator*(const Matrix &M, const double k)
 
 Matrix& operator*=(Matrix &M, const double k)
 {
-    for (size_t r=0; r<M.rows(); r++)
-        for (size_t c=0; c<M.cols(); c++)
-            M(r,c)*=k;
+    for (size_t r = 0; r < M.rows(); r++) {
+        for (size_t c = 0; c < M.cols(); c++) {
+            M(r, c) *= k;
+        }
+    }
     return M;
 }
 
@@ -231,8 +243,9 @@ Vector& operator*=(Vector &a, const Vector &b)
 {
     size_t n =a.length();
     yCAssert(MATH, n==b.length());
-    for (size_t i=0; i<n; i++)
-        a[i]*=b[i];
+    for (size_t i = 0; i < n; i++) {
+        a[i] *= b[i];
+    }
     return a;
 }
 
@@ -254,8 +267,9 @@ Vector& operator/=(Vector &a, const Vector &b)
 {
     size_t n =a.length();
     yCAssert(MATH, n==b.length());
-    for (size_t i=0; i<n; i++)
-        a[i]/=b[i];
+    for (size_t i = 0; i < n; i++) {
+        a[i] /= b[i];
+    }
     return a;
 }
 
@@ -269,8 +283,9 @@ Vector& operator/=(Vector &b, double k)
 {
     size_t n=b.length();
     yCAssert(MATH, k!=0.0);
-    for (size_t i = 0; i < n; i++)
-        b[i]/=k;
+    for (size_t i = 0; i < n; i++) {
+        b[i] /= k;
+    }
     return b;
 }
 
@@ -285,9 +300,11 @@ Matrix& operator/=(Matrix &M, const double k)
     yCAssert(MATH, k!=0.0);
     int rows=M.rows();
     int cols=M.cols();
-    for (int r=0; r<rows; r++)
-        for (int c=0; c<cols; c++)
-            M(r,c)/=k;
+    for (int r = 0; r < rows; r++) {
+        for (int c = 0; c < cols; c++) {
+            M(r, c) /= k;
+        }
+    }
     return M;
 }
 
@@ -468,9 +485,11 @@ Matrix yarp::math::outerProduct(const Vector &a, const Vector &b)
     size_t s = a.size();
     yCAssert(MATH, s==b.size());
     Matrix res(s, s);
-    for(size_t i=0;i<s;i++)
-        for(size_t j=0;j<s;j++)
-            res(i,j) = a(i) * b(j);
+    for (size_t i = 0; i < s; i++) {
+        for (size_t j = 0; j < s; j++) {
+            res(i, j) = a(i) * b(j);
+        }
+    }
     return res;
 }
 
@@ -500,10 +519,12 @@ Matrix yarp::math::crossProductMatrix(const Vector &v)
 
 bool yarp::math::crossProductMatrix(const Vector &v, Matrix &res)
 {
-    if(v.size()!=3)
+    if (v.size() != 3) {
         return false;
-    if(res.cols()!=3 || res.rows()!=3)
-        res.resize(3,3);
+    }
+    if (res.cols() != 3 || res.rows() != 3) {
+        res.resize(3, 3);
+    }
     res(0,0) = res(1,1) = res(2,2) = 0.0;
     res(1,0) = v(2);
     res(0,1) = -v(2);
@@ -526,23 +547,29 @@ double yarp::math::norm2(const Vector &v)
 
 double yarp::math::findMax(const Vector &v)
 {
-    if (v.length()<=0)
+    if (v.length() <= 0) {
         return 0.0;
+    }
     double ret=v[0];
-    for (size_t i=1; i<v.size(); i++)
-        if (v[i]>ret)
-            ret=v[i];
+    for (size_t i = 1; i < v.size(); i++) {
+        if (v[i] > ret) {
+            ret = v[i];
+        }
+    }
     return ret;
 }
 
 double yarp::math::findMin(const Vector &v)
 {
-    if (v.length()<=0)
+    if (v.length() <= 0) {
         return 0.0;
+    }
     double ret=v[0];
-    for (size_t i=1; i<v.length(); i++)
-        if (v[i]<ret)
-            ret=v[i];
+    for (size_t i = 1; i < v.length(); i++) {
+        if (v[i] < ret) {
+            ret = v[i];
+        }
+    }
     return ret;
 }
 
@@ -597,8 +624,9 @@ Matrix yarp::math::luinv(const Matrix& in)
 bool yarp::math::eigenValues(const Matrix& in, Vector &real, Vector &img)
 {
     // return error for non-square matrix
-    if(in.cols() != in.rows())
+    if (in.cols() != in.rows()) {
         return false;
+    }
 
     int n = in.cols();
     real.resize(n);
@@ -635,8 +663,9 @@ double yarp::math::sign(const double &v)
 Vector yarp::math::sign(const Vector &v)
 {
     Vector ret(v.length());
-    for (size_t i=0; i<v.length(); i++)
-        ret[i]=sign(v[i]);
+    for (size_t i = 0; i < v.length(); i++) {
+        ret[i] = sign(v[i]);
+    }
 
     return ret;
 }
@@ -690,8 +719,9 @@ Matrix yarp::math::axis2dcm(const Vector &v)
     Matrix R=eye(4,4);
 
     double theta=v[3];
-    if (theta==0.0)
+    if (theta == 0.0) {
         return R;
+    }
 
     double c=cos(theta);
     double s=sin(theta);
@@ -752,8 +782,9 @@ Vector yarp::math::dcm2euler(const Matrix &R)
         v[2]=0.0;
     }
 
-    if (singularity)
+    if (singularity) {
         yCWarning(MATH, "dcm2euler() in singularity: choosing one solution among multiple");
+    }
 
     return v;
 }
@@ -806,8 +837,9 @@ Vector yarp::math::dcm2rpy(const Matrix &R)
         v[2]=atan2(-R(1,2),R(1,1));
     }
 
-    if (singularity)
+    if (singularity) {
         yCWarning(MATH, "dcm2rpy() in singularity: choosing one solution among multiple");
+    }
 
     return v;
 }

--- a/src/libYARP_name/src/yarp/name/BootstrapServer.cpp
+++ b/src/libYARP_name/src/yarp/name/BootstrapServer.cpp
@@ -39,7 +39,9 @@ public:
     }
 
     virtual ~BootstrapServerAdapter() {
-        if (fallback!=nullptr) delete fallback;
+        if (fallback != nullptr) {
+            delete fallback;
+        }
         fallback = nullptr;
     }
 

--- a/src/libYARP_os/src/yarp/os/Publisher.h
+++ b/src/libYARP_os/src/yarp/os/Publisher.h
@@ -161,8 +161,9 @@ public:
 
     virtual int getPendingReads()
     {
-        if (buffered_port)
+        if (buffered_port) {
             return buffered_port->getPendingReads();
+        }
         return 0;
     }
 
@@ -182,8 +183,9 @@ private:
 
     Contactable& active()
     {
-        if (buffered_port)
+        if (buffered_port) {
             return *buffered_port;
+        }
         return port;
     }
 
@@ -197,8 +199,9 @@ private:
 
     void clear()
     {
-        if (!buffered_port)
+        if (!buffered_port) {
             return;
+        }
         delete buffered_port;
         buffered_port = nullptr;
     }

--- a/src/libYARP_os/src/yarp/os/Subscriber.h
+++ b/src/libYARP_os/src/yarp/os/Subscriber.h
@@ -151,8 +151,9 @@ public:
     void setStrict(bool strict = true)
     {
         isStrict = strict;
-        if (buffered_port)
+        if (buffered_port) {
             buffered_port->setStrict(strict);
+        }
     }
 
 private:
@@ -162,8 +163,9 @@ private:
 
     Contactable& active()
     {
-        if (buffered_port)
+        if (buffered_port) {
             return *buffered_port;
+        }
         return port;
     }
 
@@ -180,8 +182,9 @@ private:
 
     void clear()
     {
-        if (!buffered_port)
+        if (!buffered_port) {
             return;
+        }
         delete buffered_port;
         buffered_port = nullptr;
     }

--- a/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
+++ b/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
@@ -189,8 +189,9 @@ void YarpPluginSettings::reportFailure() const
 
 bool YarpPluginSettings::readFromSelector(const std::string& name)
 {
-    if (!selector)
+    if (!selector) {
         return false;
+    }
     Bottle plugins = selector->getSelectedPlugins();
     Bottle group = plugins.findGroup(name).tail();
     if (group.isNull()) {

--- a/src/libYARP_os/src/yarp/os/YarpPlugin.h
+++ b/src/libYARP_os/src/yarp/os/YarpPlugin.h
@@ -60,8 +60,9 @@ public:
     {
         close();
         factory = new SharedLibraryClassFactory<T>();
-        if (!factory)
+        if (!factory) {
             return false;
+        }
         if (!settings.open(*factory)) {
             settings.reportStatus(*factory);
             close();

--- a/src/libYARP_os/src/yarp/os/YarpPluginSettings.h
+++ b/src/libYARP_os/src/yarp/os/YarpPluginSettings.h
@@ -114,13 +114,16 @@ public:
         std::string iname = options.find("library").toString();
         std::string pname = options.find("part").toString();
 
-        if (iname == "")
+        if (iname == "") {
             iname = name;
-        if (pname == "")
+        }
+        if (pname == "") {
             pname = name;
+        }
 
-        if (this->name == "")
+        if (this->name == "") {
             this->name = iname;
+        }
         this->dll_name = iname;
         this->fn_name = pname;
         this->wrapper_name = options.find("wrapper").toString();

--- a/src/libYARP_profiler/src/yarp/profiler/Graph.cpp
+++ b/src/libYARP_profiler/src/yarp/profiler/Graph.cpp
@@ -64,12 +64,16 @@ Vertex::Vertex(const Vertex &vertex) = default;
 Vertex::~Vertex() = default;
 
 void Vertex::insertOuts(const yarp::profiler::graph::Edge& edge) {
-    if( find(outs.begin(), outs.end(), edge) != outs.end()) return;
+    if (find(outs.begin(), outs.end(), edge) != outs.end()) {
+        return;
+    }
     outs.push_back(edge);
 }
 
 void Vertex::insertIns(const yarp::profiler::graph::Edge& edge) {
-    if( find(ins.begin(), ins.end(), edge) != ins.end()) return;
+    if (find(ins.begin(), ins.end(), edge) != ins.end()) {
+        return;
+    }
     ins.push_back(edge);
 }
 
@@ -115,7 +119,9 @@ void Graph::insert(Vertex *vertex) {
 
 pvertex_iterator Graph::insert(const Vertex &vertex){
     pvertex_iterator itr = find(vertex);
-    if( itr != mVertices.end()) return itr;
+    if (itr != mVertices.end()) {
+        return itr;
+    }
    // Vertex* v = new Vertex(vertex);
     mVertices.push_back((Vertex*) &vertex);
     return mVertices.end()-1;
@@ -127,7 +133,9 @@ void Graph::remove(const Vertex &vertex){
 }
 
 void Graph::remove(const pvertex_iterator vi) {
-    if(vi == mVertices.end()) return;
+    if (vi == mVertices.end()) {
+        return;
+    }
     Vertex* v = *vi;
     mVertices.erase(vi);
     delete v;
@@ -152,8 +160,9 @@ void Graph::insertEdge(const pvertex_iterator vi1, const pvertex_iterator vi2,
 const pvertex_iterator Graph::find(const Vertex &vertex) {
     auto itr = mVertices.begin();
     for(;itr!=mVertices.end(); itr++) {
-        if(*(*itr) == vertex)
+        if (*(*itr) == vertex) {
             return itr;
+        }
     }
     return mVertices.end();
 
@@ -162,8 +171,9 @@ const pvertex_iterator Graph::find(const Vertex &vertex) {
 size_t Graph::size() {
     auto itr = mVertices.begin();
     size_t count = 0;
-    for(; itr!=mVertices.end(); itr++)
+    for (; itr != mVertices.end(); itr++) {
         count += (**itr).degree();
+    }
     return count/2;
 }
 
@@ -174,8 +184,9 @@ size_t Graph::nodesCount() {
 
 void Graph::clear() {
     auto itr = mVertices.begin();
-    for(; itr!=mVertices.end(); itr++)
+    for (; itr != mVertices.end(); itr++) {
         delete *itr;
+    }
     mVertices.clear();
 }
 
@@ -252,8 +263,9 @@ bool Algorithm::calcSCC(yarp::profiler::graph::Graph& graph, graph_subset &scc) 
     int index = 0;
     for(vitr = vertices.begin(); vitr!=vertices.end(); vitr++) {
         Vertex* v = (*vitr);
-        if(!v->property.check("index"))
+        if (!v->property.check("index")) {
             strongConnect(v, scc, S, index);
+        }
     }
     return true;
 }

--- a/src/libYARP_profiler/src/yarp/profiler/NetworkProfiler.h
+++ b/src/libYARP_profiler/src/yarp/profiler/NetworkProfiler.h
@@ -69,11 +69,13 @@ public:
             str<<"port name: "<<name<<std::endl;
             str<<"outputs:"<<std::endl;
             std::vector<ConnectionInfo>::const_iterator itr;
-            for(itr=outputs.begin(); itr!=outputs.end(); itr++)
-                str<<"   + "<<(*itr).name<<" ("<<(*itr).carrier<<")"<<std::endl;
+            for (itr = outputs.begin(); itr != outputs.end(); itr++) {
+                str << "   + " << (*itr).name << " (" << (*itr).carrier << ")" << std::endl;
+            }
             str<<"inputs:"<<std::endl;
-            for(itr=inputs.begin(); itr!=inputs.end(); itr++)
-                str<<"   + "<<(*itr).name<<" ("<<(*itr).carrier<<")"<<std::endl;
+            for (itr = inputs.begin(); itr != inputs.end(); itr++) {
+                str << "   + " << (*itr).name << " (" << (*itr).carrier << ")" << std::endl;
+            }
             str<<"owner:"<<std::endl;
             str<<"   + name:      "<<owner.name<<std::endl;
             str<<"   + arguments: "<<owner.arguments<<std::endl;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
@@ -392,8 +392,9 @@ bool yarp::robotinterface::Device::calibrate(const yarp::dev::PolyDriverDescript
         rem_calibrator_available = false;
     }
 
-    if (rem_calibrator_available)
+    if (rem_calibrator_available) {
         rem_calibrator_wrap->setCalibratorDevice(rem_calibrator_calib);
+    }
 
     // Start the calibrator thread
     yarp::os::Thread* calibratorThread = new yarp::robotinterface::impl::CalibratorThread(calibrator,

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -301,12 +301,15 @@ bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::De
                                                                 const yarp::robotinterface::ParamList& params)
 {
     int check = 0;
-    if (yarp::robotinterface::hasParam(params, "network"))
+    if (yarp::robotinterface::hasParam(params, "network")) {
         check++;
-    if (yarp::robotinterface::hasParam(params, "networks"))
+    }
+    if (yarp::robotinterface::hasParam(params, "networks")) {
         check++;
-    if (yarp::robotinterface::hasParam(params, "all"))
+    }
+    if (yarp::robotinterface::hasParam(params, "all")) {
         check++;
+    }
 
     if (check > 1) {
         yError() << "Action \"" << ActionTypeToString(ActionTypeAttach) << R"(" : you can have only one option: "network" , "networks" or "all" )";

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Types.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Types.cpp
@@ -69,8 +69,9 @@ yarp::robotinterface::ParamList yarp::robotinterface::mergeDuplicateGroups(const
                 param1.value() += std::string(" ");
                 param1.value() += param2.value();
                 it2 = params.erase(it2);
-            } else
+            } else {
                 it2++;
+            }
         }
     }
     return params;

--- a/src/libYARP_robottestingframework/src/yarp/robottestingframework/JointsPosMotion.cpp
+++ b/src/libYARP_robottestingframework/src/yarp/robottestingframework/JointsPosMotion.cpp
@@ -216,11 +216,13 @@ bool yarp::robottestingframework::jointsPosMotion::goTo(yarp::sig::Vector positi
         size_t in_position = 0;
         for (size_t i = 0; i < mPriv->n_joints; i++) {
             mPriv->ienc->getEncoder((int)mPriv->jointsList[i], &tmp[i]);
-            if (fabs(tmp[i]-positions[i])<mPriv->tolerance)
+            if (fabs(tmp[i] - positions[i]) < mPriv->tolerance) {
                 in_position++;
+            }
         }
-        if (in_position == mPriv->n_joints)
+        if (in_position == mPriv->n_joints) {
             break;
+        }
 
         if (yarp::os::Time::now()-time_started > mPriv->timeout) {
             ret = false;

--- a/src/libYARP_rosmsg/src/yarp/rosmsg/impl/yarpRosHelper.h
+++ b/src/libYARP_rosmsg/src/yarp/rosmsg/impl/yarpRosHelper.h
@@ -31,8 +31,9 @@ inline double convertDegreesToRadians(double degrees)
 
 inline void convertDegreesToRadians(std::vector<yarp::os::NetFloat64>  &degrees)
 {
-    for(size_t i=0; i<degrees.size(); i++)
+    for (size_t i = 0; i < degrees.size(); i++) {
         degrees[i] = convertDegreesToRadians(degrees[i]);
+    }
 }
 
 /* return false if errors occourr, like norm of the resulting vector is not 1*/

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -88,7 +88,9 @@ void sigstdio_handler(int sig)
     sprintf(msg, "SIGNAL %d", sig);
     RUNLOG(msg);
 
-    if (pTerminator) pTerminator->exit();
+    if (pTerminator) {
+        pTerminator->exit();
+    }
 }
 
 ////////////////////////////////////
@@ -788,12 +790,16 @@ int yarp::run::Run::readFromPipe(int fd, char* &data, int& buffsize)
     {
         r=read(fd, buff, c);
 
-        if (r<1) return -1;
+        if (r < 1) {
+            return -1;
+        }
 
         buff+=r;
     }
 
-    if (len<=0) return 0;
+    if (len <= 0) {
+        return 0;
+    }
 
     if (len>buffsize)
     {
@@ -807,7 +813,9 @@ int yarp::run::Run::readFromPipe(int fd, char* &data, int& buffsize)
     {
         r=read(fd, buff, c);
 
-        if (r<1) return -1;
+        if (r < 1) {
+            return -1;
+        }
 
         buff+=r;
     }
@@ -875,7 +883,9 @@ int yarp::run::Run::server()
         {
             yError() << "Yarprun failed to open port: " << mPortName.c_str();
 
-            if (mPortName[0]!='/') yError("Invalid port name '%s', it should start with '/'\n", mPortName.c_str());
+            if (mPortName[0] != '/') {
+                yError("Invalid port name '%s', it should start with '/'\n", mPortName.c_str());
+            }
             return YARPRUN_ERROR;
         }
         yarp::os::Bottle cmd, reply;
@@ -901,10 +911,14 @@ int yarp::run::Run::server()
         while (pServerPort)
         {
             RUNLOG("<<<port.read(msg, true)")
-            if (!port.read(msg, true)) break;
+            if (!port.read(msg, true)) {
+                break;
+            }
             RUNLOG(">>>port.read(msg, true)")
 
-            if (!pServerPort) break;
+            if (!pServerPort) {
+                break;
+            }
 
             if (msg.check("sysinfo"))
             {
@@ -1005,7 +1019,9 @@ int yarp::run::Run::server()
         while (true)
         {
             RUNLOG("<<<readFromPipe")
-            if (readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size)<=0) break;
+            if (readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size) <= 0) {
+                break;
+            }
             RUNLOG(">>>readFromPipe")
 
             //printf("<<< %s >>>\n", msg_str);
@@ -1268,11 +1284,21 @@ int yarp::run::Run::client(yarp::os::Property& config)
         msg.addList()=config.findGroup("as");
         msg.addList()=config.findGroup("on");
 
-        if (config.check("workdir")) msg.addList()=config.findGroup("workdir");
-        if (config.check("geometry")) msg.addList()=config.findGroup("geometry");
-        if (config.check("hold")) msg.addList()=config.findGroup("hold");
-        if (config.check("env")) msg.addList()=config.findGroup("env");
-        if (config.check("log")) msg.addList()=config.findGroup("log");
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("geometry")) {
+            msg.addList() = config.findGroup("geometry");
+        }
+        if (config.check("hold")) {
+            msg.addList() = config.findGroup("hold");
+        }
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
+        if (config.check("log")) {
+            msg.addList() = config.findGroup("log");
+        }
         /*
         {
             yarp::os::Bottle log;
@@ -1286,9 +1312,13 @@ int yarp::run::Run::client(yarp::os::Property& config)
 
         yarp::os::Bottle response=sendMsg(msg, on);
 
-        if (!response.size()) return YARPRUN_ERROR;
+        if (!response.size()) {
+            return YARPRUN_ERROR;
+        }
 
-        if (response.get(0).asInt32()<=0) return 2;
+        if (response.get(0).asInt32() <= 0) {
+            return 2;
+        }
 
         return 0;
     }
@@ -1321,8 +1351,12 @@ int yarp::run::Run::client(yarp::os::Property& config)
         msg.addList()=config.findGroup("cmd");
         msg.addList()=config.findGroup("as");
 
-        if (config.check("workdir")) msg.addList()=config.findGroup("workdir");
-        if (config.check("log")) msg.addList()=config.findGroup("log");
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("log")) {
+            msg.addList() = config.findGroup("log");
+        }
         /*
         {
             yarp::os::Bottle log;
@@ -1331,13 +1365,19 @@ int yarp::run::Run::client(yarp::os::Property& config)
             msg.addList()=log;
         }
         */
-        if (config.check("env")) msg.addList()=config.findGroup("env");
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
 
         yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
 
-        if (!response.size()) return YARPRUN_ERROR;
+        if (!response.size()) {
+            return YARPRUN_ERROR;
+        }
 
-        if (response.get(0).asInt32()<=0) return 2;
+        if (response.get(0).asInt32() <= 0) {
+            return 2;
+        }
 
         return 0;
     }
@@ -2406,7 +2446,11 @@ void yarp::run::Run::CleanZombie(int pid)
 {
     bool bFound=mProcessVector && mProcessVector->CleanZombie(pid);
 
-    if (!bFound) if (mStdioVector)  mStdioVector->CleanZombie(pid);
+    if (!bFound) {
+        if (mStdioVector) {
+            mStdioVector->CleanZombie(pid);
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -2706,7 +2750,9 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
                 if (currWorkDir)
                 {
                     char **cwd_arg_str=new char*[nargs+1];
-                    for (int i=1; i<nargs; ++i) cwd_arg_str[i]=arg_str[i];
+                    for (int i = 1; i < nargs; ++i) {
+                        cwd_arg_str[i] = arg_str[i];
+                    }
                     cwd_arg_str[nargs]=nullptr;
                     cwd_arg_str[0]=new char[strlen(currWorkDir)+strlen(arg_str[0])+16];
 
@@ -2812,7 +2858,9 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
 
                     while(true)
                     {
-                        if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) break;
+                        if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) {
+                            break;
+                        }
 
                         out+=std::string(buff);
                     }
@@ -3070,7 +3118,9 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
                 if (currWorkDir)
                 {
                     char **cwd_arg_str=new char*[nargs+1];
-                    for (int i=1; i<nargs; ++i) cwd_arg_str[i]=arg_str[i];
+                    for (int i = 1; i < nargs; ++i) {
+                        cwd_arg_str[i] = arg_str[i];
+                    }
                     cwd_arg_str[nargs]=nullptr;
                     cwd_arg_str[0]=new char[strlen(currWorkDir)+strlen(arg_str[0])+16];
 
@@ -3169,7 +3219,9 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
 
                     while(true)
                     {
-                        if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) break;
+                        if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) {
+                            break;
+                        }
 
                         out+=std::string(buff);
                     }
@@ -3354,7 +3406,9 @@ int yarp::run::Run::userStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
 
             while(true)
             {
-                if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) break;
+                if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) {
+                    break;
+                }
 
                 out+=std::string(buff);
             }
@@ -3511,7 +3565,9 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
         if (currWorkDir)
         {
             char **cwd_arg_str=new char*[nargs+1];
-            for (int i=1; i<nargs; ++i) cwd_arg_str[i]=arg_str[i];
+            for (int i = 1; i < nargs; ++i) {
+                cwd_arg_str[i] = arg_str[i];
+            }
             cwd_arg_str[nargs]=nullptr;
             cwd_arg_str[0]=new char[strlen(currWorkDir)+strlen(arg_str[0])+16];
 
@@ -3572,7 +3628,9 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
     {
         auto* pInf = new YarpRunProcInfo(strAlias, mPortName, pid_cmd, nullptr, false);
         pInf->setCmd(strCmd);
-        if (msg.check("env")) pInf->setEnv(msg.find("env").asString());
+        if (msg.check("env")) {
+            pInf->setEnv(msg.find("env").asString());
+        }
         mProcessVector->Add(pInf);
         char pidstr[16];
         sprintf(pidstr, "%d", pid_cmd);
@@ -3591,7 +3649,9 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
 
             while(true)
             {
-                if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) break;
+                if (!fgets(buff, 1024, in_from_child) || ferror(in_from_child) || feof(in_from_child)) {
+                    break;
+                }
 
                 out+=std::string(buff);
             }
@@ -3773,7 +3833,9 @@ bool yarp::run::Run::isRunning(const std::string &node, std::string &keyv)
 
     response=sendMsg(msg, node);
 
-    if (!response.size()) return false;
+    if (!response.size()) {
+        return false;
+    }
 
     return response.get(0).asString()=="running";
 }

--- a/src/libYARP_run/src/yarp/run/impl/RunCheckpoints.cpp
+++ b/src/libYARP_run/src/yarp/run/impl/RunCheckpoints.cpp
@@ -32,17 +32,23 @@ YarprunCheckpoints::YarprunCheckpoints()
 
     for (int t=10; t<256 && path[t]; ++t)
     {
-        if (path[t]=='\n' || path[t]=='\r' || path[t]==' ' || path[t]==':' || path[t]=='?') path[t]='_';
+        if (path[t] == '\n' || path[t] == '\r' || path[t] == ' ' || path[t] == ':' || path[t] == '?') {
+            path[t] = '_';
+        }
     }
 
     mLogFile=fopen(path, "w");
 
-    if (!mLogFile) perror(path);
+    if (!mLogFile) {
+        perror(path);
+    }
 }
 
 YarprunCheckpoints::~YarprunCheckpoints()
 {
-    if (mLogFile) fclose(mLogFile);
+    if (mLogFile) {
+        fclose(mLogFile);
+    }
 }
 
 YarprunCheckpoints& YarprunCheckpoints::instance()
@@ -54,7 +60,9 @@ YarprunCheckpoints& YarprunCheckpoints::instance()
 
 void YarprunCheckpoints::checkpoint(const char *prefix, const char* sFile, const char* sFunction, int line)
 {
-    if (!mLogFile) return;
+    if (!mLogFile) {
+        return;
+    }
 
     fprintf(mLogFile, "%s: file %s function %s line %d\n", prefix, sFile, sFunction, line);
     fflush(mLogFile);

--- a/src/libYARP_run/src/yarp/run/impl/RunProcManager.cpp
+++ b/src/libYARP_run/src/yarp/run/impl/RunProcManager.cpp
@@ -323,7 +323,9 @@ bool YarpRunInfoVector::CleanZombie(int zombie)
         if (m_apList[i] && m_apList[i]->Clean(zombie, pZombie))
         {
             bFound=true;
-            if (pZombie) m_apList[i] = nullptr;
+            if (pZombie) {
+                m_apList[i] = nullptr;
+            }
             break;
         }
     }
@@ -348,36 +350,37 @@ yarp::os::Bottle YarpRunInfoVector::PS()
 
     yarp::os::Bottle ps, line, grp;
 
-    for (int i=0; i<m_nProcesses; ++i) if (m_apList[i])
-    {
-        line.clear();
+    for (int i = 0; i < m_nProcesses; ++i) {
+        if (m_apList[i]) {
+            line.clear();
 
-        grp.clear();
-        grp.addString("pid");
-        grp.addInt32(m_apList[i]->mPidCmd);
-        line.addList()=grp;
+            grp.clear();
+            grp.addString("pid");
+            grp.addInt32(m_apList[i]->mPidCmd);
+            line.addList() = grp;
 
-        grp.clear();
-        grp.addString("tag");
-        grp.addString(m_apList[i]->mAlias.c_str());
-        line.addList()=grp;
+            grp.clear();
+            grp.addString("tag");
+            grp.addString(m_apList[i]->mAlias.c_str());
+            line.addList() = grp;
 
-        grp.clear();
-        grp.addString("status");
-        grp.addString(m_apList[i]->IsActive()?"running":"zombie");
-        line.addList()=grp;
+            grp.clear();
+            grp.addString("status");
+            grp.addString(m_apList[i]->IsActive() ? "running" : "zombie");
+            line.addList() = grp;
 
-        grp.clear();
-        grp.addString("cmd");
-        grp.addString(m_apList[i]->mCmd.c_str());
-        line.addList()=grp;
+            grp.clear();
+            grp.addString("cmd");
+            grp.addString(m_apList[i]->mCmd.c_str());
+            line.addList() = grp;
 
-        grp.clear();
-        grp.addString("env");
-        grp.addString(m_apList[i]->mEnv.c_str());
-        line.addList()=grp;
+            grp.clear();
+            grp.addString("env");
+            grp.addString(m_apList[i]->mEnv.c_str());
+            line.addList() = grp;
 
-        ps.addList()=line;
+            ps.addList() = line;
+        }
     }
 
     POST()
@@ -556,10 +559,18 @@ bool YarpRunCmdWithStdioInfo::Clean()
     {
         mKillingStdio=true;
 
-        if (mWriteToPipeStdinToCmd)   CLOSE(mWriteToPipeStdinToCmd);
-        if (mReadFromPipeStdinToCmd)  CLOSE(mReadFromPipeStdinToCmd);
-        if (mWriteToPipeCmdToStdout)  CLOSE(mWriteToPipeCmdToStdout);
-        if (mReadFromPipeCmdToStdout) CLOSE(mReadFromPipeCmdToStdout);
+        if (mWriteToPipeStdinToCmd) {
+            CLOSE(mWriteToPipeStdinToCmd);
+        }
+        if (mReadFromPipeStdinToCmd) {
+            CLOSE(mReadFromPipeStdinToCmd);
+        }
+        if (mWriteToPipeCmdToStdout) {
+            CLOSE(mWriteToPipeCmdToStdout);
+        }
+        if (mReadFromPipeCmdToStdout) {
+            CLOSE(mReadFromPipeCmdToStdout);
+        }
 
         mWriteToPipeStdinToCmd=0;
         mReadFromPipeStdinToCmd=0;
@@ -596,7 +607,9 @@ bool YarpRunCmdWithStdioInfo::Clean()
 
 void YarpRunCmdWithStdioInfo::TerminateStdio()
 {
-    if (!mStdioVector) return;
+    if (!mStdioVector) {
+        return;
+    }
 
     if (mOn==mStdio)
     {

--- a/src/libYARP_run/src/yarp/run/impl/RunProcManager.h
+++ b/src/libYARP_run/src/yarp/run/impl/RunProcManager.h
@@ -239,8 +239,12 @@ public:
         {
             mPidCmd=0;
 
-            if (!mKillingStdin && mPidStdin) yarp::os::impl::kill(mPidStdin, SIGTERM);
-            if (!mKillingStdout && mPidStdout) yarp::os::impl::kill(mPidStdout, SIGTERM);
+            if (!mKillingStdin && mPidStdin) {
+                yarp::os::impl::kill(mPidStdin, SIGTERM);
+            }
+            if (!mKillingStdout && mPidStdout) {
+                yarp::os::impl::kill(mPidStdout, SIGTERM);
+            }
 
             mKillingStdin=mKillingStdout=true;
         }
@@ -248,8 +252,12 @@ public:
         {
             mPidStdin=0;
 
-            if (!mKillingCmd && mPidCmd) yarp::os::impl::kill(mPidCmd, SIGTERM);
-            if (!mKillingStdout && mPidStdout) yarp::os::impl::kill(mPidStdout, SIGTERM);
+            if (!mKillingCmd && mPidCmd) {
+                yarp::os::impl::kill(mPidCmd, SIGTERM);
+            }
+            if (!mKillingStdout && mPidStdout) {
+                yarp::os::impl::kill(mPidStdout, SIGTERM);
+            }
 
             mKillingCmd=mKillingStdout=true;
         }
@@ -257,21 +265,34 @@ public:
         {
             mPidStdout=0;
 
-            if (!mKillingCmd && mPidCmd) yarp::os::impl::kill(mPidCmd, SIGTERM);
-            if (!mKillingStdin && mPidStdin) yarp::os::impl::kill(mPidStdin, SIGTERM);
+            if (!mKillingCmd && mPidCmd) {
+                yarp::os::impl::kill(mPidCmd, SIGTERM);
+            }
+            if (!mKillingStdin && mPidStdin) {
+                yarp::os::impl::kill(mPidStdin, SIGTERM);
+            }
 
             mKillingCmd=mKillingStdin=true;
+        } else {
+            return false;
         }
-        else return false;
 
         if (!mKillingStdio)
         {
             mKillingStdio=true;
 
-            if (mWriteToPipeStdinToCmd)   CLOSE(mWriteToPipeStdinToCmd);
-            if (mReadFromPipeStdinToCmd)  CLOSE(mReadFromPipeStdinToCmd);
-            if (mWriteToPipeCmdToStdout)  CLOSE(mWriteToPipeCmdToStdout);
-            if (mReadFromPipeCmdToStdout) CLOSE(mReadFromPipeCmdToStdout);
+            if (mWriteToPipeStdinToCmd) {
+                CLOSE(mWriteToPipeStdinToCmd);
+            }
+            if (mReadFromPipeStdinToCmd) {
+                CLOSE(mReadFromPipeStdinToCmd);
+            }
+            if (mWriteToPipeCmdToStdout) {
+                CLOSE(mWriteToPipeCmdToStdout);
+            }
+            if (mReadFromPipeCmdToStdout) {
+                CLOSE(mReadFromPipeCmdToStdout);
+            }
 
             mWriteToPipeStdinToCmd=0;
             mReadFromPipeStdinToCmd=0;
@@ -279,7 +300,9 @@ public:
             mReadFromPipeCmdToStdout=0;
         }
 
-        if (!mPidCmd && !mPidStdin && !mPidStdout) pRef=this;
+        if (!mPidCmd && !mPidStdin && !mPidStdout) {
+            pRef = this;
+        }
 
         return true;
     }

--- a/src/libYARP_run/src/yarp/run/impl/RunReadWrite.cpp
+++ b/src/libYARP_run/src/yarp/run/impl/RunReadWrite.cpp
@@ -37,12 +37,18 @@ int RunWrite::loop()
 
     while (mRunning)
     {
-        if (!fgets(txt, 2048, stdin) || ferror(stdin) || feof(stdin)) break;
+        if (!fgets(txt, 2048, stdin) || ferror(stdin) || feof(stdin)) {
+            break;
+        }
 
-        if (!mRunning) break;
+        if (!mRunning) {
+            break;
+        }
 
         yarp::os::Bottle bot;
-        if (mVerbose) bot.addString(tag.c_str());
+        if (mVerbose) {
+            bot.addString(tag.c_str());
+        }
         bot.addString(txt);
         wPort.write(bot);
     }
@@ -74,7 +80,9 @@ int RunRead::loop()
             break;
         }
 
-        if (!mRunning) break;
+        if (!mRunning) {
+            break;
+        }
 
         if (bot.size()==1)
         {
@@ -141,8 +149,10 @@ int RunReadWrite::loop()
         while (mRunning)
         {
             #if !defined(_WIN32)
-            if (yarp::os::impl::getppid()==1) break;
-            #endif
+            if (yarp::os::impl::getppid() == 1) {
+                break;
+            }
+#endif
 
             yarp::os::Bottle bot;
 
@@ -152,11 +162,15 @@ int RunReadWrite::loop()
                 break;
             }
 
-            if (!mRunning) break;
+            if (!mRunning) {
+                break;
+            }
 
-            #if !defined(_WIN32)
-            if (yarp::os::impl::getppid()==1) break;
-            #endif
+#if !defined(_WIN32)
+            if (yarp::os::impl::getppid() == 1) {
+                break;
+            }
+#endif
 
             if (bot.size()==1)
             {
@@ -190,7 +204,9 @@ int RunReadWrite::loop()
 
         wPort.close();
 
-        if (mForwarded) fPort.close();
+        if (mForwarded) {
+            fPort.close();
+        }
 
 #if defined(_WIN32)
         ::exit(0);
@@ -234,18 +250,26 @@ void RunReadWrite::run()
         RUNLOG("mRunning")
 
         #if !defined(_WIN32)
-        if (yarp::os::impl::getppid()==1) break;
-        #endif
+        if (yarp::os::impl::getppid() == 1) {
+            break;
+        }
+#endif
 
-        if (!fgets(txt, 2048, stdin) || ferror(stdin) || feof(stdin)) break;
+        if (!fgets(txt, 2048, stdin) || ferror(stdin) || feof(stdin)) {
+            break;
+        }
 
         RUNLOG(txt)
 
         #if !defined(_WIN32)
-        if (yarp::os::impl::getppid()==1) break;
-        #endif
+        if (yarp::os::impl::getppid() == 1) {
+            break;
+        }
+#endif
 
-        if (!mRunning) break;
+        if (!mRunning) {
+            break;
+        }
 
         RUNLOG(txt)
 

--- a/src/libYARP_serversql/src/yarp/serversql/impl/StyleNameService.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/StyleNameService.cpp
@@ -16,7 +16,9 @@ bool StyleNameService::apply(yarp::os::Bottle& cmd,
                              yarp::os::Bottle& reply,
                              yarp::os::Bottle& event,
                              const yarp::os::Contact& remote) {
-    if (cmd.get(0).asString()!="web") return false;
+    if (cmd.get(0).asString() != "web") {
+        return false;
+    }
 
     if (!content.check("main.css")) {
         if (!options.check("web")) {
@@ -64,13 +66,23 @@ a:hover{\n\
             bool first = true;
             for (size_t i=0; i<fileName.length(); i++) {
                 char ch = fileName[i];
-                if (ch == '.' && !first) continue;
+                if (ch == '.' && !first) {
+                    continue;
+                }
                 if (ch == '/') { first = true; continue; }
                 first = false;
-                if (ch>='a'&&ch<='z') continue;
-                if (ch>='A'&&ch<='Z') continue;
-                if (ch>='0'&&ch<='9') continue;
-                if (ch == '-' || ch == '_') continue;
+                if (ch >= 'a' && ch <= 'z') {
+                    continue;
+                }
+                if (ch >= 'A' && ch <= 'Z') {
+                    continue;
+                }
+                if (ch >= '0' && ch <= '9') {
+                    continue;
+                }
+                if (ch == '-' || ch == '_') {
+                    continue;
+                }
                 ((char*)fileName.c_str())[i] = '_';
             }
             if (fileName == "") {

--- a/src/libYARP_serversql/src/yarp/serversql/impl/SubscriberOnSql.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/SubscriberOnSql.cpp
@@ -192,7 +192,9 @@ bool SubscriberOnSql::addSubscription(const std::string& src,
     }
     char *msg = nullptr;
     const char *zmode = mode.c_str();
-    if (mode == "") zmode = nullptr;
+    if (mode == "") {
+        zmode = nullptr;
+    }
     char *query = sqlite3_mprintf("INSERT INTO subscriptions (src,dest,srcFull,destFull,mode) VALUES(%Q,%Q,%Q,%Q,%Q)",
                                   psrc.getPortName().c_str(),
                                   pdest.getPortName().c_str(),
@@ -570,8 +572,12 @@ bool SubscriberOnSql::setTopic(const std::string& port, const std::string& struc
         }
         sqlite3_free(query);
         mutex.unlock();
-        if (!ok) return false;
-        if (!active) return true;
+        if (!ok) {
+            return false;
+        }
+        if (!active) {
+            return true;
+        }
     }
 
     bool have_topic = false;
@@ -599,7 +605,9 @@ bool SubscriberOnSql::setTopic(const std::string& port, const std::string& struc
         mutex.lock();
         char *msg = nullptr;
         const char *pstructure = structure.c_str();
-        if (structure=="") pstructure = nullptr;
+        if (structure == "") {
+            pstructure = nullptr;
+        }
         char *query = sqlite3_mprintf("INSERT INTO topics (topic,structure) VALUES(%Q,%Q)",
                                       port.c_str(),pstructure);
         yCDebug(SUBSCRIBERONSQL, "Query: %s", query);
@@ -615,7 +623,9 @@ bool SubscriberOnSql::setTopic(const std::string& port, const std::string& struc
         }
         sqlite3_free(query);
         mutex.unlock();
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
     }
 
     vector<vector<std::string> > subs;

--- a/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
+++ b/src/libYARP_sig/src/yarp/sig/ImageFile.cpp
@@ -204,28 +204,31 @@ bool ImageReadRGB_PNG(ImageOf<PixelRgb>& img, const char* filename)
     // Read any color_type into 8bit depth, RGBA format.
     // See http://www.libpng.org/pub/png/libpng-manual.txt
 
-    if (bit_depth == 16)
+    if (bit_depth == 16) {
         png_set_strip_16(png);
+    }
 
-    if (color_type == PNG_COLOR_TYPE_PALETTE)
+    if (color_type == PNG_COLOR_TYPE_PALETTE) {
         png_set_palette_to_rgb(png);
+    }
 
     // PNG_COLOR_TYPE_GRAY_ALPHA is always 8 or 16bit depth.
-    if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+    if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
         png_set_expand_gray_1_2_4_to_8(png);
+    }
 
-    if (png_get_valid(png, info, PNG_INFO_tRNS))
+    if (png_get_valid(png, info, PNG_INFO_tRNS)) {
         png_set_tRNS_to_alpha(png);
+    }
 
     // These color_type don't have an alpha channel then fill it with 0xff.
-    if (color_type == PNG_COLOR_TYPE_RGB ||
-        color_type == PNG_COLOR_TYPE_GRAY ||
-        color_type == PNG_COLOR_TYPE_PALETTE)
+    if (color_type == PNG_COLOR_TYPE_RGB || color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_PALETTE) {
         png_set_filler(png, 0xFF, PNG_FILLER_AFTER);
+    }
 
-    if (color_type == PNG_COLOR_TYPE_GRAY ||
-        color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+    if (color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_GRAY_ALPHA) {
         png_set_gray_to_rgb(png);
+    }
 
     png_read_update_info(png, info);
 
@@ -305,7 +308,9 @@ bool ReadHeader_PxM(FILE *fp, int *height, int *width, int *color)
         return false;
     }
 
-    if (ch=='6') *color = 1;
+    if (ch == '6') {
+        *color = 1;
+    }
 
     // skip comments
     ch = fgetc(fp);
@@ -322,8 +327,9 @@ bool ReadHeader_PxM(FILE *fp, int *height, int *width, int *color)
 
     /// LATER: not portable?
     int n=fscanf(fp, "%d%d%d", width, height, &maxval);
-    if (n!=3)
+    if (n != 3) {
         return false;
+    }
 
     fgetc(fp);
     if (maxval != 255)

--- a/src/libYARP_sig/src/yarp/sig/Matrix.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Matrix.cpp
@@ -49,7 +49,7 @@ bool yarp::sig::removeCols(const Matrix &in, Matrix &out, size_t first_col, size
     size_t nrows = in.rows();
     size_t ncols = in.cols();
     Matrix ret(nrows, ncols-how_many);
-    for(size_t r=0; r<nrows; r++)
+    for (size_t r = 0; r < nrows; r++) {
         for(size_t c_in=0,c_out=0;c_in<ncols; c_in++)
         {
             if (c_in==first_col)
@@ -60,6 +60,7 @@ bool yarp::sig::removeCols(const Matrix &in, Matrix &out, size_t first_col, size
             ret[r][c_out]=(in)[r][c_in];
             c_out++;
         }
+    }
     out=ret;
     return true;
 }
@@ -69,7 +70,7 @@ bool yarp::sig::removeRows(const Matrix &in, Matrix &out, size_t first_row, size
     size_t nrows = in.rows();
     size_t ncols = in.cols();
     Matrix ret(nrows-how_many, ncols);
-    for(size_t c=0; c<ncols; c++)
+    for (size_t c = 0; c < ncols; c++) {
         for(size_t r_in=0, r_out=0; r_in<nrows; r_in++)
         {
             if (r_in==first_row)
@@ -80,6 +81,7 @@ bool yarp::sig::removeRows(const Matrix &in, Matrix &out, size_t first_row, size
             ret[r_out][c]=(in)[r_in][c];
             r_out++;
         }
+    }
      out=ret;
      return true;
 }
@@ -90,8 +92,9 @@ bool yarp::sig::submatrix(const Matrix &in, Matrix &out, size_t r1, size_t r2, s
     const double *i=in.data()+in.cols()*r1+c1;
     const int offset=in.cols()-(c2-c1+1);
 
-    if(i == nullptr || t == nullptr)
+    if (i == nullptr || t == nullptr) {
         return false;
+    }
 
     for(size_t r=0;r<=(r2-r1);r++)
     {
@@ -111,7 +114,9 @@ bool Matrix::read(yarp::os::ConnectionReader& connection) {
     connection.convertTextMode();
     MatrixPortContentHeader header;
     bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     size_t r=rows();
     size_t c=cols();
     if (header.listLen > 0)
@@ -123,11 +128,12 @@ bool Matrix::read(yarp::os::ConnectionReader& connection) {
 
         int l=0;
         double *tmp=data();
-        for(l=0;l<header.listLen;l++)
-            tmp[l]=connection.expectFloat64();
-    }
-    else
+        for (l = 0; l < header.listLen; l++) {
+            tmp[l] = connection.expectFloat64();
+        }
+    } else {
         return false;
+    }
 
     return true;
 }
@@ -150,8 +156,9 @@ bool Matrix::write(yarp::os::ConnectionWriter& connection) const {
 
     int l=0;
     const double *tmp=data();
-    for(l=0;l<header.listLen;l++)
+    for (l = 0; l < header.listLen; l++) {
         connection.appendFloat64(tmp[l]);
+    }
 
     // if someone is foolish enough to connect in text mode,
     // let them see something readable.
@@ -189,12 +196,15 @@ std::string Matrix::toString(int precision, int width, const char* endRowStr) co
 
 void Matrix::updatePointers()
 {
-    if (matrix!=nullptr)
-        delete [] matrix;
+    if (matrix != nullptr) {
+        delete[] matrix;
+    }
 
     size_t r=0;
     matrix=new double* [nrows];
-    if (nrows>0) matrix[0]=storage;
+    if (nrows > 0) {
+        matrix[0] = storage;
+    }
     for(r=1;r<nrows; r++)
     {
         matrix[r]=matrix[r-1]+ncols;
@@ -203,12 +213,15 @@ void Matrix::updatePointers()
 
 const Matrix &Matrix::operator=(const Matrix &r)
 {
-    if (this == &r) return *this;
+    if (this == &r) {
+        return *this;
+    }
 
     if(nrows!=r.nrows || ncols!=r.ncols)
     {
-        if (storage)
-            delete [] storage;
+        if (storage) {
+            delete[] storage;
+        }
 
         nrows=r.nrows;
         ncols=r.ncols;
@@ -219,8 +232,9 @@ const Matrix &Matrix::operator=(const Matrix &r)
     }
     else
     {
-        if(!storage)
-            storage=new double[ncols*nrows];
+        if (!storage) {
+            storage = new double[ncols * nrows];
+        }
         memcpy(storage, r.storage, ncols*nrows*sizeof(double));
     }
 
@@ -230,25 +244,29 @@ const Matrix &Matrix::operator=(const Matrix &r)
 const Matrix &Matrix::operator=(double v)
 {
     size_t nelem = nrows*ncols;
-    for(size_t k=0; k<nelem; k++)
-        storage[k]=v;
+    for (size_t k = 0; k < nelem; k++) {
+        storage[k] = v;
+    }
 
     return *this;
 }
 
 Matrix::~Matrix()
 {
-    if (matrix!=nullptr)
-        delete [] matrix;
+    if (matrix != nullptr) {
+        delete[] matrix;
+    }
 
-    if (storage!=nullptr)
-        delete [] storage;
+    if (storage != nullptr) {
+        delete[] storage;
+    }
 }
 
 void Matrix::resize(size_t new_r, size_t new_c)
 {
-    if(new_r==nrows && new_c==ncols)
+    if (new_r == nrows && new_c == ncols) {
         return;
+    }
 
     auto* new_storage=new double[new_r*new_c];
 
@@ -312,7 +330,7 @@ Matrix Matrix::removeCols(size_t first_col, size_t how_many)
     Matrix ret;
     ret.resize(nrows, ncols-how_many);
 
-    for(size_t r=0; r<nrows; r++)
+    for (size_t r = 0; r < nrows; r++) {
         for(size_t c_in=0,c_out=0;c_in<ncols; c_in++)
         {
             if (c_in==first_col)
@@ -323,9 +341,11 @@ Matrix Matrix::removeCols(size_t first_col, size_t how_many)
             ret[r][c_out]=(*this)[r][c_in];
             c_out++;
         }
+    }
 
-    if (storage)
-      delete [] storage;
+    if (storage) {
+        delete[] storage;
+    }
 
     nrows=ret.nrows;
     ncols=ret.ncols;
@@ -340,7 +360,7 @@ Matrix Matrix::removeRows(size_t first_row, size_t how_many)
     Matrix ret;
     ret.resize(nrows-how_many, ncols);
 
-    for(size_t c=0; c<ncols; c++)
+    for (size_t c = 0; c < ncols; c++) {
         for(size_t r_in=0, r_out=0; r_in<nrows; r_in++)
         {
             if (r_in==first_row)
@@ -351,9 +371,11 @@ Matrix Matrix::removeRows(size_t first_row, size_t how_many)
             ret[r_out][c]=(*this)[r_in][c];
             r_out++;
         }
+    }
 
-    if (storage)
-        delete [] storage;
+    if (storage) {
+        delete[] storage;
+    }
 
     nrows=ret.nrows;
     ncols=ret.ncols;
@@ -368,9 +390,11 @@ Matrix Matrix::transposed() const
     Matrix ret;
     ret.resize(ncols, nrows);
 
-    for(size_t r=0; r<nrows; r++)
-        for(size_t c=0;c<ncols; c++)
-            ret[c][r]=(*this)[r][c];
+    for (size_t r = 0; r < nrows; r++) {
+        for (size_t c = 0; c < ncols; c++) {
+            ret[c][r] = (*this)[r][c];
+        }
+    }
 
     return ret;
 }
@@ -380,8 +404,9 @@ Vector Matrix::getRow(size_t r) const
     Vector ret;
     ret.resize(ncols);
 
-    for(size_t c=0;c<ncols;c++)
-        ret[c]=(*this)[r][c];
+    for (size_t c = 0; c < ncols; c++) {
+        ret[c] = (*this)[r][c];
+    }
 
     return ret;
 }
@@ -391,34 +416,39 @@ Vector Matrix::getCol(size_t c) const
     Vector ret;
     ret.resize(nrows);
 
-    for(size_t r=0;r<nrows;r++)
-        ret[r]=(*this)[r][c];
+    for (size_t r = 0; r < nrows; r++) {
+        ret[r] = (*this)[r][c];
+    }
 
     return ret;
 }
 
 Vector Matrix::subrow(size_t r, size_t c, size_t size) const
 {
-    if(r>=rows() || c+size-1>=cols())
+    if (r >= rows() || c + size - 1 >= cols()) {
         return Vector(0);
+    }
 
     Vector ret(size);
 
-    for(size_t i=0;i<size;i++)
-        ret[i]=(*this)[r][c+i];
+    for (size_t i = 0; i < size; i++) {
+        ret[i] = (*this)[r][c + i];
+    }
 
     return ret;
 }
 
 Vector Matrix::subcol(size_t r, size_t c, size_t size) const
 {
-    if(r+size-1>=rows() || c>=cols())
+    if (r + size - 1 >= rows() || c >= cols()) {
         return Vector(0);
+    }
 
     Vector ret(size);
 
-    for(size_t i=0;i<size;i++)
-        ret[i]=(*this)[r+i][c];
+    for (size_t i = 0; i < size; i++) {
+        ret[i] = (*this)[r + i][c];
+    }
 
     return ret;
 }
@@ -427,12 +457,14 @@ const Matrix &Matrix::eye()
 {
     zero();
     size_t tmpR=nrows;
-    if (ncols<nrows)
-        tmpR=ncols;
+    if (ncols < nrows) {
+        tmpR = ncols;
+    }
 
     size_t c=0;
-    for(size_t r=0; r<tmpR; r++,c++)
-        (*this)[r][c]=1.0;
+    for (size_t r = 0; r < tmpR; r++, c++) {
+        (*this)[r][c] = 1.0;
+    }
 
     return *this;
 }
@@ -441,12 +473,14 @@ const Matrix &Matrix::diagonal(const Vector &d)
 {
     zero();
     size_t tmpR=nrows;
-    if (ncols<nrows)
-        tmpR=ncols;
+    if (ncols < nrows) {
+        tmpR = ncols;
+    }
 
     size_t c=0;
-    for(size_t r=0; r<tmpR; r++,c++)
-        (*this)[r][c]=d[r];
+    for (size_t r = 0; r < tmpR; r++, c++) {
+        (*this)[r][c] = d[r];
+    }
 
     return *this;
 }
@@ -454,20 +488,23 @@ const Matrix &Matrix::diagonal(const Vector &d)
 bool Matrix::operator==(const yarp::sig::Matrix &r) const
 {
     //check dimensions first
-    if ( (rows()!=r.rows()) || (cols()!=r.cols()))
+    if ((rows() != r.rows()) || (cols() != r.cols())) {
         return false;
+    }
 
     const double *tmp1=data();
     const double *tmp2=r.data();
 
-    if(tmp1 == nullptr || tmp2 == nullptr)
+    if (tmp1 == nullptr || tmp2 == nullptr) {
         return false;
+    }
 
     int c=rows()*cols();
     while(c--)
     {
-        if (*tmp1++!=*tmp2++)
+        if (*tmp1++ != *tmp2++) {
             return false;
+        }
     }
 
     return true;
@@ -475,56 +512,67 @@ bool Matrix::operator==(const yarp::sig::Matrix &r) const
 
 bool Matrix::setRow(size_t row, const Vector &r)
 {
-    if((row>=nrows) || (r.length() != ncols))
+    if ((row >= nrows) || (r.length() != ncols)) {
         return false;
+    }
 
-    for(size_t c=0;c<ncols;c++)
-        (*this)[row][c]=r[c];
+    for (size_t c = 0; c < ncols; c++) {
+        (*this)[row][c] = r[c];
+    }
 
     return true;
 }
 
 bool Matrix::setCol(size_t col, const Vector &c)
 {
-    if((col>=ncols) || (c.length() != nrows))
+    if ((col >= ncols) || (c.length() != nrows)) {
         return false;
+    }
 
-    for(size_t r=0;r<nrows;r++)
-        (*this)[r][col]=c[r];
+    for (size_t r = 0; r < nrows; r++) {
+        (*this)[r][col] = c[r];
+    }
 
     return true;
 }
 
 bool Matrix::setSubmatrix(const yarp::sig::Matrix &m, size_t r, size_t c)
 {
-    if((c+m.cols()>ncols) || (r+m.rows()>nrows))
+    if ((c + m.cols() > ncols) || (r + m.rows() > nrows)) {
         return false;
+    }
 
-    for(size_t i=0;i<m.rows();i++)
-        for(size_t j=0;j<m.cols();j++)
-            (*this)[r+i][c+j] = m(i,j);
+    for (size_t i = 0; i < m.rows(); i++) {
+        for (size_t j = 0; j < m.cols(); j++) {
+            (*this)[r + i][c + j] = m(i, j);
+        }
+    }
     return true;
 }
 
 bool Matrix::setSubrow(const Vector &v, size_t r, size_t c)
 {
     size_t s = v.size();
-    if(r>=nrows || c+s-1>=(size_t)ncols)
+    if (r >= nrows || c + s - 1 >= (size_t)ncols) {
         return false;
+    }
 
-    for(size_t i=0;i<s;i++)
-        (*this)[r][i+c] = v[i];
+    for (size_t i = 0; i < s; i++) {
+        (*this)[r][i + c] = v[i];
+    }
     return true;
 }
 
 bool Matrix::setSubcol(const Vector &v, size_t r, size_t c)
 {
     size_t s = v.size();
-    if(r+s-1>=(size_t)nrows || c>=ncols)
+    if (r + s - 1 >= (size_t)nrows || c >= ncols) {
         return false;
+    }
 
-    for(size_t i=0;i<s;i++)
-        (*this)[r+i][c] = v[i];
+    for (size_t i = 0; i < s; i++) {
+        (*this)[r + i][c] = v[i];
+    }
     return true;
 }
 

--- a/src/libYARP_sig/src/yarp/sig/Sound.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Sound.cpp
@@ -101,12 +101,15 @@ void Sound::synchronize()
 
 Sound Sound::subSound(size_t first_sample, size_t last_sample)
 {
-    if (last_sample  > this->m_samples)
+    if (last_sample > this->m_samples) {
         last_sample = m_samples;
-    if (first_sample > this->m_samples)
+    }
+    if (first_sample > this->m_samples) {
         first_sample = m_samples;
-    if (last_sample < first_sample)
+    }
+    if (last_sample < first_sample) {
         last_sample = first_sample;
+    }
 
     Sound s;
 
@@ -128,8 +131,9 @@ Sound Sound::subSound(size_t first_sample, size_t last_sample)
     size_t j=0;
     for (size_t i=first_sample; i<last_sample; i++)
     {
-        for (size_t c=0; c< this->m_channels; c++)
-            s.set(this->get(i,c),j,c);
+        for (size_t c = 0; c < this->m_channels; c++) {
+            s.set(this->get(i, c), j, c);
+        }
         j++;
     }
 
@@ -192,7 +196,9 @@ void Sound::clear()
 
 bool Sound::clearChannel(size_t chan)
 {
-    if (chan > this->m_channels) return false;
+    if (chan > this->m_channels) {
+        return false;
+    }
     for (size_t i = 0; i < this->m_samples; i++)
     {
         set(0, i, chan);
@@ -292,10 +298,18 @@ Sound Sound::extractChannelAsSound(size_t channel_id) const
 
 bool Sound::operator==(const Sound& alt) const
 {
-    if (this->m_channels != alt.getChannels()) return false;
-    if (this->m_bytesPerSample != alt.getBytesPerSample()) return false;
-    if (this->m_frequency != alt.getFrequency()) return false;
-    if (this->m_samples != alt.getSamples()) return false;
+    if (this->m_channels != alt.getChannels()) {
+        return false;
+    }
+    if (this->m_bytesPerSample != alt.getBytesPerSample()) {
+        return false;
+    }
+    if (this->m_frequency != alt.getFrequency()) {
+        return false;
+    }
+    if (this->m_samples != alt.getSamples()) {
+        return false;
+    }
 
     for (size_t ch = 0; ch < this->m_channels; ch++)
     {
@@ -313,8 +327,12 @@ bool Sound::operator==(const Sound& alt) const
 
 bool Sound::replaceChannel(size_t id, Sound schannel)
 {
-    if (schannel.getChannels() != 1) return false;
-    if (this->m_samples != schannel.getSamples()) return false;
+    if (schannel.getChannels() != 1) {
+        return false;
+    }
+    if (this->m_samples != schannel.getSamples()) {
+        return false;
+    }
     for (size_t s = 0; s < this->m_samples; s++)
     {
         this->setSafe(schannel.getSafe(s, 0), s, id);

--- a/src/libYARP_sig/src/yarp/sig/SoundFileMp3.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundFileMp3.cpp
@@ -108,8 +108,9 @@ int check_sample_fmt(const AVCodec * codec, enum AVSampleFormat sample_fmt)
 
     while (*p != AV_SAMPLE_FMT_NONE)
     {
-        if (*p == sample_fmt)
+        if (*p == sample_fmt) {
             return 1;
+        }
         p++;
     }
     return 0;
@@ -120,14 +121,16 @@ int select_sample_rate(const AVCodec * codec)
     const int* p;
     int best_samplerate = 0;
 
-    if (!codec->supported_samplerates)
+    if (!codec->supported_samplerates) {
         return 44100;
+    }
 
     p = codec->supported_samplerates;
     while (*p)
     {
-         if (!best_samplerate || abs(44100 - *p) < abs(44100 - best_samplerate))
+        if (!best_samplerate || abs(44100 - *p) < abs(44100 - best_samplerate)) {
             best_samplerate = *p;
+        }
          p++;
     }
     return best_samplerate;
@@ -172,8 +175,9 @@ int select_channel_layout(const AVCodec * codec)
    uint64_t best_ch_layout = 0;
    int best_nb_channels = 0;
 
-   if (!codec->channel_layouts)
-      return AV_CH_LAYOUT_STEREO;
+   if (!codec->channel_layouts) {
+       return AV_CH_LAYOUT_STEREO;
+   }
 
    p = codec->channel_layouts;
    while (*p)
@@ -297,13 +301,16 @@ bool yarp::sig::file::write_mp3_file(const Sound& sound_data, const char* filena
     for (size_t i = 0; i < nframes; i++)
     {
         ret = av_frame_make_writable(frame);
-        if (ret < 0)  exit(1);
+        if (ret < 0) {
+            exit(1);
+        }
 
         samples = (uint16_t*)frame->data[0];
         for (int j = 0; j < c->frame_size; j++)
         {
-            for (int k = 0; k < c->channels; k++)
-                samples[j*c->channels + k] = sound_data.get(j+i* c->frame_size,k);
+            for (int k = 0; k < c->channels; k++) {
+                samples[j * c->channels + k] = sound_data.get(j + i * c->frame_size, k);
+            }
         }
         if (encode(c, frame, pkt, fos) == false)
         {
@@ -403,16 +410,18 @@ bool read_mp3_istream(Sound& sound_data, std::istream& istream)
         }
         data += ret;
         data_size -= ret;
-        if (pkt->size)
+        if (pkt->size) {
             decode(c, pkt, decoded_frame, sound_data);
+        }
         if (data_size < AUDIO_REFILL_THRESH)
         {
             memmove(inbuf, data, data_size);
             data = inbuf;
             istream.read((char*)(data + data_size), AUDIO_INBUF_SIZE - data_size);
             len = istream.gcount();
-            if (len > 0)
+            if (len > 0) {
                 data_size += len;
+            }
         }
     }
     // flush the decoder

--- a/src/libYARP_sig/src/yarp/sig/Vector.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Vector.cpp
@@ -53,17 +53,22 @@ bool VectorBase::read(yarp::os::ConnectionReader& connection) {
     connection.convertTextMode();
     VectorPortContentHeader header;
     bool ok = connection.expectBlock((char*)&header, sizeof(header));
-    if (!ok) return false;
+    if (!ok) {
+        return false;
+    }
     if (header.listLen > 0 &&
       header.listTag == (BOTTLE_TAG_LIST | getBottleTag()))
     {
-        if ((size_t)getListSize() != (size_t)(header.listLen))
+        if ((size_t)getListSize() != (size_t)(header.listLen)) {
             resize(header.listLen);
+        }
         char* ptr = getMemoryBlock();
         yCAssert(VECTOR, ptr != nullptr);
         int elemSize=getElementSize();
         ok = connection.expectBlock(ptr, elemSize*header.listLen);
-        if (!ok) return false;
+        if (!ok) {
+            return false;
+        }
     } else {
         return false;
     }

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -387,8 +387,9 @@ public:
             }
         }
 
-        if (length()>=1)
-            return ret.substr(0, ret.length()-1);
+        if (length() >= 1) {
+            return ret.substr(0, ret.length() - 1);
+        }
         return ret;
     }
 
@@ -404,8 +405,9 @@ public:
         if ((first<=last)&&((int)last<(int)this->size()))
         {
             ret.resize(last-first+1);
-            for (unsigned int k=first; k<=last; k++)
-                ret[k-first]=(*this)[k];
+            for (unsigned int k = first; k <= last; k++) {
+                ret[k - first] = (*this)[k];
+            }
         }
         return ret;
     }
@@ -421,10 +423,12 @@ public:
      */
     bool setSubvector(int position, const VectorOf<T> &v)
     {
-        if (position+v.size() > this->size())
+        if (position + v.size() > this->size()) {
             return false;
-        for (size_t i=0;i<v.size();i++)
-            (*this)[position+i] = v(i);
+        }
+        for (size_t i = 0; i < v.size(); i++) {
+            (*this)[position + i] = v(i);
+        }
         return true;
     }
 

--- a/src/libYARP_sig/src/yarp/sig/impl/DeBayer.h
+++ b/src/libYARP_sig/src/yarp/sig/impl/DeBayer.h
@@ -18,24 +18,20 @@
 
 inline bool isBayer8(int v)
 {
-    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG8) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR8) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG8) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB8))
+    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG8) || (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR8) || (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG8) || (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB8)) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
 
 inline bool isBayer16(int v)
 {
-    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG16) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR16) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG16) ||
-        (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB16))
+    if ((v == VOCAB_PIXEL_ENCODING_BAYER_GRBG16) || (v == VOCAB_PIXEL_ENCODING_BAYER_BGGR16) || (v == VOCAB_PIXEL_ENCODING_BAYER_GBRG16) || (v == VOCAB_PIXEL_ENCODING_BAYER_RGGB16)) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
 
 /*

--- a/src/libYARP_sig/src/yarp/sig/impl/IplImage.cpp
+++ b/src/libYARP_sig/src/yarp/sig/impl/IplImage.cpp
@@ -13,11 +13,12 @@
 // this was from iplUtil.cpp
 bool compareHeader(IplImage* A, IplImage* B)
 {
-    if( A->nChannels == B->nChannels && !strcmp(A->colorModel, B->colorModel) && !strcmp(A->channelSeq,B->channelSeq) && A->width == B->width
-        && A->height == B->height)
+    if (A->nChannels == B->nChannels && !strcmp(A->colorModel, B->colorModel) && !strcmp(A->channelSeq, B->channelSeq) && A->width == B->width
+        && A->height == B->height) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
 
 ///
@@ -44,7 +45,9 @@ T* AllocAligned (int size)
 template <class T>
 void FreeAligned (T* ptr)
 {
-    if (ptr == nullptr) return;
+    if (ptr == nullptr) {
+        return;
+    }
 
     const char addbytes = *(((char *)ptr) - 1);
     delete[] reinterpret_cast<T*>(((char *)ptr) - addbytes);
@@ -147,8 +150,9 @@ IPLAPIIMPL(void,iplGetConvKernelFP,(IplConvKernelFP* kernel,int* nCols, int* nRo
 
 IPLAPIIMPL(void, iplDeleteConvKernel,(IplConvKernel* kernel))
 {
-    if (kernel == nullptr)
+    if (kernel == nullptr) {
         return;
+    }
 
     delete[] kernel->values;
     delete kernel;
@@ -156,8 +160,9 @@ IPLAPIIMPL(void, iplDeleteConvKernel,(IplConvKernel* kernel))
 
 IPLAPIIMPL(void, iplDeleteConvKernelFP,(IplConvKernelFP* kernel))
 {
-    if (kernel == nullptr)
+    if (kernel == nullptr) {
         return;
+    }
 
     delete[] kernel->values;
     delete kernel;
@@ -225,18 +230,19 @@ IPLAPIIMPL(void, iplConvolve2D,(IplImage* srcImage, IplImage* dstImage,
                         for (int j = borderx; j < w - borderx; j++)
                             {
                                 tmp = 0;
-                                for (int k = 0; k < krows; k++)
+                                for (int k = 0; k < krows; k++) {
                                     for (int l = 0; l < kcols; l++)
                                         {
                                             tmp += srcImage->imageData[(i + k - bordery) * w + j + l - borderx]
                                                 * values[ksize - k * kcols - l - 1];
-                                        }
+                                    }
+                                }
                                 tmp >>= ktmp->nShiftR;
-                                if (tmp > 255)
+                                if (tmp > 255) {
                                     tmp = 255;
-                                else
-                                    if (tmp < 0)
-                                        tmp = 0;
+                                } else if (tmp < 0) {
+                                    tmp = 0;
+                                }
                                 __tmp_res[i * w + j] = char(tmp);
                             }
                     }
@@ -253,18 +259,19 @@ IPLAPIIMPL(void, iplConvolve2D,(IplImage* srcImage, IplImage* dstImage,
                         for (int j = borderx; j < w - borderx; j++)
                             {
                                 tmp = 0;
-                                for (int k = 0; k < krows; k++)
+                                for (int k = 0; k < krows; k++) {
                                     for (int l = 0; l < kcols; l++)
                                         {
                                             tmp += srcImage->imageData[(i + k - bordery) * w + j + l - borderx]
                                                 * values[ksize - k * kcols - l - 1];
-                                        }
+                                    }
+                                }
                                 tmp >>= ktmp->nShiftR;
-                                if (tmp > 127)
+                                if (tmp > 127) {
                                     tmp = 127;
-                                else
-                                    if (tmp < -128)
-                                        tmp = -128;
+                                } else if (tmp < -128) {
+                                    tmp = -128;
+                                }
                                 __tmp_res[i * w + j] = char(tmp);
                             }
                     }
@@ -344,12 +351,13 @@ IPLAPIIMPL(void, iplConvolve2DFP,(IplImage* srcImage, IplImage* dstImage,
                     for (int j = borderx; j < w - borderx; j++)
                         {
                             tmp = 0;
-                            for (int k = 0; k < krows; k++)
+                            for (int k = 0; k < krows; k++) {
                                 for (int l = 0; l < kcols; l++)
                                     {
                                         tmp += source[(i + k - bordery) * w + j + l - borderx]
                                             * values[ksize - k * kcols - l - 1];
-                                    }
+                                }
+                            }
                             dest[i * w + j] = tmp;
                         }
                 }
@@ -365,12 +373,13 @@ IPLAPIIMPL(void, iplConvolve2DFP,(IplImage* srcImage, IplImage* dstImage,
                     for (int j = borderx; j < w - borderx; j++)
                         {
                             tmp = 0;
-                            for (int k = 0; k < krows; k++)
+                            for (int k = 0; k < krows; k++) {
                                 for (int l = 0; l < kcols; l++)
                                     {
                                         tmp += source[(i + k - bordery) * w + j + l - borderx]
                                             * values[ksize - k * kcols - l - 1];
-                                    }
+                                }
+                            }
                             __tmp_res[i * w + j] = tmp;
                         }
                 }
@@ -563,11 +572,11 @@ IPLAPIIMPL(void, iplConvolveSep2D,(IplImage* srcImage, IplImage* dstImage,
                                                     * xvalues[xksize - k - 1];
                                             }
                                         tmp >>= xKernel->nShiftR;
-                                        if (tmp > 255)
+                                        if (tmp > 255) {
                                             tmp = 255;
-                                        else
-                                            if (tmp < 0)
-                                                tmp = 0;
+                                        } else if (tmp < 0) {
+                                            tmp = 0;
+                                        }
                                         __tmp_res[i * w + j] = char(tmp);
                                     }
                             }
@@ -589,11 +598,11 @@ IPLAPIIMPL(void, iplConvolveSep2D,(IplImage* srcImage, IplImage* dstImage,
                                                     * yvalues[yksize - k - 1];
                                             }
                                         tmp >>= yKernel->nShiftR;
-                                        if (tmp > 255)
+                                        if (tmp > 255) {
                                             tmp = 255;
-                                        else
-                                            if (tmp < 0)
-                                                tmp = 0;
+                                        } else if (tmp < 0) {
+                                            tmp = 0;
+                                        }
                                         dstImage->imageData[i * w + j] = char(tmp);
                                     }
                             }
@@ -617,11 +626,11 @@ IPLAPIIMPL(void, iplConvolveSep2D,(IplImage* srcImage, IplImage* dstImage,
                                                     * xvalues[xksize - k - 1];
                                             }
                                         tmp >>= xKernel->nShiftR;
-                                        if (tmp > 127)
+                                        if (tmp > 127) {
                                             tmp = 127;
-                                        else
-                                            if (tmp < -128)
-                                                tmp = -128;
+                                        } else if (tmp < -128) {
+                                            tmp = -128;
+                                        }
                                         __tmp_res[i * w + j] = char(tmp);
                                     }
                             }
@@ -641,11 +650,11 @@ IPLAPIIMPL(void, iplConvolveSep2D,(IplImage* srcImage, IplImage* dstImage,
                                                     * yvalues[yksize - k - 1];
                                             }
                                         tmp >>= yKernel->nShiftR;
-                                        if (tmp > 127)
+                                        if (tmp > 127) {
                                             tmp = 127;
-                                        else
-                                            if (tmp < -128)
-                                                tmp = -128;
+                                        } else if (tmp < -128) {
+                                            tmp = -128;
+                                        }
                                         dstImage->imageData[i * w + j] = char(tmp);
                                     }
                             }
@@ -666,10 +675,11 @@ IPLAPIIMPL(void, iplAllocateImage,(IplImage* image, int doFill, int fillValue))
     image->imageData = AllocAligned<char> (image->imageSize); // new char[image->imageSize];
     yAssert(image->imageData != nullptr);
 
-    if (image->origin == IPL_ORIGIN_TL)
+    if (image->origin == IPL_ORIGIN_TL) {
         image->imageDataOrigin = image->imageData + image->imageSize - image->widthStep;
-    else
+    } else {
         image->imageDataOrigin = image->imageData;
+    }
 
     if (doFill)
         {
@@ -698,10 +708,11 @@ IPLAPIIMPL(void, iplAllocateImageFP,(IplImage* image, int doFill, float fillValu
     image->imageData = AllocAligned<char> (image->imageSize);
     yAssert(image->imageData != nullptr);
 
-    if (image->origin == IPL_ORIGIN_TL)
+    if (image->origin == IPL_ORIGIN_TL) {
         image->imageDataOrigin = image->imageData + image->imageSize - image->widthStep;
-    else
+    } else {
         image->imageDataOrigin = image->imageData;
+    }
 
     if (doFill)
         {
@@ -727,8 +738,9 @@ IPLAPIIMPL(void, iplAllocateImageFP,(IplImage* image, int doFill, float fillValu
 
 IPLAPIIMPL(void, iplDeallocateImage,(IplImage* image))
 {
-    if (image->imageData != nullptr)
-        FreeAligned<char> (image->imageData); ///delete[] image->imageData;
+    if (image->imageData != nullptr) {
+        FreeAligned<char>(image->imageData); ///delete[] image->imageData;
+    }
     image->imageData = nullptr;
 
     // Not allocated.
@@ -881,8 +893,9 @@ IPLAPIIMPL(void, iplCopy, (IplImage* srcImage, IplImage* dstImage))
 
 IPLAPIIMPL(void, iplDeallocateHeader,(IplImage* image))
 {
-    if (image == nullptr)
+    if (image == nullptr) {
         return;
+    }
 
     yAssert(image->nSize == sizeof(IplImage));
     if (image->imageData != nullptr)
@@ -918,12 +931,13 @@ IPLAPIIMPL(void, iplDeallocate,(IplImage* image, int flag))
 
 IPLAPIIMPL(void,iplSetBorderMode,(IplImage *src,int mode,int border,int constVal))
 {
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; i++) {
         if ((border >> i) & 0x1)
             {
                 src->BorderMode[i] = mode;
                 src->BorderConst[i] = constVal;
-            }
+        }
+    }
 }
 
 // this is ok only for 8 bits pixel/planes images. RGB and HSV are ok too.
@@ -941,8 +955,9 @@ IPLAPIIMPL(void, iplSetFP, (IplImage* image, float fillValue))
 
     const int size = image->imageSize / sizeof(float);
     auto* tmp = reinterpret_cast<float*>(image->imageData);
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i < size; i++) {
         *tmp++ = fillValue;
+    }
 }
 
 // only 8 bits supported. Clipping is carried out to be ipl compatible.
@@ -965,11 +980,11 @@ IPLAPIIMPL(void, iplAddS,(IplImage* srcImage, IplImage* dstImage, int value))
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src++ + value;
-                        if (tmp < 0)
+                        if (tmp < 0) {
                             tmp = 0;
-                        else
-                            if (tmp > 255)
-                                tmp = 255;
+                        } else if (tmp > 255) {
+                            tmp = 255;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -986,11 +1001,11 @@ IPLAPIIMPL(void, iplAddS,(IplImage* srcImage, IplImage* dstImage, int value))
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src++ + value;
-                        if (tmp < -128)
+                        if (tmp < -128) {
                             tmp = -128;
-                        else
-                            if (tmp > 127)
-                                tmp = 127;
+                        } else if (tmp > 127) {
+                            tmp = 127;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -1027,8 +1042,9 @@ IPLAPIIMPL(void, iplAdd,(IplImage* srcImageA, IplImage* srcImageB,
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src1++ + *src2++;
-                        if (tmp > 255)
+                        if (tmp > 255) {
                             tmp = 255;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -1046,11 +1062,11 @@ IPLAPIIMPL(void, iplAdd,(IplImage* srcImageA, IplImage* srcImageB,
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src1++ + *src2++;
-                        if (tmp < -128)
+                        if (tmp < -128) {
                             tmp = -128;
-                        else
-                            if (tmp > 127)
-                                tmp = 127;
+                        } else if (tmp > 127) {
+                            tmp = 127;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -1098,10 +1114,12 @@ IPLAPIIMPL(void, iplSubtract,(IplImage* srcImageA, IplImage* srcImageB,
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src1++ - *src2++;
-                        if (tmp < 0)
+                        if (tmp < 0) {
                             tmp = 0;
-                        if (tmp > 255)
+                        }
+                        if (tmp > 255) {
                             tmp = 255;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -1119,11 +1137,11 @@ IPLAPIIMPL(void, iplSubtract,(IplImage* srcImageA, IplImage* srcImageB,
                 for (int i = 0; i < size; i++)
                     {
                         tmp = *src1++ - *src2++;
-                        if (tmp < -128)
+                        if (tmp < -128) {
                             tmp = -128;
-                        else
-                            if (tmp > 127)
-                                tmp = 127;
+                        } else if (tmp > 127) {
+                            tmp = 127;
+                        }
                         *dst++ = char(tmp);
                     }
             }
@@ -1166,16 +1184,17 @@ IPLAPIIMPL(void, iplSubtractS,(IplImage* srcImage, IplImage* dstImage, int value
 
                 for (int i = 0; i < size; i++)
                     {
-                        if (flip)
-                            tmp = value - *src++;
-                        else
-                            tmp = *src++ - value;
+                    if (flip) {
+                        tmp = value - *src++;
+                    } else {
+                        tmp = *src++ - value;
+                    }
 
-                        if (tmp < 0)
-                            tmp = 0;
-                        else
-                            if (tmp > 255)
-                                tmp = 255;
+                    if (tmp < 0) {
+                        tmp = 0;
+                    } else if (tmp > 255) {
+                        tmp = 255;
+                    }
                         *dst++ = char(tmp);
                     }
             }
@@ -1191,16 +1210,17 @@ IPLAPIIMPL(void, iplSubtractS,(IplImage* srcImage, IplImage* dstImage, int value
 
                 for (int i = 0; i < size; i++)
                     {
-                        if (flip)
-                            tmp = value - *src++;
-                        else
-                            tmp = *src++ - value;
+                    if (flip) {
+                        tmp = value - *src++;
+                    } else {
+                        tmp = *src++ - value;
+                    }
 
-                        if (tmp < -128)
-                            tmp = -128;
-                        else
-                            if (tmp > 127)
-                                tmp = 127;
+                    if (tmp < -128) {
+                        tmp = -128;
+                    } else if (tmp > 127) {
+                        tmp = 127;
+                    }
                         *dst++ = char(tmp);
                     }
             }
@@ -1247,10 +1267,11 @@ IPLAPIIMPL(void, iplAbs,(IplImage* srcImage, IplImage* dstImage))
 
                 for (int i = 0; i < size; i++)
                     {
-                        if (*src < 0)
-                            *dst++ = -*src++;
-                        else
-                            *dst++ = *src++;
+                    if (*src < 0) {
+                        *dst++ = -*src++;
+                    } else {
+                        *dst++ = *src++;
+                    }
                     }
             }
             break;
@@ -1274,10 +1295,11 @@ IPLAPIIMPL(void, iplThreshold, (IplImage* srcImage, IplImage* dstImage, int thre
 
                 for (int i = 0; i < size; i++)
                     {
-                        if (*src++ < threshold)
-                            *dst++ = 0;
-                        else
-                            *dst++ = 255;
+                    if (*src++ < threshold) {
+                        *dst++ = 0;
+                    } else {
+                        *dst++ = 255;
+                    }
                     }
             }
             break;
@@ -1290,10 +1312,11 @@ IPLAPIIMPL(void, iplThreshold, (IplImage* srcImage, IplImage* dstImage, int thre
 
                 for (int i = 0; i < size; i++)
                     {
-                        if (*src++ < threshold)
-                            *dst++ = -128;
-                        else
-                            *dst++ = 127;
+                    if (*src++ < threshold) {
+                        *dst++ = -128;
+                    } else {
+                        *dst++ = 127;
+                    }
                     }
             }
             break;
@@ -1373,27 +1396,30 @@ IPLAPIIMPL(void, iplRGB2HSV,(IplImage* rgbImage, IplImage* hsvImage))
             if (red > green && red > blue)
                 {
                     max = red;
-                    if (green > blue)
+                    if (green > blue) {
                         min = blue;
-                    else
+                    } else {
                         min = green;
+                    }
                 }
             else
                 if (green > red && green > blue)
                     {
                         max = green;
-                        if (red > blue)
+                        if (red > blue) {
                             min = blue;
-                        else
+                        } else {
                             min = red;
+                        }
                     }
                 else
                     {
                         max = blue;
-                        if (red > green)
+                        if (red > green) {
                             min = green;
-                        else
+                        } else {
                             min = red;
+                        }
                     }
 
             // value
@@ -1404,42 +1430,42 @@ IPLAPIIMPL(void, iplRGB2HSV,(IplImage* rgbImage, IplImage* hsvImage))
             if (max != 0.0)
                 {
                     sat = *ddata1 = (unsigned char)(255 * (max - min) / max);
-                }
-            else
+            } else {
                 sat = *ddata1 = 0;
+            }
             ddata1 += 3;
 
             // hue
-            if (sat == 0)
+            if (sat == 0) {
                 *ddata0 = 0;
-            else
-                {
-                    double rc = (max - red) / (max - min);
-                    double gc = (max - green) / (max - min);
-                    double bc = (max - blue) / (max - min);
-                    if (red == max)
-                        hue = bc - gc;
-                    else
-                        if (green == max)
-                            hue = 2 + rc - bc;
-                        else
-                            if (blue == max)
-                                hue = 4 + gc - rc;
-
-                    hue *= 60.0;
-                    if (hue < 0.0)
-                        hue += 360.0;
-
-                    yAssert(hue >= 0.0 && hue < 360.0);
-                    // IPL 2.5 compatibility. Scaling to 0-255
-                    // there's a little chance that the value rounds to 256.0!
-                    // need clipping rather than truncation.
-                    hue = (hue / 360.0 * 256.0);
-                    if (hue == 256.0)
-                        hue = 255.0;
-
-                    *ddata0 = (unsigned char)(hue);
+            } else {
+                double rc = (max - red) / (max - min);
+                double gc = (max - green) / (max - min);
+                double bc = (max - blue) / (max - min);
+                if (red == max) {
+                    hue = bc - gc;
+                } else if (green == max) {
+                    hue = 2 + rc - bc;
+                } else if (blue == max) {
+                    hue = 4 + gc - rc;
                 }
+
+                hue *= 60.0;
+                if (hue < 0.0) {
+                    hue += 360.0;
+                }
+
+                yAssert(hue >= 0.0 && hue < 360.0);
+                // IPL 2.5 compatibility. Scaling to 0-255
+                // there's a little chance that the value rounds to 256.0!
+                // need clipping rather than truncation.
+                hue = (hue / 360.0 * 256.0);
+                if (hue == 256.0) {
+                    hue = 255.0;
+                }
+
+                *ddata0 = (unsigned char)(hue);
+            }
 
             ddata0 += 3;
         }

--- a/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireBottle.h
+++ b/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireBottle.h
@@ -38,13 +38,17 @@ public:
 
     size_t length(size_t index) const override {
         index += payload_index;
-        if (index==payload_index) return delegate->length(index)-payload_offset;
+        if (index == payload_index) {
+            return delegate->length(index) - payload_offset;
+        }
         return delegate->length(index);
     }
 
     const char *data(size_t index) const override {
         index += payload_index;
-        if (index==payload_index) return delegate->data(index)+payload_offset;
+        if (index == payload_index) {
+            return delegate->data(index) + payload_offset;
+        }
         return delegate->data(index);
     }
 

--- a/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireImage.h
+++ b/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireImage.h
@@ -71,7 +71,9 @@ public:
         image = &img;
         yarp::os::ConnectionWriter *pbuf =
             yarp::os::ConnectionWriter::createBufferedConnectionWriter();
-        if (!pbuf) ::exit(1);
+        if (!pbuf) {
+            ::exit(1);
+        }
         yarp::os::ConnectionWriter& buf = *pbuf;
         yarp::os::StringOutputStream ss;
         // probably need to translate encoding format better, but at

--- a/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireTwiddler.cpp
+++ b/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireTwiddler.cpp
@@ -52,7 +52,9 @@ int WireTwiddler::configure(Bottle& desc, int offset, bool& ignored,
         return offset;
     }
     if (kind=="skip"||kind=="compute") {
-        if (kind=="compute") computing = true;
+        if (kind == "compute") {
+            computing = true;
+        }
         ignore = true;
         var = kind = desc.get(offset).asString();
         offset++;
@@ -78,7 +80,9 @@ int WireTwiddler::configure(Bottle& desc, int offset, bool& ignored,
     }
     int len = 1;
     bool data = false;
-    if (computing) data = true;
+    if (computing) {
+        data = true;
+    }
     if (is_vector||is_list) {
         Value v = desc.get(offset);
         offset++;
@@ -169,7 +173,9 @@ int WireTwiddler::configure(Bottle& desc, int offset, bool& ignored,
             buffer.push_back(BOTTLE_TAG_LIST);
             buffer.push_back(len);
         } else {
-            if (!item) buffer.push_back(tag);
+            if (!item) {
+                buffer.push_back(tag);
+            }
         }
     }
 
@@ -204,7 +210,9 @@ int WireTwiddler::configure(Bottle& desc, int offset, bool& ignored,
         while (i<len) {
             bool ign = false;
             offset = configure(desc,offset,ign,kind);
-            if (!ign) i++;
+            if (!ign) {
+                i++;
+            }
         }
     }
     return offset;
@@ -258,7 +266,9 @@ bool WireTwiddler::configure(const char *txt, const char *prompt) {
             gap.byte_length = 0;
         }
     }
-    if (dbg_flag) show();
+    if (dbg_flag) {
+        show();
+    }
     return at == desc.size();
 }
 
@@ -309,8 +319,12 @@ std::string WireTwiddler::fromTemplate(const yarp::os::Bottle& msg) {
     for (int i=0; i<len; i++) {
         Value&v = msg.get(i);
         int icode = v.getCode();
-        if (i==0) code = icode;
-        if (icode!=code) code = -1;
+        if (i == 0) {
+            code = icode;
+        }
+        if (icode != code) {
+            code = -1;
+        }
     }
     string codeName = nameThatCode(code);
     if (code == -1) {
@@ -380,7 +394,9 @@ std::string WireTwiddler::toString() const {
             }
             item += buf;
         }
-        if (result!="") result += " ";
+        if (result != "") {
+            result += " ";
+        }
         result += item;
     }
     return result;
@@ -464,10 +480,9 @@ void WireTwiddlerReader::compute(const WireTwiddlerGap& gap) {
         case yarp::os::createVocab32('b', 'a', 'y', 'e'):
             bpp = 1;
             translated_encoding = VOCAB_PIXEL_MONO;
-            if (encoding == "bayer_grbg8")
+            if (encoding == "bayer_grbg8") {
                 translated_encoding = VOCAB_PIXEL_ENCODING_BAYER_GRBG8;
-            else
-            {
+            } else {
                 fprintf(stderr, "Warning automatic debayering not yet supported, keeping raw format.\n");
             }
 
@@ -549,7 +564,9 @@ yarp::conf::ssize_t WireTwiddlerReader::read(Bytes& b) {
             dbg_printf("LOOKING TO EXTERNAL\n");
             Bytes bytes(reinterpret_cast<char*>(&lengthBuffer), sizeof(NetInt32));
             int r = is.readFull(bytes);
-            if (r!=sizeof(NetInt32)) return -1;
+            if (r != sizeof(NetInt32)) {
+                return -1;
+            }
             dbg_printf("Read length %d\n", lengthBuffer);
             pending_length = sizeof(lengthBuffer);
             if (gap.length==-1) {
@@ -590,7 +607,9 @@ yarp::conf::ssize_t WireTwiddlerReader::read(Bytes& b) {
                 dbg_printf("Checking string length\n");
                 Bytes bytes(reinterpret_cast<char*>(&lengthBuffer), sizeof(NetInt32));
                 int r = is.readFull(bytes);
-                if (r!=sizeof(NetInt32)) return -1;
+                if (r != sizeof(NetInt32)) {
+                    return -1;
+                }
                 dbg_printf("Read length %d\n", lengthBuffer);
                 pending_string_length = sizeof(lengthBuffer);
                 pending_string_data = lengthBuffer;
@@ -628,7 +647,9 @@ yarp::conf::ssize_t WireTwiddlerReader::read(Bytes& b) {
             }
         }
         int extern_length = gap.length * gap.unit_length;
-        if (gap.unit_length<0||gap.length<0) extern_length = override_length;
+        if (gap.unit_length < 0 || gap.length < 0) {
+            extern_length = override_length;
+        }
         dbg_printf("extern_length %d\n", extern_length);
 
         if (extern_length>sent-consumed) {
@@ -720,7 +741,9 @@ bool WireTwiddlerWriter::update() {
     dbg_printf("Parent headers %zu blocks %zu\n", parent->headerLength(), parent->length());
 
     for (int i=0; i<twiddler->getGapCount(); i++) {
-        if (errorState) return false;
+        if (errorState) {
+            return false;
+        }
         std::string item;
         const WireTwiddlerGap& gap = twiddler->getGap(i);
         if (gap.buffer_length!=0) {
@@ -746,7 +769,9 @@ bool WireTwiddlerWriter::update() {
                     if (gap.unit_length!=gap.wire_unit_length) {
                         dbg_printf("Need to tweak length (not correct for neg numbers yet)...\n");
                         for (int i=0; i<gap.length; i++) {
-                            if (errorState) return false;
+                            if (errorState) {
+                                return false;
+                            }
                             transform(gap);
                         }
                     } else {
@@ -789,19 +814,25 @@ bool WireTwiddlerWriter::pad(size_t len) {
 bool WireTwiddlerWriter::readLengthAndPass(int unitLength,
                                            const WireTwiddlerGap *gap) {
     int len = readLength();
-    if (len==0) return false;
+    if (len == 0) {
+        return false;
+    }
     if (unitLength!=-1) {
         if (gap == nullptr || gap->wire_unit_length == unitLength) {
             advance(unitLength*len,true);
         } else {
             for (int i=0; i<len; i++) {
-                if (!transform(*gap)) return false;
+                if (!transform(*gap)) {
+                    return false;
+                }
             }
         }
     } else {
         for (int i=0; i<len; i++) {
             bool ok = readLengthAndPass(1,gap);
-            if (!ok) return false;
+            if (!ok) {
+                return false;
+            }
         }
     }
     return true;
@@ -841,8 +872,12 @@ int WireTwiddlerWriter::readLength() {
 bool WireTwiddlerWriter::advance(int length, bool shouldEmit,
                                  bool shouldAccum, bool shouldCheck) {
     accumOffset = 0;
-    if (length==0) return true;
-    if (length<0) return false;
+    if (length == 0) {
+        return true;
+    }
+    if (length < 0) {
+        return false;
+    }
     while (length>0) {
         if (blockPtr == nullptr) {
             blockPtr = parent->data(block);
@@ -861,7 +896,9 @@ bool WireTwiddlerWriter::advance(int length, bool shouldEmit,
             dbg_printf("  moved on to block %d\n",block);
             continue;
         }
-        if (rem>length) rem = length;
+        if (rem > length) {
+            rem = length;
+        }
         if (shouldCheck) {
             dbg_printf("Type check against %ld\n", (long int)activeCheck);
             int result = memcmp(activeCheck,blockPtr+offset,rem);

--- a/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireTwiddler.h
+++ b/src/libYARP_wire_rep_utils/src/yarp/wire_rep_utils/WireTwiddler.h
@@ -74,7 +74,9 @@ public:
     }
 
     virtual ~WireTwiddler() {
-        if (writer) delete writer;
+        if (writer) {
+            delete writer;
+        }
         writer = nullptr;
     }
 
@@ -314,7 +316,9 @@ public:
     }
 
     const char *data(size_t index) const override {
-        if (srcs[index].offset<0) return srcs[index].src;
+        if (srcs[index].offset < 0) {
+            return srcs[index].src;
+        }
         return scratch.get()+srcs[index].offset;
     }
 

--- a/src/portmonitors/depthimage_to_mono/DepthImage.cpp
+++ b/src/portmonitors/depthimage_to_mono/DepthImage.cpp
@@ -88,10 +88,12 @@ yarp::os::Things& DepthImageConverter::update(yarp::os::Things& thing)
                 pixels[w + (h * (img->width() ))] = 0;
             } else {
                 int val = (int) (255.0 - (inVal * 255.0 / (max - min)));
-                if(val >= 255)
+                if (val >= 255) {
                     val = 255;
-                if(val <= 0)
+                }
+                if (val <= 0) {
                     val = 0;
+                }
                 pixels[w + (h * (img->width() ))] = (char) val;
             }
         }

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
@@ -75,8 +75,9 @@ bool FfmpegMonitorObject::create(const yarp::os::Property& options)
 
     // Parse command line parameters and set them into global variable "paramsMap"
     std::string str = options.find("carrier").asString();
-    if (getParamsFromCommandLine(str, codecId) == -1)
+    if (getParamsFromCommandLine(str, codecId) == -1) {
         return false;
+    }
 
     // Find encoder/decoder
     if (senderSide) {
@@ -107,8 +108,9 @@ bool FfmpegMonitorObject::create(const yarp::os::Property& options)
     codecContext->time_base.num = 1;
     codecContext->time_base.den = 15;
     // Set command line params
-    if (setCommandLineParams() == -1)
+    if (setCommandLineParams() == -1) {
         return false;
+    }
 
     return true;
 }

--- a/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
+++ b/src/robottestingframework-plugins/fixture-managers/yarpmanager/YarpFixManager.cpp
@@ -88,8 +88,9 @@ bool YarpFixManager::setup(int argc, char** argv) {
 void YarpFixManager::tearDown() {
     ROBOTTESTINGFRAMEWORK_FIXTURE_REPORT("yarpmanager is tearing down the fixture...");
     bool ret = manager->stop();
-    if(!ret)
+    if (!ret) {
         ret = manager->kill();
+    }
     const char* szerror = manager->getLogger()->getLastError();
     ROBOTTESTINGFRAMEWORK_ASSERT_ERROR_IF_FALSE(ret,
                         "yarpmanager cannot teardown the fixture because " +

--- a/src/robottestingframework-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
+++ b/src/robottestingframework-plugins/fixture-managers/yarpplugin/YarpPluginFixture.cpp
@@ -33,13 +33,15 @@ bool YarpPluginFixture::scanPlugins(std::string name, std::string type)
         Value& options = lst.get(i);
         if(!type.empty())
         {
-            if(name == options.check("name",Value("untitled")).asString() && type== options.check("type",Value("untitled")).asString())
-                res=true;
+            if (name == options.check("name", Value("untitled")).asString() && type == options.check("type", Value("untitled")).asString()) {
+                res = true;
+            }
         }
         else
         {
-            if(name == options.check("name",Value("untitled")).asString())
-                    res=true;
+            if (name == options.check("name", Value("untitled")).asString()) {
+                res = true;
+            }
         }
     }
     return res;

--- a/src/yarp-config/yarpcontext.cpp
+++ b/src/yarp-config/yarpcontext.cpp
@@ -53,12 +53,15 @@ YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
         if(options.check("user") || options.check("sysadm") || options.check("installed"))
         {
-            if (options.check("user"))
+            if (options.check("user")) {
                 printUserFolders(rf, CONTEXTS);
-            if (options.check("sysadm"))
+            }
+            if (options.check("sysadm")) {
                 printSysadmFolders(rf, CONTEXTS);
-            if (options.check("installed"))
+            }
+            if (options.check("installed")) {
                 printInstalledFolders(rf, CONTEXTS);
+            }
         }
         else
         {
@@ -111,12 +114,15 @@ YARP_WARNING_POP
         if (options.check("user") || options.check("sysadm") || options.check("installed"))
         {
             opts.searchLocations=ResourceFinderOptions::NoLocation;
-            if(options.check("user"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::User);
-            if(options.check("sysadm"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Sysadmin);
-            if (options.check("installed"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Installed);
+            if (options.check("user")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::User);
+            }
+            if (options.check("sysadm")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::Sysadmin);
+            }
+            if (options.check("installed")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::Installed);
+            }
         }
         yarp::os::ResourceFinder rf;
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.4
@@ -128,8 +134,9 @@ YARP_DISABLE_DEPRECATED_WARNING
 YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
         yarp::os::Bottle paths=rf.findPaths(std::string("contexts") + PATH_SEPARATOR +contextName, opts);
-        for (size_t curCont=0; curCont<paths.size(); ++curCont)
+        for (size_t curCont = 0; curCont < paths.size(); ++curCont) {
             printf("%s\n", paths.get(curCont).asString().c_str());
+        }
         return 0;
     }
 

--- a/src/yarp-config/yarpcontextutils.cpp
+++ b/src/yarp-config/yarpcontextutils.cpp
@@ -83,8 +83,9 @@ bool isHidden(std::string fileName)
     if (attributes & FILE_ATTRIBUTE_HIDDEN)
         return true;
 #else
-    if (fileName[0] == '.')
+    if (fileName[0] == '.') {
         return true;
+    }
 #endif
     return false;
 }
@@ -96,8 +97,9 @@ bool fileCopy(std::string srcFileName, std::string destFileName, bool force, boo
     FILE* source = fopen(srcFileName.c_str(), "rb");
     if (source == nullptr)
     {
-        if (verbose)
+        if (verbose) {
             printf("Could not open source file %s\n", srcFileName.c_str());
+        }
         return false;
     }
     if (!yarp::os::stat(destFileName.c_str()))
@@ -108,8 +110,9 @@ bool fileCopy(std::string srcFileName, std::string destFileName, bool force, boo
         }
         else
         {
-            if (verbose)
+            if (verbose) {
                 printf("File already exists : %s\n", destFileName.c_str());
+            }
             fclose(source);
             return false;
         }
@@ -117,8 +120,9 @@ bool fileCopy(std::string srcFileName, std::string destFileName, bool force, boo
     FILE* dest = fopen(destFileName.c_str(), "wb");
     if (dest == nullptr)
     {
-        if (verbose)
+        if (verbose) {
             printf("Could not open target file %s\n", destFileName.c_str());
+        }
         fclose(source);
         return false;
     }
@@ -147,20 +151,21 @@ int recursiveCopy(std::string srcDirName, std::string destDirName, bool force, b
     yarp::os::impl::YARP_stat statbuf;
     if (yarp::os::impl::stat(srcDirName.c_str(), &statbuf) == -1)
     {
-        if (verbose)
+        if (verbose) {
             printf("Error in checking properties for %s\n", srcDirName.c_str());
+        }
         return -1;
     }
-    if ((statbuf.st_mode & S_IFMT) == S_IFREG)
+    if ((statbuf.st_mode & S_IFMT) == S_IFREG) {
         ok = fileCopy(srcDirName, destDirName, force, verbose) && ok;
-    else if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
-    {
+    } else if ((statbuf.st_mode & S_IFMT) == S_IFDIR) {
         yarp::os::impl::dirent **namelist;
         int n = yarp::os::impl::scandir(srcDirName.c_str(), &namelist, nullptr, yarp::os::impl::alphasort);
         if (n<0)
         {
-            if (verbose)
+            if (verbose) {
                 std::cerr << "Could not read from directory " << srcDirName << std::endl;
+            }
             return -1;
         }
         if (yarp::os::mkdir((destDirName).c_str()) < 0)
@@ -171,8 +176,9 @@ int recursiveCopy(std::string srcDirName, std::string destDirName, bool force, b
                 ok = ok && !yarp::os::mkdir((destDirName).c_str());
                 if (!ok)
                 {
-                    if (verbose)
+                    if (verbose) {
                         printf("Could not create directory %s\n", destDirName.c_str());
+                    }
                     return -1;
                 }
             }
@@ -205,7 +211,6 @@ int recursiveCopy(std::string srcDirName, std::string destDirName, bool force, b
             free(namelist[i]);
         }
         free(namelist);
-
     }
     return (ok == true ? 0 : -1);
 }
@@ -215,20 +220,21 @@ int recursiveRemove(std::string dirName, bool verbose)
     yarp::os::impl::YARP_stat statbuf;
     if (yarp::os::impl::stat(dirName.c_str(), &statbuf) == -1)
     {
-        if (verbose)
+        if (verbose) {
             printf("Error in checking properties for %s\n", dirName.c_str());
+        }
         return -1;
     }
-    if ((statbuf.st_mode & S_IFMT) == S_IFREG)
+    if ((statbuf.st_mode & S_IFMT) == S_IFREG) {
         return fileRemove(dirName) ? 0 : -1;
-    else if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
-    {
+    } else if ((statbuf.st_mode & S_IFMT) == S_IFDIR) {
         yarp::os::impl::dirent **namelist;
         int n = yarp::os::impl::scandir(dirName.c_str(), &namelist, nullptr, yarp::os::impl::alphasort);
         if (n<0)
         {
-            if (verbose)
+            if (verbose) {
                 printf("Could not read from  directory %s\n", dirName.c_str());
+            }
             return yarp::os::rmdir(dirName.c_str()); // TODO check if this is useful...
         }
 
@@ -245,9 +251,9 @@ int recursiveRemove(std::string dirName, bool verbose)
         free(namelist);
 
         return yarp::os::rmdir(dirName.c_str());
-    }
-    else
+    } else {
         return -1;
+    }
 }
 
 std::vector<std::string> listContentDirs(const std::string &curPath)
@@ -265,11 +271,13 @@ std::vector<std::string> listContentDirs(const std::string &curPath)
         {
             yarp::os::impl::YARP_stat statbuf;
             std::string path = std::string(curPath).append(PATH_SEPARATOR).append(name);
-            if (yarp::os::impl::stat(path.c_str(), &statbuf) == -1)
+            if (yarp::os::impl::stat(path.c_str(), &statbuf) == -1) {
                 printf("Error in checking properties for %s\n", path.c_str());
+            }
 
-            if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
+            if ((statbuf.st_mode & S_IFMT) == S_IFDIR) {
                 dirsList.push_back(name);
+            }
         }
         free(namelist[i]);
     }
@@ -301,8 +309,9 @@ std::vector<std::string> listContentFiles(const std::string &curPath)
         {
             yarp::os::impl::YARP_stat statbuf;
             std::string path = std::string(curPath).append(PATH_SEPARATOR).append(name);
-            if (yarp::os::impl::stat(path.c_str(), &statbuf) == -1)
+            if (yarp::os::impl::stat(path.c_str(), &statbuf) == -1) {
                 printf("Error in checking properties for %s\n", path.c_str());
+            }
             if ((statbuf.st_mode & S_IFMT) == S_IFREG)
             {
                 fileList.push_back(path);
@@ -311,8 +320,9 @@ std::vector<std::string> listContentFiles(const std::string &curPath)
             if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
             {
                 std::vector<std::string> nestedFiles = listContentFiles(path);
-                for (auto& nestedFile : nestedFiles)
-                    fileStack.push_back(std::string{path}.append(PATH_SEPARATOR).append(nestedFile));
+                for (auto& nestedFile : nestedFiles) {
+                    fileStack.push_back(std::string {path}.append(PATH_SEPARATOR).append(nestedFile));
+                }
             }
         }
         fileStack.pop_front();
@@ -323,8 +333,9 @@ std::vector<std::string> listContentFiles(const std::string &curPath)
 void printContentDirs(const std::string &curPath)
 {
     std::vector<std::string> dirsList = listContentDirs(curPath);
-    for (auto& dirsIt : dirsList)
+    for (auto& dirsIt : dirsList) {
         printf("%s\n", dirsIt.c_str());
+    }
 }
 
 
@@ -398,10 +409,9 @@ void prepareHomeFolder(yarp::os::ResourceFinder &rf, folderType ftype)
 bool prepareSubFolders(const std::string& startDir, const std::string& fileName)
 {
     string fname(fileName);
-    if (fname.find('/') == string::npos)
+    if (fname.find('/') == string::npos) {
         return true;
-    else
-    {
+    } else {
         size_t curPos, startPos = 0;
         while ((curPos = fname.find('/', startPos)) != string::npos)
         {
@@ -415,15 +425,15 @@ bool prepareSubFolders(const std::string& startDir, const std::string& fileName)
 bool recursiveFileList(const char* basePath, const char* suffix, std::set<std::string>& filenames)
 {
     string strPath = string(basePath);
-    if ((strPath.rfind('/') == string::npos) ||
-        (strPath.rfind('/') != strPath.size() - 1))
+    if ((strPath.rfind('/') == string::npos) || (strPath.rfind('/') != strPath.size() - 1)) {
         strPath = strPath + string(PATH_SEPARATOR);
+    }
 
     string mySuffix = string(suffix);
 
-    if (((mySuffix.rfind('/') == string::npos) ||
-        (mySuffix.rfind('/') != mySuffix.size() - 1)) && mySuffix != "")
+    if (((mySuffix.rfind('/') == string::npos) || (mySuffix.rfind('/') != mySuffix.size() - 1)) && mySuffix != "") {
         mySuffix = mySuffix + string(PATH_SEPARATOR);
+    }
 
     strPath += mySuffix;
 
@@ -467,8 +477,9 @@ int recursiveDiff(std::string srcDirName, std::string destDirName, std::ostream 
     std::set<std::string> destFileList;
     ok = ok && recursiveFileList(destDirName.c_str(), "", destFileList);
 
-    if (!ok)
+    if (!ok) {
         return -1;
+    }
     size_t nModifiedFiles = 0;
     for (const auto& srcIt : srcFileList)
     {
@@ -477,8 +488,9 @@ int recursiveDiff(std::string srcDirName, std::string destDirName, std::ostream 
         {
             diff_match_patch<std::string> dmp;
             std::string srcFileName = std::string{srcDirName}.append(PATH_SEPARATOR).append(srcIt);
-            if (isHidden(srcFileName))
+            if (isHidden(srcFileName)) {
                 continue;
+            }
 
             std::ifstream in(srcFileName.c_str());
             std::string srcStr((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
@@ -549,14 +561,16 @@ int recursiveMerge(std::string srcDirName, std::string destDirName, std::string 
     std::set<std::string> hiddenFilesList;
     ok = ok && recursiveFileList(commonParentName.c_str(), "", hiddenFilesList);
 
-    if (!ok)
+    if (!ok) {
         return -1;
+    }
 
     for (const auto& srcIt : srcFileList)
     {
         std::string srcFileName = std::string{srcDirName}.append(PATH_SEPARATOR).append(srcIt);
-        if (isHidden(srcFileName))
+        if (isHidden(srcFileName)) {
             continue;
+        }
 
         auto destPos = destFileList.find(srcIt);
         if (destPos != destFileList.end())
@@ -601,8 +615,9 @@ int import(yarp::os::Bottle& importArg, folderType fType)
 #endif
 {
     std::string contextName;
-    if (importArg.size() >1)
+    if (importArg.size() > 1) {
         contextName = importArg.get(1).asString();
+    }
     if (contextName == "")
     {
         printf("No %s name provided\n", fType == CONTEXTS ? "context" : "robot");
@@ -659,15 +674,15 @@ YARP_WARNING_POP
         int result = recursiveCopy(originalpath, destDirname);
         recursiveCopy(originalpath, hiddenDirname, true, false);
 
-        if (result < 0)
+        if (result < 0) {
             printf("ERRORS OCCURRED WHILE IMPORTING %s %s\n", fType == CONTEXTS ? "CONTEXT" : "ROBOT", contextName.c_str());
-        else
-        {
+        } else {
             printf("Copied %s %s from %s to %s .\n", fType == CONTEXTS ? "context" : "robot", contextName.c_str(), originalpath.c_str(), destDirname.c_str());
             printf("Current locations for this %s:\n", fType == CONTEXTS ? "context" : "robot");
             yarp::os::Bottle paths = rf.findPaths(getFolderStringName(fType).append(PATH_SEPARATOR).append(contextName));
-            for (size_t curCont = 0; curCont<paths.size(); ++curCont)
+            for (size_t curCont = 0; curCont < paths.size(); ++curCont) {
                 printf("%s\n", paths.get(curCont).asString().c_str());
+            }
         }
         return result;
     }
@@ -741,8 +756,9 @@ int remove(yarp::os::Bottle& removeArg, folderType fType)
 #endif
 {
     std::string contextName;
-    if (removeArg.size() >1)
+    if (removeArg.size() > 1) {
         contextName = removeArg.get(1).asString();
+    }
     if (contextName == "")
     {
         printf("No %s name provided\n", fType == CONTEXTS ? "context" : "robot");
@@ -775,14 +791,16 @@ YARP_WARNING_POP
             if (choice == 'y')
             {
                 int result = recursiveRemove(targetPath);
-                if (result < 0)
+                if (result < 0) {
                     printf("ERRORS OCCURRED WHILE REMOVING %s\n", targetPath.c_str());
-                else
+                } else {
                     printf("Removed folder %s\n", targetPath.c_str());
+                }
                 //remove hidden folder:
                 std::string hiddenPath = rf.findPath(getFolderStringNameHidden(fType).append(PATH_SEPARATOR).append(contextName), opts);
-                if (hiddenPath != "")
+                if (hiddenPath != "") {
                     recursiveRemove(hiddenPath, false);
+                }
                 return result;
             }
             else
@@ -802,8 +820,9 @@ YARP_WARNING_POP
                 bool ok = true;
                 bool removeHidden = true;
                 std::string hiddenPath = rf.findPath(getFolderStringNameHidden(fType).append(PATH_SEPARATOR).append(contextName), opts);
-                if (hiddenPath != "")
+                if (hiddenPath != "") {
                     removeHidden = false;
+                }
 
                 for (size_t i = 2; i<removeArg.size(); ++i)
                 {
@@ -811,8 +830,9 @@ YARP_WARNING_POP
                     if (fileName != "")
                     {
                         ok = (recursiveRemove(std::string(targetPath).append(PATH_SEPARATOR).append(fileName)) >= 0) && ok;
-                        if (removeHidden)
+                        if (removeHidden) {
                             recursiveRemove(std::string(hiddenPath).append(PATH_SEPARATOR).append(fileName), false);
+                        }
                     }
                 }
                 if (ok)
@@ -905,12 +925,14 @@ YARP_DISABLE_DEPRECATED_WARNING
 YARP_WARNING_POP
 #endif
             std::string userPath = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(subDir), opts);
-            if (userPath == "")
+            if (userPath == "") {
                 continue;
+            }
             try
             {
-                if (recursiveDiff(installedPath.append(PATH_SEPARATOR).append(subDir), userPath, tmp)>0)
+                if (recursiveDiff(installedPath.append(PATH_SEPARATOR).append(subDir), userPath, tmp) > 0) {
                     std::cout << subDir << std::endl;
+                }
             }
             catch (...)
             {
@@ -929,8 +951,9 @@ int merge(yarp::os::Bottle& mergeArg, folderType fType)
 #endif
 {
     std::string contextName;
-    if (mergeArg.size() >1)
+    if (mergeArg.size() > 1) {
         contextName = mergeArg.get(1).asString();
+    }
     if (contextName == "")
     {
         printf("No %s name provided\n", fType == CONTEXTS ? "context" : "robot");
@@ -960,12 +983,13 @@ YARP_WARNING_POP
                 opts.searchLocations = ResourceFinderOptions::Installed;
                 std::string installedFileName = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(contextName).append(PATH_SEPARATOR).append(fileName), opts);
 
-                if (userFileName != "" && hiddenFileName != "" && installedFileName != "")
+                if (userFileName != "" && hiddenFileName != "" && installedFileName != "") {
                     fileMerge(installedFileName, userFileName, hiddenFileName);
-                else if (userFileName != ""  && installedFileName != "")
+                } else if (userFileName != "" && installedFileName != "") {
                     printf("Need to use mergetool\n");
-                else
+                } else {
                     printf("Could not merge file %s\n", fileName.c_str());
+                }
             }
         }
     }

--- a/src/yarp-config/yarprobot.cpp
+++ b/src/yarp-config/yarprobot.cpp
@@ -51,12 +51,15 @@ YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
         if(options.check("user") || options.check("sysadm") || options.check("installed"))
         {
-            if (options.check("user"))
+            if (options.check("user")) {
                 printUserFolders(rf, ROBOTS);
-            if (options.check("sysadm"))
+            }
+            if (options.check("sysadm")) {
                 printSysadmFolders(rf, ROBOTS);
-            if (options.check("installed"))
+            }
+            if (options.check("installed")) {
                 printInstalledFolders(rf, ROBOTS);
+            }
         }
         else
         {
@@ -109,12 +112,15 @@ YARP_WARNING_POP
         if (options.check("user") || options.check("sysadm") || options.check("installed"))
         {
             opts.searchLocations=ResourceFinderOptions::NoLocation;
-            if(options.check("user"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::User);
-            if(options.check("sysadm"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Sysadmin);
-            if (options.check("installed"))
-                opts.searchLocations= ResourceFinderOptions::SearchLocations ( opts.searchLocations | ResourceFinderOptions::Installed);
+            if (options.check("user")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::User);
+            }
+            if (options.check("sysadm")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::Sysadmin);
+            }
+            if (options.check("installed")) {
+                opts.searchLocations = ResourceFinderOptions::SearchLocations(opts.searchLocations | ResourceFinderOptions::Installed);
+            }
         }
         yarp::os::ResourceFinder rf;
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.4
@@ -127,17 +133,19 @@ YARP_WARNING_POP
 #endif // YARP_NO_DEPRECATED
 
         yarp::os::Bottle paths=rf.findPaths(std::string("robots") + PATH_SEPARATOR +contextName, opts);
-        for (size_t curCont=0; curCont<paths.size(); ++curCont)
+        for (size_t curCont = 0; curCont < paths.size(); ++curCont) {
             printf("%s\n", paths.get(curCont).asString().c_str());
+        }
         return 0;
     }
     if(options.check("current"))
     {
         std::string result = yarp::conf::environment::get_string("YARP_ROBOT_NAME");
-        if (result.empty())
+        if (result.empty()) {
             printf("Current robot is %s, identified by the environment variable YARP_ROBOT_NAME\n", result.c_str());
-        else
+        } else {
             printf("No robot is set; please set the YARP_ROBOT_NAME environment variable.\n");
+        }
         return 0;
 
     }

--- a/src/yarpbatterygui/display.cpp
+++ b/src/yarpbatterygui/display.cpp
@@ -121,8 +121,11 @@ void MainWindow::updateMain()
         int n_blocks = int(charge * 11 / 100.0);
         for (int i = 0; i < n_blocks; i++)
         {
-            if (current < -0.3) qpp = &qpm0;   //draw charging arrows
-            else                qpp = &qpm1;   //draw standard boxes
+            if (current < -0.3) {
+                qpp = &qpm0; //draw charging arrows
+            } else {
+                qpp = &qpm1; //draw standard boxes
+            }
 
             int xpos = 166;
             int ypos = 135 - i * 6;
@@ -141,7 +144,9 @@ void MainWindow::updateMain()
         int point_off = 0;
         for (int i = 0; i < len; i++)
         {
-            if (buff[i] == '.') point_off = 17;
+            if (buff[i] == '.') {
+                point_off = 17;
+            }
             if (buff[i] >= '0' && buff[i] <= '9')
             {
                 QRect rect((buff[i] - '0') * 29, 0, 29, 52);
@@ -161,7 +166,9 @@ void MainWindow::updateMain()
         int point_off = 0;
         for (int i = 0; i < len; i++)
         {
-            if (buff[i] == '.') point_off = 17;
+            if (buff[i] == '.') {
+                point_off = 17;
+            }
             if (buff[i] >= '0' && buff[i] <= '9')
             {
                 QRect rect((buff[i] - '0') * 29, 0, 29, 52);

--- a/src/yarpdatadumper/main.cpp
+++ b/src/yarpdatadumper/main.cpp
@@ -214,24 +214,27 @@ public:
     void setTxStamp(const double stamp) { txStamp=stamp; txOk=true; }
     double getStamp() const
     {
-        if (txOk)
+        if (txOk) {
             return txStamp;
-        else if (rxOk)
+        } else if (rxOk) {
             return rxStamp;
-        else
+        } else {
             return -1.0;
+        }
     }
     string getString() const
     {
         ostringstream ret;
         ret<<fixed;
 
-        if (txOk)
-            ret<<txStamp;
+        if (txOk) {
+            ret << txStamp;
+        }
         if (rxOk)
         {
-            if (!ret.str().empty())
-                ret<<' ';
+            if (!ret.str().empty()) {
+                ret << ' ';
+            }
             ret<<rxStamp;
         }
         return ret.str();
@@ -307,11 +310,13 @@ private:
             BufferedPort<T>::getEnvelope(info);
             item.seqNumber=info.getCount();
 
-            if (txTime || (info.isValid() && !rxTime))
+            if (txTime || (info.isValid() && !rxTime)) {
                 item.timeStamp.setTxStamp(info.getTime());
+            }
 
-            if (rxTime || !info.isValid())
+            if (rxTime || !info.isValid()) {
                 item.timeStamp.setRxStamp(Time::now());
+            }
 
             item.obj=factory(obj);
             item.obj->attachFormat(itemformat);
@@ -425,43 +430,35 @@ public:
         }
 
         finfo<<"Type: ";
-        if (type== DumpFormat::bottle)
+        if (type == DumpFormat::bottle) {
             finfo<<"Bottle;";
-        else if (type== DumpFormat::image)
-        {
+        } else if (type == DumpFormat::image) {
             ///this is ppm/pgm image format
             finfo<<"Image;";
-            if (videoOn) finfo<<" Video:"<<videoType<<"(huffyuv);";
-        }
-        else if (type == DumpFormat::depth)
-        {
+            if (videoOn) {
+                finfo << " Video:" << videoType << "(huffyuv);";
+            }
+        } else if (type == DumpFormat::depth) {
             finfo << "Depth;";
-        }
-        else if (type == DumpFormat::depth_compressed)
-        {
+        } else if (type == DumpFormat::depth_compressed) {
             finfo << "DepthCompressed;";
-        }
-        else if (type == DumpFormat::image_jpg)
-        {
+        } else if (type == DumpFormat::image_jpg) {
             finfo << "Image:jpg;";
-        }
-        else if (type == DumpFormat::image_png)
-        {
+        } else if (type == DumpFormat::image_png) {
             finfo << "Image:png;";
-        }
-        else
-        {
+        } else {
             yError() << "I should not reach this line! Unknown data type" << (int)type;
         }
         finfo<<endl;
 
         finfo<<"Stamp: ";
-        if (txTime && rxTime)
+        if (txTime && rxTime) {
             finfo<<"tx+rx;";
-        else if (txTime)
+        } else if (txTime) {
             finfo<<"tx;";
-        else
-            finfo<<"rx;";
+        } else {
+            finfo << "rx;";
+        }
         finfo<<endl;
 
         fdata.open(dataFile.c_str());
@@ -542,16 +539,15 @@ public:
                 buf.unlock();
 
                 fdata << item.seqNumber << ' ' << item.timeStamp.getString() << ' ';
-                if (saveData)
+                if (saveData) {
                     fdata << item.obj->toFile(dirName,counter++) << endl;
-                else
-                {
+                } else {
                     ostringstream frame;
                     frame << "frame_" << setw(8) << setfill('0') << counter++;
                     fdata << frame.str() << endl;
                 }
 
-            #ifdef ADD_VIDEO
+#ifdef ADD_VIDEO
                 if (doSaveFrame)
                 {
                     videoWriter << static_cast<DumpImage*>(item.obj)->getImage();
@@ -580,9 +576,10 @@ public:
         fdata.close();
 
     #ifdef ADD_VIDEO
-        if (videoOn)
+        if (videoOn) {
             ftimecodes.close();
-    #endif
+        }
+#endif
     }
 };
 
@@ -598,8 +595,9 @@ public:
     void setThread(DumpThread *thread) { this->thread=thread; }
     void report(const PortInfo &info) override
     {
-        if ((thread!=nullptr) && info.incoming)
-            thread->writeSource(info.sourceName,info.created);
+        if ((thread != nullptr) && info.incoming) {
+            thread->writeSource(info.sourceName, info.created);
+        }
     }
 };
 
@@ -644,8 +642,9 @@ public:
     bool configure(ResourceFinder &rf) override
     {
         portName=rf.check("name",Value("/dump")).asString();
-        if (portName[0]!='/')
-            portName="/"+portName;
+        if (portName[0] != '/') {
+            portName = "/" + portName;
+        }
 
         bool saveData=true;
         bool videoOn=false;
@@ -670,22 +669,28 @@ public:
             {
                 dumptype = DumpFormat::image;
                 #ifdef ADD_VIDEO
-                if (rf.check("addVideo"))   videoOn = true;
-                #endif
+                if (rf.check("addVideo")) {
+                    videoOn = true;
+                }
+#endif
             }
             else if ((optTypeName == "image_jpg"))
             {
                 dumptype = DumpFormat::image_jpg;
                 #ifdef ADD_VIDEO
-                if (rf.check("addVideo"))   videoOn = true;
-                #endif
+                if (rf.check("addVideo")) {
+                    videoOn = true;
+                }
+#endif
             }
             else if ((optTypeName == "image_png"))
             {
                 dumptype = DumpFormat::image_png;
                 #ifdef ADD_VIDEO
-                if (rf.check("addVideo"))   videoOn = true;
-                #endif
+                if (rf.check("addVideo")) {
+                    videoOn = true;
+                }
+#endif
             }
         #ifdef ADD_VIDEO
             else if (optTypeName=="video")
@@ -711,23 +716,24 @@ public:
         txTime=rf.check("txTime");
         string templateDirName=rf.check("dir")?rf.find("dir").asString():portName;
         polish_filename(templateDirName);
-        if (templateDirName[0]!='/')
-            templateDirName="/"+templateDirName;
+        if (templateDirName[0] != '/') {
+            templateDirName = "/" + templateDirName;
+        }
 
         string dirName;
-        if (rf.check("overwrite"))
+        if (rf.check("overwrite")) {
             dirName="."+templateDirName;
-        else
-        {
+        } else {
             // look for a proper directory
             int i=0;
             do
             {
                 ostringstream checkDirName;
-                if (i>0)
+                if (i > 0) {
                     checkDirName << "." << templateDirName << "_" << setw(5) << setfill('0') << i;
-                else
+                } else {
                     checkDirName << "." << templateDirName;
+                }
 
                 dirName=checkDirName.str();
                 i++;
@@ -776,10 +782,11 @@ public:
             ostringstream msg;
             msg << "Connection to " << srcPort << " " << (ok?"successful":"failed");
 
-            if (ok)
+            if (ok) {
                 yInfo() << msg.str();
-            else
+            } else {
                 yWarning() << msg.str();
+            }
         }
 
         // this port serves to handle the "quit" rpc command

--- a/src/yarpdataplayer-console/main.cpp
+++ b/src/yarpdataplayer-console/main.cpp
@@ -216,8 +216,9 @@ class dataplayer_module : public yarp::os::RFModule, public yarpdataplayer_conso
                 {
                     yInfo() << "done stopping!";
                 }
-                for (int i=0; i < subDirCnt; i++)
+                for (int i = 0; i < subDirCnt; i++) {
                     utilities->partDetails[i].currFrame = 1;
+                }
 
                 if (verbose)
                 {
@@ -233,8 +234,9 @@ class dataplayer_module : public yarp::os::RFModule, public yarpdataplayer_conso
                     yInfo() << "asking the thread to resume";
                 }
 
-                for (int i=0; i < subDirCnt; i++)
+                for (int i = 0; i < subDirCnt; i++) {
                     utilities->partDetails[i].worker->resetTime();
+                }
 
                 utilities->dataplayerEngine->resume();
             }
@@ -246,8 +248,9 @@ class dataplayer_module : public yarp::os::RFModule, public yarpdataplayer_conso
                     yInfo() <<"initializing the workers...";
                 }
 
-                for (int i=0; i < subDirCnt; i++)
+                for (int i = 0; i < subDirCnt; i++) {
                     utilities->partDetails[i].worker->init();
+                }
 
                 if (verbose)
                 {
@@ -331,8 +334,9 @@ class dataplayer_module : public yarp::os::RFModule, public yarpdataplayer_conso
             {
                 yInfo() << "done stopping!";
             }
-            for (int i=0; i < subDirCnt; i++)
+            for (int i = 0; i < subDirCnt; i++) {
                 utilities->partDetails[i].currFrame = 1;
+            }
 
             if (verbose)
             {
@@ -611,8 +615,9 @@ class dataplayer_module : public yarp::os::RFModule, public yarpdataplayer_conso
             {
                 yInfo() << "done stopping!";
             }
-            for (int i=0; i < subDirCnt; i++)
+            for (int i = 0; i < subDirCnt; i++) {
                 utilities->partDetails[i].currFrame = 1;
+            }
 
             if (verbose)
             {

--- a/src/yarpdataplayer/include/mainwindow.h
+++ b/src/yarpdataplayer/include/mainwindow.h
@@ -101,7 +101,7 @@ public:
     /**
      * function that returns the player status (playing, paused, stopped)
      */
-    std::string getStatus() override;
+    std::string getStatus();
     /**
      * function that handles an IDL message - play
      */

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -386,8 +386,9 @@ bool MainWindow::cmdSafeExit()
         if (verbose){
             yInfo() << "done stopping!";
         }
-        for (int i=0; i < subDirCnt; i++)
+        for (int i = 0; i < subDirCnt; i++) {
             qutilities->partDetails[i].currFrame = 1;
+        }
 
         if (verbose){
             yInfo() << "Module closing...\nCleaning up...";
@@ -430,8 +431,9 @@ bool MainWindow::safeExit()
         if (verbose){
             yInfo() << "done stopping!";
         }
-        for (int i=0; i < subDirCnt; i++)
+        for (int i = 0; i < subDirCnt; i++) {
             qutilities->partDetails[i].currFrame = 1;
+        }
 
         if (verbose){
             yInfo() << "Module closing...\nCleaning up...";
@@ -748,8 +750,9 @@ void MainWindow::onMenuFileOpen()
     if(!dir.isEmpty())
     {
         ui->mainWidget->clear();
-        for (int x=0; x < subDirCnt; x++)
+        for (int x = 0; x < subDirCnt; x++) {
             qutilities->closePorts(qutilities->partDetails[x]);
+        }
 
         doGuiSetup(dir);
     }
@@ -849,8 +852,9 @@ void MainWindow::onMenuPlayBackPlay()
             if (verbose){
                 yInfo() << "done stopping!";
             }
-            for (int i=0; i < subDirCnt; i++)
+            for (int i = 0; i < subDirCnt; i++) {
                 qutilities->partDetails[i].currFrame = 1;
+            }
 
             if (verbose){
                 yInfo() << "done stopping the thread...";
@@ -871,8 +875,9 @@ void MainWindow::onMenuPlayBackPlay()
                 yInfo() << "asking the thread to resume";
             }
 
-            for (int i=0; i < subDirCnt; i++)
+            for (int i = 0; i < subDirCnt; i++) {
                 qutilities->partDetails[i].worker->resetTime();
+            }
 
             qutilities->qengine->resume();
         } else if (!qutilities->qengine->isRunning()) {
@@ -881,8 +886,9 @@ void MainWindow::onMenuPlayBackPlay()
                 yInfo() <<"initializing the workers...";
             }
 
-            for (int i=0; i < subDirCnt; i++)
+            for (int i = 0; i < subDirCnt; i++) {
                 qutilities->partDetails[i].worker->init();
+            }
 
             if (verbose){
                 yInfo() << "starting the master thread...";
@@ -943,8 +949,9 @@ void MainWindow::onMenuPlayBackStop()
         if (verbose){
             yInfo() << "done stopping!";
         }
-        for (int i=0; i < subDirCnt; i++)
+        for (int i = 0; i < subDirCnt; i++) {
             qutilities->partDetails[i].currFrame = 1;
+        }
 
         if (verbose){
             yInfo() << "done stopping the thread...";
@@ -964,15 +971,17 @@ void MainWindow::onMenuPlayBackStop()
 /**********************************************************/
 void MainWindow::onMenuPlayBackForward()
 {
-    if (subDirCnt > 0)
+    if (subDirCnt > 0) {
         qutilities->qengine->forward(5);
+    }
 }
 
 /**********************************************************/
 void MainWindow::onMenuPlayBackBackward()
 {
-    if (subDirCnt > 0)
+    if (subDirCnt > 0) {
         qutilities->qengine->backward(5);
+    }
 }
 
 /**********************************************************/
@@ -1122,8 +1131,9 @@ void MainWindow::onUpdateGuiRateThread()
                     double time = qutilities->partDetails[i].worker->getTimeTaken();
                     if (time > 700000){ //value of a time stamp...
                         setTimeTaken(qutilities->partDetails[i].name.c_str(),0.0);
-                    }else
-                        setTimeTaken(qutilities->partDetails[i].name.c_str(),time);
+                    } else {
+                        setTimeTaken(qutilities->partDetails[i].name.c_str(), time);
+                    }
                 }
             }
             //percentage = 0;

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -125,8 +125,9 @@ void QEngine::runNormally()
 
                     if (stopAll == this->numPart){
                         yInfo() << "All parts have Finished!";
-                        if (qutils->partDetails[i].currFrame > 1)
+                        if (qutils->partDetails[i].currFrame > 1) {
                             emit qutils->updateGuiThread();
+                        }
                         qutils->stopAtEnd();
                         qutils->resetButton();
                         allPartsStatus = true;

--- a/src/yarpidl_rosmsg/src/RosType.cpp
+++ b/src/yarpidl_rosmsg/src/RosType.cpp
@@ -40,7 +40,9 @@ std::vector<std::string> normalizedMessage(const std::string& line) {
             pending = true;
         } else if (ch=='\r'||ch=='\t'||((ch==' '||ch=='=')&&can_quote)) {
             if (pending) {
-                if (result[0]=='#') return all;
+                if (result[0] == '#') {
+                    return all;
+                }
                 all.push_back(result);
                 pending = false;
             }
@@ -55,7 +57,9 @@ std::vector<std::string> normalizedMessage(const std::string& line) {
         }
     }
     if (pending&&result!="") {
-        if (result[0]=='#'&&can_quote) return all;
+        if (result[0] == '#' && can_quote) {
+            return all;
+        }
         all.push_back(result);
     }
     return all;
@@ -205,7 +209,9 @@ bool RosType::read(const char *tname, RosTypeSearch& env, RosTypeCodeGen& gen,
     char buf[2048];
     do {
         result = fgets(buf,sizeof(buf),fin);
-        if (result==nullptr) break;
+        if (result == nullptr) {
+            break;
+        }
         txt += "//   ";
         txt += result;
         source += result;
@@ -347,7 +353,9 @@ bool RosType::cache(const char *tname, RosTypeSearch& env,
     do {
         char buf[2048];
         char *result = fgets(buf,sizeof(buf),fin);
-        if (result==nullptr) break;
+        if (result == nullptr) {
+            break;
+        }
         fputs(result,fout);
     } while (true);
     fclose(fout);
@@ -361,14 +369,18 @@ void RosType::show() {
     if (rosName!="") {
         printf("%s:",rosName.c_str());
     }
-    if (!isValid) printf("INVALID:");
+    if (!isValid) {
+        printf("INVALID:");
+    }
     if (isPrimitive) {
         printf("%s", rosType.c_str());
     }
     if (!isPrimitive) {
         printf("(");
         for (size_t i=0; i<subRosType.size(); i++) {
-            if (i>0) printf(" ");
+            if (i > 0) {
+                printf(" ");
+            }
             subRosType[i].show();
         }
         printf(")");
@@ -460,56 +472,106 @@ bool RosType::emitType(RosTypeCodeGen& gen,
         }
     }
 
-    if (!gen.beginType(rosType,state)) return false;
-
-    if (!gen.beginDeclare()) return false;
-    for (const auto& i : subRosType) {
-        if (!gen.declareField(i)) return false;
+    if (!gen.beginType(rosType, state)) {
+        return false;
     }
-    if (!gen.endDeclare()) return false;
 
-    if (!gen.beginConstruct()) return false;
+    if (!gen.beginDeclare()) {
+        return false;
+    }
+    for (const auto& i : subRosType) {
+        if (!gen.declareField(i)) {
+            return false;
+        }
+    }
+    if (!gen.endDeclare()) {
+        return false;
+    }
+
+    if (!gen.beginConstruct()) {
+        return false;
+    }
     bool isFirst = true;
     for (const auto& i : subRosType) {
-        if (!gen.initField(i, isFirst)) return false;
+        if (!gen.initField(i, isFirst)) {
+            return false;
+        }
     }
-    if (!gen.endInitConstruct()) return false;
+    if (!gen.endInitConstruct()) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.constructField(i)) return false;
+        if (!gen.constructField(i)) {
+            return false;
+        }
     }
-    if (!gen.endConstruct()) return false;
+    if (!gen.endConstruct()) {
+        return false;
+    }
 
-    if (!gen.beginClear()) return false;
+    if (!gen.beginClear()) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.clearField(i)) return false;
+        if (!gen.clearField(i)) {
+            return false;
+        }
     }
-    if (!gen.endClear()) return false;
+    if (!gen.endClear()) {
+        return false;
+    }
 
-    if (!gen.beginRead(true,(int)subRosType.size())) return false;
+    if (!gen.beginRead(true, (int)subRosType.size())) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.readField(true,i)) return false;
+        if (!gen.readField(true, i)) {
+            return false;
+        }
     }
-    if (!gen.endRead(true)) return false;
+    if (!gen.endRead(true)) {
+        return false;
+    }
 
-    if (!gen.beginRead(false,(int)subRosType.size())) return false;
+    if (!gen.beginRead(false, (int)subRosType.size())) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.readField(false,i)) return false;
+        if (!gen.readField(false, i)) {
+            return false;
+        }
     }
-    if (!gen.endRead(false)) return false;
+    if (!gen.endRead(false)) {
+        return false;
+    }
 
-    if (!gen.beginWrite(true,(int)subRosType.size())) return false;
+    if (!gen.beginWrite(true, (int)subRosType.size())) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.writeField(true,i)) return false;
+        if (!gen.writeField(true, i)) {
+            return false;
+        }
     }
-    if (!gen.endWrite(true)) return false;
+    if (!gen.endWrite(true)) {
+        return false;
+    }
 
-    if (!gen.beginWrite(false,(int)subRosType.size())) return false;
+    if (!gen.beginWrite(false, (int)subRosType.size())) {
+        return false;
+    }
     for (const auto& i : subRosType) {
-        if (!gen.writeField(false,i)) return false;
+        if (!gen.writeField(false, i)) {
+            return false;
+        }
     }
-    if (!gen.endWrite(false)) return false;
+    if (!gen.endWrite(false)) {
+        return false;
+    }
 
-    if (!gen.endType(rosType,*this)) return false;
+    if (!gen.endType(rosType, *this)) {
+        return false;
+    }
 
     state.generated[rosType] = this;
 
@@ -528,7 +590,9 @@ static std::vector<std::string> &split(const std::string &s, char delim, std::ve
 std::string RosTypeSearch::readFile(const char *fname) {
     char buf[25600];
     FILE *fin = fopen(fname,"r");
-    if (fin==nullptr) return {};
+    if (fin == nullptr) {
+        return {};
+    };
     std::string result;
     while(fgets(buf, sizeof(buf)-1, fin) != nullptr) {
         result += buf;

--- a/src/yarpidl_rosmsg/src/RosTypeCodeGenYarp.cpp
+++ b/src/yarpidl_rosmsg/src/RosTypeCodeGenYarp.cpp
@@ -413,7 +413,9 @@ bool RosTypeCodeGenYarp::beginRead(bool bare, int len)
 
 bool RosTypeCodeGenYarp::readField(bool bare, const RosField& field)
 {
-    if (field.isConst()) return true;
+    if (field.isConst()) {
+        return true;
+    }
     RosYarpType t = mapPrimitive(field);
     if (!first) {
         fprintf(out, "\n");
@@ -600,7 +602,9 @@ bool RosTypeCodeGenYarp::beginWrite(bool bare, int len)
 
 bool RosTypeCodeGenYarp::writeField(bool bare, const RosField& field)
 {
-    if (field.isConst()) return true;
+    if (field.isConst()) {
+        return true;
+    }
     RosYarpType t = mapPrimitive(field);
     if (!first) {
         fprintf(out, "\n");

--- a/src/yarpidl_rosmsg/src/main.cpp
+++ b/src/yarpidl_rosmsg/src/main.cpp
@@ -55,7 +55,9 @@ void show_usage()
 
 static void generateTypeMap1(RosType& t, std::string& txt)
 {
-    if (!t.isValid) return;
+    if (!t.isValid) {
+        return;
+    }
     std::vector<RosType>& lst = t.subRosType;
     if (lst.size()>0) {
         bool simple = true;
@@ -84,7 +86,9 @@ static void generateTypeMap1(RosType& t, std::string& txt)
         }
         return;
     }
-    if (!t.isPrimitive) return;
+    if (!t.isPrimitive) {
+        return;
+    }
     txt += " ";
     if (t.isArray) {
         txt += "vector ";
@@ -102,7 +106,9 @@ static void generateTypeMap(RosType& t, std::string& txt)
     if (txt.length()>0) {
         txt = txt.substr(1,txt.length());
     }
-    if (!t.reply) return;
+    if (!t.reply) {
+        return;
+    }
     txt += " ---";
     generateTypeMap1(*(t.reply),txt);
 }
@@ -262,11 +268,15 @@ int main(int argc, char *argv[])
         } else {
             resp.addString("?");
         }
-        if (!has_cmd) port.reply(resp);
+        if (!has_cmd) {
+            port.reply(resp);
+        }
         if (verbose||has_cmd) {
             printf("Response: %s\n", resp.toString().c_str());
         }
-        if (has_cmd) break;
+        if (has_cmd) {
+            break;
+        }
     }
     return 0;
 }

--- a/src/yarpidl_thrift/src/t_yarp_generator.cc
+++ b/src/yarpidl_thrift/src/t_yarp_generator.cc
@@ -3674,8 +3674,9 @@ void t_yarp_generator::generate_service_method(t_service* tservice, t_function* 
         f_cpp_ << indent_cpp() << helper_class << " helper{";
         bool first = true;
         for (const auto& arg : function->get_arglist()->get_members()) {
-            if (!first)
+            if (!first) {
                 f_cpp_ << ", ";
+            }
             first = false;
             f_cpp_ << arg->get_name();
         }

--- a/src/yarplaserscannergui/main.cpp
+++ b/src/yarplaserscannergui/main.cpp
@@ -70,10 +70,11 @@ void drawGrid(IplImage *img, double scale)
 */
     char buff [10];
     int  rad_step=0;
-    if   (scale>60)
+    if (scale > 60) {
         rad_step=1;
-    else
-        rad_step=2;
+    } else {
+        rad_step = 2;
+    }
     for (int rad=0; rad<20; rad+=rad_step)
     {
         sprintf (buff,"%3.1fm",float(rad)/2);
@@ -88,9 +89,18 @@ void drawRobot (IplImage *img, double robot_radius, double scale)
     cvRectangle(img,cvPoint(0,0),cvPoint(img->width,img->height),cvScalar(0,0,0),CV_FILLED);
 
     //draw a circle
-    double v1 = robot_radius*scale; if (v1 < 0) v1 = 0;
-    double v2 = robot_radius*scale - 1; if (v2 < 0) v2 = 0;
-    double v3 = robot_radius*scale - 2; if (v3 < 0) v3 = 0;
+    double v1 = robot_radius*scale;
+    if (v1 < 0) {
+        v1 = 0;
+    }
+    double v2 = robot_radius*scale - 1;
+    if (v2 < 0) {
+        v2 = 0;
+    }
+    double v3 = robot_radius*scale - 2;
+    if (v3 < 0) {
+        v3 = 0;
+    }
 
     cvCircle(img,cvPoint(img->width/2,img->height/2),(int)(v1),color_gray,CV_FILLED);
     cvCircle(img,cvPoint(img->width/2,img->height/2),(int)(v2),color_black);
@@ -110,8 +120,11 @@ void drawCompass(const yarp::sig::Vector *comp, IplImage *img, bool absolute)
     for (int i=0; i<360; i+=10)
     {
         double ang;
-        if  (absolute) ang = i+180;
-        else           ang = i+(*comp)[0]+180;
+        if (absolute) {
+            ang = i + 180;
+        } else {
+            ang = i + (*comp)[0] + 180;
+        }
         sx = int(-250*sin(ang/180.0*M_PI)+img->width/2);
         sy = int(250*cos(ang/180.0*M_PI)+img->height/2);
         ex = int(-260*sin(ang/180.0*M_PI)+img->width/2);
@@ -181,8 +194,11 @@ void drawLaser(const Vector *comp, vector<yarp::dev::LaserMeasurementData> *las,
     CvPoint center;
 
     double center_angle=sens_position_t;
-    if (!absolute) center_angle = 0;
-    else center_angle = -180 - (*comp)[0];
+    if (!absolute) {
+        center_angle = 0;
+    } else {
+        center_angle = -180 - (*comp)[0];
+    }
     center.x = (int)(img->width / 2 + (sens_position_x*scale)*sin(center_angle / 180 * M_PI));
     center.y = (int)(img->height / 2 - (sens_position_y*scale)*cos(center_angle / 180 * M_PI));
 
@@ -194,10 +210,16 @@ void drawLaser(const Vector *comp, vector<yarp::dev::LaserMeasurementData> *las,
     }
 
     double curr_time = yarp::os::Time::now();
-    if (verbose) yError("received vector size:%d ", int(las->size()));
+    if (verbose) {
+        yError("received vector size:%d ", int(las->size()));
+    }
     static int timeout_count = 0;
-    if (curr_time - old_time > 0.40) timeout_count++;
-    if (verbose) yWarning("time:%f timeout:%d\n", curr_time - old_time, timeout_count);
+    if (curr_time - old_time > 0.40) {
+        timeout_count++;
+    }
+    if (verbose) {
+        yWarning("time:%f timeout:%d\n", curr_time - old_time, timeout_count);
+    }
     old_time = curr_time;
     for (int i = 0; i<scans; i++)
     {
@@ -421,7 +443,9 @@ int main(int argc, char *argv[])
         if (compass)
         {
             yarp::sig::Vector *cmp = compassInPort.read(false);
-            if (cmp) compass_data = *cmp;
+            if (cmp) {
+                compass_data = *cmp;
+            }
         }
 
         iLas->getLaserMeasurement(laser_data);
@@ -465,7 +489,9 @@ int main(int argc, char *argv[])
             }
             drawRobot(img2,robot_radius, scale);
             drawGrid(img,scale);
-            if (compass) drawCompass(&compass_data,img,absolute);
+            if (compass) {
+                drawCompass(&compass_data, img, absolute);
+            }
 
             yarp::os::Bottle *nav_display = navDisplayInPort.read(false);
             if (nav_display)
@@ -482,7 +508,9 @@ int main(int argc, char *argv[])
         //if ESC is pressed, exit.
         int keypressed = cvWaitKey(2); //wait 2ms. Lower values do not work under Linux
         keypressed &= 0xFF; //this mask is required in Linux systems
-        if(keypressed == 27) exit = true;
+        if (keypressed == 27) {
+            exit = true;
+        }
         if(keypressed == 'w' && scale <500)
         {
             //scale+=0.001;
@@ -498,21 +526,32 @@ int main(int argc, char *argv[])
         if(keypressed == 'v' )
         {
            verbose= (!verbose);
-           if (verbose) yInfo("verbose mode is now ON");
-           else         yInfo("verbose mode is now OFF");
+           if (verbose) {
+               yInfo("verbose mode is now ON");
+           } else {
+               yInfo("verbose mode is now OFF");
+           }
         }
         if(keypressed == 'a' )
         {
             absolute= (!absolute);
-            if (absolute) yInfo("display is now in ABSOLUTE mode");
-            else          yInfo("display is now in RELATIVE mode");
+            if (absolute) {
+                yInfo("display is now in ABSOLUTE mode");
+            } else {
+                yInfo("display is now in RELATIVE mode");
+            }
         }
         if(keypressed == 'r' )
         {
-            if      (period == 0)  period = 50;
-            else if (period == 50) period = 100;
-            else if (period == 100) period = 200;
-            else if (period == 200) period = 0;
+            if (period == 0) {
+                period = 50;
+            } else if (period == 50) {
+                period = 100;
+            } else if (period == 100) {
+                period = 200;
+            } else if (period == 200) {
+                period = 0;
+            }
             yInfo("refresh period set to %d ms.", period);
         }
         if(keypressed == 'c' )
@@ -524,7 +563,9 @@ int main(int argc, char *argv[])
         if (keypressed == 'b')
         {
             aspect = aspect + 1;
-            if (aspect > 1) aspect = 0;
+            if (aspect > 1) {
+                aspect = 0;
+            }
         }
         if(keypressed == 'h' ||
             keypressed == 'H')
@@ -545,5 +586,7 @@ int main(int argc, char *argv[])
     navDisplayInPort.close();
     cvDestroyAllWindows();
     cvReleaseImage(&img);
-    if (drv) delete drv;
+    if (drv) {
+        delete drv;
+    }
 }

--- a/src/yarplogger-console/main.cpp
+++ b/src/yarplogger-console/main.cpp
@@ -108,8 +108,9 @@ class logger_module : public yarp::os::RFModule
             std::list<MessageEntry> m;
             the_logger->get_messages_by_process(proc_name, m);
             std::list<MessageEntry>::iterator it;
-            for (it = m.begin(); it != m.end(); it++)
-                printf(" %s %d %s \n",it->yarprun_timestamp.c_str(), it->level.toInt(), it->text.c_str());
+            for (it = m.begin(); it != m.end(); it++) {
+                printf(" %s %d %s \n", it->yarprun_timestamp.c_str(), it->level.toInt(), it->text.c_str());
+            }
             reply.addString("ack");
         }
         else if (command.get(0).asString()=="ask_all")
@@ -117,8 +118,9 @@ class logger_module : public yarp::os::RFModule
              std::list<MessageEntry> m;
              the_logger->get_messages(m);
              std::list<MessageEntry>::iterator it;
-             for (it = m.begin(); it != m.end(); it++)
-                 printf(" %s %d %s \n",it->yarprun_timestamp.c_str(), it->level.toInt(), it->text.c_str());
+             for (it = m.begin(); it != m.end(); it++) {
+                 printf(" %s %d %s \n", it->yarprun_timestamp.c_str(), it->level.toInt(), it->text.c_str());
+             }
              reply.addString("ack");
         }
         else if (command.get(0).asString()=="discover")
@@ -142,10 +144,11 @@ class logger_module : public yarp::os::RFModule
              for (it = infos.begin(); it != infos.end(); it++)
              {
                  std::tm* tm = localtime(&it->last_update);
-                 if (tm)
-                 printf("%s %s hour:%d minute:%d sec:%d \n",it->port_prefix.c_str(), it->port_complete.c_str(), tm->tm_hour,tm->tm_min, tm->tm_sec);
-                 else
-                 printf("%s %s no data received yet \n",it->port_prefix.c_str(), it->port_complete.c_str());
+                 if (tm) {
+                     printf("%s %s hour:%d minute:%d sec:%d \n", it->port_prefix.c_str(), it->port_complete.c_str(), tm->tm_hour, tm->tm_min, tm->tm_sec);
+                 } else {
+                     printf("%s %s no data received yet \n", it->port_prefix.c_str(), it->port_complete.c_str());
+                 }
              }
              reply.addString("ack");
         }

--- a/src/yarplogger/advanced_dialog.cpp
+++ b/src/yarplogger/advanced_dialog.cpp
@@ -26,8 +26,11 @@ advanced_dialog::advanced_dialog(yarp::yarpLogger::LoggerEngine* logger, QWidget
     bool enable_log_lines_limit;
     int  log_lines_limit;
     theLogger->get_log_lines_max_size(enable_log_lines_limit,log_lines_limit);
-    if (enable_log_lines_limit) ui->radio_log_limited->setChecked(true);
-    else  ui->radio_log_unlimited->setChecked(true);
+    if (enable_log_lines_limit) {
+        ui->radio_log_limited->setChecked(true);
+    } else {
+        ui->radio_log_unlimited->setChecked(true);
+    }
     char log_lines_limit_s [20];
     sprintf(log_lines_limit_s, "%d", log_lines_limit);
     ui->log_max_size->setText(log_lines_limit_s);
@@ -35,8 +38,11 @@ advanced_dialog::advanced_dialog(yarp::yarpLogger::LoggerEngine* logger, QWidget
     bool enable_log_ports_limit;
     int  log_ports_limit;
     theLogger->get_log_list_max_size(enable_log_ports_limit,log_ports_limit);
-    if (enable_log_ports_limit) ui->radio_ports_limited->setChecked(true);
-    else  ui->radio_ports_unlimited->setChecked(true);
+    if (enable_log_ports_limit) {
+        ui->radio_ports_limited->setChecked(true);
+    } else {
+        ui->radio_ports_unlimited->setChecked(true);
+    }
     char log_ports_limit_s [20];
     sprintf(log_ports_limit_s, "%d", log_ports_limit);
     ui->ports_max_size->setText(log_ports_limit_s);

--- a/src/yarplogger/mainwindow.cpp
+++ b/src/yarplogger/mainwindow.cpp
@@ -38,9 +38,9 @@ void MainWindow::updateMain()
         {
             std::tm* tm = localtime(&it->last_update);
             sprintf(time_text, "%02d:%02d:%02d %02d/%02d/%02d", tm->tm_hour, tm->tm_min, tm->tm_sec, tm->tm_mday, tm->tm_mon, tm->tm_year+1900);
+        } else {
+            sprintf(time_text, "no data received yet");
         }
-        else
-           sprintf ( time_text, "no data received yet");
 
         char logsize_text[10];
         sprintf (logsize_text, "%d", it->logsize);
@@ -72,10 +72,14 @@ void MainWindow::updateMain()
                 bool     log_enabled =  this->theLogger->get_log_enable_by_port_complete(it->port_complete);
                 if (log_enabled)
                 {
-                    if      (last_error==yarp::yarpLogger::LOGLEVEL_ERROR)   rowcolor = QColor("#FF7070");
-                    else if (last_error==yarp::yarpLogger::LOGLEVEL_WARNING) rowcolor = QColor("#FFFF70");
-                    for (int j=0; j<model_yarprunports->columnCount(); j++)
-                        model_yarprunports->item(i,j)->setBackground(rowcolor);
+                    if (last_error == yarp::yarpLogger::LOGLEVEL_ERROR) {
+                        rowcolor = QColor("#FF7070");
+                    } else if (last_error == yarp::yarpLogger::LOGLEVEL_WARNING) {
+                        rowcolor = QColor("#FFFF70");
+                    }
+                    for (int j = 0; j < model_yarprunports->columnCount(); j++) {
+                        model_yarprunports->item(i, j)->setBackground(rowcolor);
+                    }
                 }
 
                 existing = true;
@@ -172,16 +176,18 @@ void MainWindow::on_enableLogTab(int model_row)
     if (log_enabled)
     {
         theLogger->set_log_enable_by_port_complete(logname,false);
-        for (int j=0; j<model_yarprunports->columnCount(); j++)
-            model_yarprunports->item(model_row,j)->setBackground(QColor("#808080"));
+        for (int j = 0; j < model_yarprunports->columnCount(); j++) {
+            model_yarprunports->item(model_row, j)->setBackground(QColor("#808080"));
+        }
         QString message = logname.c_str() + QString(" log disabled");
         system_message->addMessage(message);
     }
     else
     {
         theLogger->set_log_enable_by_port_complete(logname,true);
-        for (int j=0; j<model_yarprunports->columnCount(); j++)
-            model_yarprunports->item(model_row,j)->setBackground(QColor(Qt::white));
+        for (int j = 0; j < model_yarprunports->columnCount(); j++) {
+            model_yarprunports->item(model_row, j)->setBackground(QColor(Qt::white));
+        }
         QString message = logname.c_str() + QString(" log enabled");
         system_message->addMessage(message);
     }
@@ -209,7 +215,9 @@ void MainWindow::on_clearLogTab(int model_row)
         if (ui->logtabs->tabText(i) == logname)
         {
             auto* l = ui->logtabs->widget(i)->findChild<LogTab*>("logtab");
-            if (l) l->clearLogModel();
+            if (l) {
+                l->clearLogModel();
+            }
             break;
         }
     }
@@ -245,8 +253,9 @@ void MainWindow::on_saveLogTab(int model_row)
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export log to text file"),preferred_filename.c_str(), tr("Text Files (*.txt)"));
     if (fileName.size()!=0)
     {
-        if (theLogger->export_log_to_text_file(fileName.toStdString(),logname))
+        if (theLogger->export_log_to_text_file(fileName.toStdString(), logname)) {
             system_message->addMessage(QString("Current log successfully exported to file: ") + fileName);
+        }
     }
 }
 
@@ -371,7 +380,9 @@ void MainWindow::on_filterLineEdit_textChanged(const QString &text)
     QRegExp regExp(filter, Qt::CaseInsensitive, QRegExp::Wildcard);
 
     auto* logtab = ui->logtabs->currentWidget()->findChild<LogTab*>("logtab");
-    if (logtab) logtab->proxyModelSearch->setFilterRegExp(regExp);
+    if (logtab) {
+        logtab->proxyModelSearch->setFilterRegExp(regExp);
+    }
 #endif
 }
 
@@ -392,8 +403,11 @@ void MainWindow::on_yarprunTreeView_doubleClicked(const QModelIndex &pre_index)
     QString tabname = model_yarprunports->item(model_row,1)->text();
 
     int exists = -1;
-    for (int i=0; i<ui->logtabs->count(); i++)
-        if (ui->logtabs->tabText(i) == tabname) exists = i;
+    for (int i = 0; i < ui->logtabs->count(); i++) {
+        if (ui->logtabs->tabText(i) == tabname) {
+            exists = i;
+        }
+    }
 
     if (exists>=0)
     {
@@ -443,12 +457,48 @@ QString MainWindow::recomputeFilters()
     bool e_all     = this->ui->DisplayUnformattedEnable->isChecked();
     int f = 0;
     if (e_trace)                                {filter = filter + "^TRACE$";   f++;}
-    if (e_debug)   {if (f>0) filter=filter +"|"; filter = filter + "^DEBUG$";   f++;}
-    if (e_info)    {if (f>0) filter=filter +"|"; filter = filter + "^INFO$";    f++;}
-    if (e_warning) {if (f>0) filter=filter +"|"; filter = filter + "^WARNING$"; f++;}
-    if (e_error)   {if (f>0) filter=filter +"|"; filter = filter + "^ERROR$";   f++;}
-    if (e_all)     {if (f>0) filter=filter +"|"; filter = filter + "^$";        f++;}
-    if (true)      {if (f>0) filter=filter +"|"; filter = filter + "^FATAL$";   f++;}
+    if (e_debug)   {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^DEBUG$";
+        f++;
+    }
+    if (e_info)    {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^INFO$";
+        f++;
+    }
+    if (e_warning) {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^WARNING$";
+        f++;
+    }
+    if (e_error)   {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^ERROR$";
+        f++;
+    }
+    if (e_all)     {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^$";
+        f++;
+    }
+    if (true)      {
+        if (f > 0) {
+            filter = filter + "|";
+        }
+        filter = filter + "^FATAL$";
+        f++;
+    }
     std::string debug = filter.toStdString();
     return filter;
 }
@@ -721,10 +771,11 @@ void MainWindow::on_actionSave_Log_triggered(bool checked)
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save to log file"),preferred_filename, tr("Log Files (*.log)"));
     if (fileName.size()!=0)
     {
-        if (theLogger->save_all_logs_to_file(fileName.toStdString()))
+        if (theLogger->save_all_logs_to_file(fileName.toStdString())) {
             system_message->addMessage(QString("Log saved to file: ") + fileName);
-        else
-           system_message->addMessage(QString("Unable to save file: ") + fileName,MESSAGE_LEVEL_ERROR);
+        } else {
+            system_message->addMessage(QString("Unable to save file: ") + fileName, MESSAGE_LEVEL_ERROR);
+        }
     }
 }
 
@@ -735,10 +786,11 @@ void MainWindow::on_actionLoad_Log_triggered()
     {
         on_actionStop_Logger_triggered();
         on_actionClear_triggered();
-        if (theLogger->load_all_logs_from_file(fileName.toStdString()))
+        if (theLogger->load_all_logs_from_file(fileName.toStdString())) {
             system_message->addMessage(QString("Log loaded from file: ") + fileName);
-        else
-            system_message->addMessage(QString("Unable to load file: ") + fileName,MESSAGE_LEVEL_ERROR);
+        } else {
+            system_message->addMessage(QString("Unable to load file: ") + fileName, MESSAGE_LEVEL_ERROR);
+        }
     }
 }
 
@@ -815,7 +867,9 @@ void MainWindow::on_actionClear_triggered()
             model_yarprunports->clear();
             resetMainWindowHeaders();
         }
-        if (ui->logtabs) ui->logtabs->clear();
+        if (ui->logtabs) {
+            ui->logtabs->clear();
+        }
 
         system_message->addMessage("Log cleared");
     }
@@ -889,8 +943,9 @@ void MainWindow::dropEvent(QDropEvent *e)
     on_actionStop_Logger_triggered();
     on_actionClear_triggered();
 
-    if (theLogger->load_all_logs_from_file(fileName.toStdString()))
+    if (theLogger->load_all_logs_from_file(fileName.toStdString())) {
         system_message->addMessage(QString("Log loaded from file: ") + fileName);
-    else
-        system_message->addMessage(QString("Unable to load file: ") + fileName,MESSAGE_LEVEL_ERROR);
+    } else {
+        system_message->addMessage(QString("Unable to load file: ") + fileName, MESSAGE_LEVEL_ERROR);
+    }
 }

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -160,73 +160,87 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
     std::string inifile=rf.findFile("from");
     std::string inipath;
     size_t lastSlash=inifile.rfind('/');
-    if (lastSlash!=std::string::npos)
+    if (lastSlash != std::string::npos) {
         inipath=inifile.substr(0, lastSlash+1);
-    else
-    {
+    } else {
         lastSlash=inifile.rfind('\\');
-        if (lastSlash!=std::string::npos)
-            inipath=inifile.substr(0, lastSlash+1);
+        if (lastSlash != std::string::npos) {
+            inipath = inifile.substr(0, lastSlash + 1);
+        }
     }
 
 //     if(!config.check("ymanagerini_dir"))
 //         config.put("ymanagerini_dir", inipath.c_str());
 
-    if(!config.check("apppath"))
+    if (!config.check("apppath")) {
         config.put("apppath", "./");
+    }
 
-    if(!config.check("modpath"))
+    if (!config.check("modpath")) {
         config.put("modpath", "./");
+    }
 
-    if(!config.check("respath"))
+    if (!config.check("respath")) {
         config.put("respath", "./");
+    }
 
-    if(!config.check("load_subfolders"))
+    if (!config.check("load_subfolders")) {
         config.put("load_subfolders", "no");
+    }
 
-    if(!config.check("watchdog"))
+    if (!config.check("watchdog")) {
         config.put("watchdog", "no");
+    }
 
-    if(!config.check("module_failure"))
+    if (!config.check("module_failure")) {
         config.put("module_failure", "prompt");
+    }
 
-    if(!config.check("connection_failure"))
+    if (!config.check("connection_failure")) {
         config.put("connection_failure", "prompt");
+    }
 
-    if(!config.check("auto_connect"))
+    if (!config.check("auto_connect")) {
         config.put("auto_connect", "no");
+    }
 
-    if(!config.check("auto_dependency"))
+    if (!config.check("auto_dependency")) {
         config.put("auto_dependency", "no");
+    }
 
-    if(!config.check("color_theme"))
+    if (!config.check("color_theme")) {
         config.put("color_theme", "light");
+    }
 
 
     /**
      * Set configuration
      */
-    if(config.find("color_theme").asString() == "dark")
+    if (config.find("color_theme").asString() == "dark") {
         setColorTheme(THEME_DARK);
-    else if(config.find("color_theme").asString() == "light")
+    } else if (config.find("color_theme").asString() == "light") {
         setColorTheme(THEME_LIGHT);
-    else
+    } else {
         setColorTheme(THEME_NONE);
+    }
 
-    if(config.find("watchdog").asString() == "yes")
+    if (config.find("watchdog").asString() == "yes") {
         enableWatchDog();
-    else
+    } else {
         disableWatchod();
+    }
 
-    if(config.find("auto_dependency").asString() == "yes")
+    if (config.find("auto_dependency").asString() == "yes") {
         enableAutoDependency();
-    else
+    } else {
         disableAutoDependency();
+    }
 
-    if(config.find("auto_connect").asString() == "yes")
+    if (config.find("auto_connect").asString() == "yes") {
         enableAutoConnect();
-    else
+    } else {
         disableAutoConnect();
+    }
 
     if(!config.check("silent"))
     {
@@ -241,8 +255,9 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
         while (getline(modPaths, strPath, ';'))
         {
             trimString(strPath);
-            if (!isAbsolute(strPath.c_str()))
+            if (!isAbsolute(strPath.c_str())) {
                 strPath = std::string(inipath).append(strPath);
+            }
             addModules(strPath.c_str());
         }
     }
@@ -254,8 +269,9 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
         while (getline(resPaths, strPath, ';'))
         {
             trimString(strPath);
-            if (!isAbsolute(strPath.c_str()))
+            if (!isAbsolute(strPath.c_str())) {
                 strPath = std::string(inipath).append(strPath);
+            }
             addResources(strPath.c_str());
         }
     }
@@ -268,15 +284,17 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
         while (getline(appPaths, strPath, ';'))
         {
             trimString(strPath);
-            if (!isAbsolute(strPath.c_str()))
+            if (!isAbsolute(strPath.c_str())) {
                 strPath = std::string(inipath).append(strPath);
+            }
             if(config.find("load_subfolders").asString() == "yes")
             {
-                if(!loadRecursiveApplications(strPath.c_str()))
+                if (!loadRecursiveApplications(strPath.c_str())) {
                     logger->addError("Cannot load the applications from  " + strPath);
-            }
-            else
+                }
+            } else {
                 addApplications(strPath.c_str());
+            }
         }
     }
 
@@ -300,14 +318,17 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
     new_action.sa_flags = 0;
 
     sigaction (SIGINT, nullptr, &old_action);
-    if (old_action.sa_handler != SIG_IGN)
-        sigaction (SIGINT, &new_action, nullptr);
+    if (old_action.sa_handler != SIG_IGN) {
+        sigaction(SIGINT, &new_action, nullptr);
+    }
     sigaction (SIGHUP, nullptr, &old_action);
-    if (old_action.sa_handler != SIG_IGN)
-        sigaction (SIGHUP, &new_action, nullptr);
+    if (old_action.sa_handler != SIG_IGN) {
+        sigaction(SIGHUP, &new_action, nullptr);
+    }
     sigaction (SIGTERM, nullptr, &old_action);
-    if (old_action.sa_handler != SIG_IGN)
-        sigaction (SIGTERM, &new_action, nullptr);
+    if (old_action.sa_handler != SIG_IGN) {
+        sigaction(SIGTERM, &new_action, nullptr);
+    }
 #endif
 
     if(config.check("application"))
@@ -319,32 +340,37 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
             if(application)
             {
                 // add this application to the manager if does not exist
-                if(!getKnowledgeBase()->getApplication(application->getName()))
+                if (!getKnowledgeBase()->getApplication(application->getName())) {
                     getKnowledgeBase()->addApplication(application);
+                }
 
-                #ifdef YARP_HAS_Libedit
+#ifdef YARP_HAS_Libedit
                 updateAppNames(&appnames);
                 #endif
 
                 if(loadApplication(application->getName()))
                 {
-                    if(!config.check("silent"))
+                    if (!config.check("silent")) {
                         which();
+                    }
 
-                    if(config.check("assign_hosts"))
+                    if (config.check("assign_hosts")) {
                         loadBalance();
+                    }
 
                     if(config.check("run"))
                     {
-                        if(config.check("connect"))
+                        if (config.check("connect")) {
                             enableAutoConnect();
+                        }
                          bShouldRun = run();
+                    } else if (config.check("connect")) {
+                        connect();
                     }
-                    else if(config.check("connect"))
-                            connect();
 
-                    if(config.check("disconnect"))
-                         disconnect();
+                    if (config.check("disconnect")) {
+                        disconnect();
+                    }
 
                     if(config.check("stop"))
                     {
@@ -354,8 +380,9 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
                         bShouldRun = false;
                         for(moditr=modules.begin(); moditr<modules.end(); moditr++)
                         {
-                            if(running(id))
+                            if (running(id)) {
                                 stop(id);
+                            }
                             id++;
                         }
                         bShouldRun = !suspended();
@@ -367,24 +394,30 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
                          kill();
                     }
 
-                    if(config.check("check_con"))
+                    if (config.check("check_con")) {
                         checkConnections();
+                    }
 
-                    if(config.check("check_state"))
+                    if (config.check("check_state")) {
                         checkStates();
+                    }
 
-                    if(config.check("check_dep"))
-                        if(checkDependency())
-                            cout<<INFO<<"All of resource dependencies are satisfied."<<ENDC<<endl;
+                    if (config.check("check_dep")) {
+                        if (checkDependency()) {
+                            cout << INFO << "All of resource dependencies are satisfied." << ENDC << endl;
+                        }
+                    }
                 }
             }
         }
-        if(!config.check("silent"))
+        if (!config.check("silent")) {
             reportErrors();
+        }
     }
 
-    if(!config.check("exit"))
+    if (!config.check("exit")) {
         YConsoleManager::myMain();
+    }
 }
 
 YConsoleManager::~YConsoleManager() = default;
@@ -428,9 +461,9 @@ void YConsoleManager::myMain()
         {
             temp = szLine;
             add_history(szLine);
-        }
-        else
+        } else {
             temp = "";
+        }
 #else
         cout << ">> ";
         getline(cin, temp);
@@ -442,15 +475,18 @@ void YConsoleManager::myMain()
         string s;
         while (foo >> s)
         {
-            if (s[0]=='~') s = getenv("HOME") + s.substr(1);
+            if (s[0] == '~') {
+                s = getenv("HOME") + s.substr(1);
+            }
             cmdList.push_back(s);
         }
         if(!process(cmdList))
         {
             if(cmdList[0] == "exit")
             {
-                if(YConsoleManager::exit())
+                if (YConsoleManager::exit()) {
                     break;
+                }
             }
             else
             {
@@ -473,8 +509,9 @@ void YConsoleManager::myMain()
 
 bool YConsoleManager::exit()
 {
-    if(!bShouldRun)
+    if (!bShouldRun) {
         return true;
+    }
 
     string ans;
     cout<<WARNING<<"WARNING: ";
@@ -493,8 +530,9 @@ bool YConsoleManager::exit()
 
 bool YConsoleManager::process(const vector<string> &cmdList)
 {
-    if (!cmdList.size() || cmdList[0] == "")
+    if (!cmdList.size() || cmdList[0] == "") {
         return true;
+    }
 
     /**
      * help
@@ -513,8 +551,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
      if((cmdList.size() == 3) &&
         (cmdList[0] == "add") && (cmdList[1] == "app"))
      {
-         if(addApplication(cmdList[2].c_str()))
-            cout<<INFO<<cmdList[2]<<" is successfully added."<<ENDC<<endl;
+         if (addApplication(cmdList[2].c_str())) {
+             cout << INFO << cmdList[2] << " is successfully added." << ENDC << endl;
+         }
          reportErrors();
         #ifdef YARP_HAS_Libedit
         updateAppNames(&appnames);
@@ -528,8 +567,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
      if((cmdList.size() == 3) &&
         (cmdList[0] == "add") && (cmdList[1] == "mod"))
      {
-         if(addModule(cmdList[2].c_str()))
-            cout<<INFO<<cmdList[2]<<" is successfully added."<<ENDC<<endl;
+         if (addModule(cmdList[2].c_str())) {
+             cout << INFO << cmdList[2] << " is successfully added." << ENDC << endl;
+         }
          reportErrors();
          return true;
      }
@@ -540,8 +580,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
      if((cmdList.size() == 3) &&
         (cmdList[0] == "add") && (cmdList[1] == "res"))
      {
-         if(addResource(cmdList[2].c_str()))
-            cout<<INFO<<cmdList[2]<<" is successfully added."<<ENDC<<endl;
+         if (addResource(cmdList[2].c_str())) {
+             cout << INFO << cmdList[2] << " is successfully added." << ENDC << endl;
+         }
          reportErrors();
          return true;
      }
@@ -596,8 +637,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
         (cmdList[0] == "run"))
      {
         bShouldRun = false;
-        for(unsigned int i=1; i<cmdList.size(); i++)
+        for (unsigned int i = 1; i < cmdList.size(); i++) {
             bShouldRun |= run(atoi(cmdList[i].c_str()));
+        }
         reportErrors();
         return true;
      }
@@ -617,8 +659,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
         (cmdList[0] == "stop"))
      {
          //bShouldRun = false;
-        for(unsigned int i=1; i<cmdList.size(); i++)
-            stop(atoi(cmdList[i].c_str()));
+         for (unsigned int i = 1; i < cmdList.size(); i++) {
+             stop(atoi(cmdList[i].c_str()));
+         }
          bShouldRun = !suspended();
          reportErrors();
          return true;
@@ -639,8 +682,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
         (cmdList[0] == "kill"))
      {
          //bShouldRun = false;
-         for(unsigned int i=1; i<cmdList.size(); i++)
-            kill(atoi(cmdList[i].c_str()));
+         for (unsigned int i = 1; i < cmdList.size(); i++) {
+             kill(atoi(cmdList[i].c_str()));
+         }
          bShouldRun = !suspended();
          reportErrors();
          return true;
@@ -659,8 +703,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
      if((cmdList.size() >= 2) &&
         (cmdList[0] == "connect"))
      {
-        for(unsigned int i=1; i<cmdList.size(); i++)
-            connect(atoi(cmdList[i].c_str()));
+         for (unsigned int i = 1; i < cmdList.size(); i++) {
+             connect(atoi(cmdList[i].c_str()));
+         }
         reportErrors();
         return true;
      }
@@ -679,8 +724,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
      if((cmdList.size() >= 2) &&
         (cmdList[0] == "disconnect"))
      {
-        for(unsigned int i=1; i<cmdList.size(); i++)
-            disconnect(atoi(cmdList[i].c_str()));
+         for (unsigned int i = 1; i < cmdList.size(); i++) {
+             disconnect(atoi(cmdList[i].c_str()));
+         }
         reportErrors();
         return true;
      }
@@ -702,8 +748,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
     if((cmdList.size() == 2) &&
         (cmdList[0] == "check") && (cmdList[1] == "dep"))
     {
-        if(checkDependency())
-            cout<<INFO<<"All of resource dependencies are satisfied."<<ENDC<<endl;
+        if (checkDependency()) {
+            cout << INFO << "All of resource dependencies are satisfied." << ENDC << endl;
+        }
         reportErrors();
         return true;
     }
@@ -723,10 +770,11 @@ bool YConsoleManager::process(const vector<string> &cmdList)
             return true;
         }
 
-        if(running(id))
+        if (running(id)) {
             cout<<OKGREEN<<"<RUNNING> ";
-        else
-            cout<<FAIL<<"<STOPPED> ";
+        } else {
+            cout << FAIL << "<STOPPED> ";
+        }
         cout<<INFO<<"("<<id<<") ";
         cout<<modules[id]->getCommand();
         cout<<" ["<<modules[id]->getHost()<<"]"<<ENDC<<endl;
@@ -757,10 +805,11 @@ bool YConsoleManager::process(const vector<string> &cmdList)
             return true;
         }
 
-        if(connected(id))
+        if (connected(id)) {
             cout<<OKGREEN<<"<CONNECTED> ";
-        else
-            cout<<FAIL<<"<DISCONNECTED> ";
+        } else {
+            cout << FAIL << "<DISCONNECTED> ";
+        }
 
         cout<<INFO<<"("<<id<<") ";
         cout<<connections[id].from()<<" - "<<connections[id].to();
@@ -792,10 +841,11 @@ bool YConsoleManager::process(const vector<string> &cmdList)
             string fpath = mod->getXmlFile();
 
             size_t pos = fpath.rfind(directorySeparator);
-            if(pos!=string::npos)
+            if (pos != string::npos) {
                 fname = fpath.substr(pos);
-            else
+            } else {
                 fname = fpath;
+            }
             cout<<INFO<<"("<<id++<<") ";
             cout<<OKBLUE<<mod->getName()<<ENDC;
             cout<<INFO<<" ["<<fname<<"]"<<ENDC<<endl;
@@ -819,10 +869,11 @@ bool YConsoleManager::process(const vector<string> &cmdList)
             string fpath = app->getXmlFile();
 
             size_t pos = fpath.rfind(directorySeparator);
-            if(pos!=string::npos)
+            if (pos != string::npos) {
                 fname = fpath.substr(pos);
-            else
+            } else {
                 fname = fpath;
+            }
             cout<<INFO<<"("<<id++<<") ";
             cout<<OKBLUE<<app->getName()<<ENDC;
             cout<<INFO<<" ["<<fname<<"]"<<ENDC<<endl;
@@ -847,15 +898,17 @@ bool YConsoleManager::process(const vector<string> &cmdList)
                 string fname;
                 string fpath = comp->getXmlFile();
                 size_t pos = fpath.rfind(directorySeparator);
-                if(pos!=string::npos)
+                if (pos != string::npos) {
                     fname = fpath.substr(pos);
-                else
+                } else {
                     fname = fpath;
+                }
                 cout<<INFO<<"("<<id++<<") ";
-                if(comp->getDisable())
+                if (comp->getDisable()) {
                     cout<<WARNING<<comp->getName()<<ENDC;
-                else
-                    cout<<OKBLUE<<comp->getName()<<ENDC;
+                } else {
+                    cout << OKBLUE << comp->getName() << ENDC;
+                }
                 cout<<INFO<<" ["<<fname<<"]"<<ENDC<<endl;
             }
         }
@@ -869,8 +922,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
     if((cmdList.size() == 2) &&
         (cmdList[0] == "export") )
     {
-        if(!exportDependencyGraph(cmdList[1].c_str()))
-            cout<<FAIL<<"ERROR:   "<<INFO<<"Cannot export graph to "<<cmdList[1]<<"."<<ENDC<<endl;
+        if (!exportDependencyGraph(cmdList[1].c_str())) {
+            cout << FAIL << "ERROR:   " << INFO << "Cannot export graph to " << cmdList[1] << "." << ENDC << endl;
+        }
         return true;
     }
 
@@ -904,36 +958,40 @@ bool YConsoleManager::process(const vector<string> &cmdList)
 
         if(cmdList[1] == string("watchdog"))
         {
-            if(cmdList[2] == string("yes"))
+            if (cmdList[2] == string("yes")) {
                 enableWatchDog();
-            else
+            } else {
                 disableWatchod();
+            }
         }
 
         if(cmdList[1] == string("auto_dependency"))
         {
-            if(cmdList[2] == string("yes"))
+            if (cmdList[2] == string("yes")) {
                 enableAutoDependency();
-            else
+            } else {
                 disableAutoDependency();
+            }
         }
 
         if(cmdList[1] == string("auto_connect"))
         {
-            if(cmdList[2] == string("yes"))
+            if (cmdList[2] == string("yes")) {
                 enableAutoConnect();
-            else
+            } else {
                 disableAutoConnect();
+            }
         }
 
         if(cmdList[1] == string("color_theme"))
         {
-            if(cmdList[2] == string("dark"))
+            if (cmdList[2] == string("dark")) {
                 setColorTheme(THEME_DARK);
-            else if(cmdList[2] == string("light"))
+            } else if (cmdList[2] == string("light")) {
                 setColorTheme(THEME_LIGHT);
-            else
+            } else {
                 setColorTheme(THEME_NONE);
+            }
         }
 
         return true;
@@ -950,9 +1008,9 @@ bool YConsoleManager::process(const vector<string> &cmdList)
          {
             cout<<OKBLUE<<cmdList[1]<<INFO<<" = ";
             cout<<OKGREEN<<config.find(cmdList[1]).asString()<<ENDC<<endl;
+         } else {
+             cout << FAIL << "ERROR:   " << INFO << "'" << cmdList[1].c_str() << "' not found." << ENDC << endl;
          }
-         else
-            cout<<FAIL<<"ERROR:   "<<INFO<<"'"<<cmdList[1].c_str()<<"' not found."<<ENDC<<endl;
          return true;
      }
 
@@ -1057,9 +1115,9 @@ void YConsoleManager::checkStates()
         {
             bShouldRun = true;
             cout<<OKGREEN<<"<RUNNING> ";
+        } else {
+            cout << FAIL << "<STOPPED> ";
         }
-        else
-            cout<<FAIL<<"<STOPPED> ";
         cout<<INFO<<"("<<id<<") ";
         cout<<(*moditr)->getCommand();
         cout<<" ["<<(*moditr)->getHost()<<"]"<<ENDC<<endl;
@@ -1074,10 +1132,11 @@ void YConsoleManager::checkConnections()
     int id = 0;
     for(cnnitr=connections.begin(); cnnitr<connections.end(); cnnitr++)
     {
-        if(connected(id))
+        if (connected(id)) {
             cout<<OKGREEN<<"<CONNECTED> ";
-        else
-            cout<<FAIL<<"<DISCONNECTED> ";
+        } else {
+            cout << FAIL << "<DISCONNECTED> ";
+        }
 
         cout<<INFO<<"("<<id<<") ";
         cout<<(*cnnitr).from()<<" - "<<(*cnnitr).to();
@@ -1092,11 +1151,13 @@ void YConsoleManager::reportErrors()
     if(logger->errorCount() || logger->warningCount())
     {
         const char* msg;
-        while((msg=logger->getLastError()))
-            cout<<FAIL<<"ERROR:   "<<INFO<<msg<<ENDC<<endl;
+        while ((msg = logger->getLastError())) {
+            cout << FAIL << "ERROR:   " << INFO << msg << ENDC << endl;
+        }
 
-        while((msg=logger->getLastWarning()))
-            cout<<WARNING<<"WARNING: "<<INFO<<msg<<ENDC<<endl;
+        while ((msg = logger->getLastWarning())) {
+            cout << WARNING << "WARNING: " << INFO << msg << ENDC << endl;
+        }
     }
 }
 
@@ -1110,8 +1171,9 @@ void YConsoleManager::onExecutableDied(void* which) { }
 void YConsoleManager::onExecutableFailed(void* which)
 {
     auto* exe = (Executable*) which;
-    if(config.find("module_failure").asString() == "prompt")
-        cout<<exe->getCommand()<<" from "<<exe->getHost()<<" is failed!"<<endl;
+    if (config.find("module_failure").asString() == "prompt") {
+        cout << exe->getCommand() << " from " << exe->getHost() << " is failed!" << endl;
+    }
 
     if(config.find("module_failure").asString() == "recover")
     {
@@ -1133,9 +1195,10 @@ void YConsoleManager::onCnnStablished(void* which) { }
 void YConsoleManager::onCnnFailed(void* which)
 {
     auto* cnn = (Connection*) which;
-    if(config.check("connection_failure") &&
-     config.find("connection_failure").asString() == "prompt")
-        cout<<endl<<"connection failed between "<<cnn->from()<<" and "<<cnn->to()<<endl;
+    if (config.check("connection_failure") && config.find("connection_failure").asString() == "prompt") {
+        cout << endl
+             << "connection failed between " << cnn->from() << " and " << cnn->to() << endl;
+    }
 
     if(bShouldRun && config.check("connection_failure") &&
      config.find("connection_failure").asString() == "terminate")
@@ -1152,14 +1215,15 @@ bool YConsoleManager::loadRecursiveApplications(const char* szPath)
 {
     const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     string strPath = szPath;
-    if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
-            strPath = strPath + string(directorySeparator);
+    if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
+        strPath = strPath + string(directorySeparator);
+    }
 
     DIR *dir;
     struct dirent *entry;
-    if ((dir = opendir(strPath.c_str())) == nullptr)
+    if ((dir = opendir(strPath.c_str())) == nullptr) {
         return false;
+    }
 
     addApplications(strPath.c_str());
 
@@ -1183,8 +1247,9 @@ void YConsoleManager::updateAppNames(vector<string>* names)
     names->clear();
     KnowledgeBase* kb = getKnowledgeBase();
     ApplicaitonPContainer apps =  kb->getApplications();
-    for(auto& app : apps)
+    for (auto& app : apps) {
         names->push_back(app->getName());
+    }
 }
 
 
@@ -1256,10 +1321,11 @@ char ** my_completion (const char* text, int start, int end)
   /* If this word is at the start of the line, then it is a command
      to complete.  Otherwise it is the name of a file in the current
      directory. */
-    if (start == 0)
+    if (start == 0) {
         matches = rl_completion_matches(text, &command_generator);
-   else
+    } else {
         matches = rl_completion_matches(text, &appname_generator);
+    }
 
     return (matches);
 }
@@ -1287,8 +1353,9 @@ char* command_generator (const char* text, int state)
   while ((list_index<CMD_COUNTS) && (name = (char*)commands[list_index]))
     {
       list_index++;
-      if (strncmp (name, text, len) == 0)
-        return (dupstr(name));
+      if (strncmp(name, text, len) == 0) {
+          return (dupstr(name));
+      }
     }
 
   /* if no names matched, then return null. */
@@ -1311,8 +1378,9 @@ char* appname_generator (const char* text, int state)
   while ((list_index<appnames.size()) && (name = (char*)appnames[list_index].c_str()))
     {
       list_index++;
-      if (strncmp (name, text, len) == 0)
-        return (dupstr(name));
+      if (strncmp(name, text, len) == 0) {
+          return (dupstr(name));
+      }
     }
 
   return ((char *)nullptr);

--- a/src/yarpmanager/src-builder/applicationitem.cpp
+++ b/src/yarpmanager/src-builder/applicationitem.cpp
@@ -461,8 +461,9 @@ PortItem* ApplicationItem::findModelFromOutput(OutputData* output)
                         //QString prefix = QString("%1%2").arg(application->getInnerApplication()->getPrefix()).arg(module->getInnerModule()->getBasePrefix());
 
                         //if(!strcmp(port->outData.getPort(), (*output).getPort()) && modulePrefix == prefix)  {
-                        if(port->outData == output)
+                        if (port->outData == output) {
                             return port;
+                        }
                     }
                 }
             }

--- a/src/yarpmanager/src-builder/builderitem.cpp
+++ b/src/yarpmanager/src-builder/builderitem.cpp
@@ -38,10 +38,9 @@ QList<Arrow *>* BuilderItem::getArrows()
 void BuilderItem::removeArrow(Arrow *arrow){
     int index = arrows.indexOf(arrow);
 
-    if (index != -1)
+    if (index != -1) {
         arrows.removeAt(index);
-
-
+    }
 }
 
 bool BuilderItem::arrowAlreadyPresent(BuilderItem *endItem)

--- a/src/yarpmanager/src-builder/builderwindow.cpp
+++ b/src/yarpmanager/src-builder/builderwindow.cpp
@@ -102,8 +102,9 @@ bool BuilderWindow::save()
         return true;
     }
     Application* application = manager.getKnowledgeBase()->getApplication();
-    if(!application)
+    if (!application) {
         return true;
+    }
 
     foreach (QGraphicsItem *it, scene->items()) {
         if(it->type() == QGraphicsItem::UserType+SourcePortItemType){
@@ -126,29 +127,33 @@ bool BuilderWindow::save()
 QString BuilderWindow::getFileName()
 {
     Application* application = manager.getKnowledgeBase()->getApplication();
-    if(!application)
+    if (!application) {
         return {};
+    };
     return QString(application->getXmlFile());
 }
 void BuilderWindow::setFileName(QString filename)
 {
     Application* application = manager.getKnowledgeBase()->getApplication();
-    if(application)
+    if (application) {
         application->setXmlFile(filename.toStdString().c_str());
+    }
     return;
 }
 QString BuilderWindow::getAppName()
 {
     Application* application = manager.getKnowledgeBase()->getApplication();
-    if(!application)
+    if (!application) {
         return {};
+    };
     return QString(application->getName());
 }
 void BuilderWindow::setAppName(QString appName)
 {
     Application* application = manager.getKnowledgeBase()->getApplication();
-    if(application)
+    if (application) {
         application->setName(appName.toStdString().c_str());
+    }
     return;
 }
 
@@ -160,16 +165,19 @@ void BuilderWindow::prepareManagerFrom(Manager* lazy,
     KnowledgeBase* lazy_kb = lazy->getKnowledgeBase();
 
     ModulePContainer mods =  lazy_kb->getModules();
-    for(auto& mod : mods)
+    for (auto& mod : mods) {
         manager.getKnowledgeBase()->addModule(mod);
+    }
 
     ResourcePContainer res =  lazy_kb->getResources();
-    for(auto& re : res)
+    for (auto& re : res) {
         manager.getKnowledgeBase()->addResource(re);
+    }
 
     ApplicaitonPContainer apps =  lazy_kb->getApplications();
-    for(auto& app : apps)
+    for (auto& app : apps) {
         manager.getKnowledgeBase()->addApplication(app);
+    }
 
     // loading application
     manager.loadApplication(szAppName);
@@ -835,8 +843,9 @@ void BuilderWindow::onAddedApplication(void *app,QPointF pos)
     iapp.setModelBase(modBase);
 
     Application* mainApplication = manager.getKnowledgeBase()->getApplication();
-    if(!mainApplication)
+    if (!mainApplication) {
         return;
+    }
 
     string strPrefix = "/";
     string  uniqeId = manager.getKnowledgeBase()->getUniqueAppID(mainApplication, iapp.getName());

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -195,16 +195,18 @@ bool ApplicationViewWidget::save()
 
 QString ApplicationViewWidget::getFileName()
 {
-    if (builder)
+    if (builder) {
         return builder->getFileName();
-    else
+    } else {
         return {};
+    };
 }
 
 void ApplicationViewWidget::setFileName(QString filename)
 {
-    if (builder)
+    if (builder) {
         builder->setFileName(filename);
+    }
     return;
 }
 
@@ -212,15 +214,16 @@ QString ApplicationViewWidget::getAppName()
 {
     if (builder) {
         return builder->getAppName();
-    }
-    else
+    } else {
         return {};
+    };
 }
 
 void ApplicationViewWidget::setAppName(QString appName)
 {
-    if (builder)
+    if (builder) {
         builder->setAppName(appName);
+    }
     return;
 }
 
@@ -614,10 +617,11 @@ void ApplicationViewWidget::updateApplicationWindow()
         l << command << id << "stopped" << host << param << stdio << workDir << env;
 
         CustomTreeWidgetItem *it;
-        if (!appNode)
+        if (!appNode) {
             it = new CustomTreeWidgetItem(ui->moduleList,l);
-        else
-            it = new CustomTreeWidgetItem(appNode,l);
+        } else {
+            it = new CustomTreeWidgetItem(appNode, l);
+        }
 
         //it->setFlags(it->flags() | Qt::ItemIsEditable);
         it->setData(0,Qt::UserRole,yarp::manager::MODULE);
@@ -630,14 +634,14 @@ void ApplicationViewWidget::updateApplicationWindow()
     for(cnnitr=connections.begin(); cnnitr<connections.end(); cnnitr++)
     {
         QString type;
-        if ((*cnnitr).isPersistent())
+        if ((*cnnitr).isPersistent()) {
             type = "Persistent";
-        else
-        {
-            if ((*cnnitr).isExternalFrom() || (*cnnitr).isExternalTo())
+        } else {
+            if ((*cnnitr).isExternalFrom() || (*cnnitr).isExternalTo()) {
                 type = "External";
-            else
+            } else {
                 type = "Internal";
+            }
         }
         QString sId = QString("%1").arg(id);
         QString from = QString("%1").arg((*cnnitr).from());
@@ -1497,10 +1501,11 @@ bool ApplicationViewWidget::scanAvailableCarriers(QString carrier, bool isConnec
     stringLst.push_back(carrier);
     for (size_t i=0; i<lst.size(); i++)
     {
-        if (lst.get(i).asString() == carrier.toStdString())
+        if (lst.get(i).asString() == carrier.toStdString()) {
             res = true;
-        else
+        } else {
             stringLst.push_back(lst.get(i).asString().c_str());
+        }
     }
     if (!res && isConnection)
     {
@@ -1613,40 +1618,45 @@ void ApplicationViewWidget::selectAll()
 /*! \brief Run all modules in the application */
 void ApplicationViewWidget::runApplicationSet(bool onlySelected)
 {
-    if(!onlySelected)
+    if (!onlySelected) {
         selectAllModule(true);
+    }
     onRun();
 }
 
 /*! \brief Stop all modules in the application */
 void ApplicationViewWidget::stopApplicationSet(bool onlySelected)
 {
-    if(!onlySelected)
+    if (!onlySelected) {
         selectAllModule(true);
+    }
     onStop();
 }
 
 /*! \brief Kill all running modules in the application */
 void ApplicationViewWidget::killApplicationSet(bool onlySelected)
 {
-    if(!onlySelected)
+    if (!onlySelected) {
         selectAllModule(true);
+    }
     onKill();
 }
 
 /*! \brief Connect all modules in the application to their ports using connections list*/
 void ApplicationViewWidget::connectConnectionSet(bool onlySelected)
 {
-    if(!onlySelected)
+    if (!onlySelected) {
         selectAllConnections(true);
+    }
     onConnect();
 }
 
 /*! \brief Disconnect all modules in the application to their ports using connections list*/
 void ApplicationViewWidget::disconnectConnectionSet(bool onlySelected)
 {
-    if(!onlySelected)
+    if (!onlySelected) {
         selectAllConnections(true);
+    }
     onDisconnect();
 }
 
@@ -1922,8 +1932,11 @@ void ApplicationViewWidget::onYARPScope()
                 else{
                     // waiting for the port to get open
                     double base = yarp::os::SystemClock::nowSystem();
-                    while(!timeout(base, 3.0))
-                        if (launcher.exists(to.toLatin1().data())) break;
+                    while (!timeout(base, 3.0)) {
+                        if (launcher.exists(to.toLatin1().data())) {
+                            break;
+                        }
+                    }
                     if (!launcher.connect(from.toLatin1().data(), to.toLatin1().data(), "udp")) {
                         QString msg;
                         msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error());
@@ -1944,8 +1957,9 @@ void ApplicationViewWidget::onYARPScope()
 bool ApplicationViewWidget::timeout(double base, double timeout)
 {
     yarp::os::SystemClock::delaySystem(1.0);
-    if ((yarp::os::SystemClock::nowSystem()-base) > timeout)
+    if ((yarp::os::SystemClock::nowSystem() - base) > timeout) {
         return true;
+    }
     return false;
 }
 

--- a/src/yarpmanager/src-manager/clusterWidget.cpp
+++ b/src/yarpmanager/src-manager/clusterWidget.cpp
@@ -92,8 +92,9 @@ void ClusterWidget::init()
     {
         addRow(node.name, node.displayValue, node.user, node.address, node.onOff, node.log, i);
         i++;
-        if (cluster.nsNode == node.name)
+        if (cluster.nsNode == node.name) {
             continue;
+        }
         l.push_back(node.name.c_str());
     }
 
@@ -432,10 +433,11 @@ void ClusterWidget::onNodeSelectionChanged()
 
 void ClusterWidget::onExecuteTextChanged()
 {
-    if (ui->lineEditExecute->text().trimmed().size() > 0)
+    if (ui->lineEditExecute->text().trimmed().size() > 0) {
         ui->executeBtn->setDisabled(false);
-    else
+    } else {
         ui->executeBtn->setDisabled(true);
+    }
 }
 
 

--- a/src/yarpmanager/src-manager/entitiestreewidget.cpp
+++ b/src/yarpmanager/src-manager/entitiestreewidget.cpp
@@ -460,8 +460,9 @@ void EntitiesTreeWidget::clearPorts()
 
 QTreeWidgetItem * EntitiesTreeWidget::getWidgetItemByFilename(const QString xmlFile){
     QList<QTreeWidgetItem*> clist = this->findItems(xmlFile, Qt::MatchContains|Qt::MatchRecursive, 0);
-    if (clist.size())
+    if (clist.size()) {
         return clist.at(0)->parent();
+    }
     return nullptr;
 }
 

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -219,14 +219,16 @@ void MainWindow::init(yarp::os::Property config)
             string::size_type pos=modPaths.find(';');
             strPath=modPaths.substr(0, pos);
             yarp::manager::trimString(strPath);
-            if (!isAbsolute(strPath.c_str()))
+            if (!isAbsolute(strPath.c_str())) {
                 strPath.insert(0, basepath);
-            if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+            }
+            if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
                 strPath.append(directorySeparator);
+            }
             lazyManager.addModules(strPath.c_str());
-            if (pos==string::npos || pos==0)
+            if (pos == string::npos || pos == 0) {
                 break;
+            }
             modPaths=modPaths.substr(pos+1);
         }
     }
@@ -238,16 +240,18 @@ void MainWindow::init(yarp::os::Property config)
             string::size_type pos=resPaths.find(';');
             strPath=resPaths.substr(0, pos);
             yarp::manager::trimString(strPath);
-            if (!isAbsolute(strPath.c_str()))
+            if (!isAbsolute(strPath.c_str())) {
                 strPath.insert(0, basepath);
+            }
 
-            if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
+            if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
                 strPath.append(directorySeparator);
+            }
 
             lazyManager.addResources(strPath.c_str());
-            if (pos==string::npos)
+            if (pos == string::npos) {
                 break;
+            }
             resPaths=resPaths.substr(pos+1);
         }
     }
@@ -431,8 +435,9 @@ bool MainWindow::loadRecursiveTemplates(const char* szPath)
 
     DIR *dir;
     struct dirent *entry;
-    if ((dir = opendir(strPath.c_str())) == nullptr)
+    if ((dir = opendir(strPath.c_str())) == nullptr) {
         return false;
+    }
 
     // loading from current folder
     yarp::manager::AppTemplate* tmp;
@@ -466,14 +471,15 @@ bool MainWindow::loadRecursiveApplications(const char* szPath)
 {
     const std::string directorySeparator{yarp::conf::filesystem::preferred_separator};
     string strPath = szPath;
-    if((strPath.rfind(directorySeparator)==string::npos) ||
-            (strPath.rfind(directorySeparator)!=strPath.size()-1))
-            strPath = strPath + directorySeparator;
+    if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
+        strPath = strPath + directorySeparator;
+    }
 
     DIR *dir;
     struct dirent *entry;
-    if ((dir = opendir(strPath.c_str())) == nullptr)
+    if ((dir = opendir(strPath.c_str())) == nullptr) {
         return false;
+    }
 
     lazyManager.addApplications(strPath.c_str());
 
@@ -502,14 +508,15 @@ bool MainWindow::initializeFile(string _class)
                  "      </authors>\n"
                  "</application>\n";
     if(b){
-        if(_class == "Resource")
+        if (_class == "Resource") {
             f.write(str_res_template.c_str());
-        else if(_class == "Module")
+        } else if (_class == "Module") {
             f.write(str_mod_template.c_str());
-        else if(_class == "Application")
+        } else if (_class == "Application") {
             f.write(appTemplate.toStdString().c_str());
-        else
+        } else {
             return false;
+        }
         f.flush();
         f.close();
         return true;
@@ -1081,12 +1088,14 @@ void MainWindow::onImportFiles()
                                                     | QFileDialog::DontResolveSymlinks);
     if(!dir.isEmpty()){
         if(config.find("load_subfolders").asString() == "yes"){
-            if(loadRecursiveApplications(dir.toLatin1().data()))
+            if (loadRecursiveApplications(dir.toLatin1().data())) {
                 syncApplicationList();
+            }
         }
         else{
-            if(lazyManager.addApplications(dir.toLatin1().data()))
+            if (lazyManager.addApplications(dir.toLatin1().data())) {
                 syncApplicationList();
+            }
         }
 
         if(lazyManager.addResources(dir.toLatin1().data())){
@@ -1144,8 +1153,9 @@ void MainWindow::onFileChanged(const QString &path)
     reply = QMessageBox::question(this, "File changed", "Xml file '" + path +
                                   "' changed.\nDo you want to reload the application? If open, the respective tab will be closed",
                                   QMessageBox::Yes|QMessageBox::No);
-    if (reply == QMessageBox::No)
+    if (reply == QMessageBox::No) {
         return;
+    }
 
     Application* app = (Application*) lazyManager.getNode(appName.toStdString());
     if (app)

--- a/src/yarpmanager/src-manager/newapplicationwizard.cpp
+++ b/src/yarpmanager/src-manager/newapplicationwizard.cpp
@@ -119,16 +119,18 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
             string::size_type pos=appPaths.find(';');
             strPath=appPaths.substr(0, pos);
             trimString(strPath);
-            if (!absolute(strPath.c_str()))
-                strPath=basepath+strPath;
+            if (!absolute(strPath.c_str())) {
+                strPath = basepath + strPath;
+            }
 
-            if((strPath.rfind(directorySeparator)==string::npos) ||
-                    (strPath.rfind(directorySeparator)!=strPath.size()-1))
+            if ((strPath.rfind(directorySeparator) == string::npos) || (strPath.rfind(directorySeparator) != strPath.size() - 1)) {
                 strPath = strPath + string(directorySeparator);
+            }
             folderCombo->addItem(QString("%1").arg(strPath.c_str()));
 
-            if (pos==string::npos)
+            if (pos == string::npos) {
                 break;
+            }
             appPaths=appPaths.substr(pos+1);
         }
         while (appPaths!="");
@@ -139,8 +141,9 @@ NewApplicationWizard::NewApplicationWizard(yarp::os::Property *config, bool _sav
 
        homePath +=  string(directorySeparator) + string("applications");
 
-       if (appPaths.find(homePath)==string::npos)
+       if (appPaths.find(homePath) == string::npos) {
            folderCombo->addItem(QString("%1").arg(homePath.c_str()));
+       }
    }
 
     if(folderCombo->count() <= 0){

--- a/src/yarpmanager/src-manager/safe_manager.cpp
+++ b/src/yarpmanager/src-manager/safe_manager.cpp
@@ -35,35 +35,41 @@ bool SafeManager::prepare(Manager* lazy,
     eventReceiver = event;
     m_pConfig = pConfig;
 
-    if(pConfig->find("watchdog").asString() == "yes")
+    if (pConfig->find("watchdog").asString() == "yes") {
         enableWatchDog();
-    else
+    } else {
         disableWatchod();
+    }
 
-    if(pConfig->find("auto_dependency").asString() == "yes")
+    if (pConfig->find("auto_dependency").asString() == "yes") {
         enableAutoDependency();
-    else
+    } else {
         disableAutoDependency();
+    }
 
-    if(pConfig->find("auto_connect").asString() == "yes")
+    if (pConfig->find("auto_connect").asString() == "yes") {
         enableAutoConnect();
-    else
+    } else {
         disableAutoConnect();
+    }
 
     // making manager from lazy manager
     KnowledgeBase* lazy_kb = lazy->getKnowledgeBase();
 
     ModulePContainer mods =  lazy_kb->getModules();
-    for(auto& mod : mods)
+    for (auto& mod : mods) {
         getKnowledgeBase()->addModule(mod);
+    }
 
     ResourcePContainer res =  lazy_kb->getResources();
-    for(auto& re : res)
+    for (auto& re : res) {
         getKnowledgeBase()->addResource(re);
+    }
 
     ApplicaitonPContainer apps =  lazy_kb->getApplications();
-    for(auto& app : apps)
+    for (auto& app : apps) {
         getKnowledgeBase()->addApplication(app);
+    }
 
     return true;
 }
@@ -195,8 +201,9 @@ void SafeManager::run()
             break;
         }
     case MKILL:{
-            for(int local_modId : local_modIds)
-                Manager::kill(local_modId, true);
+        for (int local_modId : local_modIds) {
+            Manager::kill(local_modId, true);
+        }
             /*for(unsigned int i=0; i<local_modIds.size(); i++)
                 Manager::waitingModuleKill(local_modIds[i]);
 
@@ -231,11 +238,15 @@ void SafeManager::run()
                 refreshPortStatus(local_conId);
                 if(Manager::connect(local_conId))
                 {
-                    if(eventReceiver) eventReceiver->onConConnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConConnect(local_conId);
+                    }
                 }
                 else
                 {
-                    if(eventReceiver) eventReceiver->onConDisconnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConDisconnect(local_conId);
+                    }
                 }
             }
             break;
@@ -246,11 +257,15 @@ void SafeManager::run()
                 refreshPortStatus(local_conId);
                 if(Manager::disconnect(local_conId))
                 {
-                    if(eventReceiver) eventReceiver->onConDisconnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConDisconnect(local_conId);
+                    }
                 }
                 else
                 {
-                    if(eventReceiver) eventReceiver->onConConnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConConnect(local_conId);
+                    }
                 }
             }
             break;
@@ -263,11 +278,15 @@ void SafeManager::run()
             {
                 if(Manager::running(local_modId))
                 {
-                    if(eventReceiver) eventReceiver->onModStart(local_modId);
+                    if (eventReceiver) {
+                        eventReceiver->onModStart(local_modId);
+                    }
                 }
                 else //if(Manager::suspended(local_modIds[i]))
                 {
-                    if(eventReceiver) eventReceiver->onModStop(local_modId);
+                    if (eventReceiver) {
+                        eventReceiver->onModStop(local_modId);
+                    }
                 }
             }
 
@@ -276,11 +295,15 @@ void SafeManager::run()
                 refreshPortStatus(local_conId);
                 if(Manager::connected(local_conId))
                 {
-                    if(eventReceiver) eventReceiver->onConConnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConConnect(local_conId);
+                    }
                 }
                 else
                 {
-                    if(eventReceiver) eventReceiver->onConDisconnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConDisconnect(local_conId);
+                    }
                 }
             }
 
@@ -288,11 +311,15 @@ void SafeManager::run()
             {
                 if(Manager::exist(local_resId))
                 {
-                    if(eventReceiver) eventReceiver->onResAvailable(local_resId);
+                    if (eventReceiver) {
+                        eventReceiver->onResAvailable(local_resId);
+                    }
                 }
                 else
                 {
-                    if(eventReceiver) eventReceiver->onResUnAvailable(local_resId);
+                    if (eventReceiver) {
+                        eventReceiver->onResUnAvailable(local_resId);
+                    }
                 }
             }
             busyAction = false;
@@ -305,32 +332,40 @@ void SafeManager::run()
                 refreshPortStatus(local_conId);
                 if(Manager::connected(local_conId))
                 {
-                    if(eventReceiver) eventReceiver->onConConnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConConnect(local_conId);
+                    }
                 }
                 else
                 {
-                    if(eventReceiver) eventReceiver->onConDisconnect(local_conId);
+                    if (eventReceiver) {
+                        eventReceiver->onConDisconnect(local_conId);
+                    }
                 }
             }
             break;
         }
 
     case MATTACHSTDOUT:{
-            for(int local_modId : local_modIds)
-                Manager::attachStdout(local_modId);
+        for (int local_modId : local_modIds) {
+            Manager::attachStdout(local_modId);
+        }
             break;
         }
 
     case MDETACHSTDOUT:{
-            for(int local_modId : local_modIds)
-                Manager::detachStdout(local_modId);
+        for (int local_modId : local_modIds) {
+            Manager::detachStdout(local_modId);
+        }
             break;
         }
 
     case MLOADBALANCE:{
                 busyAction = true;
                 Manager::loadBalance();
-                if(eventReceiver) eventReceiver->onLoadBalance();
+                if (eventReceiver) {
+                    eventReceiver->onLoadBalance();
+                }
                 busyAction = false;
             break;
         }
@@ -340,13 +375,16 @@ void SafeManager::run()
         break;
     };
 
-    if(eventReceiver)
+    if (eventReceiver) {
         eventReceiver->onError();
+    }
 }
 
 void SafeManager::safeRun(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int> &RIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
@@ -354,13 +392,16 @@ void SafeManager::safeRun(std::vector<int>& MIDs, std::vector<int>& CIDs, std::v
     resIds = RIDs;
     action = MRUN;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 void SafeManager::safeStop(std::vector<int>& MIDs, std::vector<int>& CIDs, std::vector<int> &RIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
@@ -368,13 +409,16 @@ void SafeManager::safeStop(std::vector<int>& MIDs, std::vector<int>& CIDs, std::
     resIds = RIDs;
     action = MSTOP;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 void SafeManager::safeKill(std::vector<int>& MIDs, std::vector<int> &CIDs, std::vector<int> &RIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
@@ -382,35 +426,41 @@ void SafeManager::safeKill(std::vector<int>& MIDs, std::vector<int> &CIDs, std::
     resIds = RIDs;
     action = MKILL;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
-
+    }
 }
 
 
 void SafeManager::safeConnect(std::vector<int>& CIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     conIds = CIDs;
     action = MCONNECT;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 
 void SafeManager::safeDisconnect(std::vector<int>& CIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     conIds = CIDs;
     action = MDISCONNECT;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 
@@ -418,7 +468,9 @@ void SafeManager::safeRefresh(std::vector<int>& MIDs,
                      std::vector<int>& CIDs,
                      std::vector<int>& RIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
@@ -426,51 +478,62 @@ void SafeManager::safeRefresh(std::vector<int>& MIDs,
     resIds = RIDs;
     action = MREFRESH;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 
 void SafeManager::safeAttachStdout(std::vector<int>& MIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
     WAIT_SEMAPHOR();
     modIds = MIDs;
     action = MATTACHSTDOUT;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 void SafeManager::safeDetachStdout(std::vector<int>& MIDs)
 {
-    if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
     WAIT_SEMAPHOR();
     modIds = MIDs;
     action = MDETACHSTDOUT;
     POST_SEMAPHOR();
-    if(!yarp::os::Thread::isRunning())
+    if (!yarp::os::Thread::isRunning()) {
         yarp::os::Thread::start();
+    }
 }
 
 void SafeManager::safeLoadBalance()
 {
-   if(busy()) return;
+    if (busy()) {
+        return;
+    }
 
    WAIT_SEMAPHOR();
    action = MLOADBALANCE;
    POST_SEMAPHOR();
-   if(!yarp::os::Thread::isRunning())
+   if (!yarp::os::Thread::isRunning()) {
        yarp::os::Thread::start();
+   }
 }
 
 void SafeManager::onExecutableStart(void* which)
 {
     WAIT_SEMAPHOR();
     auto* exe = static_cast<Executable*>(which);
-    if(eventReceiver && exe)
+    if (eventReceiver && exe) {
         eventReceiver->onModStart(exe->getID());
+    }
     POST_SEMAPHOR();
 }
 
@@ -478,8 +541,9 @@ void SafeManager::onExecutableStop(void* which)
 {
     WAIT_SEMAPHOR();
     auto* exe = static_cast<Executable*>(which);
-    if(eventReceiver && exe)
+    if (eventReceiver && exe) {
         eventReceiver->onModStop(exe->getID());
+    }
     POST_SEMAPHOR();
     // Experimental:
     //  do auto refresh on connections whenever a module stops
@@ -503,8 +567,9 @@ void SafeManager::onExecutableDied(void* which)
 {
     WAIT_SEMAPHOR();
     auto* exe = static_cast<Executable*>(which);
-    if(eventReceiver && exe)
+    if (eventReceiver && exe) {
         eventReceiver->onModStop(exe->getID());
+    }
     POST_SEMAPHOR();
 }
 
@@ -521,8 +586,9 @@ void SafeManager::onExecutableFailed(void* which)
             OSTRINGSTREAM err;
             err<<exe->getCommand()<<" from "<<exe->getHost()<<" is failed! [id:"<<exe->getID()<<"]";
             logger->addError(err);
-            if(eventReceiver && exe)
+            if (eventReceiver && exe) {
                 eventReceiver->onModStop(exe->getID());
+            }
         }
 
         if(m_pConfig->find("module_failure").asString() == "recover")
@@ -542,8 +608,9 @@ void SafeManager::onExecutableFailed(void* which)
         }
     }
 
-    if(eventReceiver)
-            eventReceiver->onError();
+    if (eventReceiver) {
+        eventReceiver->onError();
+    }
     POST_SEMAPHOR();
 }
 
@@ -574,8 +641,9 @@ void SafeManager::onCnnFailed(void* which)
         }
     }
 
-    if(eventReceiver)
+    if (eventReceiver) {
         eventReceiver->onError();
+    }
     POST_SEMAPHOR();
 }
 
@@ -584,16 +652,18 @@ void SafeManager::onExecutableStdout(void* which, const char* msg)
 {
     WAIT_SEMAPHOR();
     auto* exe = static_cast<Executable*>(which);
-    if(eventReceiver)
+    if (eventReceiver) {
         eventReceiver->onModStdout(exe->getID(), msg);
+    }
     POST_SEMAPHOR();
 }
 
 void SafeManager::onError(void* which)
 {
     WAIT_SEMAPHOR();
-    if(eventReceiver)
+    if (eventReceiver) {
         eventReceiver->onError();
+    }
     POST_SEMAPHOR();
 }
 
@@ -602,19 +672,27 @@ void SafeManager::refreshPortStatus(int id)
     // refreshing ports status
     if(Manager::existPortFrom(id))
     {
-        if(eventReceiver) eventReceiver->onConAvailable(id, -1);
+        if (eventReceiver) {
+            eventReceiver->onConAvailable(id, -1);
+        }
     }
     else
     {
-        if(eventReceiver) eventReceiver->onConUnAvailable(id, -1);
+        if (eventReceiver) {
+            eventReceiver->onConUnAvailable(id, -1);
+        }
     }
 
     if(Manager::existPortTo(id))
     {
-        if(eventReceiver) eventReceiver->onConAvailable(-1, id);
+        if (eventReceiver) {
+            eventReceiver->onConAvailable(-1, id);
+        }
     }
     else
     {
-        if(eventReceiver) eventReceiver->onConUnAvailable(-1, id);
+        if (eventReceiver) {
+            eventReceiver->onConUnAvailable(-1, id);
+        }
     }
 }

--- a/src/yarpmobilebasegui/display.cpp
+++ b/src/yarpmobilebasegui/display.cpp
@@ -261,28 +261,36 @@ void MainWindow::handleButton_Er()
 void MainWindow::handleButton_I()
 {
     max_vel_lin += lin_vel_step;
-    if (max_vel_lin < 0) max_vel_lin = 0;
+    if (max_vel_lin < 0) {
+        max_vel_lin = 0;
+    }
     snprintf(buff,100, s_max_lin_vel, max_vel_lin);
     ui->label_max_lin_vel->setText(buff);
 }
 void MainWindow::handleButton_K()
 {
     max_vel_lin -= lin_vel_step;
-    if (max_vel_lin < 0) max_vel_lin = 0;
+    if (max_vel_lin < 0) {
+        max_vel_lin = 0;
+    }
     snprintf(buff, 100, s_max_lin_vel, max_vel_lin);
     ui->label_max_lin_vel->setText(buff);
 }
 void MainWindow::handleButton_O()
 {
     max_vel_theta += ang_vel_step;
-    if (max_vel_theta < 0) max_vel_theta = 0;
+    if (max_vel_theta < 0) {
+        max_vel_theta = 0;
+    }
     snprintf(buff, 100, s_max_ang_vel, max_vel_theta);
     ui->label_max_ang_vel->setText(buff);
 }
 void MainWindow::handleButton_L()
 {
     max_vel_theta -= ang_vel_step;
-    if (max_vel_theta < 0) max_vel_theta = 0;
+    if (max_vel_theta < 0) {
+        max_vel_theta = 0;
+    }
     snprintf(buff, 100, s_max_ang_vel, max_vel_theta);
     ui->label_max_ang_vel->setText(buff);
 }

--- a/src/yarpmotorgui/flowlayout.cpp
+++ b/src/yarpmotorgui/flowlayout.cpp
@@ -68,8 +68,9 @@ FlowLayout::FlowLayout(int margin, int hSpacing, int vSpacing)
 FlowLayout::~FlowLayout()
 {
     QLayoutItem *item;
-    while ((item = takeAt(0)))
+    while ((item = takeAt(0))) {
         delete item;
+    }
 }
 
 
@@ -113,10 +114,11 @@ QLayoutItem *FlowLayout::itemAt(int index) const
 
 QLayoutItem *FlowLayout::takeAt(int index)
 {
-    if (index >= 0 && index < itemList.size())
+    if (index >= 0 && index < itemList.size()) {
         return itemList.takeAt(index);
-    else
+    } else {
         return nullptr;
+    }
 }
 
 
@@ -177,13 +179,19 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
     foreach (item, itemList) {
         QWidget *wid = item->widget();
         int spaceX = horizontalSpacing();
-        if (spaceX == -1)
+        if (spaceX == -1) {
             spaceX = wid->style()->layoutSpacing(
-                QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Horizontal);
+                QSizePolicy::PushButton,
+                QSizePolicy::PushButton,
+                Qt::Horizontal);
+        }
         int spaceY = verticalSpacing();
-        if (spaceY == -1)
+        if (spaceY == -1) {
             spaceY = wid->style()->layoutSpacing(
-                QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
+                QSizePolicy::PushButton,
+                QSizePolicy::PushButton,
+                Qt::Vertical);
+        }
 
         int nextX = x + item->sizeHint().width() + spaceX;
         if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
@@ -193,8 +201,9 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
             lineHeight = 0;
         }
 
-        if (!testOnly)
+        if (!testOnly) {
             item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+        }
 
         x = nextX;
         lineHeight = qMax(lineHeight, item->sizeHint().height());

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -319,8 +319,9 @@ bool JointItem::eventFilter(QObject *obj, QEvent *event)
                 }
             }
 
-            if(slider == nullptr)
+            if (slider == nullptr) {
                 return false;
+            }
 
 
             if(keyEvent->type() == QEvent::KeyPress){
@@ -1332,7 +1333,9 @@ double JointItem::getTrajectoryPositionValue()
 {
     //this function is mainly used used by the sequencer
     double pos = (double)ui->sliderTrajectoryPosition->value() / ui->sliderTrajectoryPosition->getSliderStep();
-    if (fabs(pos) < 1e-6) pos = 0;
+    if (fabs(pos) < 1e-6) {
+        pos = 0;
+    }
     return pos;
 }
 
@@ -1340,7 +1343,9 @@ double JointItem::getTrajectoryVelocityValue()
 {
     //this function is mainly used used by the sequencer
     double vel = (double)ui->sliderTrajectoryVelocity->value() / ui->sliderTrajectoryVelocity->getSliderStep();
-    if (fabs(vel) < 1e-6) vel = 0;
+    if (fabs(vel) < 1e-6) {
+        vel = 0;
+    }
     return vel;
 }
 

--- a/src/yarpmotorgui/main.cpp
+++ b/src/yarpmotorgui/main.cpp
@@ -233,7 +233,9 @@ int main(int argc, char *argv[])
         QString part = QString("%1").arg(pParts.get(n).asString().c_str());
         if (b_part_skip)
         {
-            if (b_part_skip->check(part.toStdString())) continue;
+            if (b_part_skip->check(part.toStdString())) {
+                continue;
+            }
         }
         yDebug("Appending %s", part.toUtf8().constData());
         partsName.append(part);

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -98,18 +98,23 @@ MainWindow::MainWindow(QWidget *parent) :
     for (size_t index = 0; index < ini.size(); ++index) {
         //Look for groups starting with "customPosition_"
         yarp::os::Value item = ini.get(index);
-        if (!item.isList()) continue;
+        if (!item.isList()) {
+            continue;
+        }
         yarp::os::Bottle *subElement = item.asList();
         //At least two elements and first should be string
         if (!subElement
             || subElement->size() < 2
-            || !subElement->get(0).isString())
+            || !subElement->get(0).isString()) {
             continue;
+        }
         //get first element
         std::string key = subElement->get(0).asString();
         std::string pattern = "customPosition_";
         size_t subStringPosition = key.find(pattern);
-        if (subStringPosition != 0) continue; //not starting or not found
+        if (subStringPosition != 0) {
+            continue; //not starting or not found
+        }
 
         std::string customPositionName = key.substr(pattern.size());
         customPositions.insert(std::map<std::string, yarp::os::Bottle>::value_type(customPositionName, subElement->tail()));
@@ -574,7 +579,9 @@ bool MainWindow::init(QStringList enabledParts,
         {
             robot_type r;
             r.robot_name_without_slash = cur_robot_name;
-            if (r.robot_name_without_slash[0]=='/') r.robot_name_without_slash.erase(0, 1);
+            if (r.robot_name_without_slash[0] == '/') {
+                r.robot_name_without_slash.erase(0, 1);
+            }
             r.tree_pointer = nullptr;
             robots[cur_robot_name]=r;
         }
@@ -582,7 +589,9 @@ bool MainWindow::init(QStringList enabledParts,
         p.partindex = i;
         p.complete_name = enabledParts.at(i).toStdString();
         p.part_name_without_slash = ss.substr(b2);
-        if (p.part_name_without_slash[0] == '/') p.part_name_without_slash.erase(0, 1);
+        if (p.part_name_without_slash[0] == '/') {
+            p.part_name_without_slash.erase(0, 1);
+        }
         p.robot_name = cur_robot_name;
         p.robot_name_without_slash = robots[cur_robot_name].robot_name_without_slash;
         parts[ss.substr(b2)] = p;

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -62,8 +62,12 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
 
     //PolyDriver *cartesiandd[MAX_NUMBER_ACTIVATED];
 
-    if (robotName.at(0) == '/') robotName.remove(0, 1);
-    if (partName.at(0) == '/')  partName.remove(0, 1);
+    if (robotName.at(0) == '/') {
+        robotName.remove(0, 1);
+    }
+    if (partName.at(0) == '/') {
+        partName.remove(0, 1);
+    }
     m_robotPartPort = QString("/%1/%2").arg(robotName).arg(partName);
     m_partName = partName;
     m_robotName = robotName;
@@ -135,16 +139,46 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
         m_iPos->getAxes(&number_of_joints);
 
         m_controlModes = new int[number_of_joints]; //for (i = 0; i < number_of_joints; i++) m_controlModes = 0;
-        m_refTrajectorySpeeds = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_refTrajectorySpeeds[i] = std::nan("");
-        m_refTrajectoryPositions = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_refTrajectoryPositions[i] = std::nan("");
-        m_refTorques = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_refTorques[i] = std::nan("");
-        m_refVelocitySpeeds = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_refVelocitySpeeds[i] = std::nan("");
-        m_torques = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_torques[i] = std::nan("");
-        m_positions = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_positions[i] = std::nan("");
-        m_speeds = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_speeds[i] = std::nan("");
-        m_currents = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_currents[i] = std::nan("");
-        m_motorPositions = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_motorPositions[i] = std::nan("");
-        m_dutyCycles = new double[number_of_joints]; for (i = 0; i < number_of_joints; i++) m_dutyCycles[i] = std::nan("");
+        m_refTrajectorySpeeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTrajectorySpeeds[i] = std::nan("");
+        }
+        m_refTrajectoryPositions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTrajectoryPositions[i] = std::nan("");
+        }
+        m_refTorques = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTorques[i] = std::nan("");
+        }
+        m_refVelocitySpeeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refVelocitySpeeds[i] = std::nan("");
+        }
+        m_torques = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_torques[i] = std::nan("");
+        }
+        m_positions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_positions[i] = std::nan("");
+        }
+        m_speeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_speeds[i] = std::nan("");
+        }
+        m_currents = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_currents[i] = std::nan("");
+        }
+        m_motorPositions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_motorPositions[i] = std::nan("");
+        }
+        m_dutyCycles = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_dutyCycles[i] = std::nan("");
+        }
         m_done = new bool[number_of_joints];
         m_interactionModes = new yarp::dev::InteractionModeEnum[number_of_joints];
 
@@ -186,7 +220,9 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
 
             QSettings settings("YARP", "yarpmotorgui");
             double max_slider_vel = settings.value("velocity_slider_limit", 100.0).toDouble();
-            if (max_vel > max_slider_vel) max_vel = max_slider_vel;
+            if (max_vel > max_slider_vel) {
+                max_vel = max_slider_vel;
+            }
 
             m_iinfo->getAxisName(k, jointname);
             yarp::dev::JointTypeEnum jtype = yarp::dev::VOCAB_JOINTTYPE_REVOLUTE;
@@ -810,10 +846,11 @@ void PartItem::onCalibClicked(JointItem *joint)
         // provide better feedback to user by verifying if the calibrator device was set or not
         bool isCalib = false;
         m_iremCalib->isCalibratorDevicePresent(&isCalib);
-        if(!isCalib)
+        if (!isCalib) {
             QMessageBox::critical(this,"Calibration failed", QString("No calibrator device was configured to perform this action, please verify that the wrapper config file has the 'Calibrator' keyword in the attach phase"));
-        else
-            QMessageBox::critical(this,"Calibration failed", QString("The remote calibrator reported that something went wrong during the calibration procedure"));
+        } else {
+            QMessageBox::critical(this, "Calibration failed", QString("The remote calibrator reported that something went wrong during the calibration procedure"));
+        }
     }
 
 }
@@ -1077,10 +1114,11 @@ void PartItem::calibratePart()
         // provide better feedback to user by verifying if the calibrator device was set or not
         bool isCalib = false;
         m_iremCalib->isCalibratorDevicePresent(&isCalib);
-        if(!isCalib)
+        if (!isCalib) {
             QMessageBox::critical(this, "Calibration failed", QString("No calibrator device was configured to perform this action, please verify that the wrapper config file for part %1 has the 'Calibrator' keyword in the attach phase").arg(m_partName));
-        else
-            QMessageBox::critical(this,"Calibration failed", QString("The remote calibrator reported that something went wrong during the calibration procedure"));
+        } else {
+            QMessageBox::critical(this, "Calibration failed", QString("The remote calibrator reported that something went wrong during the calibration procedure"));
+        }
     }
 }
 
@@ -2109,8 +2147,11 @@ bool PartItem::updatePart()
     bool ret = false;
     int number_of_joints=0;
     m_iPos->getAxes(&number_of_joints);
-    if (m_slow_k >= number_of_joints - 1) m_slow_k = 0;
-    else m_slow_k++;
+    if (m_slow_k >= number_of_joints - 1) {
+        m_slow_k = 0;
+    } else {
+        m_slow_k++;
+    }
 
     if (number_of_joints == 0)
     {

--- a/src/yarpmotorgui/piddlg.cpp
+++ b/src/yarpmotorgui/piddlg.cpp
@@ -219,7 +219,9 @@ void PidDlg::onSendRemoteVariable()
             break;
         }
     }
-    if (i == -1) return;
+    if (i == -1) {
+        return;
+    }
 
     std::string key = ui->tableVariables->item(i, 0)->text().toStdString();
     std::string val = ui->tableVariables->item(i, 1)->text().toStdString();

--- a/src/yarpmotorgui/sliderOptions.cpp
+++ b/src/yarpmotorgui/sliderOptions.cpp
@@ -95,17 +95,29 @@ sliderOptions::sliderOptions( QWidget *parent) :
 
 sliderOptions::~sliderOptions()
 {
-    if      (ui->radio_pos_auto->isChecked()) val_pos_choice = 0;
-    else if (ui->radio_pos_user->isChecked()) val_pos_choice = 1;
-    else if (ui->radio_pos_one->isChecked())  val_pos_choice = 2;
+    if (ui->radio_pos_auto->isChecked()) {
+        val_pos_choice = 0;
+    } else if (ui->radio_pos_user->isChecked()) {
+        val_pos_choice = 1;
+    } else if (ui->radio_pos_one->isChecked()) {
+        val_pos_choice = 2;
+    }
 
-    if      (ui->radio_vel_auto->isChecked()) val_vel_choice = 0;
-    else if (ui->radio_vel_user->isChecked()) val_vel_choice = 1;
-    else if (ui->radio_vel_one->isChecked())  val_vel_choice = 2;
+    if (ui->radio_vel_auto->isChecked()) {
+        val_vel_choice = 0;
+    } else if (ui->radio_vel_user->isChecked()) {
+        val_vel_choice = 1;
+    } else if (ui->radio_vel_one->isChecked()) {
+        val_vel_choice = 2;
+    }
 
-    if      (ui->radio_trq_auto->isChecked()) val_trq_choice = 0;
-    else if (ui->radio_trq_user->isChecked()) val_trq_choice = 1;
-    else if (ui->radio_trq_one->isChecked())  val_trq_choice = 2;
+    if (ui->radio_trq_auto->isChecked()) {
+        val_trq_choice = 0;
+    } else if (ui->radio_trq_user->isChecked()) {
+        val_trq_choice = 1;
+    } else if (ui->radio_trq_one->isChecked()) {
+        val_trq_choice = 2;
+    }
 
     val_pos_custom_step = ui->pos_step->text().toDouble();
     val_vel_custom_step = ui->vel_step->text().toDouble();

--- a/src/yarpscope/plugin/plotmanager.cpp
+++ b/src/yarpscope/plugin/plotmanager.cpp
@@ -77,8 +77,9 @@ void PlotManager::setInterval(int interval)
 {
 
     timer.setInterval(interval);
-    if(!timer.isActive())
+    if (!timer.isActive()) {
         timer.start();
+    }
 }
 
 /*! \brief Timeout of the refresh timer */

--- a/src/yarpscope/src/qtquick2applicationviewer/qtquick2applicationviewer.cpp
+++ b/src/yarpscope/src/qtquick2applicationviewer/qtquick2applicationviewer.cpp
@@ -37,12 +37,14 @@ QString QtQuick2ApplicationViewerPrivate::adjustPath(const QString &path)
 #elif !defined(Q_OS_ANDROID)
     QString pathInInstallDir =
             QString::fromLatin1("%1/../%2").arg(QCoreApplication::applicationDirPath(), path);
-    if (QFileInfo(pathInInstallDir).exists())
+    if (QFileInfo(pathInInstallDir).exists()) {
         return pathInInstallDir;
+    }
     pathInInstallDir =
             QString::fromLatin1("%1/%2").arg(QCoreApplication::applicationDirPath(), path);
-    if (QFileInfo(pathInInstallDir).exists())
+    if (QFileInfo(pathInInstallDir).exists()) {
         return pathInInstallDir;
+    }
 #elif defined(Q_OS_ANDROID_NO_SDK)
     return QLatin1String("/data/user/qt/") + path;
 #endif

--- a/src/yarpview/plugin/FpsStats.h
+++ b/src/yarpview/plugin/FpsStats.h
@@ -48,10 +48,12 @@ public:
         if (iterations>0){
             double dt=now-prev;
 
-            if (dt>max)
-                max=dt;
-            if (dt<min)
-                min=dt;
+            if (dt > max) {
+                max = dt;
+            }
+            if (dt < min) {
+                min = dt;
+            }
         }
 
         prev=now;
@@ -80,10 +82,11 @@ public:
         \param av the average value
     */
     void getStats(double &av){
-        if (iterations>0)
+        if (iterations > 0) {
             av=(yarp::os::Time::now()-t0)/iterations;
-        else
-            av=0;
+        } else {
+            av = 0;
+        }
     }
 };
 

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -157,20 +157,23 @@ QString QtYARPView::getPixelAsStr(int x, int y){
 
 void QtYARPView::periodToFreq(double avT, double mT, double MT, double &avH, double &mH, double &MH)
 {
-    if (avT!=0)
+    if (avT != 0) {
         avH=1.0/avT;
-    else
-        avH=0;
+    } else {
+        avH = 0;
+    }
 
-    if (mT!=0)
+    if (mT != 0) {
         MH=1.0/mT;
-    else
-        MH=0;
+    } else {
+        MH = 0;
+    }
 
-    if (MT!=0)
+    if (MT != 0) {
         mH=1.0/MT;
-    else
-        mH=0;
+    } else {
+        mH = 0;
+    }
 }
 
 void QtYARPView::onSendFps(double portAvg, double portMin, double portMax,
@@ -214,10 +217,12 @@ void QtYARPView::createObjects() {
 
 /*! \brief Deletes the input port and the port callback.*/
 void QtYARPView::deleteObjects() {
-    if (ptr_inputPort!=nullptr)
+    if (ptr_inputPort != nullptr) {
         delete ptr_inputPort;
-    if (ptr_portCallback!=nullptr)
+    }
+    if (ptr_portCallback != nullptr) {
         delete ptr_portCallback;
+    }
 }
 
 /*! \brief parse the parameters received from the main container in QstringList form
@@ -438,10 +443,11 @@ void QtYARPView::closePorts()
     if (_options.m_outputEnabled == 1 && _pOutPort){
         _pOutPort->close();
         bool ok = true;
-        if  (ok)
+        if (ok) {
             qDebug("Port %s unregistration succeed!\n", _options.m_outPortName);
-        else
+        } else {
             qDebug("ERROR: Port %s unregistration failed.\n", _options.m_outPortName);
+        }
         delete _pOutPort;
         _pOutPort = nullptr;
     }
@@ -449,10 +455,11 @@ void QtYARPView::closePorts()
     if (_options.m_rightEnabled == 1 && _pOutRightPort){
         _pOutRightPort->close();
         bool ok = true;
-        if  (ok)
+        if (ok) {
             qDebug("Port %s unregistration succeed!\n", _options.m_outRightPortName);
-        else
+        } else {
             qDebug("ERROR: Port %s unregistration failed.\n", _options.m_outRightPortName);
+        }
         delete _pOutRightPort;
         _pOutRightPort = nullptr;
     }

--- a/src/yarpview/plugin/signalhandler.cpp
+++ b/src/yarpview/plugin/signalhandler.cpp
@@ -252,8 +252,9 @@ void SignalHandler::checkDefaultNameCounterCount()
 
     while(li.hasNext()){
         QFileInfo fi = li.next();
-        if(fi.fileName().contains("frame") )
+        if (fi.fileName().contains("frame")) {
             defaultNameCounter++;
+        }
     }
 
 }
@@ -276,8 +277,9 @@ void SignalHandler::checkCustomNameCounterCount(QString file)
 
     while(li.hasNext()){
         QFileInfo fi = li.next();
-        if(fi.fileName().contains(sfile) )
+        if (fi.fileName().contains(sfile)) {
             customNameCounter++;
+        }
     }
 
 }
@@ -288,8 +290,9 @@ void SignalHandler::checkCustomNameCounterCount(QString file)
  */
 void SignalHandler::setFileNames(QUrl url)
 {
-    if(b_saveSetFrameMode == false)
+    if (b_saveSetFrameMode == false) {
         this->fileNames = url.toLocalFile();
+    }
 }
 
 /*! \brief Enables the Dump frame modality (Save frame set).*/

--- a/src/yarpview/src/qtquick2applicationviewer/qtquick2applicationviewer.cpp
+++ b/src/yarpview/src/qtquick2applicationviewer/qtquick2applicationviewer.cpp
@@ -37,12 +37,14 @@ QString QtQuick2ApplicationViewerPrivate::adjustPath(const QString &path)
 #elif !defined(Q_OS_ANDROID)
     QString pathInInstallDir =
             QString::fromLatin1("%1/../%2").arg(QCoreApplication::applicationDirPath(), path);
-    if (QFileInfo(pathInInstallDir).exists())
+    if (QFileInfo(pathInInstallDir).exists()) {
         return pathInInstallDir;
+    }
     pathInInstallDir =
             QString::fromLatin1("%1/%2").arg(QCoreApplication::applicationDirPath(), path);
-    if (QFileInfo(pathInInstallDir).exists())
+    if (QFileInfo(pathInInstallDir).exists()) {
         return pathInInstallDir;
+    }
 #elif defined(Q_OS_ANDROID_NO_SDK)
     return QLatin1String("/data/user/qt/") + path;
 #endif

--- a/src/yarpviz/src/MainWindow.cpp
+++ b/src/yarpviz/src/MainWindow.cpp
@@ -125,15 +125,17 @@ void MainWindow::initScene() {
 
 void MainWindow::onProgress(unsigned int percentage) {
     //yInfo()<<percentage<<"%";
-    if(progressDlg)
+    if (progressDlg) {
         progressDlg->setValue(percentage);
+    }
 }
 
 void MainWindow::drawGraph(Graph &graph)
 {
     initScene();
-    if(graph.nodesCount() == 0)
+    if (graph.nodesCount() == 0) {
         return;
+    }
 
     layoutSubgraph = ui->actionSubgraph->isChecked();
 
@@ -186,14 +188,15 @@ void MainWindow::drawGraph(Graph &graph)
                     sgraphLabel = nodeS+sgraphLabel+nodeS;
                     sgraph->setAttribute("label", sgraphLabel.c_str());
                     string host = prop.find("os").asString();
-                    if(host == "Linux")
+                    if (host == "Linux") {
                         sgraph->setIcon(QImage(":/icons/resources/os-linux.png"));
-                    else if(host == "Windows")
+                    } else if (host == "Windows") {
                         sgraph->setIcon(QImage(":/icons/resources/os-windows.png"));
-                    else if(host == "Mac")
+                    } else if (host == "Mac") {
                         sgraph->setIcon(QImage(":/icons/resources/os-macos.png"));
-                    else
+                    } else {
                         sgraph->setIcon(QImage(":/icons/resources/system-run.png"));
+                    }
                     std::string endNodeName = key.str() + ".end";
                     QGVNode * node = sgraph->addNode(endNodeName.c_str());
                     node->setAttribute("shape", "circle");
@@ -289,19 +292,21 @@ void MainWindow::drawGraph(Graph &graph)
         if(dynamic_cast<PortVertex*>(*itr)) {
             auto* pv = dynamic_cast<PortVertex*>(*itr);
             auto* v = (ProcessVertex*) pv->getOwner();
-            if(ui->actionHideDisconnectedPorts->isChecked() && pv->property.find("orphan").asBool())
+            if (ui->actionHideDisconnectedPorts->isChecked() && pv->property.find("orphan").asBool()) {
                 continue;
-            if(!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos ))
+            }
+            if (!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos)) {
                 continue;
+            }
             std::stringstream key;
             if(v->property.find("hidden").asBool())
             {
                 pv->property.put("hidden",true);
                 updateNodeWidgetItems();
                 continue;
-            }
-            else if(prop.find("hidden").asBool())
+            } else if (prop.find("hidden").asBool()) {
                 continue;
+            }
             QGVNode *node;
             QString colorProcess;
 
@@ -318,16 +323,17 @@ void MainWindow::drawGraph(Graph &graph)
                     if(ui->actionColorMode->isChecked())
                     {
                         QColor color(sgraph->getAttribute("colorOfTheProcess"));
-                        if(color.lightness()<100)
-                            node->setAttribute("labelfontcolor","#ffffff");
+                        if (color.lightness() < 100) {
+                            node->setAttribute("labelfontcolor", "#ffffff");
+                        }
                         colorProcess = sgraph->getAttribute("colorOfTheProcess");
                     }
+                } else {
+                    node = scene->addNode(nodeName.c_str());
                 }
-                else
-                    node =  scene->addNode(nodeName.c_str());
+            } else {
+                node = scene->addNode(nodeName.c_str());
             }
-            else
-                node =  scene->addNode(nodeName.c_str());
             node->setAttribute("shape", "ellipse");
             if(prop.check("color")) {
                 node->setAttribute("fillcolor", prop.find("color").asString().c_str());
@@ -360,8 +366,9 @@ void MainWindow::drawGraph(Graph &graph)
         for(const auto& edge : v1.outEdges()) {
             const Vertex &v2 = edge.second();
             string targetName = v2.property.find("name").asString();
-            if(!ui->actionDebugMode->isChecked() && targetName.find("/yarplogger") != string::npos)
+            if (!ui->actionDebugMode->isChecked() && targetName.find("/yarplogger") != string::npos) {
                 continue;
+            }
             //yInfo()<<"Drawing:"<<v1.property.find("name").asString()<<" -> "<<v2.property.find("name").asString();
             // add ownership edges
             if(!v1.property.find("hidden").asBool() && !v2.property.find("hidden").asBool()) {
@@ -424,8 +431,9 @@ void MainWindow::drawGraph(Graph &graph)
 
 void MainWindow::edgeContextMenu(QGVEdge* edge) {
     const Edge* e  = (const Edge*)edge->getEdge();
-    if(e == nullptr)
+    if (e == nullptr) {
         return;
+    }
 
     //yInfo()<<"edge clicked!";
     //Context menu example
@@ -435,8 +443,9 @@ void MainWindow::edgeContextMenu(QGVEdge* edge) {
     menu.addAction(tr("Configure Qos..."));
     //menu.addAction(tr("Hide"));
     QAction *action = menu.exec(QCursor::pos());
-    if(action == nullptr)
+    if (action == nullptr) {
         return;
+    }
     if(action->text().toStdString() == "Information...") {
         InformationDialog dialog;
         dialog.setEdgeInfo((Edge*)e);
@@ -454,18 +463,20 @@ void MainWindow::nodeContextMenu(QGVNode *node)
 {
     auto* v = (GraphicVertex*) node->getVertex();
     yAssert(v != nullptr);
-    if(v->property.find("type").asString() == "port")
+    if (v->property.find("type").asString() == "port") {
         onNodeContextMenuPort(node, v);
-    else
-        yWarning()<<"nodeContextMenu(): Unknown node!";
+    } else {
+        yWarning() << "nodeContextMenu(): Unknown node!";
+    }
 }
 
 void MainWindow::onSubGraphContextMenuProcess(QGVSubGraph *sgraph) {
     GraphicVertex* vertex;
     vertex = (GraphicVertex*) sgraph->getVertex();
 
-    if(!vertex || vertex->property.find("type").asString() != "process")
+    if (!vertex || vertex->property.find("type").asString() != "process") {
         return;
+    }
 
 
     QMenu menu(sgraph->getAttribute("label"));
@@ -473,8 +484,9 @@ void MainWindow::onSubGraphContextMenuProcess(QGVSubGraph *sgraph) {
     menu.addAction(tr("Information..."));
     menu.addAction(tr("Hide"));
     QAction *action = menu.exec(QCursor::pos());
-    if(action == nullptr)
+    if (action == nullptr) {
         return;
+    }
     if(action->text().toStdString() == "Information...") {
         InformationDialog dialog;
         dialog.setProcessVertexInfo((ProcessVertex*)vertex);
@@ -500,8 +512,9 @@ void MainWindow::onNodeContextMenuPort(QGVNode *node, GraphicVertex* vertex) {
     menu.addAction(tr("Information..."));
     menu.addAction(tr("Hide"));
     QAction *action = menu.exec(QCursor::pos());
-    if(action == nullptr)
+    if (action == nullptr) {
         return;
+    }
     if(action->text().toStdString() == "Information...") {
         InformationDialog dialog;
         dialog.setPortVertexInfo((PortVertex*)vertex);
@@ -527,8 +540,9 @@ void MainWindow::onProfileYarpNetwork() {
         QMessageBox::StandardButton reply;
         reply = QMessageBox::question(this, "Profiling: clear current project", "Running profiler will clear the current project.\n Are you sure?",
                                       QMessageBox::Yes|QMessageBox::No);
-        if (reply == QMessageBox::No)
+        if (reply == QMessageBox::No) {
             return;
+        }
     }
 
     mainGraph.clear();
@@ -568,11 +582,13 @@ void MainWindow::onProfileYarpNetwork() {
         std::string portname = ports[i].find("name").asString();
         std::string msg = string("Checking ") + portname + "...";
         messages.append(QString(msg.c_str()));
-        if(NetworkProfiler::getPortDetails(portname, info))
+        if (NetworkProfiler::getPortDetails(portname, info)) {
             portsInfo.push_back(info);
+        }
         progressDlg->setValue(i);
-        if (progressDlg->wasCanceled())
+        if (progressDlg->wasCanceled()) {
             return;
+        }
     }
     //progressDlg->setValue(ports.size());
     stringModel.setStringList(messages);
@@ -609,8 +625,9 @@ void MainWindow::onProfileYarpNetwork() {
 }
 
 void MainWindow::onHighlightLoops() {
-    if(!currentGraph)
+    if (!currentGraph) {
         return;
+    }
 
     if(ui->actionHighlight_Loops->isChecked()) {
         graph_subset scc;
@@ -622,8 +639,9 @@ void MainWindow::onHighlightLoops() {
 
         for(auto& vset : scc) {
             QColor color(udistH(randengine), udistL(randengine), udistH(randengine));
-            for(auto& j : vset)
+            for (auto& j : vset) {
                 j->property.put("color", color.name().toStdString());
+            }
         }
     }
     else {
@@ -688,11 +706,13 @@ void MainWindow::populateTreeWidget(){
         else if(dynamic_cast<PortVertex*>(*itr) && !ui->actionHidePorts->isChecked()) {
             string portName = prop.find("name").asString();
             if(ui->actionHideDisconnectedPorts->isChecked()){
-                if(prop.check("orphan"))
+                if (prop.check("orphan")) {
                     continue;
+                }
             }
-            if(!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos ))
+            if (!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos)) {
                 continue;
+            }
             auto* portItem =  new NodeWidgetItem(portParentItem, (*itr), PORT);
             portItem->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
             portItem->check(true);
@@ -713,8 +733,9 @@ void MainWindow::onLayoutOrthogonal() {
     ui->actionLine->setChecked(false);
     ui->actionCurved->setChecked(false);
     layoutStyle = "ortho";
-    if(currentGraph)
+    if (currentGraph) {
         drawGraph(*currentGraph);
+    }
 }
 
 void MainWindow::onLayoutPolyline() {
@@ -722,8 +743,9 @@ void MainWindow::onLayoutPolyline() {
     ui->actionLine->setChecked(false);
     ui->actionCurved->setChecked(false);
     layoutStyle = "polyline";
-    if(currentGraph)
+    if (currentGraph) {
         drawGraph(*currentGraph);
+    }
 }
 
 void MainWindow::onLayoutLine() {
@@ -731,8 +753,9 @@ void MainWindow::onLayoutLine() {
     ui->actionPolyline->setChecked(false);
     ui->actionCurved->setChecked(false);
     layoutStyle = "line";
-    if(currentGraph)
+    if (currentGraph) {
         drawGraph(*currentGraph);
+    }
 }
 
 void MainWindow::onLayoutCurved() {
@@ -760,14 +783,16 @@ void MainWindow::onUpdateGraph() {
 }
 
 void MainWindow::onNodesTreeItemClicked(QTreeWidgetItem *item, int column){
-    if(item->type() != MODULE && item->type() != PORT )
+    if (item->type() != MODULE && item->type() != PORT) {
         return;
+    }
 
     bool state = (item->checkState(column) == Qt::Checked);
     bool needUpdate = state != ((NodeWidgetItem*)(item))->checked();
     ((NodeWidgetItem*)(item))->check(state);
-    if(needUpdate)
+    if (needUpdate) {
         drawGraph(*currentGraph);
+    }
 
     QList<QGraphicsItem *> items = scene->selectedItems();
     foreach( QGraphicsItem *item, items )
@@ -814,8 +839,9 @@ void MainWindow::onExportConList() {
     QString filename = QFileDialog::getSaveFileName(nullptr, "Export connections list",
                                                     QDir::homePath(),
                                                     filters, &defaultFilter);
-    if(filename.size() == 0)
+    if (filename.size() == 0) {
         return;
+    }
 
     ofstream file;
     file.open(filename.toStdString().c_str());
@@ -854,16 +880,18 @@ void MainWindow::onExportScene() {
     QString filename = QFileDialog::getSaveFileName(nullptr, "Export scene",
                                                     QDir::homePath(),
                                                     filters, &defaultFilter);
-    if(filename.size() == 0)
+    if (filename.size() == 0) {
         return;
+    }
 
     QImage image(scene->sceneRect().size().toSize(), QImage::Format_ARGB32);  // Create the image with the exact size of the shrunk scene
     image.fill(QColor("#2e3e56"));
     QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing);
     scene->render(&painter);
-    if(!image.save(filename))
-        yError()<<"Cannot save scene to"<<filename.toStdString();
+    if (!image.save(filename)) {
+        yError() << "Cannot save scene to" << filename.toStdString();
+    }
 
     /*
     QPrinter printer( QPrinter::HighResolution );

--- a/src/yarpviz/src/MainWindow.h
+++ b/src/yarpviz/src/MainWindow.h
@@ -46,10 +46,15 @@ public:
     void check(bool flag) {
         checkFlag = flag;
         setCheckState( 0, (flag == true) ? Qt::Checked : Qt::Unchecked);
-        if(!checkFlag)
-            vertex->property.put("hidden", true);
-        else
-            vertex->property.put("hidden",false);
+        if (!checkFlag) {
+            {
+                vertex->property.put("hidden", true);
+            }
+        } else {
+            {
+                vertex->property.put("hidden", false);
+            }
+        }
     }
 
     bool checked() { return checkFlag; }

--- a/src/yarpviz/src/QGraphicsViewEc.cpp
+++ b/src/yarpviz/src/QGraphicsViewEc.cpp
@@ -18,6 +18,7 @@ void QGraphicsViewEc::wheelEvent(QWheelEvent* event)
 {
     qreal scaleFactor = qPow(2.0, event->angleDelta().y() / 240.0); //How fast we zoom
     qreal factor = transform().scale(scaleFactor, scaleFactor).mapRect(QRectF(0, 0, 1, 1)).width();
-    if(0.05 < factor && factor < 10) //Zoom factor limitation
+    if (0.05 < factor && factor < 10) { //Zoom factor limitation
         scale(scaleFactor, scaleFactor);
+    }
 }

--- a/src/yarpviz/src/batchqosconfdialog.cpp
+++ b/src/yarpviz/src/batchqosconfdialog.cpp
@@ -50,8 +50,9 @@ void BatchQosConfDialog::openCons()
     QString filename = QFileDialog::getOpenFileName(nullptr, "Load connections list",
                                                     QDir::homePath(),
                                                     filters, &defaultFilter);
-    if(filename.size() == 0)
+    if (filename.size() == 0) {
         return;
+    }
 
     fstream file;
     file.open(filename.toStdString().c_str());
@@ -78,9 +79,9 @@ void BatchQosConfDialog::openCons()
             prop.append(sample.get(2).asString().c_str());
             item = new QTreeWidgetItem( ui->treeWidgetCons, prop);
             YARP_UNUSED(item);
+        } else {
+            yWarning() << "Wrong connection data at line" << count;
         }
-        else
-            yWarning()<<"Wrong connection data at line"<<count;
     }
     file.close();
 
@@ -139,9 +140,9 @@ void BatchQosConfDialog::updateQos()
             qosStr = NetworkProfiler::packetPrioToString(toStyle.getPacketPriorityAsLevel()).c_str();
             qosStr += ", " + QString::number(toStyle.getThreadPolicy()) + ", " + QString::number(toStyle.getThreadPriority());
             item->setText(5, qosStr);
+        } else {
+            yWarning() << "Cannot retrieve Qos property of" << item->text(0).toUtf8().constData() << "->" << item->text(0).toUtf8().constData();
         }
-        else
-            yWarning()<<"Cannot retrieve Qos property of"<<item->text(0).toUtf8().constData()<<"->"<<item->text(0).toUtf8().constData();
     }
     ui->treeWidgetCons->update();
 }
@@ -150,8 +151,9 @@ void BatchQosConfDialog::configureQos() {
     yarp::os::QosStyle fromStyle, toStyle;
     QosConfigDialog dialog(nullptr);
     dialog.setModal(true);
-    if(dialog.exec() != QDialog::Accepted )
+    if (dialog.exec() != QDialog::Accepted) {
         return;
+    }
     dialog.getUserQosStyles(fromStyle, toStyle);
     for( int i=0; i < ui->treeWidgetCons->topLevelItemCount(); ++i ){
         QTreeWidgetItem *item = ui->treeWidgetCons->topLevelItem(i);

--- a/src/yarpviz/src/portloggerdialog.cpp
+++ b/src/yarpviz/src/portloggerdialog.cpp
@@ -82,8 +82,9 @@ void PortLoggerDialog::openCons()
     QString filename = QFileDialog::getOpenFileName(nullptr, "Load connections list",
                                                     QDir::homePath(),
                                                     filters, &defaultFilter);
-    if(filename.size() == 0)
+    if (filename.size() == 0) {
         return;
+    }
 
     fstream file;
     file.open(filename.toStdString().c_str());
@@ -109,9 +110,9 @@ void PortLoggerDialog::openCons()
             prop.append(sample.get(2).asString().c_str());
             item = new QTreeWidgetItem( ui->treeWidgetCons, prop);
             YARP_UNUSED(item);
+        } else {
+            yWarning() << "Wrong connection data at line" << count;
         }
-        else
-            yWarning()<<"Wrong connection data at line"<<count;
     }
     file.close();
 }
@@ -219,8 +220,9 @@ void PortLoggerDialog::startStopLoggers() {
                     QString filename = portname.c_str();
                     filename.replace("/", "_");
                     filename = ui->lineEditLogPath->text() + "/port." +filename + ".log";
-                    if(!saveLog(filename.toStdString(), samples))
-                        yError()<<"could not save the result into "<<filename.toStdString();
+                    if (!saveLog(filename.toStdString(), samples)) {
+                        yError() << "could not save the result into " << filename.toStdString();
+                    }
                 }
             }
             else {
@@ -273,7 +275,8 @@ void PortLoggerDialog::setLogPath() {
     //QString defaultFilter("Log file (*.log)");
     QString filename = QFileDialog::getExistingDirectory(nullptr, "Set the log files path",
                                                     QDir::homePath(),QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
-    if(filename.size() == 0)
+    if (filename.size() == 0) {
         return;
+    }
     ui->lineEditLogPath->setText(filename);
 }

--- a/src/yarpviz/src/qosconfigdialog.cpp
+++ b/src/yarpviz/src/qosconfigdialog.cpp
@@ -32,8 +32,9 @@ void QosConfigDialog::createGui() {
     srcPacketProCombo = new QComboBox(this);
     srcPacketProCombo->addItems(QStringList() << "LOW" << "NORMAL" << "HIGH" << "CRITIC");
     yarp::os::QosStyle::PacketPriorityLevel level = yarp::os::QosStyle::PacketPriorityNormal;
-    if(edge)
+    if (edge) {
         level = (yarp::os::QosStyle::PacketPriorityLevel)edge->property.find("FromPacketPriority").asInt32();
+    }
     switch(level) {
     case yarp::os::QosStyle::PacketPriorityNormal :
         srcPacketProCombo->setCurrentIndex(1);
@@ -55,28 +56,31 @@ void QosConfigDialog::createGui() {
     // source thread priority and policy
     srcThreadPro = new QLineEdit;
     srcThreadPro->setValidator( new QIntValidator(-100, 100, this) );
-    if(edge)
+    if (edge) {
         srcThreadPro->setText(QString::number(edge->property.find("FromThreadPriority").asInt32()));
-    else
+    } else {
         srcThreadPro->setText(QString::number(0));
+    }
     ui->treeWidgetProperty->setItemWidget(*it++, 1, srcThreadPro);
 
     srcThreadPolicy = new QLineEdit;
     srcThreadPolicy->setValidator( new QIntValidator(-100, 100, this) );
-    if(edge)
+    if (edge) {
         srcThreadPolicy->setText(QString::number(edge->property.find("FromThreadPolicy").asInt32()));
-    else
+    } else {
         srcThreadPolicy->setText(QString::number(0));
+    }
     ui->treeWidgetProperty->setItemWidget(*it++, 1, srcThreadPolicy);
 
 
     // destination packet priority
     dstPacketProCombo = new QComboBox(this);
     dstPacketProCombo->addItems(QStringList() << "LOW" << "NORMAL" << "HIGH" << "CRITIC");
-    if(edge)
+    if (edge) {
         level = (yarp::os::QosStyle::PacketPriorityLevel)edge->property.find("ToPacketPriority").asInt32();
-    else
+    } else {
         level = yarp::os::QosStyle::PacketPriorityNormal;
+    }
 
     switch(level) {
     case yarp::os::QosStyle::PacketPriorityNormal :
@@ -99,18 +103,20 @@ void QosConfigDialog::createGui() {
     // destination thread priority and policy
     dstThreadPro = new QLineEdit;
     dstThreadPro->setValidator( new QIntValidator(-100, 100, this) );
-    if(edge)
+    if (edge) {
         dstThreadPro->setText(QString::number(edge->property.find("ToThreadPriority").asInt32()));
-    else
+    } else {
         dstThreadPro->setText(QString::number(0));
+    }
     ui->treeWidgetProperty->setItemWidget(*it++, 1, dstThreadPro);
 
     dstThreadPolicy = new QLineEdit;
     dstThreadPolicy->setValidator( new QIntValidator(-100, 100, this) );
-    if(edge)
+    if (edge) {
         dstThreadPolicy->setText(QString::number(edge->property.find("ToThreadPolicy").asInt32()));
-    else
+    } else {
         dstThreadPolicy->setText(QString::number(0));
+    }
     ui->treeWidgetProperty->setItemWidget(*it++, 1, dstThreadPolicy);
 }
 

--- a/tests/devices/harness_devices.cpp
+++ b/tests/devices/harness_devices.cpp
@@ -32,7 +32,9 @@ static std::string getFile(const char *fname)
 {
     char buf[25600];
     FILE *fin = fopen(fname, "r");
-    if (fin==nullptr) return "";
+    if (fin == nullptr) {
+        return "";
+    }
     std::string result = "";
     while(fgets(buf, sizeof(buf)-1, fin) != nullptr) {
         result += buf;

--- a/tests/libYARP_math/MathTest.cpp
+++ b/tests/libYARP_math/MathTest.cpp
@@ -63,9 +63,9 @@ void checkEqual(const Matrix &A, const Vector &b)
     if(A.cols() == 1){
         Vector a = A.getCol(0);
         checkEqual(a, b);
-    }
-    else if(A.rows() == 1)
+    } else if (A.rows() == 1) {
         checkEqual(A.getRow(0), b);
+    }
 }
 
 void checkEqual(const Vector &b, const Matrix &A)
@@ -202,9 +202,11 @@ TEST_CASE("math::MathTest", "[yarp::math]")
         res = A/3.0; //divide all by 3
         //sum elements
         double acc = 0.0;
-        for(size_t r = 0; r<res.rows(); r++)
-            for(size_t c = 0; c<res.cols(); c++)
-                    acc += res[r][c];
+        for (size_t r = 0; r < res.rows(); r++) {
+            for (size_t c = 0; c < res.cols(); c++) {
+                acc += res[r][c];
+            }
+        }
 
         double expected = res.rows()*res.cols()*3.0;
 
@@ -213,12 +215,13 @@ TEST_CASE("math::MathTest", "[yarp::math]")
         A = 3.0; //initialize all with 3
         res = A*3.0; // multiply all by 3
         acc = 0.0;
-        for(size_t r = 0; r<res.rows(); r++)
+        for (size_t r = 0; r < res.rows(); r++) {
             for(size_t c = 0; c<res.cols(); c++)
             {
                 //INFO(res[r][c]);
                 acc += res[r][c];
             }
+        }
 
         expected = res.rows()*res.cols()*9;
 
@@ -265,13 +268,14 @@ TEST_CASE("math::MathTest", "[yarp::math]")
 
         bool invGood = true;
         Matrix ref = eye(4, 4);
-        for(size_t r = 0; r<I.rows(); r++)
+        for (size_t r = 0; r < I.rows(); r++) {
             for(size_t c = 0; c<I.cols(); c++)
             {
-                if (fabs(I[r][c]-ref[r][c])>0.0001)
+                if (fabs(I[r][c] - ref[r][c]) > 0.0001) {
                     invGood = false;
-
+                }
             }
+        }
 
         CHECK(invGood); // luinv
 

--- a/tests/libYARP_math/RandTest.cpp
+++ b/tests/libYARP_math/RandTest.cpp
@@ -69,10 +69,12 @@ TEST_CASE("math::RandTest", "[yarp::math]")
         bool avOk=false;
         bool stdOk=false;
 
-        if (fabs(average-u)<0.075)
-            avOk=true;
-        if (fabs(std-sigma)<0.075)
-            stdOk=true;
+        if (fabs(average - u) < 0.075) {
+            avOk = true;
+        }
+        if (fabs(std - sigma) < 0.075) {
+            stdOk = true;
+        }
 
         CHECK(avOk); // normal distribution average ~as requested
         CHECK(stdOk); // normal distribution std ~as requested
@@ -84,15 +86,17 @@ TEST_CASE("math::RandTest", "[yarp::math]")
         int C=100;
         Matrix rndM=Rand::matrix(R,C);
         double average=0.0;
-        for(int r=0; r<R; r++)
+        for (int r = 0; r < R; r++) {
             for(int c=0; c<C;c++)
             {
                 average+=rndM[r][c];
             }
+        }
         average/=R*C;
         bool mGood=false;
-        if(fabs(average-0.5)<0.01)
-            mGood=true;
+        if (fabs(average - 0.5) < 0.01) {
+            mGood = true;
+        }
 
         CHECK(mGood); // random matrix
     }
@@ -117,10 +121,12 @@ TEST_CASE("math::RandTest", "[yarp::math]")
         int k=0;
         for(k=0;k<N;k++)
         {
-            if (rv[k]>max)
-                max=rv[k];
-            if (rv[k]<min)
-                min=rv[k];
+            if (rv[k] > max) {
+                max = rv[k];
+            }
+            if (rv[k] < min) {
+                min = rv[k];
+            }
 
             average+=rv[k];
         }
@@ -146,10 +152,12 @@ TEST_CASE("math::RandTest", "[yarp::math]")
         bool stdGood=false;
 
         // 0.01 looks like a reasonable threhold, no particular reasons
-        if (fabs(average-0.5)<0.01)
-            avGood=true;
-        if (fabs(std-0.28)<0.01)
-            stdGood=true;
+        if (fabs(average - 0.5) < 0.01) {
+            avGood = true;
+        }
+        if (fabs(std - 0.28) < 0.01) {
+            stdGood = true;
+        }
 
         CHECK(avGood); // average is ~0.5;
         CHECK(stdGood); // std is ~0.28;

--- a/tests/libYARP_math/svdTest.cpp
+++ b/tests/libYARP_math/svdTest.cpp
@@ -32,14 +32,18 @@ const double TOL = 1e-8;
 void assertEqual(const Matrix &A, const Matrix &B, string testName, bool verbose=false)
 {
     if(A.cols() != B.cols() || A.rows()!=B.rows()){
-        if(verbose) printf("A != B: %s != %s\n", A.toString(3).c_str(), B.toString(3).c_str());
+        if (verbose) {
+            printf("A != B: %s != %s\n", A.toString(3).c_str(), B.toString(3).c_str());
+        }
         CHECK(false);
         INFO(testName);
     }
     for(size_t r=0; r<A.rows(); r++){
         for(size_t c=0; c<A.cols(); c++){
             if(fabs(A(r,c)-B(r,c))>TOL){
-                if(verbose) printf("A != B: %s != %s\n", A.toString(3).c_str(), B.toString(3).c_str());
+                if (verbose) {
+                    printf("A != B: %s != %s\n", A.toString(3).c_str(), B.toString(3).c_str());
+                }
                 CHECK(false);
                 INFO(testName);
             }
@@ -57,13 +61,15 @@ void assertNotEqual(const Matrix &A, const Matrix &B, string testName, bool verb
         INFO(testName);
         return;
     }
-    for(size_t r=0; r<A.rows(); r++)
-        for(size_t c=0; c<A.cols(); c++)
+    for (size_t r = 0; r < A.rows(); r++) {
+        for (size_t c = 0; c < A.cols(); c++) {
             if(fabs(A(r,c)-B(r,c))>TOL){
                 CHECK(true);
                 INFO(testName);
                 return;
             }
+        }
+    }
     CHECK(false);
     INFO(testName);
 }

--- a/tests/libYARP_os/PeriodicThreadTest.cpp
+++ b/tests/libYARP_os/PeriodicThreadTest.cpp
@@ -90,10 +90,11 @@ public:
 
     void threadRelease() override
     {
-        if (n>0)
+        if (n > 0) {
             period=average/(n-1);
-        else
-            period=0;
+        } else {
+            period = 0;
+        }
     }
 
 };
@@ -163,10 +164,11 @@ public:
 
     void afterStart(bool s) override
     {
-        if (s)
+        if (s) {
             state++;
-        else
-            state=-2;
+        } else {
+            state = -2;
+        }
     }
 
     void run() override
@@ -191,8 +193,9 @@ public:
             count--;
 
             //terminate when count is zero
-            if (count==0)
+            if (count == 0) {
                 PeriodicThread::askToStop();
+            }
     }
 
 };
@@ -237,7 +240,9 @@ public:
     }
 
     void run() override {
-        if (done) askToStop();
+        if (done) {
+            askToStop();
+        }
     }
 
     void threadRelease() override {
@@ -421,13 +426,17 @@ TEST_CASE("os::PeriodicThreadTest", "[yarp::os]")
         SystemClock clk;
         for (int i=0; i<20; i++) {
             clk.delay(0.1);
-            if (thread.count == 1) break;
+            if (thread.count == 1) {
+                break;
+            }
         }
         CHECK(thread.count); // 1
         clock.t += 100*1000;
         for (int i=0; i<20; i++) {
             clk.delay(0.1);
-            if (thread.count == 2) break;
+            if (thread.count == 2) {
+                break;
+            }
         }
         CHECK(thread.count); // 2
         clock.done = true;

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -39,7 +39,9 @@ static void restoreEnvironment()
 {
     for (size_t i=0; i<env.size(); i++) {
         Bottle *lst = env.get(i).asList();
-        if (lst==nullptr) continue;
+        if (lst == nullptr) {
+            continue;
+        }
         std::string key = lst->get(0).asString();
         std::string val = lst->get(1).asString();
         bool found = lst->get(2).asInt32()?true:false;
@@ -82,7 +84,9 @@ static void mkdir(const Bottle& dirs)
     std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
     std::string dir = "";
     for (size_t i=0; i<dirs.size(); i++) {
-        if (i>0) dir += slash;
+        if (i > 0) {
+            dir += slash;
+        }
         dir = dir + dirs.get(i).asString();
         mkdir(dir);
     }
@@ -761,7 +765,9 @@ YARP_WARNING_POP
 
             bool found;
             std::string robot = yarp::conf::environment::get_string("YARP_ROBOT_NAME", &found);
-            if (!found) robot = "default";
+            if (!found) {
+                robot = "default";
+            }
             CHECK(rf.getHomeContextPath() == yarp::conf::dirs::yarpdatahome() + slash + "contexts" + slash + "my_app"); // $YARP_DATA_HOME/contexts/my_app found as directory for writing
             CHECK(rf.getHomeRobotPath() == yarp::conf::dirs::yarpdatahome() + slash + "robots" + slash + robot); // $YARP_DATA_HOME/robots/dummyRobot found as directory for writing
 

--- a/tests/libYARP_os/ThreadTest.cpp
+++ b/tests/libYARP_os/ThreadTest.cpp
@@ -217,8 +217,9 @@ public:
     void afterStart(bool s) override
     {
         mutex.lock();
-        if(!s)
+        if (!s) {
             state++;
+        }
         mutex.unlock();
     }
 
@@ -382,14 +383,20 @@ TEST_CASE("os::ThreadTest", "[yarp::os]")
     SECTION("testing IDs...")
     {
         ThreadIdentity t[3];
-        for (int i=0; i<3; i++) t[i].start();
-        for (int i=0; i<3; i++) t[i].stop();
+        for (int i = 0; i < 3; i++) {
+            t[i].start();
+        }
+        for (int i = 0; i < 3; i++) {
+            t[i].stop();
+        }
         for (int i=0; i<3; i++) {
             CHECK(t[i].staticId == t[i].dynamicId); // IDs match appropriately
         }
         for (int i=0; i<3; i++) {
             for (int j=0; j<3; j++) {
-                if (i==j) continue;
+                if (i == j) {
+                    continue;
+                }
                 CHECK_FALSE(t[i].staticId==t[j].staticId); // IDs differ appropriately
             }
         }

--- a/tests/libYARP_os/TimerTest.cpp
+++ b/tests/libYARP_os/TimerTest.cpp
@@ -84,10 +84,11 @@ static void monoMultiThreadTest(bool multiThread)
         t->start();
     }
 
-    if (multiThread)
+    if (multiThread) {
         CHECK(yarp::os::Thread::getCount() - threadCount == 3); // multiThread test
-    else
+    } else {
         CHECK(yarp::os::Thread::getCount() - threadCount == 1); // singleThread test
+    }
 
     for (auto& t : timers)
     {

--- a/tests/libYARP_os/impl/PortCoreTest.cpp
+++ b/tests/libYARP_os/impl/PortCoreTest.cpp
@@ -106,7 +106,9 @@ public:
         expectation = bot.toString();
         sender.send(bot);
         for (int i=0; i<1000; i++) {
-            if (receives==1) break;
+            if (receives == 1) {
+                break;
+            }
             Time::delay(0.3);
         }
         CHECK(receives == 1); // "something received");
@@ -152,7 +154,9 @@ public:
         expectation = bot.toString();
         sender.send(bot);
         for (int i=0; i<1000; i++) {
-            if (receives==1) break;
+            if (receives == 1) {
+                break;
+            }
             Time::delay(0.3);
         }
         CHECK(receives == 1);  // "something received");

--- a/tests/libYARP_run/RunTest.cpp
+++ b/tests/libYARP_run/RunTest.cpp
@@ -38,8 +38,9 @@ public:
             delete [] _argv[a];
         }
 
-        if (_argv)
-            delete [] _argv;
+        if (_argv) {
+            delete[] _argv;
+        }
         _argv=nullptr;
     }
 

--- a/tests/libYARP_run/module.cpp
+++ b/tests/libYARP_run/module.cpp
@@ -38,10 +38,11 @@ public:
     bool respond(const Bottle& command, Bottle& reply) override
     {
         printf("Got something, echo is on\n");
-        if (command.get(0).asString()=="quit")
+        if (command.get(0).asString() == "quit") {
             return false;
-        else
-            reply=command;
+        } else {
+            reply = command;
+        }
         return true;
     }
 

--- a/tests/libYARP_sig/ImageTest.cpp
+++ b/tests/libYARP_sig/ImageTest.cpp
@@ -509,24 +509,25 @@ TEST_CASE("sig::ImageTest", "[yarp::sig]")
 
         // do the same on img2, but using the
         // pixel function
-        for(r=0; r<img2.height(); r++)
-            for(c=0;c<img2.width(); c++)
-                {
+            for (r = 0; r < img2.height(); r++) {
+                for (c = 0; c < img2.width(); c++) {
                     img2(c,r).r=r;
                     img2(c,r).g=r;
                     img2(c,r).b=r;
                 }
+            }
 
 
         // now make sure the two images are the same
         int acc=0;
-        for(r=0; r<img2.height(); r++)
+        for (r = 0; r < img2.height(); r++) {
             for(c=0;c<img2.width(); c++)
                 {
                     acc+=(img2(c,r).r-img1(c,r).r);
                     acc+=(img2(c,r).g-img1(c,r).g);
                     acc+=(img2(c,r).b-img1(c,r).b);
-                }
+            }
+        }
 
         CHECK(acc == 0); // pointer to row access
     }
@@ -541,12 +542,13 @@ TEST_CASE("sig::ImageTest", "[yarp::sig]")
         size_t r,c;
         int acc1=0;
         int acc2=0;
-        for(r=0; r<img1.height(); r++)
+        for (r = 0; r < img1.height(); r++) {
             for(c=0;c<img1.width(); c++)
                 {
                     img1(c,r)=(unsigned char) r;
                     acc1+=r;
-                }
+            }
+        }
 
         const ImageOf<PixelMono> &constImg=img1;
         for(r=0; r<constImg.height(); r++)

--- a/tests/libYARP_sig/MatrixTest.cpp
+++ b/tests/libYARP_sig/MatrixTest.cpp
@@ -52,17 +52,21 @@ public:
             m.resize(4,4);
             int r=0;
             int c=0;
-            for(r=0; r<4; r++)
-                for (c=0; c<4; c++)
-                    m[r][c]=99;
+            for (r = 0; r < 4; r++) {
+                for (c = 0; c < 4; c++) {
+                    m[r][c] = 99;
+                }
+            }
 
             portOut->write(m);
             Time::delay(0.1);
 
             m.resize(2,4);
-            for(r=0; r<2; r++)
-                for (c=0; c<4; c++)
-                    m[r][c]=66;
+            for (r = 0; r < 2; r++) {
+                for (c = 0; c < 4; c++) {
+                    m[r][c] = 66;
+                }
+            }
 
             portOut->write(m);
         }
@@ -97,14 +101,16 @@ public:
         while(times--)
         {
             portIn->read(m);
-            if ( (m.rows()!=4)||(m.cols()!=4))
-                ok=false;
+            if ((m.rows() != 4) || (m.cols() != 4)) {
+                ok = false;
+            }
 
 
             portIn->read(m);
 
-            if ( (m.rows()!=2)||(m.cols()!=4))
-                ok=false;
+            if ((m.rows() != 2) || (m.cols() != 4)) {
+                ok = false;
+            }
         }
 
         success=ok;
@@ -122,20 +128,25 @@ bool checkConsistency(Matrix &a)
     tmp=(gsl_matrix *)(tmpGSL.getGslMatrix());
 
     bool ret=true;
-    if (tmp->size1!=a.rows())
-        ret=false;
+    if (tmp->size1 != a.rows()) {
+        ret = false;
+    }
 
-    if (tmp->size2!=a.cols())
-        ret=false;
+    if (tmp->size2 != a.cols()) {
+        ret = false;
+    }
 
-    if (tmp->block->size!=a.cols()*a.rows())
-        ret=false;
+    if (tmp->block->size != a.cols() * a.rows()) {
+        ret = false;
+    }
 
-    if (tmp->data!=a.data())
-        ret=false;
+    if (tmp->data != a.data()) {
+        ret = false;
+    }
 
-    if (tmp->block->data!=a.data())
-        ret=false;
+    if (tmp->block->data != a.data()) {
+        ret = false;
+    }
 
     return ret;
 }
@@ -164,13 +175,15 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         M2=1; //now we have to identical vectors
 
         bool ok=false;
-        if (M1==M2)
-            ok=true;
+        if (M1 == M2) {
+            ok = true;
+        }
 
         M1=2;
         M2=1; //now vectors are different
-        if (M1==M2)
-            ok=false;
+        if (M1 == M2) {
+            ok = false;
+        }
 
         CHECK(ok); // operator== for matrix work
     }
@@ -211,8 +224,9 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         int c=0;
         for(r=0; r<10; r++)
         {
-            for (c=0; c<40; c++)
-                m[r][c]=1333;
+            for (c = 0; c < 40; c++) {
+                m[r][c] = 1333;
+            }
         }
 
         Matrix m2(m);
@@ -220,9 +234,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         CHECK(m.cols() == m2.cols()); // cols matches
 
         bool ok=true;
-        for(r=0; r<10; r++)
-            for (c=0; c<40; c++)
-                ok=ok && ((m[r])[c]==(m2[r])[c]);
+        for (r = 0; r < 10; r++) {
+            for (c = 0; c < 40; c++) {
+                ok = ok && ((m[r])[c] == (m2[r])[c]);
+            }
+        }
 
         CHECK(ok); // elements match
 
@@ -236,9 +252,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         Matrix m(10,40);
         int r=0;
         int c=0;
-        for(r=0; r<10; r++)
-            for (c=0; c<40; c++)
-                m[r][c]=99;
+        for (r = 0; r < 10; r++) {
+            for (c = 0; c < 40; c++) {
+                m[r][c] = 99;
+            }
+        }
 
         Matrix m2;
         m2=m;
@@ -246,9 +264,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         CHECK(m.cols() == m2.cols()); // cols matches
 
         bool ok=true;
-        for(r=0; r<10; r++)
-            for (c=0; c<40; c++)
-                ok=ok && (m[r][c]==m2[r][c]);
+        for (r = 0; r < 10; r++) {
+            for (c = 0; c < 40; c++) {
+                ok = ok && (m[r][c] == m2[r][c]);
+            }
+        }
         CHECK(ok); // elements match
     }
 
@@ -275,9 +295,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         size_t r=0;
         size_t c=0;
         int kk=0;
-        for(r=0; r<R; r++)
-            for (c=0; c<C; c++)
-                m[r][c]=kk++;
+        for (r = 0; r < R; r++) {
+            for (c = 0; c < C; c++) {
+                m[r][c] = kk++;
+            }
+        }
 
         INFO("extracting submatrix...");
         size_t r1=5;
@@ -296,8 +318,9 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
             int cc=kk;
             for(c=0;c<m2.cols();c++)
             {
-                if (m2[r][c]!=cc++)
-                    ok=false;
+                if (m2[r][c] != cc++) {
+                    ok = false;
+                }
             }
             kk+=C;
         }
@@ -316,8 +339,9 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
             int cc=kk;
             for(c=0;c<m3.cols();c++)
             {
-                if (m3[r][c]!=cc++)
-                    ok=false;
+                if (m3[r][c] != cc++) {
+                    ok = false;
+                }
             }
             kk+=C;
         }
@@ -353,9 +377,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         resized.resize(12, 15);
 
         bool ok=true;
-        for(unsigned int r=0; r<10; r++)
-            for(unsigned int c=0; c<10; c++)
-                ok=ok&&(resized[r][c]==1.1);
+        for (unsigned int r = 0; r < 10; r++) {
+            for (unsigned int c = 0; c < 10; c++) {
+                ok = ok && (resized[r][c] == 1.1);
+            }
+        }
 
         CHECK(ok); // resize(int r, int c) keeps old values [1]
 
@@ -372,18 +398,22 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         resized.resize(6, 5);
 
         ok=true;
-        for(unsigned int r=0; r<5; r++)
-            for(unsigned int c=0; c<5; c++)
-                ok=ok&&(resized[r][c]==eye[r][c]);
+        for (unsigned int r = 0; r < 5; r++) {
+            for (unsigned int c = 0; c < 5; c++) {
+                ok = ok && (resized[r][c] == eye[r][c]);
+            }
+        }
 
         CHECK(ok); // resize(int r, int c) keeps old values [2]
 
         resized=ones;
         resized.resize(3, 5);
         ok=true;
-        for(unsigned int r=0; r<3; r++)
-            for(unsigned int c=0; c<5; c++)
-                ok=ok&&(resized[r][c]==ones[r][c]);
+        for (unsigned int r = 0; r < 3; r++) {
+            for (unsigned int c = 0; c < 5; c++) {
+                ok = ok && (resized[r][c] == ones[r][c]);
+            }
+        }
 
         CHECK(ok); // resizing to smaller size keeps old values [1]
 
@@ -391,9 +421,11 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         resized.resize(3,5);
 
         ok=true;
-        for(unsigned int r=0; r<3; r++)
-            for(unsigned int c=0; c<5; c++)
-                ok=ok&&(resized[r][c]==eye[r][c]);
+        for (unsigned int r = 0; r < 3; r++) {
+            for (unsigned int c = 0; c < 5; c++) {
+                ok = ok && (resized[r][c] == eye[r][c]);
+            }
+        }
 
         CHECK(ok); // resizing to smaller size keeps old values [2]
 
@@ -415,9 +447,13 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         CHECK((size_t) bot.get(1).asInt32() == cc); // column count matches
         Bottle *lst = bot.get(2).asList();
         CHECK(lst!=nullptr); // have data
-        if (!lst) return;
+        if (!lst) {
+            return;
+        }
         CHECK(lst->size() == (rr*cc)); // data length matches
-        if (lst->size()!=(rr*cc)) return;
+        if (lst->size() != (rr * cc)) {
+            return;
+        }
         bool ok = true;
         for (int i=0; i<(int)(rr*cc); i++) {
             double v = lst->get(i).asFloat64();
@@ -458,12 +494,16 @@ TEST_CASE("sig::MatrixTest", "[yarp::sig]")
         Bottle *bot1 = bot.get(0).asList();
         Bottle *bot2 = bot.get(1).asList();
         CHECK((bot1!=nullptr&&bot2!=nullptr)); // got head/body
-        if (bot1==nullptr || bot2==nullptr) return;
+        if (bot1 == nullptr || bot2 == nullptr) {
+            return;
+        }
         CHECK((size_t) bot1->get(0).asInt32() == rr); // row count matches
         CHECK((size_t) bot1->get(1).asInt32() == cc); // column count matches
         Bottle *lst = bot1->get(2).asList();
         CHECK(lst!=nullptr); // have data
-        if (!lst) return;
+        if (!lst) {
+            return;
+        }
         CHECK(lst->size() == (rr*cc)); // data length matches
         CHECK(bot2->get(0).asFloat64() == Approx(value)); // "value match"
     }

--- a/tests/libYARP_sig/SoundTest.cpp
+++ b/tests/libYARP_sig/SoundTest.cpp
@@ -78,7 +78,7 @@ TEST_CASE("sig::SoundTest", "[yarp::sig]")
         snd1.resize(10, 3);
         generate_test_sound(snd1, 10, 3);
 
-        for (auto i=0; i<10; i++)
+        for (auto i = 0; i < 10; i++) {
             for (auto j = 0; j < 3; j++)
             {
                 ok = true;
@@ -89,6 +89,7 @@ TEST_CASE("sig::SoundTest", "[yarp::sig]")
                 ok &= (snd1 == snd2);
                 CHECK(!ok);
             }
+        }
     }
 
     SECTION("check replace channel.")

--- a/tests/libYARP_sig/VectorOfTest.cpp
+++ b/tests/libYARP_sig/VectorOfTest.cpp
@@ -66,8 +66,9 @@ TEST_CASE("sig::VectorOfTest", "[yarp::sig]")
             {
                 for (unsigned int k = 0; k < vector.size(); k++)
                 {
-                    if (tmp[k] != vector[k])
+                    if (tmp[k] != vector[k]) {
                         success = false;
+                    }
                 }
             }
 
@@ -114,8 +115,9 @@ TEST_CASE("sig::VectorOfTest", "[yarp::sig]")
             {
                 for (unsigned int k = 0; k < vector.size(); k++)
                 {
-                    if (tmp2.get(k).asInt32() != vector[k])
+                    if (tmp2.get(k).asInt32() != vector[k]) {
                         success = false;
+                    }
                 }
             }
 

--- a/tests/libYARP_sig/VectorTest.cpp
+++ b/tests/libYARP_sig/VectorTest.cpp
@@ -48,15 +48,17 @@ public:
         {
             v.clear();
             int k=0;
-            for(k=0;k<10;k++)
+            for (k = 0; k < 10; k++) {
                 v.push_back(3.14159265);
+            }
 
             portOut->write(v);
             Time::delay(0.1);
             v.clear();
 
-            for(k=0;k<5;k++)
+            for (k = 0; k < 5; k++) {
                 v.push_back(k);
+            }
 
             portOut->write(v);
         }
@@ -95,22 +97,26 @@ public:
 
             int k;
             int s=(int)v.size();
-            if (s!=10)
-                ok=false;
+            if (s != 10) {
+                ok = false;
+            }
             for(k=0;k<s;k++)
             {
-                if (v[k]!=3.14159265)
-                    ok=false;
+                if (v[k] != 3.14159265) {
+                    ok = false;
+                }
             }
 
             portIn->read(v);
             s=(int)v.size();
-            if (s!=5)
-                ok=false;
+            if (s != 5) {
+                ok = false;
+            }
             for(k=0;k<s;k++)
             {
-                if (v[k]!=k)
-                    ok=false;
+                if (v[k] != k) {
+                    ok = false;
+                }
             }
 
         }
@@ -128,14 +134,17 @@ bool checkConsistency(Vector &a) {
     tmp = (gsl_vector *)(tmpGSL.getGslVector());
 
     bool ret=true;
-    if ((int)tmp->size!=(int)a.size())
-        ret=false;
+    if ((int)tmp->size != (int)a.size()) {
+        ret = false;
+    }
 
-    if (tmp->data!=a.data())
-        ret=false;
+    if (tmp->data != a.data()) {
+        ret = false;
+    }
 
-    if (tmp->block->data!=a.data())
-        ret=false;
+    if (tmp->block->data != a.data()) {
+        ret = false;
+    }
 
     return ret;
 }
@@ -160,8 +169,9 @@ TEST_CASE("sig::VectorTest", "[yarp::sig]")
         b.resize(100);
         CHECK(checkConsistency(b)); // gsldata consistent after resize
 
-        for(int k=0;k<100;k++)
+        for (int k = 0; k < 100; k++) {
             a.push_back(1.0);
+        }
 
         checkConsistency(a);
         CHECK(checkConsistency(a)); // gsldata consistent after push
@@ -242,8 +252,9 @@ TEST_CASE("sig::VectorTest", "[yarp::sig]")
         CHECK((int)v.size() == (int)v2.size()); // size matches
 
         bool ok=true;
-        for (int k=0; k<4; k++)
-            ok=ok&&(v2[k]==v[k]);
+        for (int k = 0; k < 4; k++) {
+            ok = ok && (v2[k] == v[k]);
+        }
 
         CHECK(ok); // elements match
 
@@ -266,8 +277,9 @@ TEST_CASE("sig::VectorTest", "[yarp::sig]")
         CHECK((int)v.size() == (int)v2.size()); // size matches
 
         bool ok=true;
-        for (int k=0; k<4; k++)
-            ok=ok&&(v2[k]==v[k]);
+        for (int k = 0; k < 4; k++) {
+            ok = ok && (v2[k] == v[k]);
+        }
 
         CHECK(ok); // elements match
 
@@ -291,13 +303,15 @@ TEST_CASE("sig::VectorTest", "[yarp::sig]")
         v2=1; //now we have to identical vectors
 
         bool ok=false;
-        if (v1==v2)
-            ok=true;
+        if (v1 == v2) {
+            ok = true;
+        }
 
         v1=2;
         v2=1; //now vectors are different
-        if (v1==v2)
-            ok=false;
+        if (v1 == v2) {
+            ok = false;
+        }
 
         CHECK(ok); // operator== for vectors works
     }
@@ -308,34 +322,39 @@ TEST_CASE("sig::VectorTest", "[yarp::sig]")
         ones.resize(10, 1.1);
 
         bool ok=true;
-        for(unsigned int k=0; k<ones.size(); k++)
-            ok=ok&&(ones[k]==1.1);
+        for (unsigned int k = 0; k < ones.size(); k++) {
+            ok = ok && (ones[k] == 1.1);
+        }
 
         CHECK(ok); // resize(int, double) works
 
         ones.resize(15);
         // fill new values
-        for(unsigned int k=10; k<ones.size(); k++)
-            ones[k]=1.1;
+        for (unsigned int k = 10; k < ones.size(); k++) {
+            ones[k] = 1.1;
+        }
 
         ok=true;
-        for(unsigned int k=0; k<ones.size(); k++)
-            ok=ok&&(ones[k]==1.1);
+        for (unsigned int k = 0; k < ones.size(); k++) {
+            ok = ok && (ones[k] == 1.1);
+        }
 
         CHECK(ok); // resize(int) works
 
         ones.resize(9);
         ok=true;
-        for(unsigned int k=0; k<ones.size(); k++)
-            ok=ok&&(ones[k]==1.1);
+        for (unsigned int k = 0; k < ones.size(); k++) {
+            ok = ok && (ones[k] == 1.1);
+        }
 
         CHECK(ok); // resizing to smaller vector
 
         ones.resize(10, 42.42);
 
         ok=true;
-        for(unsigned int k=0; k<ones.size(); k++)
-            ok=ok&&(ones[k]==42.42);
+        for (unsigned int k = 0; k < ones.size(); k++) {
+            ok = ok && (ones[k] == 42.42);
+        }
 
         CHECK(ok); // resize(int, double) works
     }


### PR DESCRIPTION
This is mostly to test the new clang-tidy + codacy integration, it touches lots of files.

It was generated by running `run-clang-tidy-12 -fix -format -style file -checks='-*,readability-braces-around-statements'`

In order to avoid conflicts with other PR/branches/work in progress, if you want to remove some files or directories from this PR, just let me know...