### PR TITLE
Fix issues with FFMPEG libraries

### DIFF
--- a/.ci/initial-cache.gh.linux.cmake
+++ b/.ci/initial-cache.gh.linux.cmake
@@ -29,6 +29,7 @@ set(ENABLE_yarpcar_segmentationimage ON CACHE BOOL "")
 set(ENABLE_yarpcar_h264 ON CACHE BOOL "" ON CACHE BOOL "")
 set(ENABLE_yarpcar_unix_stream ON CACHE BOOL "")
 set(ENABLE_yarpcar_libffmpeg ON CACHE BOOL "")
+set(ENABLE_yarpcar_mp3Sound ON CACHE BOOL "")
 
 set(ENABLE_yarpmod_AudioPlayerWrapper ON CACHE BOOL "")
 set(ENABLE_yarpmod_AudioRecorderWrapper ON CACHE BOOL "")

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,0 +1,195 @@
+#[==[
+Provides the following variables:
+
+  * `FFMPEG_INCLUDE_DIRS`: Include directories necessary to use FFMPEG.
+  * `FFMPEG_LIBRARIES`: Libraries necessary to use FFMPEG. Note that this only
+    includes libraries for the components requested.
+  * `FFMPEG_VERSION`: The version of FFMPEG found.
+
+The following components are supported:
+
+  * `avcodec`
+  * `avdevice`
+  * `avfilter`
+  * `avformat`
+  * `avresample`
+  * `avutil`
+  * `swresample`
+  * `swscale`
+
+For each component, the following are provided:
+
+  * `FFMPEG_<component>_FOUND`: Libraries for the component.
+  * `FFMPEG_<component>_INCLUDE_DIRS`: Include directories for
+    the component.
+  * `FFMPEG_<component>_LIBRARIES`: Libraries for the component.
+  * `FFMPEG::<component>`: A target to use with `target_link_libraries`.
+
+Note that only components requested with `COMPONENTS` or `OPTIONAL_COMPONENTS`
+are guaranteed to set these variables or provide targets.
+#]==]
+
+function (_ffmpeg_find component headername)
+  find_path("FFMPEG_${component}_INCLUDE_DIR"
+    NAMES
+      "lib${component}/${headername}"
+    PATHS
+      "${FFMPEG_ROOT}/include"
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /usr/local/include
+      /usr/include
+      /sw/include # Fink
+      /opt/local/include # DarwinPorts
+      /opt/csw/include # Blastwave
+      /opt/include
+      /usr/freeware/include
+    PATH_SUFFIXES
+      ffmpeg
+    DOC "FFMPEG's ${component} include directory")
+  mark_as_advanced("FFMPEG_${component}_INCLUDE_DIR")
+
+  # On Windows, static FFMPEG is sometimes built as `lib<name>.a`.
+  if (WIN32)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".lib")
+    list(APPEND CMAKE_FIND_LIBRARY_PREFIXES "" "lib")
+  endif ()
+
+  find_library("FFMPEG_${component}_LIBRARY"
+    NAMES
+      "${component}"
+    PATHS
+      "${FFMPEG_ROOT}/lib"
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /usr/local/lib
+      /usr/local/lib64
+      /usr/lib
+      /usr/lib64
+      /sw/lib
+      /opt/local/lib
+      /opt/csw/lib
+      /opt/lib
+      /usr/freeware/lib64
+      "${FFMPEG_ROOT}/bin"
+    DOC "FFMPEG's ${component} library")
+  mark_as_advanced("FFMPEG_${component}_LIBRARY")
+
+  if (FFMPEG_${component}_LIBRARY AND FFMPEG_${component}_INCLUDE_DIR)
+    set(_deps_found TRUE)
+    set(_deps_link)
+    foreach (_ffmpeg_dep IN LISTS ARGN)
+      if (TARGET "FFMPEG::${_ffmpeg_dep}")
+        list(APPEND _deps_link "FFMPEG::${_ffmpeg_dep}")
+      else ()
+        set(_deps_found FALSE)
+      endif ()
+    endforeach ()
+    if (_deps_found)
+      if (NOT TARGET "FFMPEG::${component}")
+        add_library("FFMPEG::${component}" UNKNOWN IMPORTED)
+        set_target_properties("FFMPEG::${component}" PROPERTIES
+          IMPORTED_LOCATION "${FFMPEG_${component}_LIBRARY}"
+          INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_${component}_INCLUDE_DIR}"
+          IMPORTED_LINK_INTERFACE_LIBRARIES "${_deps_link}")
+      endif ()
+      set("FFMPEG_${component}_FOUND" 1
+        PARENT_SCOPE)
+
+      set(version_header_path "${FFMPEG_${component}_INCLUDE_DIR}/lib${component}/version.h")
+      if (EXISTS "${version_header_path}")
+        string(TOUPPER "${component}" component_upper)
+        file(STRINGS "${version_header_path}" version
+          REGEX "#define  *LIB${component_upper}_VERSION_(MAJOR|MINOR|MICRO) ")
+        string(REGEX REPLACE ".*_MAJOR *\([0-9]*\).*" "\\1" major "${version}")
+        string(REGEX REPLACE ".*_MINOR *\([0-9]*\).*" "\\1" minor "${version}")
+        string(REGEX REPLACE ".*_MICRO *\([0-9]*\).*" "\\1" micro "${version}")
+        if (NOT major STREQUAL "" AND
+            NOT minor STREQUAL "" AND
+            NOT micro STREQUAL "")
+          set("FFMPEG_${component}_VERSION" "${major}.${minor}.${micro}"
+            PARENT_SCOPE)
+        endif ()
+      endif ()
+    else ()
+      set("FFMPEG_${component}_FOUND" 0
+        PARENT_SCOPE)
+      set(what)
+      if (NOT FFMPEG_${component}_LIBRARY)
+        set(what "library")
+      endif ()
+      if (NOT FFMPEG_${component}_INCLUDE_DIR)
+        if (what)
+          string(APPEND what " or headers")
+        else ()
+          set(what "headers")
+        endif ()
+      endif ()
+      set("FFMPEG_${component}_NOT_FOUND_MESSAGE"
+        "Could not find the ${what} for ${component}."
+        PARENT_SCOPE)
+    endif ()
+  endif ()
+endfunction ()
+
+_ffmpeg_find(avutil     avutil.h)
+_ffmpeg_find(avresample avresample.h
+  avutil)
+_ffmpeg_find(swresample swresample.h
+  avutil)
+_ffmpeg_find(swscale    swscale.h
+  avutil)
+_ffmpeg_find(avcodec    avcodec.h
+  avutil)
+_ffmpeg_find(avformat   avformat.h
+  avcodec avutil)
+_ffmpeg_find(avfilter   avfilter.h
+  avutil)
+_ffmpeg_find(avdevice   avdevice.h
+  avformat avutil)
+
+if (TARGET FFMPEG::avutil)
+  set(_ffmpeg_version_header_path "${FFMPEG_avutil_INCLUDE_DIR}/libavutil/ffversion.h")
+  if (EXISTS "${_ffmpeg_version_header_path}")
+    file(STRINGS "${_ffmpeg_version_header_path}" _ffmpeg_version
+      REGEX "FFMPEG_VERSION")
+    string(REGEX REPLACE ".*\"n?\(.*\)\"" "\\1" FFMPEG_VERSION "${_ffmpeg_version}")
+    unset(_ffmpeg_version)
+  else ()
+    set(FFMPEG_VERSION FFMPEG_VERSION-NOTFOUND)
+  endif ()
+  unset(_ffmpeg_version_header_path)
+endif ()
+
+set(FFMPEG_INCLUDE_DIRS)
+set(FFMPEG_LIBRARIES)
+set(_ffmpeg_required_vars)
+foreach (_ffmpeg_component IN LISTS FFMPEG_FIND_COMPONENTS)
+  if (TARGET "FFMPEG::${_ffmpeg_component}")
+    set(FFMPEG_${_ffmpeg_component}_INCLUDE_DIRS
+      "${FFMPEG_${_ffmpeg_component}_INCLUDE_DIR}")
+    set(FFMPEG_${_ffmpeg_component}_LIBRARIES
+      "${FFMPEG_${_ffmpeg_component}_LIBRARY}")
+    list(APPEND FFMPEG_INCLUDE_DIRS
+      "${FFMPEG_${_ffmpeg_component}_INCLUDE_DIRS}")
+    list(APPEND FFMPEG_LIBRARIES
+      "${FFMPEG_${_ffmpeg_component}_LIBRARIES}")
+    if (FFMEG_FIND_REQUIRED_${_ffmpeg_component})
+      list(APPEND _ffmpeg_required_vars
+        "FFMPEG_${_ffmpeg_required_vars}_INCLUDE_DIRS"
+        "FFMPEG_${_ffmpeg_required_vars}_LIBRARIES")
+    endif ()
+  endif ()
+endforeach ()
+unset(_ffmpeg_component)
+
+if (FFMPEG_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES FFMPEG_INCLUDE_DIRS)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFMPEG
+  REQUIRED_VARS FFMPEG_INCLUDE_DIRS FFMPEG_LIBRARIES ${_ffmpeg_required_vars}
+  VERSION_VAR FFMPEG_VERSION
+  HANDLE_COMPONENTS)
+unset(_ffmpeg_required_vars)

--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -363,7 +363,7 @@ checkandset_dependency(OpenGL)
 find_package(FTDI QUIET)
 checkandset_dependency(FTDI)
 
-find_package(FFMPEG QUIET)
+find_package(FFMPEG COMPONENTS avcodec avutil OPTIONAL_COMPONENTS avformat avdevice QUIET)
 checkandset_dependency(FFMPEG)
 
 find_package(SDL QUIET)

--- a/src/carriers/libffmpeg_portmonitor/CMakeLists.txt
+++ b/src/carriers/libffmpeg_portmonitor/CMakeLists.txt
@@ -20,8 +20,9 @@ if(NOT SKIP_libffmpeg)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_sig)
 
-  target_include_directories(yarp_pm_libffmpeg SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIR})
-  target_link_libraries(yarp_pm_libffmpeg PRIVATE ${FFMPEG_LIBRARIES})
+  target_include_directories(yarp_pm_libffmpeg SYSTEM PRIVATE ${FFMPEG_avcodec_INCLUDE_DIRS})
+  target_link_libraries(yarp_pm_libffmpeg PRIVATE ${FFMPEG_avcodec_LIBRARIES})
+  # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets
 
   yarp_install(TARGETS yarp_pm_libffmpeg
                EXPORT YARP_${YARP_PLUGIN_MASTER}

--- a/src/carriers/mp3Sound_portmonitor/CMakeLists.txt
+++ b/src/carriers/mp3Sound_portmonitor/CMakeLists.txt
@@ -19,8 +19,9 @@ if(NOT SKIP_mp3Sound)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_sig)
 
-  target_include_directories(yarp_pm_mp3Sound SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIR})
-  target_link_libraries(yarp_pm_mp3Sound PRIVATE ${FFMPEG_LIBRARIES})
+  target_include_directories(yarp_pm_mp3Sound SYSTEM PRIVATE ${FFMPEG_avcodec_INCLUDE_DIRS})
+  target_link_libraries(yarp_pm_mp3Sound PRIVATE ${FFMPEG_avcodec_LIBRARIES})
+  # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets
 
   yarp_install(TARGETS yarp_pm_mp3Sound
                EXPORT YARP_${YARP_PLUGIN_MASTER}

--- a/src/devices/ffmpeg/CMakeLists.txt
+++ b/src/devices/ffmpeg/CMakeLists.txt
@@ -10,12 +10,12 @@ yarp_prepare_plugin(ffmpeg_grabber
                     TYPE FfmpegGrabber
                     INCLUDE FfmpegGrabber.h
                     EXTRA_CONFIG WRAPPER=grabberDual
-                    DEPENDS "YARP_HAS_FFMPEG")
+                    DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND")
 yarp_prepare_plugin(ffmpeg_writer
                     CATEGORY device
                     TYPE FfmpegWriter
                     INCLUDE FfmpegWriter.h
-                    DEPENDS "YARP_HAS_FFMPEG")
+                    DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND")
 
 if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
   yarp_add_plugin(yarp_ffmpeg)
@@ -34,9 +34,13 @@ if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
                                                       YARP_sig
                                                       YARP_dev)
 
-  target_include_directories(yarp_ffmpeg SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIR})
-  target_link_libraries(yarp_ffmpeg PRIVATE ${FFMPEG_LIBRARIES})
-#   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) (not using targets)
+  target_include_directories(yarp_ffmpeg SYSTEM PRIVATE ${FFMPEG_avcodec_INCLUDE_DIRS}
+                                                        ${FFMPEG_avformat_INCLUDE_DIRS}
+                                                        ${FFMPEG_avdevice_INCLUDE_DIRS})
+  target_link_libraries(yarp_ffmpeg PRIVATE ${FFMPEG_avcodec_LIBRARIES}
+                                            ${FFMPEG_avformat_LIBRARIES}
+                                            ${FFMPEG_avdevice_LIBRARIES})
+  # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets
 
   if(MINGW)
     target_link_libraries(yarp_ffmpeg PRIVATE ws2_32)

--- a/src/libYARP_sig/src/CMakeLists.txt
+++ b/src/libYARP_sig/src/CMakeLists.txt
@@ -107,10 +107,12 @@ if(YARP_HAS_PNG)
 endif()
 
 if (YARP_HAS_FFMPEG)
-  target_include_directories(YARP_sig SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIR})
+  target_include_directories(YARP_sig SYSTEM PRIVATE ${FFMPEG_avcodec_INCLUDE_DIRS}
+                                                     ${FFMPEG_avutil_INCLUDE_DIRS})
   target_compile_definitions(YARP_sig PRIVATE YARP_HAS_FFMPEG)
-  target_link_libraries(YARP_sig PRIVATE ${FFMPEG_LIBRARIES})
-  list(APPEND YARP_sig_PRIVATE_DEPS FFMPEG)
+  target_link_libraries(YARP_sig PRIVATE ${FFMPEG_avcodec_LIBRARIES}
+                                         ${FFMPEG_avutil_LIBRARIES})
+  # list(APPEND YARP_sig_PRIVATE_DEPS FFMPEG) # Not using targets
 endif()
 
 set_property(TARGET YARP_sig PROPERTY PUBLIC_HEADER ${YARP_sig_HDRS})

--- a/tests/misc/check_license_skip.txt
+++ b/tests/misc/check_license_skip.txt
@@ -2,3 +2,4 @@ bindings/java/examples/matlab/simulink/sfun_time.c
 bindings/lua/argcargv.i
 src/devices/opencv/OpenCVGrabber.cpp
 src/devices/opencv/OpenCVGrabber.h
+cmake/FindFFMPEG.cmake


### PR DESCRIPTION
Import the latest FindFFMPEG.cmake from VTK, and use the targets from
this module.

WARNING: This file should be imported in YCM, but it requires a bit of
caution, since it breaks the calls to `find_package(FFMPEG)` without
`COMPONENTS`.

Fixes #2529