### PR TITLE
Deprecate yarp::dev::IFrameGrabber and yarp::dev::IFrameGrabberRgb interfaces

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -399,7 +399,9 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/DeviceDriver.h>
 %include <yarp/dev/PolyDriver.h>
 %include <yarp/dev/Drivers.h>
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
 %include <yarp/dev/IFrameGrabber.h>
+#endif YARP_NO_DEPRECATED // Since YARP 3.5.0
 %include <yarp/dev/IFrameGrabberRgb.h>
 %include <yarp/dev/IFrameGrabberImage.h>
 %include <yarp/dev/IFrameGrabberControls.h>

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -401,8 +401,8 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/Drivers.h>
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
 %include <yarp/dev/IFrameGrabber.h>
-#endif YARP_NO_DEPRECATED // Since YARP 3.5.0
 %include <yarp/dev/IFrameGrabberRgb.h>
+#endif YARP_NO_DEPRECATED // Since YARP 3.5.0
 %include <yarp/dev/IFrameGrabberImage.h>
 %include <yarp/dev/IFrameGrabberControls.h>
 %include <yarp/dev/IFrameGrabberControlsDC1394.h>

--- a/doc/release/master/FrameGrabberInterfacesRefactor6.md
+++ b/doc/release/master/FrameGrabberInterfacesRefactor6.md
@@ -1,0 +1,8 @@
+FrameGrabberInterfacesRefactor6 {#master}
+-------------------------------
+
+## Libraries
+
+### `dev`
+
+* The interfaces `IFrameGrabber` and `IFrameGrabberRgb` are now deprecated.

--- a/src/devices/usbCamera/common/USBcamera.cpp
+++ b/src/devices/usbCamera/common/USBcamera.cpp
@@ -80,20 +80,20 @@ bool USBCameraDriver::open(yarp::os::Searchable& config)
         return false;
     }
 
-    os_device->view(deviceRgb);
-    os_device->view(deviceRaw);
+    os_device->view(frameGrabberImage);
+    os_device->view(frameGrabberImageRaw);
     os_device->view(deviceControls);
     os_device->view(deviceTimed);
     os_device->view(deviceRgbVisualParam);
 
-    if (deviceRaw != nullptr) {
-        _width = deviceRaw->width();
-        _height = deviceRaw->height();
+    if (frameGrabberImage != nullptr) {
+        _width = frameGrabberImage->width();
+        _height = frameGrabberImage->height();
     }
 
-    if (deviceRgb != nullptr) {
-        _width = deviceRgb->width();
-        _height = deviceRgb->height();
+    if (frameGrabberImageRaw != nullptr) {
+        _width = frameGrabberImageRaw->width();
+        _height = frameGrabberImageRaw->height();
     }
     return true;
 }
@@ -108,42 +108,26 @@ bool USBCameraDriver::close()
 
 int USBCameraDriver::width() const
 {
-    if (deviceRaw != nullptr) {
-        return deviceRaw->width();
+    if (frameGrabberImage != nullptr) {
+        return frameGrabberImage->width();
     }
-    if (deviceRgb != nullptr) {
-        return deviceRgb->width();
-    } else {
-        return 0;
+    if (frameGrabberImageRaw != nullptr) {
+        return frameGrabberImageRaw->width();
     }
+
+    return 0;
 }
 
 int USBCameraDriver::height() const
 {
-    if (deviceRaw != nullptr) {
-        return deviceRaw->height();
+    if (frameGrabberImage != nullptr) {
+        return frameGrabberImage->height();
     }
-    if (deviceRgb != nullptr) {
-        return deviceRgb->height();
-    } else {
-        return 0;
+    if (frameGrabberImageRaw != nullptr) {
+        return frameGrabberImageRaw->height();
     }
-}
 
-
-bool USBCameraDriver::getRawBuffer(unsigned char* buff)
-{
-    return false;
-}
-
-int USBCameraDriver::getRawBufferSize()
-{
     return 0;
-}
-
-bool USBCameraDriver::getRgbBuffer(unsigned char* buff)
-{
-    return false;
 }
 
 yarp::os::Stamp USBCameraDriver::getLastInputStamp()
@@ -258,21 +242,12 @@ USBCameraDriverRgb::~USBCameraDriverRgb()
 
 bool USBCameraDriverRgb::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
 {
-    if ((image.width() != _width) || (image.height() != _height)) {
-        image.resize(_width, _height);
-    }
-    deviceRgb->getRgbBuffer(image.getRawImage());
-    return true;
+    return frameGrabberImage->getImage(image);
 }
 
 bool USBCameraDriverRgb::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
 {
-    if ((image.width() != _width) || (image.height() != _height)) {
-        image.resize(_width, _height);
-    }
-
-    deviceRaw->getRawBuffer(image.getRawImage());
-    return true;
+    return frameGrabberImageRaw->getImage(image);
 }
 
 int USBCameraDriverRgb::width() const
@@ -300,12 +275,7 @@ USBCameraDriverRaw::~USBCameraDriverRaw()
 
 bool USBCameraDriverRaw::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
 {
-    if ((image.width() != _width) || (image.height() != _height)) {
-        image.resize(_width, _height);
-    }
-
-    deviceRaw->getRawBuffer(image.getRawImage());
-    return true;
+    return frameGrabberImageRaw->getImage(image);
 }
 
 int USBCameraDriverRaw::width() const

--- a/src/devices/usbCamera/common/USBcamera.h
+++ b/src/devices/usbCamera/common/USBcamera.h
@@ -26,8 +26,6 @@
 #include <yarp/os/Stamp.h>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IFrameGrabber.h>
-#include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameGrabberImageRaw.h>
@@ -45,8 +43,6 @@
 class USBCameraDriver :
         public yarp::dev::DeviceDriver,
         public yarp::dev::IPreciselyTimed,
-        public yarp::dev::IFrameGrabber,
-        public yarp::dev::IFrameGrabberRgb,
         public yarp::dev::IFrameGrabberControls,
         public yarp::dev::IRgbVisualParams
 {
@@ -54,9 +50,9 @@ class USBCameraDriver :
     void operator=(const USBCameraDriver&) = delete;
 
 protected:
-    yarp::dev::IFrameGrabberRgb* deviceRgb;
     yarp::dev::IPreciselyTimed* deviceTimed;
-    yarp::dev::IFrameGrabber* deviceRaw;
+    yarp::dev::IFrameGrabberImage* frameGrabberImage;
+    yarp::dev::IFrameGrabberImageRaw* frameGrabberImageRaw;
     yarp::dev::DeviceDriver* os_device;
     yarp::dev::IFrameGrabberControls* deviceControls;
     yarp::dev::IRgbVisualParams* deviceRgbVisualParam;
@@ -89,38 +85,8 @@ public:
      */
     bool close() override;
 
-    /**
-     * Implements FrameGrabber basic interface.
-     */
-    int height() const override;
-
-    /**
-     * Implements FrameGrabber basic interface.
-     */
-    int width() const override;
-
-    /**
-     * Implements FrameGrabber basic interface.
-     * @param buffer the pointer to the array to store the last frame.
-     * @return returns true/false on success/failure.
-     */
-    bool getRawBuffer(unsigned char* buffer) override;
-
-    /**
-     * Implements the Frame grabber basic interface.
-     * @return the size of the raw buffer (for the Dragonfly
-     * camera this is 1x640x480).
-     */
-    int getRawBufferSize() override;
-
-    /**
-     * FrameGrabber bgr interface, returns the last acquired frame as
-     * a buffer of bgr triplets. A demosaicking method is applied to
-     * reconstuct the color from the Bayer pattern of the sensor.
-     * @param buffer pointer to the array that will contain the last frame.
-     * @return true/false upon success/failure
-     */
-    bool getRgbBuffer(unsigned char* buffer) override;
+    int height() const;
+    int width() const;
 
     /**
      * Implements the IPreciselyTimed interface.

--- a/src/devices/usbCamera/linux/V4L_camera.cpp
+++ b/src/devices/usbCamera/linux/V4L_camera.cpp
@@ -898,10 +898,10 @@ bool V4L_camera::close()
     return true;
 }
 
-
-// IFrameGrabberRgb Interface 777
-bool V4L_camera::getRgbBuffer(unsigned char* buffer)
+bool V4L_camera::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
 {
+    image.resize(width(), height());
+
     bool res = false;
     mutex.wait();
     if (configured) {
@@ -909,9 +909,9 @@ bool V4L_camera::getRgbBuffer(unsigned char* buffer)
         imageProcess();
 
         if (!param.addictionalResize) {
-            memcpy(buffer, param.dst_image_rgb, param.dst_image_size_rgb);
+            memcpy(image.getRawImage(), param.dst_image_rgb, param.dst_image_size_rgb);
         } else {
-            memcpy(buffer, param.outMat.data, param.outMat.total() * 3);
+            memcpy(image.getRawImage(), param.outMat.data, param.outMat.total() * 3);
         }
         mutex.post();
         res = true;
@@ -923,14 +923,15 @@ bool V4L_camera::getRgbBuffer(unsigned char* buffer)
     return res;
 }
 
-// IFrameGrabber Interface
-bool V4L_camera::getRawBuffer(unsigned char* buffer)
+bool V4L_camera::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
 {
+    image.resize(width(), height());
+
     bool res = false;
     mutex.wait();
     if (configured) {
         imagePreProcess();
-        memcpy(buffer, param.src_image, param.src_image_size);
+        memcpy(image.getRawImage(), param.src_image, param.src_image_size);
         res = true;
     } else {
         yCError(USBCAMERA) << "unable to get the buffer, device uninitialized";
@@ -938,11 +939,6 @@ bool V4L_camera::getRawBuffer(unsigned char* buffer)
     }
     mutex.post();
     return res;
-}
-
-int V4L_camera::getRawBufferSize()
-{
-    return param.src_image_size;
 }
 
 /**

--- a/src/devices/usbCamera/linux/V4L_camera.h
+++ b/src/devices/usbCamera/linux/V4L_camera.h
@@ -24,8 +24,8 @@
 #include <yarp/os/Semaphore.h>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IFrameGrabber.h>
-#include <yarp/dev/IFrameGrabberRgb.h>
+#include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/dev/IFrameGrabberImageRaw.h>
 #include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IVisualParams.h>
 #include <yarp/dev/IPreciselyTimed.h>
@@ -142,8 +142,8 @@ typedef struct
 
 class V4L_camera :
         public yarp::dev::DeviceDriver,
-        public yarp::dev::IFrameGrabberRgb,
-        public yarp::dev::IFrameGrabber,
+        public yarp::dev::IFrameGrabberImage,
+        public yarp::dev::IFrameGrabberImageRaw,
         public yarp::dev::IFrameGrabberControls,
         public yarp::dev::IPreciselyTimed,
         public yarp::os::PeriodicThread,
@@ -158,23 +158,10 @@ public:
 
     yarp::os::Stamp getLastInputStamp() override;
 
-    // IFrameGrabberRgb    Interface
-    bool getRgbBuffer(unsigned char* buffer) override;
-
-    // IFrameGrabber Interface
-    bool getRawBuffer(unsigned char* buffer) override;
-    int getRawBufferSize() override;
-
-    /**
-     * Return the height of each frame.
-     * @return image height
-     */
+    /*Implementation of IFrameGrabberImage and IFrameGrabberImageRaw interfaces*/
+    bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override;
+    bool getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image) override;
     int height() const override;
-
-    /**
-     * Return the width of each frame.
-     * @return image width
-     */
     int width() const override;
 
     /*Implementation of IRgbVisualParams interface*/

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -51,7 +51,6 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/ICurrentControl.h
                   yarp/dev/IEncoders.h
                   yarp/dev/IEncodersTimed.h
-                  yarp/dev/IFrameGrabberRgb.h
                   yarp/dev/IFrameGrabberImage.h
                   yarp/dev/IFrameGrabberImageRaw.h
                   yarp/dev/IFrameGrabberControls.h
@@ -143,6 +142,7 @@ if(NOT YARP_NO_DEPRECATED)
                             yarp/dev/Wrapper.h                 # DEPRECATED Since YARP 3.3.0
                             yarp/dev/FrameGrabberInterfaces.h  # DEPRECATED Since YARP 3.5.0
                             yarp/dev/IFrameGrabber.h           # DEPRECATED Since YARP 3.5.0
+                            yarp/dev/IFrameGrabberRgb.h        # DEPRECATED Since YARP 3.5.0
   )
 endif()
 
@@ -167,7 +167,6 @@ set(YARP_dev_SRCS yarp/dev/AudioBufferSize.cpp
                   yarp/dev/IAudioVisualGrabber.cpp
                   yarp/dev/IAudioVisualStream.cpp
                   yarp/dev/IBattery.cpp
-                  yarp/dev/IFrameGrabberRgb.cpp
                   yarp/dev/IFrameGrabberImage.cpp
                   yarp/dev/IFrameGrabberImageRaw.cpp
                   yarp/dev/IFrameGrabberControls.cpp
@@ -227,6 +226,8 @@ endif()
 
 if(NOT YARP_NO_DEPRECATED)
   list(APPEND YARP_dev_SRCS yarp/dev/IFrameGrabber.cpp         # DEPRECATED Since YARP 3.5.0
+                            yarp/dev/IFrameGrabberRgb.cpp      # DEPRECATED Since YARP 3.5.0
+
   )
 endif()
 

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -51,7 +51,6 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/ICurrentControl.h
                   yarp/dev/IEncoders.h
                   yarp/dev/IEncodersTimed.h
-                  yarp/dev/IFrameGrabber.h
                   yarp/dev/IFrameGrabberRgb.h
                   yarp/dev/IFrameGrabberImage.h
                   yarp/dev/IFrameGrabberImageRaw.h
@@ -143,6 +142,7 @@ if(NOT YARP_NO_DEPRECATED)
                             yarp/dev/SerialInterfaces.h        # DEPRECATED Since YARP 3.3.0
                             yarp/dev/Wrapper.h                 # DEPRECATED Since YARP 3.3.0
                             yarp/dev/FrameGrabberInterfaces.h  # DEPRECATED Since YARP 3.5.0
+                            yarp/dev/IFrameGrabber.h           # DEPRECATED Since YARP 3.5.0
   )
 endif()
 
@@ -167,7 +167,6 @@ set(YARP_dev_SRCS yarp/dev/AudioBufferSize.cpp
                   yarp/dev/IAudioVisualGrabber.cpp
                   yarp/dev/IAudioVisualStream.cpp
                   yarp/dev/IBattery.cpp
-                  yarp/dev/IFrameGrabber.cpp
                   yarp/dev/IFrameGrabberRgb.cpp
                   yarp/dev/IFrameGrabberImage.cpp
                   yarp/dev/IFrameGrabberImageRaw.cpp
@@ -225,6 +224,12 @@ if(TARGET YARP::YARP_math)
                             yarp/dev/Map2DPath.cpp
                             yarp/dev/MapGrid2DInfo.cpp)
 endif()
+
+if(NOT YARP_NO_DEPRECATED)
+  list(APPEND YARP_dev_SRCS yarp/dev/IFrameGrabber.cpp         # DEPRECATED Since YARP 3.5.0
+  )
+endif()
+
 
 # Handle the YARP thrift messages
 include(YarpChooseIDL)

--- a/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
@@ -16,7 +16,6 @@ YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberInterfaces.h> file is deprecated")
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
 
-#include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameGrabberImageRaw.h>
 #include <yarp/dev/IFrameGrabberControls.h>
@@ -26,6 +25,7 @@ YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberInterfaces.h> file is deprecated")
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/FrameGrabberControl2.h>
 #include <yarp/dev/IFrameGrabber.h>
+#include <yarp/dev/IFrameGrabberRgb.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
 #endif // YARP_NO_DEPRECATED

--- a/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameGrabberInterfaces.h
@@ -16,7 +16,6 @@ YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberInterfaces.h> file is deprecated")
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
 
-#include <yarp/dev/IFrameGrabber.h>
 #include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameGrabberImageRaw.h>
@@ -26,6 +25,7 @@ YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberInterfaces.h> file is deprecated")
 
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/FrameGrabberControl2.h>
+#include <yarp/dev/IFrameGrabber.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
 #endif // YARP_NO_DEPRECATED

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabber.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabber.cpp
@@ -6,6 +6,8 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/IFrameGrabber.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
 yarp::dev::IFrameGrabber::~IFrameGrabber() = default;

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabber.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabber.h
@@ -10,6 +10,13 @@
 #ifndef YARP_DEV_IFRAMEGRABBER_H
 #define YARP_DEV_IFRAMEGRABBER_H
 
+#include <yarp/conf/system.h>
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabber.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
+
 #include <yarp/dev/api.h>
 
 namespace yarp {
@@ -19,8 +26,10 @@ namespace dev {
  * @ingroup dev_iface_media
  *
  * Common interface to a FrameGrabber.
+ *
+ * @deprecated Since YARP 3.5
  */
-class YARP_dev_API IFrameGrabber
+class YARP_dev_DEPRECATED_API IFrameGrabber
 {
 public:
     virtual ~IFrameGrabber();
@@ -58,5 +67,7 @@ public:
 
 } // namespace dev
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_DEV_IFRAMEGRABBER_H

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberRgb.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberRgb.cpp
@@ -6,6 +6,8 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/IFrameGrabberRgb.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 
 yarp::dev::IFrameGrabberRgb::~IFrameGrabberRgb() = default;

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberRgb.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberRgb.h
@@ -10,6 +10,13 @@
 #ifndef YARP_DEV_IFRAMEGRABBERRGB_H
 #define YARP_DEV_IFRAMEGRABBERRGB_H
 
+#include <yarp/conf/system.h>
+#if !defined(YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE)
+YARP_COMPILER_WARNING("<yarp/dev/IFrameGrabberRgb.h> file is deprecated")
+#endif
+
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
+
 #include <yarp/dev/api.h>
 
 namespace yarp {
@@ -19,8 +26,10 @@ namespace dev {
  * @ingroup dev_iface_media
  *
  * RGB Interface to a FrameGrabber device.
+ *
+ * @deprecated Since YARP 3.5
  */
-class YARP_dev_API IFrameGrabberRgb
+class YARP_dev_DEPRECATED_API IFrameGrabberRgb
 {
 public:
     virtual ~IFrameGrabberRgb();
@@ -48,5 +57,7 @@ public:
 
 } // namespace dev
 } // namespace yarp
+
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_DEV_IFRAMEGRABBERRGB_H

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -24,7 +24,6 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/DriverLinkCreator.h>
 #include <yarp/dev/Drivers.h>
-#include <yarp/dev/IFrameGrabber.h>
 #include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameGrabberControls.h>
@@ -54,6 +53,12 @@
 #ifndef YARP_NO_DEPRECATED // since YARP 3.3
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/DataSource.h>
+#undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#endif // YARP_NO_DEPRECATED
+
+#ifndef YARP_NO_DEPRECATED // since YARP 3.5
+#define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
+#include <yarp/dev/IFrameGrabber.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif // YARP_NO_DEPRECATED
 

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -24,7 +24,6 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/DriverLinkCreator.h>
 #include <yarp/dev/Drivers.h>
-#include <yarp/dev/IFrameGrabberRgb.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IFrameGrabberControlsDC1394.h>
@@ -59,6 +58,7 @@
 #ifndef YARP_NO_DEPRECATED // since YARP 3.5
 #define YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #include <yarp/dev/IFrameGrabber.h>
+#include <yarp/dev/IFrameGrabberRgb.h>
 #undef YARP_INCLUDING_DEPRECATED_HEADER_ON_PURPOSE
 #endif // YARP_NO_DEPRECATED
 


### PR DESCRIPTION
As discussed in #2576 and #1868, the `yarp::dev::IFrameGrabber` and `yarp::dev::IFrameGrabberRgb` interfaces are not used by anyone and are missing some very important information about the image, which makes the useless.