### PR TITLE
Add missing includes to ControlBoardInterfacesImpl.h file

### DIFF
--- a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfacesImpl.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfacesImpl.h
@@ -17,6 +17,8 @@
 #include <yarp/dev/ImplementMotor.h>
 #include <yarp/dev/ImplementRemoteVariables.h>
 #include <yarp/dev/ImplementControlMode.h>
+#include <yarp/dev/ImplementPositionControl.h>
+#include <yarp/dev/ImplementVelocityControl.h>
 #include <yarp/dev/ImplementTorqueControl.h>
 #include <yarp/dev/ImplementCurrentControl.h>
 #include <yarp/dev/ImplementPWMControl.h>


### PR DESCRIPTION
The `ControlBoardInterfacesImpl.h` should include the `ImplementPositionControl.h` and `ImplementVelocityControl.h` headers that define the `yarp::dev::ImplementPositionControl`  and `yarp::dev::ImplementVelocityControl`, but those were removed in https://github.com/robotology/yarp/pull/2596 .  This PR restores them. 

Fix part of https://github.com/robotology/robotology-superbuild/issues/794 .