### PR TITLE
Avoid cumulative drift in PeriodicThread

### DIFF
--- a/doc/release/master/fix_periodic_thread_drift.md
+++ b/doc/release/master/fix_periodic_thread_drift.md
@@ -1,0 +1,17 @@
+fix_periodic_thread_drift {#master}
+-----------
+
+### Libraries
+
+#### `os`
+
+##### `PeriodicThread`
+
+* The constructor now accepts a third (optional) parameter, `clockAccuracy`,
+  which enables drift compensation using an absolute time reference to ensure
+  all steps trigger at precise intervals, thus avoiding error accumulation over
+  time. Set it to `PeriodicThreadClock::Absolute` to enable the new behavior,
+  default is `PeriodicThreadClock::Relative` (old behavior). Beware that, in
+  absolute mode, starvation may occur if two busy threads share a common
+  resource. Another constructor has been added for ease of usage:
+  `PeriodicThread(double period, PeriodicThreadClock clockAccuracy)`. (#2488)

--- a/src/libYARP_os/src/yarp/os/PeriodicThread.h
+++ b/src/libYARP_os/src/yarp/os/PeriodicThread.h
@@ -16,6 +16,12 @@
 namespace yarp {
 namespace os {
 
+enum class PeriodicThreadClock
+{
+    Relative,
+    Absolute
+};
+
 /**
  * \ingroup key_class
  *
@@ -27,16 +33,34 @@ public:
     /**
      * Constructor.  Thread begins in a dormant state.  Call PeriodicThread::start
      * to get things going.
-     * @param period The period in seconds [sec] between
-     * successive calls to the PeriodicThread::run method
-     * (remember you need to call PeriodicThread::start first
-     * before anything happens)
-     * @param useSystemClock whether the thread should always
-     * use the system clock, or depend on the current
-     * configuration of the network.
+     * @param period The period in seconds [sec] between successive calls to the
+     * PeriodicThread::run method (remember you need to call PeriodicThread::start
+     * first before anything happens)
+     * @param useSystemClock whether the thread should always use the system clock,
+     * or depend on the current configuration of the network
+     * @param clockAccuracy whether the thread should ensure all steps wake up
+     * at precise intervals using an absolute reference, otherwise compute them
+     * in a relative fashion assuming error accumulation over time due to drifts.
+     * @warning PeriodicThreadClock::Absolute may cause starvation if two or more
+     * busy threads lock on a common resource
      */
     explicit PeriodicThread(double period,
-                            ShouldUseSystemClock useSystemClock = ShouldUseSystemClock::No);
+                            ShouldUseSystemClock useSystemClock = ShouldUseSystemClock::No,
+                            PeriodicThreadClock clockAccuracy = PeriodicThreadClock::Relative);
+
+    /**
+     * Constructor.  Thread begins in a dormant state.  Call PeriodicThread::start
+     * to get things going.
+     * @param period The period in seconds [sec] between successive calls to the
+     * PeriodicThread::run method (remember you need to call PeriodicThread::start
+     * first before anything happens)
+     * @param clockAccuracy whether the thread should ensure all steps wake up
+     * at precise intervals using an absolute reference, otherwise compute them
+     * in a relative fashion assuming error accumulation over time due to drifts
+     * @warning PeriodicThreadClock::Absolute may cause starvation if two or more
+     * busy threads lock on a common resource
+     */
+    explicit PeriodicThread(double period, PeriodicThreadClock clockAccuracy);
 
     virtual ~PeriodicThread();
 


### PR DESCRIPTION
Fixes https://github.com/robotology/yarp/issues/2488. Instead of a relative value obtained from the time elapsed on each step, which was prone to cause error accumulation over time, now I am using an absolute initial reference that helps getting the exact delay to prevent just that. This reference needs to be reset whenever the period is changed. In short, the new computed delay boils down to:

```cxx
delay = absolute_reference + period * iterations_since_absolute_reference - now;
```

In addition, I have added new checks to PeriodicThreadTest, which I'm not sure why weren't there, for testing the timer accuracy.

Please review. I have tested this on the code snippet attached in https://github.com/robotology/yarp/issues/2488 (using a system clock), and also on a similar example app with `yarp::os::Timer` instead.