### PR TITLE
fix_yarplogger_clear

### DIFF
--- a/doc/release/yarp_3_4/fix_yarplogger_clear.md
+++ b/doc/release/yarp_3_4/fix_yarplogger_clear.md
@@ -1,0 +1,9 @@
+fix_yarplogger_clear {#yarp_3_4}
+-------------------
+
+### Tools
+
+#### `yarplogger`
+
+* Yarplogger does not crash anymore when attempting to clear a selected log with its log tab opened.
+

--- a/src/yarplogger/logmodel.cpp
+++ b/src/yarplogger/logmodel.cpp
@@ -405,7 +405,7 @@ void LogModel::clear()
 {
     beginResetModel();
     this->m_messages.clear();
-    endInsertRows();
+    endResetModel();
 }
 
 QString LogModel::logLevelToString(yarp::yarpLogger::LogLevel l)


### PR DESCRIPTION
Now yarplogger does not crash anymore when attempting to clear a
selected log with its log tab opened