### PR TITLE
Deprecate the yarp/dev/FrameGrabberControl2.h and yarp/dev/FrameGrabberInterfaces.h files

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -405,7 +405,6 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IFrameGrabberControls.h>
 %include <yarp/dev/IFrameGrabberControlsDC1394.h>
 %include <yarp/dev/IFrameWriterImage.h>
-%include <yarp/dev/FrameGrabberInterfaces.h>
 %include <yarp/dev/AudioVisualInterfaces.h>
 %include <yarp/dev/ControlBoardInterfaces.h>
 %include <yarp/dev/IAxisInfo.h>

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -435,7 +435,9 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IAnalogSensor.h>
 %include <yarp/dev/IRemoteVariables.h>
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 %include <yarp/dev/FrameGrabberControl2.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif
 %include <yarp/dev/IPidControl.h>
 %include <yarp/dev/IPositionDirect.h>

--- a/doc/release/master/FrameGrabberInterfacesRefactor4.md
+++ b/doc/release/master/FrameGrabberInterfacesRefactor4.md
@@ -1,0 +1,11 @@
+FrameGrabberInterfacesRefactor4 {#master}
+-------------------------------
+
+## Libraries
+
+### `dev`
+
+* Properly mark the `yarp/dev/FrameGrabberControl2.h` header file as deprecated
+  (it should have been deprecated in YARP 3.0)
+* The `yarp/dev/FrameGrabberInterfaces.h` header file was deprecated.
+  All interfaces were moved in the corresponding header.

--- a/src/devices/DevicePipe/DevicePipe.cpp
+++ b/src/devices/DevicePipe/DevicePipe.cpp
@@ -12,6 +12,7 @@
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/Time.h>
 
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameWriterImage.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
@@ -16,7 +16,6 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/ImageUtils.h>
 #include <yarp/os/PortablePair.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 
 #include <yarp/proto/framegrabber/CameraVocabs.h>
 

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.h
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.h
@@ -12,6 +12,9 @@
 
 #include <cstdio>
 
+
+#include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/dev/IFrameGrabberImageRaw.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/ServiceInterfaces.h>

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -15,6 +15,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/dev/IFrameGrabberImageRaw.h>
 #include <yarp/dev/AudioVisualInterfaces.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/Searchable.h>

--- a/src/devices/ffmpeg/FfmpegGrabber.h
+++ b/src/devices/ffmpeg/FfmpegGrabber.h
@@ -23,6 +23,7 @@ extern "C" {
  */
 
 #include <yarp/dev/AudioVisualInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/DeviceDriver.h>
 
 #include "ffmpeg_api.h"

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -30,7 +30,6 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/DeviceDriver.h
                   yarp/dev/DriverLinkCreator.h
                   yarp/dev/Drivers.h
-                  yarp/dev/FrameGrabberInterfaces.h
                   yarp/dev/GPUInterface.h
                   yarp/dev/GazeControl.h
                   yarp/dev/GenericVocabs.h
@@ -142,7 +141,9 @@ if(NOT YARP_NO_DEPRECATED)
                             yarp/dev/GenericSensorInterfaces.h # DEPRECATED Since YARP 3.3.0
                             yarp/dev/PreciselyTimed.h          # DEPRECATED Since YARP 3.3.0
                             yarp/dev/SerialInterfaces.h        # DEPRECATED Since YARP 3.3.0
-                            yarp/dev/Wrapper.h)                # DEPRECATED Since YARP 3.3.0
+                            yarp/dev/Wrapper.h                 # DEPRECATED Since YARP 3.3.0
+                            yarp/dev/FrameGrabberInterfaces.h  # DEPRECATED Since YARP 3.5.0
+  )
 endif()
 
 set(YARP_dev_IMPL_HDRS yarp/dev/impl/FixedSizeBuffersManager.h

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -30,7 +30,6 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/DeviceDriver.h
                   yarp/dev/DriverLinkCreator.h
                   yarp/dev/Drivers.h
-                  yarp/dev/FrameGrabberControl2.h
                   yarp/dev/FrameGrabberInterfaces.h
                   yarp/dev/GPUInterface.h
                   yarp/dev/GazeControl.h
@@ -138,7 +137,8 @@ if(TARGET YARP::YARP_math)
 endif()
 
 if(NOT YARP_NO_DEPRECATED)
-  list(APPEND YARP_dev_HDRS yarp/dev/DataSource.h              # DEPRECATED Since YARP 3.3.0
+  list(APPEND YARP_dev_HDRS yarp/dev/FrameGrabberControl2.h    # DEPRECATED Since YARP 3.0.0
+                            yarp/dev/DataSource.h              # DEPRECATED Since YARP 3.3.0
                             yarp/dev/GenericSensorInterfaces.h # DEPRECATED Since YARP 3.3.0
                             yarp/dev/PreciselyTimed.h          # DEPRECATED Since YARP 3.3.0
                             yarp/dev/SerialInterfaces.h        # DEPRECATED Since YARP 3.3.0

--- a/src/libYARP_dev/src/yarp/dev/AudioVisualInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/AudioVisualInterfaces.h
@@ -10,7 +10,10 @@
 #ifndef YARP_DEV_AUDIOVISUALINTERFACES_H
 #define YARP_DEV_AUDIOVISUALINTERFACES_H
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/FrameGrabberInterfaces.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+
 #include <yarp/dev/AudioGrabberInterfaces.h>
 
 #include <yarp/dev/IAudioVisualGrabber.h>

--- a/src/libYARP_dev/src/yarp/dev/FrameGrabberControl2.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameGrabberControl2.h
@@ -9,14 +9,20 @@
 #ifndef YARP_DEV_FRAMEGRABBERCONTROL2_H
 #define YARP_DEV_FRAMEGRABBERCONTROL2_H
 
+#include <yarp/conf/system.h>
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/dev/FrameGrabberControl2.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+
 #include <yarp/dev/IFrameGrabberControls.h>
 
 /*! \file FrameGrabberControl2.h define common interfaces to discover
  * remote camera capabilities */
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 
-namespace yarp{
+namespace yarp {
 namespace dev {
 /**
  * This interface exports a list of general methods to discover the remote camera
@@ -28,6 +34,7 @@ YARP_DEPRECATED_TYPEDEF_MSG("Use yarp::dev::IFrameGrabberControl instead") IFram
 
 } // namespace dev
 } // namespace yarp
-#endif
+
+#endif // YARP_NO_DEPRECATED
 
 #endif  // YARP_DEV_FRAMEGRABBERCONTROL2_H

--- a/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
- * Copyright (C) 2006-2010 RobotCub Consortium
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms of the
@@ -10,6 +9,13 @@
 #ifndef YARP_FRAMEGRABBERINTERFACES_H
 #define YARP_FRAMEGRABBERINTERFACES_H
 
+#include <yarp/conf/system.h>
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberInterfaces.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
+
 #include <yarp/dev/IFrameGrabber.h>
 #include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberImage.h>
@@ -18,10 +24,10 @@
 #include <yarp/dev/IFrameGrabberControlsDC1394.h>
 #include <yarp/dev/IFrameWriterImage.h>
 
-#ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/FrameGrabberControl2.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+
 #endif // YARP_NO_DEPRECATED
 
 #endif // YARP_FRAMEGRABBERINTERFACES_H

--- a/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
@@ -19,7 +19,9 @@
 #include <yarp/dev/IFrameWriterImage.h>
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/FrameGrabberControl2.h>
-#endif
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_FRAMEGRABBERINTERFACES_H

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
@@ -56,7 +56,7 @@ public:
      *       it. The crop is meant to be created by the image producer upon user
      *       request via RPC call.
      *
-     * @param cropType enum specifying how the crop shall be generated, defined at FrameGrabberInterfaces.h
+     * @param cropType enum specifying how the crop shall be generated
      * @param vertices the input coordinate (u,v) required by the cropType
      * @param image the image to be filled
      * @return true/false upon success/failure

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.h
@@ -49,7 +49,7 @@ public:
      *       it. The crop is meant to be created by the image producer upon user
      *       request via RPC call.
      *
-     * @param cropType enum specifying how the crop shall be generated, defined at FrameGrabberInterfaces.h
+     * @param cropType enum specifying how the crop shall be generated
      * @param vertices the input coordinate (u,v) required by the cropType
      * @param image the image to be filled
      * @return true/false upon success/failure

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -30,7 +30,6 @@
 #include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IFrameGrabberControlsDC1394.h>
 #include <yarp/dev/IFrameWriterImage.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/GazeControl.h>
 #include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/GPUInterface.h>

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -31,7 +31,6 @@
 #include <yarp/dev/IFrameGrabberControlsDC1394.h>
 #include <yarp/dev/IFrameWriterImage.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
-#include <yarp/dev/FrameGrabberControl2.h>
 #include <yarp/dev/GazeControl.h>
 #include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/GPUInterface.h>
@@ -46,6 +45,12 @@
 #include <yarp/dev/ServiceInterfaces.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.0
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#include <yarp/dev/FrameGrabberControl2.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
 
 #ifndef YARP_NO_DEPRECATED // since YARP 3.3
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE


### PR DESCRIPTION
## Libraries

### `dev`

* Properly mark the `yarp/dev/FrameGrabberControl2.h` header file as deprecated
  (it should have been deprecated in YARP 3.0)
* The `yarp/dev/FrameGrabberInterfaces.h` header file was deprecated.
  All interfaces were moved in the corresponding header.

Depends on #2569 and #2570