### PR TITLE
Fix compilation of YARP Python bindings on Windows

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -12,12 +12,6 @@ set(CMAKE_SWIG_FLAGS "-module;yarp;-threads;${SWIG_COMMON_FLAGS}")
 
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-## in Windows it seems necessary to declare explictly the link_directory
-if(WIN32)
-  get_filename_component(Python3_DIR ${Python3_LIBRARY} DIRECTORY)
-  link_directories(${Python3_DIR})
-endif()
-
 set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/python3")
 set(SWIG_OUTFILE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/doc/release/yarp_3_4/fix_python_bindings_windows.md
+++ b/doc/release/yarp_3_4/fix_python_bindings_windows.md
@@ -1,0 +1,6 @@
+fix_python_bindings_windows {#yarp_3_4}
+--------------
+
+## Build System
+
+* Fixed the build of Python bindings on Windows (https://github.com/robotology/yarp/pull/2525).


### PR DESCRIPTION
Without this fix, the compilation of Python bindings is failing with error:
~~~
2021-03-22T08:34:49.9037393Z   -- Found Python3: C:/Miniconda/envs/test/python.exe (found version "3.9.2") found components: Interpreter Development Development.Module Development.Embed 
2021-03-22T08:34:49.9045986Z   CMake Error at bindings/python/CMakeLists.txt:17 (get_filename_component):
2021-03-22T08:34:49.9047185Z     get_filename_component called with incorrect number of arguments
2021-03-22T08:34:49.9047925Z   
2021-03-22T08:34:49.9079080Z   -- Configuring incomplete, errors occurred!
~~~

The reason is that for the modern `FindPython3` CMake module `Python3_LIBRARY` is not an output, so the code does not work. However, the whole logic seems not to be necessary anymore with modern CMake and modern Python (tested with Python 3.9), so I think we can just remove it altogether. 