### PR TITLE
fakeFrameGrabber enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,9 +533,10 @@ jobs:
       with:
         path: |
           .ccache
-        key: build-${{ matrix.config.id }}-ccache-${{ steps.prepare_cache_timestamp.outputs.timestamp }}
+        key: build-${{ matrix.config.id }}-ccache-${{ github.ref }}-${{ steps.prepare_cache_timestamp.outputs.timestamp }}
         restore-keys: |
-          build-${{ matrix.config.id }}-ccache-
+          build-${{ matrix.config.id }}-${{ github.base_ref }}-ccache-
+          build-${{ matrix.config.id }}-${{ github.ref }}-ccache-
 
     - name: Dependencies [Linux]
       if: runner.os == 'Linux'

--- a/data/yarpmanager/tests/xml/modules/fakeFrameGrabber.xml
+++ b/data/yarpmanager/tests/xml/modules/fakeFrameGrabber.xml
@@ -1,6 +1,6 @@
 <module>
     <name>fakeFrameGrabber</name>
-    <description> A frame grabber test device (start up a fake image source)</description>
+    <description> A fake frame grabber device (start up a fake image source)</description>
     <version>1.0</version>
 
     <arguments>
@@ -9,26 +9,27 @@
         <param default="240" required="no" desc="desired height of test image">height</param>
         <param default="0.033" required="no" desc="period of test images in second">period</param>
         <param default="30" required="no" desc="rate of test images in Hz">freq</param>
-        <param default="line" required="no" desc="bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand]">mode</param>
+        <param default="line" required="no" desc="bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], noise [nois], none [none], time test[time]">mode</param>
+        <param default="" required="no" desc="background image to use, if any">src</param>
+        <param default="0.5" required="no" desc="Signal noise ratio ([0.0-1.0] default 0.5)">snr</param>
+        <param default="0" required="no" desc="mirroring disabled by default">mirror</param>
+        <param default="0" required="no" desc="should emit bayer test image?">bayer</param>
+        <param default="0" required="no" desc="should emit a monochrome image?">mono</param>
         <param default="1.0" required="no" desc="desired horizontal fov of test image">horizontalFov</param>
         <param default="2.0" required="no" desc="desired vertical fov of test image">verticalFov</param>
-        <param default="0" required="no" desc="mirroring disabled by default">mirror</param>
-        <param default="4.0" required="no" desc="">focalLengthX</param>
-        <param default="5.0" required="no" desc="">focalLengthY</param>
-        <param default="6.0" required="no" desc="">principalPointX</param>
-        <param default="7.0" required="no" desc="">principalPointY</param>
-        <param default="1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0" required="no" desc="">retificationMatrix</param>
-        <param default="FishEye" required="no" desc="">distortionModel</param>
-        <param default="8.0" required="no" desc="">k1</param>
-        <param default="9.0" required="no" desc="">k2</param>
-        <param default="10.0" required="no" desc="">k3</param>
-        <param default="11.0" required="no" desc="">t1</param>
-        <param default="12.0" required="no" desc="">t2</param>
+        <param default="3.0" required="no" desc="Physical focal length of the fakeFrameGrabber">physFocalLength</param>
+        <param default="4.0" required="no" desc="Horizontal component of the focal length of the fakeFrameGrabber">focalLengthX</param>
+        <param default="5.0" required="no" desc="Vertical component of the focal length of the fakeFrameGrabber">focalLengthY</param>
+        <param default="6.0" required="no" desc="X coordinate of the principal point of the fakeFrameGrabber">principalPointX</param>
+        <param default="7.0" required="no" desc="Y coordinate of the principal point of the fakeFrameGrabber">principalPointY</param>
+        <param default="8.0" required="no" desc="Radial distortion coefficient of the lens(fake)">k1</param>
+        <param default="9.0" required="no" desc="Radial distortion coefficient of the lens(fake)">k2</param>
+        <param default="10.0" required="no" desc="Radial distortion coefficient of the lens(fake)">k3</param>
+        <param default="11.0" required="no" desc="Tangential distortion of the lens(fake)">t1</param>
+        <param default="12.0" required="no" desc="Tangential distortion of the lens(fake)">t2</param>
+        <param default="1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0" required="no" desc="Matrix that describes the lens' distortion(fake)">retificationMatrix</param>
+        <param default="FishEye" required="no" desc="Reference to group of parameters describing the distortion model of the camera">distortionModel</param>
     </arguments>
-
-    <authors>
-        <author email="paulfitz@alum.mit.edu"> Paul Fitzpatrick </author>
-    </authors>
 
     <data>
         <input port_type="service">

--- a/doc/device_invocation/fakeFrameGrabber_basic.dox
+++ b/doc/device_invocation/fakeFrameGrabber_basic.dox
@@ -51,8 +51,10 @@ So this is just an example
 <tr><td>t2</td><td>Tangential distortion of the lens(fake)</td><td>12.0</td></tr>
 <tr><td>freq</td><td>rate of test images in Hz</td><td></td></tr>
 <tr><td>period</td><td>period of test images in seconds</td><td></td></tr>
-<tr><td>mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], none [none], time test[time]</td><td>line</td></tr>
+<tr><td>mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], noise [nois], none [none], time test[time]</td><td>line</td></tr>
 <tr><td>src</td><td></td><td></td></tr>
+<tr><td>timestamp</td><td>should write the timestamp in the first bytes of the image</td><td></td></tr>
+<tr><td>snr</td><td>Signal noise ratio ([0.0-1.0] default 0.5)</td><td>0.5</td></tr>
 <tr><td>bayer</td><td>should emit bayer test image?</td><td></td></tr>
 <tr><td>mono</td><td>should emit a monochrome image?</td><td></td></tr>
 </table>

--- a/doc/release/master/fakeFrameGrabber_enh.md
+++ b/doc/release/master/fakeFrameGrabber_enh.md
@@ -1,0 +1,15 @@
+fakeFrameGrabber_enh  {#master}
+--------------------
+
+## Devices
+
+### `fakeFrameGrabber`
+
+* Added `--timestamp` option to write the timestamp in the first bytes of the
+  image. This was previously automatically enabled in `line` mode, but it can
+  now be used in all modes.
+* Add `nois` (noise) mode. This can be used alone to generate a white noise,
+  image, or while passing `--src` to add some noise to the image.
+  The `--snr` can be pass to specify the signal noise ratio (default 0.5).
+* Double buffering is now used to produce the image on a separate thread. This
+  should improve performances when generating large images.

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -212,6 +212,7 @@ bool FakeFrameGrabber::open(yarp::os::Searchable& config) {
         }
     }
 
+    add_timestamp = config.check("timestamp", "should write the timestamp in the first bytes of the image");
     use_bayer = config.check("bayer","should emit bayer test image?");
     use_mono = config.check("mono","should emit a monochrome image?");
     use_mono = use_mono||use_bayer;
@@ -527,35 +528,6 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>&
             for (size_t i=0; i<image.width(); i++) {
                 image.pixel(i,ct).r = 255;
             }
-            char ttxt[50];
-            std::snprintf(ttxt, 50, "%021.10f", t);
-            image.pixel(0, 0).r = ttxt[0] - '0';
-            image.pixel(0, 0).g = ttxt[1] - '0';
-            image.pixel(0, 0).b = ttxt[2] - '0';
-
-            image.pixel(1, 0).r = ttxt[3] - '0';
-            image.pixel(1, 0).g = ttxt[4] - '0';
-            image.pixel(1, 0).b = ttxt[5] - '0';
-
-            image.pixel(2, 0).r = ttxt[6] - '0';
-            image.pixel(2, 0).g = ttxt[7] - '0';
-            image.pixel(2, 0).b = ttxt[8] - '0';
-
-            image.pixel(3, 0).r = ttxt[9] - '0';
-            image.pixel(3, 0).g = ttxt[10] - '0';
-            image.pixel(3, 0).b = ttxt[11] - '0';
-
-            image.pixel(4, 0).r = ttxt[12] - '0';
-            image.pixel(4, 0).g = ttxt[13] - '0';
-            image.pixel(4, 0).b = ttxt[14] - '0';
-
-            image.pixel(5, 0).r = ttxt[15] - '0';
-            image.pixel(5, 0).g = ttxt[16] - '0';
-            image.pixel(5, 0).b = ttxt[17] - '0';
-
-            image.pixel(6, 0).r = ttxt[18] - '0';
-            image.pixel(6, 0).g = ttxt[19] - '0';
-            image.pixel(6, 0).b = ttxt[20] - '0';
         }
         break;
     case VOCAB_RAND:
@@ -598,6 +570,38 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>&
     }
     if (bx>=image.width()) {
         bx = image.width()-1;
+    }
+
+    if (add_timestamp) {
+        char ttxt[50];
+        std::snprintf(ttxt, 50, "%021.10f", t);
+        image.pixel(0, 0).r = ttxt[0] - '0';
+        image.pixel(0, 0).g = ttxt[1] - '0';
+        image.pixel(0, 0).b = ttxt[2] - '0';
+
+        image.pixel(1, 0).r = ttxt[3] - '0';
+        image.pixel(1, 0).g = ttxt[4] - '0';
+        image.pixel(1, 0).b = ttxt[5] - '0';
+
+        image.pixel(2, 0).r = ttxt[6] - '0';
+        image.pixel(2, 0).g = ttxt[7] - '0';
+        image.pixel(2, 0).b = ttxt[8] - '0';
+
+        image.pixel(3, 0).r = ttxt[9] - '0';
+        image.pixel(3, 0).g = ttxt[10] - '0';
+        image.pixel(3, 0).b = ttxt[11] - '0';
+
+        image.pixel(4, 0).r = ttxt[12] - '0';
+        image.pixel(4, 0).g = ttxt[13] - '0';
+        image.pixel(4, 0).b = ttxt[14] - '0';
+
+        image.pixel(5, 0).r = ttxt[15] - '0';
+        image.pixel(5, 0).g = ttxt[16] - '0';
+        image.pixel(5, 0).b = ttxt[17] - '0';
+
+        image.pixel(6, 0).r = ttxt[18] - '0';
+        image.pixel(6, 0).g = ttxt[19] - '0';
+        image.pixel(6, 0).b = ttxt[20] - '0';
     }
 }
 

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -60,10 +60,11 @@ public:
      * <TR><TD> height </TD><TD> Height of image (default 128). </TD></TR>
      * <TR><TD> freq </TD><TD> Frequency in Hz to generate images (default 20Hz). </TD></TR>
      * <TR><TD> period </TD><TD> Inverse of freq - only set one of these. </TD></TR>
-     * <TR><TD> mode </TD><TD> Can be [line] (default), [ball], [grid], [rand], [none]. </TD></TR>
+     * <TR><TD> mode </TD><TD> Can be [line] (default), [ball], [grid], [rand], [nois], [none]. </TD></TR>
      * <TR><TD> src </TD><TD> Image file to read from (default: none). </TD></TR>
      * <TR><TD> bayer </TD><TD> Emit a bayer image. </TD></TR>
      * <TR><TD> mono </TD><TD> Emit a monochrome image. </TD></TR>
+     * <TR><TD> snr </TD><TD> Signal noise ratio ([nois] mode only) (default 0.5). </TD></TR>
      * </TABLE>
      *
      * @param config The options to use
@@ -143,6 +144,7 @@ private:
     static constexpr size_t default_w = 128;
     static constexpr size_t default_h = 128;
     static constexpr size_t default_freq = 30;
+    static constexpr double default_snr = 0.5;
 
     size_t ct{0};
     size_t bx{0};
@@ -159,6 +161,7 @@ private:
     bool have_bg{false};
     int mode{0};
     bool add_timestamp{false};
+    double snr{default_snr};
     bool use_bayer{false};
     bool use_mono{false};
     bool mirror{false};
@@ -168,6 +171,7 @@ private:
     std::random_device rnddev;
     std::default_random_engine randengine{rnddev()};
     std::uniform_int_distribution<int> udist{-1, 1};
+    std::uniform_real_distribution<double> ucdist{0.0, 1.0};
 
     yarp::sig::ImageOf<yarp::sig::PixelRgb> background;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> rgb_image;

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -17,6 +17,7 @@
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/Searchable.h>
+#include <yarp/os/Thread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Log.h>
@@ -25,6 +26,7 @@
 
 #include <cstdio>
 #include <random>
+#include <condition_variable>
 
 /**
  * @ingroup dev_impl_media dev_impl_fake
@@ -41,7 +43,8 @@ class FakeFrameGrabber :
         public yarp::dev::IFrameGrabberControls,
         public yarp::dev::IPreciselyTimed,
         public yarp::dev::IAudioVisualStream,
-        public yarp::dev::IRgbVisualParams
+        public yarp::dev::IRgbVisualParams,
+        public yarp::os::Thread
 {
 public:
     FakeFrameGrabber() = default;
@@ -71,6 +74,10 @@ public:
      * @return true iff the object could be configured.
      */
     bool open(yarp::os::Searchable& config) override;
+
+    // yarp::os::Thread
+    void run() override;
+    void onStop() override;
 
     void timing();
 
@@ -173,11 +180,21 @@ private:
     std::uniform_int_distribution<int> udist{-1, 1};
     std::uniform_real_distribution<double> ucdist{0.0, 1.0};
 
+    size_t curr_buff{1};
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> buffs[2];
+    bool img_ready[2] {false, false};
+    bool img_consumed[2] {true, true};
+    std::mutex mutex[2];
+    std::condition_variable img_ready_cv[2];
+    std::condition_variable img_consumed_cv[2];
+    double buff_ts[2];
+
     yarp::sig::ImageOf<yarp::sig::PixelRgb> background;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> rgb_image;
     yarp::os::Stamp stamp;
 
-    void createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image);
+    void createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image,
+                         double& timestamp);
 
     bool makeSimpleBayer(yarp::sig::ImageOf<yarp::sig::PixelRgb>& src,
                          yarp::sig::ImageOf<yarp::sig::PixelMono>& bayer);

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -158,6 +158,7 @@ private:
     double prev{0};
     bool have_bg{false};
     int mode{0};
+    bool add_timestamp{false};
     bool use_bayer{false};
     bool use_mono{false};
     bool mirror{false};


### PR DESCRIPTION
## Devices

### `fakeFrameGrabber`

* Added `--timestamp` option to write the timestamp in the first bytes of the
  image. This was previously automatically enabled in `line` mode, but it can
  now be used in all modes.
* Add `nois` (noise) mode. This can be used alone to generate a white noise,
  image, or while passing `--src` to add some noise to the image.
  The `--snr` option can be pass to specify the signal noise ratio (default 0.5).
  
  
  ![Peek 2021-02-22 00-52](https://user-images.githubusercontent.com/1100056/108722584-9dff6e00-7523-11eb-8855-d069f74fe0a5.gif)

  
* Double buffering is now used to produce the image on a separate thread. This
  should improve performances when generating large images.
  
  
 Depends on #2504 