### PR TITLE
Move directories specifications in yarp::conf

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -28,6 +28,7 @@
 #include <yarp/conf/numeric.h>
 #include <yarp/conf/string.h>
 #include <yarp/conf/environment.h>
+#include <yarp/conf/dirs.h>
 %}
 
 %include "yarp/conf/version.h"
@@ -35,9 +36,9 @@
 %import "yarp/conf/system.h"
 %import "yarp/conf/api.h"
 %import "yarp/conf/numeric.h"
-%import <yarp/conf/string.h>
-%import <yarp/conf/environment.h>
-
+%include "yarp/conf/string.h"
+%include "yarp/conf/environment.h"
+%include "yarp/conf/dirs.h"
 
 // YARP_os
 %{

--- a/doc/release/conf_dirs.md
+++ b/doc/release/conf_dirs.md
@@ -1,0 +1,63 @@
+conf_dirs {#master}
+---------
+
+
+Deprecation and Behaviour Changes
+---------------------------------
+
+* A few default values for the environment variables used by yarp are now
+  different:
+  * Linux:
+    * `YARP_CONFIG_DIRS` defaults to `/etc/xdg/yarp` to be compliant with the
+      [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+  * Windows:
+    * `YARP_DATA_DIRS` defaults to `%%ALLUSERSPROFILE%%\yarp`
+    * `YARP_CONFIG_DIRS` defaults to `%%ALLUSERSPROFILE%%\yarp\config`
+
+
+New Features
+------------
+
+## Libraries
+
+### `conf`
+
+* Added the new `dirs.h` file with methods to retrieve the important folders
+* Added the following methods:
+   * `std::string yarp::conf::dirs::home()`
+   * `std::string yarp::conf::dirs::tempdir()`
+   * `std::string yarp::conf::dirs::datahome()`
+   * `std::vector<std::string> yarp::conf::dirs::datadirs()`
+   * `std::string yarp::conf::dirs::confighome()`
+   * `std::vector<std::string> yarp::conf::dirs::configdirs()`
+   * `std::string yarp::conf::dirs::cachehome()`
+   * `std::string yarp::conf::dirs::runtimedir()`
+   * `std::string yarp::conf::dirs::yarpdatahome()`
+   * `std::vector<std::string> yarp::conf::dirs::yarpdatadirs()`
+   * `std::string yarp::conf::dirs::yarpconfighome()`
+   * `std::vector<std::string> yarp::conf::dirs::yarpconfigdirs()`
+   * `std::string yarp::conf::dirs::yarpcachehome()`
+   * `std::string yarp::conf::dirs::yarpruntimedir()`
+
+### `os`
+
+#### `ResourceFinder`
+
+* Deprecated methods with alternatives in `yarp::conf::dirs`.
+  The following methods are now deprecated:
+    * `yarp::os::ResourceFinder::getDataHome()`
+    * `yarp::os::ResourceFinder::getDataHomeNoCreate()`
+    * `yarp::os::ResourceFinder::getConfigHome()`
+    * `yarp::os::ResourceFinder::getConfigHomeNoCreate()`
+    * `yarp::os::ResourceFinder::getDataDirs()`
+    * `yarp::os::ResourceFinder::getConfigDirs()`
+  in favour of:
+    * `yarp::conf::dirs::yarpdatahome()`
+    * `yarp::conf::dirs::yarpconfighome()`
+    * `yarp::conf::dirs::yarpdatadirs()`
+  Warnings:
+    * The return value of `yarpdatadirs()` is different
+      (`std::vector<std::string>` instead of `std::string`).
+    * The `yarpdatahome()` and `yarpconfighome()` do not create the directory,
+      it must be created manually (for example with `yarp::os::mkdir_p()`) if
+      required.

--- a/doc/resource_finder_spec.dox
+++ b/doc/resource_finder_spec.dox
@@ -32,76 +32,9 @@ Broadly speaking, there are three ways in which the ResourceFinder operates to l
 When searching for files and directories, the ResourceFinder looks inside these directories in the above order, so that files modified by the user take precedence over installed ones.
 
 The default value for these variables is dependent on the operating system.
+See the documentation for the methods in the yarp::conf::dirs namespace for
+details.
 
-Linux
------
-
-Default values for Linux are based on the XDG Base Directory Specification (see <http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html>). They rely on XDG environment variables, whose default values are:
-
-<b>$XDG_DATA_HOME</b>:
-> \$HOME/.local/share/
-<b>$XDG_CONFIG_HOME</b>:
-> \$HOME/.config/
-<b>$XDG_DATA_DIRS</b>:
-> /usr/local/share/:/usr/share/
-<b>$XDG_CONFIG_DIRS</b>:
-> /etc/xdg/
-
-Default values for YARP are:
-
-<b>$YARP_DATA_HOME</b>:
-> $XDG_DATA_HOME + /yarp/
-<b>$YARP_CONFIG_HOME</b>:
-> $XDG_CONFIG_HOME + /yarp/
-<b>$YARP_DATA_DIRS</b>:
-> $XDG_DATA_DIRS + /yarp/ (appended to each dir)
-<b>$YARP_CONFIG_DIRS</b>:
-> $XDG_CONFIG_DIRS + /yarp/ (appended to each dir)
-> [NOTE: /etc/yarp is used as default instead of /etc/xdg/yarp ]
-
-Windows
--------
-
-The following environment variables (with their respective default values) are available on windows:
-
-<b>\%YARP_DIR%</b>:
-> `C:\Program Files\robotology\YARP_2.X.XX` or `C:\Program Files (x86)\robotology\YARP_2.X.XX` (Set by the installer or by the user)
-<b>\%HOMEPATH%</b>:
-> `C:\Users\<username>` or `C:\Documents and Settings\<username>` (User home)
-<b>\%APPDATA%</b>:
-> `%%HOMEPATH%\AppData\Roaming` (Windows 7) or `%%HOMEPATH%\Application Data` (Windows XP) (Location where applications should store their data by default)
-<b>\%ALLUSERSPROFILE%</b>:
-> `C:\ProgramData` (Windows Vista) or `C:\Documents and Settings\All Users` (Windows XP) (Location of the "All Users" or "Common" profile folder)
-
-Default values for YARP are therefore:
-
-<b>\%YARP\_DATA\_HOME%</b>:
-> `%%APPDATA%\yarp`
-<b>\%YARP\_CONFIG\_HOME%</b>:
-> `%%APPDATA%\yarp\config\`
-<b>\%YARP\_DATA\_DIRS%</b>:
-> `%%YARP_DIR%\share\yarp\`
-<b>\%YARP\_CONFIG\_DIRS%</b>:
-> `%%ALLUSERSPROFILE%\yarp\`
-
-macOS
------
-
-On macOS, the following environment variable is used:
-
-<b>$HOME</b>:
-> `/Users/<username>`
-
-Default values for YARP are therefore:
-
-<b>$YARP\_DATA\_HOME</b>:
-> `$HOME/Library/Application Support/yarp`
-<b>$YARP\_CONFIG\_HOME</b>:
-> `$HOME/Library/Preferences/yarp`
-<b>$YARP\_DATA\_DIRS</b>:
-> `/usr/local/share/yarp:/usr/share/yarp`
-<b>$YARP\_CONFIG\_DIRS</b>:
-> `/etc/yarp:/Library/Preferences/yarp`
 
 Configuration Files
 ===================

--- a/doc/yarp_env_variables.md
+++ b/doc/yarp_env_variables.md
@@ -9,7 +9,7 @@ Logger and print configuration
 ==============================
 
 | Environmental variable        | Description | Related documentation page |
-|:----------------------       :|:-----------:|:--------------------------:|
+|:-----------------------------:|:-----------:|:--------------------------:|
 | `YARP_QUIET`                  | If this variables exists and is set to a positive integer, it disables the (internal) YARP messages prints. Note: this variable **do not** modify the behavior of `yError`, `yDebug`, ... . | \ref yarp_log |
 | `YARP_VERBOSE`                | If this variables exists and is set to a nonnegative integer, it sets the verbosity level (the higher the integer, the more messages will be printed) for YARP messages prints. This variable is ignored if `YARP_QUIET` is set to a positive integer. Note: this variable **does not** modify the behavior of `yError`, `yDebug`, ... . | \ref yarp_log |
 | `YARP_COLORED_OUTPUT`         | If this variable exists and is set to 1, it enables the YARP colored prints. Otherwise disable the colored prints. | \ref yarp_log |
@@ -20,25 +20,56 @@ Logger and print configuration
 | `YARP_FORWARD_LOG_ENABLE`     | If this variable exists and is set to 1, enables the forwarding of log over ports to be used by the yarplogger. Otherwise disable the forwarding. | \ref yarp_log |
 
 
-Configuration files
+Directories
+===========
+
+| Environmental variable        | Description | Related documentation page |
+|:-----------------------------:|:-----------:|:--------------------------:|
+| `YARP_DATA_HOME`              | Directory where user-specific YARP data files should be written.                     | yarp::conf::dirs::yarpdatahome()   |
+| `YARP_CONFIG_HOME`            | Directory where user-specific YARP configuration files should be written.            | yarp::conf::dirs::yarpconfighome() |
+| `YARP_DATA_DIRS`              | Directories where YARP data files are be searched.                                   | yarp::conf::dirs::yarpdatadirs()   |
+| `YARP_CONFIG_DIRS`            | Directories where YARP configuration files are searched.                             | yarp::conf::dirs::yarpconfigdirs() |
+| `YARP_CACHE_HOME`             | Directory where user-specific non-essential (cached) YARP data should be written.    | yarp::conf::dirs::yarpcachehome()  |
+| `YARP_RUNTIME_DIR`            | Directory where user-specific runtime files and other file objects should be placed. | yarp::conf::dirs::yarpruntimedir() |
+
+
+Defaults for these variables depend on the operating system and on other
+environment variables. See the relative documentation to understand how these
+influence each variable
+
+| Environmental variables checked on Linux |
+|:-----------------------------:|
+| `XDG_CONFIG_HOME`             |
+| `XDG_DATA_HOME`               |
+| `XDG_CONFIG_DIRS`             |
+| `XDG_DATA_DIRS`               |
+| `XDG_CACHE_HOME`              |
+| `XDG_RUNTIME_DIR`             |
+| `USER`                        |
+| `HOME`                        |
+| `TMPDIR`                      |
+
+| Environmental variables checked on Windows |
+|:-----------------------------:|
+| `APPDATA`                     |
+| `LOCALAPPDATA`                |
+| `ALLUSERSPROFILE`             |
+| `USERNAME`                    |
+| `USERPROFILE`                 |
+| `TEMP`                        |
+
+| Environmental variables checked on macOS |
+|:-----------------------------:|
+| `USER`                        |
+| `TMPDIR`                      |
+| `HOME`                        |
+
+Robot Configuration
 ===================
 
 | Environmental variable        | Description | Related documentation page |
 |:-----------------------------:|:-----------:|:--------------------------:|
-| `YARP_CONFIG_HOME`            | Location where user config files are stored. | \ref resource_finder_spec |
-| `XDG_CONFIG_HOME`             | Location where user config files are stored (only if `YARP_CONFIG_HOME` is not set). | \ref resource_finder_spec |
-| `YARP_DATA_HOME`              | Location where user data files are stored. | \ref resource_finder_spec |
-| `XDG_DATA_HOME`               | Location where user data files are stored (only if `YARP_DATA_HOME` is not set). | \ref resource_finder_spec |
-| `YARP_CONFIG_DIRS`            | Locations where system administrator data and config files are stored. | \ref resource_finder_spec |
-| `XDG_CONFIG_DIRS`             | Locations where system administrator data and config files are stored (only if `YARP_CONFIG_DIRS` is not set). | \ref resource_finder_spec |
-| `YARP_DATA_DIRS`              | Locations where installed data and config files are stored. | \ref resource_finder_spec |
-| `XDG_DATA_DIRS`               | Locations where installed data and config files are stored (only if `YARP_DATA_DIRS` is not set). | \ref resource_finder_spec |
 | `YARP_ROBOT_NAME`             | Variable used to refer to the name of the specific robot used in the system, to load its specific configuration files. | \ref yarp_data_dirs |
-
-Note that more platform-specific non-YARP environmental variables are used when
-searching for YARP configuration files.
-See \ref resource_finder_spec for a full description of the environmental
-variables used for finding configuration files.
 
 
 UDP Carrier configuration

--- a/doc/yarp_plugins.dox
+++ b/doc/yarp_plugins.dox
@@ -126,12 +126,12 @@ code, in subdirectories of the `src/devices` and
 `src/carriers` directories.
 
 YARP is configured to aggregate `plugin.ini` files in a directory
-called `etc/yarp/plugins`.  The `ini` files are collected
+called `yarp/plugins`.  The `ini` files are collected
 in this directory irrespective of whether the corresponding plugins
 are compiled or not.  To add plugins not included with YARP, an `ini`
-file may be placed in `etc/yarp/plugins`.
+file may be placed in `yarp/plugins`.
 
-YARP looks for `etc/yarp/plugins` using
+YARP looks for `yarp/plugins` using
 a yarp::os::ResourceFinder.  If you don't already use configuration
 files with YARP, one way to get going would be to create a file
 in your home directory called `.yarp/plugins.ini` (or `yarp\plugins.ini` on Windows) containing:
@@ -146,7 +146,7 @@ and then set a `YARP_POLICY` environment variable to
 
 Each operating system has a convention for finding library files which
 YARP will also use (`LD_LIBRARY_PATH` etc), with one addition.
-Once the configuration files in `etc/yarp/plugins` can be
+Once the configuration files in `yarp/plugins` can be
 found, YARP will also use any "search" blocks it finds there.
 They look like this:
 \code

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdWrite.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdWrite.cpp
@@ -14,9 +14,9 @@
 #include <yarp/os/impl/Terminal.h>
 
 #ifdef YARP_HAS_Libedit
+#include <yarp/conf/dirs.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/Os.h>
-#include <yarp/os/ResourceFinder.h>
 #include <yarp/os/impl/PlatformUnistd.h>
 #include <yarp/os/impl/PlatformStdio.h>
 #include <algorithm>
@@ -28,10 +28,6 @@ using yarp::os::Bottle;
 using yarp::os::Port;
 using yarp::os::SystemClock;
 
-#ifdef YARP_HAS_Libedit
-using yarp::os::ResourceFinder;
-#endif
-
 int Companion::write(const char *name, int ntargets, char *targets[]) {
     Port port;
     applyArgs(port);
@@ -41,14 +37,11 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
     bool disable_file_history=false;
     if (yarp::os::impl::isatty(yarp::os::impl::fileno(stdin))) //if interactive mode
     {
-        hist_file=yarp::os::ResourceFinder::getDataHome();
-        std::string slash{yarp::conf::filesystem::preferred_separator};
-        hist_file += slash;
-        hist_file += "yarp_write";
+        auto yarpdatahome = yarp::conf::dirs::yarpdatahome();
+        std::string hist_file = yarpdatahome + yarp::conf::filesystem::preferred_separator + "yarp_write";
         if (yarp::os::mkdir_p(hist_file.c_str(), 1) != 0)
         {
-            yCError(COMPANION, "Unable to create directory into \"%s\"",
-                    yarp::os::ResourceFinder::getDataHome().c_str());
+            yCError(COMPANION, "Unable to create directory into \"%s\"", yarpdatahome.c_str());
             return 1;
         }
         std::string temp;
@@ -58,7 +51,7 @@ int Companion::write(const char *name, int ntargets, char *targets[]) {
             temp = "any";
         }
         std::replace(temp.begin(), temp.end(), '/', '_');
-        hist_file += slash;
+        hist_file += yarp::conf::filesystem::preferred_separator;
         hist_file += temp;
         read_history(hist_file.c_str());
         disable_file_history=false;

--- a/src/libYARP_conf/src/yarp/conf/dirs.h
+++ b/src/libYARP_conf/src/yarp/conf/dirs.h
@@ -1,0 +1,385 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#ifndef YARP_CONF_DIRS_H
+#define YARP_CONF_DIRS_H
+
+#include <yarp/conf/filesystem.h>
+#include <yarp/conf/environment.h>
+
+#include <string>
+#include <vector>
+
+namespace yarp {
+namespace conf {
+namespace dirs {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+// Constants defining environment variables names
+static constexpr const char YARP_DATA_HOME[]{"YARP_DATA_HOME"};
+static constexpr const char YARP_DATA_DIRS[]{"YARP_DATA_DIRS"};
+static constexpr const char YARP_CONFIG_HOME[]{"YARP_CONFIG_HOME"};
+static constexpr const char YARP_CONFIG_DIRS[]{"YARP_CONFIG_DIRS"};
+static constexpr const char YARP_CACHE_HOME[]{"YARP_CACHE_HOME"};
+static constexpr const char YARP_RUNTIME_DIR[]{"YARP_RUNTIME_DIR"};
+
+static constexpr const char USER[]{"USER"};
+static constexpr const char USERNAME[]{"USERNAME"};
+static constexpr const char HOME[]{"HOME"};
+static constexpr const char USERPROFILE[]{"USERPROFILE"};
+static constexpr const char TMP[]{"TMP"};
+static constexpr const char TEMP[]{"TEMP"};
+static constexpr const char TMPDIR[]{"TMPDIR"};
+static constexpr const char XDG_DATA_HOME[]{"XDG_DATA_HOME"};
+static constexpr const char XDG_DATA_DIRS[]{"XDG_DATA_DIRS"};
+static constexpr const char XDG_CONFIG_HOME[]{"XDG_CONFIG_HOME"};
+static constexpr const char XDG_CONFIG_DIRS[]{"XDG_CONFIG_DIRS"};
+static constexpr const char XDG_CACHE_HOME[]{"XDG_CACHE_HOME"};
+static constexpr const char XDG_RUNTIME_DIR[]{"XDG_RUNTIME_DIR"};
+static constexpr const char APPDATA[]{"APPDATA"};
+static constexpr const char LOCALAPPDATA[]{"LOCALAPPDATA"};
+static constexpr const char ALLUSERSPROFILE[]{"ALLUSERSPROFILE"};
+
+// Paths and suffixes
+static constexpr const char XDG_DATA_HOME_SUFFIX[]{"/.local/share"};
+static constexpr const char XDG_CONFIG_HOME_SUFFIX[]{"/.config"};
+static constexpr const char XDG_CACHE_HOME_SUFFIX[]{"/.cache"};
+static constexpr const char XDG_DATA_DIRS_DEFAULT[]{"/usr/local/share:/usr/share"};
+static constexpr const char XDG_CONFIG_DIRS_DEFAULT[]{"/etc/xdg"};
+
+static constexpr const char UNIX_TMP_DIR_DEFAULT[]{"/tmp"};
+static constexpr const char WIN_APPDATA_SUFFIX[]{"\\AppData\\Roaming"};
+static constexpr const char WIN_LOCALAPPDATA_SUFFIX[]{"\\AppData\\Local"};
+static constexpr const char WIN_APPDATA_LOCAL_TEMP_SUFFIX[]{"\\AppData\\Local\\Temp"};
+static constexpr const char WIN_ALLUSERSPROFILE_DEFAULT[]{"C:\\ProgramData"};
+static constexpr const char MACOS_DATAHOME_SUFFIX[]{"/Library/Application Support"};
+static constexpr const char MACOS_CONFIGHOME_SUFFIX[]{"/Library/Preferences"};
+static constexpr const char MACOS_DATA_DIRS_DEFAULT[]{"/usr/local/share:/usr/share"};
+static constexpr const char MACOS_CONFIG_DIRS_DEFAULT[]{"/etc:/Library/Preferences"};
+static constexpr const char MACOS_CACHEHOME_SUFFIX[]{"/Library/Caches"};
+
+// FIXME C++17 Use string_view?
+static constexpr const char YARP_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'y', 'a', 'r', 'p', '\0' }; // "/yarp" or "\\yarp"
+static constexpr const char YARP_CONFIG_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'y', 'a', 'r', 'p', yarp::conf::filesystem::preferred_separator, 'c', 'o', 'n', 'f', 'i', 'g', '\0' }; // "yarp/config" or "\\yarp\\config"
+static constexpr const char RUNTIME_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'r', 'u', 'n', 't', 'i', 'm', 'e', '\0' };  // "/runtime" or "\\runtime"
+static constexpr const char RUNTIME_YARP_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'r', 'u', 'n', 't', 'i', 'm', 'e', yarp::conf::filesystem::preferred_separator, 'y', 'a', 'r', 'p', '\0' };  // "/runtime/yarp" or "\\runtime\\yarp"
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+/** @{ */
+// Basic paths
+
+/**
+ * @brief Returns the home directory for current user.
+ *
+ *  - Windows: `USERPROFILE` environment variable
+ *  - Others: `HOME` environment variable
+ *
+ * @since YARP 3.5
+ */
+inline std::string home()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(USERPROFILE);
+#else
+    return yarp::conf::environment::get_string(HOME);
+#endif
+}
+
+/**
+ * @brief Returns the directory for temporary files.
+ *
+ *  - Windows: `TEMP` or `TMP` environment variables (default: `[HOME]\AppData\Local\Temp`)
+ *  - Others: `TMPDIR` environment variables (default: `/tmp`)
+ *
+ * @since YARP 3.5
+ */
+inline std::string tempdir()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(TEMP, yarp::conf::dirs::home() + WIN_APPDATA_LOCAL_TEMP_SUFFIX);
+#else
+    return yarp::conf::environment::get_string(TMPDIR, UNIX_TMP_DIR_DEFAULT);
+#endif
+}
+
+
+/** @} */
+/** @{ */
+// XDG Base Directory specifications (and equivalents for windows and macos)
+
+/**
+ * @brief Returns the directory where user-specific data files should be
+ *        written.
+ *
+ *  - Windows: `APPDATA` environment variable (default: `[HOME]\AppData\Roaming`)
+ *  - macOS: `[HOME]/Library/Application Support`
+ *  - Others: `XDG_DATA_HOME` environment variable (default: `[HOME]/.local/share`)
+ *
+ * @since YARP 3.5
+ */
+inline std::string datahome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(APPDATA, yarp::conf::dirs::home() + WIN_APPDATA_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::dirs::home() + MACOS_DATAHOME_SUFFIX;
+#else
+    return yarp::conf::environment::get_string(XDG_DATA_HOME, yarp::conf::dirs::home() + XDG_DATA_HOME_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directories where data files should be searched.
+ *
+ *  - Windows: `ALLUSERSPROFILE` environment variable (default: `C:\\ProgramData`)
+ *  - macOS: `/usr/local/share:/usr/share`
+ *  - Others: `XDG_DATA_DIRS` environment variable (default: `/usr/local/share:/usr/share`)
+ *
+ * @since YARP 3.5
+ */
+inline std::vector<std::string> datadirs()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_path(ALLUSERSPROFILE, WIN_ALLUSERSPROFILE_DEFAULT);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::split_path(MACOS_DATA_DIRS_DEFAULT);
+#else
+    return yarp::conf::environment::get_path(XDG_DATA_DIRS, XDG_DATA_DIRS_DEFAULT);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific configuration files should
+ *        be written.
+ *
+ *  - Windows: `APPDATA` environment variable (default: `[HOME]\AppData\Roaming`)
+ *  - macOS: `[HOME]/Library/Preferences`
+ *  - Others: `XDG_CONFIG_HOME` environment variable (default: `[HOME]/.config`)
+ *
+ * @since YARP 3.5
+ */
+inline std::string confighome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(APPDATA, yarp::conf::dirs::home() + WIN_APPDATA_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::dirs::home() + MACOS_CONFIGHOME_SUFFIX;
+#else
+    return yarp::conf::environment::get_string(XDG_CONFIG_HOME, yarp::conf::dirs::home() + XDG_CONFIG_HOME_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directories where configuration files should be searched.
+ *
+ *  - Windows: `ALLUSERSPROFILE` environment variable (default: `C:\\ProgramData`)
+ *  - macOS: `/etc:/Library/Preferences`
+ *  - Others: `XDG_CONFIG_DIRS` environment variable (default: `/etc/xdg`)
+ *
+ * @since YARP 3.5
+ */
+inline std::vector<std::string> configdirs()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_path(ALLUSERSPROFILE, WIN_ALLUSERSPROFILE_DEFAULT);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::split_path(MACOS_CONFIG_DIRS_DEFAULT);
+#else
+    return yarp::conf::environment::get_path(XDG_CONFIG_DIRS, XDG_CONFIG_DIRS_DEFAULT);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific non-essential (cached) data
+ *        should be written.
+ *
+ *  - Windows: `LOCALAPPDATA` environment variable (default: `[HOME]\AppData\Local`)
+ *  - macOS: `[HOME]/Library/Caches`
+ *  - Others: `XDG_CACHE_HOME` environment variable (default: `[HOME]/.cache`)
+ *
+ * @since YARP 3.5
+ */
+inline std::string cachehome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(LOCALAPPDATA, yarp::conf::dirs::home() + WIN_LOCALAPPDATA_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::dirs::home() + MACOS_CACHEHOME_SUFFIX;
+#else
+    return yarp::conf::environment::get_string(XDG_CACHE_HOME, yarp::conf::dirs::home() + XDG_CACHE_HOME_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific runtime files and other file
+ *        objects should be placed.
+ *
+ *  - Windows: [TEMP]\runtime
+ *  - macOS: [TEMP]/runtime-[USER]
+ *  - Others: `XDG_RUNTIME_DIR` environment variable (default: `[TEMP]/runtime-[USER]`)
+ *
+ * @since YARP 3.5
+ */
+inline std::string runtimedir()
+{
+#if defined(_WIN32)
+    return yarp::conf::dirs::tempdir() + RUNTIME_SUFFIX;
+#elif defined(__APPLE__)
+    return yarp::conf::dirs::tempdir() + RUNTIME_SUFFIX + '-' + yarp::conf::environment::get_string(USER);
+#else
+    return yarp::conf::environment::get_string(XDG_RUNTIME_DIR, yarp::conf::dirs::tempdir() + RUNTIME_SUFFIX + '-' + yarp::conf::environment::get_string(USER));
+#endif
+}
+
+
+/** @} */
+/** @{ */
+// YARP Base Directory specifications
+
+/**
+ * @brief Returns the directory where user-specific YARP data files should be
+ *        written.
+ *
+ * Uses `YARP_DATA_HOME` environment variable, if defined.
+ * Otherwise uses the "yarp" folder inside the folder returned by
+ * yarp::conf::dirs::datahome()
+ *
+ * @since YARP 3.5
+ */
+inline std::string yarpdatahome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(YARP_DATA_HOME, APPDATA, yarp::conf::dirs::home() + WIN_APPDATA_SUFFIX, YARP_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_string(YARP_DATA_HOME, yarp::conf::dirs::home() + MACOS_DATAHOME_SUFFIX + YARP_SUFFIX);
+#else
+    return yarp::conf::environment::get_string(YARP_DATA_HOME, XDG_DATA_HOME, yarp::conf::dirs::home() + XDG_DATA_HOME_SUFFIX, YARP_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directories where YARP data files should be searched.
+ *
+ * Uses `YARP_DATA_DIRS` environment variable, if defined.
+ * Otherwise uses the "yarp" folder inside each folder returned by
+ * yarp::conf::dirs::datadirs()
+ *
+ * @since YARP 3.5
+ */
+inline std::vector<std::string> yarpdatadirs()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_path(YARP_DATA_DIRS, ALLUSERSPROFILE, WIN_ALLUSERSPROFILE_DEFAULT, YARP_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_path(YARP_DATA_DIRS, "", MACOS_DATA_DIRS_DEFAULT, YARP_SUFFIX);
+#else
+    return yarp::conf::environment::get_path(YARP_DATA_DIRS, XDG_DATA_DIRS, XDG_DATA_DIRS_DEFAULT, YARP_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific YARP configuration files
+ *        should be written.
+ *
+ * Uses `YARP_CONFIG_HOME` environment variable, if defined.
+ * Otherwise uses the `yarp` folder (`yarp\config` on Windows) inside the folder
+ * returned by yarp::conf::dirs::confighome()
+ *
+ * @since YARP 3.5
+ */
+inline std::string yarpconfighome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(YARP_CONFIG_HOME, APPDATA, yarp::conf::dirs::home() + WIN_APPDATA_SUFFIX, YARP_CONFIG_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_string(YARP_CONFIG_HOME, yarp::conf::dirs::home() + MACOS_CONFIGHOME_SUFFIX + YARP_SUFFIX);
+#else
+    return yarp::conf::environment::get_string(YARP_CONFIG_HOME, XDG_CONFIG_HOME, yarp::conf::dirs::home() + XDG_CONFIG_HOME_SUFFIX, YARP_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directories where YARP configuration files should be
+ *        searched.
+ *
+ * Uses `YARP_CONFIG_DIRS` environment variable, if defined.
+ * Otherwise uses the `yarp` folder (`yarp\config` on Windows) inside each
+ * folder returned by yarp::conf::dirs::configdirs()
+ *
+ * @warning On linux, if `XDG_CONFIG_DIRS` is not defined, the folder
+ *          `/etc/yarp` is used instead of `/etc/xdg/yarp`. This might change in
+ *          the future.
+ *
+ * @since YARP 3.5
+ */
+inline std::vector<std::string> yarpconfigdirs()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, ALLUSERSPROFILE, WIN_ALLUSERSPROFILE_DEFAULT, YARP_CONFIG_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, "", MACOS_CONFIG_DIRS_DEFAULT, YARP_SUFFIX);
+#else
+// FIXME In order to be compliant with xdg specifications, this should be
+//     return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, XDG_CONFIG_DIRS, XDG_CONFIG_DIRS_DEFAULT, YARP_SUFFIX);
+//       but traditionally yarp uses "/etc" and not "/etc/xdg
+    return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, XDG_CONFIG_DIRS, "/etc", YARP_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific non-essential (cached) YARP
+ *        data should be written.
+ *
+ * Uses `YARP_CACHE_HOME` environment variable, if defined.
+ * Otherwise uses the `yarp` folder inside the folder returned by
+ * yarp::conf::dirs::cachehome()
+ *
+ * @since YARP 3.5
+ */
+inline std::string yarpcachehome()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(YARP_CACHE_HOME, LOCALAPPDATA, yarp::conf::dirs::home() + WIN_LOCALAPPDATA_SUFFIX, YARP_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_string(YARP_CACHE_HOME, yarp::conf::dirs::home() + MACOS_CACHEHOME_SUFFIX + YARP_SUFFIX);
+#else
+    return yarp::conf::environment::get_string(YARP_CACHE_HOME, XDG_CACHE_HOME, yarp::conf::dirs::home() + XDG_CACHE_HOME_SUFFIX, YARP_SUFFIX);
+#endif
+}
+
+/**
+ * @brief Returns the directory where user-specific runtime YARP files and other
+ *        YARP file objects should be placed.
+ *
+ * Uses `YARP_RUNTIME_DIR` environment variable, if defined.
+ * Otherwise uses the `yarp` folder inside the folder returned by
+ * yarp::conf::dirs::runtimedir()
+ *
+ * @since YARP 3.5
+ */
+inline std::string yarpruntimedir()
+{
+#if defined(_WIN32)
+    return yarp::conf::environment::get_string(YARP_RUNTIME_DIR, yarp::conf::dirs::tempdir() + RUNTIME_YARP_SUFFIX);
+#elif defined(__APPLE__)
+    return yarp::conf::environment::get_string(YARP_RUNTIME_DIR, yarp::conf::dirs::tempdir() + RUNTIME_SUFFIX + '-' + yarp::conf::environment::get_string(USER) + YARP_SUFFIX);
+#else
+    return yarp::conf::environment::get_string(YARP_RUNTIME_DIR, XDG_RUNTIME_DIR, yarp::conf::dirs::tempdir() + RUNTIME_SUFFIX + '-' + yarp::conf::environment::get_string(USER), YARP_SUFFIX);
+#endif
+}
+/** @} */
+
+} // namespace dirs
+} // namespace conf
+} // namespace yarp
+
+
+#endif // YARP_CONF_DIRS_H

--- a/src/libYARP_conf/src/yarp/conf/dirs.h
+++ b/src/libYARP_conf/src/yarp/conf/dirs.h
@@ -327,10 +327,7 @@ inline std::vector<std::string> yarpconfigdirs()
 #elif defined(__APPLE__)
     return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, "", MACOS_CONFIG_DIRS_DEFAULT, YARP_SUFFIX);
 #else
-// FIXME In order to be compliant with xdg specifications, this should be
-//     return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, XDG_CONFIG_DIRS, XDG_CONFIG_DIRS_DEFAULT, YARP_SUFFIX);
-//       but traditionally yarp uses "/etc" and not "/etc/xdg
-    return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, XDG_CONFIG_DIRS, "/etc", YARP_SUFFIX);
+    return yarp::conf::environment::get_path(YARP_CONFIG_DIRS, XDG_CONFIG_DIRS, XDG_CONFIG_DIRS_DEFAULT, YARP_SUFFIX);
 #endif
 }
 

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.h
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.h
@@ -40,33 +40,6 @@ public:
 
     const ResourceFinder& operator=(const ResourceFinder& alt);
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
-    /**
-     * Request that information be printed to the console on how
-     * resources are being found.  This is especially useful to
-     * understand why resources are *not* found or the wrong resource
-     * is picked up.
-     *
-     * @param verbose set/suppress printing of information
-     *
-     * @return true iff information will be printed
-     * @deprecated since YARP 3.4
-     */
-    bool setVerbose(bool verbose = true);
-
-    /**
-     * Request that information be suppressed from the console.  By
-     * default ResourceFinder will print messages if it fails to find
-     * files, for example.
-     *
-     * @param quiet suppress printing of information
-     *
-     * @return true iff information will be suppressed
-     * @deprecated since YARP 3.4
-     */
-    bool setQuiet(bool quiet = true);
-#endif // YARP_NO_DEPRECATED
-
     /**
      * Sets up the ResourceFinder.
      *
@@ -258,122 +231,15 @@ public:
     using Searchable::check;
     using Searchable::findGroup;
 
-
-    /* YARP 2.4 changes begin */
-
     /**
-     *
-     * Location where user data files are stored.
-     * If $YARP_DATA_HOME is set, that is returned.  We do not check
-     * to see if that directory exists.
-     * Otherwise:
-     *   (In all the following cases, we attempt to create the directory
-     *   returned if it does not already exist).
-     *   If $XDG_DATA_HOME is set, "yarp" is appended to it after the
-     *   OS-appropriate directory separator, and the result returned.
-     *   Otherwise:
-     *     On Windows
-     *       %APPDATA%\yarp is returned.
-     *     On Linux and all others:
-     *       $HOME/.local/share is returned.
-     *     (an OSX-specific case remains to be defined)
-     *
-     */
-    static std::string getDataHome()
-    {
-        return getDataHomeWithPossibleCreation(true);
-    }
-
-
-    /**
-     *
-     * Variant of getDataHome that will never create the directory
-     * returned.
-     *
-     */
-    static std::string getDataHomeNoCreate()
-    {
-        return getDataHomeWithPossibleCreation(false);
-    }
-
-    /**
-     *
-     * Location where user config files are stored.
-     * If $YARP_CONFIG_HOME is set, that is returned.
-     * Otherwise:
-     *   If $XDG_CONFIG_HOME is set, "yarp" is appended to it after the
-     *   OS-appropriate directory separator, and the result returned.
-     *   Otherwise:
-     *     On Windows
-     *       %APPDATA%\yarp\config is returned.
-     *     On Linux and all others:
-     *       $HOME/.config/yarp is returned.
-     *     (an OSX-specific case remains to be defined)
-     *
-     */
-    static std::string getConfigHome()
-    {
-        return getConfigHomeWithPossibleCreation(true);
-    }
-
-    /**
-     *
-     * Variant of getConfigHome that will never create the directory
-     * returned.
-     *
-     */
-    static std::string getConfigHomeNoCreate()
-    {
-        return getConfigHomeWithPossibleCreation(false);
-    }
-
-    /**
-     *
      * Return the path to the "user" context directory for the current context
-     *
      */
     std::string getHomeContextPath();
 
     /**
-     *
      * Return the path to the "user" robot directory
-     *
      */
     std::string getHomeRobotPath();
-
-    /**
-     *
-     * Locations where packaged data and config files are stored.
-     * If $YARP_DATA_DIRS is set, that is returned.
-     * Otherwise:
-     *   If $XDG_DATA_DIRS is set, "/yarp" or "\yarp" as appropriate
-     *   is appended to each path and the result returned.
-     *   Otherwise:
-     *     On Windows
-     *       %YARP_DIR%\share\yarp
-     *     On Linux and all others:
-     *       /usr/local/share/yarp:/usr/share/yarp is returned.
-     *     (an OSX-specific case remains to be defined)
-     *
-     */
-    static Bottle getDataDirs();
-
-    /**
-     *
-     * Locations where system administrator data and config files are stored.
-     * If $YARP_CONFIG_DIRS is set, that is returned.
-     * Otherwise:
-     *   If $XDG_CONFIG_DIRS is set, "/yarp" or "\yarp" as appropriate
-     *   is appended to each path and the result returned.
-     *   Otherwise:
-     *     On Windows
-     *       %ALLUSERSPROFILE%\yarp
-     *     On Linux and all others:
-     *       /etc/yarp is returned.
-     *     (an OSX-specific case remains to be defined)
-     *
-     */
-    static Bottle getConfigDirs();
 
     yarp::os::Bottle findPaths(const std::string& name,
                                const ResourceFinderOptions& options);
@@ -391,7 +257,141 @@ public:
                     const std::string& key,
                     const ResourceFinderOptions& options);
 
-    /* YARP 2.4 changes end */
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.4
+    /**
+     * Request that information be printed to the console on how
+     * resources are being found.  This is especially useful to
+     * understand why resources are *not* found or the wrong resource
+     * is picked up.
+     *
+     * @param verbose set/suppress printing of information
+     *
+     * @return true iff information will be printed
+     * @deprecated since YARP 3.4
+     */
+    bool setVerbose(bool verbose = true);
+
+    /**
+     * Request that information be suppressed from the console.  By
+     * default ResourceFinder will print messages if it fails to find
+     * files, for example.
+     *
+     * @param quiet suppress printing of information
+     *
+     * @return true iff information will be suppressed
+     * @deprecated since YARP 3.4
+     */
+    bool setQuiet(bool quiet = true);
+#endif // YARP_NO_DEPRECATED
+
+#ifndef YARP_NO_DEPRECATED // SINCE YARP 3.5
+    /**
+     * Location where user data files are stored.
+     * If $YARP_DATA_HOME is set, that is returned.  We do not check
+     * to see if that directory exists.
+     * Otherwise:
+     *   (In all the following cases, we attempt to create the directory
+     *   returned if it does not already exist).
+     *   If $XDG_DATA_HOME is set, "yarp" is appended to it after the
+     *   OS-appropriate directory separator, and the result returned.
+     *   Otherwise:
+     *     On Windows
+     *       %APPDATA%\yarp is returned.
+     *     On Linux and all others:
+     *       $HOME/.local/share is returned.
+     *     (an OSX-specific case remains to be defined)
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::data_home() + yarp::os::mkdir_p() instead")
+    static std::string getDataHome()
+    {
+        return getDataHomeWithPossibleCreation(true);
+    }
+
+
+    /**
+     * Variant of getDataHome that will never create the directory
+     * returned.
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::data_home() instead")
+    static std::string getDataHomeNoCreate()
+    {
+        return getDataHomeWithPossibleCreation(false);
+    }
+
+    /**
+     * Location where user config files are stored.
+     * If $YARP_CONFIG_HOME is set, that is returned.
+     * Otherwise:
+     *   If $XDG_CONFIG_HOME is set, "yarp" is appended to it after the
+     *   OS-appropriate directory separator, and the result returned.
+     *   Otherwise:
+     *     On Windows
+     *       %APPDATA%\yarp\config is returned.
+     *     On Linux and all others:
+     *       $HOME/.config/yarp is returned.
+     *     (an OSX-specific case remains to be defined)
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::config_home() + yarp::os::mkdir_p() instead")
+    static std::string getConfigHome()
+    {
+        return getConfigHomeWithPossibleCreation(true);
+    }
+
+    /**
+     * Variant of getConfigHome that will never create the directory
+     * returned.
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::config_home() instead")
+    static std::string getConfigHomeNoCreate()
+    {
+        return getConfigHomeWithPossibleCreation(false);
+    }
+
+    /**
+     * Locations where packaged data and config files are stored.
+     * If $YARP_DATA_DIRS is set, that is returned.
+     * Otherwise:
+     *   If $XDG_DATA_DIRS is set, "/yarp" or "\yarp" as appropriate
+     *   is appended to each path and the result returned.
+     *   Otherwise:
+     *     On Windows
+     *       %YARP_DIR%\share\yarp
+     *     On Linux and all others:
+     *       /usr/local/share/yarp:/usr/share/yarp is returned.
+     *     (an OSX-specific case remains to be defined)
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::yarpdatadirs() instead")
+    static Bottle getDataDirs();
+
+    /**
+     * Locations where system administrator data and config files are stored.
+     * If $YARP_CONFIG_DIRS is set, that is returned.
+     * Otherwise:
+     *   If $XDG_CONFIG_DIRS is set, "/yarp" or "\yarp" as appropriate
+     *   is appended to each path and the result returned.
+     *   Otherwise:
+     *     On Windows
+     *       %ALLUSERSPROFILE%\yarp
+     *     On Linux and all others:
+     *       /etc/yarp is returned.
+     *     (an OSX-specific case remains to be defined)
+     *
+     * @deprecated since YARP 3.5
+     */
+    YARP_DEPRECATED_MSG("Use yarp::conf::dirs::config_dirs() instead")
+    static Bottle getConfigDirs();
+#endif // YARP_NO_DEPRECATED
+
 
 private:
     // this might be useful, but is not in spec
@@ -405,9 +405,12 @@ private:
     bool m_isConfiguredFlag;
     yarp::os::Property m_configprop;
 
+    static std::string createIfAbsent(bool mayCreate, const std::string& path);
+
+#ifndef YARP_NO_DEPRECATED // SINCE YARP 3.5
     static std::string getDataHomeWithPossibleCreation(bool mayCreate);
     static std::string getConfigHomeWithPossibleCreation(bool mayCreate);
-    static std::string createIfAbsent(bool mayCreate, const std::string& path);
+#endif
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.h
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.h
@@ -383,7 +383,7 @@ public:
      *     On Windows
      *       %ALLUSERSPROFILE%\yarp\config
      *     On Linux and all others:
-     *       /etc/yarp is returned.
+     *       /etc/xdg/yarp is returned.
      *     (an OSX-specific case remains to be defined)
      *
      * @deprecated since YARP 3.5

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.h
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.h
@@ -363,7 +363,7 @@ public:
      *   is appended to each path and the result returned.
      *   Otherwise:
      *     On Windows
-     *       %YARP_DIR%\share\yarp
+     *       %ALLUSERSPROFILE%\yarp
      *     On Linux and all others:
      *       /usr/local/share/yarp:/usr/share/yarp is returned.
      *     (an OSX-specific case remains to be defined)
@@ -381,7 +381,7 @@ public:
      *   is appended to each path and the result returned.
      *   Otherwise:
      *     On Windows
-     *       %ALLUSERSPROFILE%\yarp
+     *       %ALLUSERSPROFILE%\yarp\config
      *     On Linux and all others:
      *       /etc/yarp is returned.
      *     (an OSX-specific case remains to be defined)

--- a/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
@@ -11,6 +11,7 @@
 #include <yarp/os/impl/NameConfig.h>
 
 #include <yarp/conf/system.h>
+#include <yarp/conf/dirs.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/conf/environment.h>
 #include <yarp/conf/string.h>
@@ -20,7 +21,6 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Property.h>
-#include <yarp/os/ResourceFinder.h>
 #include <yarp/os/impl/LogComponent.h>
 #include <yarp/os/impl/PlatformIfaddrs.h>
 #include <yarp/os/impl/PlatformLimits.h>
@@ -97,7 +97,7 @@ bool NameConfig::fromString(const std::string& txt)
 
 std::string NameConfig::expandFilename(const char* fname)
 {
-    std::string root = ResourceFinder::getConfigHome();
+    std::string root = yarp::conf::dirs::yarpconfighome();
     std::string conf;
     if (!root.empty()) {
         conf = root + std::string{yarp::conf::filesystem::preferred_separator} + fname;

--- a/src/yarp-config/yarpcontextutils.cpp
+++ b/src/yarp-config/yarpcontextutils.cpp
@@ -8,6 +8,7 @@
 
 #include "yarpcontextutils.h"
 
+#include <yarp/conf/dirs.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/impl/PlatformDirent.h>
@@ -371,24 +372,25 @@ void printInstalledFolders(yarp::os::ResourceFinder &rf, folderType ftype)
 
 void prepareHomeFolder(yarp::os::ResourceFinder &rf, folderType ftype)
 {
-    yarp::os::impl::DIR* dir = yarp::os::impl::opendir((rf.getDataHome()).c_str());
+    std::string yarpdatahome = yarp::conf::dirs::yarpdatahome();
+    yarp::os::impl::DIR* dir = yarp::os::impl::opendir((yarpdatahome).c_str());
     if (dir != nullptr) {
         yarp::os::impl::closedir(dir);
     } else {
-        yarp::os::mkdir((rf.getDataHome()).c_str());
+        yarp::os::mkdir((yarpdatahome).c_str());
     }
 
-    dir = yarp::os::impl::opendir((rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringName(ftype))).c_str());
+    dir = yarp::os::impl::opendir((yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringName(ftype))).c_str());
     if (dir != nullptr) {
         yarp::os::impl::closedir(dir);
     } else {
-        yarp::os::mkdir((rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringName(ftype))).c_str());
+        yarp::os::mkdir((yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringName(ftype))).c_str());
     }
-    dir = yarp::os::impl::opendir((rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringNameHidden(ftype))).c_str());
+    dir = yarp::os::impl::opendir((yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringNameHidden(ftype))).c_str());
     if (dir != nullptr) {
         yarp::os::impl::closedir(dir);
     } else {
-        std::string hiddenPath = (rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringNameHidden(ftype)));
+        std::string hiddenPath = (yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringNameHidden(ftype)));
         yarp::os::mkdir(hiddenPath.c_str());
 #if defined(_WIN32)
         SetFileAttributes(hiddenPath.c_str(), FILE_ATTRIBUTE_HIDDEN);
@@ -618,10 +620,11 @@ YARP_WARNING_POP
 #endif
     ResourceFinderOptions opts;
     opts.searchLocations = ResourceFinderOptions::Installed;
+    std::string yarpdatahome = yarp::conf::dirs::yarpdatahome();
     std::string originalpath = rf.findPath(getFolderStringName(fType).append(PATH_SEPARATOR).append(contextName), opts);
-    std::string destDirname = rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringName(fType)).append(PATH_SEPARATOR).append(contextName);
+    std::string destDirname = yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringName(fType)).append(PATH_SEPARATOR).append(contextName);
     //tmp:
-    std::string hiddenDirname = rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringNameHidden(fType)).append(PATH_SEPARATOR).append(contextName);
+    std::string hiddenDirname = yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringNameHidden(fType)).append(PATH_SEPARATOR).append(contextName);
     prepareHomeFolder(rf, fType);
     if (fType== CONTEXTS && importArg.size() >= 3)
     {
@@ -695,6 +698,7 @@ YARP_WARNING_POP
     prepareHomeFolder(rf, fType);
     ResourceFinderOptions opts;
     opts.searchLocations = ResourceFinderOptions::Installed;
+    std::string yarpdatahome = yarp::conf::dirs::yarpdatahome();
     yarp::os::Bottle contextPaths = rf.findPaths(getFolderStringName(fType), opts);
     for (size_t curPathId = 0; curPathId<contextPaths.size(); ++curPathId)
     {
@@ -717,9 +721,9 @@ YARP_WARNING_POP
                 yarp::os::impl::stat(originalpath.c_str(), &statbuf);
                 if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
                 {
-                    std::string destDirname = rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringName(fType)).append(PATH_SEPARATOR).append(name);
+                    std::string destDirname = yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringName(fType)).append(PATH_SEPARATOR).append(name);
                     recursiveCopy(originalpath, destDirname);
-                    std::string hiddenDirname = rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringNameHidden(fType)).append(PATH_SEPARATOR).append(name);
+                    std::string hiddenDirname = yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringNameHidden(fType)).append(PATH_SEPARATOR).append(name);
                     recursiveCopy(originalpath, hiddenDirname, true, false);// TODO: check result!
                 }
             }
@@ -729,7 +733,7 @@ YARP_WARNING_POP
     }
 
     printf("New user %s:\n", fType == CONTEXTS ? "contexts" : "robots");
-    printContentDirs(rf.getDataHome().append(PATH_SEPARATOR).append(getFolderStringName(fType)));
+    printContentDirs(yarpdatahome.append(PATH_SEPARATOR).append(getFolderStringName(fType)));
     return 0;
 }
 

--- a/src/yarp-config/yarpcontextutils.h
+++ b/src/yarp-config/yarpcontextutils.h
@@ -12,15 +12,11 @@
 
 #include <string>
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/conf/filesystem.h>
 #include <iostream>
 #include <vector>
 
-
-#if defined(_WIN32)
-    #define PATH_SEPARATOR      "\\"
-#else
-    #define PATH_SEPARATOR      "/"
-#endif
+#define PATH_SEPARATOR std::string{yarp::conf::filesystem::preferred_separator}
 
 enum folderType{CONTEXTS=0, ROBOTS=1};
 //helpers:

--- a/tests/libYARP_conf/CMakeLists.txt
+++ b/tests/libYARP_conf/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(harness_conf)
 
 target_sources(harness_conf
   PRIVATE
+    dirs.cpp
     environment.cpp
     numeric.cpp
     string.cpp)

--- a/tests/libYARP_conf/dirs.cpp
+++ b/tests/libYARP_conf/dirs.cpp
@@ -1,0 +1,726 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/conf/environment.h>
+#include <yarp/conf/dirs.h>
+
+#include <tuple>
+#include <vector>
+
+#include <catch.hpp>
+#include <harness.h>
+
+// static std::map<std::string, std::string> env;
+
+static std::vector<std::tuple<std::string, std::string, bool>> env;
+
+static void saveEnvironment(const std::string& key)
+{
+    bool found = false;
+    std::string val = yarp::conf::environment::get_string(key, &found);
+    env.emplace_back(key, val, found);
+    yarp::conf::environment::unset(key);
+}
+
+static void restoreEnvironment()
+{
+    for (const auto& var : env) {
+        if (std::get<2>(var)) {
+            yarp::conf::environment::set_string(std::get<0>(var), std::get<1>(var));
+        } else {
+            yarp::conf::environment::unset(std::get<0>(var));
+        }
+    }
+    env.clear();
+}
+
+
+TEST_CASE("conf::dirs", "[yarp::conf]")
+{
+    saveEnvironment(yarp::conf::dirs::USER);
+    saveEnvironment(yarp::conf::dirs::USERNAME);
+    saveEnvironment(yarp::conf::dirs::HOME);
+    saveEnvironment(yarp::conf::dirs::USERPROFILE);
+    saveEnvironment(yarp::conf::dirs::TMP);
+    saveEnvironment(yarp::conf::dirs::TEMP);
+    saveEnvironment(yarp::conf::dirs::TMPDIR);
+    saveEnvironment(yarp::conf::dirs::XDG_DATA_HOME);
+    saveEnvironment(yarp::conf::dirs::XDG_DATA_DIRS);
+    saveEnvironment(yarp::conf::dirs::XDG_CONFIG_HOME);
+    saveEnvironment(yarp::conf::dirs::XDG_CONFIG_DIRS);
+    saveEnvironment(yarp::conf::dirs::XDG_CACHE_HOME);
+    saveEnvironment(yarp::conf::dirs::XDG_RUNTIME_DIR);
+    saveEnvironment(yarp::conf::dirs::APPDATA);
+    saveEnvironment(yarp::conf::dirs::LOCALAPPDATA);
+    saveEnvironment(yarp::conf::dirs::ALLUSERSPROFILE);
+    saveEnvironment(yarp::conf::dirs::YARP_DATA_HOME);
+    saveEnvironment(yarp::conf::dirs::YARP_DATA_DIRS);
+    saveEnvironment(yarp::conf::dirs::YARP_CONFIG_HOME);
+    saveEnvironment(yarp::conf::dirs::YARP_CONFIG_DIRS);
+    saveEnvironment(yarp::conf::dirs::YARP_CACHE_HOME);
+    saveEnvironment(yarp::conf::dirs::YARP_RUNTIME_DIR);
+
+#if defined(_WIN32)
+    yarp::conf::environment::set_string(yarp::conf::dirs::USERNAME, "C:\\Users\\yarptest");
+    yarp::conf::environment::set_string(yarp::conf::dirs::USERPROFILE, "C:\\Users\\yarptest");
+#else
+    yarp::conf::environment::set_string(yarp::conf::dirs::USER, "yarptest");
+    yarp::conf::environment::set_string(yarp::conf::dirs::HOME, "/home/yarptest");
+#endif
+
+
+    const std::string slash = std::string{yarp::conf::filesystem::preferred_separator};
+    const std::string colon = std::string{yarp::conf::environment::path_separator};
+
+#if defined(_WIN32)
+    const std::string yfoo = "C:\\foo\\yarp";
+    const std::string ybar = "C:\\bar\\yarp";
+#else
+    const std::string yfoo = "/foo/yarp";
+    const std::string ybar = "/bar/yarp";
+#endif
+
+
+    SECTION("Test yarp::conf::dirs::home()")
+    {
+#if defined(_WIN32)
+        CHECK(yarp::conf::dirs::home() == "C:\\Users\\yarptest");
+#else
+        CHECK(yarp::conf::dirs::home() == "/home/yarptest");
+#endif
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::tempdir()")
+    {
+#if defined(_WIN32)
+        // Test with TEMP set
+        yarp::conf::environment::set_string(yarp::conf::dirs::TEMP, "C:\\foo");
+        CHECK(yarp::conf::dirs::tempdir() == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::TEMP);
+
+        // Test default
+        CHECK(yarp::conf::dirs::tempdir() == "C:\\Users\\yarptest\\AppData\\Local\\Temp");
+#else
+        // Test with TMPDIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::TMPDIR, "/foo");
+        CHECK(yarp::conf::dirs::tempdir() == "/foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::TMPDIR);
+
+        // Test default
+        CHECK(yarp::conf::dirs::tempdir() == "/tmp");
+#endif
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::datahome()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "__ignored__");
+
+#if defined(_WIN32)
+        // Test with APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::datahome() == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::datahome() == "C:\\Users\\yarptest\\AppData\\Roaming");
+
+#elif defined(__APPLE__)
+        // Test default
+        CHECK(yarp::conf::dirs::datahome() == "/home/yarptest/Library/Application Support");
+
+#else
+        // Test XDG_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_HOME, "/foo");
+        CHECK(yarp::conf::dirs::datahome() == "/foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::datahome() == "/home/yarptest/.local/share");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+    }
+
+
+
+    SECTION("test yarp::conf::dirs::datadirs()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "__ignored__");
+
+        std::vector<std::string> dirs;
+
+#if defined(_WIN32)
+        // Test ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::datadirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test default
+        dirs = yarp::conf::dirs::datadirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\ProgramData");
+
+#elif defined(__APPLE__)
+        // Test default
+        dirs = yarp::conf::dirs::datadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/usr/local/share");
+        CHECK(dirs[1] == "/usr/share");
+#else
+        // Test XDG_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::datadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/foo");
+        CHECK(dirs[1] == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::datadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/usr/local/share");
+        CHECK(dirs[1] == "/usr/share");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::confighome()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "__ignored__");
+
+#if defined(_WIN32)
+        // Test with APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::confighome() == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::confighome() == "C:\\Users\\yarptest\\AppData\\Roaming");
+
+#elif defined(__APPLE__)
+        // Test default
+        CHECK(yarp::conf::dirs::confighome() == "/home/yarptest/Library/Preferences");
+
+#else
+        // Test XDG_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_HOME, "/foo");
+        CHECK(yarp::conf::dirs::confighome() == "/foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::confighome() == "/home/yarptest/.config");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+    }
+
+
+
+    SECTION("test yarp::conf::dirs::configdirs()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "__ignored__");
+
+        std::vector<std::string> dirs;
+
+#if defined(_WIN32)
+        // Test ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::configdirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test default
+        dirs = yarp::conf::dirs::configdirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\ProgramData");
+
+#elif defined(__APPLE__)
+        // Test default
+        dirs = yarp::conf::dirs::configdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/etc");
+        CHECK(dirs[1] == "/Library/Preferences");
+#else
+
+        // Test XDG_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::configdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/foo");
+        CHECK(dirs[1] == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::configdirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "/etc/xdg");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::cachehome()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CACHE_HOME, "__ignored__");
+
+#if defined(_WIN32)
+        // Test with LOCALAPPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::LOCALAPPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::cachehome() == "C:\\foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::LOCALAPPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::cachehome() == "C:\\Users\\yarptest\\AppData\\Local");
+
+#elif defined(__APPLE__)
+        // Test default
+        CHECK(yarp::conf::dirs::cachehome() == "/home/yarptest/Library/Caches");
+
+#else
+        // Test XDG_CACHE_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CACHE_HOME, "/foo");
+        CHECK(yarp::conf::dirs::cachehome() == "/foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CACHE_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::cachehome() == "/home/yarptest/.cache");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CACHE_HOME);
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::runtimedir()")
+    {
+        // This should be ignored everywhere
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_RUNTIME_DIR, "__ignored__");
+
+#if defined(_WIN32)
+        // Test default
+        CHECK(yarp::conf::dirs::runtimedir() == "C:\\Users\\yarptest\\AppData\\Local\\Temp\\runtime");
+
+#elif defined(__APPLE__)
+        // Test default
+        CHECK(yarp::conf::dirs::runtimedir() == "/tmp/runtime-yarptest");
+#else
+        // Test XDG_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_RUNTIME_DIR, "/foo");
+        CHECK(yarp::conf::dirs::runtimedir() == "/foo");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_RUNTIME_DIR);
+
+        // Test default
+        CHECK(yarp::conf::dirs::runtimedir() == "/tmp/runtime-yarptest");
+#endif
+
+        // Restore environment variables
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_RUNTIME_DIR);
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::yarpdatahome()")
+    {
+#if defined(_WIN32)
+        // Test with YARP_DATA_HOME and APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "C:\\bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test with YARP_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "C:\\bar");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+
+        // Test with APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "C:\\foo\\yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpdatahome() == "C:\\Users\\yarptest\\AppData\\Roaming\\yarp");
+
+#elif defined(__APPLE__)
+        // Test with YARP_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "/bar");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/home/yarptest/Library/Application Support/yarp");
+
+#else
+        // Test with YARP_DATA_HOME and XDG_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "/bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_HOME, "/foo");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_HOME);
+
+        // Test with YARP_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_HOME, "/bar");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_HOME);
+
+        // Test XDG_DATA_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_HOME, "/foo");
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/foo/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpdatahome() == "/home/yarptest/.local/share/yarp");
+#endif
+    }
+
+
+
+    SECTION("test yarp::conf::dirs::yarpdatadirs()")
+    {
+        std::vector<std::string> dirs;
+
+#if defined(_WIN32)
+        // Test YARP_DATA_DIRS and ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "C:\\baz;C:\\zot");
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "C:\\baz");
+        CHECK(dirs[1] == "C:\\zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test YARP_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "C:\\baz;C:\\zot");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "C:\\baz");
+        CHECK(dirs[1] == "C:\\zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+
+        // Test ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\foo\\yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\ProgramData\\yarp");
+
+#elif defined(__APPLE__)
+        // Test YARP_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "/baz:/zot");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/usr/local/share/yarp");
+        CHECK(dirs[1] == "/usr/share/yarp");
+#else
+        // Test YARP_DATA_DIRS and XDG_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "/baz:/zot");
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_DIRS);
+
+        // Test YARP_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_DATA_DIRS, "/baz:/zot");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_DATA_DIRS);
+
+        // Test XDG_DATA_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_DATA_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/foo/yarp");
+        CHECK(dirs[1] == "/bar/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_DATA_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpdatadirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/usr/local/share/yarp");
+        CHECK(dirs[1] == "/usr/share/yarp");
+#endif
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::yarpconfighome()")
+    {
+#if defined(_WIN32)
+        // Test YARP_CONFIG_HOME and APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "C:\\bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test YARP_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "C:\\bar");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+
+        // Test with APPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::APPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "C:\\foo\\yarp\\config");
+        yarp::conf::environment::unset(yarp::conf::dirs::APPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpconfighome() == "C:\\Users\\yarptest\\AppData\\Roaming\\yarp\\config");
+
+#elif defined(__APPLE__)
+        // Test YARP_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "/bar");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/home/yarptest/Library/Preferences/yarp");
+
+#else
+        // Test YARP_CONFIG_HOME and XDG_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "/bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_HOME, "/foo");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_HOME);
+
+        // Test YARP_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_HOME, "/bar");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_HOME);
+
+        // Test XDG_CONFIG_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_HOME, "/foo");
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/foo/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpconfighome() == "/home/yarptest/.config/yarp");
+#endif
+    }
+
+
+
+    SECTION("test yarp::conf::dirs::yarpconfigdirs()")
+    {
+        std::vector<std::string> dirs;
+
+#if defined(_WIN32)
+        // Test YARP_CONFIG_DIRS and ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "C:\\baz;C:\\zot");
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "C:\\baz");
+        CHECK(dirs[1] == "C:\\zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test YARP_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "C:\\baz;C:\\zot");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "C:\\baz");
+        CHECK(dirs[1] == "C:\\zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+
+        // Test ALLUSERSPROFILE set
+        yarp::conf::environment::set_string(yarp::conf::dirs::ALLUSERSPROFILE, "C:\\foo");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\foo\\yarp\\config");
+        yarp::conf::environment::unset(yarp::conf::dirs::ALLUSERSPROFILE);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 1);
+        CHECK(dirs[0] == "C:\\ProgramData\\yarp\\config");
+
+#elif defined(__APPLE__)
+        // Test YARP_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "/baz:/zot");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/etc/yarp");
+        CHECK(dirs[1] == "/Library/Preferences/yarp");
+
+#else
+        // Test YARP_CONFIG_DIRS and XDG_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "/baz:/zot");
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_DIRS);
+
+        // Test YARP_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CONFIG_DIRS, "/baz:/zot");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/baz");
+        CHECK(dirs[1] == "/zot");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CONFIG_DIRS);
+
+        // Test XDG_CONFIG_DIRS set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CONFIG_DIRS, "/foo:/bar");
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 2);
+        CHECK(dirs[0] == "/foo/yarp");
+        CHECK(dirs[1] == "/bar/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CONFIG_DIRS);
+
+        // Test default
+        dirs = yarp::conf::dirs::yarpconfigdirs();
+        CHECK(dirs.size() == 1);
+// FIXME
+//         CHECK(dirs[0] == "/etc/xdg/yarp");
+        CHECK(dirs[0] == "/etc/yarp");
+#endif
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::yarpcachehome()")
+    {
+#if defined(_WIN32)
+        // Test with YARP_CACHE_HOME and LOCALAPPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CACHE_HOME, "C:\\bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::LOCALAPPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpcachehome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CACHE_HOME);
+        yarp::conf::environment::unset(yarp::conf::dirs::LOCALAPPDATA);
+
+        // Test with YARP_CACHE_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CACHE_HOME, "C:\\bar");
+        CHECK(yarp::conf::dirs::yarpcachehome() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CACHE_HOME);
+
+        // Test with LOCALAPPDATA set
+        yarp::conf::environment::set_string(yarp::conf::dirs::LOCALAPPDATA, "C:\\foo");
+        CHECK(yarp::conf::dirs::yarpcachehome() == "C:\\foo\\yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::LOCALAPPDATA);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpcachehome() == "C:\\Users\\yarptest\\AppData\\Local\\yarp");
+
+#elif defined(__APPLE__)
+        // Test with YARP_CACHE_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_CACHE_HOME, "/bar");
+        CHECK(yarp::conf::dirs::yarpcachehome() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_CACHE_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpcachehome() == "/home/yarptest/Library/Caches/yarp");
+
+#else
+        // Test XDG_CACHE_HOME set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_CACHE_HOME, "/foo");
+        CHECK(yarp::conf::dirs::yarpcachehome() == "/foo/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_CACHE_HOME);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpcachehome() == "/home/yarptest/.cache/yarp");
+#endif
+    }
+
+
+
+    SECTION("Test yarp::conf::dirs::yarpruntimedir()")
+    {
+#if defined(_WIN32)
+        // Test YARP_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_RUNTIME_DIR, "C:\\bar");
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "C:\\bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_RUNTIME_DIR);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "C:\\Users\\yarptest\\AppData\\Local\\Temp\\runtime\\yarp");
+
+#elif defined(__APPLE__)
+        // Test YARP_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_RUNTIME_DIR, "/bar");
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_RUNTIME_DIR);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/tmp/runtime-yarptest/yarp");
+#else
+        // Test YARP_RUNTIME_DIR and XDG_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_RUNTIME_DIR, "/bar");
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_RUNTIME_DIR, "/foo");
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_RUNTIME_DIR);
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_RUNTIME_DIR);
+
+        // Test YARP_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::YARP_RUNTIME_DIR, "/bar");
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/bar");
+        yarp::conf::environment::unset(yarp::conf::dirs::YARP_RUNTIME_DIR);
+
+        // Test XDG_RUNTIME_DIR set
+        yarp::conf::environment::set_string(yarp::conf::dirs::XDG_RUNTIME_DIR, "/foo");
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/foo/yarp");
+        yarp::conf::environment::unset(yarp::conf::dirs::XDG_RUNTIME_DIR);
+
+        // Test default
+        CHECK(yarp::conf::dirs::yarpruntimedir() == "/tmp/runtime-yarptest/yarp");
+#endif
+    }
+
+    restoreEnvironment();
+}

--- a/tests/libYARP_conf/dirs.cpp
+++ b/tests/libYARP_conf/dirs.cpp
@@ -627,9 +627,7 @@ TEST_CASE("conf::dirs", "[yarp::conf]")
         // Test default
         dirs = yarp::conf::dirs::yarpconfigdirs();
         CHECK(dirs.size() == 1);
-// FIXME
-//         CHECK(dirs[0] == "/etc/xdg/yarp");
-        CHECK(dirs[0] == "/etc/yarp");
+        CHECK(dirs[0] == "/etc/xdg/yarp");
 #endif
     }
 

--- a/tests/libYARP_os/ResourceFinderTest.cpp
+++ b/tests/libYARP_os/ResourceFinderTest.cpp
@@ -613,7 +613,7 @@ YARP_DISABLE_DEPRECATED_WARNING
         yarp::conf::environment::unset("XDG_CONFIG_DIRS");
         dirs = ResourceFinder::getConfigDirs();
         CHECK(dirs.size() == (size_t) 1); // CONFIG_DIRS default length 1
-        CHECK(dirs.get(0).asString() == "/etc/yarp"); // CONFIG_DIRS default is ok
+        CHECK(dirs.get(0).asString() == "/etc/xdg/yarp"); // CONFIG_DIRS default is ok
 
         restoreEnvironment();
     }


### PR DESCRIPTION
Following #2506, this patch moves another bunch of functionalities from `yarp::os` (`ResourceFinder`) to `yarp::conf`, and adds several new utilities.

Again, this also implies deprecating a few utilities in `yarp::os`, in order to avoid having the same functionalities in different places.

----------

Deprecation and Behaviour Changes
---------------------------------

* A few default values for the environment variables used by yarp are now
  different:
  * Linux:
    * `YARP_CONFIG_DIRS` defaults to `/etc/xdg/yarp` to be compliant with the
      [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
  * Windows:
    * `YARP_DATA_DIRS` defaults to `%%ALLUSERSPROFILE%%\yarp`
    * `YARP_CONFIG_DIRS` defaults to `%%ALLUSERSPROFILE%%\yarp\config`


New Features
------------

## Libraries

### `conf`

* Added the new `dirs.h` file with methods to retrieve the important folders
* Added the following methods:
   * `std::string yarp::conf::dirs::home()`
   * `std::string yarp::conf::dirs::tempdir()`
   * `std::string yarp::conf::dirs::datahome()`
   * `std::vector<std::string> yarp::conf::dirs::datadirs()`
   * `std::string yarp::conf::dirs::confighome()`
   * `std::vector<std::string> yarp::conf::dirs::configdirs()`
   * `std::string yarp::conf::dirs::cachehome()`
   * `std::string yarp::conf::dirs::runtimedir()`
   * `std::string yarp::conf::dirs::yarpdatahome()`
   * `std::vector<std::string> yarp::conf::dirs::yarpdatadirs()`
   * `std::string yarp::conf::dirs::yarpconfighome()`
   * `std::vector<std::string> yarp::conf::dirs::yarpconfigdirs()`
   * `std::string yarp::conf::dirs::yarpcachehome()`
   * `std::string yarp::conf::dirs::yarpruntimedir()`

### `os`

#### `ResourceFinder`

* Deprecated methods with alternatives in `yarp::conf::dirs`.
  The following methods are now deprecated:
    * `yarp::os::ResourceFinder::getDataHome()`
    * `yarp::os::ResourceFinder::getDataHomeNoCreate()`
    * `yarp::os::ResourceFinder::getConfigHome()`
    * `yarp::os::ResourceFinder::getConfigHomeNoCreate()`
    * `yarp::os::ResourceFinder::getDataDirs()`
    * `yarp::os::ResourceFinder::getConfigDirs()`
  in favour of:
    * `yarp::conf::dirs::yarpdatahome()`
    * `yarp::conf::dirs::yarpconfighome()`
    * `yarp::conf::dirs::yarpdatadirs()`
  Warnings:
    * The return value of `yarpdatadirs()` is different
      (`std::vector<std::string>` instead of `std::string`).
    * The `yarpdatahome()` and `yarpconfighome()` do not create the directory,
      it must be created manually (for example with `yarp::os::mkdir_p()`) if
      required.
