### PR TITLE
[WIP] PublisherLatched

### DIFF
--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -94,6 +94,7 @@ set(YARP_os_HDRS yarp/os/AbstractCarrier.h
                  yarp/os/PortWriter.h
                  yarp/os/Property.h
                  yarp/os/Publisher.h
+                 yarp/os/PublisherLatched.h
                  yarp/os/Random.h
                  yarp/os/ResourceFinder.h
                  yarp/os/ResourceFinderOptions.h

--- a/src/libYARP_os/src/yarp/os/Publisher.h
+++ b/src/libYARP_os/src/yarp/os/Publisher.h
@@ -179,7 +179,7 @@ public:
         return port;
     }
 
-private:
+protected:
     Port port;
     BufferedPort<T>* buffered_port;
 

--- a/src/libYARP_os/src/yarp/os/PublisherLatched.h
+++ b/src/libYARP_os/src/yarp/os/PublisherLatched.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_OS_PUBLISHER_LATCHED_H
+#define YARP_OS_PUBLISHER_LATCHED_H
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Publisher.h>
+
+namespace yarp {
+namespace os {
+
+/**
+ * A port specialized for publishing data of a constant type on a topic.
+ * `Latched` means that the last published message is saved internally and automatically
+ * sent to any future subscribers that connects to the publisher.
+ *
+ * \sa yarp::os::PublisherLatched
+ */
+template <class TT>
+class PublisherLatched : public yarp::os::Publisher<TT>, public yarp::os::PeriodicThread
+{
+    private:
+    size_t           m_currently_connected=0;
+    yarp::os::Port*  m_p=nullptr;
+    std::mutex       m_mutex;
+
+    public:
+    PublisherLatched(const std::string& name = "") : yarp::os::Publisher<TT>(name), yarp::os::PeriodicThread(0.010)
+    {
+        m_p = &(this->asPort());
+        this->start();
+    }
+
+    virtual ~PublisherLatched()
+    {
+        this->stop();
+    }
+
+    TT& prepare()
+    {
+        std::lock_guard<std::mutex> lock (m_mutex);
+        return this->buffer().prepare();
+    }
+
+    public:
+    void run() override
+    {
+        size_t cc = m_p->getOutputCount();
+        if (cc != m_currently_connected)
+        {
+            m_mutex.lock();
+            TT& data = this->buffer().prepare();
+            // bool b= this->unprepare();
+            // if (b)
+            if (cc != 0)
+            {
+               //yDebug() << "Latched!";
+               this->write();
+            }
+            m_currently_connected = cc;
+            m_mutex.unlock();
+        }
+    }
+};
+
+} // namespace os
+} // namespace yarp
+
+#endif // YARP_OS_PUBLISHER_LATCHED_H


### PR DESCRIPTION
* added the new class `yarp::os::PublisherLatched`
* added test to `PublisherTest`

From http://wiki.ros.org/roscpp/Overview/Publishers%20and%20Subscribers#Publisher_Options :
_"When a connection is latched, the last message published is saved and automatically sent to any future subscribers that connect. This is useful for slow-changing to static data like a map."_