### PR TITLE
Fix installation path of Python bindings

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
 endif()
 
 install(FILES ${CMAKE_BINARY_DIR}/lib/python3/yarp.py
-        DESTINATION ${Python3_INSTDIR})
+        DESTINATION ${CMAKE_INSTALL_PYTHON3DIR})
 
 
 # Update RPATH

--- a/doc/release/yarp_3_4/fix_cmake_install_python.md
+++ b/doc/release/yarp_3_4/fix_cmake_install_python.md
@@ -1,0 +1,6 @@
+fix_cmake_install_python {#yarp_3_4}
+--------------
+
+## Build System
+
+* Fixed use of `CMAKE_INSTALL_PYTHON3DIR` CMake variable to specify the installation path of Python bindings, as in previous versions the variable was defined but ignored (https://github.com/robotology/yarp/pull/2523).


### PR DESCRIPTION
As mentioned in https://github.com/robotology/yarp/issues/2511#issuecomment-787429494 , the `CMAKE_INSTALL_PYTHON3DIR` variable was defined but never used. This PR does not change the default behaviour (as `CMAKE_INSTALL_PYTHON3DIR` default value is `${Python3_INSTDIR}`), but it permits users to specify the location where to install the Python bindings.