### PR TITLE
Add `yarp::sig::utils::cropRect()`, adopt in grabberDual

### DIFF
--- a/doc/release/master/add_cropRect.md
+++ b/doc/release/master/add_cropRect.md
@@ -1,0 +1,11 @@
+add_cropRect {#master}
+-----------
+
+### Libraries
+
+#### `sig`
+
+##### `utils`
+
+* Added `cropRect()` helper function for cropping a rectangle area out of an
+  image given two opposite vertices.

--- a/src/libYARP_sig/src/yarp/sig/ImageUtils.h
+++ b/src/libYARP_sig/src/yarp/sig/ImageUtils.h
@@ -9,6 +9,7 @@
 #ifndef YARP_SIG_IMAGEUTILS_H
 #define YARP_SIG_IMAGEUTILS_H
 
+#include <utility> // std::pair
 #include <yarp/sig/Image.h>
 
 namespace yarp {
@@ -22,30 +23,30 @@ namespace utils
 {
 
 /**
- * @brief vertSplit, split vertically an image in two images of the same size.
- * @param inImg[in] image to be vertically split.
- * @param outImgL[out] left half of inImg.
- * @param outImgR[out] right half of inImg.
+ * @brief Split vertically an image in two images of the same size.
+ * @param[in] inImg image to be vertically split.
+ * @param[out] outImgL left half of inImg.
+ * @param[out] outImgR right half of inImg.
  * @note The input image must have same height, double width of the output images and same pixel type.
  * @return true on success, false otherwise.
  */
 bool YARP_sig_API vertSplit(const yarp::sig::Image& inImg, yarp::sig::Image& outImgL, yarp::sig::Image& outImgR);
 
 /**
- * @brief horzSplit, split horizontally an image in two images of the same size.
- * @param inImg[in] image to be horizontally split.
- * @param outImgUp[out] top half of inImg.
- * @param outImgDown[out] bottom half of inImg.
+ * @brief Split horizontally an image in two images of the same size.
+ * @param[in] inImg image to be horizontally split.
+ * @param[out] outImgUp top half of inImg.
+ * @param[out] outImgDown bottom half of inImg.
  * @note The input image must have same height, double width of the output images and same pixel type.
  * @return true on success, false otherwise.
  */
 bool YARP_sig_API horzSplit(const yarp::sig::Image& inImg, yarp::sig::Image& outImgUp, yarp::sig::Image& outImgDown);
 
 /**
- * @brief horzConcat, concatenate horizontally two images of the same size in one with double width.
- * @param inImgL[in] input left image.
- * @param inImgR[in] input right image.
- * @param outImg[out] result of the horizontal concatenation.
+ * @brief Concatenate horizontally two images of the same size in one with double width.
+ * @param[in] inImgL input left image.
+ * @param[in] inImgR input right image.
+ * @param[out] outImg result of the horizontal concatenation.
  * @note The input images must have same dimensions and pixel type, and the output image must have same height and
  * double width.
  * @return true on success, false otherwise.
@@ -53,15 +54,30 @@ bool YARP_sig_API horzSplit(const yarp::sig::Image& inImg, yarp::sig::Image& out
 bool YARP_sig_API horzConcat(const yarp::sig::Image& inImgL, const yarp::sig::Image& inImgR, yarp::sig::Image& outImg);
 
 /**
- * @brief vertConcat, concatenate vertically two images of the same size in one with double height.
- * @param inImgUp[in] input top image.
- * @param inImgDown[in] input bottom image.
- * @param outImg[out] result of the horizontal concatenation.
+ * @brief Concatenate vertically two images of the same size in one with double height.
+ * @param[in] inImgUp input top image.
+ * @param[in] inImgDown input bottom image.
+ * @param[out] outImg result of the horizontal concatenation.
  * @note The input images must have same dimensions and pixel type, and the output image must have same width and
  * double height.
  * @return true on success, false otherwise.
  */
 bool YARP_sig_API vertConcat(const yarp::sig::Image& inImgUp, const yarp::sig::Image& inImgDown, yarp::sig::Image& outImg);
+
+/**
+ * @brief Crop a rectangle area out of an image given two opposite vertices.
+ * @param[in] inImg input image.
+ * @param[in] vertex1 first vertex of the crop rectangle area.
+ * @param[in] vertex2 second vertex of the crop rectangle area.
+ * @param[out] outImg result of cropping the input image.
+ * @note Input and output images must have same pixel type and the crop area must lay within the input image. Vertices
+ * needn't be passed in the usual top-left, bottom-right order. The output image is resized to match the crop dimensions.
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API cropRect(const yarp::sig::Image& inImg,
+                           const std::pair<unsigned int, unsigned int>& vertex1,
+                           const std::pair<unsigned int, unsigned int>& vertex2,
+                           yarp::sig::Image& outImg);
 } // namespace utils
 } // namespace sig
 } // namespace yarp

--- a/tests/libYARP_sig/ImageTest.cpp
+++ b/tests/libYARP_sig/ImageTest.cpp
@@ -743,5 +743,41 @@ TEST_CASE("sig::ImageTest", "[yarp::sig]")
         CHECK(ok); // Checking data consistency bottom split
     }
 
+    SECTION("test image crop.")
+    {
+        ImageOf<PixelRgb> inImg, outImg;
+        inImg.resize(10, 10);
+
+        size_t tlx = 4;
+        size_t tly = 5;
+        size_t brx = 8;
+        size_t bry = 7;
+
+        PixelRgb pixelValue {255, 0, 0};
+
+        for (size_t u = tlx; u <= brx; u++) {
+            for (size_t v = tly; v <= bry; v++) {
+                inImg.pixel(u, v) = pixelValue;
+            }
+        }
+
+        CHECK(utils::cropRect(inImg, {tlx, tly}, {brx, bry}, outImg));
+
+        CHECK(outImg.width() == brx - tlx + 1);
+        CHECK(outImg.height() == bry - tly + 1);
+
+        bool ok = true;
+
+        for (size_t u = 0; u < outImg.width(); u++) {
+            for (size_t v = 0; v < outImg.height(); v++) {
+                ok &= outImg.pixel(u, v).r == pixelValue.r;
+                ok &= outImg.pixel(u, v).g == pixelValue.g;
+                ok &= outImg.pixel(u, v).b == pixelValue.b;
+            }
+        }
+
+        CHECK(ok);
+    }
+
     NetworkBase::setLocalMode(false);
 }


### PR DESCRIPTION
`ServerGrabber` (a.k.a. `grabberDual`) features rectangular image cropping ([ref](https://github.com/robotology/yarp/blob/dca3a0cb57664042537bfcd7ff3f54ee6ad1bf9c/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp#L576-L589)). This patch proposes a refactorization and public exposure via a helper method in the `yarp::sig::utils` namespace, further extending it to any underlying pixel type (as long as input-output types match).

Proposed signature:

```cxx
bool yarp::sig::utils::cropRect(const yarp::sig::Image& inImg,
                                const std::pair<unsigned int, unsigned int>& vertex1,
                                const std::pair<unsigned int, unsigned int>& vertex2,
                                yarp::sig::Image& outImg)
```

If this addition is deemed useful, please double-check the logic behind the now-deleted `u_offset` variable in the NWS responder. Previously, the vector of vertices was passed as-is to the device's `getImageCrop` method, if available, and actually corrected in the local fallback implementation of an image cropper. I believe the offset should have been taken into account in both scenarios, which now is. I'm not entirely sure whether it was a bug since this method is apparently not implemented in any camera device, hence it might have slipped unnoticed.