### PR TITLE
fixed bug in YarpPluginSelector::scan()

### DIFF
--- a/doc/release/yarp_3_4/fix_race_condition_scan_plugin.md
+++ b/doc/release/yarp_3_4/fix_race_condition_scan_plugin.md
@@ -1,0 +1,6 @@
+fix_race_condition_yarp_scan_plugin {#yarp_3_4}
+--------------
+
+## Build System
+
+* Fixed error in race condition during the scan of plugins in YarpPluginSelector, avoided concurrent access to variables.

--- a/doc/release/yarp_3_4/fix_race_condition_scan_plugin.md
+++ b/doc/release/yarp_3_4/fix_race_condition_scan_plugin.md
@@ -1,6 +1,8 @@
 fix_race_condition_yarp_scan_plugin {#yarp_3_4}
 --------------
 
-## Build System
+## libraries
+
+## yarp_os
 
 * Fixed error in race condition during the scan of plugins in YarpPluginSelector, avoided concurrent access to variables.

--- a/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
+++ b/src/libYARP_os/src/yarp/os/YarpPlugin.cpp
@@ -229,6 +229,9 @@ void YarpPluginSelector::scan()
 
     // Search plugins directories
     ResourceFinder& rf = ResourceFinder::getResourceFinderSingleton();
+    static std::mutex rf_mutex;
+    std::lock_guard<std::mutex> rf_guard(rf_mutex);
+
     if (!rf.isConfigured()) {
         rf.configure(0, nullptr);
     }


### PR DESCRIPTION
added a static mutex in order to avoid multiple concurrent accesses to singleton instance (ResourceFinder::getResourceFinderSingleton())