### PR TITLE
Add framegrabber_protocol object library, and use it inside the devices

### DIFF
--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -10,6 +10,7 @@ include(YarpPrintFeature)
 
 yarp_begin_plugin_library(yarpmod OPTION YARP_COMPILE_DEVICE_PLUGINS
                                   DEFAULT ON)
+  add_subdirectory(framegrabber_protocol)
   add_subdirectory(audioPlayerWrapper)
   add_subdirectory(audioRecorderWrapper)
   add_subdirectory(audioFromFileDevice)

--- a/src/devices/RGBDSensorClient/CMakeLists.txt
+++ b/src/devices/RGBDSensorClient/CMakeLists.txt
@@ -19,6 +19,9 @@ if(NOT SKIP_RGBDSensorClient)
                                                RGBDSensorClient_StreamingMsgParser.cpp
                                                RGBDSensorClient_StreamingMsgParser.h)
 
+  target_sources(yarp_RGBDSensorClient PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_RGBDSensorClient PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
   target_link_libraries(yarp_RGBDSensorClient PRIVATE YARP::YARP_os
                                                       YARP::YARP_sig
                                                       YARP::YARP_dev)

--- a/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
@@ -24,9 +24,9 @@ YARP_LOG_COMPONENT(RGBDSENSORCLIENT, "yarp.devices.RGBDSensorClient")
 
 
 RGBDSensorClient::RGBDSensorClient() :
-        FrameGrabberControls_Sender(rpcPort),
-        RgbMsgSender(new Implement_RgbVisualParams_Sender(rpcPort)),
-        DepthMsgSender(new Implement_DepthVisualParams_Sender(rpcPort)),
+        yarp::proto::framegrabber::FrameGrabberControls_Forwarder(rpcPort),
+        RgbMsgSender(new yarp::proto::framegrabber::RgbVisualParams_Forwarder(rpcPort)),
+        DepthMsgSender(new yarp::proto::framegrabber::DepthVisualParams_Forwarder(rpcPort)),
         streamingReader(new RGBDSensor_StreamingMsgParser)
 {
 }
@@ -261,13 +261,13 @@ bool RGBDSensorClient::close()
 /*
  * IDepthVisualParams interface. Look at IVisualParams.h for documentation
  *
- * Implemented by Implement_DepthVisualParams_Sender
+ * Implemented by DepthVisualParams_Forwarder
  */
 
 /*
  * IDepthVisualParams interface. Look at IVisualParams.h for documentation
  *
- * Implemented by Implement_DepthVisualParams_Sender
+ * Implemented by DepthVisualParams_Forwarder
  */
 
 
@@ -337,7 +337,7 @@ bool RGBDSensorClient::getImages(FlexImage &rgbImage, ImageOf<PixelFloat> &depth
 }
 
 //
-// IFrame Grabber Control 2 interface is implemented by FrameGrabberControls2_Sender
+// IFrame Grabber Control 2 interface is implemented by FrameGrabberControls2_Forwarder
 //
 
 //

--- a/src/devices/RGBDSensorClient/RGBDSensorClient.h
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient.h
@@ -18,9 +18,10 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
 #include <yarp/dev/IPreciselyTimed.h>
-#include <yarp/dev/IVisualParamsImpl.h>
-#include <yarp/dev/FrameGrabberControl2.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
+
+#include <yarp/proto/framegrabber/FrameGrabberControls_Forwarder.h>
+#include <yarp/proto/framegrabber/RgbVisualParams_Forwarder.h>
+#include <yarp/proto/framegrabber/DepthVisualParams_Forwarder.h>
 
 #define DEFAULT_THREAD_PERIOD       20    //ms
 #define RGBDSENSOR_TIMEOUT_DEFAULT  100   //ms
@@ -83,14 +84,14 @@ class RGBDSensor_StreamingMsgParser;
 
 class RGBDSensorClient :
         public yarp::dev::DeviceDriver,
-        public yarp::dev::FrameGrabberControls_Sender,
+        public yarp::proto::framegrabber::FrameGrabberControls_Forwarder,
         public yarp::dev::IRGBDSensor
 {
 protected:
     yarp::os::Port rpcPort;
 private:
-    yarp::dev::Implement_RgbVisualParams_Sender* RgbMsgSender{nullptr};
-    yarp::dev::Implement_DepthVisualParams_Sender* DepthMsgSender{nullptr};
+    yarp::proto::framegrabber::RgbVisualParams_Forwarder* RgbMsgSender{nullptr};
+    yarp::proto::framegrabber::DepthVisualParams_Forwarder* DepthMsgSender{nullptr};
 protected:
     std::string local_colorFrame_StreamingPort_name;
     std::string local_depthFrame_StreamingPort_name;
@@ -272,21 +273,21 @@ public:
 
     // IFrame Grabber Control 2
     //
-    // Implemented by FrameGrabberControls2_Sender
+    // Implemented by FrameGrabberControls2_Forwarder
     //
-    using FrameGrabberControls_Sender::getCameraDescription;
-    using FrameGrabberControls_Sender::hasFeature;
-    using FrameGrabberControls_Sender::setFeature;
-    using FrameGrabberControls_Sender::getFeature;
-    using FrameGrabberControls_Sender::hasOnOff;
-    using FrameGrabberControls_Sender::setActive;
-    using FrameGrabberControls_Sender::getActive;
-    using FrameGrabberControls_Sender::hasAuto;
-    using FrameGrabberControls_Sender::hasManual;
-    using FrameGrabberControls_Sender::hasOnePush;
-    using FrameGrabberControls_Sender::setMode;
-    using FrameGrabberControls_Sender::getMode;
-    using FrameGrabberControls_Sender::setOnePush;
+    using FrameGrabberControls_Forwarder::getCameraDescription;
+    using FrameGrabberControls_Forwarder::hasFeature;
+    using FrameGrabberControls_Forwarder::setFeature;
+    using FrameGrabberControls_Forwarder::getFeature;
+    using FrameGrabberControls_Forwarder::hasOnOff;
+    using FrameGrabberControls_Forwarder::setActive;
+    using FrameGrabberControls_Forwarder::getActive;
+    using FrameGrabberControls_Forwarder::hasAuto;
+    using FrameGrabberControls_Forwarder::hasManual;
+    using FrameGrabberControls_Forwarder::hasOnePush;
+    using FrameGrabberControls_Forwarder::setMode;
+    using FrameGrabberControls_Forwarder::getMode;
+    using FrameGrabberControls_Forwarder::setOnePush;
 };
 
 #endif // YARP_DEV_RGBDSENSORCLIENT_RGBDSENSORCLIENT_H

--- a/src/devices/RGBDSensorFromRosTopic/RGBDSensorFromRosTopic.h
+++ b/src/devices/RGBDSensorFromRosTopic/RGBDSensorFromRosTopic.h
@@ -15,7 +15,6 @@
 #include <mutex>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberControl2.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/all.h>
 #include <yarp/sig/Matrix.h>
@@ -234,10 +233,10 @@ public:
     bool   getExtrinsicParam(yarp::sig::Matrix &extrinsic) override;
     bool   getRgbImage(FlexImage& rgbImage, Stamp* timeStamp = nullptr) override;
     bool   getDepthImage(depthImage& depthImage, Stamp* timeStamp = nullptr) override;
-    bool   getImages(FlexImage& colorFrame, depthImage& depthFrame, Stamp* colorStamp=NULL, Stamp* depthStamp=NULL) override;
+    bool   getImages(FlexImage& colorFrame, depthImage& depthFrame, Stamp* colorStamp = nullptr, Stamp* depthStamp = nullptr) override;
 
     RGBDSensor_status     getSensorStatus() override;
-    std::string getLastErrorMsg(Stamp* timeStamp = NULL) override;
+    std::string getLastErrorMsg(Stamp* timeStamp = nullptr) override;
 
     /*
     //IFrameGrabberControls

--- a/src/devices/RGBDSensorWrapper/CMakeLists.txt
+++ b/src/devices/RGBDSensorWrapper/CMakeLists.txt
@@ -16,8 +16,11 @@ if(NOT SKIP_RGBDSensorWrapper)
 
   target_sources(yarp_RGBDSensorWrapper PRIVATE RGBDSensorWrapper.cpp
                                                 RGBDSensorWrapper.h)
-  target_sources(yarp_RGBDSensorWrapper PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
 
+  target_sources(yarp_RGBDSensorWrapper PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_RGBDSensorWrapper PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
+  target_sources(yarp_RGBDSensorWrapper PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
   target_include_directories(yarp_RGBDSensorWrapper PRIVATE $<TARGET_PROPERTY:RGBDRosConversionUtils,INTERFACE_INCLUDE_DIRECTORIES>)
 
   target_link_libraries(yarp_RGBDSensorWrapper PRIVATE YARP::YARP_os
@@ -55,8 +58,11 @@ if(NOT SKIP_rgbdSensor_nws_ros)
 
   target_sources(yarp_rgbdSensor_nws_ros PRIVATE rgbdSensor_nws_ros.cpp
                                                  rgbdSensor_nws_ros.h)
-  target_sources(yarp_rgbdSensor_nws_ros PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
 
+  target_sources(yarp_rgbdSensor_nws_ros PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_rgbdSensor_nws_ros PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
+  target_sources(yarp_rgbdSensor_nws_ros PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
   target_include_directories(yarp_rgbdSensor_nws_ros PRIVATE $<TARGET_PROPERTY:RGBDRosConversionUtils,INTERFACE_INCLUDE_DIRECTORIES>)
 
   target_link_libraries(yarp_rgbdSensor_nws_ros PRIVATE YARP::YARP_os
@@ -95,6 +101,9 @@ if(NOT SKIP_rgbdSensor_nws_yarp)
 
   target_sources(yarp_rgbdSensor_nws_yarp PRIVATE rgbdSensor_nws_yarp.cpp
                                                   rgbdSensor_nws_yarp.h)
+
+  target_sources(yarp_rgbdSensor_nws_yarp PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_rgbdSensor_nws_yarp PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
 
   target_link_libraries(yarp_rgbdSensor_nws_yarp PRIVATE YARP::YARP_os
                                                          YARP::YARP_sig

--- a/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -12,10 +12,11 @@
 #include <cstring>
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/dev/GenericVocabs.h>
 #include <yarp/rosmsg/impl/yarpRosHelper.h>
 #include "rosPixelCode.h"
 #include <RGBDRosConversionUtils.h>
+// #include <yarp/proto/framegrabber/CameraVocabs.h> // FIXME
+#include <yarp/dev/GenericVocabs.h>
 
 using namespace RGBDImpl;
 using namespace yarp::sig;

--- a/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
+++ b/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.h
@@ -30,8 +30,10 @@
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
-#include <yarp/dev/IVisualParamsImpl.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
+
+#include <yarp/proto/framegrabber/FrameGrabberControls_Responder.h>
+#include <yarp/proto/framegrabber/RgbVisualParams_Responder.h>
+#include <yarp/proto/framegrabber/DepthVisualParams_Responder.h>
 
 // ROS stuff
 #include <yarp/os/Node.h>
@@ -68,9 +70,9 @@ class RGBDImpl::RGBDSensorParser :
 {
 private:
     yarp::dev::IRGBDSensor  *iRGBDSensor;
-    yarp::dev::Implement_RgbVisualParams_Parser  rgbParser;
-    yarp::dev::Implement_DepthVisualParams_Parser depthParser;
-    yarp::dev::FrameGrabberControls_Parser fgCtrlParsers;
+    yarp::proto::framegrabber::RgbVisualParams_Responder  rgbParser;
+    yarp::proto::framegrabber::DepthVisualParams_Responder depthParser;
+    yarp::proto::framegrabber::FrameGrabberControls_Responder fgCtrlParsers;
 
 public:
     RGBDSensorParser();

--- a/src/devices/RGBDSensorWrapper/rgbdSensor_nws_ros.h
+++ b/src/devices/RGBDSensorWrapper/rgbdSensor_nws_ros.h
@@ -27,7 +27,7 @@
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
 
 // ROS stuff
 #include <yarp/os/Node.h>

--- a/src/devices/RGBDSensorWrapper/rgbdSensor_nws_yarp.cpp
+++ b/src/devices/RGBDSensorWrapper/rgbdSensor_nws_yarp.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
+
+// #include <yarp/proto/framegrabber/CameraVocabs.h> // FIXME
 #include <yarp/dev/GenericVocabs.h>
 
 using namespace RGBDImpl;

--- a/src/devices/RGBDSensorWrapper/rgbdSensor_nws_yarp.h
+++ b/src/devices/RGBDSensorWrapper/rgbdSensor_nws_yarp.h
@@ -30,14 +30,12 @@
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
-#include <yarp/dev/IVisualParamsImpl.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
 
+#include <yarp/proto/framegrabber/FrameGrabberControls_Responder.h>
+#include <yarp/proto/framegrabber/RgbVisualParams_Responder.h>
+#include <yarp/proto/framegrabber/DepthVisualParams_Responder.h>
 
-namespace RGBDImpl
-{
-    class RGBDSensorParser;
-}
+namespace RGBDImpl {
 
 #define DEFAULT_THREAD_PERIOD   0.03 // s
 
@@ -49,14 +47,14 @@ constexpr yarp::conf::vocab32_t VOCAB_PROTOCOL_VERSION = yarp::os::createVocab('
 
 
 
-class RGBDImpl::RGBDSensorParser :
+class RGBDSensorParser :
         public yarp::dev::DeviceResponder
 {
 private:
-    yarp::dev::IRGBDSensor  *iRGBDSensor;
-    yarp::dev::Implement_RgbVisualParams_Parser  rgbParser;
-    yarp::dev::Implement_DepthVisualParams_Parser depthParser;
-    yarp::dev::FrameGrabberControls_Parser fgCtrlParsers;
+    yarp::dev::IRGBDSensor *iRGBDSensor;
+    yarp::proto::framegrabber::RgbVisualParams_Responder rgbParser;
+    yarp::proto::framegrabber::DepthVisualParams_Responder depthParser;
+    yarp::proto::framegrabber::FrameGrabberControls_Responder fgCtrlParsers;
 
 public:
     RGBDSensorParser();
@@ -67,6 +65,7 @@ public:
     bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
 };
 
+} // RGBDImpl
 
 /**
  *  @ingroup dev_impl_wrapper

--- a/src/devices/RGBDToPointCloudSensorWrapper/RGBDToPointCloudSensor_nws_ros.h
+++ b/src/devices/RGBDToPointCloudSensorWrapper/RGBDToPointCloudSensor_nws_ros.h
@@ -27,7 +27,7 @@
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRGBDSensor.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
 
 // ROS stuff
 #include <yarp/os/Node.h>

--- a/src/devices/RemoteFrameGrabber/CMakeLists.txt
+++ b/src/devices/RemoteFrameGrabber/CMakeLists.txt
@@ -17,6 +17,9 @@ if(NOT SKIP_remote_grabber)
   target_sources(yarp_remote_grabber PRIVATE RemoteFrameGrabber.cpp
                                              RemoteFrameGrabber.h)
 
+  target_sources(yarp_remote_grabber PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_remote_grabber PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
   target_link_libraries(yarp_remote_grabber PRIVATE YARP::YARP_os
                                                     YARP::YARP_sig
                                                     YARP::YARP_dev)

--- a/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.cpp
+++ b/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.cpp
@@ -16,7 +16,7 @@ using namespace yarp::sig;
 YARP_LOG_COMPONENT(REMOTEFRAMEGRABBER, "yarp.devices.RemoteFrameGrabber")
 
 RemoteFrameGrabber::RemoteFrameGrabber() :
-        FrameGrabberControls_Sender(port),
-        Implement_RgbVisualParams_Sender(port)
+        FrameGrabberControls_Forwarder(port),
+        RgbVisualParams_Forwarder(port)
 {
 }

--- a/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.h
+++ b/src/devices/RemoteFrameGrabber/RemoteFrameGrabber.h
@@ -15,358 +15,18 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
-#include <yarp/dev/IVisualParamsImpl.h>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
+
+#include <yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.h>
+#include <yarp/proto/framegrabber/FrameGrabberControls_Forwarder.h>
+#include <yarp/proto/framegrabber/RgbVisualParams_Forwarder.h>
+// #include <yarp/proto/framegrabber/CameraVocabs.h> // FIXME
 #include <yarp/dev/GenericVocabs.h>
 
 #include <mutex>
 
 YARP_DECLARE_LOG_COMPONENT(REMOTEFRAMEGRABBER)
-
-class ImplementDC1394 :
-        public yarp::dev::IFrameGrabberControlsDC1394
-{
-private:
-    yarp::os::Port* _port{nullptr};
-
-public:
-    void init(yarp::os::Port *__port)
-    {
-        _port = __port;
-    }
-
-private:
-    bool setCommand(int code, double v)
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_SET);
-        cmd.addVocab(code);
-        cmd.addFloat64(v);
-        _port->write(cmd,response);
-        return true;
-    }
-
-    bool setCommand(int code, double b, double r)
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_SET);
-        cmd.addVocab(code);
-        cmd.addFloat64(b);
-        cmd.addFloat64(r);
-        _port->write(cmd,response);
-        return true;
-    }
-
-    double getCommand(int code) const
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_GET);
-        cmd.addVocab(code);
-        _port->write(cmd,response);
-        // response should be [cmd] [name] value
-        return response.get(2).asFloat64();
-    }
-
-    bool getCommand(int code, double &b, double &r) const
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_GET);
-        cmd.addVocab(code);
-        _port->write(cmd,response);
-        // response should be [cmd] [name] value
-        b=response.get(2).asFloat64();
-        r=response.get(3).asFloat64();
-        return true;
-    }
-
-public:
-
-    // 12
-    unsigned int getVideoModeMaskDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETMSK);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 13
-    unsigned int getVideoModeDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETVMD);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 14
-    bool setVideoModeDC1394(int video_mode) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETVMD);
-        cmd.addInt32(video_mode);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 15
-    unsigned int getFPSMaskDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETFPM);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 16
-    unsigned int getFPSDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETFPS);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 17
-    bool setFPSDC1394(int fps) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETFPS);
-        cmd.addInt32(fps);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 18
-    unsigned int getISOSpeedDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETISO);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 19
-    bool setISOSpeedDC1394(int speed) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETISO);
-        cmd.addInt32(speed);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 20
-    unsigned int getColorCodingMaskDC1394(unsigned int video_mode) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETCCM);
-        cmd.addInt32(video_mode);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 21
-    unsigned int getColorCodingDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETCOD);
-        _port->write(cmd,response);
-
-        // I'll bite your sweet little fingers ^__^
-        return (unsigned)response.get(0).asInt32();
-        //return response.get(0).asInt32()!=0? true:false;
-    }
-    // 22
-    bool setColorCodingDC1394(int coding) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETCOD);
-        cmd.addInt32(coding);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    bool getFormat7MaxWindowDC1394(unsigned int &xdim,unsigned int &ydim,unsigned int &xstep,unsigned int &ystep,unsigned int &xoffstep,unsigned int &yoffstep) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETF7M);
-        _port->write(cmd,response);
-
-        xdim=response.get(0).asInt32();
-        ydim=response.get(1).asInt32();
-        xstep=response.get(2).asInt32();
-        ystep=response.get(3).asInt32();
-        xoffstep=response.get(4).asInt32();
-        yoffstep=response.get(5).asInt32();
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 26
-    bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETWF7);
-        _port->write(cmd,response);
-        xdim=response.get(0).asInt32();
-        ydim=response.get(1).asInt32();
-        x0=response.get(2).asInt32();
-        y0=response.get(3).asInt32();
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 27
-    bool setFormat7WindowDC1394(unsigned int xdim,unsigned int ydim,int x0,int y0) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETWF7);
-        cmd.addInt32(xdim);
-        cmd.addInt32(ydim);
-        cmd.addInt32(x0);
-        cmd.addInt32(y0);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 28
-    bool setOperationModeDC1394(bool b1394b) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETOPM);
-        cmd.addInt32(int(b1394b));
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 29
-    bool getOperationModeDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETOPM);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 30
-    bool setTransmissionDC1394(bool bTxON) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETTXM);
-        cmd.addInt32(int(bTxON));
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 31
-    bool getTransmissionDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETTXM);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 34
-    bool setBroadcastDC1394(bool onoff) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETBCS);
-        cmd.addInt32((int)onoff);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 35
-    bool setDefaultsDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETDEF);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 36
-    bool setResetDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETRST);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-    // 37
-    bool setPowerDC1394(bool onoff) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETPWR);
-        cmd.addInt32((int)onoff);
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 38
-    bool setCaptureDC1394(bool bON) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETCAP);
-        cmd.addInt32(int(bON));
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 39
-    bool setBytesPerPacketDC1394(unsigned int bpp) override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRSETBPP);
-        cmd.addInt32(int(bpp));
-        _port->write(cmd,response);
-        return response.get(0).asInt32()!=0? true:false;
-    }
-
-    // 40
-    unsigned int getBytesPerPacketDC1394() override
-    {
-        yarp::os::Bottle cmd, response;
-        cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
-        cmd.addVocab(VOCAB_DRGETBPP);
-        _port->write(cmd,response);
-        return (unsigned)response.get(0).asInt32();
-    }
-};
 
 /**
  * @ingroup dev_impl_network_clients
@@ -377,11 +37,11 @@ public:
  * the network protocol used.
  */
 class RemoteFrameGrabber :
+        public yarp::dev::DeviceDriver,
         public yarp::dev::IFrameGrabberImage,
-        public yarp::dev::FrameGrabberControls_Sender,
-        public ImplementDC1394,
-        public yarp::dev::Implement_RgbVisualParams_Sender,
-        public yarp::dev::DeviceDriver
+        public yarp::proto::framegrabber::FrameGrabberControls_Forwarder,
+        public yarp::proto::framegrabber::FrameGrabberControlsDC1394_Forwarder,
+        public yarp::proto::framegrabber::RgbVisualParams_Forwarder
 {
 public:
     RemoteFrameGrabber();
@@ -402,7 +62,7 @@ public:
             return false;
         }
 
-        if (reader.read(true)!=NULL) {
+        if (reader.read(true)!=nullptr) {
             image = *(reader.lastRead());
             lastHeight = image.height();
             lastWidth = image.width();
@@ -415,7 +75,8 @@ public:
 
     bool getImageCrop(cropType_id_t cropType, yarp::sig::VectorOf<std::pair<int, int> > vertices, yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override
     {
-        yarp::os::Bottle cmd, response;
+        yarp::os::Bottle cmd;
+        yarp::os::Bottle response;
         cmd.addVocab(VOCAB_FRAMEGRABBER_IMAGE);
         cmd.addVocab(VOCAB_GET);
         cmd.addVocab(VOCAB_CROP);
@@ -497,7 +158,7 @@ public:
             yarp::os::Network::connect(local,remote);
         }
         reader.attach(port);
-        ImplementDC1394::init(&port);
+        FrameGrabberControlsDC1394_Forwarder::init(&port);
         return true;
     }
 
@@ -636,7 +297,8 @@ protected:
         return true;
     }
 
-    double getCommand(int code) const {
+    double getCommand(int code) const
+    {
         yarp::os::Bottle cmd, response;
         cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
         cmd.addVocab(VOCAB_GET);

--- a/src/devices/ServerFrameGrabber/CMakeLists.txt
+++ b/src/devices/ServerFrameGrabber/CMakeLists.txt
@@ -18,6 +18,9 @@ if(NOT SKIP_grabber)
   target_sources(yarp_grabber PRIVATE ServerFrameGrabber.cpp
                                       ServerFrameGrabber.h)
 
+  target_sources(yarp_grabber PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_grabber PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
   target_link_libraries(yarp_grabber PRIVATE YARP::YARP_os
                                              YARP::YARP_sig
                                              YARP::YARP_dev)

--- a/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
+++ b/src/devices/ServerFrameGrabber/ServerFrameGrabber.cpp
@@ -11,6 +11,8 @@
 
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
+// #include <yarp/proto/framegrabber/CameraVocabs.h> // FIXME
+#include <yarp/dev/GenericVocabs.h>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -98,7 +100,7 @@ bool ServerFrameGrabber::open(yarp::os::Searchable& config)
         }
         poly.view(fgCtrl);
         if(fgCtrl)
-            ifgCtrl_Parser.configure(fgCtrl);
+            ifgCtrl_Responder.configure(fgCtrl);
         poly.view(fgTimed);
         poly.view(rgbVis_p);
 
@@ -205,7 +207,7 @@ bool ServerFrameGrabber::respond(const yarp::os::Bottle& cmd,
     // first check if requests are coming from new iFrameGrabberControl2 interface and process them
     case VOCAB_FRAMEGRABBER_CONTROL:
     {
-        return ifgCtrl_Parser.respond(cmd, response);    // I don't like all those returns everywhere!!! :-(
+        return ifgCtrl_Responder.respond(cmd, response);    // I don't like all those returns everywhere!!! :-(
     } break;
     case VOCAB_RGB_VISUAL_PARAMS:
     {

--- a/src/devices/ServerFrameGrabber/ServerFrameGrabber.h
+++ b/src/devices/ServerFrameGrabber/ServerFrameGrabber.h
@@ -13,7 +13,6 @@
 #include <cstdio>
 
 #include <yarp/dev/FrameGrabberInterfaces.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/ServiceInterfaces.h>
@@ -23,12 +22,14 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Bottle.h>
-#include <yarp/dev/IVisualParamsImpl.h>
 
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/os/RateThread.h>
 #include <yarp/dev/DataSource.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+
+#include <yarp/proto/framegrabber/RgbVisualParams_Responder.h>
+#include <yarp/proto/framegrabber/FrameGrabberControls_Responder.h>
 
 YARP_WARNING_PUSH
 YARP_DISABLE_DEPRECATED_WARNING
@@ -88,7 +89,7 @@ class ServerFrameGrabber :
         public yarp::dev::DataSource2<yarp::sig::ImageOf<yarp::sig::PixelRgb>,yarp::sig::Sound>
 {
 private:
-    yarp::dev::Implement_RgbVisualParams_Parser  rgbParser;
+    yarp::proto::framegrabber::RgbVisualParams_Responder rgbParser;
     yarp::dev::IRgbVisualParams* rgbVis_p{nullptr};
     yarp::os::Port p;
     yarp::os::Port *p2{nullptr};
@@ -109,7 +110,7 @@ YARP_WARNING_POP
     bool active{false};
     bool singleThreaded{false};
 
-    yarp::dev::FrameGrabberControls_Parser ifgCtrl_Parser;
+    yarp::proto::framegrabber::FrameGrabberControls_Responder ifgCtrl_Responder;
 
 public:
     ServerFrameGrabber() = default;

--- a/src/devices/ServerFrameGrabberDual/CMakeLists.txt
+++ b/src/devices/ServerFrameGrabberDual/CMakeLists.txt
@@ -17,6 +17,9 @@ if(NOT SKIP_grabberDual)
   target_sources(yarp_grabberDual PRIVATE ServerFrameGrabberDual.cpp
                                           ServerFrameGrabberDual.h)
 
+  target_sources(yarp_grabberDual PRIVATE $<TARGET_OBJECTS:framegrabber_protocol>)
+  target_include_directories(yarp_grabberDual PRIVATE $<TARGET_PROPERTY:framegrabber_protocol,INTERFACE_INCLUDE_DIRECTORIES>)
+
   target_link_libraries(yarp_grabberDual PRIVATE YARP::YARP_os
                                                  YARP::YARP_sig
                                                  YARP::YARP_dev)

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
@@ -17,6 +17,8 @@
 #include <yarp/sig/ImageUtils.h>
 #include <yarp/os/PortablePair.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
+
+// #include <yarp/proto/framegrabber/CameraVocabs.h> // FIXME
 #include <yarp/dev/GenericVocabs.h>
 
 #include <cstring>
@@ -30,128 +32,6 @@ namespace {
 YARP_LOG_COMPONENT(SERVERGRABBER, "yarp.device.grabberDual")
 }
 
-
-bool DC1394Parser::configure(IFrameGrabberControlsDC1394 *interface)
-{
-    fgCtrl_DC1394 = interface;
-    return true;
-}
-
-bool DC1394Parser::respond(const Bottle& cmd, Bottle& response)
-{
-    int code = cmd.get(1).asVocab();
-    if (fgCtrl_DC1394)
-    {
-        switch(code)
-        {
-        case VOCAB_DRGETMSK: // VOCAB_DRGETMSK 12
-            response.addInt32(int(fgCtrl_DC1394->getVideoModeMaskDC1394()));
-            return true;
-        case VOCAB_DRGETVMD: // VOCAB_DRGETVMD 13
-            response.addInt32(int(fgCtrl_DC1394->getVideoModeDC1394()));
-            return true;
-        case VOCAB_DRSETVMD: // VOCAB_DRSETVMD 14
-            response.addInt32(int(fgCtrl_DC1394->setVideoModeDC1394(cmd.get(1).asInt32())));
-            return true;
-        case VOCAB_DRGETFPM: // VOCAB_DRGETFPM 15
-            response.addInt32(int(fgCtrl_DC1394->getFPSMaskDC1394()));
-            return true;
-        case VOCAB_DRGETFPS: // VOCAB_DRGETFPS 16
-            response.addInt32(int(fgCtrl_DC1394->getFPSDC1394()));
-            return true;
-        case VOCAB_DRSETFPS: // VOCAB_DRSETFPS 17
-            response.addInt32(int(fgCtrl_DC1394->setFPSDC1394(cmd.get(1).asInt32())));
-            return true;
-
-        case VOCAB_DRGETISO: // VOCAB_DRGETISO 18
-            response.addInt32(int(fgCtrl_DC1394->getISOSpeedDC1394()));
-            return true;
-        case VOCAB_DRSETISO: // VOCAB_DRSETISO 19
-            response.addInt32(int(fgCtrl_DC1394->setISOSpeedDC1394(cmd.get(1).asInt32())));
-            return true;
-
-        case VOCAB_DRGETCCM: // VOCAB_DRGETCCM 20
-            response.addInt32(int(fgCtrl_DC1394->getColorCodingMaskDC1394(cmd.get(1).asInt32())));
-            return true;
-        case VOCAB_DRGETCOD: // VOCAB_DRGETCOD 21
-            response.addInt32(int(fgCtrl_DC1394->getColorCodingDC1394()));
-            return true;
-        case VOCAB_DRSETCOD: // VOCAB_DRSETCOD 22
-            response.addInt32(int(fgCtrl_DC1394->setColorCodingDC1394(cmd.get(1).asInt32())));
-            return true;
-
-        case VOCAB_DRGETF7M: // VOCAB_DRGETF7M 25
-            {
-                unsigned int xstep,ystep,xdim,ydim,xoffstep,yoffstep;
-                fgCtrl_DC1394->getFormat7MaxWindowDC1394(xdim,ydim,xstep,ystep,xoffstep,yoffstep);
-                response.addInt32(xdim);
-                response.addInt32(ydim);
-                response.addInt32(xstep);
-                response.addInt32(ystep);
-                response.addInt32(xoffstep);
-                response.addInt32(yoffstep);
-            }
-            return true;
-        case VOCAB_DRGETWF7: // VOCAB_DRGETWF7 26
-            {
-                unsigned int xdim,ydim;
-                int x0,y0;
-                fgCtrl_DC1394->getFormat7WindowDC1394(xdim,ydim,x0,y0);
-                response.addInt32(xdim);
-                response.addInt32(ydim);
-                response.addInt32(x0);
-                response.addInt32(y0);
-            }
-            return true;
-        case VOCAB_DRSETWF7: // VOCAB_DRSETWF7 27
-            response.addInt32(int(fgCtrl_DC1394->setFormat7WindowDC1394(cmd.get(1).asInt32(),cmd.get(2).asInt32(),cmd.get(3).asInt32(),cmd.get(4).asInt32())));
-            return true;
-        case VOCAB_DRSETOPM: // VOCAB_DRSETOPM 28
-            response.addInt32(int(fgCtrl_DC1394->setOperationModeDC1394(cmd.get(1).asInt32()!=0)));
-            return true;
-        case VOCAB_DRGETOPM: // VOCAB_DRGETOPM 29
-            response.addInt32(fgCtrl_DC1394->getOperationModeDC1394());
-            return true;
-
-        case VOCAB_DRSETTXM: // VOCAB_DRSETTXM 30
-            response.addInt32(int(fgCtrl_DC1394->setTransmissionDC1394(cmd.get(1).asInt32()!=0)));
-            return true;
-        case VOCAB_DRGETTXM: // VOCAB_DRGETTXM 31
-            response.addInt32(fgCtrl_DC1394->getTransmissionDC1394());
-            return true;
-        case VOCAB_DRSETBCS: // VOCAB_DRSETBCS 34
-            response.addInt32(int(fgCtrl_DC1394->setBroadcastDC1394(cmd.get(1).asInt32()!=0)));
-            return true;
-        case VOCAB_DRSETDEF: // VOCAB_DRSETDEF 35
-            response.addInt32(int(fgCtrl_DC1394->setDefaultsDC1394()));
-            return true;
-        case VOCAB_DRSETRST: // VOCAB_DRSETRST 36
-            response.addInt32(int(fgCtrl_DC1394->setResetDC1394()));
-            return true;
-        case VOCAB_DRSETPWR: // VOCAB_DRSETPWR 37
-            response.addInt32(int(fgCtrl_DC1394->setPowerDC1394(cmd.get(1).asInt32()!=0)));
-            return true;
-        case VOCAB_DRSETCAP: // VOCAB_DRSETCAP 38
-            response.addInt32(int(fgCtrl_DC1394->setCaptureDC1394(cmd.get(1).asInt32()!=0)));
-            return true;
-        case VOCAB_DRSETBPP: // VOCAB_DRSETCAP 39
-            response.addInt32(int(fgCtrl_DC1394->setBytesPerPacketDC1394(cmd.get(1).asInt32())));
-            return true;
-        case VOCAB_DRGETBPP: // VOCAB_DRGETTXM 40
-            response.addInt32(fgCtrl_DC1394->getBytesPerPacketDC1394());
-            return true;
-        }
-    }
-    else
-    {
-        yCWarning(SERVERGRABBER) << "DC1394Parser:  firewire interface not implemented in subdevice, some features could not be available";
-//        response.clear();
-//        response.addVocab(VOCAB_FAILED);
-        return DeviceResponder::respond(cmd,response);
-    }
-
-    return true;
-}
 
 // **********ServerGrabberResponder**********
 
@@ -624,8 +504,8 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
         {
             bool ret;
             if(both){
-                ret=ifgCtrl_Parser.respond(cmd, response);
-                ret&=ifgCtrl2_Parser.respond(cmd, response2);
+                ret=ifgCtrl_Responder.respond(cmd, response);
+                ret&=ifgCtrl2_Responder.respond(cmd, response2);
                 if(!ret || (response!=response2))
                 {
                     response.clear();
@@ -638,17 +518,17 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
             {
                 if(left)
                 {
-                    ret=ifgCtrl_Parser.respond(cmd, response);
+                    ret=ifgCtrl_Responder.respond(cmd, response);
                 }
                 else
                 {
-                    ret=ifgCtrl2_Parser.respond(cmd, response);
+                    ret=ifgCtrl2_Responder.respond(cmd, response);
                 }
             }
             return ret;
         }
         else
-            return ifgCtrl_Parser.respond(cmd, response);
+            return ifgCtrl_Responder.respond(cmd, response);
     } break;
 
     case VOCAB_RGB_VISUAL_PARAMS:
@@ -700,8 +580,8 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
             bool ret;
             if(both)
             {
-                ret=ifgCtrl_DC1394_Parser.respond(cmd, response);
-                ret&=ifgCtrl2_DC1394_Parser.respond(cmd, response2);
+                ret=ifgCtrl_DC1394_Responder.respond(cmd, response);
+                ret&=ifgCtrl2_DC1394_Responder.respond(cmd, response2);
                 if(!ret || (response!=response2))
                 {
                     response.clear();
@@ -715,17 +595,17 @@ bool ServerGrabber::respond(const yarp::os::Bottle& cmd,
             {
                 if(left)
                 {
-                    ret=ifgCtrl_DC1394_Parser.respond(cmd, response);
+                    ret=ifgCtrl_DC1394_Responder.respond(cmd, response);
                 }
                 else
                 {
-                    ret=ifgCtrl2_DC1394_Parser.respond(cmd, response);
+                    ret=ifgCtrl2_DC1394_Responder.respond(cmd, response);
                 }
             }
             return ret;
         }
         else
-            return ifgCtrl_DC1394_Parser.respond(cmd, response);
+            return ifgCtrl_DC1394_Responder.respond(cmd, response);
     } break;
     }
     yCError(SERVERGRABBER) << "Command not recognized" << cmd.toString();
@@ -811,7 +691,7 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
         }
         if(fgCtrl != nullptr && fgCtrl2 != nullptr)
         {
-            if(!(ifgCtrl_Parser.configure(fgCtrl)) || !(ifgCtrl2_Parser.configure(fgCtrl2)))
+            if(!(ifgCtrl_Responder.configure(fgCtrl)) || !(ifgCtrl2_Responder.configure(fgCtrl2)))
             {
                 yCError(SERVERGRABBER) << "Error configuring interfaces for parsers";
                 return false;
@@ -819,7 +699,7 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
         }
         if(fgCtrl_DC1394 != nullptr && fgCtrl2_DC1394 != nullptr)
         {
-            if(!(ifgCtrl_DC1394_Parser.configure(fgCtrl_DC1394)) || !(ifgCtrl2_DC1394_Parser.configure(fgCtrl2_DC1394)))
+            if(!(ifgCtrl_DC1394_Responder.configure(fgCtrl_DC1394)) || !(ifgCtrl2_DC1394_Responder.configure(fgCtrl2_DC1394)))
             {
                 yCError(SERVERGRABBER) << "Error configuring interfaces for parsers";
                 return false;
@@ -880,7 +760,7 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
         }
         if(fgCtrl != nullptr)
         {
-            if(!(ifgCtrl_Parser.configure(fgCtrl)))
+            if(!(ifgCtrl_Responder.configure(fgCtrl)))
             {
                 yCError(SERVERGRABBER) << "Error configuring interfaces for parsers";
                 return false;
@@ -889,7 +769,7 @@ bool ServerGrabber::attachAll(const PolyDriverList &device2attach)
 
         if(fgCtrl_DC1394 != nullptr)
         {
-            if(!(ifgCtrl_DC1394_Parser.configure(fgCtrl_DC1394)))
+            if(!(ifgCtrl_DC1394_Responder.configure(fgCtrl_DC1394)))
             {
                 yCError(SERVERGRABBER) << "Error configuring interfaces for parsers";
                 return false;

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.h
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.h
@@ -12,8 +12,6 @@
 
 #include <cstdio>
 
-#include <yarp/dev/FrameGrabberInterfaces.h>
-#include <yarp/dev/FrameGrabberControlImpl.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/ServiceInterfaces.h>
@@ -25,25 +23,14 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Bottle.h>
-#include <yarp/dev/IVisualParamsImpl.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
 
+#include <yarp/proto/framegrabber/FrameGrabberControls_Responder.h>
+#include <yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.h>
+#include <yarp/proto/framegrabber/RgbVisualParams_Responder.h>
 
 class ServerGrabber;
-
-class DC1394Parser :
-        public yarp::dev::DeviceResponder
-{
-private:
-    yarp::dev::IFrameGrabberControlsDC1394  *fgCtrl_DC1394{nullptr};
-
-public:
-    DC1394Parser() = default;
-    ~DC1394Parser() override = default;
-    bool configure(yarp::dev::IFrameGrabberControlsDC1394 *interface);
-    bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
-};
 
 
 class ServerGrabberResponder :
@@ -190,8 +177,8 @@ private:
     int count2{0};
     ServerGrabberResponder* responder{nullptr};
     ServerGrabberResponder* responder2{nullptr};
-    yarp::dev::Implement_RgbVisualParams_Parser  rgbParser;
-    yarp::dev::Implement_RgbVisualParams_Parser  rgbParser2;
+    yarp::proto::framegrabber::RgbVisualParams_Responder rgbParser;
+    yarp::proto::framegrabber::RgbVisualParams_Responder rgbParser2;
     yarp::dev::IRgbVisualParams* rgbVis_p{nullptr};
     yarp::dev::IRgbVisualParams* rgbVis_p2{nullptr};
     std::string rpcPort_Name;
@@ -216,10 +203,10 @@ private:
     yarp::dev::IFrameGrabberControlsDC1394* fgCtrl_DC1394{nullptr};
     yarp::dev::IFrameGrabberControlsDC1394* fgCtrl2_DC1394{nullptr};
     yarp::dev::IPreciselyTimed *fgTimed{nullptr};
-    yarp::dev::FrameGrabberControls_Parser ifgCtrl_Parser;
-    yarp::dev::FrameGrabberControls_Parser ifgCtrl2_Parser;
-    DC1394Parser ifgCtrl_DC1394_Parser;
-    DC1394Parser ifgCtrl2_DC1394_Parser;
+    yarp::proto::framegrabber::FrameGrabberControls_Responder ifgCtrl_Responder;
+    yarp::proto::framegrabber::FrameGrabberControls_Responder ifgCtrl2_Responder;
+    yarp::proto::framegrabber::FrameGrabberControlsDC1394_Responder ifgCtrl_DC1394_Responder;
+    yarp::proto::framegrabber::FrameGrabberControlsDC1394_Responder ifgCtrl2_DC1394_Responder;
     Configuration param;
     yarp::sig::ImageOf<yarp::sig::PixelRgb>* img{nullptr};
     yarp::sig::ImageOf<yarp::sig::PixelRgb>* img2{nullptr};

--- a/src/devices/depthCamera/depthCameraDriver.h
+++ b/src/devices/depthCamera/depthCameraDriver.h
@@ -23,7 +23,7 @@
 #include <map>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberControl2.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/all.h>
 #include <yarp/sig/Matrix.h>

--- a/src/devices/framegrabber_protocol/CMakeLists.txt
+++ b/src/devices/framegrabber_protocol/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+if(YARP_COMPILE_DEVICE_PLUGINS)
+  add_library(framegrabber_protocol OBJECT)
+
+  target_sources(framegrabber_protocol
+    PRIVATE
+      yarp/proto/framegrabber/DepthVisualParams_Responder.cpp
+      yarp/proto/framegrabber/DepthVisualParams_Responder.h
+      yarp/proto/framegrabber/DepthVisualParams_Forwarder.cpp
+      yarp/proto/framegrabber/DepthVisualParams_Forwarder.h
+      yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.cpp
+      yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.h
+      yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.cpp
+      yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.h
+      yarp/proto/framegrabber/FrameGrabberControls_Responder.cpp
+      yarp/proto/framegrabber/FrameGrabberControls_Responder.h
+      yarp/proto/framegrabber/FrameGrabberControls_Forwarder.cpp
+      yarp/proto/framegrabber/FrameGrabberControls_Forwarder.h
+      yarp/proto/framegrabber/RgbVisualParams_Responder.cpp
+      yarp/proto/framegrabber/RgbVisualParams_Responder.h
+      yarp/proto/framegrabber/RgbVisualParams_Forwarder.cpp
+      yarp/proto/framegrabber/RgbVisualParams_Forwarder.h
+  )
+
+  target_link_libraries(framegrabber_protocol
+    PRIVATE
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+  )
+  target_include_directories(framegrabber_protocol PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+  set_property(TARGET framegrabber_protocol PROPERTY FOLDER "Libraries/Msgs")
+endif()

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/CameraVocabs.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/CameraVocabs.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_CAMERAVOCABS_H
+#define YARP_FRAMEGRABBER_PROTOCOL_CAMERAVOCABS_H
+
+#include <yarp/conf/numeric.h>
+#include <yarp/dev/GenericVocabs.h>
+
+/*
+ *  Vocab for interfaces
+ */
+constexpr yarp::conf::vocab32_t VOCAB_FRAMEGRABBER_IMAGE        = yarp::os::createVocab('f','g','i');
+constexpr yarp::conf::vocab32_t VOCAB_FRAMEGRABBER_IMAGERAW     = yarp::os::createVocab('f','g','i','r');
+
+
+/*
+ * Generic capabilities defines
+ */
+
+constexpr yarp::conf::vocab32_t VOCAB_BRIGHTNESS                = yarp::os::createVocab('b','r','i');
+constexpr yarp::conf::vocab32_t VOCAB_EXPOSURE                  = yarp::os::createVocab('e','x','p','o');
+constexpr yarp::conf::vocab32_t VOCAB_SHARPNESS                 = yarp::os::createVocab('s','h','a','r');
+constexpr yarp::conf::vocab32_t VOCAB_WHITE                     = yarp::os::createVocab('w','h','i','t');
+constexpr yarp::conf::vocab32_t VOCAB_HUE                       = yarp::os::createVocab('h','u','e');
+constexpr yarp::conf::vocab32_t VOCAB_SATURATION                = yarp::os::createVocab('s','a','t','u');
+constexpr yarp::conf::vocab32_t VOCAB_GAMMA                     = yarp::os::createVocab('g','a','m','m');
+constexpr yarp::conf::vocab32_t VOCAB_SHUTTER                   = yarp::os::createVocab('s','h','u','t');
+constexpr yarp::conf::vocab32_t VOCAB_GAIN                      = yarp::os::createVocab('g','a','i','n');
+constexpr yarp::conf::vocab32_t VOCAB_IRIS                      = yarp::os::createVocab('i','r','i','s');
+
+// General usage vocabs
+constexpr yarp::conf::vocab32_t VOCAB_CROP                      = yarp::os::createVocab('c','r','o','p');
+constexpr yarp::conf::vocab32_t VOCAB_FRAMEGRABBER_CONTROL      = yarp::os::createVocab('f','g','c');
+constexpr yarp::conf::vocab32_t VOCAB_FRAMEGRABBER_CONTROL_DC1394 = yarp::os::createVocab('f','g','f','w');
+constexpr yarp::conf::vocab32_t VOCAB_CAMERA_DESCRIPTION        = yarp::os::createVocab('c','a','m','d');
+constexpr yarp::conf::vocab32_t VOCAB_HAS                       = yarp::os::createVocab('h','a','s');
+constexpr yarp::conf::vocab32_t VOCAB_FEATURE                   = yarp::os::createVocab('f','e','a','t');
+constexpr yarp::conf::vocab32_t VOCAB_FEATURE2                  = yarp::os::createVocab('f','e','a','2');
+constexpr yarp::conf::vocab32_t VOCAB_ONOFF                     = yarp::os::createVocab('o','n','o','f');
+constexpr yarp::conf::vocab32_t VOCAB_AUTO                      = yarp::os::createVocab('a','u','t','o');
+constexpr yarp::conf::vocab32_t VOCAB_MANUAL                    = yarp::os::createVocab('m','a','n');
+constexpr yarp::conf::vocab32_t VOCAB_ONEPUSH                   = yarp::os::createVocab('o','n','e','p');
+constexpr yarp::conf::vocab32_t VOCAB_ACTIVE                    = yarp::os::createVocab('a','c','t','v');
+constexpr yarp::conf::vocab32_t VOCAB_MODE                      = yarp::os::createVocab('m','o','d','e');
+
+
+/*
+ * For usage with IFrameGrabberControlsDC1394 interface
+ */
+
+constexpr yarp::conf::vocab32_t VOCAB_DRHASFEA = yarp::os::createVocab('D','R','2','a');// 00
+constexpr yarp::conf::vocab32_t VOCAB_DRSETVAL = yarp::os::createVocab('D','R','2','b');// 01
+constexpr yarp::conf::vocab32_t VOCAB_DRGETVAL = yarp::os::createVocab('D','R','2','c');// 02
+constexpr yarp::conf::vocab32_t VOCAB_DRHASACT = yarp::os::createVocab('D','R','2','d');// 03
+constexpr yarp::conf::vocab32_t VOCAB_DRSETACT = yarp::os::createVocab('D','R','2','e');// 04
+constexpr yarp::conf::vocab32_t VOCAB_DRGETACT = yarp::os::createVocab('D','R','2','f');// 05
+constexpr yarp::conf::vocab32_t VOCAB_DRHASMAN = yarp::os::createVocab('D','R','2','g');// 06
+constexpr yarp::conf::vocab32_t VOCAB_DRHASAUT = yarp::os::createVocab('D','R','2','h');// 07
+constexpr yarp::conf::vocab32_t VOCAB_DRHASONP = yarp::os::createVocab('D','R','2','i');// 08
+constexpr yarp::conf::vocab32_t VOCAB_DRSETMOD = yarp::os::createVocab('D','R','2','j');// 09
+constexpr yarp::conf::vocab32_t VOCAB_DRGETMOD = yarp::os::createVocab('D','R','2','k');// 10
+constexpr yarp::conf::vocab32_t VOCAB_DRSETONP = yarp::os::createVocab('D','R','2','l');// 11
+
+// masks
+constexpr yarp::conf::vocab32_t VOCAB_DRGETMSK = yarp::os::createVocab('D','R','2','m'); // 12
+constexpr yarp::conf::vocab32_t VOCAB_DRGETVMD = yarp::os::createVocab('D','R','2','n'); // 13
+constexpr yarp::conf::vocab32_t VOCAB_DRSETVMD = yarp::os::createVocab('D','R','2','o'); // 14
+constexpr yarp::conf::vocab32_t VOCAB_DRGETFPM = yarp::os::createVocab('D','R','2','p'); // 15
+constexpr yarp::conf::vocab32_t VOCAB_DRGETFPS = yarp::os::createVocab('D','R','2','q'); // 16
+constexpr yarp::conf::vocab32_t VOCAB_DRSETFPS = yarp::os::createVocab('D','R','2','r'); // 17
+constexpr yarp::conf::vocab32_t VOCAB_DRGETISO = yarp::os::createVocab('D','R','2','s'); // 18
+constexpr yarp::conf::vocab32_t VOCAB_DRSETISO = yarp::os::createVocab('D','R','2','t'); // 19
+constexpr yarp::conf::vocab32_t VOCAB_DRGETCCM = yarp::os::createVocab('D','R','2','u'); // 20
+constexpr yarp::conf::vocab32_t VOCAB_DRGETCOD = yarp::os::createVocab('D','R','2','v'); // 21
+constexpr yarp::conf::vocab32_t VOCAB_DRSETCOD = yarp::os::createVocab('D','R','2','w'); // 22
+constexpr yarp::conf::vocab32_t VOCAB_DRSETWHB = yarp::os::createVocab('D','R','2','x'); // 23
+constexpr yarp::conf::vocab32_t VOCAB_DRGETWHB = yarp::os::createVocab('D','R','2','y'); // 24
+constexpr yarp::conf::vocab32_t VOCAB_DRGETF7M = yarp::os::createVocab('D','R','2','z'); // 25
+constexpr yarp::conf::vocab32_t VOCAB_DRGETWF7 = yarp::os::createVocab('D','R','2','A'); // 26
+constexpr yarp::conf::vocab32_t VOCAB_DRSETWF7 = yarp::os::createVocab('D','R','2','B'); // 27
+constexpr yarp::conf::vocab32_t VOCAB_DRSETOPM = yarp::os::createVocab('D','R','2','C'); // 28
+constexpr yarp::conf::vocab32_t VOCAB_DRGETOPM = yarp::os::createVocab('D','R','2','D'); // 29
+constexpr yarp::conf::vocab32_t VOCAB_DRSETTXM = yarp::os::createVocab('D','R','2','E'); // 30
+constexpr yarp::conf::vocab32_t VOCAB_DRGETTXM = yarp::os::createVocab('D','R','2','F'); // 31
+
+
+constexpr yarp::conf::vocab32_t VOCAB_DRSETBCS = yarp::os::createVocab('D','R','2','I'); // 34
+constexpr yarp::conf::vocab32_t VOCAB_DRSETDEF = yarp::os::createVocab('D','R','2','J'); // 35
+constexpr yarp::conf::vocab32_t VOCAB_DRSETRST = yarp::os::createVocab('D','R','2','K'); // 36
+constexpr yarp::conf::vocab32_t VOCAB_DRSETPWR = yarp::os::createVocab('D','R','2','L'); // 37
+constexpr yarp::conf::vocab32_t VOCAB_DRSETCAP = yarp::os::createVocab('D','R','2','M'); // 38
+constexpr yarp::conf::vocab32_t VOCAB_DRSETBPP = yarp::os::createVocab('D','R','2','N'); // 39
+constexpr yarp::conf::vocab32_t VOCAB_DRGETBPP = yarp::os::createVocab('D','R','2','O'); // 40
+
+
+
+#if 0
+    cameraFeature_id_t featureVOCABEnum(int vocab)
+    {
+        switch (vocab) {
+        case VOCAB_BRIGHTNESS:
+            return YARP_FEATURE_BRIGHTNESS;
+        case VOCAB_EXPOSURE:
+            return YARP_FEATURE_EXPOSURE;
+        case VOCAB_SHARPNESS:
+            return YARP_FEATURE_SHARPNESS;
+        case VOCAB_WHITE:
+            return YARP_FEATURE_WHITE_BALANCE;
+        case VOCAB_HUE:
+            return YARP_FEATURE_HUE;
+        case VOCAB_SATURATION:
+            return YARP_FEATURE_SATURATION;
+        case VOCAB_GAMMA:
+            return YARP_FEATURE_GAMMA;
+        case VOCAB_SHUTTER:
+            return YARP_FEATURE_SHUTTER;
+        case VOCAB_GAIN:
+            return YARP_FEATURE_GAIN;
+        case VOCAB_IRIS:
+            return YARP_FEATURE_IRIS;
+        default:
+            return YARP_FEATURE_INVALID;
+        }
+
+    }
+
+    int featureEnum2Vocab(cameraFeature_id_t _enum)
+    {
+        switch (_enum) {
+        case YARP_FEATURE_BRIGHTNESS:
+            return VOCAB_BRIGHTNESS;
+        case YARP_FEATURE_EXPOSURE:
+            return VOCAB_EXPOSURE;
+        case YARP_FEATURE_SHARPNESS:
+            return VOCAB_SHARPNESS;
+        case YARP_FEATURE_WHITE_BALANCE:
+            return VOCAB_WHITE;
+        case YARP_FEATURE_HUE:
+            return VOCAB_HUE;
+        case YARP_FEATURE_SATURATION:
+            return VOCAB_SATURATION;
+        case YARP_FEATURE_GAMMA:
+            return VOCAB_GAMMA;
+        case YARP_FEATURE_SHUTTER:
+            return VOCAB_SHUTTER;
+        case YARP_FEATURE_GAIN:
+            return VOCAB_GAIN;
+        case YARP_FEATURE_IRIS:
+            return VOCAB_IRIS;
+        default:
+            return -1;
+        }
+
+    }
+#endif
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_CAMERAVOCABS_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Forwarder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Forwarder.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "DepthVisualParams_Forwarder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+using yarp::proto::framegrabber::DepthVisualParams_Forwarder;
+
+DepthVisualParams_Forwarder::DepthVisualParams_Forwarder(yarp::os::Port& port) :
+        m_port(port)
+{
+};
+
+int DepthVisualParams_Forwarder::getDepthHeight()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_HEIGHT);
+    m_port.write(cmd, response);
+    return response.get(3).asInt32();
+}
+
+int DepthVisualParams_Forwarder::getDepthWidth()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_WIDTH);
+    m_port.write(cmd, response);
+    return response.get(3).asInt32();
+}
+
+bool DepthVisualParams_Forwarder::setDepthResolution(int width, int height)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_RESOLUTION);
+    cmd.addInt32(width);
+    cmd.addInt32(height);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+bool DepthVisualParams_Forwarder::getDepthFOV(double& horizontalFov, double& verticalFov)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FOV);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        horizontalFov = 0;
+        verticalFov = 0;
+        return false;
+    }
+    horizontalFov = response.get(3).asFloat64();
+    verticalFov = response.get(4).asFloat64();
+    return true;
+}
+
+bool DepthVisualParams_Forwarder::setDepthFOV(double horizontalFov, double verticalFov)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_FOV);
+    cmd.addFloat64(horizontalFov);
+    cmd.addFloat64(verticalFov);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+double DepthVisualParams_Forwarder::getDepthAccuracy()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_ACCURACY);
+    m_port.write(cmd, response);
+    return response.get(3).asFloat64();
+}
+
+bool DepthVisualParams_Forwarder::setDepthAccuracy(double accuracy)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_ACCURACY);
+    cmd.addFloat64(accuracy);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+bool DepthVisualParams_Forwarder::getDepthClipPlanes(double& nearPlane, double& farPlane)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_CLIP_PLANES);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        nearPlane = 0;
+        farPlane = 0;
+        return false;
+    }
+    nearPlane = response.get(3).asFloat64();
+    farPlane = response.get(4).asFloat64();
+    return true;
+}
+
+bool DepthVisualParams_Forwarder::setDepthClipPlanes(double nearPlane, double farPlane)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_CLIP_PLANES);
+    cmd.addFloat64(nearPlane);
+    cmd.addFloat64(farPlane);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+bool DepthVisualParams_Forwarder::getDepthIntrinsicParam(yarp::os::Property& intrinsic)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_INTRINSIC_PARAM);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        intrinsic.clear();
+        return false;
+    }
+
+    yarp::os::Property::copyPortable(response.get(3), intrinsic); // will it really work??
+    return true;
+}
+
+bool DepthVisualParams_Forwarder::getDepthMirroring(bool& mirror)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_MIRROR);
+    m_port.write(cmd, response);
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        return false;
+    }
+    mirror = response.get(3).asBool();
+    return true;
+}
+
+bool DepthVisualParams_Forwarder::setDepthMirroring(bool mirror)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_MIRROR);
+    cmd.addInt32(mirror);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Forwarder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Forwarder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_FORWARDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_FORWARDER_H
+
+#include <yarp/dev/IVisualParams.h>
+#include <yarp/os/Port.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class DepthVisualParams_Forwarder :
+        public yarp::dev::IDepthVisualParams
+{
+private:
+    yarp::os::Port& m_port;
+
+public:
+    DepthVisualParams_Forwarder(yarp::os::Port& port);
+    ~DepthVisualParams_Forwarder() override = default;
+
+    int getDepthHeight() override;
+    int getDepthWidth() override;
+    bool setDepthResolution(int width, int height) override;
+    bool getDepthFOV(double& horizontalFov, double& verticalFov) override;
+    bool setDepthFOV(double horizontalFov, double verticalFov) override;
+    double getDepthAccuracy() override;
+    bool setDepthAccuracy(double accuracy) override;
+    bool getDepthClipPlanes(double& nearPlane, double& farPlane) override;
+    bool setDepthClipPlanes(double nearPlane, double farPlane) override;
+    bool getDepthIntrinsicParam(yarp::os::Property& intrinsic) override;
+    bool getDepthMirroring(bool& mirror) override;
+    bool setDepthMirroring(bool mirror) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_FORWARDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Responder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Responder.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "DepthVisualParams_Responder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+#include <yarp/os/LogStream.h>
+
+using yarp::proto::framegrabber::DepthVisualParams_Responder;
+
+DepthVisualParams_Responder::DepthVisualParams_Responder() :
+        iDepthVisual(nullptr)
+{
+}
+// DepthVisualParams_Responder::~DepthVisualParams_Responder() { }
+
+bool DepthVisualParams_Responder::configure(yarp::dev::IDepthVisualParams* interface)
+{
+    bool ret = false;
+    if (interface) {
+        iDepthVisual = interface;
+        ret = true;
+    } else {
+        iDepthVisual = nullptr;
+        ret = false;
+    }
+    return ret;
+}
+
+bool DepthVisualParams_Responder::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response)
+{
+    bool ret = false;
+    response.clear();
+    if (!iDepthVisual) {
+        yError() << "Depth Visual parameter Parser has not been correctly configured. IDepthVisualParams interface is not valid";
+        response.addVocab(VOCAB_FAILED);
+        return false;
+    }
+
+    int code = cmd.get(0).asVocab();
+    if (code != VOCAB_DEPTH_VISUAL_PARAMS) {
+        yError() << "Depth Visual Params Parser received a command not belonging to this interface. Required interface was " << yarp::os::Vocab::decode(code);
+        response.addVocab(VOCAB_FAILED);
+        return false;
+    }
+
+    switch (cmd.get(1).asVocab()) {
+    case VOCAB_GET: {
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_HEIGHT: {
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_HEIGHT);
+            response.addVocab(VOCAB_IS);
+            response.addInt32(iDepthVisual->getDepthHeight());
+        } break;
+
+        case VOCAB_WIDTH: {
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_WIDTH);
+            response.addVocab(VOCAB_IS);
+            response.addInt32(iDepthVisual->getDepthWidth());
+        } break;
+
+        case VOCAB_FOV: {
+            double hFov;
+            double vFov;
+            ret = iDepthVisual->getDepthFOV(hFov, vFov);
+            if (ret) {
+                response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+                response.addVocab(VOCAB_FOV);
+                response.addVocab(VOCAB_IS);
+                response.addFloat64(hFov);
+                response.addFloat64(vFov);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        case VOCAB_INTRINSIC_PARAM: {
+            yarp::os::Property params;
+            ret = iDepthVisual->getDepthIntrinsicParam(params);
+            if (ret) {
+                response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+                response.addVocab(VOCAB_INTRINSIC_PARAM);
+                response.addVocab(VOCAB_IS);
+                yarp::os::Bottle& tmp = response.addList();
+                ret &= yarp::os::Property::copyPortable(params, tmp);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        case VOCAB_ACCURACY: {
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_ACCURACY);
+            response.addVocab(VOCAB_IS);
+            response.addFloat64(iDepthVisual->getDepthAccuracy());
+        } break;
+
+        case VOCAB_CLIP_PLANES: {
+            double nearPlane;
+            double farPlane;
+            iDepthVisual->getDepthClipPlanes(nearPlane, farPlane);
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_CLIP_PLANES);
+            response.addVocab(VOCAB_IS);
+            response.addFloat64(nearPlane);
+            response.addFloat64(farPlane);
+        } break;
+
+        case VOCAB_MIRROR: {
+            bool mirror;
+            ret = iDepthVisual->getDepthMirroring(mirror);
+            if (ret) {
+                response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+                response.addVocab(VOCAB_MIRROR);
+                response.addVocab(VOCAB_IS);
+                response.addInt32(mirror);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        default:
+        {
+            yError() << "Depth Visual Parameter interface parser received am unknown GET command. Command is " << cmd.toString();
+            response.addVocab(VOCAB_FAILED);
+            ret = false;
+        } break;
+        }
+    } break;
+
+    case VOCAB_SET: {
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_RESOLUTION: {
+            ret = iDepthVisual->setDepthResolution(cmd.get(3).asInt32(), cmd.get(4).asInt32());
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        case VOCAB_FOV: {
+            ret = iDepthVisual->setDepthFOV(cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        case VOCAB_ACCURACY: {
+            ret = iDepthVisual->setDepthAccuracy(cmd.get(3).asFloat64());
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        case VOCAB_CLIP_PLANES: {
+            ret = iDepthVisual->setDepthClipPlanes(cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        case VOCAB_MIRROR: {
+            ret = iDepthVisual->setDepthMirroring(cmd.get(3).asBool());
+            response.addVocab(VOCAB_DEPTH_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        default:
+        {
+            yError() << "Rgb Visual Parameter interface parser received am unknown SET command. Command is " << cmd.toString();
+            response.addVocab(VOCAB_FAILED);
+            ret = false;
+        } break;
+        }
+    } break;
+
+    default:
+    {
+        yError() << "Rgb Visual parameter interface Parser received a malformed request. Command should either be 'set' or 'get', received " << cmd.toString();
+        response.addVocab(VOCAB_FAILED);
+        ret = false;
+    } break;
+    }
+    return ret;
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Responder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/DepthVisualParams_Responder.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_RESPONDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_RESPONDER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IVisualParams.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class DepthVisualParams_Responder :
+        public yarp::dev::DeviceResponder
+{
+private:
+    yarp::dev::IDepthVisualParams* iDepthVisual;
+
+public:
+    DepthVisualParams_Responder();
+    ~DepthVisualParams_Responder() override = default;
+
+    bool configure(yarp::dev::IDepthVisualParams* interface);
+    bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_DEPTHVISUALPARAMS_RESPONDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameGrabberControlsDC1394_Forwarder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+using yarp::proto::framegrabber::FrameGrabberControlsDC1394_Forwarder;
+
+void FrameGrabberControlsDC1394_Forwarder::init(yarp::os::Port* port)
+{
+    m_port = port;
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setCommand(int code, double v)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(code);
+    cmd.addFloat64(v);
+    m_port->write(cmd, response);
+    return true;
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setCommand(int code, double b, double r)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(code);
+    cmd.addFloat64(b);
+    cmd.addFloat64(r);
+    m_port->write(cmd, response);
+    return true;
+}
+
+
+double FrameGrabberControlsDC1394_Forwarder::getCommand(int code) const
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(code);
+    m_port->write(cmd, response);
+    // response should be [cmd] [name] value
+    return response.get(2).asFloat64();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::getCommand(int code, double& b, double& r) const
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(code);
+    m_port->write(cmd, response);
+    // response should be [cmd] [name] value
+    b = response.get(2).asFloat64();
+    r = response.get(3).asFloat64();
+    return true;
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getVideoModeMaskDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETMSK);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getVideoModeDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETVMD);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setVideoModeDC1394(int video_mode)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETVMD);
+    cmd.addInt32(video_mode);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getFPSMaskDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETFPM);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getFPSDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETFPS);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setFPSDC1394(int fps)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETFPS);
+    cmd.addInt32(fps);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getISOSpeedDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETISO);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setISOSpeedDC1394(int speed)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETISO);
+    cmd.addInt32(speed);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getColorCodingMaskDC1394(unsigned int video_mode)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETCCM);
+    cmd.addInt32(video_mode);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getColorCodingDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETCOD);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setColorCodingDC1394(int coding)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETCOD);
+    cmd.addInt32(coding);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::getFormat7MaxWindowDC1394(unsigned int& xdim,
+                                                unsigned int& ydim,
+                                                unsigned int& xstep,
+                                                unsigned int& ystep,
+                                                unsigned int& xoffstep,
+                                                unsigned int& yoffstep)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETF7M);
+    m_port->write(cmd, response);
+
+    xdim = response.get(0).asInt32();
+    ydim = response.get(1).asInt32();
+    xstep = response.get(2).asInt32();
+    ystep = response.get(3).asInt32();
+    xoffstep = response.get(4).asInt32();
+    yoffstep = response.get(5).asInt32();
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::getFormat7WindowDC1394(unsigned int& xdim, unsigned int& ydim, int& x0, int& y0)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETWF7);
+    m_port->write(cmd, response);
+    xdim = response.get(0).asInt32();
+    ydim = response.get(1).asInt32();
+    x0 = response.get(2).asInt32();
+    y0 = response.get(3).asInt32();
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setFormat7WindowDC1394(unsigned int xdim, unsigned int ydim, int x0, int y0)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETWF7);
+    cmd.addInt32(xdim);
+    cmd.addInt32(ydim);
+    cmd.addInt32(x0);
+    cmd.addInt32(y0);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setOperationModeDC1394(bool b1394b)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETOPM);
+    cmd.addInt32(int(b1394b));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::getOperationModeDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETOPM);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setTransmissionDC1394(bool bTxON)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETTXM);
+    cmd.addInt32(int(bTxON));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::getTransmissionDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETTXM);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setBroadcastDC1394(bool onoff)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETBCS);
+    cmd.addInt32(static_cast<int>(onoff));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setDefaultsDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETDEF);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setResetDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETRST);
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setPowerDC1394(bool onoff)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETPWR);
+    cmd.addInt32(static_cast<int>(onoff));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setCaptureDC1394(bool bON)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETCAP);
+    cmd.addInt32(int(bON));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+bool FrameGrabberControlsDC1394_Forwarder::setBytesPerPacketDC1394(unsigned int bpp)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRSETBPP);
+    cmd.addInt32(int(bpp));
+    m_port->write(cmd, response);
+    return response.get(0).asBool();
+}
+
+
+unsigned int FrameGrabberControlsDC1394_Forwarder::getBytesPerPacketDC1394()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL_DC1394);
+    cmd.addVocab(VOCAB_DRGETBPP);
+    m_port->write(cmd, response);
+    return static_cast<unsigned int>(response.get(0).asInt32());
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Forwarder.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_FORWARDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_FORWARDER_H
+
+#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/os/Port.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class FrameGrabberControlsDC1394_Forwarder :
+        public yarp::dev::IFrameGrabberControlsDC1394
+{
+public:
+    void init(yarp::os::Port* port);
+
+    unsigned int getVideoModeMaskDC1394() override;
+    unsigned int getVideoModeDC1394() override;
+    bool setVideoModeDC1394(int video_mode) override;
+    unsigned int getFPSMaskDC1394() override;
+    unsigned int getFPSDC1394() override;
+    bool setFPSDC1394(int fps) override;
+    unsigned int getISOSpeedDC1394() override;
+    bool setISOSpeedDC1394(int speed) override;
+    unsigned int getColorCodingMaskDC1394(unsigned int video_mode) override;
+    unsigned int getColorCodingDC1394() override;
+    bool setColorCodingDC1394(int coding) override;
+    bool getFormat7MaxWindowDC1394(unsigned int& xdim,
+                                   unsigned int& ydim,
+                                   unsigned int& xstep,
+                                   unsigned int& ystep,
+                                   unsigned int& xoffstep,
+                                   unsigned int& yoffstep) override;
+    bool getFormat7WindowDC1394(unsigned int& xdim,
+                                unsigned int& ydim,
+                                int& x0,
+                                int& y0) override;
+    bool setFormat7WindowDC1394(unsigned int xdim,
+                                unsigned int ydim,
+                                int x0,
+                                int y0) override;
+    bool setOperationModeDC1394(bool b1394b) override;
+    bool getOperationModeDC1394() override;
+    bool setTransmissionDC1394(bool bTxON) override;
+    bool getTransmissionDC1394() override;
+    bool setBroadcastDC1394(bool onoff) override;
+    bool setDefaultsDC1394() override;
+    bool setResetDC1394() override;
+    bool setPowerDC1394(bool onoff) override;
+    bool setCaptureDC1394(bool bON) override;
+    bool setBytesPerPacketDC1394(unsigned int bpp) override;
+    unsigned int getBytesPerPacketDC1394() override;
+
+private:
+    yarp::os::Port* m_port {nullptr};
+
+    bool setCommand(int code, double v);
+    bool setCommand(int code, double b, double r);
+    double getCommand(int code) const;
+    bool getCommand(int code, double& b, double& r) const;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_FORWARDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameGrabberControlsDC1394_Responder.h"
+// #include "CameraVocabs.h" // FIXME
+
+#include <yarp/os/LogStream.h>
+
+using yarp::proto::framegrabber::FrameGrabberControlsDC1394_Responder;
+
+bool FrameGrabberControlsDC1394_Responder::configure(yarp::dev::IFrameGrabberControlsDC1394* interface)
+{
+    fgCtrl_DC1394 = interface;
+    return true;
+}
+
+bool FrameGrabberControlsDC1394_Responder::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response)
+{
+    int code = cmd.get(1).asVocab();
+    if (fgCtrl_DC1394) {
+        switch (code) {
+        case VOCAB_DRGETMSK:
+            response.addInt32(int(fgCtrl_DC1394->getVideoModeMaskDC1394()));
+            return true;
+
+        case VOCAB_DRGETVMD:
+            response.addInt32(int(fgCtrl_DC1394->getVideoModeDC1394()));
+            return true;
+
+        case VOCAB_DRSETVMD:
+            response.addInt32(int(fgCtrl_DC1394->setVideoModeDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETFPM:
+            response.addInt32(int(fgCtrl_DC1394->getFPSMaskDC1394()));
+            return true;
+
+        case VOCAB_DRGETFPS:
+            response.addInt32(int(fgCtrl_DC1394->getFPSDC1394()));
+            return true;
+
+        case VOCAB_DRSETFPS:
+            response.addInt32(int(fgCtrl_DC1394->setFPSDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETISO:
+            response.addInt32(int(fgCtrl_DC1394->getISOSpeedDC1394()));
+            return true;
+
+        case VOCAB_DRSETISO:
+            response.addInt32(int(fgCtrl_DC1394->setISOSpeedDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETCCM:
+            response.addInt32(int(fgCtrl_DC1394->getColorCodingMaskDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETCOD:
+            response.addInt32(int(fgCtrl_DC1394->getColorCodingDC1394()));
+            return true;
+
+        case VOCAB_DRSETCOD:
+            response.addInt32(int(fgCtrl_DC1394->setColorCodingDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETF7M:
+        {
+            unsigned int xstep;
+            unsigned int ystep;
+            unsigned int xdim;
+            unsigned int ydim;
+            unsigned int xoffstep;
+            unsigned int yoffstep;
+            fgCtrl_DC1394->getFormat7MaxWindowDC1394(xdim, ydim, xstep, ystep, xoffstep, yoffstep);
+            response.addInt32(xdim);
+            response.addInt32(ydim);
+            response.addInt32(xstep);
+            response.addInt32(ystep);
+            response.addInt32(xoffstep);
+            response.addInt32(yoffstep);
+        }
+            return true;
+
+        case VOCAB_DRGETWF7:
+        {
+            unsigned int xdim;
+            unsigned int ydim;
+            int x0;
+            int y0;
+            fgCtrl_DC1394->getFormat7WindowDC1394(xdim, ydim, x0, y0);
+            response.addInt32(xdim);
+            response.addInt32(ydim);
+            response.addInt32(x0);
+            response.addInt32(y0);
+        }
+            return true;
+
+        case VOCAB_DRSETWF7:
+            response.addInt32(int(fgCtrl_DC1394->setFormat7WindowDC1394(cmd.get(1).asInt32(), cmd.get(2).asInt32(), cmd.get(3).asInt32(), cmd.get(4).asInt32())));
+            return true;
+
+        case VOCAB_DRSETOPM:
+            response.addInt32(int(fgCtrl_DC1394->setOperationModeDC1394(cmd.get(1).asInt32() != 0)));
+            return true;
+
+        case VOCAB_DRGETOPM:
+            response.addInt32(fgCtrl_DC1394->getOperationModeDC1394());
+            return true;
+
+        case VOCAB_DRSETTXM:
+            response.addInt32(int(fgCtrl_DC1394->setTransmissionDC1394(cmd.get(1).asInt32() != 0)));
+            return true;
+
+        case VOCAB_DRGETTXM:
+            response.addInt32(fgCtrl_DC1394->getTransmissionDC1394());
+            return true;
+
+        case VOCAB_DRSETBCS:
+            response.addInt32(int(fgCtrl_DC1394->setBroadcastDC1394(cmd.get(1).asInt32() != 0)));
+            return true;
+
+        case VOCAB_DRSETDEF:
+            response.addInt32(int(fgCtrl_DC1394->setDefaultsDC1394()));
+            return true;
+
+        case VOCAB_DRSETRST:
+            response.addInt32(int(fgCtrl_DC1394->setResetDC1394()));
+            return true;
+
+        case VOCAB_DRSETPWR:
+            response.addInt32(int(fgCtrl_DC1394->setPowerDC1394(cmd.get(1).asInt32() != 0)));
+            return true;
+
+        case VOCAB_DRSETCAP:
+            response.addInt32(int(fgCtrl_DC1394->setCaptureDC1394(cmd.get(1).asInt32() != 0)));
+            return true;
+
+        case VOCAB_DRSETBPP:
+            response.addInt32(int(fgCtrl_DC1394->setBytesPerPacketDC1394(cmd.get(1).asInt32())));
+            return true;
+
+        case VOCAB_DRGETBPP:
+            response.addInt32(fgCtrl_DC1394->getBytesPerPacketDC1394());
+            return true;
+        }
+    } else {
+        yWarning() << "FrameGrabberControlsDC1394_Responder:  firewire interface not implemented in subdevice, some features could not be available";
+        return yarp::dev::DeviceResponder::respond(cmd, response);
+    }
+
+    return true;
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControlsDC1394_Responder.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * Copyright (C) 2006-2010 RobotCub Consortium
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_RESPONDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_RESPONDER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class FrameGrabberControlsDC1394_Responder :
+        public yarp::dev::DeviceResponder
+{
+private:
+    yarp::dev::IFrameGrabberControlsDC1394  *fgCtrl_DC1394{nullptr};
+
+public:
+    FrameGrabberControlsDC1394_Responder() = default;
+    ~FrameGrabberControlsDC1394_Responder() override = default;
+    bool configure(yarp::dev::IFrameGrabberControlsDC1394 *interface);
+    bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLSDC1394_RESPONDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameGrabberControls_Forwarder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/LogStream.h>
+
+using yarp::proto::framegrabber::FrameGrabberControls_Forwarder;
+
+FrameGrabberControls_Forwarder::FrameGrabberControls_Forwarder(yarp::os::Port& port) :
+        m_port(port)
+{
+};
+
+
+bool FrameGrabberControls_Forwarder::getCameraDescription(CameraDescriptor* camera)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_CAMERA_DESCRIPTION);
+    yInfo() << m_port.isOpen();
+    bool ret = m_port.write(cmd, response);
+
+    // response should be [fgc2] [camd] [is] [busType] [description]
+    camera->busType = static_cast<BusType>(response.get(3).asInt32());
+    camera->deviceDescription = response.get(4).asString();
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::hasFeature(int feature, bool* hasFeature)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_HAS);
+    cmd.addVocab(VOCAB_FEATURE);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *hasFeature = response.get(4).asInt32() != 0 ? true : false;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::setFeature(int feature, double value)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_FEATURE);
+    cmd.addInt32(feature);
+    cmd.addFloat64(value);
+    return m_port.write(cmd, response);
+}
+
+bool FrameGrabberControls_Forwarder::setFeature(int feature, double value1, double value2)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_FEATURE2);
+    cmd.addInt32(feature);
+    cmd.addFloat64(value1);
+    cmd.addFloat64(value2);
+    return m_port.write(cmd, response);
+}
+
+bool FrameGrabberControls_Forwarder::getFeature(int feature, double* value)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FEATURE);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *value = response.get(3).asFloat64();
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::getFeature(int feature, double* value1, double* value2)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FEATURE2);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *value1 = response.get(3).asFloat64();
+    *value2 = response.get(4).asFloat64();
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::hasOnOff(int feature, bool* _hasOnOff)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_HAS);
+    cmd.addVocab(VOCAB_ONOFF);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *_hasOnOff = response.get(4).asInt32() != 0 ? true : false;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::setActive(int feature, bool onoff)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_ACTIVE);
+    cmd.addInt32(feature);
+    cmd.addInt32(onoff);
+    return m_port.write(cmd, response);
+}
+
+bool FrameGrabberControls_Forwarder::getActive(int feature, bool* _isActive)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_ACTIVE);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *_isActive = response.get(3).asInt32() != 0 ? true : false;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::hasAuto(int feature, bool* _hasAuto)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_HAS);
+    cmd.addVocab(VOCAB_AUTO);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *_hasAuto = response.get(4).asInt32() != 0 ? true : false;
+    ;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::hasManual(int feature, bool* _hasManual)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_HAS);
+    cmd.addVocab(VOCAB_MANUAL);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *_hasManual = response.get(4).asInt32() != 0 ? true : false;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::hasOnePush(int feature, bool* _hasOnePush)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_HAS);
+    cmd.addVocab(VOCAB_ONEPUSH);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *_hasOnePush = response.get(4).asInt32() != 0 ? true : false;
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::setMode(int feature, FeatureMode mode)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_MODE);
+    cmd.addInt32(feature);
+    cmd.addInt32(mode);
+    return m_port.write(cmd, response);
+}
+
+bool FrameGrabberControls_Forwarder::getMode(int feature, FeatureMode* mode)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_MODE);
+    cmd.addInt32(feature);
+    bool ret = m_port.write(cmd, response);
+
+    *mode = static_cast<FeatureMode>(response.get(3).asInt32());
+    return ret;
+}
+
+bool FrameGrabberControls_Forwarder::setOnePush(int feature)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_ONEPUSH);
+    cmd.addInt32(feature);
+    return m_port.write(cmd, response);
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_FORWARDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_FORWARDER_H
+
+#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/os/Port.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+/**
+ * This classes implement a sender / parser for IFrameGrabberControls
+ * interface messages
+ */
+class FrameGrabberControls_Forwarder :
+        public yarp::dev::IFrameGrabberControls
+{
+private:
+    yarp::os::Port& m_port;
+
+public:
+    FrameGrabberControls_Forwarder(yarp::os::Port& port);
+    ~FrameGrabberControls_Forwarder() override = default;
+
+    bool getCameraDescription(CameraDescriptor* camera) override;
+    bool hasFeature(int feature, bool* hasFeature) override;
+    bool setFeature(int feature, double value) override;
+    bool getFeature(int feature, double* value) override;
+    bool setFeature(int feature, double value1, double value2) override;
+    bool getFeature(int feature, double* value1, double* value2) override;
+    bool hasOnOff(int feature, bool* HasOnOff) override;
+    bool setActive(int feature, bool onoff) override;
+    bool getActive(int feature, bool* isActive) override;
+    bool hasAuto(int feature, bool* hasAuto) override;
+    bool hasManual(int feature, bool* hasManual) override;
+    bool hasOnePush(int feature, bool* hasOnePush) override;
+    bool setMode(int feature, FeatureMode mode) override;
+    bool getMode(int feature, FeatureMode* mode) override;
+    bool setOnePush(int feature) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_FORWARDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "FrameGrabberControls_Responder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+#include <yarp/os/LogStream.h>
+
+using yarp::proto::framegrabber::FrameGrabberControls_Responder;
+
+FrameGrabberControls_Responder::FrameGrabberControls_Responder() :
+        fgCtrl(nullptr)
+{
+}
+
+bool FrameGrabberControls_Responder::configure(yarp::dev::IFrameGrabberControls* interface)
+{
+    bool ret = false;
+    if (interface) {
+        fgCtrl = interface;
+        ret = true;
+    } else {
+        fgCtrl = nullptr;
+        ret = false;
+    }
+    return ret;
+}
+
+
+bool FrameGrabberControls_Responder::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response)
+{
+    bool ok = false;
+    int action = cmd.get(1).asVocab();
+    int param = cmd.get(2).asVocab();
+
+    //     yTrace() << "cmd received\n\t" << cmd.toString().c_str();
+
+
+    if (!fgCtrl) {
+        yError() << " Selected camera device has no IFrameGrabberControl interface";
+        return false;
+    }
+
+    response.clear();
+
+    switch (action) {
+    case VOCAB_HAS: {
+        response.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+        response.addVocab(VOCAB_HAS);
+        response.addVocab(VOCAB_FEATURE);
+        response.addInt32(param);
+
+        switch (param) {
+        case VOCAB_FEATURE: {
+            bool _hasFeat;
+            ok = fgCtrl->hasFeature(cmd.get(3).asInt32(), &_hasFeat);
+            response.addInt32(_hasFeat);
+        } break;
+
+        case VOCAB_ONOFF: {
+            bool _hasOnOff;
+            ok = fgCtrl->hasOnOff(cmd.get(3).asInt32(), &_hasOnOff);
+            response.addInt32(_hasOnOff);
+        } break;
+
+        case VOCAB_AUTO: {
+            bool _hasAuto;
+
+            ok = fgCtrl->hasAuto(cmd.get(3).asInt32(), &_hasAuto);
+            response.addInt32(_hasAuto);
+        } break;
+
+        case VOCAB_MANUAL: {
+            bool _hasManual;
+            ok = fgCtrl->hasManual(cmd.get(3).asInt32(), &_hasManual);
+            response.addInt32(_hasManual);
+        } break;
+
+        case VOCAB_ONEPUSH: {
+            bool _hasOnePush;
+            ok = fgCtrl->hasOnePush(cmd.get(3).asInt32(), &_hasOnePush);
+            response.addInt32(_hasOnePush);
+        } break;
+
+        default:
+        {
+            yError() << "Unknown command 'HAS " << yarp::os::Vocab::decode(param) << "' received on IFrameGrabber2 interface";
+            response.clear();
+            ok = false;
+        } break;
+        }
+        break; // end switch (param)
+
+    } break; // end VOCAB_HAS
+
+    case VOCAB_SET: {
+        switch (param) {
+        case VOCAB_FEATURE: {
+            ok = fgCtrl->setFeature(cmd.get(3).asInt32(), cmd.get(4).asFloat64());
+        } break;
+
+        case VOCAB_FEATURE2: {
+            ok = fgCtrl->setFeature(cmd.get(3).asInt32(), cmd.get(4).asFloat64(), cmd.get(5).asFloat64());
+        } break;
+
+        case VOCAB_ACTIVE: {
+            ok = fgCtrl->setActive(cmd.get(3).asInt32(), cmd.get(4).asInt32());
+        } break;
+
+        case VOCAB_MODE: {
+            ok = fgCtrl->setMode(cmd.get(3).asInt32(), static_cast<FeatureMode>(cmd.get(4).asInt32()));
+        } break;
+
+        case VOCAB_ONEPUSH: {
+            ok = fgCtrl->setOnePush(cmd.get(3).asInt32());
+        } break;
+
+        default:
+        {
+            yError() << "Unknown command 'SET " << yarp::os::Vocab::decode(param) << "' received on IFrameGrabber2 interface";
+            response.clear();
+            ok = false;
+        }
+        }
+        break; // end switch (param)
+
+    } break; // end VOCAB_SET
+
+    case VOCAB_GET: {
+        response.addVocab(VOCAB_FRAMEGRABBER_CONTROL);
+        response.addVocab(param);
+        response.addVocab(VOCAB_IS);
+        switch (param) {
+        case VOCAB_CAMERA_DESCRIPTION: {
+            CameraDescriptor camera;
+            ok = fgCtrl->getCameraDescription(&camera);
+            response.addInt32(camera.busType);
+            response.addString(camera.deviceDescription);
+            yDebug() << "Response is " << response.toString();
+        } break;
+
+        case VOCAB_FEATURE: {
+            double value;
+            ok = fgCtrl->getFeature(cmd.get(3).asInt32(), &value);
+            response.addFloat64(value);
+        } break;
+
+        case VOCAB_FEATURE2: {
+            double value1;
+            double value2;
+            ok = fgCtrl->getFeature(cmd.get(3).asInt32(), &value1, &value2);
+            response.addFloat64(value1);
+            response.addFloat64(value2);
+        } break;
+
+        case VOCAB_ACTIVE: {
+            bool _isActive;
+            ok = fgCtrl->getActive(cmd.get(3).asInt32(), &_isActive);
+            response.addInt32(_isActive);
+        } break;
+
+        case VOCAB_MODE: {
+            FeatureMode _mode;
+            ok = fgCtrl->getMode(cmd.get(3).asInt32(), &_mode);
+            response.addInt32(_mode);
+        } break;
+
+        default:
+        {
+            yError() << "Unknown command 'GET " << yarp::os::Vocab::decode(param) << "' received on IFrameGrabber2 interface";
+            response.clear();
+            ok = false;
+        }
+        }
+        break; // end switch (param)
+
+    } break; // end VOCAB_GET
+    }
+    //     yTrace() << "response is\n\t" << response.toString().c_str();
+    return ok;
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_RESPONDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_RESPONDER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class FrameGrabberControls_Responder :
+        public yarp::dev::DeviceResponder
+{
+private:
+    yarp::dev::IFrameGrabberControls* fgCtrl;
+
+public:
+    FrameGrabberControls_Responder();
+    ~FrameGrabberControls_Responder() override = default;
+
+    bool configure(yarp::dev::IFrameGrabberControls* interface);
+    bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_FRAMEGRABBERCONTROLS_RESPONDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Forwarder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Forwarder.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "RgbVisualParams_Forwarder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+using yarp::proto::framegrabber::RgbVisualParams_Forwarder;
+
+RgbVisualParams_Forwarder::RgbVisualParams_Forwarder(yarp::os::Port& port) :
+        m_port(port)
+{
+};
+
+int RgbVisualParams_Forwarder::getRgbHeight()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_HEIGHT);
+    m_port.write(cmd, response);
+    return response.get(3).asInt32();
+}
+
+int RgbVisualParams_Forwarder::getRgbWidth()
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_WIDTH);
+    m_port.write(cmd, response);
+    return response.get(3).asInt32();
+}
+bool RgbVisualParams_Forwarder::getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig>& configurations)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_SUPPORTED_CONF);
+    m_port.write(cmd, response);
+
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        configurations.clear();
+        return false;
+    }
+    configurations.resize(response.get(3).asInt32());
+    for (int i = 0; i < response.get(3).asInt32(); i++) {
+        configurations[i].width = response.get(4 + i * 4).asInt32();
+        configurations[i].height = response.get(4 + i * 4 + 1).asInt32();
+        configurations[i].framerate = response.get(4 + i * 4 + 2).asFloat64();
+        configurations[i].pixelCoding = static_cast<YarpVocabPixelTypesEnum>(response.get(4 + i * 4 + 3).asVocab());
+    }
+    return true;
+}
+bool RgbVisualParams_Forwarder::getRgbResolution(int& width, int& height)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_RESOLUTION);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        width = 0;
+        height = 0;
+        return false;
+    }
+    width = response.get(3).asInt32();
+    height = response.get(4).asInt32();
+    return true;
+}
+
+bool RgbVisualParams_Forwarder::setRgbResolution(int width, int height)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_RESOLUTION);
+    cmd.addInt32(width);
+    cmd.addInt32(height);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+bool RgbVisualParams_Forwarder::getRgbFOV(double& horizontalFov, double& verticalFov)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FOV);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        horizontalFov = 0;
+        verticalFov = 0;
+        return false;
+    }
+    horizontalFov = response.get(3).asFloat64();
+    verticalFov = response.get(4).asFloat64();
+    return true;
+}
+
+bool RgbVisualParams_Forwarder::setRgbFOV(double horizontalFov, double verticalFov)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_FOV);
+    cmd.addFloat64(horizontalFov);
+    cmd.addFloat64(verticalFov);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}
+
+bool RgbVisualParams_Forwarder::getRgbIntrinsicParam(yarp::os::Property& intrinsic)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_INTRINSIC_PARAM);
+    m_port.write(cmd, response);
+
+    // Minimal check on response, we suppose the response is always correctly formatted
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        intrinsic.clear();
+        return false;
+    }
+    bool ret;
+    ret = yarp::os::Property::copyPortable(response.get(3), intrinsic);
+    if (!response.get(4).isNull()) {
+        yarp::os::Property& p = intrinsic.addGroup("right");
+        ret &= yarp::os::Property::copyPortable(response.get(4), p);
+        return ret;
+    }
+    return ret;
+}
+
+bool RgbVisualParams_Forwarder::getRgbMirroring(bool& mirror)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_MIRROR);
+    m_port.write(cmd, response);
+    if ((response.get(0).asVocab()) == VOCAB_FAILED) {
+        return false;
+    }
+    mirror = response.get(3).asBool();
+    return true;
+}
+
+bool RgbVisualParams_Forwarder::setRgbMirroring(bool mirror)
+{
+    yarp::os::Bottle cmd;
+    yarp::os::Bottle response;
+    cmd.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+    cmd.addVocab(VOCAB_SET);
+    cmd.addVocab(VOCAB_MIRROR);
+    cmd.addInt32(mirror);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Forwarder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Forwarder.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_FORWARDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_FORWARDER_H
+
+#include <yarp/dev/IVisualParams.h>
+#include <yarp/os/Port.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class RgbVisualParams_Forwarder :
+        public yarp::dev::IRgbVisualParams
+{
+protected:
+    yarp::os::Port& m_port;
+
+public:
+    RgbVisualParams_Forwarder(yarp::os::Port& port);
+    ~RgbVisualParams_Forwarder() override = default;
+
+    int getRgbHeight() override;
+    int getRgbWidth() override;
+    bool getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig>& configurations) override;
+    bool getRgbResolution(int& width, int& height) override;
+    bool setRgbResolution(int width, int height) override;
+    bool getRgbFOV(double& horizontalFov, double& verticalFov) override;
+    bool setRgbFOV(double horizontalFov, double verticalFov) override;
+    bool getRgbIntrinsicParam(yarp::os::Property& intrinsic) override;
+    bool getRgbMirroring(bool& mirror) override;
+    bool setRgbMirroring(bool mirror) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_FORWARDER_H

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Responder.cpp
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Responder.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "RgbVisualParams_Responder.h"
+// #include "CameraVocabs.h" // FIXME
+#include <yarp/dev/GenericVocabs.h>
+
+#include <yarp/os/LogStream.h>
+
+using yarp::proto::framegrabber::RgbVisualParams_Responder;
+
+bool RgbVisualParams_Responder::configure(yarp::dev::IRgbVisualParams* interface)
+{
+    bool ret = false;
+    if (interface) {
+        iRgbVisual = interface;
+        ret = true;
+    } else {
+        iRgbVisual = nullptr;
+        ret = false;
+    }
+    return ret;
+}
+
+bool RgbVisualParams_Responder::respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response)
+{
+    bool ret = false;
+    response.clear();
+    if (!iRgbVisual) {
+        yError() << "Rgb Visual parameter Parser has not been correctly configures. IRgbVisualParams interface is not valid";
+        response.addVocab(VOCAB_FAILED);
+        return false;
+    }
+
+    int code = cmd.get(0).asVocab();
+    if (code != VOCAB_RGB_VISUAL_PARAMS) {
+        yError() << "Rgb Visual Params Parser received a command not belonging to this interface. Required interface is " << yarp::os::Vocab::decode(code);
+        response.addVocab(VOCAB_FAILED);
+        return false;
+    }
+
+    switch (cmd.get(1).asVocab()) {
+    case VOCAB_GET: {
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_HEIGHT:
+            response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+            response.addVocab(VOCAB_HEIGHT);
+            response.addVocab(VOCAB_IS);
+            response.addInt32(iRgbVisual->getRgbHeight());
+            ret = true;
+            break;
+
+        case VOCAB_WIDTH:
+            response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+            response.addVocab(VOCAB_WIDTH);
+            response.addVocab(VOCAB_IS);
+            response.addInt32(iRgbVisual->getRgbWidth());
+            ret = true;
+            break;
+
+        case VOCAB_SUPPORTED_CONF: {
+            yarp::sig::VectorOf<yarp::dev::CameraConfig> conf;
+            ret = iRgbVisual->getRgbSupportedConfigurations(conf);
+            if (ret) {
+                response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+                response.addVocab(VOCAB_SUPPORTED_CONF);
+                response.addVocab(VOCAB_IS);
+                response.addInt32(conf.size());
+                for (const auto& i : conf) {
+                    response.addInt32(i.width);
+                    response.addInt32(i.height);
+                    response.addFloat64(i.framerate);
+                    response.addVocab(i.pixelCoding);
+                }
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+
+        case VOCAB_RESOLUTION: {
+            int width;
+            int height;
+            ret = iRgbVisual->getRgbResolution(width, height);
+            if (ret) {
+                response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+                response.addVocab(VOCAB_RESOLUTION);
+                response.addVocab(VOCAB_IS);
+                response.addInt32(width);
+                response.addInt32(height);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        case VOCAB_FOV: {
+            double hFov;
+            double vFov;
+            ret = iRgbVisual->getRgbFOV(hFov, vFov);
+            if (ret) {
+                response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+                response.addVocab(VOCAB_FOV);
+                response.addVocab(VOCAB_IS);
+                response.addFloat64(hFov);
+                response.addFloat64(vFov);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        case VOCAB_INTRINSIC_PARAM: {
+            yarp::os::Property params;
+            ret = iRgbVisual->getRgbIntrinsicParam(params);
+            if (ret) {
+                response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+                response.addVocab(VOCAB_INTRINSIC_PARAM);
+                response.addVocab(VOCAB_IS);
+                yarp::os::Bottle& tmp = response.addList();
+                ret &= yarp::os::Property::copyPortable(params, tmp);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        case VOCAB_MIRROR: {
+            bool mirror;
+            ret = iRgbVisual->getRgbMirroring(mirror);
+            if (ret) {
+                response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+                response.addVocab(VOCAB_MIRROR);
+                response.addVocab(VOCAB_IS);
+                response.addInt32(mirror);
+            } else {
+                response.addVocab(VOCAB_FAILED);
+            }
+        } break;
+
+        default:
+        {
+            yError() << "Rgb Visual Parameter interface parser received an unknown GET command. Command is " << cmd.toString();
+            response.addVocab(VOCAB_FAILED);
+            ret = false;
+        } break;
+        }
+    } break;
+
+    case VOCAB_SET: {
+        switch (cmd.get(2).asVocab()) {
+        case VOCAB_RESOLUTION:
+            ret = iRgbVisual->setRgbResolution(cmd.get(3).asInt32(), cmd.get(4).asInt32());
+            response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+            break;
+
+        case VOCAB_FOV:
+            ret = iRgbVisual->setRgbFOV(cmd.get(3).asFloat64(), cmd.get(4).asFloat64());
+            response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+            break;
+
+        case VOCAB_MIRROR: {
+            ret = iRgbVisual->setRgbMirroring(cmd.get(3).asBool());
+            response.addVocab(VOCAB_RGB_VISUAL_PARAMS);
+            response.addVocab(VOCAB_SET);
+            response.addInt32(ret);
+        } break;
+
+        default:
+        {
+            yError() << "Rgb Visual Parameter interface parser received am unknown SET command. Command is " << cmd.toString();
+            response.addVocab(VOCAB_FAILED);
+            ret = false;
+        } break;
+        }
+    } // end VOCAB
+    break;
+
+    default:
+    {
+        yError() << "Rgb Visual parameter interface Parser received a malformed request. Command should either be 'set' or 'get', received " << cmd.toString();
+        response.addVocab(VOCAB_FAILED);
+        ret = false;
+    } break;
+    }
+    return ret;
+}

--- a/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Responder.h
+++ b/src/devices/framegrabber_protocol/yarp/proto/framegrabber/RgbVisualParams_Responder.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_RESPONDER_H
+#define YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_RESPONDER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IVisualParams.h>
+
+namespace yarp {
+namespace proto {
+namespace framegrabber {
+
+class RgbVisualParams_Responder :
+        public yarp::dev::DeviceResponder
+{
+private:
+    yarp::dev::IRgbVisualParams* iRgbVisual {nullptr};
+
+public:
+    RgbVisualParams_Responder() = default;
+    ~RgbVisualParams_Responder() override = default;
+
+    bool configure(yarp::dev::IRgbVisualParams* interface);
+    bool respond(const yarp::os::Bottle& cmd, yarp::os::Bottle& response) override;
+};
+
+} // namespace framegrabber
+} // namespace proto
+} // namespace yarp
+
+#endif // YARP_FRAMEGRABBER_PROTOCOL_RGBVISUALPARAMS_RESPONDER_H

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -26,7 +26,6 @@
 #include "OpenCVGrabber.h"
 
 #include <yarp/dev/Drivers.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 
 #include <string>

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -53,7 +53,7 @@ public:
      * reasonable default values, the real initialization is done in
      * open().
      */
-    OpenCVGrabber() : IFrameGrabberImage(), DeviceDriver(),
+    OpenCVGrabber() :
         m_w(0),
         m_h(0),
         m_loop(false),

--- a/src/devices/usbCamera/common/USBcamera.cpp
+++ b/src/devices/usbCamera/common/USBcamera.cpp
@@ -31,7 +31,6 @@
 #include <yarp/os/Stamp.h>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 
 using namespace yarp::os;
 using namespace yarp::dev;


### PR DESCRIPTION
The classes that implement the nws/nwc protocol related to the frame grabber interfaces were moved to the new library and are used internally by all the devices that used the old ones.

The original classes will be deprecated/removed in a later pull request.