### PR TITLE
robotinterface: Allow to pass the "device" parameter without defining networks

### DIFF
--- a/doc/release/master/robotinterface_attach_single_device.md
+++ b/doc/release/master/robotinterface_attach_single_device.md
@@ -1,0 +1,18 @@
+robotinterface_attach_single_device {#master}
+-----------------------------------
+
+## Libraries
+
+### `robotinterface`
+
+* It is now possible to pass the `device` parameter to the `attach` action,
+  without defining `network` or `networks`. For example:
+
+  ```.xml
+  <device name="foo_name" type="foo_type">
+    <action phase="startup" level="5" type="attach">
+      <param name="device"> bar_name </param>
+    </action>
+    <action phase="shutdown" level="5" type="detach" />
+  </device>
+  ```

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/experimental/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/experimental/Robot.cpp
@@ -318,14 +318,13 @@ bool yarp::robotinterface::experimental::Robot::Private::attach(const yarp::robo
 
     yarp::dev::PolyDriverList drivers;
 
-    if (yarp::robotinterface::experimental::hasParam(params, "network")) {
-        std::string targetNetwork = yarp::robotinterface::experimental::findParam(params, "network");
-
-        if (!yarp::robotinterface::experimental::hasParam(params, "device")) {
-            yError() << "Action \"" << ActionTypeToString(ActionTypeAttach) << R"(" requires "device" parameter)";
-            return false;
-        }
+    if (yarp::robotinterface::experimental::hasParam(params, "device")) {
         std::string targetDeviceName = yarp::robotinterface::experimental::findParam(params, "device");
+
+        std::string targetNetwork = "...";
+        if (yarp::robotinterface::experimental::hasParam(params, "network")) {
+            targetNetwork = yarp::robotinterface::experimental::findParam(params, "network");
+        }
 
         if (!hasDeviceIncludingExternal(targetDeviceName)) {
             yError() << "Target device" << targetDeviceName << "(network =" << targetNetwork << ") does not exist.";


### PR DESCRIPTION
## Libraries

### `robotinterface`

* It is now possible to pass the `device` parameter to the `attach` action,
  without defining `network` or `networks`. For example:

  ```.xml
  <device name="foo_name" type="foo_type">
    <action phase="startup" level="5" type="attach">
      <param name="device"> bar_name </param>
    </action>
    <action phase="shutdown" level="5" type="detach" />
  </device>
  ```