### PR TITLE
yarp-read: Add `trim` argument to reduce the number of characters printed

### DIFF
--- a/doc/release/master/yarp-read_trim.md
+++ b/doc/release/master/yarp-read_trim.md
@@ -1,0 +1,9 @@
+yarp-read_trim {#master}
+--------------
+
+## Tools
+
+### `yarp`
+
+* The `read` subcommand now accepts the `trim` argument to reduce the number of
+  characters printed for each message received.

--- a/src/libYARP_companion/src/yarp/companion/impl/BottleReader.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/BottleReader.h
@@ -42,6 +42,7 @@ private:
     yarp::os::Semaphore done;
     bool raw;
     bool env;
+    std::string::size_type trim;
     Contact address;
 public:
     Port core;
@@ -49,12 +50,14 @@ public:
     BottleReader() : done(0) {
         raw = false;
         env = false;
+        trim = std::string::npos;
         core.setReader(*this);
         core.setReadOnly();
     }
 
-    void open(const char *name, bool showEnvelope) {
+    void open(const char *name, bool showEnvelope, int trim_at = -1) {
         env = showEnvelope;
+        trim = (trim_at > 0 ? static_cast<std::string::size_type>(trim_at) : std::string::npos);
         if (core.open(name)) {
             Companion::setActivePort(&core);
             address = core.where();
@@ -90,7 +93,7 @@ public:
                 int code = bot.get(0).asInt32();
                 if (code!=1) {
                     showEnvelope();
-                    yCInfo(COMPANION, "%s", bot.get(1).asString().c_str());
+                    yCInfo(COMPANION, "%s", bot.get(1).asString().substr(0, trim).c_str());
                     fflush(stdout);
                 }
                 if (code==1) {
@@ -99,7 +102,7 @@ public:
             } else {
                 // raw = true; // don't make raw mode "sticky"
                 showEnvelope();
-                yCInfo(COMPANION, "%s", bot.toString().c_str());
+                yCInfo(COMPANION, "%s", bot.toString().substr(0, trim).c_str());
                 fflush(stdout);
             }
             return true;

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
@@ -27,16 +27,16 @@ using yarp::os::NetworkBase;
  * The string is what gets printed.
  * @param name the name which which to register the port
  * @param src name of a port to connect from, if any
- * @param showEnvelope set to true if you want envelope information
- * shown
+ * @param showEnvelope set to true if you want envelope information shown
+ * @param trim number of characters of the string that should be printed
  * @return 0 on success, non-zero on failure
  */
-int Companion::read(const char *name, const char *src, bool showEnvelope)
+int Companion::read(const char *name, const char *src, bool showEnvelope, int trim)
 {
     Companion::installHandler();
     BottleReader reader;
     applyArgs(reader.core);
-    reader.open(name, showEnvelope);
+    reader.open(name, showEnvelope, trim);
     if (src != nullptr) {
         ContactStyle style;
         style.quiet = false;
@@ -53,21 +53,32 @@ int Companion::read(const char *name, const char *src, bool showEnvelope)
 int Companion::cmdRead(int argc, char *argv[])
 {
     if (argc<1) {
-        yCError(COMPANION, "Please supply the port name");
+        yCError(COMPANION, "Usage:");
+        yCError(COMPANION, "  yarp read <port> [remote port] [envelope] [trim [length]]");
         return 1;
     }
 
     const char *name = argv[0];
     const char *src = nullptr;
     bool showEnvelope = false;
+    size_t trim = -1;
     while (argc>1) {
         if (strcmp(argv[1], "envelope")==0) {
             showEnvelope = true;
+        } else if (strcmp(argv[1], "trim") == 0) {
+            argc--;
+            argv++;
+            if (argc > 1) {
+                trim = atoi(argv[1]);
+            } else {
+                static constexpr int default_trim = 80;
+                trim = default_trim;
+            }
         } else {
             src = argv[1];
         }
         argc--;
         argv++;
     }
-    return read(name, src, showEnvelope);
+    return read(name, src, showEnvelope, trim);
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -107,7 +107,7 @@ public:
     int cmdPrioritySched(int argc, char *argv[]);
 
     // Defined in Companion.cmdRead.cpp
-    int read(const char *name, const char *src = nullptr, bool showEnvelope = false);
+    int read(const char *name, const char *src = nullptr, bool showEnvelope = false, int trim = -1);
     int cmdRead(int argc, char *argv[]);
 
     // Defined in Companion.cmdReadWrite.cpp


### PR DESCRIPTION
## Tools

### `yarp`

* The `read` subcommand now accepts the `trim` argument to reduce the number of
  characters printed for each message received.