### PR TITLE
yarp: Add emergency sub-command

### DIFF
--- a/doc/release/master/yarp_emergency_cmd.md
+++ b/doc/release/master/yarp_emergency_cmd.md
@@ -1,0 +1,12 @@
+yarp_emergency_cmd {#master}
+------------------
+
+## Tools
+
+### `yarp`
+
+* Added `emergency` sub-command
+  This command calls an emergency meeting and try to determine the impostor
+  port.
+  Each open port gets a vote, and the port who receives more votes is ejected
+  from YARP.

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(YARP_companion_IMPL_SRCS yarp/companion/impl/Companion.cpp
                              yarp/companion/impl/Companion.cmdConnect.cpp
                              yarp/companion/impl/Companion.cmdDetect.cpp
                              yarp/companion/impl/Companion.cmdDisconnect.cpp
+                             yarp/companion/impl/Companion.cmdEmergency.cpp
                              yarp/companion/impl/Companion.cmdEnv.cpp
                              yarp/companion/impl/Companion.cmdExists.cpp
                              yarp/companion/impl/Companion.cmdHelp.cpp

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdEmergency.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdEmergency.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/companion/impl/Companion.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Value.h>
+#include <yarp/os/Vocab.h>
+#include <yarp/os/impl/NameConfig.h>
+
+#include <algorithm>
+
+using yarp::companion::impl::Companion;
+using yarp::os::Bottle;
+using yarp::os::NetworkBase;
+using yarp::os::Value;
+using yarp::os::impl::NameConfig;
+
+
+int Companion::cmdEmergency(int argc, char* argv[])
+{
+    YARP_UNUSED(argc);
+    YARP_UNUSED(argv);
+
+    yCInfo(COMPANION);
+    yCInfo(COMPANION, " --- EMERGENCY MEETING ---");
+    yCInfo(COMPANION);
+
+    NameConfig nc;
+    std::string name = nc.getNamespace();
+    Bottle msg;
+    Bottle reply;
+    msg.addString("bot");
+    msg.addString("list");
+    NetworkBase::write(name, msg, reply);
+
+    msg.clear();
+    msg.addVocab(yarp::os::createVocab('e', 'm', 'e', 'r'));
+    Bottle& ports = msg.addList();
+    std::map<size_t, size_t> votes;
+
+    for (size_t i = 1 /* 0 is the string "ports" */; i < reply.size(); i++) {
+        Bottle* entry = reply.get(i).asList();
+        if (entry != nullptr) {
+            std::string port = entry->check("name", Value("")).asString();
+            if (!port.empty() && port != "fallback") {
+                ports.addString(port);
+                votes[ports.size() - 1] = 0;
+            }
+        }
+    }
+
+    if (ports.size() < 3) {
+        yCInfo(COMPANION, "No one was ejected. (Skipped)");
+        return -1;
+    }
+
+    for (size_t i = 0; i < ports.size(); i++) {
+        auto port = ports.get(i).asString();
+        NetworkBase::write(port, msg, reply, true);
+        yCInfo(COMPANION, "<%s> %s", ports.get(i).asString().c_str(), reply.get(1).asString().c_str());
+
+        size_t index = reply.get(0).asInt32();
+        votes[index]++;
+    }
+    yCInfo(COMPANION);
+
+    auto max = std::max_element(votes.begin(),
+                                votes.end(),
+                                [] (const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b) -> bool { return a.second < b.second; } );
+    auto rmax = std::max_element(votes.rbegin(),
+                                votes.rend(),
+                                [] (const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b) -> bool { return a.second < b.second; } );
+
+    if (max->first != rmax->first) {
+        yCInfo(COMPANION, "No one was ejected. (Tie)");
+        yCInfo(COMPANION);
+        return -1;
+    }
+
+    auto impostor = ports.get(max->first).asString();
+    NetworkBase::unregisterName(impostor);
+    yCInfo(COMPANION, "%s was ejected.", impostor.c_str());
+    yCInfo(COMPANION);
+    yCInfo(COMPANION, "%s was not The Impostor.", impostor.c_str());
+    yCInfo(COMPANION);
+
+    return 0;
+}

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -143,6 +143,7 @@ Companion::Companion() :
     add("connect",         &Companion::cmdConnect,        "create a connection between two ports");
     add("detect",          &Companion::cmdDetect,         "search for the yarp name server");
     add("disconnect",      &Companion::cmdDisconnect,     "remove a connection between two ports");
+    add("emergency",       &Companion::cmdEmergency,      "call an emergency meeting");
     add("env",             &Companion::cmdEnv,            "print the value of environment variables");
     add("exists",          &Companion::cmdExists,         "check if a port or connection is alive");
     add("help",            &Companion::cmdHelp,           "get this list");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -75,6 +75,9 @@ public:
     // Defined in Companion.cmdExists.cpp
     int cmdExists(int argc, char *argv[]);
 
+    // Defined in Companion.cmdEmergency.cpp
+    int cmdEmergency(int argc, char *argv[]);
+
     // Defined in Companion.cmdHelp.cpp
     int cmdHelp(int argc, char *argv[]);
 


### PR DESCRIPTION
Following up the discussion about IP Theft (#2520), this patch introduces a simple way to try determine which port is the `impostor` port. This method is not 100% guaranteed to work, there is a chance to make things worse, but in some cases it is worth giving it a try.

## Tools

### `yarp`

* Added `emergency` sub-command
  This command calls an emergency meeting and try to determine the impostor port.
  Each open port gets a vote, and the port who receives more votes is ejected from YARP.

![image](https://user-images.githubusercontent.com/1100056/113294587-76a47980-92f7-11eb-87fc-e444cb24cd83.png)

![213-YARPino-sus](https://user-images.githubusercontent.com/1100056/113294751-aeabbc80-92f7-11eb-88dd-f958ac50ce5e.png)
