### PR TITLE
dev: Rename ControlBoardPid.h to Pid.h

### DIFF
--- a/doc/release/master/rename_controlboardpid.md
+++ b/doc/release/master/rename_controlboardpid.md
@@ -1,0 +1,8 @@
+rename_controlboardpid {#master}
+----------------------
+
+## Libraries
+
+### `dev`
+
+* The header `yarp/dev/ControlBoardPid.h` was renamed `yarp/dev/Pid.h`

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -24,7 +24,6 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/ControlBoardHelpers.h
                   yarp/dev/ControlBoardInterfaces.h
                   yarp/dev/ControlBoardInterfacesImpl.h
-                  yarp/dev/ControlBoardPid.h
                   yarp/dev/ControlBoardVocabs.h
                   yarp/dev/DeviceDriver.h
                   yarp/dev/DriverLinkCreator.h
@@ -110,6 +109,7 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/LaserMeasurementData.h
                   yarp/dev/Lidar2DDeviceBase.h
                   yarp/dev/MultipleAnalogSensorsInterfaces.h
+                  yarp/dev/Pid.h
                   yarp/dev/PidEnums.h
                   yarp/dev/PolyDriver.h
                   yarp/dev/PolyDriverDescriptor.h
@@ -136,7 +136,8 @@ if(NOT YARP_NO_DEPRECATED)
                             yarp/dev/GenericSensorInterfaces.h # DEPRECATED Since YARP 3.3.0
                             yarp/dev/PreciselyTimed.h          # DEPRECATED Since YARP 3.3.0
                             yarp/dev/SerialInterfaces.h        # DEPRECATED Since YARP 3.3.0
-                            yarp/dev/Wrapper.h)                # DEPRECATED Since YARP 3.3.0
+                            yarp/dev/Wrapper.h                 # DEPRECATED Since YARP 3.3.0
+                            yarp/dev/ControlBoardPid.h)        # DEPRECATED Since YARP 3.5.0
 endif()
 
 set(YARP_dev_IMPL_HDRS yarp/dev/impl/FixedSizeBuffersManager.h

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -9,7 +9,7 @@
 #ifndef YARP_DEV_CONTROLBOARDHELPER_H
 #define YARP_DEV_CONTROLBOARDHELPER_H
 
-#include <yarp/dev/ControlBoardPid.h>
+#include <yarp/dev/Pid.h>
 #include <yarp/dev/PidEnums.h>
 #include <yarp/os/Log.h>
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
@@ -11,7 +11,7 @@
 #define YARP_DEV_CONTROLBOARDINTERFACES_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/ControlBoardPid.h>
+#include <yarp/dev/Pid.h>
 
 #include <yarp/dev/ICalibrator.h>
 #include <yarp/dev/IRemoteCalibrator.h>

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardPid.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardPid.h
@@ -7,153 +7,17 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <yarp/dev/api.h>
-
 #ifndef YARP_DEV_CONTROLBOARDPID_H
 #define YARP_DEV_CONTROLBOARDPID_H
+
+#include <yarp/conf/system.h>
+
+YARP_COMPILER_DEPRECATED_WARNING(<yarp/dev/ControlBoardPid.h> header is deprecated. Use <yarp/dev/Pid.h> instead)
+
+#include <yarp/dev/Pid.h>
 
 /*!
  * \file ControlBoardPid.h define control board standard interfaces
  */
-
-namespace yarp{
-    namespace dev{
-        class Pid;
-    }
-}
-
-/*!
- * \brief Contains the parameters for a PID
- */
-class YARP_dev_API yarp::dev::Pid
-{
-public:
-    double kp;                 //!< proportional gain
-    double kd;                 //!< derivative gain
-    double ki;                 //!< integrative gain
-    double max_int;            //!< saturation threshold for the integrator
-    double scale;              //!< scale for the pid output
-    double max_output;         //!< max output
-    double offset;             //!< pwm offset added to the pid output
-    double stiction_up_val;    //!< up stiction offset added to the pid output
-    double stiction_down_val;  //!< down stiction offset added to the pid output
-    double kff;                //!< feedforward gain
-
-public:
-    /*!
-     * \brief Default Constructor.
-     */
-    Pid();
-
-    /*!
-     * \brief Destructor.
-     */
-    ~Pid();
-
-    /*!
-     * \brief Basic constructor.
-     *
-     * \param kp proportional gain
-     * \param kd derivative gain
-     * \param ki integrative gain
-     * \param int_max  integrator max output
-     * \param scale scaling factor
-     * \param out_max cap on output
-     */
-    Pid(double kp, double kd, double ki, double int_max, double scale, double out_max);
-
-    /*!
-     * \brief Advanced constructor.
-     *
-     * \param kp proportional gain
-     * \param kd derivative gain
-     * \param ki integrative gain
-     * \param int_max  integrator max output
-     * \param scale scaling factor
-     * \param out_max cap on output
-     * \param st_up up stiction offset
-     * \param st_down down stiction offset
-     * \param kff feedforward gain
-     */
-    Pid(double kp, double kd, double ki,
-        double int_max, double scale, double out_max, double st_up, double st_down, double kff);
-
-    /*!
-     * \brief Set proportional gain.
-     *
-     * \param p new gain
-     */
-    void setKp(double p);
-
-    /*!
-     * \brief Set integrative gain.
-     *
-     * \param i new gain
-     */
-    void setKi(double i);
-
-    /*!
-     * \brief Set derivative gain.
-     *
-     * \param d new gain
-     */
-    void setKd(double d);
-
-    /*!
-     * \brief Set max threshold for the integrative part.
-     *
-     * \param m new max
-     */
-    void setMaxInt(double m);
-
-    /*!
-     * \brief Set output scale for the pid.
-     *
-     * \param sc scale value
-     */
-    void setScale(double sc);
-
-    /*!
-     * \brief Set max output value for the pid.
-     *
-     * \param m new value
-     */
-    void setMaxOut(double m);
-
-    /*!
-     * \brief Set offset value for the pid.
-     *
-     * \param o new offset value
-     */
-    void setOffset(double o);
-
-    /*!
-     * \brief Set the two stiction values for the pid.
-     *
-     * \param up_value the new up value
-     * \param down_value the new down value
-     */
-    void setStictionValues(double up_value, double down_value);
-
-    /*!
-     * \brief Set the feedforward gain for the pid.
-     *
-     * \param Kff new gain
-     */
-    void setKff(double Kff);
-
-    /*!
-     * \brief return true if all params are equal
-     *
-     * \param p pid to be compared
-     */
-    bool operator==(const yarp::dev::Pid &p) const;
-
-    /*!
-    * \brief Set all pid parameters to zero
-    *
-    */
-    void clear();
-};
 
 #endif // YARP_DEV_CONTROLBOARDPID_H

--- a/src/libYARP_dev/src/yarp/dev/IPidControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IPidControl.h
@@ -12,8 +12,8 @@
 #include <yarp/os/Vocab.h>
 #include <yarp/dev/api.h>
 #include <yarp/dev/GenericVocabs.h>
+#include <yarp/dev/Pid.h>
 #include <yarp/dev/PidEnums.h>
-#include <yarp/dev/ControlBoardPid.h>
 
 namespace yarp
 {

--- a/src/libYARP_dev/src/yarp/dev/Pid.h
+++ b/src/libYARP_dev/src/yarp/dev/Pid.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_DEV_PID_H
+#define YARP_DEV_PID_H
+
+#include <yarp/dev/api.h>
+
+namespace yarp {
+namespace dev {
+
+/*!
+ * \brief Contains the parameters for a PID
+ */
+class YARP_dev_API Pid
+{
+public:
+    double kp;                 //!< proportional gain
+    double kd;                 //!< derivative gain
+    double ki;                 //!< integrative gain
+    double max_int;            //!< saturation threshold for the integrator
+    double scale;              //!< scale for the pid output
+    double max_output;         //!< max output
+    double offset;             //!< pwm offset added to the pid output
+    double stiction_up_val;    //!< up stiction offset added to the pid output
+    double stiction_down_val;  //!< down stiction offset added to the pid output
+    double kff;                //!< feedforward gain
+
+public:
+    /*!
+     * \brief Default Constructor.
+     */
+    Pid();
+
+    /*!
+     * \brief Destructor.
+     */
+    ~Pid();
+
+    /*!
+     * \brief Basic constructor.
+     *
+     * \param kp proportional gain
+     * \param kd derivative gain
+     * \param ki integrative gain
+     * \param int_max  integrator max output
+     * \param scale scaling factor
+     * \param out_max cap on output
+     */
+    Pid(double kp, double kd, double ki, double int_max, double scale, double out_max);
+
+    /*!
+     * \brief Advanced constructor.
+     *
+     * \param kp proportional gain
+     * \param kd derivative gain
+     * \param ki integrative gain
+     * \param int_max  integrator max output
+     * \param scale scaling factor
+     * \param out_max cap on output
+     * \param st_up up stiction offset
+     * \param st_down down stiction offset
+     * \param kff feedforward gain
+     */
+    Pid(double kp, double kd, double ki,
+        double int_max, double scale, double out_max, double st_up, double st_down, double kff);
+
+    /*!
+     * \brief Set proportional gain.
+     *
+     * \param p new gain
+     */
+    void setKp(double p);
+
+    /*!
+     * \brief Set integrative gain.
+     *
+     * \param i new gain
+     */
+    void setKi(double i);
+
+    /*!
+     * \brief Set derivative gain.
+     *
+     * \param d new gain
+     */
+    void setKd(double d);
+
+    /*!
+     * \brief Set max threshold for the integrative part.
+     *
+     * \param m new max
+     */
+    void setMaxInt(double m);
+
+    /*!
+     * \brief Set output scale for the pid.
+     *
+     * \param sc scale value
+     */
+    void setScale(double sc);
+
+    /*!
+     * \brief Set max output value for the pid.
+     *
+     * \param m new value
+     */
+    void setMaxOut(double m);
+
+    /*!
+     * \brief Set offset value for the pid.
+     *
+     * \param o new offset value
+     */
+    void setOffset(double o);
+
+    /*!
+     * \brief Set the two stiction values for the pid.
+     *
+     * \param up_value the new up value
+     * \param down_value the new down value
+     */
+    void setStictionValues(double up_value, double down_value);
+
+    /*!
+     * \brief Set the feedforward gain for the pid.
+     *
+     * \param Kff new gain
+     */
+    void setKff(double Kff);
+
+    /*!
+     * \brief return true if all params are equal
+     *
+     * \param p pid to be compared
+     */
+    bool operator==(const yarp::dev::Pid &p) const;
+
+    /*!
+    * \brief Set all pid parameters to zero
+    *
+    */
+    void clear();
+};
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_PID_H

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -20,7 +20,7 @@
 #include <yarp/dev/IAmplifierControl.h>
 #include <yarp/dev/IControlDebug.h>
 #include <yarp/dev/IControlLimits.h>
-#include <yarp/dev/ControlBoardPid.h>
+#include <yarp/dev/Pid.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/DriverLinkCreator.h>
 #include <yarp/dev/Drivers.h>


### PR DESCRIPTION
## Libraries

### `dev`

* The header `yarp/dev/ControlBoardPid.h` was renamed `yarp/dev/Pid.h`