### PR TITLE
Thrift enhancements

### DIFF
--- a/doc/release/master/thrift_enhancement.md
+++ b/doc/release/master/thrift_enhancement.md
@@ -1,0 +1,54 @@
+thrift_enhancement {#master}
+------------------
+
+## Libraries
+
+### `os`
+
+#### `WireReader`
+
+* Vocabs are now accepted in readI32
+
+
+## Tools
+
+### `yarpidl_thrift`
+
+* Types annotated with "yarp.type" are no longer serialized as nested.
+  This improves the compatibility with existing services returning Bottle
+  or other YARP types, and makes it possible to write a thrift file for
+  existing protocols.
+  On the other hand, this breaks compatibility with thrift services
+  returning Bottles or other annotated types, generated before this
+  commit. This is a breaking change, but should impact only a very
+  limited number of cases, and it can be easily fixed by regenerating the
+  files.
+* Added support for vocabs in structs (#2476).
+  Vocabs can be defined in this way:
+  ```cpp
+  typedef i32 ( yarp.type = "yarp::conf::vocab32_t" ) vocab
+
+  struct FooStruct
+  {
+      1: vocab foo;
+  }
+  ```
+* Added "yarp.nested" annotation for struct fields
+  When defined = "true", this serialize a struct as a bottle instead of as a
+  flat structure.
+  For example, given these 2 structs:
+  ```cpp
+  struct Foo
+  {
+      1: double foo1;
+      2: double foo2;
+  }
+
+  struct Bar
+  {
+      1: double bar1;
+      2: Foo ( yarp.nested = "true" );
+  }
+  ```
+  The `Bar` struct will be serialized as `bar1 (foo1 foo2)`, instead of as a
+  flat struct `bar1 foo1 foo2`.

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -378,7 +378,13 @@ std::string t_yarp_generator::type_to_enum(t_type* type)
         case t_base_type::TYPE_I16:
             return "BOTTLE_TAG_INT16";
         case t_base_type::TYPE_I32:
+        {
+            auto it = type->annotations_.find("yarp.type");
+            if (it != type->annotations_.end() && it->second == "yarp::conf::vocab32_t") {
+                return "BOTTLE_TAG_VOCAB";
+            }
             return "BOTTLE_TAG_INT32";
+        }
         case t_base_type::TYPE_I64:
             return "BOTTLE_TAG_INT64";
         case t_base_type::TYPE_DOUBLE:
@@ -445,6 +451,11 @@ std::string t_yarp_generator::type_name(t_type* ttype, bool in_typedef, bool arg
 {
     if (ttype->is_base_type()) {
         std::string bname = base_type_name(((t_base_type*)ttype)->get_base());
+        auto it = ttype->annotations_.find("yarp.type");
+        if (it != ttype->annotations_.end()) {
+            bname = it->second;
+        }
+
         if (!arg) {
             return bname;
         }
@@ -1007,8 +1018,15 @@ void t_yarp_generator::generate_serialize_field(std::ostringstream& f_cpp_,
                 f_cpp_ << "writeI16(" << name << ")";
                 break;
             case t_base_type::TYPE_I32:
-                f_cpp_ << "writeI32(" << name << ")";
+            {
+                auto it = type->annotations_.find("yarp.type");
+                if (it != type->annotations_.end() && it->second == "yarp::conf::vocab32_t") {
+                    f_cpp_ << "writeVocab(" << name << ")";
+                } else {
+                    f_cpp_ << "writeI32(" << name << ")";
+                }
                 break;
+            }
             case t_base_type::TYPE_I64:
                 f_cpp_ << "writeI64(" << name << ")";
                 break;
@@ -1190,8 +1208,15 @@ void t_yarp_generator::generate_deserialize_field(std::ostringstream& f_cpp_,
             f_cpp_ << "readI16(" << name << ")";
             break;
         case t_base_type::TYPE_I32:
-            f_cpp_ << "readI32(" << name << ")";
+        {
+            auto it = type->annotations_.find("yarp.type");
+            if (it != type->annotations_.end() && it->second == "yarp::conf::vocab32_t") {
+                f_cpp_ << "readVocab(" << name << ")";
+            } else {
+                f_cpp_ << "readI32(" << name << ")";
+            }
             break;
+        }
         case t_base_type::TYPE_I64:
             f_cpp_ << "readI64(" << name << ")";
             break;

--- a/src/idls/thrift/src/t_yarp_generator.cc
+++ b/src/idls/thrift/src/t_yarp_generator.cc
@@ -3470,7 +3470,12 @@ void t_yarp_generator::generate_service_helper_classes_impl_read(t_function* fun
     {
         if (!function->is_oneway()) {
             f_cpp_ << indent_cpp() << "yarp::os::idl::WireReader reader(connection);\n";
-            f_cpp_ << indent_cpp() << "if (!reader.readListReturn())" << inline_return_cpp("false");
+            if (returntype->annotations_.find("yarp.name") == (returntype->annotations_.end())) {
+                // Types annotated with yarp.name therefore are expected
+                // to be able to serialize by themselves, therefore there is
+                // no need to read them as lists.
+                f_cpp_ << indent_cpp() << "if (!reader.readListReturn())" << inline_return_cpp("false");
+            }
             if (!returntype->is_void()) {
                 generate_deserialize_field(f_cpp_, &returnfield, "");
             }
@@ -3744,7 +3749,13 @@ void t_yarp_generator::generate_service_read(t_service* tservice, std::ostringst
                     indent_up_cpp();
                     {
                         if (!function->is_oneway()) {
-                            f_cpp_ << indent_cpp() << "if (!writer.writeListHeader(" << flat_element_count(returntype) << "))" << inline_return_cpp("false");
+                            if (returntype->annotations_.find("yarp.name") == (returntype->annotations_.end())) {
+                                // Types annotated with yarp.name therefore are expected
+                                // to be able to serialize by themselves, therefore there is
+                                // no need to write them as lists.
+                                // For all the other types, append the number of fields
+                                f_cpp_ << indent_cpp() << "if (!writer.writeListHeader(" << flat_element_count(returntype) << "))" << inline_return_cpp("false");
+                            }
                             if (!returntype->is_void()) {
                                 generate_serialize_field(f_cpp_, &returnfield, helper_class + "::");
                             }

--- a/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
+++ b/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
@@ -197,6 +197,9 @@ bool WireReader::readI32(std::int32_t& x)
     case BOTTLE_TAG_INT32:
         x = reader.expectInt32();
         break;
+    case BOTTLE_TAG_VOCAB:
+        x = reader.expectInt32();
+        break;
     default:
         return false;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/
 
 
 #########################################################################
-# Prepare 'build_generator', 'build_options' and 'build_module_path' variables
+# Prepare 'build_generator' and 'build_options' variables
 # for tests in subdirectories
 set(build_generator --build-generator "${CMAKE_GENERATOR}")
 if(CMAKE_GENERATOR_PLATFORM)
@@ -59,10 +59,6 @@ if(YARP_TEST_LAUNCHER)
   string(REPLACE ";" "\;" _test_launcher "${_test_launcher}")
   list(APPEND build_options "${_test_launcher}")
 endif()
-
-# Use only if cmake modules not installed by YARP are required by the test
-set(build_module_path "-DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}")
-string(REPLACE ";" "\;" build_module_path "${build_module_path}")
 
 # Add the CMAKE_BINARY_DIR as a macro so the testing infrastructure
 # can find the device compiled as dynamic plugins

--- a/tests/yarpidl_rosmsg/CMakeLists.txt
+++ b/tests/yarpidl_rosmsg/CMakeLists.txt
@@ -53,7 +53,7 @@ add_test(NAME idl::rosmsg::demo::run
                                         ${build_generator}
                                         --build-project demo
                                         --build-options ${build_options}
-                                                        ${build_module_path}
+                                                        -DYCM_DIR=${YCM_DIR}
                                                         -DYARP_DIR=${CMAKE_BINARY_DIR}
                                                         -DALLOW_IDL_GENERATION=TRUE
                                         --test-command ${CMAKE_CTEST_COMMAND} ${build_generator}

--- a/tests/yarpidl_rosmsg/demo/CMakeLists.txt
+++ b/tests/yarpidl_rosmsg/demo/CMakeLists.txt
@@ -56,6 +56,10 @@ target_sources(demo_yarp_idl_to_dir PRIVATE ${IDL_GEN_SRCS}
 target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_os
                                                    YARP::YARP_init
                                                    YARP::YARP_sig)
+get_property(_tests TARGET demo_yarp_idl_to_dir PROPERTY ParseAndAddCatchTests_TESTS)
+foreach(_test IN LISTS _tests)
+  set_property(TEST ${_test} PROPERTY TIMEOUT 120)
+endforeach()
 
 
 
@@ -70,4 +74,7 @@ target_sources(demo_yarp_add_idl PRIVATE ${IDL_GEN_FILES})
 target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_os
                                                 YARP::YARP_init
                                                 YARP::YARP_sig)
-
+get_property(_tests TARGET demo_yarp_add_idl PROPERTY ParseAndAddCatchTests_TESTS)
+foreach(_test IN LISTS _tests)
+  set_property(TEST ${_test} PROPERTY TIMEOUT 120)
+endforeach()

--- a/tests/yarpidl_rosmsg/demo/CMakeLists.txt
+++ b/tests/yarpidl_rosmsg/demo/CMakeLists.txt
@@ -15,6 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS 1)
 set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER "Autogen Targets")
 set_property(GLOBAL PROPERTY AUTOGEN_SOURCE_GROUP "Generated Files")
 
+find_package(YCM 0.11.0 REQUIRED)
 find_package(YARP COMPONENTS os sig idl_tools REQUIRED)
 
 include(ParseAndAddCatchTests)

--- a/tests/yarpidl_rosmsg/demo/CMakeLists.txt
+++ b/tests/yarpidl_rosmsg/demo/CMakeLists.txt
@@ -48,24 +48,26 @@ yarp_idl_to_dir(INPUT_FILES ${IDL_FILES}
 add_executable(demo_yarp_idl_to_dir)
 
 target_include_directories(demo_yarp_idl_to_dir PRIVATE ${generated_libs_dir}/include)
-target_sources(demo_yarp_idl_to_dir PRIVATE main.cpp
-                                            ${IDL_GEN_SRCS}
+target_sources(demo_yarp_idl_to_dir PRIVATE main.cpp)
+# Parse now, before adding the generated which do not exist yet
+ParseAndAddCatchTests(demo_yarp_idl_to_dir)
+target_sources(demo_yarp_idl_to_dir PRIVATE ${IDL_GEN_SRCS}
                                             ${IDL_GEN_HDRS})
 target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_os
                                                    YARP::YARP_init
                                                    YARP::YARP_sig)
 
-ParseAndAddCatchTests(demo_yarp_idl_to_dir)
 
 
 # Test using yarp_add_idl
 yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
 
 add_executable(demo_yarp_add_idl)
-target_sources(demo_yarp_add_idl PRIVATE main.cpp
-                                         ${IDL_GEN_FILES})
+target_sources(demo_yarp_add_idl PRIVATE main.cpp)
+# Parse now, before adding the generated which do not exist yet
+ParseAndAddCatchTests(demo_yarp_add_idl)
+target_sources(demo_yarp_add_idl PRIVATE ${IDL_GEN_FILES})
 target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_os
                                                 YARP::YARP_init
                                                 YARP::YARP_sig)
 
-ParseAndAddCatchTests(demo_yarp_add_idl)

--- a/tests/yarpidl_thrift/CMakeLists.txt
+++ b/tests/yarpidl_thrift/CMakeLists.txt
@@ -51,7 +51,7 @@ add_test(NAME idl::thrift::demo::run
                                         ${build_generator}
                                         --build-project demo
                                         --build-options ${build_options}
-                                                        ${build_module_path}
+                                                        -DYCM_DIR=${YCM_DIR}
                                                         -DYARP_DIR=${CMAKE_BINARY_DIR}
                                                         -DALLOW_IDL_GENERATION=TRUE
                                         --test-command ${CMAKE_CTEST_COMMAND} ${build_generator}

--- a/tests/yarpidl_thrift/demo/CMakeLists.txt
+++ b/tests/yarpidl_thrift/demo/CMakeLists.txt
@@ -48,15 +48,16 @@ yarp_idl_to_dir(INPUT_FILES ${IDL_FILES}
 add_executable(demo_yarp_idl_to_dir)
 target_compile_definitions(demo_yarp_idl_to_dir PRIVATE THRIFT_INCLUDE_PREFIX
                                                         THRIFT_NO_NAMESPACE_PREFIX)
-target_sources(demo_yarp_idl_to_dir PRIVATE main.cpp
-                                            ${IDL_GEN_SRCS}
+target_sources(demo_yarp_idl_to_dir PRIVATE main.cpp)
+# Parse now, before adding the generated which do not exist yet
+ParseAndAddCatchTests(demo_yarp_idl_to_dir)
+target_sources(demo_yarp_idl_to_dir PRIVATE ${IDL_GEN_SRCS}
                                             ${IDL_GEN_HDRS})
 target_include_directories(demo_yarp_idl_to_dir PRIVATE ${generated_libs_dir}/include)
 target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_os
                                                    YARP::YARP_init
                                                    YARP::YARP_sig)
 
-ParseAndAddCatchTests(demo_yarp_idl_to_dir)
 
 
 # Test using yarp_add_idl
@@ -64,10 +65,11 @@ yarp_add_idl(IDL_GEN_FILES ${IDL_FILES})
 add_executable(demo_yarp_add_idl)
 target_compile_definitions(demo_yarp_add_idl PRIVATE THRIFT_INCLUDE_PREFIX
                                                      THRIFT_NO_NAMESPACE_PREFIX)
-target_sources(demo_yarp_add_idl PRIVATE main.cpp
-                                         ${IDL_GEN_FILES})
+target_sources(demo_yarp_add_idl PRIVATE main.cpp)
+# Parse now, before adding the generated which do not exist yet
+ParseAndAddCatchTests(demo_yarp_add_idl)
+target_sources(demo_yarp_add_idl PRIVATE ${IDL_GEN_FILES})
 target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_os
                                                 YARP::YARP_init
                                                 YARP::YARP_sig)
 
-ParseAndAddCatchTests(demo_yarp_add_idl)

--- a/tests/yarpidl_thrift/demo/CMakeLists.txt
+++ b/tests/yarpidl_thrift/demo/CMakeLists.txt
@@ -57,6 +57,10 @@ target_include_directories(demo_yarp_idl_to_dir PRIVATE ${generated_libs_dir}/in
 target_link_libraries(demo_yarp_idl_to_dir PRIVATE YARP::YARP_os
                                                    YARP::YARP_init
                                                    YARP::YARP_sig)
+get_property(_tests TARGET demo_yarp_idl_to_dir PROPERTY ParseAndAddCatchTests_TESTS)
+foreach(_test IN LISTS _tests)
+  set_property(TEST ${_test} PROPERTY TIMEOUT 120)
+endforeach()
 
 
 
@@ -72,4 +76,7 @@ target_sources(demo_yarp_add_idl PRIVATE ${IDL_GEN_FILES})
 target_link_libraries(demo_yarp_add_idl PRIVATE YARP::YARP_os
                                                 YARP::YARP_init
                                                 YARP::YARP_sig)
-
+get_property(_tests TARGET demo_yarp_add_idl PROPERTY ParseAndAddCatchTests_TESTS)
+foreach(_test IN LISTS _tests)
+  set_property(TEST ${_test} PROPERTY TIMEOUT 120)
+endforeach()

--- a/tests/yarpidl_thrift/demo/CMakeLists.txt
+++ b/tests/yarpidl_thrift/demo/CMakeLists.txt
@@ -15,6 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS 1)
 set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER "Autogen Targets")
 set_property(GLOBAL PROPERTY AUTOGEN_SOURCE_GROUP "Generated Files")
 
+find_package(YCM 0.11.0 REQUIRED)
 find_package(YARP COMPONENTS os sig idl_tools REQUIRED)
 
 include(ParseAndAddCatchTests)

--- a/tests/yarpidl_thrift/demo/main.cpp
+++ b/tests/yarpidl_thrift/demo/main.cpp
@@ -584,8 +584,7 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         cmd.fromString("getBottle");
         client_port.write(cmd,reply);
         INFO("Bottle is " << reply.get(0).toString());
-        REQUIRE(reply.get(0).isList());
-        CHECK(reply.get(0).asList()->size() == 5);
+        CHECK(reply.size() == 5);
     }
 
     SECTION("test_missing_method")


### PR DESCRIPTION
## Libraries

### `os`

#### `WireReader`

* Vocabs are now accepted in readI32


## Tools

### `yarpidl_thrift`

* Types annotated with "yarp.type" are no longer serialized as nested.
  This improves the compatibility with existing services returning Bottle
  or other YARP types, and makes it possible to write a thrift file for
  existing protocols.
  On the other hand, this breaks compatibility with thrift services
  returning Bottles or other annotated types, generated before this
  commit. This is a breaking change, but should impact only a very
  limited number of cases, and it can be easily fixed by regenerating the
  files.
* Added support for vocabs in structs (#2476).
  Vocabs can be defined in this way:
  ```cpp
  typedef i32 ( yarp.type = "yarp::conf::vocab32_t" ) vocab

  struct FooStruct
  {
      1: vocab foo;
  }
  ```
* Added "yarp.nested" annotation for struct fields
  When defined = "true", this serialize a struct as a bottle instead of as a
  flat structure.
  For example, given these 2 structs:
  ```cpp
  struct Foo
  {
      1: double foo1;
      2: double foo2;
  }

  struct Bar
  {
      1: double bar1;
      2: Foo ( yarp.nested = "true" );
  }
  ```
  The `Bar` struct will be serialized as `bar1 (foo1 foo2)`, instead of as a
  flat struct `bar1 foo1 foo2`.
