### PR TITLE
os: Add Header class, intended to gradually replace the Stamp class

### DIFF
--- a/doc/release/master/os_Header.md
+++ b/doc/release/master/os_Header.md
@@ -1,0 +1,18 @@
+os_Header {#master}
+---------
+
+## Libraries
+
+### yarp::os
+
+* Introduced the `yarp::os::Header` class, intended to gradually replace the
+  `yarp::os::Stamp` class to handle envelopes, maintaining backwards
+  compatibility.
+  The differences with the `Stamp` class:
+  * `Header` has an extra field to handle the frame id, making it comparable
+    with ROS [`std_msgs/Header`](http://docs.ros.org/en/api/std_msgs/html/msg/Header.html)
+    message.
+  * The counter uses unsigned int instead of int.
+  * `Stamp::getMaxCount()` is replaced with `Header::npos`
+  * `Stamp::getCount()` is replaced with `Header::count()`
+  * `Stamp::getTime()` is replaced with `Header::timeStamp()`

--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(YARP_os_HDRS yarp/os/AbstractCarrier.h
                  yarp/os/Election.h
                  yarp/os/Event.h
                  yarp/os/Face.h
+                 yarp/os/Header.h
                  yarp/os/IConfig.h
                  yarp/os/InputProtocol.h
                  yarp/os/InputStream.h
@@ -159,6 +160,7 @@ set(YARP_os_SRCS yarp/os/AbstractCarrier.cpp
                  yarp/os/ContactStyle.cpp
                  yarp/os/DummyConnector.cpp
                  yarp/os/Event.cpp
+                 yarp/os/Header.cpp
                  yarp/os/IConfig.cpp
                  yarp/os/InputStream.cpp
                  yarp/os/Log.cpp

--- a/src/libYARP_os/src/yarp/os/Header.cpp
+++ b/src/libYARP_os/src/yarp/os/Header.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/Header.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/ConnectionReader.h>
+#include <yarp/os/ConnectionWriter.h>
+#include <yarp/os/impl/LogComponent.h>
+#include <yarp/os/Time.h>
+
+#include <algorithm>
+
+
+using yarp::os::Header;
+
+namespace {
+YARP_OS_LOG_COMPONENT(HEADER, "yarp.os.Header");
+}
+
+class Header::Private
+{
+public:
+    Private(Header::count_t count,
+            yarp::conf::float64_t time,
+            std::string&& frameId) :
+            sequenceNumber(count),
+            timeStamp(time),
+            frameId(std::move(frameId))
+    {
+    }
+
+    Private() = default;
+
+    void clear()
+    {
+        sequenceNumber = Header::npos;
+        timeStamp = 0.0;
+        frameId.clear();
+    }
+
+    void update(yarp::conf::float64_t time)
+    {
+        sequenceNumber++;
+        if (sequenceNumber == Header::npos) {
+            // npos is not used to store a valid header, just restart the
+            // counter
+            sequenceNumber = 0;
+        }
+        timeStamp = time;
+    }
+
+    Header::count_t sequenceNumber = Header::npos;
+    yarp::conf::float64_t timeStamp = 0.0;
+    std::string frameId;
+};
+
+
+Header::Header(Header::count_t count, yarp::conf::float64_t time, std::string frameId) :
+        mPriv(new Private(count, time, std::move(frameId)))
+{
+    yCAssert(HEADER, mPriv->frameId.find(' ') == std::string::npos);
+}
+
+Header::Header() :
+        mPriv(new Private())
+{
+}
+
+Header::Header(const Header& rhs) :
+        mPriv(new Private(*(rhs.mPriv)))
+{
+}
+
+Header::Header(Header&& rhs) noexcept :
+        mPriv(std::exchange(rhs.mPriv, nullptr))
+{
+}
+
+Header::~Header()
+{
+    delete mPriv;
+}
+
+Header& Header::operator=(const Header& rhs)
+{
+    if (&rhs != this) {
+        *mPriv = *(rhs.mPriv);
+    }
+    return *this;
+}
+
+Header& Header::operator=(Header&& rhs) noexcept
+{
+    if (&rhs != this) {
+        std::swap(mPriv, rhs.mPriv);
+    }
+    return *this;
+}
+
+Header::count_t Header::count() const
+{
+    return mPriv->sequenceNumber;
+}
+
+yarp::conf::float64_t Header::timeStamp() const
+{
+    return mPriv->timeStamp;
+}
+
+std::string Header::frameId() const
+{
+    return mPriv->frameId;
+}
+
+bool Header::isValid() const
+{
+    return mPriv->sequenceNumber != npos;
+}
+
+bool Header::read(ConnectionReader& connection)
+{
+    if (connection.isTextMode()) {
+        std::string stampStr = connection.expectText();
+        Header::count_t seqNum;
+        yarp::conf::float64_t ts;
+        int used;
+
+        int ret = std::sscanf(stampStr.c_str(), "%u %lg %n", &seqNum, &ts, &used);
+        if (ret != 2 && used > 0) {
+            mPriv->clear();
+            return false;
+        }
+        mPriv->sequenceNumber = seqNum;
+        mPriv->timeStamp = ts;
+        mPriv->frameId = stampStr.substr((size_t)used, stampStr.find(' ', used));
+    } else {
+        connection.convertTextMode();
+
+        // Read list length (must be 3 or 2 for compatibility with Stamp)
+        std::int32_t header = connection.expectInt32();
+        if (header != BOTTLE_TAG_LIST) {
+            mPriv->clear();
+            return false;
+        }
+        std::int32_t len = connection.expectInt32();
+        if (len != 2 && len != 3) {
+            mPriv->clear();
+            return false;
+        }
+
+        // Read sequence number
+        std::int32_t code = connection.expectInt32();
+        if (code != BOTTLE_TAG_INT32) {
+            mPriv->clear();
+            return false;
+        }
+        mPriv->sequenceNumber = static_cast<Header::count_t>(connection.expectInt32());
+
+        // Read timestamp
+        code = connection.expectInt32();
+        if (code != BOTTLE_TAG_FLOAT64) {
+            mPriv->clear();
+            return false;
+        }
+        mPriv->timeStamp = connection.expectFloat64();
+
+        // Read frameId (unless receiving a Stamp)
+        if (len == 3) {
+            code = connection.expectInt32();
+            if (code != BOTTLE_TAG_STRING) {
+                mPriv->clear();
+                return false;
+            }
+            mPriv->frameId = connection.expectString();
+            yCAssert(HEADER, mPriv->frameId.find(' ') == std::string::npos);
+        } else {
+            mPriv->frameId.clear();
+        }
+
+        if (connection.isError()) {
+            mPriv->clear();
+            return false;
+        }
+    }
+    return !connection.isError();
+}
+
+
+// In order to keep the Header class as much compatible as possible with
+// Stamp, if the frameId is empty, it is not serialized at all.
+bool Header::write(ConnectionWriter& connection) const
+{
+    if (connection.isTextMode()) {
+        static constexpr size_t buf_size = 512;
+        char buf[buf_size];
+        if (!mPriv->frameId.empty()) {
+            std::snprintf(buf, buf_size, "%d %.*g %s", mPriv->sequenceNumber, DBL_DIG, mPriv->timeStamp, mPriv->frameId.c_str());
+        } else {
+            std::snprintf(buf, buf_size, "%d %.*g", mPriv->sequenceNumber, DBL_DIG, mPriv->timeStamp);
+        }
+        connection.appendText(buf);
+    } else {
+        connection.appendInt32(BOTTLE_TAG_LIST); // nested structure
+        connection.appendInt32(mPriv->frameId.empty() ? 2 : 3); // with two or three elements
+        connection.appendInt32(BOTTLE_TAG_INT32);
+        connection.appendInt32(static_cast<std::int32_t>(mPriv->sequenceNumber));
+        connection.appendInt32(BOTTLE_TAG_FLOAT64);
+        connection.appendFloat64(mPriv->timeStamp);
+        if (!mPriv->frameId.empty()) {
+            connection.appendInt32(BOTTLE_TAG_STRING);
+            connection.appendString(mPriv->frameId);
+        }
+        connection.convertTextMode();
+    }
+    return !connection.isError();
+}
+
+void Header::update()
+{
+    mPriv->update(Time::now());;
+}
+
+void Header::update(yarp::conf::float64_t time)
+{
+    mPriv->update(time);
+}
+
+void Header::setFrameId(std::string frameId)
+{
+    mPriv->frameId = std::move(frameId);
+}

--- a/src/libYARP_os/src/yarp/os/Header.h
+++ b/src/libYARP_os/src/yarp/os/Header.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_OS_HEADER_H
+#define YARP_OS_HEADER_H
+
+#include <yarp/os/Portable.h>
+#include <yarp/conf/numeric.h>
+
+#include <string>
+
+namespace yarp {
+namespace os {
+
+/**
+ * An abstraction for a sequence number, time stamp and/or frame id.
+ *
+ * This class is compatible with the Stamp class
+ */
+class YARP_os_API Header :
+        public Portable
+{
+public:
+    using count_t = std::uint32_t;
+
+    /**
+     * Maximum sequence number, after which an incrementing sequence
+     * should return to zero.
+     */
+    static constexpr count_t npos = static_cast<count_t>(-1);
+
+    /**
+     * Construct an invalid Header.
+     */
+    explicit Header();
+
+    /**
+     * Construct a Header with a given sequence number and time.
+     *
+     * @param count the sequence number.
+     * @param time the time stamp (in seconds, relative to an arbitrary zero time).
+     * @param frameId the frame id.
+     */
+    Header(count_t count, yarp::conf::float64_t time, std::string frameId = {});
+
+    /**
+     * @brief Copy constructor.
+     *
+     * @param rhs the Header to copy
+     */
+    Header(const Header& rhs);
+
+    /**
+     * @brief Move constructor.
+     *
+     * @param rhs the Header to be moved
+     */
+    Header(Header&& rhs) noexcept;
+
+    /**
+     * @brief Destructor.
+     */
+    ~Header() override;
+
+    /**
+     * Copy assignment operator.
+     *
+     * @param rhs the Header to copy
+     * @return this object
+     */
+    Header& operator=(const Header& rhs);
+
+    /**
+     * @brief Move assignment operator.
+     *
+     * @param rhs the Header to be moved
+     * @return this object
+     */
+    Header& operator=(Header&& rhs) noexcept;
+
+    /**
+     * Get the sequence number.
+     *
+     * @return the sequence number.
+     */
+    count_t count() const;
+
+    /**
+     * Get the time stamp.
+     *
+     * @return the time stamp.
+     */
+    yarp::conf::float64_t timeStamp() const;
+
+    /**
+     * Get the frame id.
+     *
+     * @return the frame id.
+     */
+    std::string frameId() const;
+
+    /**
+     * Check if this Header is valid.
+     *
+     * @return true if this is a valid Header
+     */
+    bool isValid() const;
+
+    /**
+     * Set the timestamp to the current time, and increment the sequence number
+     * (wrapping to 0 if the sequence number exceeds npos)
+     */
+    void update();
+
+    /**
+     * Set the timestamp to a given time, and increments the sequence number
+     * (wrapping to 0 if the sequence exceeds npos)
+     */
+    void update(yarp::conf::float64_t time);
+
+    /**
+     * Set the frame id for this header
+     *
+     * @param frameId the new frame id for this header
+     */
+    void setFrameId(std::string frameId);
+
+
+    // Documented in Portable
+    bool read(ConnectionReader& connection) override;
+
+    // Documented in Portable
+    bool write(ConnectionWriter& connection) const override;
+
+private:
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    class Private;
+    Private* mPriv;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+};
+
+
+} // namespace os
+} // namespace yarp
+
+#endif // YARP_OS_HEADER_H

--- a/src/libYARP_os/src/yarp/os/Stamp.cpp
+++ b/src/libYARP_os/src/yarp/os/Stamp.cpp
@@ -65,7 +65,8 @@ bool yarp::os::Stamp::read(ConnectionReader& connection)
             return false;
         }
         std::int32_t len = connection.expectInt32();
-        if (len != 2) {
+        // len should be 2 for Stamp, 3 for Header
+        if (len != 2 && len != 3) {
             return false;
         }
         std::int32_t code = connection.expectInt32();
@@ -83,6 +84,19 @@ bool yarp::os::Stamp::read(ConnectionReader& connection)
             timeStamp = 0;
             return false;
         }
+
+        // Read frameId (unless receiving a Stamp), but just discard its value
+        if (len == 3) {
+            code = connection.expectInt32();
+            if (code != BOTTLE_TAG_STRING) {
+                sequenceNumber = -1;
+                timeStamp = 0;
+                return false;
+            }
+            std::string unused = connection.expectString();
+            YARP_UNUSED(unused);
+        }
+
     }
     return !connection.isError();
 }

--- a/tests/libYARP_os/CMakeLists.txt
+++ b/tests/libYARP_os/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(harness_os PRIVATE BinPortableTest.cpp
                                   ContactTest.cpp
                                   ElectionTest.cpp
                                   EventTest.cpp
+                                  HeaderTest.cpp
                                   LogStreamTest.cpp
                                   LogTest.cpp
                                   MessageStackTest.cpp

--- a/tests/libYARP_os/HeaderTest.cpp
+++ b/tests/libYARP_os/HeaderTest.cpp
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/Header.h>
+
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/DummyConnector.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Stamp.h>
+
+#include <yarp/os/impl/BufferedConnectionWriter.h>
+
+#include <catch.hpp>
+#include <harness.h>
+
+using namespace yarp::os;
+using yarp::os::impl::BufferedConnectionWriter;
+
+// This cannot be constexpr because pow is not constexpr
+static yarp::conf::float64_t extreme()
+{
+    constexpr yarp::conf::float64_t exp = -DBL_DIG;
+    yarp::conf::float64_t smallest = pow(10.0, exp);
+
+    // Create a number like 0.123456789012345... using the maximum number of digits
+    // the platform can support.
+    yarp::conf::float64_t timeValue = smallest;
+    for(int i=2; i<DBL_DIG+1; i++) {
+        timeValue = timeValue*10 + (i%10)*smallest;
+    }
+    return timeValue;
+}
+
+static constexpr yarp::conf::float64_t realistic()
+{
+    // Create a realistic timestamp with tenth of millisecond as granularity,
+    // like 1234567890.12345
+    return 1234567890.12345;
+}
+
+static void checkEnvelope(const char *mode)
+{
+    BufferedPort<Bottle> in;
+    BufferedPort<Bottle> out;
+
+    in.setStrict();
+    in.open("/in");
+    out.open("/out");
+    Network::connect("/out", "/in", mode);
+
+    Bottle& outBot1 = out.prepare();   // Get the object
+    outBot1.fromString("hello world"); // Set it up the way we want
+    Header header(54, 1.0, "firstFrameId");
+    out.setEnvelope(header);
+    out.write();                       // Now send it on its way
+
+    Bottle& outBot2 = out.prepare();
+    outBot2.fromString("2 3 5 7 11");
+    Header header2(55, 4.0, "secondFrameId");
+    out.setEnvelope(header2);
+    out.writeStrict();                 // writeStrict() will wait for any
+
+    do {
+        Time::delay(0.1);
+    } while (in.getPendingReads() < 2);
+
+    // Read the first object
+    in.read();
+    Header inHeader;
+    in.getEnvelope(inHeader);
+    CHECK(inHeader.count() == 54);
+    CHECK(inHeader.timeStamp() == Approx(1.0));
+    CHECK(inHeader.frameId() == "firstFrameId");
+
+    // Read the second object
+    in.read();
+    in.getEnvelope(inHeader);
+    CHECK(inHeader.count() == 55);
+    CHECK(inHeader.timeStamp() == Approx(4.0));
+    CHECK(inHeader.frameId() == "secondFrameId");
+}
+
+
+TEST_CASE("os::HeaderTest", "[yarp::os]")
+{
+    Network::setLocalMode(true);
+
+    SECTION("checking Header can serialize ok (with frameId)")
+    {
+        for (int i=0; i<=1; i++) {
+            DummyConnector con;
+
+            bool textMode = (i==0);
+            if (textMode) {
+                INFO("checking in text mode");
+            } else {
+                INFO("checking in binary mode");
+            }
+            con.setTextMode(textMode);
+
+            Header headerToWrite(55, 1.0, "theFrameId");
+            Header headerRead;
+
+            headerToWrite.write(con.getWriter());
+            Bottle bot;
+            bot.read(con.getReader());
+
+            CHECK(bot.size() == 3);
+            CHECK(bot.get(0).asInt32() == 55); // sequence number write
+            CHECK(bot.get(1).asFloat64() == Approx(1.0).epsilon(0.0001)); // time stamp write
+            CHECK(bot.get(2).asString() == "theFrameId"); // frame id write
+
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            CHECK(headerRead.count() == 55); // sequence number read
+            CHECK(headerRead.timeStamp() == Approx(1.0).epsilon(0.0001)); // time stamp read
+            CHECK(headerRead.frameId() == "theFrameId"); // frame id read
+
+            // Test extreme numbers as timestamp
+            yarp::conf::float64_t timeValue = extreme();
+            INFO(timeValue);
+            headerToWrite.update(timeValue);
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            // Check sequence number is updated automatically
+            CHECK(headerRead.count() == 56); // sequence number read
+            // Check the number is read back with error smaller than machine epsilon
+            CHECK(headerRead.timeStamp() == Approx(timeValue).epsilon(DBL_EPSILON)); // time stamp read
+            // Check the frameId should not be changed
+            CHECK(headerRead.frameId() == "theFrameId"); // frame id read
+
+            // Test a realistic timestamp
+            timeValue = realistic();
+            headerToWrite.update(timeValue);
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            // Check sequence number is updated automatically
+            CHECK(headerRead.count() == 57); // sequence number read
+            // Check the number is read back with error smaller than machine epsilon
+            CHECK(headerRead.timeStamp() == Approx(timeValue).epsilon(DBL_EPSILON)); // time stamp read
+            // Check the frameId should not be changed
+            CHECK(headerRead.frameId() == "theFrameId"); // frame id read
+
+
+            // Change the frame id
+            headerToWrite.setFrameId("theNewFrameId");
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            // Check sequence number is not changed
+            CHECK(headerRead.count() == 57); // sequence number read
+            // Check the number is read back with error smaller than machine epsilon
+            CHECK(headerRead.timeStamp() == Approx(timeValue).epsilon(DBL_EPSILON)); // time stamp read
+            // Check the frameId should be changed to the new value
+            CHECK(headerRead.frameId() == "theNewFrameId"); // frame id read
+
+        }
+    }
+
+    SECTION("checking Header can serialize ok (without frameId)")
+    {
+        for (int i=0; i<=1; i++) {
+            DummyConnector con;
+
+            bool textMode = (i==0);
+            if (textMode) {
+                INFO("checking in text mode");
+            } else {
+                INFO("checking in binary mode");
+            }
+            con.setTextMode(textMode);
+
+            Header headerToWrite(55, 1.0);
+            Header headerRead;
+
+            headerToWrite.write(con.getWriter());
+            Bottle bot;
+            bot.read(con.getReader());
+
+            CHECK(bot.size() == 2);
+            CHECK(bot.get(0).asInt32() == 55); // sequence number write
+            CHECK(bot.get(1).asFloat64() == Approx(1.0).epsilon(0.0001)); // time stamp write
+
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            CHECK(headerRead.count() == 55); // sequence number read
+            CHECK(headerRead.timeStamp() == Approx(1.0).epsilon(0.0001)); // time stamp read
+
+            // Test extreme numbers as timestamp
+            yarp::conf::float64_t timeValue = extreme();
+            INFO(timeValue);
+            headerToWrite.update(timeValue);
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            // Check sequence number is updated automatically
+            CHECK(headerRead.count() == 56); // sequence number read
+            // Check the number is read back with error smaller than machine epsilon
+            CHECK(headerRead.timeStamp() == Approx(timeValue).epsilon(DBL_EPSILON)); // time stamp read
+
+            // Test a realistic timestamp
+            timeValue = realistic();
+            headerToWrite.update(timeValue);
+
+            headerToWrite.write(con.getCleanWriter());
+            headerRead.read(con.getReader());
+
+            // Check sequence number is updated automatically
+            CHECK(headerRead.count() == 57); // sequence number read
+            // Check the number is read back with error smaller than machine epsilon
+            CHECK(headerRead.timeStamp() == Approx(timeValue).epsilon(DBL_EPSILON)); // time stamp read
+        }
+    }
+
+    SECTION("checking Header (with frame id) can serialize to a Stamp")
+    {
+        for (int i=0; i<=1; i++) {
+            DummyConnector con;
+
+            bool textMode = (i==0);
+            if (textMode) {
+                INFO("checking in text mode");
+            } else {
+                INFO("checking in binary mode");
+            }
+            con.setTextMode(textMode);
+
+            Header headerToWrite(55, realistic(), "theFrameId");
+            Stamp stampRead;
+
+            headerToWrite.write(con.getWriter());
+            stampRead.read(con.getReader());
+
+            CHECK(stampRead.getCount() == 55); // sequence number read
+            CHECK(stampRead.getTime() == Approx(realistic()).epsilon(0.0001)); // time stamp read
+        }
+    }
+
+    SECTION("checking Header (without frame id) can serialize to a Stamp")
+    {
+        for (int i=0; i<=1; i++) {
+            DummyConnector con;
+
+            bool textMode = (i==0);
+            if (textMode) {
+                INFO("checking in text mode");
+            } else {
+                INFO("checking in binary mode");
+            }
+            con.setTextMode(textMode);
+
+            Header headerToWrite(55, realistic());
+            Stamp stampRead;
+
+            headerToWrite.write(con.getWriter());
+            stampRead.read(con.getReader());
+
+            CHECK(stampRead.getCount() == 55); // sequence number read
+            CHECK(stampRead.getTime() == Approx(realistic()).epsilon(0.0001)); // time stamp read
+        }
+    }
+
+    SECTION("checking Stamp can serialize to a Header")
+    {
+        for (int i=0; i<=1; i++) {
+            DummyConnector con;
+
+            bool textMode = (i==0);
+            if (textMode) {
+                INFO("checking in text mode");
+            } else {
+                INFO("checking in binary mode");
+            }
+            con.setTextMode(textMode);
+
+            Stamp stampToWrite(55, realistic());
+            Header headerRead(42, 1.0, "theFrameId");
+
+            stampToWrite.write(con.getWriter());
+            headerRead.read(con.getReader());
+
+            CHECK(headerRead.count() == 55); // sequence number read
+            CHECK(headerRead.timeStamp() == Approx(realistic()).epsilon(0.0001)); // time stamp read
+            CHECK(headerRead.frameId().empty()); // frame id read is empty
+        }
+    }
+
+    SECTION("checking envelopes work...")
+    {
+        checkEnvelope("tcp");
+    }
+
+    SECTION("checking envelopes work (text mode)")
+    {
+        checkEnvelope("text");
+    }
+
+    SECTION("check string serialization")
+    {
+        Header env(42, 3.0);
+        BufferedConnectionWriter buf(true);
+        env.write(buf);
+        std::string str = buf.toString();
+        Bottle bot(str.c_str());
+        CHECK(bot.get(0).asInt32() == 42); // sequence ok
+        CHECK(bot.get(1).asFloat64() == Approx(3)); // time ok
+    }
+
+    Network::setLocalMode(false);
+}


### PR DESCRIPTION
## Libraries

### yarp::os

* Introduced the `yarp::os::Header` class, intended to gradually replace the `yarp::os::Stamp` class to handle envelopes, maintaining backwards compatibility.
  The differences with the `Stamp` class:
  * `Header` has an extra field to handle the frame id, making it comparable with ROS [`std_msgs/Header`](http://docs.ros.org/en/api/std_msgs/html/msg/Header.html) message.
  * The counter uses unsigned int instead of int.
  * `Stamp::getMaxCount()` is replaced with `Header::npos`
  * `Stamp::getCount()` is replaced with `Header::count()`
  * `Stamp::getTime()` is replaced with `Header::timeStamp()`