### PR TITLE
fakeFrameGrabber enhancements

### DIFF
--- a/doc/device_invocation/fakeFrameGrabber_basic.dox
+++ b/doc/device_invocation/fakeFrameGrabber_basic.dox
@@ -39,6 +39,7 @@ So this is just an example
 <tr><td>verticalFov</td><td>desired vertical fov of test image</td><td>2.0</td></tr>
 <tr><td>mirror</td><td>mirroring disabled by default</td><td>0</td></tr>
 <tr><td>syncro</td><td>syncronize producer and consumer, so that all images are used once and only once</td><td>0</td></tr>
+<tr><td>topIsLow</td><td>explicitly set the topIsLow field in the images</td><td>1</td></tr>
 <tr><td>physFocalLength</td><td>Physical focal length of the fakeFrameGrabber</td><td>3.0</td></tr>
 <tr><td>focalLengthX</td><td>Horizontal component of the focal length of the fakeFrameGrabber</td><td>4.0</td></tr>
 <tr><td>focalLengthY</td><td>Vertical component of the focal length of the fakeFrameGrabber</td><td>5.0</td></tr>
@@ -53,9 +54,10 @@ So this is just an example
 <tr><td>t2</td><td>Tangential distortion of the lens(fake)</td><td>12.0</td></tr>
 <tr><td>freq</td><td>rate of test images in Hz</td><td></td></tr>
 <tr><td>period</td><td>period of test images in seconds</td><td></td></tr>
-<tr><td>mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], noise [nois], none [none], time test[time]</td><td>line</td></tr>
+<tr><td>mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], none [none], time test[time]</td><td>line</td></tr>
 <tr><td>src</td><td></td><td></td></tr>
 <tr><td>timestamp</td><td>should write the timestamp in the first bytes of the image</td><td></td></tr>
+<tr><td>noise</td><td>Should add noise to the image (uses snr)</td><td></td></tr>
 <tr><td>snr</td><td>Signal noise ratio ([0.0-1.0] default 0.5)</td><td>0.5</td></tr>
 <tr><td>bayer</td><td>should emit bayer test image?</td><td></td></tr>
 <tr><td>mono</td><td>should emit a monochrome image?</td><td></td></tr>

--- a/doc/device_invocation/fakeFrameGrabber_basic.dox
+++ b/doc/device_invocation/fakeFrameGrabber_basic.dox
@@ -38,6 +38,7 @@ So this is just an example
 <tr><td>horizontalFov</td><td>desired horizontal fov of test image</td><td>1.0</td></tr>
 <tr><td>verticalFov</td><td>desired vertical fov of test image</td><td>2.0</td></tr>
 <tr><td>mirror</td><td>mirroring disabled by default</td><td>0</td></tr>
+<tr><td>syncro</td><td>syncronize producer and consumer, so that all images are used once and only once</td><td>0</td></tr>
 <tr><td>physFocalLength</td><td>Physical focal length of the fakeFrameGrabber</td><td>3.0</td></tr>
 <tr><td>focalLengthX</td><td>Horizontal component of the focal length of the fakeFrameGrabber</td><td>4.0</td></tr>
 <tr><td>focalLengthY</td><td>Vertical component of the focal length of the fakeFrameGrabber</td><td>5.0</td></tr>

--- a/doc/device_invocation/group_basic.dox
+++ b/doc/device_invocation/group_basic.dox
@@ -64,6 +64,7 @@ So this is just an example
 <tr><td>mycam.horizontalFov</td><td>desired horizontal fov of test image</td><td>1.0</td></tr>
 <tr><td>mycam.verticalFov</td><td>desired vertical fov of test image</td><td>2.0</td></tr>
 <tr><td>mycam.mirror</td><td>mirroring disabled by default</td><td>0</td></tr>
+<tr><td>mycam.syncro</td><td>syncronize producer and consumer, so that all images are used once and only once</td><td>0</td></tr>
 <tr><td>mycam.physFocalLength</td><td>Physical focal length of the fakeFrameGrabber</td><td>3.0</td></tr>
 <tr><td>mycam.focalLengthX</td><td>Horizontal component of the focal length of the fakeFrameGrabber</td><td>4.0</td></tr>
 <tr><td>mycam.focalLengthY</td><td>Vertical component of the focal length of the fakeFrameGrabber</td><td>5.0</td></tr>

--- a/doc/device_invocation/group_basic.dox
+++ b/doc/device_invocation/group_basic.dox
@@ -65,6 +65,7 @@ So this is just an example
 <tr><td>mycam.verticalFov</td><td>desired vertical fov of test image</td><td>2.0</td></tr>
 <tr><td>mycam.mirror</td><td>mirroring disabled by default</td><td>0</td></tr>
 <tr><td>mycam.syncro</td><td>syncronize producer and consumer, so that all images are used once and only once</td><td>0</td></tr>
+<tr><td>mycam.topIsLow</td><td>explicitly set the topIsLow field in the images</td><td>1</td></tr>
 <tr><td>mycam.physFocalLength</td><td>Physical focal length of the fakeFrameGrabber</td><td>3.0</td></tr>
 <tr><td>mycam.focalLengthX</td><td>Horizontal component of the focal length of the fakeFrameGrabber</td><td>4.0</td></tr>
 <tr><td>mycam.focalLengthY</td><td>Vertical component of the focal length of the fakeFrameGrabber</td><td>5.0</td></tr>
@@ -79,9 +80,10 @@ So this is just an example
 <tr><td>mycam.t2</td><td>Tangential distortion of the lens(fake)</td><td>12.0</td></tr>
 <tr><td>mycam.freq</td><td>rate of test images in Hz</td><td></td></tr>
 <tr><td>mycam.period</td><td>period of test images in seconds</td><td></td></tr>
-<tr><td>mycam.mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], noise [nois], none [none], time test[time]</td><td>line</td></tr>
+<tr><td>mycam.mode</td><td>bouncy [ball], scrolly [line], grid [grid], grid multisize [size], random [rand], none [none], time test[time]</td><td>line</td></tr>
 <tr><td>mycam.src</td><td></td><td></td></tr>
 <tr><td>mycam.timestamp</td><td>should write the timestamp in the first bytes of the image</td><td></td></tr>
+<tr><td>mycam.noise</td><td>Should add noise to the image (uses snr)</td><td></td></tr>
 <tr><td>mycam.snr</td><td>Signal noise ratio ([0.0-1.0] default 0.5)</td><td>0.5</td></tr>
 <tr><td>mycam.bayer</td><td>should emit bayer test image?</td><td></td></tr>
 <tr><td>mycam.mono</td><td>should emit a monochrome image?</td><td></td></tr>

--- a/doc/release/master/fakeFrameGrabber_enh2.md
+++ b/doc/release/master/fakeFrameGrabber_enh2.md
@@ -1,0 +1,16 @@
+fakeFrameGrabber_enh2 {#master}
+---------------------
+
+## Devices
+
+### `fakeFrameGrabber`
+
+* The `getImage()` method no longer blocks the caller.
+  The `--syncro` option was added to restore the old behavior.
+
+* The `topIsLow` option and the `set_topIsLow` rpc command were added to produce
+  images with bottom to top scanlines.
+
+* The `nois` mode (introduced in fakeFrameGrabber_enh) was removed in favour of
+  the `--noise` option and `set_noise` and `set_snr` commands that adds noise
+  to the generated images.

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -138,6 +138,7 @@ bool FakeFrameGrabber::read(yarp::os::ConnectionReader& connection)
         reply.addString("set_mode <mode>");
         reply.addString("set_image <file_name>/off");
         reply.addString("available modes: ball, line, grid, size, rand, nois, none, time");
+        reply.addString("set_topIsLow on/off");
         reply.addString("");
     }
     else if (command.get(0).asString() == "set_mode")
@@ -166,6 +167,18 @@ bool FakeFrameGrabber::read(yarp::os::ConnectionReader& connection)
                 have_bg = false;
                 reply.addString("err");
             }
+        }
+    }
+    else if (command.get(0).asString() == "set_topIsLow")
+    {
+        if (command.get(1).asString() == "off") {
+            topIsLow = false;
+            reply.addString("ack");
+        } else if (command.get(1).asString() == "on") {
+            topIsLow = true;
+            reply.addString("ack");
+        } else {
+            reply.addString("err");
         }
     }
     else
@@ -202,6 +215,8 @@ bool FakeFrameGrabber::open(yarp::os::Searchable& config) {
                         "mirroring disabled by default").asBool();
     syncro=config.check("syncro",Value(false),
                         "syncronize producer and consumer, so that all images are used once and only once").asBool();
+    topIsLow=config.check("topIsLow",Value(true),
+                          "explicitly set the topIsLow field in the images").asBool();
     intrinsic.put("physFocalLength",config.check("physFocalLength",Value(3.0),"Physical focal length of the fakeFrameGrabber").asFloat64());
     intrinsic.put("focalLengthX",config.check("focalLengthX",Value(4.0),"Horizontal component of the focal length of the fakeFrameGrabber").asFloat64());
     intrinsic.put("focalLengthY",config.check("focalLengthY",Value(5.0),"Vertical component of the focal length of the fakeFrameGrabber").asFloat64());
@@ -817,6 +832,8 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
         image.pixel(6, 0).g = ttxt[19] - '0';
         image.pixel(6, 0).b = ttxt[20] - '0';
     }
+
+    image.setTopIsLowIndex(topIsLow);
 }
 
 

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -549,6 +549,21 @@ bool FakeFrameGrabber::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
     return true;
 }
 
+bool FakeFrameGrabber::getImageCrop(cropType_id_t cropType,
+                                    yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                                    yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
+{
+    yCDebugThrottle(FAKEFRAMEGRABBER, 5.0) << "Hardware crop requested!";
+    return yarp::dev::IFrameGrabberOf<yarp::sig::ImageOf<yarp::sig::PixelRgb>>::getImageCrop(cropType, vertices, image);
+}
+
+bool FakeFrameGrabber::getImageCrop(cropType_id_t cropType,
+                                    yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                                    yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
+{
+    yCDebugThrottle(FAKEFRAMEGRABBER, 5.0) << "Hardware crop requested!";
+    return yarp::dev::IFrameGrabberOf<yarp::sig::ImageOf<yarp::sig::PixelMono>>::getImageCrop(cropType, vertices, image);
+}
 
 yarp::os::Stamp FakeFrameGrabber::getLastInputStamp() {
     return stamp;

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -176,6 +176,7 @@ private:
     bool have_bg{false};
     int mode{0};
     bool add_timestamp{false};
+    bool add_noise{false};
     double snr{default_snr};
     bool use_bayer{false};
     bool use_mono{false};

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -180,6 +180,7 @@ private:
     bool use_bayer{false};
     bool use_mono{false};
     bool mirror{false};
+    bool syncro{false};
     yarp::os::Property intrinsic;
     yarp::sig::VectorOf<yarp::dev::CameraConfig> configurations;
 
@@ -188,6 +189,7 @@ private:
     std::uniform_int_distribution<int> udist{-1, 1};
     std::uniform_real_distribution<double> ucdist{0.0, 1.0};
 
+    std::mutex curr_buff_mutex;
     size_t curr_buff{1};
     yarp::sig::ImageOf<yarp::sig::PixelRgb> buffs[2];
     bool img_ready[2] {false, false};

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -111,8 +111,14 @@ public:
     bool setRgbMirroring(bool mirror) override;
     //
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override;
-
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image) override;
+
+    bool getImageCrop(cropType_id_t cropType,
+                      yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                      yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override;
+    bool getImageCrop(cropType_id_t cropType,
+                      yarp::sig::VectorOf<std::pair<int, int>> vertices,
+                      yarp::sig::ImageOf<yarp::sig::PixelMono>& image) override;
 
     yarp::os::Stamp getLastInputStamp() override;
 

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -181,6 +181,7 @@ private:
     bool use_mono{false};
     bool mirror{false};
     bool syncro{false};
+    bool topIsLow{true};
     yarp::os::Property intrinsic;
     yarp::sig::VectorOf<yarp::dev::CameraConfig> configurations;
 

--- a/src/libYARP_dev/src/yarp/dev/IVisualParams.h
+++ b/src/libYARP_dev/src/yarp/dev/IVisualParams.h
@@ -31,12 +31,10 @@ namespace yarp {
  */
 YARP_BEGIN_PACK
 struct yarp::dev::CameraConfig {
-    int width;
-    int height;
-    double framerate;
-    YarpVocabPixelTypesEnum pixelCoding;
-
-    CameraConfig() : width(0), height(0), framerate(0.0), pixelCoding(VOCAB_PIXEL_INVALID) {}
+    int width {0};
+    int height {0};
+    double framerate {0.0};
+    YarpVocabPixelTypesEnum pixelCoding {VOCAB_PIXEL_INVALID};
 };
 YARP_END_PACK
 


### PR DESCRIPTION
## Devices

### `fakeFrameGrabber`

* The `getImage()` method no longer blocks the caller.
  The `--syncro` option was added to restore the old behavior.

* The `topIsLow` option and the `set_topIsLow` rpc command were added to produce
  images with bottom to top scanlines.

* The `nois` mode (introduced in fakeFrameGrabber_enh) was removed in favour of
  the `--noise` option and `set_noise` and `set_snr` commands that adds noise
  to the generated images.

Depends on #2593 and #2583
