### PR TITLE
yarpmotorgui: Fix colors on dark mode desktop

### DIFF
--- a/doc/release/yarp_3_4/yarpmotorgui_fix_dark_mode.md
+++ b/doc/release/yarp_3_4/yarpmotorgui_fix_dark_mode.md
@@ -1,0 +1,8 @@
+yarpmotorgui_fix_dark_mode {#yarp_3_4}
+--------------------------
+
+## GUI
+
+### yarpmotorgui
+
+* Fixed colors on dark mode desktop (#2466).

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -182,7 +182,8 @@ JointItem::JointItem(int index,QWidget *parent) :
             "padding: 1px 18px 1px 3px;"
             "min-width: 6em;}"
             "QComboBox:editable {"
-            "background: white;}"
+            "background: white;"
+            "foreground: rgb(35, 38, 41);}"
             "QComboBox::down-arrow {"
             "image: url(:/images/downArrow.png);}";
 
@@ -205,8 +206,9 @@ JointItem::JointItem(int index,QWidget *parent) :
 
     installFilter();
 
-    ui->comboInteraction->setItemData(0,QColor(Qt::darkGray),Qt::BackgroundRole);
-    ui->comboInteraction->setItemData(1,QColor(0,80,255),Qt::BackgroundRole);
+    ui->comboInteraction->setItemData(0,QColor(Qt::darkGray), Qt::BackgroundRole);
+    ui->comboInteraction->setItemData(1,QColor(0,80,255), Qt::BackgroundRole);
+    ui->comboInteraction->setItemData(1,QColor(35, 38, 41), Qt::ForegroundRole);
 
     ui->comboMode->setItemData( IDLE,           idleColor, Qt::BackgroundRole );
     ui->comboMode->setItemData( POSITION,       positionColor, Qt::BackgroundRole );
@@ -217,6 +219,15 @@ JointItem::JointItem(int index,QWidget *parent) :
     ui->comboMode->setItemData( PWM,            pwmColor, Qt::BackgroundRole );
     ui->comboMode->setItemData( CURRENT,        currentColor, Qt::BackgroundRole);
 
+    ui->comboMode->setItemData( IDLE,           QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( POSITION,       QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( POSITION_DIR,   QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( MIXED,          QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( VELOCITY,       QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( TORQUE,         QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( PWM,            QColor(35, 38, 41), Qt::ForegroundRole );
+    ui->comboMode->setItemData( CURRENT,        QColor(35, 38, 41), Qt::ForegroundRole );
+
     ui->comboMode->setItemData( IDLE,           Idle, Qt::UserRole);
     ui->comboMode->setItemData( POSITION,       Position, Qt::UserRole );
     ui->comboMode->setItemData( POSITION_DIR,   PositionDirect, Qt::UserRole );
@@ -226,17 +237,7 @@ JointItem::JointItem(int index,QWidget *parent) :
     ui->comboMode->setItemData( PWM,            Pwm, Qt::UserRole);
     ui->comboMode->setItemData( CURRENT,        Current, Qt::UserRole);
 
-  //  QString styleSheet = QString("%1 QComboBox:!editable, QComboBox::drop-down:editable {background-color: rgb(149,221,186);} %2").arg(comboStyle1).arg(comboStyle2);
- //   ui->comboMode->setStyleSheet(styleSheet);
-
     setJointInternalState(IDLE);
-
-    QVariant variant = ui->comboInteraction->itemData(0,Qt::BackgroundRole);
-//    QColor c = variant.value<QColor>();
-
-  //  styleSheet = QString("%1 QComboBox:!editable, QComboBox::drop-down:editable {background-color: rgb(%2,%3,%4);} %5").arg(comboStyle1).arg(c.red()).arg(c.green()).arg(c.blue()).arg(comboStyle2);
-//    ui->comboInteraction->setStyleSheet(styleSheet);
-
 
     ui->stackedWidget->widget(VELOCITY)->setEnabled(false);
     velocityTimer.setInterval(50);
@@ -1362,21 +1363,21 @@ void JointItem::updateMotionDone(bool done)
     int index = ui->stackedWidget->currentIndex();
     if (index == POSITION) {
         if(!done){
-            ui->editPositionJointPos->setStyleSheet("background-color: rgb(255, 38, 41);");
+            ui->editPositionJointPos->setStyleSheet("background-color: rgb(255, 38, 41); color: rgb(35, 38, 41);");
         }else{
-            ui->editPositionJointPos->setStyleSheet("background-color: rgb(255, 255, 255);");
+            ui->editPositionJointPos->setStyleSheet("background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);");
         }
     } else if (index == POSITION_DIR) {
         if(!done){
-            ui->editPositionDirJointPos->setStyleSheet("background-color: rgb(255, 38, 41);");
+            ui->editPositionDirJointPos->setStyleSheet("background-color: rgb(255, 38, 41); color: rgb(35, 38, 41);");
         }else{
-            ui->editPositionDirJointPos->setStyleSheet("background-color: rgb(255, 255, 255);");
+            ui->editPositionDirJointPos->setStyleSheet("background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);");
         }
     } else if (index == MIXED) {
         if(!done){
-            ui->editMixedJointPos->setStyleSheet("background-color: rgb(255, 38, 41);");
+            ui->editMixedJointPos->setStyleSheet("background-color: rgb(255, 38, 41); color: rgb(35, 38, 41);");
         }else{
-            ui->editMixedJointPos->setStyleSheet("background-color: rgb(255, 255, 255);");
+            ui->editMixedJointPos->setStyleSheet("background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);");
         }
     }
 }
@@ -1539,12 +1540,12 @@ void JointItem::setRefTrajectorySpeed(double val)
 
         if (val < 0.001)
         {
-            ui->groupBox_12->setStyleSheet("background-color:orange;");
+            ui->groupBox_12->setStyleSheet("background-color:orange; color: rgb(35, 38, 41);");
             ui->groupBox_12->setTitle("Velocity is ZERO!");
         }
         else
         {
-            ui->groupBox_12->setStyleSheet("background-color:transparent;");
+            ui->groupBox_12->setStyleSheet("background-color:transparent; color: rgb(35, 38, 41);");
             ui->groupBox_12->setTitle("Velocity");
         }
     }
@@ -1769,14 +1770,6 @@ void JointItem::setJointInternalInteraction(int interaction)
     disconnect(ui->comboInteraction,SIGNAL(currentIndexChanged(int)),this,SLOT(onInteractionChanged(int)));
     ui->comboInteraction->setCurrentIndex(interaction);
     connect(ui->comboInteraction,SIGNAL(currentIndexChanged(int)),this,SLOT(onInteractionChanged(int)));
-
-    if(ui->stackedWidget->widget(interaction)){
-        QVariant variant = ui->comboInteraction->itemData(interaction,Qt::BackgroundRole);
-  //      QColor c = variant.value<QColor>();
-
-  //      QString styleSheet = QString("%1 QComboBox:!editable, QComboBox::drop-down:editable {background-color: rgb(%2,%3,%4);} %5").arg(comboStyle1).arg(c.red()).arg(c.green()).arg(c.blue()).arg(comboStyle2);
-  //      ui->comboInteraction->setStyleSheet(styleSheet);
-    }
 }
 
 void JointItem::setJointInternalState(int mode)
@@ -1819,12 +1812,7 @@ void JointItem::setJointInternalState(int mode)
             }
         }
 
-
-        //ui->stackedWidget->widget(mode)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-        setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-
-        QString styleSheet = QString("%1 QComboBox:!editable, QComboBox::drop-down:editable {background-color: rgb(%2,%3,%4);} %5").arg(comboStyle1).arg(c.red()).arg(c.green()).arg(c.blue()).arg(comboStyle2);
-  //      ui->comboMode->setStyleSheet(styleSheet);
+        setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
     }
 }
 
@@ -1866,8 +1854,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = calibratingColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1879,8 +1866,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = calibratingColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1910,8 +1896,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = calibratingColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1924,8 +1909,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = calibratingColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1937,8 +1921,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = calibratingColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1957,8 +1940,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = hwFaultColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }
@@ -1970,8 +1952,7 @@ void JointItem::setJointState(JointState newState)
         int index = ui->stackedWidget->currentIndex();
         if(ui->stackedWidget->widget(index)){
             QColor c = disconnectColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
-            //ui->stackedWidget->widget(index)->setStyleSheet(QString("background-color: rgb(%1,%2,%3);").arg(c.red()).arg(c.green()).arg(c.blue()));
+            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
         }
         break;
     }

--- a/src/yarpmotorgui/jointitem.ui
+++ b/src/yarpmotorgui/jointitem.ui
@@ -109,6 +109,7 @@
      border-radius: 4px;
      background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                                        stop: 0 #f6f7fa, stop: 1 #dadbde);
+     color: rgb(35, 38, 41);
      min-width: 80px;
 	min-height:18px;
  }
@@ -116,11 +117,19 @@
  QPushButton:pressed {
      background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                                        stop: 0 #dadbde, stop: 1 #f6f7fa);
+     color: rgb(35, 38, 41);
  }
 
  QPushButton:flat {
      border: none; /* no border for a flat push button */
  }
+
+ QPushButton:disabled {
+     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                       stop: 0 #dadbde, stop: 1 #f6f7fa);
+     color: rgb(169, 152, 163);
+ }
+
 
  QPushButton:default {
      border-color: navy; /* make the default button prominent */
@@ -461,7 +470,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editIdleCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -491,7 +500,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -515,7 +524,7 @@ QSlider::groove:horizontal:disabled {
              <item row="3" column="1">
               <widget class="QLineEdit" name="editIdleMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -545,7 +554,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -562,7 +571,7 @@ QSlider::groove:horizontal:disabled {
              <item row="0" column="1">
               <widget class="QLineEdit" name="editIdleJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -820,7 +829,7 @@ QSlider::groove:horizontal:disabled {
              <item row="5" column="1">
               <widget class="QLineEdit" name="editPositionCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -836,7 +845,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -880,7 +889,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -890,7 +899,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editPositionMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1018,7 +1027,7 @@ QSlider::groove:horizontal:disabled {
              <item row="0" column="1">
               <widget class="QLineEdit" name="editPositionDirJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1062,7 +1071,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1100,7 +1109,7 @@ QSlider::groove:horizontal:disabled {
              <item row="5" column="1">
               <widget class="QLineEdit" name="editPositionDirCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1116,7 +1125,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1133,7 +1142,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editPositionDirMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -1147,7 +1156,7 @@ QSlider::groove:horizontal:disabled {
              <item row="1" column="1">
               <widget class="QLineEdit" name="editPositionDirDuty">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -1374,7 +1383,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1408,7 +1417,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1439,7 +1448,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editMixedCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1477,7 +1486,7 @@ QSlider::groove:horizontal:disabled {
              <item row="3" column="1">
               <widget class="QLineEdit" name="editMixedMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -1589,7 +1598,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1612,7 +1621,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1636,7 +1645,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editVelocityCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1653,7 +1662,7 @@ QSlider::groove:horizontal:disabled {
              <item row="0" column="1">
               <widget class="QLineEdit" name="editVelocityJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1677,7 +1686,7 @@ QSlider::groove:horizontal:disabled {
              <item row="3" column="1">
               <widget class="QLineEdit" name="editVelocityMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -1818,7 +1827,7 @@ QSlider::groove:horizontal:disabled {
              <item row="2" column="1">
               <widget class="QLineEdit" name="editTorqueJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1828,7 +1837,7 @@ QSlider::groove:horizontal:disabled {
              <item row="6" column="1">
               <widget class="QLineEdit" name="editTorqueCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1851,7 +1860,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1867,7 +1876,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -1905,7 +1914,7 @@ QSlider::groove:horizontal:disabled {
              <item row="5" column="1">
               <widget class="QLineEdit" name="editTorqueMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -1919,7 +1928,7 @@ QSlider::groove:horizontal:disabled {
              <item row="1" column="1">
               <widget class="QLineEdit" name="editTorqueDuty">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -2034,7 +2043,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2057,7 +2066,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2095,7 +2104,7 @@ QSlider::groove:horizontal:disabled {
              <item row="5" column="1">
               <widget class="QLineEdit" name="editPWMCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2112,7 +2121,7 @@ QSlider::groove:horizontal:disabled {
              <item row="1" column="1">
               <widget class="QLineEdit" name="editPWMJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2129,7 +2138,7 @@ QSlider::groove:horizontal:disabled {
              <item row="0" column="1">
               <widget class="QLineEdit" name="editPWMDuty">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -2164,7 +2173,7 @@ QSlider::groove:horizontal:disabled {
              <item row="4" column="1">
               <widget class="QLineEdit" name="editPWMMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -2279,7 +2288,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2302,7 +2311,7 @@ QSlider::groove:horizontal:disabled {
                 </size>
                </property>
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2312,7 +2321,7 @@ QSlider::groove:horizontal:disabled {
              <item row="0" column="1">
               <widget class="QLineEdit" name="editCurrentCurrent">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -2333,7 +2342,7 @@ QSlider::groove:horizontal:disabled {
              <item row="2" column="1">
               <widget class="QLineEdit" name="editCurrentJointPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -2364,7 +2373,7 @@ QSlider::groove:horizontal:disabled {
              <item row="5" column="1">
               <widget class="QLineEdit" name="editCurrentMotorPos">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>
@@ -2399,7 +2408,7 @@ QSlider::groove:horizontal:disabled {
              <item row="1" column="1">
               <widget class="QLineEdit" name="editCurrentDuty">
                <property name="styleSheet">
-                <string notr="true">background-color: rgb(255, 255, 255);</string>
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
                </property>
               </widget>
              </item>

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -1342,6 +1342,8 @@ void MainWindow::updateModesTree(PartItem *part)
             QColor c = getColorMode(modes.at(i));
             jointNode->setBackground(0,c);
             jointNode->setBackground(1,c);
+            jointNode->setForeground(0,QColor(Qt::black));
+            jointNode->setForeground(1,QColor(Qt::black));
 
 
             if(c == hwFaultColor){
@@ -1381,6 +1383,8 @@ void MainWindow::updateModesTree(PartItem *part)
                 if(item->background(0) != c){
                     item->setBackground(0,c);
                     item->setBackground(1,c);
+                    item->setForeground(0,QColor(Qt::black));
+                    item->setForeground(1,QColor(Qt::black));
                 }
             }
         }

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -133,6 +133,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -155,6 +164,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -183,6 +201,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -205,6 +232,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -233,6 +269,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -255,6 +300,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -283,6 +337,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -308,6 +371,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -330,6 +402,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -439,6 +520,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -461,6 +551,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -489,6 +588,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -511,6 +619,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -539,6 +656,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -561,6 +687,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -589,6 +724,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -614,6 +758,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -636,6 +789,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -777,6 +939,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -799,6 +970,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -827,6 +1007,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -849,6 +1038,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -877,6 +1075,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -899,6 +1106,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -927,6 +1143,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -949,6 +1174,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -977,6 +1211,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -999,6 +1242,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1027,6 +1279,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1049,6 +1310,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1077,6 +1347,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1099,6 +1378,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1197,6 +1485,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1214,6 +1511,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1228,6 +1534,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1256,6 +1571,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1273,6 +1597,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1287,6 +1620,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1315,6 +1657,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1332,6 +1683,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1346,6 +1706,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1429,6 +1798,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1454,6 +1832,15 @@
             </color>
            </brush>
           </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
           </property>
@@ -1468,6 +1855,15 @@
              <red>207</red>
              <green>207</green>
              <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
             </color>
            </brush>
           </property>
@@ -1559,6 +1955,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -1581,6 +1986,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -1609,6 +2023,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -1631,6 +2054,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>
@@ -1659,6 +2091,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -1684,6 +2125,15 @@
           </color>
          </brush>
         </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
+          </color>
+         </brush>
+        </property>
         <property name="flags">
          <set>ItemIsEnabled</set>
         </property>
@@ -1706,6 +2156,15 @@
            <red>207</red>
            <green>207</green>
            <blue>207</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="foreground">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>35</red>
+           <green>38</green>
+           <blue>41</blue>
           </color>
          </brush>
         </property>

--- a/src/yarpmotorgui/sequencewindow.ui
+++ b/src/yarpmotorgui/sequencewindow.ui
@@ -61,7 +61,9 @@
            <string notr="true">QTreeWidget{
 	alternate-background-color: rgb(225, 224, 234);
 background-color: rgb(255, 255, 255);
-}</string>
+alternate-color: rgb(35, 38, 41);
+color: rgb(35, 38, 41);
+          }</string>
           </property>
           <property name="editTriggers">
            <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
@@ -116,6 +118,8 @@ background-color: rgb(255, 255, 255);
            <string notr="true">QTreeWidget{
 	alternate-background-color: rgb(225, 224, 234);
 background-color: rgb(255, 255, 255);
+alternate-color: rgb(35, 38, 41);
+color: rgb(35, 38, 41);
 }</string>
           </property>
           <attribute name="headerDefaultSectionSize">


### PR DESCRIPTION
## GUI

### yarpmotorgui

* Fixed colors on dark mode desktop (#2466).

---

I'd appreciate if someone with a light theme could give me some feedback.

Fixes #2466

![image](https://user-images.githubusercontent.com/1100056/106612989-ffa66b00-6569-11eb-9e2e-8d982d139ccb.png)

![image](https://user-images.githubusercontent.com/1100056/106613476-865b4800-656a-11eb-9e5a-3f0b7ef1573d.png)

![image](https://user-images.githubusercontent.com/1100056/106613045-0d5bf080-656a-11eb-8a4b-fa81604aa460.png)

![image](https://user-images.githubusercontent.com/1100056/106613102-1cdb3980-656a-11eb-8e78-3f2b5beeb022.png)

![image](https://user-images.githubusercontent.com/1100056/106613134-2795ce80-656a-11eb-9922-38fcfe95d639.png)
