### PR TITLE
dev/IFrameGrabberImage,IFrameGrabberImageRaw: Implement getImageCrop

### DIFF
--- a/doc/release/master/FrameGrabberInterfacesRefactor5.md
+++ b/doc/release/master/FrameGrabberInterfacesRefactor5.md
@@ -1,0 +1,14 @@
+FrameGrabberInterfacesRefactor5 {#master}
+-------------------------------
+
+## Libraries
+
+### `dev`
+
+#### `IFrameGrabberImage`
+
+* The `getImageCrop` method has now a working default implementation.
+
+#### `IFrameGrabberImageRaw`
+
+* The `getImageCrop` method has now a working default implementation.

--- a/doc/yarp_code_examples.dox
+++ b/doc/yarp_code_examples.dox
@@ -219,9 +219,19 @@ Demonstrates one way to access bottle objects.  See also \ref os/bottle_add/bott
 /**
  * \example dev/grabber_client/grabber_client.cpp
 
-How to grab images from a remote source using the yarp::dev::IFrameGrabber
+How to grab images from a remote source using the yarp::dev::IFrameGrabberImage
 interface.
 
+@sa yarp::dev::IFrameGrabberImage::getImage
+*/
+
+/**
+ * \example dev/grabber_crop/grabber_crop.cpp
+
+How to grab cropped images from a remote source using the
+yarp::dev::IFrameGrabberImage interface.
+
+@sa yarp::dev::IFrameGrabberImage::getImageCrop
 */
 
 /**

--- a/example/dev/CMakeLists.txt
+++ b/example/dev/CMakeLists.txt
@@ -18,6 +18,7 @@ foreach(example_name attachable
                      fake_motor
                      file_grabber
                      grabber_client
+                     grabber_crop
                      motortest
                      RGBD)
 

--- a/example/dev/grabber_crop/CMakeLists.txt
+++ b/example/dev/grabber_crop/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
+  cmake_minimum_required(VERSION 3.12)
+  project(grabber_crop)
+  find_package(YARP REQUIRED COMPONENTS os sig dev)
+endif()
+
+add_executable(grabber_crop)
+target_sources(grabber_crop PRIVATE grabber_crop.cpp)
+target_link_libraries(grabber_crop
+  PRIVATE
+    YARP::YARP_os
+    YARP::YARP_init
+    YARP::YARP_sig
+    YARP::YARP_dev
+)
+set_property(TARGET grabber_crop PROPERTY FOLDER "Examples/dev")

--- a/example/dev/grabber_crop/grabber_crop.cpp
+++ b/example/dev/grabber_crop/grabber_crop.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/os/Network.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Property.h>
+#include <yarp/sig/Image.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IFrameGrabberImage.h>
+
+
+int main(int argc, char* argv[])
+{
+    YARP_UNUSED(argc);
+    YARP_UNUSED(argv);
+    using ImageType = yarp::sig::ImageOf<yarp::sig::PixelRgb>;
+
+    yarp::os::Network yarp;
+
+    yarp::os::BufferedPort<ImageType> out;
+    out.open("/test_yarp_crop");
+
+    yarp::dev::PolyDriver dd;
+    yarp::os::Property p;
+    p.put("device", "fakeFrameGrabber");
+    p.put("mode", "grid");
+    dd.open(p);
+    yarp::dev::IFrameGrabberImage *grabber = nullptr;
+    dd.view(grabber);
+
+    const yarp::sig::VectorOf<std::pair< int, int>> vertices {{50,50}, {149, 149}};
+
+    while (true) {
+        auto& crop = out.prepare();
+        grabber->getImageCrop(YARP_CROP_RECT, vertices, crop);
+        out.write();
+    }
+
+    return 0;
+}

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.cpp
@@ -7,5 +7,35 @@
  */
 
 #include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/sig/ImageUtils.h>
+#include <yarp/os/LogComponent.h>
+
+namespace {
+YARP_LOG_COMPONENT(IFRAMEGRABBERIMAGE, "yarp.dev.IFrameGrabberImage")
+}
 
 yarp::dev::IFrameGrabberImage::~IFrameGrabberImage() = default;
+
+bool yarp::dev::IFrameGrabberImage::getImageCrop(cropType_id_t cropType,
+                                                 yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                                                 yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
+{
+    if (cropType == YARP_CROP_RECT) {
+        if (vertices.size() != 2) {
+            yCError(IFRAMEGRABBERIMAGE, "GetImageCrop failed: RECT mode requires 2 vertices");
+            return false;
+        }
+        yarp::sig::ImageOf<yarp::sig::PixelRgb> full;
+        getImage(full);
+
+        if (!yarp::sig::utils::cropRect(full, vertices[0], vertices[1], image)) {
+            yCError(IFRAMEGRABBERIMAGE, "GetImageCrop failed: utils::cropRect error");
+            return false;
+        }
+    } else if(cropType == YARP_CROP_LIST) {
+        yCError(IFRAMEGRABBERIMAGE, "List type not yet implemented");
+        return false;
+    }
+
+    return true;
+}

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
@@ -61,10 +61,9 @@ public:
      * @param image the image to be filled
      * @return true/false upon success/failure
      */
-    virtual bool getImageCrop(cropType_id_t cropType, yarp::sig::VectorOf<std::pair<int, int>> vertices, yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
-    {
-        return false;
-    };
+    virtual bool getImageCrop(cropType_id_t cropType,
+                              yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                              yarp::sig::ImageOf<yarp::sig::PixelRgb>& image);
 
     /**
      * Return the height of each frame.

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.cpp
@@ -7,5 +7,35 @@
  */
 
 #include <yarp/dev/IFrameGrabberImageRaw.h>
+#include <yarp/sig/ImageUtils.h>
+#include <yarp/os/LogComponent.h>
+
+namespace {
+YARP_LOG_COMPONENT(IFRAMEGRABBERIMAGERAW, "yarp.dev.IFrameGrabberImageRaw")
+}
 
 yarp::dev::IFrameGrabberImageRaw::~IFrameGrabberImageRaw() = default;
+
+bool yarp::dev::IFrameGrabberImageRaw::getImageCrop(cropType_id_t cropType,
+                                                    yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                                                    yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
+{
+    if (cropType == YARP_CROP_RECT) {
+        if (vertices.size() != 2) {
+            yCError(IFRAMEGRABBERIMAGERAW, "GetImageCrop failed: RECT mode requires 2 vertices");
+            return false;
+        }
+        yarp::sig::ImageOf<yarp::sig::PixelMono> full;
+        getImage(full);
+
+        if (!yarp::sig::utils::cropRect(full, vertices[0], vertices[1], image)) {
+            yCError(IFRAMEGRABBERIMAGERAW, "GetImageCrop failed: utils::cropRect error");
+            return false;
+        }
+    } else if(cropType == YARP_CROP_LIST) {
+        yCError(IFRAMEGRABBERIMAGERAW, "List type not yet implemented");
+        return false;
+    }
+
+    return true;
+}

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImageRaw.h
@@ -54,10 +54,9 @@ public:
      * @param image the image to be filled
      * @return true/false upon success/failure
      */
-    virtual bool getImageCrop(cropType_id_t cropType, yarp::sig::VectorOf<std::pair<int, int>> vertices, yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
-    {
-        return false;
-    };
+    virtual bool getImageCrop(cropType_id_t cropType,
+                              yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                              yarp::sig::ImageOf<yarp::sig::PixelMono>& image);
 
     /**
      * Return the height of each frame.

--- a/tests/libYARP_dev/fakeFrameGrabberTest.cpp
+++ b/tests/libYARP_dev/fakeFrameGrabberTest.cpp
@@ -45,6 +45,16 @@ TEST_CASE("dev::fakeFrameGrabberTest", "[yarp::dev]")
         REQUIRE(dd.view(grabber)); // interface reported
         ImageOf<PixelRgb> img;
         grabber->getImage(img);
+
+        // Test the crop function - must work.
+        ImageOf<PixelRgb> crop;
+        const yarp::sig::VectorOf<std::pair< int, int>> vertices {{0,0}, {10, 10}};
+
+        // check crop function
+        CHECK(grabber->getImageCrop(YARP_CROP_RECT, vertices, crop));
+        CHECK(crop.width() > 0);
+        CHECK(crop.height() > 0);
+
         CHECK(img.width() > 0); // interface seems functional");
         CHECK(dd.close()); // close reported successful
     }
@@ -175,20 +185,22 @@ TEST_CASE("dev::fakeFrameGrabberTest", "[yarp::dev]")
         CHECK(configurations[2].framerate == 15.0);
         CHECK(configurations[2].pixelCoding == VOCAB_PIXEL_MONO);
 
-        // Test the crop function - must NOT work.
-        // It is not implemeted in the old server
+        // Test the crop function - must work.
         IFrameGrabberImage *grabber = nullptr;
         REQUIRE(dd.view(grabber));
-        ImageOf<PixelRgb> img, crop;
+        ImageOf<PixelRgb> img;
+        ImageOf<PixelRgb> crop;
         grabber->getImage(img);
 
-        yarp::sig::VectorOf<std::pair< int, int> > vertices;
-        vertices.clear();
+        yarp::sig::VectorOf<std::pair< int, int>> vertices;
         vertices.resize(2);
         vertices[0] = std::pair <int, int> (0, 0);
-        vertices[1] = std::pair <int, int> ( 10, 10); // Configure a doable crop.
+        vertices[1] = std::pair <int, int> (10, 10); // Configure a doable crop.
 
+        // check crop function
         CHECK(grabber->getImageCrop(YARP_CROP_RECT, vertices, crop));
+        CHECK(crop.width() > 0);
+        CHECK(crop.height() > 0);
 
         CHECK(dd2.close()); // server close reported successful
         CHECK(dd.close()); // client close reported successful
@@ -399,15 +411,11 @@ TEST_CASE("dev::fakeFrameGrabberTest", "[yarp::dev]")
         CHECK(imgL->width() == width/2);
         CHECK(imgR->width() == width/2);
 
-        //Test the crop function - must work
+        // Test the crop function - must work
         ImageOf<PixelRgb> crop;
 
         // Configure a doable crop.
-        yarp::sig::VectorOf<std::pair< int, int> > vertices;
-        vertices.clear();
-        vertices.resize(2);
-        vertices[0] = std::pair <int, int> (0, 0);
-        vertices[1] = std::pair <int, int> (10, 10);
+        const yarp::sig::VectorOf<std::pair< int, int>> vertices {{0,0}, {10, 10}};
 
         // check crop function
         CHECK(grabber->getImageCrop(YARP_CROP_RECT, vertices, crop));


### PR DESCRIPTION
## Libraries

### `dev`

#### `IFrameGrabberImage`

* The `getImageCrop` method has now a working default implementation.

#### `IFrameGrabberImageRaw`

* The `getImageCrop` method has now a working default implementation.

Depends on #2571