### PR TITLE
mp3Sound portmonitor

### DIFF
--- a/doc/release/master/mp3Sound_portmonitor.md
+++ b/doc/release/master/mp3Sound_portmonitor.md
@@ -1,0 +1,10 @@
+mp3sound_portmonitor {#master}
+-------------------------
+
+## Important Changes
+
+### portmonitors
+
+* added new portmonitor `mp3sound` to decompress a mp3 bytestream to `yarp::sig::Sound`. Encoding not suppoerted yet.
+
+

--- a/src/carriers/CMakeLists.txt
+++ b/src/carriers/CMakeLists.txt
@@ -26,6 +26,7 @@ yarp_begin_plugin_library(yarpcar OPTION YARP_COMPILE_CARRIER_PLUGINS
   add_subdirectory(h264_carrier)
   add_subdirectory(unix)
   add_subdirectory(libffmpeg_portmonitor)
+  add_subdirectory(mp3Sound_portmonitor)
 yarp_end_plugin_library(yarpcar QUIET)
 add_library(YARP::yarpcar ALIAS yarpcar)
 

--- a/src/carriers/mp3Sound_portmonitor/CMakeLists.txt
+++ b/src/carriers/mp3Sound_portmonitor/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(mp3Sound TYPE Mp3SoundConverter
+                                INCLUDE Mp3Sound.h
+                                CATEGORY portmonitor
+                                DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_FFMPEG")
+
+if(NOT SKIP_mp3Sound)
+  yarp_add_plugin(yarp_pm_mp3Sound)
+
+  target_sources(yarp_pm_mp3Sound PRIVATE Mp3Sound.cpp
+                                          Mp3Sound.h)
+  target_link_libraries(yarp_pm_mp3Sound PRIVATE YARP::YARP_os
+                                                 YARP::YARP_sig)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_sig)
+
+  target_include_directories(yarp_pm_mp3Sound SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIR})
+  target_link_libraries(yarp_pm_mp3Sound PRIVATE ${FFMPEG_LIBRARIES})
+
+  yarp_install(TARGETS yarp_pm_mp3Sound
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_pm_mp3Sound PROPERTY FOLDER "Plugins/Port Monitor")
+endif()

--- a/src/carriers/mp3Sound_portmonitor/Mp3Sound.cpp
+++ b/src/carriers/mp3Sound_portmonitor/Mp3Sound.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "Mp3Sound.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <yarp/os/LogComponent.h>
+#include <yarp/sig/SoundFile.h>
+
+using namespace yarp::os;
+using namespace yarp::sig;
+
+namespace {
+YARP_LOG_COMPONENT(MP3TOSOUND,
+                   "yarp.carrier.portmonitor.mp3Sound",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)
+}
+
+bool Mp3SoundConverter::create(const yarp::os::Property& options)
+{
+    senderSide = (options.find("sender_side").asBool());
+    return true;
+}
+
+void Mp3SoundConverter::destroy()
+{
+}
+
+bool Mp3SoundConverter::setparam(const yarp::os::Property& params)
+{
+    return false;
+}
+
+bool Mp3SoundConverter::getparam(yarp::os::Property& params)
+{
+    return false;
+}
+
+bool Mp3SoundConverter::accept(yarp::os::Things& thing)
+{
+    if (senderSide)
+    {
+        yCError(MP3TOSOUND, "accept(): Sender side not yet supported!");
+        return false;
+    }
+    else
+    {
+        auto* bot = thing.cast_as<Bottle>();
+        if(bot == nullptr || bot->size()!=1)
+        {
+            yCError(MP3TOSOUND, "Data cannot be accepted!");
+            return false;
+        }
+    }
+    return true;
+}
+
+yarp::os::Things& Mp3SoundConverter::update(yarp::os::Things& thing)
+{
+    if (senderSide)
+    {
+        yCError(MP3TOSOUND, "update(): Sender side not yet supported!");
+    }
+    else
+    {
+        yarp::os::Bottle* bot = thing.cast_as<Bottle>();
+        if (bot)
+        {
+            const char* binary_data = bot->get(0).asBlob();
+            size_t length = bot->get(0).asBlobLength();
+
+            yarp::sig::file::read_bytestream(snd, binary_data, length, ".mp3");
+        }
+        else
+        {
+            yCError(MP3TOSOUND, "Conversion failed!");
+        }
+    }
+
+    th.setPortWriter(&snd);
+    return th;
+}

--- a/src/carriers/mp3Sound_portmonitor/Mp3Sound.h
+++ b/src/carriers/mp3Sound_portmonitor/Mp3Sound.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_MP3SOUND_CONVERTER_H
+#define YARP_MP3SOUND_CONVERTER_H
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Things.h>
+#include <yarp/sig/Sound.h>
+#include <yarp/os/MonitorObject.h>
+
+//example usage:
+//yarp connect /src /dest tcp+recv.portmonitor+type.dll+file.mp3Sound
+
+class Mp3SoundConverter : public yarp::os::MonitorObject
+{
+public:
+    bool create(const yarp::os::Property& options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property& params) override;
+    bool getparam(yarp::os::Property& params) override;
+
+    bool accept(yarp::os::Things& thing) override;
+    yarp::os::Things& update(yarp::os::Things& thing) override;
+
+private:
+    bool senderSide;
+    yarp::sig::Sound snd;
+    yarp::os::Things th;
+};
+
+#endif  // YARP_MP3SOUND_CONVERTER_H


### PR DESCRIPTION
Added new portmonitor `mp3Sound` to decompress a mp3 bytestream to `yarp::sig::Sound`

- [x] to be rebased after https://github.com/robotology/yarp/pull/2519 has been merged