### PR TITLE
dev: Add WrapperSingle and WrapperMultiple helpers

### DIFF
--- a/doc/release/master/IWrapper_helpers.md
+++ b/doc/release/master/IWrapper_helpers.md
@@ -1,0 +1,10 @@
+IWrapper_helpers {#master}
+----------------
+
+## Libraries
+
+### `dev`
+
+* Added the new `WrapperSingle` and `WrapperMultiple` helper classes, that
+  inherit from both `IWrapper` and `IMultipleWrapper` but require to implement
+  only one of these interfaces.

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -117,7 +117,9 @@ set(YARP_dev_HDRS yarp/dev/all.h
                   yarp/dev/PolyDriverDescriptor.h
                   yarp/dev/PolyDriverList.h
                   yarp/dev/RGBDSensorParamParser.h
-                  yarp/dev/ServiceInterfaces.h)
+                  yarp/dev/ServiceInterfaces.h
+                  yarp/dev/WrapperMultiple.h
+                  yarp/dev/WrapperSingle.h)
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_HDRS yarp/dev/IFrameTransform.h
@@ -210,7 +212,9 @@ set(YARP_dev_SRCS yarp/dev/AudioBufferSize.cpp
                   yarp/dev/PolyDriver.cpp
                   yarp/dev/PolyDriverDescriptor.cpp
                   yarp/dev/PolyDriverList.cpp
-                  yarp/dev/RGBDSensorParamParser.cpp)
+                  yarp/dev/RGBDSensorParamParser.cpp
+                  yarp/dev/WrapperMultiple.cpp
+                  yarp/dev/WrapperSingle.cpp)
 
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_SRCS yarp/dev/IFrameTransform.cpp

--- a/src/libYARP_dev/src/yarp/dev/WrapperMultiple.cpp
+++ b/src/libYARP_dev/src/yarp/dev/WrapperMultiple.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/WrapperMultiple.h>
+
+#include <yarp/os/LogComponent.h>
+
+namespace {
+YARP_LOG_COMPONENT(WRAPPERSINGLE, "yarp.dev.WrapperMultiple")
+} // namespace
+
+
+yarp::dev::WrapperMultiple::~WrapperMultiple() = default;
+
+
+bool yarp::dev::WrapperMultiple::attach(PolyDriver *driver)
+{
+    if (!driver || !driver->isValid()) {
+        yCError(WRAPPERSINGLE, "Could not attach an invalid device");
+        return false;
+    }
+
+    yarp::dev::PolyDriverList drivers;
+    drivers.push(driver, "...");
+
+    return attachAll(drivers);
+}
+
+
+bool yarp::dev::WrapperMultiple::detach()
+{
+    return detachAll();
+}

--- a/src/libYARP_dev/src/yarp/dev/WrapperMultiple.h
+++ b/src/libYARP_dev/src/yarp/dev/WrapperMultiple.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_WRAPPERMULTIPLE_H
+#define YARP_DEV_WRAPPERMULTIPLE_H
+
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ * @ingroup dev_iwrapper
+ *
+ * @brief Helper interface for an object that can wrap/or "attach" to one or
+ * more other devices.
+ *
+ * The IMultipleWrapper methods should be implemented by the user, but the
+ * device can be used also through the IWrapper interface when only a single
+ * device should be passed.
+ */
+class YARP_dev_API WrapperMultiple :
+        public yarp::dev::IWrapper,
+        public yarp::dev::IMultipleWrapper
+{
+    /**
+     * Destructor.
+     */
+    ~WrapperMultiple() override;
+
+    // yarp::dev::IWrapper
+    bool attach(PolyDriver *driver) final;
+    bool detach() final;
+};
+
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_WRAPPERMULTIPLE_H

--- a/src/libYARP_dev/src/yarp/dev/WrapperSingle.cpp
+++ b/src/libYARP_dev/src/yarp/dev/WrapperSingle.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <yarp/dev/WrapperSingle.h>
+
+#include <yarp/os/LogComponent.h>
+
+namespace {
+YARP_LOG_COMPONENT(WRAPPERSINGLE, "yarp.dev.WrapperSingle")
+} // namespace
+
+
+yarp::dev::WrapperSingle::~WrapperSingle() = default;
+
+
+bool yarp::dev::WrapperSingle::attachAll(const yarp::dev::PolyDriverList& drivers)
+{
+    if (drivers.size() != 1) {
+        yCError(WRAPPERSINGLE, "Expected only one device to be attached");
+        return false;
+    }
+
+    if (!drivers[0]->poly || !drivers[0]->poly->isValid()) {
+        yCError(WRAPPERSINGLE, "Could not attach an invalid device");
+        return false;
+    }
+
+    return attach(drivers[0]->poly);
+}
+
+
+bool yarp::dev::WrapperSingle::detachAll()
+{
+    return detach();
+}

--- a/src/libYARP_dev/src/yarp/dev/WrapperSingle.h
+++ b/src/libYARP_dev/src/yarp/dev/WrapperSingle.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_DEV_WRAPPERSINGLE_H
+#define YARP_DEV_WRAPPERSINGLE_H
+
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+
+namespace yarp {
+namespace dev {
+
+/**
+ *
+ */
+
+
+/**
+ * @ingroup dev_iwrapper
+ *
+ * @brief Helper interface for an object that can wrap/or "attach" to a single
+ * other device.
+ *
+ * The IWrapper methods should be implemented by the user, but the device can
+ * be used also through the IMultipleWrapper interface.
+ */
+class YARP_dev_API WrapperSingle :
+        public yarp::dev::IWrapper,
+        public yarp::dev::IMultipleWrapper
+{
+    /**
+     * Destructor.
+     */
+    ~WrapperSingle() override;
+
+    // yarp::dev::IMultipleWrapper
+    bool attachAll(const yarp::dev::PolyDriverList& drivers) final;
+    bool detachAll() final;
+};
+
+
+} // namespace dev
+} // namespace yarp
+
+#endif // YARP_DEV_WRAPPERSINGLE_H


### PR DESCRIPTION
## Libraries
### `dev`

* Added the new `WrapperSingle` and `WrapperMultiple` helper classes, that inherit from both `IWrapper` and `IMultipleWrapper` but require to implement only one of these interfaces.

CC-Discussion #2489 