### PR TITLE
Avoid targeting too many subdevice joints by ControlBoardWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,11 @@ compile_commands.json
 *.aps
 /CMakeSettings.json
 /.vs/
+/.vscode/
 /.idea/
+/.project
+/.cproject
+/.settings/
 /cmake-build*/
 .clangd/
 *.srctrlbm

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperAmplifierControl.cpp
@@ -69,28 +69,17 @@ bool ControlBoardWrapperAmplifierControl::disableAmp(int j)
 
 bool ControlBoardWrapperAmplifierControl::getAmpStatus(int* st)
 {
-    int* status = new int[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->amp) && (ret = p->amp->getAmpStatus(status))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                st[juser] = status[jdevice];
-            }
-        } else {
-            printError("getAmpStatus", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->amp || !p->amp->getAmpStatus(static_cast<int>(off + p->base), &st[l])) {
+            return false;
         }
     }
 
-    delete[] status;
-    return ret;
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperCommon.h
@@ -67,23 +67,6 @@ public:
      */
     bool getCurrent(int m, double* curr);
     bool getCurrents(double* currs);
-
-// UTILITIES
-    inline void printError(const std::string& func_name, const std::string& info, bool result)
-    {
-        // FIXME: Check if it is still required.
-        //        This method was commented out by these commits:
-        //          afc039962f3667cc954e7a50ce6963ec60886611
-        //          0c0de4a9331b9b843ac4b3d3746c074dd0427249
-
-        // If result is false, this means that en error occurred in function named func_name, otherwise means that the device doesn't implement the interface to witch func_name belongs to.
-        // if(false == result) {
-        //     yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << " returns false";
-        // } else {
-        // Commented in order to maintain the old behaviour (none message appear if device desn't implement the interface)
-        // yCError(CONTROLBOARDREMAPPER) << "CBW(" << partName << "): " << func_name.c_str() << " on device" << info.c_str() << ": the interface is not available.";
-        // }
-    }
 };
 
 #endif // YARP_DEV_CONTROLBOARDWRAPPER_CONTROLBOARDWRAPPERCOMMON_H

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
@@ -128,58 +128,33 @@ bool ControlBoardWrapperEncodersTimed::getEncoder(int j, double* v)
 
 bool ControlBoardWrapperEncodersTimed::getEncoders(double* encs)
 {
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoders(encValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                encs[juser] = encValues[jdevice];
-            }
-        } else {
-            printError("getEncoders", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iJntEnc || !p->iJntEnc->getEncoder(static_cast<int>(off + p->base), &encs[l])) {
+            return false;
         }
     }
 
-    delete[] encValues;
-    return ret;
+    return true;
 }
 
 
 bool ControlBoardWrapperEncodersTimed::getEncodersTimed(double* encs, double* t)
 {
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    auto* tValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncodersTimed(encValues, tValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                encs[juser] = encValues[jdevice];
-                t[juser] = tValues[jdevice];
-            }
-        } else {
-            printError("getEncodersTimed", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iJntEnc || !p->iJntEnc->getEncoderTimed(static_cast<int>(off + p->base), &encs[l], &t[l])) {
+            return false;
         }
     }
 
-    delete[] encValues;
-    delete[] tValues;
-    return ret;
+    return true;
 }
 
 
@@ -233,28 +208,17 @@ bool ControlBoardWrapperEncodersTimed::getEncoderSpeed(int j, double* sp)
 
 bool ControlBoardWrapperEncodersTimed::getEncoderSpeeds(double* spds)
 {
-    auto* sValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderSpeeds(sValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                spds[juser] = sValues[jdevice];
-            }
-        } else {
-            printError("getEncoderSpeeds", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iJntEnc || !p->iJntEnc->getEncoderSpeed(static_cast<int>(off + p->base), &spds[l])) {
+            return false;
         }
     }
 
-    delete[] sValues;
-    return ret;
+    return true;
 }
 
 
@@ -284,26 +248,15 @@ bool ControlBoardWrapperEncodersTimed::getEncoderAcceleration(int j, double* acc
 
 bool ControlBoardWrapperEncodersTimed::getEncoderAccelerations(double* accs)
 {
-    auto* aValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iJntEnc) && (ret = p->iJntEnc->getEncoderAccelerations(aValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                accs[juser] = aValues[jdevice];
-            }
-        } else {
-            printError("getEncoderAccelerations", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iJntEnc || !p->iJntEnc->getEncoderAcceleration(static_cast<int>(off + p->base), &accs[l])) {
+            return false;
         }
     }
 
-    delete[] aValues;
-    return ret;
+    return true;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperEncodersTimed.cpp
@@ -35,24 +35,17 @@ bool ControlBoardWrapperEncodersTimed::resetEncoder(int j)
 
 bool ControlBoardWrapperEncodersTimed::resetEncoders()
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->iJntEnc || !p->iJntEnc->resetEncoder(static_cast<int>(off + p->base))) {
             return false;
         }
-
-        if (p->iJntEnc) {
-            ret = ret && p->iJntEnc->resetEncoder(static_cast<int>(off + p->base));
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 
@@ -81,24 +74,17 @@ bool ControlBoardWrapperEncodersTimed::setEncoder(int j, double val)
 
 bool ControlBoardWrapperEncodersTimed::setEncoders(const double* vals)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->iJntEnc || !p->iJntEnc->setEncoder(static_cast<int>(off + p->base), vals[l])) {
             return false;
         }
-
-        if (p->iJntEnc) {
-            ret = ret && p->iJntEnc->setEncoder(static_cast<int>(off + p->base), vals[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotor.cpp
@@ -29,28 +29,17 @@ bool ControlBoardWrapperMotor::getTemperature(int m, double* val)
 
 bool ControlBoardWrapperMotor::getTemperatures(double* vals)
 {
-    auto* temps = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->imotor) && (ret = p->imotor->getTemperatures(temps))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                vals[juser] = temps[jdevice];
-            }
-        } else {
-            printError("getTemperatures", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->imotor || !p->imotor->getTemperature(static_cast<int>(off + p->base), &vals[l])) {
+            return false;
         }
     }
 
-    delete[] temps;
-    return ret;
+    return true;
 }
 
 bool ControlBoardWrapperMotor::getTemperatureLimit(int m, double* val)

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
@@ -145,59 +145,33 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoder(int m, double* v)
 
 bool ControlBoardWrapperMotorEncoders::getMotorEncoders(double* encs)
 {
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
-
-        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoders(encValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                encs[juser] = encValues[jdevice];
-            }
-        } else {
-            printError("getMotorEncoders", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iMotEnc || !p->iMotEnc->getMotorEncoder(static_cast<int>(off + p->base), &encs[l])) {
+            return false;
         }
     }
 
-    delete[] encValues;
-    return ret;
+    return true;
 }
 
 
 bool ControlBoardWrapperMotorEncoders::getMotorEncodersTimed(double* encs, double* t)
 {
-    auto* encValues = new double[device.maxNumOfJointsInDevices];
-    auto* tValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncodersTimed(encValues, tValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                encs[juser] = encValues[jdevice];
-                t[juser] = tValues[jdevice];
-            }
-        } else {
-            printError("getMotorEncodersTimed", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iMotEnc || !p->iMotEnc->getMotorEncoderTimed(static_cast<int>(off + p->base), &encs[l], &t[l])) {
+            return false;
         }
     }
 
-    delete[] encValues;
-    delete[] tValues;
-    return ret;
+    return true;
 }
 
 
@@ -239,28 +213,17 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeed(int m, double* sp)
 
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderSpeeds(double* spds)
 {
-    auto* sValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderSpeeds(sValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                spds[juser] = sValues[jdevice];
-            }
-        } else {
-            printError("getMotorEncoderSpeeds", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iMotEnc || !p->iMotEnc->getMotorEncoderSpeed(static_cast<int>(off + p->base), &spds[l])) {
+            return false;
         }
     }
 
-    delete[] sValues;
-    return ret;
+    return true;
 }
 
 
@@ -284,28 +247,17 @@ bool ControlBoardWrapperMotorEncoders::getMotorEncoderAcceleration(int m, double
 
 bool ControlBoardWrapperMotorEncoders::getMotorEncoderAccelerations(double* accs)
 {
-    auto* aValues = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iMotEnc) && (ret = p->iMotEnc->getMotorEncoderAccelerations(aValues))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                accs[juser] = aValues[jdevice];
-            }
-        } else {
-            printError("getMotorEncoderAccelerations", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iMotEnc || !p->iMotEnc->getMotorEncoderAcceleration(static_cast<int>(off + p->base), &accs[l])) {
+            return false;
         }
     }
 
-    delete[] aValues;
-    return ret;
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperMotorEncoders.cpp
@@ -29,24 +29,17 @@ bool ControlBoardWrapperMotorEncoders::resetMotorEncoder(int m)
 
 bool ControlBoardWrapperMotorEncoders::resetMotorEncoders()
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->iMotEnc || !p->iMotEnc->resetMotorEncoder(static_cast<int>(off + p->base))) {
             return false;
         }
-
-        if (p->iMotEnc) {
-            ret = ret && p->iMotEnc->resetMotorEncoder(static_cast<int>(off + p->base));
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 
@@ -69,24 +62,17 @@ bool ControlBoardWrapperMotorEncoders::setMotorEncoder(int m, const double val)
 
 bool ControlBoardWrapperMotorEncoders::setMotorEncoders(const double* vals)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->iMotEnc || !p->iMotEnc->setMotorEncoder(static_cast<int>(off + p->base), vals[l])) {
             return false;
         }
-
-        if (p->iMotEnc) {
-            ret = ret && p->iMotEnc->setMotorEncoder(static_cast<int>(off + p->base), vals[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
@@ -35,24 +35,17 @@ bool ControlBoardWrapperPWMControl::setRefDutyCycle(int j, double v)
 
 bool ControlBoardWrapperPWMControl::setRefDutyCycles(const double* v)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->iPWM || !p->iPWM->setRefDutyCycle(static_cast<int>(off + p->base), v[l])) {
             return false;
         }
-
-        if (p->iPWM) {
-            ret = ret && p->iPWM->setRefDutyCycle(static_cast<int>(off + p->base), v[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 bool ControlBoardWrapperPWMControl::getRefDutyCycle(int j, double* v)

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPWMControl.cpp
@@ -79,28 +79,17 @@ bool ControlBoardWrapperPWMControl::getRefDutyCycle(int j, double* v)
 
 bool ControlBoardWrapperPWMControl::getRefDutyCycles(double* v)
 {
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iPWM) && (ret = p->iPWM->getRefDutyCycles(references))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                v[juser] = references[jdevice];
-            }
-        } else {
-            printError("getRefDutyCycles", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iPWM || !p->iPWM->getRefDutyCycle(static_cast<int>(off + p->base), &v[l])) {
+            return false;
         }
     }
 
-    delete[] references;
-    return ret;
+    return true;
 }
 
 bool ControlBoardWrapperPWMControl::getDutyCycle(int j, double* v)
@@ -127,26 +116,15 @@ bool ControlBoardWrapperPWMControl::getDutyCycle(int j, double* v)
 
 bool ControlBoardWrapperPWMControl::getDutyCycles(double* v)
 {
-    auto* dutyCicles = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->iPWM) && (ret = p->iPWM->getDutyCycles(dutyCicles))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                v[juser] = dutyCicles[jdevice];
-            }
-        } else {
-            printError("getDutyCycles", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->iPWM || !p->iPWM->getDutyCycle(static_cast<int>(off + p->base), &v[l])) {
+            return false;
         }
     }
 
-    delete[] dutyCicles;
-    return ret;
+    return true;
 }

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
@@ -43,24 +43,17 @@ bool ControlBoardWrapperPidControl::setPid(const PidControlTypeEnum& pidtype, in
 
 bool ControlBoardWrapperPidControl::setPids(const PidControlTypeEnum& pidtype, const Pid* ps)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->pid || !p->pid->setPid(pidtype, static_cast<int>(off + p->base), ps[l])) {
             return false;
         }
-
-        if (p->pid) {
-            ret = ret && p->pid->setPid(pidtype, static_cast<int>(off + p->base), ps[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 
@@ -93,24 +86,17 @@ bool ControlBoardWrapperPidControl::setPidReference(const PidControlTypeEnum& pi
 
 bool ControlBoardWrapperPidControl::setPidReferences(const PidControlTypeEnum& pidtype, const double* refs)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->pid || !p->pid->setPidReference(pidtype, static_cast<int>(off + p->base), refs[l])) {
             return false;
         }
-
-        if (p->pid) {
-            ret = ret && p->pid->setPidReference(pidtype, static_cast<int>(off + p->base), refs[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 
@@ -139,24 +125,17 @@ bool ControlBoardWrapperPidControl::setPidErrorLimit(const PidControlTypeEnum& p
 
 bool ControlBoardWrapperPidControl::setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits)
 {
-    bool ret = true;
-
     for (size_t l = 0; l < controlledJoints; l++) {
         int off = device.lut[l].offset;
         size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (!p || !p->pid || !p->pid->setPidErrorLimit(pidtype, static_cast<int>(off + p->base), limits[l])) {
             return false;
         }
-
-        if (p->pid) {
-            ret = ret && p->pid->setPidErrorLimit(pidtype, static_cast<int>(off + p->base), limits[l]);
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPidControl.cpp
@@ -186,28 +186,17 @@ bool ControlBoardWrapperPidControl::getPidError(const PidControlTypeEnum& pidtyp
 
 bool ControlBoardWrapperPidControl::getPidErrors(const PidControlTypeEnum& pidtype, double* errs)
 {
-    auto* errors = new double[device.maxNumOfJointsInDevices];
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
-        if ((p->pid) && (ret = p->pid->getPidErrors(pidtype, errors))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                errs[juser] = errors[jdevice];
-            }
-        } else {
-            printError("getPidErrors", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->pid || !p->pid->getPidError(pidtype, static_cast<int>(off + p->base), &errs[l])) {
+            return false;
         }
     }
 
-    delete[] errors;
-    return ret;
+    return true;
 }
 
 
@@ -237,28 +226,17 @@ bool ControlBoardWrapperPidControl::getPidOutput(const PidControlTypeEnum& pidty
 
 bool ControlBoardWrapperPidControl::getPidOutputs(const PidControlTypeEnum& pidtype, double* outs)
 {
-    auto* outputs = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->pid) && (ret = p->pid->getPidOutputs(pidtype, outputs))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                outs[juser] = outputs[jdevice];
-            }
-        } else {
-            printError("getPidOutouts", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->pid || !p->pid->getPidOutput(pidtype, static_cast<int>(off + p->base), &outs[l])) {
+            return false;
         }
     }
 
-    delete[] outputs;
-    return ret;
+    return true;
 }
 
 
@@ -311,28 +289,17 @@ bool ControlBoardWrapperPidControl::getPid(const PidControlTypeEnum& pidtype, in
 
 bool ControlBoardWrapperPidControl::getPids(const PidControlTypeEnum& pidtype, Pid* pids)
 {
-    Pid* pids_device = new Pid[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->pid) && (ret = p->pid->getPids(pidtype, pids_device))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                pids[juser] = pids_device[jdevice];
-            }
-        } else {
-            printError("getPids", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->pid || !p->pid->getPid(pidtype, static_cast<int>(off + p->base), &pids[l])) {
+            return false;
         }
     }
 
-    delete[] pids_device;
-    return ret;
+    return true;
 }
 
 
@@ -360,28 +327,17 @@ bool ControlBoardWrapperPidControl::getPidReference(const PidControlTypeEnum& pi
 
 bool ControlBoardWrapperPidControl::getPidReferences(const PidControlTypeEnum& pidtype, double* refs)
 {
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->pid) && (ret = p->pid->getPidReferences(pidtype, references))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                refs[juser] = references[jdevice];
-            }
-        } else {
-            printError("getPidReferences", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->pid || !p->pid->getPidReference(pidtype, static_cast<int>(off + p->base), &refs[l])) {
+            return false;
         }
     }
 
-    delete[] references;
-    return ret;
+    return true;
 }
 
 
@@ -410,28 +366,17 @@ bool ControlBoardWrapperPidControl::getPidErrorLimit(const PidControlTypeEnum& p
 
 bool ControlBoardWrapperPidControl::getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits)
 {
-    auto* lims = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    for (size_t l = 0; l < controlledJoints; l++) {
+        int off = device.lut[l].offset;
+        size_t subIndex = device.lut[l].deviceEntry;
+        auto* p = device.getSubdevice(subIndex);
 
-        if ((p->pid) && (ret = p->pid->getPidErrorLimits(pidtype, lims))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                limits[juser] = lims[jdevice];
-            }
-        } else {
-            printError("getPidErrorLimits", p->id, ret);
-            ret = false;
-            break;
+        if (!p || !p->pid || !p->pid->getPidErrorLimit(pidtype, static_cast<int>(off + p->base), &limits[l])) {
+            return false;
         }
     }
 
-    delete[] lims;
-    return ret;
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapperPositionDirect.cpp
@@ -10,6 +10,9 @@
 
 #include "ControlBoardWrapperLogComponent.h"
 
+#include <numeric> // std::iota
+#include <vector>
+
 
 bool ControlBoardWrapperPositionDirect::setPosition(int j, double ref)
 {
@@ -69,24 +72,26 @@ bool ControlBoardWrapperPositionDirect::setPositions(const int n_joints, const i
 
 bool ControlBoardWrapperPositionDirect::setPositions(const double* refs)
 {
-    bool ret = true;
+    int j_wrap = 0;
 
-    for (size_t l = 0; l < controlledJoints; l++) {
-        int off = device.lut[l].offset;
-        size_t subIndex = device.lut[l].deviceEntry;
+    for (size_t subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+        auto* p = device.getSubdevice(subDev_idx);
 
-        SubDevice* p = device.getSubdevice(subIndex);
-        if (!p) {
+        if (p && p->posDir) {
+            std::vector<int> joints((p->top - p->base) + 1);
+            std::iota(joints.begin(), joints.end(), p->base);
+
+            if (!p->posDir->setPositions(joints.size(), joints.data(), &refs[j_wrap])) {
+                return false;
+            }
+
+            j_wrap += joints.size();
+        } else {
             return false;
         }
-
-        if (p->posDir) {
-            ret = p->posDir->setPosition(static_cast<int>(off + p->base), refs[l]) && ret;
-        } else {
-            ret = false;
-        }
     }
-    return ret;
+
+    return true;
 }
 
 
@@ -118,28 +123,26 @@ bool ControlBoardWrapperPositionDirect::getRefPosition(const int j, double* ref)
 
 bool ControlBoardWrapperPositionDirect::getRefPositions(double* spds)
 {
-    auto* references = new double[device.maxNumOfJointsInDevices];
-    bool ret = true;
-    for (size_t d = 0; d < device.subdevices.size(); d++) {
-        SubDevice* p = device.getSubdevice(d);
-        if (!p) {
-            ret = false;
-            break;
-        }
+    int j_wrap = 0;
 
-        if ((p->posDir) && (ret = p->posDir->getRefPositions(references))) {
-            for (size_t juser = p->wbase, jdevice = p->base; juser <= p->wtop; juser++, jdevice++) {
-                spds[juser] = references[jdevice];
+    for (size_t subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
+        auto* p = device.getSubdevice(subDev_idx);
+
+        if (p && p->posDir) {
+            std::vector<int> joints((p->top - p->base) + 1);
+            std::iota(joints.begin(), joints.end(), p->base);
+
+            if (!p->posDir->getRefPositions(joints.size(), joints.data(), &spds[j_wrap])) {
+                return false;
             }
+
+            j_wrap += joints.size();
         } else {
-            printError("getRefPositions", p->id, ret);
-            ret = false;
-            break;
+            return false;
         }
     }
 
-    delete[] references;
-    return ret;
+    return true;
 }
 
 

--- a/src/devices/ControlBoardWrapper/SubDevice.cpp
+++ b/src/devices/ControlBoardWrapper/SubDevice.cpp
@@ -197,17 +197,6 @@ bool SubDevice::attach(yarp::dev::PolyDriver* d, const std::string& k)
     if (pos != nullptr) {
         int tmp_axes;
         if (!pos->getAxes(&tmp_axes)) {
-            yCError(CONTROLBOARDWRAPPER) << "Failed to get axes number for subdevice " << k.c_str();
-            return false;
-        }
-        if (tmp_axes <= 0) {
-            yCError(CONTROLBOARDWRAPPER, "Part <%s>: attached device has an invalid number of joints (%d)", parentName.c_str(), tmp_axes);
-            return false;
-        }
-        deviceJoints = static_cast<size_t>(tmp_axes);
-    } else {
-        int tmp_axes;
-        if (!pos->getAxes(&tmp_axes)) {
             yCError(CONTROLBOARDWRAPPER, "Part <%s>: failed to get axes number for subdevice %s.", parentName.c_str(), k.c_str());
             return false;
         }
@@ -225,13 +214,6 @@ bool SubDevice::attach(yarp::dev::PolyDriver* d, const std::string& k)
                 deviceJoints,
                 axes,
                 k.c_str());
-        return false;
-    }
-
-    int subdevAxes;
-    if (!pos || !pos->getAxes(&subdevAxes)) {
-        yCError(CONTROLBOARDWRAPPER) << "Device <" << parentName << "> attached to subdevice " << k.c_str() << " but it was not ready yet. \n"
-                                     << "Please check the device has been correctly created and all required initialization actions has been performed.";
         return false;
     }
 


### PR DESCRIPTION
For the sake of describing the problem this PR tries to solve, let me introduce and outline the following terms I've just made up related to families of methods found across several [motor interfaces](http://www.yarp.it/git-master/group__dev__iface__motor.html):

* Single-joint signature: `singleJointSignature(int joint, double value)` targets one joint
* Group signature: `groupSignature(int n_joints, const int* joints, double* values)` targets specific joints
* Whole-wrapper signature: `wholeWrapperSignature(double* values)` targets all wrapped joints

Sometimes, the last signature attempts to target way too much. Our research team has proposed a single whole-body CAN controller device for a humanoid robot that encompasses up to 40 controlled joints distributed over eight network wrappers (legs, arms, hands, head and trunk). In other words, these eight `controlboardwrapper2` instances must share a common subdevice, and none of them will be responsible of exposing more than 6 robot joints over the YARP network.

Here comes trouble: whole-wrapper mappings on the network wrapper side (e.g. `ControlBoardWrapper::xxx(double*)`) usually target whole-wrapper signatures on the subdevice side. That is, even though we just want to address 6 subdevice joints, this mapping calls a method on the subdevice that affects all 40 joints. If this action happens to produce one CAN message per joint, 34 messages are needlessly consuming bandwidth in addition to the 6 we actually require.

**Solution:** map whole-wrapper signatures on the network wrapper side to group signatures on the subdevice side, whenever possible. In this way, we can more accurately target specific joints in the whole subdevice matrix. If there is no group signature available, I propose to resort to iterating over single-joint calls (premise: better just as many times as necessary than once and too much).

**1. Proposed whole-wrapper (network wrapper side) to group (subdevice side) implementation and affected methods:**

```cxx
#include <numeric> // std::iota
#include <vector>

bool wholeWrapperSignature(double* values)
{
    int j_wrap = 0;

    for (size_t subDev_idx = 0; subDev_idx < device.subdevices.size(); subDev_idx++) {
        auto* p = device.getSubdevice(subDev_idx);

        if (p && p->iface) {
            std::vector<int> joints((p->top - p->base) + 1);
            std::iota(joints.begin(), joints.end(), p->base);

            if (!p->iface->groupSignature(joints.size(), joints.data(), &values[j_wrap])) {
                return false;
            }

            j_wrap += joints.size();
        } else {
            return false;
        }
    }

    return true;
}
```

* `getControlModes(int*)` in `IControlMode`
* `getInteractionModes(yarp::dev::InteractionModeEnum*)` in `IInteractionMode`
* `getRefSpeeds(double*)` in `IPositionControl`
* `getRefAccelerations(double*)` in `IPositionControl` and `IVelocityControl`
* `getTargetPositions(double*)` in `IPositionControl`
* `getRefPositions(double*)` in `IPositionDirect`
* `getRefVelocities(double*)` in `IVelocityControl`

**2. Proposed whole-wrapper (network wrapper side) to single-joint (subdevice side) implementation and affected methods:**

```cxx
bool wholeWrapperSignature(double* values)
{
    for (size_t l = 0; l < controlledJoints; l++) {
        int off = device.lut[l].offset;
        size_t subIndex = device.lut[l].deviceEntry;
        auto* p = device.getSubdevice(subIndex);

        if (!p || !p->iface|| !p->iface->singleJointSignature(static_cast<int>(off + p->base), &values[l])) {
            return false;
        }
    }
    
    return true;
}
```

* `getAmpStatus(int*)` in `IAmplifierControl`
* `getCurrents(double*)` in `IAmplifierControl` and `ICurrentControl`
* `getCurrentRanges(double*, double*)` in `ICurrentControl`
* `getRefCurrents(double*)` in `ICurrentControl`
* `getEncoders(double*)` in `IEncodersTimed`
* `getEncoderSpeeds(double*)` in `IEncodersTimed`
* `getEncoderAccelerations(double*)` in `IEncodersTimed`
* `getEncodersTimed(double*, double*)` in `IEncodersTimed`
* `getTemperatures(double*)` in `IMotor`
* `getMotorEncoders(double*)` in `IMotorEncoders`
* `getMotorEncoderSpeeds(double*)` in `IMotorEncoders`
* `getMotorEncoderAccelerations(double*)` in `IMotorEncoders`
* `getMotorEncodersTimed(double*, double*)` in `IMotorEncoders`
* `getPids(const PidControlTypeEnum&, double*)` in `IPidControl`
* `getPidErrors(const PidControlTypeEnum&, double*)` in `IPidControl`
* `getPidErrorLimits(const PidControlTypeEnum&, double*)` in `IPidControl`
* `getPidReferences(const PidControlTypeEnum&, Pid*)` in `IPidControl`
* `getPidOutputs(const PidControlTypeEnum&, double*)` in `IPidControl`
* `getDutyCycles(double*)` in `IPWMControl`
* `getRefDutyCycles(double*)` in `IPWMControl`
* `getRefTorques(double*)` in `ITorqueControl`
* `getTorques(double*)` in `ITorqueControl`
* `getTorqueRanges(double*, double*)` in `ITorqueControl`

**3. Miscellanea, single-joint implementations migrated to group signature**

* `setRefCurrents(const double*)` in `ICurrentControl`
* `setInteractionModes(yarp::dev::InteractionModeEnum*)` in `IInteractionMode`
* `relativeMove(const double*)` in `IPositionControl`
* `setPositions(const double*)` in `IPositionDirect`
* `setRefTorques(const double*)` in `ITorqueControl`
* `stop()` in `IPositionControl` and `IVelocityControl`

There is a bunch of other methods I'm harmonizing according to the proposed implementation, although they still map in the same way they did before. Additional changes:

* Remove superfluous checks in `SubDevice::attach` that made no sense since the deprecation of `IPositionControl2` (https://github.com/robotology/yarp/commit/b8727d4575d7238dce21fca15d8d609f96667713, https://github.com/robotology/yarp/commit/6a1ac2959cef62b18e366b5a7d980fd95656a7d1).
* Remove the now unused `printError` helper method.
* Add Eclipse and VS Code bits to .gitignore.

These changes have been tested with the code provided in [this gist](https://gist.github.com/PeterBowman/5c99113b191c255624d5f540598e6ea3). Includes console output before and after the fix.