### PR TITLE
fix for AudioPlayerDevices

### DIFF
--- a/src/devices/audioToFileDevice/audioToFileDevice.cpp
+++ b/src/devices/audioToFileDevice/audioToFileDevice.cpp
@@ -128,7 +128,7 @@ bool audioToFileDevice::close()
 
 bool audioToFileDevice::startPlayback()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     yCDebug(AUDIOTOFILE) << "start";
     m_playback_enabled = true;
     if (m_save_mode != save_mode_t::save_append_data)
@@ -140,7 +140,7 @@ bool audioToFileDevice::startPlayback()
 
 bool audioToFileDevice::stopPlayback()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     yCDebug(AUDIOTOFILE) << "stop";
     m_playback_enabled = false;
     if (m_save_mode != save_mode_t::save_append_data)
@@ -152,7 +152,7 @@ bool audioToFileDevice::stopPlayback()
 
 bool audioToFileDevice::renderSound(const yarp::sig::Sound& sound)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (m_playback_enabled)
     {
         m_sounds.push_back(sound);
@@ -162,7 +162,7 @@ bool audioToFileDevice::renderSound(const yarp::sig::Sound& sound)
 
 bool audioToFileDevice::setHWGain(double gain)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_hw_gain = gain;

--- a/src/devices/fakeSpeaker/fakeSpeaker.cpp
+++ b/src/devices/fakeSpeaker/fakeSpeaker.cpp
@@ -119,7 +119,7 @@ void fakeSpeaker::run()
 
 bool fakeSpeaker::setHWGain(double gain)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_hw_gain = gain;

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
@@ -315,6 +315,8 @@ void PortAudioPlayerDeviceDriver::waitUntilPlaybackStreamIsComplete()
     while (Pa_IsStreamStopped(m_stream) == 0)
     {
         yarp::os::Time::delay(SLEEP_TIME);
+        size_t tmp = m_outputBuffer->size().getSamples();
+        if (tmp == 0) break;
     }
 }
 

--- a/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.h
@@ -53,7 +53,7 @@ class YARP_dev_API AudioPlayerDeviceBase : public yarp::dev::IAudioRender
 protected:
     bool                                m_enable_buffer_autoclear = false;
     bool                                m_playback_enabled = false;
-    std::mutex                          m_mutex;
+    std::recursive_mutex                m_mutex;
     yarp::dev::CircularAudioBuffer_16t* m_outputBuffer = nullptr;
     AudioDeviceDriverSettings           m_audioplayer_cfg;
     double                              m_sw_gain = 1.0;


### PR DESCRIPTION
now using recursive_mutex to avoid deadlocks when a device re-initialization is required