### PR TITLE
[YarpDataplayer] fixed timestamp propagation

### DIFF
--- a/doc/release/master/yarpdataplayer_fix.md
+++ b/doc/release/master/yarpdataplayer_fix.md
@@ -1,0 +1,8 @@
+yarpdataplayer_fix {#master}
+------------------
+
+### Tools
+
+#### yarpdataplayer
+
+* fixed `yarpdataplayer` to interpret the timestamp correctly, dealing with locale issues, as described in [#2558](https://github.com/robotology/yarp/issues/2558). 

--- a/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
+++ b/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
@@ -726,7 +726,8 @@ int DataplayerWorker::sendBottle(int part, int frame)
     outBot = tmp;
 
     //propagate timestamp
-    Stamp ts(frame, utilities->partDetails[part].timestamp[frame]);
+    std::string time = yarp::conf::numeric::to_string(utilities->partDetails[part].timestamp[frame]);
+    Bottle ts(time);
     the_port->setEnvelope(ts);
 
     if (utilities->sendStrict) {


### PR DESCRIPTION
This PR fixes [2558](https://github.com/robotology/yarp/issues/2558), by interpreting correctly the timestamp propagated, dealing with locale issues.