### PR TITLE
Do not wrap static constexpr variables from yarp conf dirs in SWIG

### DIFF
--- a/src/libYARP_conf/src/yarp/conf/dirs.h
+++ b/src/libYARP_conf/src/yarp/conf/dirs.h
@@ -21,6 +21,7 @@ namespace conf {
 namespace dirs {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
+#ifndef SWIG
 
 // Constants defining environment variables names
 static constexpr const char YARP_DATA_HOME[]{"YARP_DATA_HOME"};
@@ -71,6 +72,7 @@ static constexpr const char YARP_CONFIG_SUFFIX[]{ yarp::conf::filesystem::prefer
 static constexpr const char RUNTIME_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'r', 'u', 'n', 't', 'i', 'm', 'e', '\0' };  // "/runtime" or "\\runtime"
 static constexpr const char RUNTIME_YARP_SUFFIX[]{ yarp::conf::filesystem::preferred_separator, 'r', 'u', 'n', 't', 'i', 'm', 'e', yarp::conf::filesystem::preferred_separator, 'y', 'a', 'r', 'p', '\0' };  // "/runtime/yarp" or "\\runtime\\yarp"
 
+#endif // SWIG
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /** @{ */


### PR DESCRIPTION
If I am not wrong, those variables are not part of the public interface, and they are in a public header only because they are used in header-only functions. For this reason, I think we can avoid to include them in SWIG bindings.

As a side effect, this fixes robotology/yarp-matlab-bindings#69 .

As this variables were introduced in https://github.com/robotology/yarp/pull/2557, no changelog is necessary.