### PR TITLE
NetworkClock: unblock all waiting threads if a network reset is detected

### DIFF
--- a/doc/release/yarp_3_4/detect_clock_reset.md
+++ b/doc/release/yarp_3_4/detect_clock_reset.md
@@ -1,0 +1,8 @@
+detect_clock_reset {#yarp_3_4}
+-----------------------
+
+### Libraries
+
+#### `os`
+
+* If in a `yarp::os::NetworkClock` a clock reset is detected, fill the gap between the waiter and the time published by the network clock port. A network clock reset is defined as a jump in the past of the time published by the network clock port. This fix avoids that all the threads that are waiting a `yarp::os::NetworkClock::delay` call on that network clock remain blocked when a time reset occurs.


### PR DESCRIPTION
This PR implements the suggestions of @traversaro (see https://github.com/robotology/yarp/issues/800#issuecomment-775112896) to handle the time reset. 

This fix should avoid the phenomena of threads stopping and resuming after the time at which the clock was previously reset has passed.