### PR TITLE
sig/Image: Fix topIsLow handling

### DIFF
--- a/doc/release/master/fix_topIsLow.md
+++ b/doc/release/master/fix_topIsLow.md
@@ -1,0 +1,29 @@
+fix_topIsLow {#master}
+------------
+
+# Important Changes
+
+* Bottom to top images are no longer flipped when sent through the network. This
+  means that the image needs to be manually flipped after it is received.
+
+* Bottom to top images might cause issues when received by YARP 3.4.5 or
+  earlier.
+
+
+# Bugfix
+
+
+## Libraries
+
+### `sig`
+
+#### `Image`
+
+* The `topIsLow` flag is now properly handled, kept in sync with the IplImage,
+  and forwarded through the network.
+
+## Devices
+
+### `grabberDual`
+
+* The `topIsLow` flag is no longer changed.

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
@@ -810,6 +810,7 @@ void ServerGrabber::setupFlexImage(const Image &_img, FlexImage &flex_i)
 {
     flex_i.setPixelCode(_img.getPixelCode());
     flex_i.setQuantum(_img.getQuantum());
+    flex_i.setTopIsLowIndex(_img.topIsLowIndex());
     flex_i.setExternal(_img.getRawImage(), _img.width(),_img.height());
 
 }
@@ -1196,6 +1197,7 @@ void ServerGrabber::shallowCopyImages(const yarp::sig::FlexImage& src, yarp::sig
 {
     dest.setPixelCode(src.getPixelCode());
     dest.setQuantum(src.getQuantum());
+    dest.setTopIsLowIndex(src.topIsLowIndex());
     dest.setExternal(src.getRawImage(), src.width(), src.height());
 }
 void ServerGrabber::cleanUp()

--- a/src/libYARP_sig/src/yarp/sig/Image.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Image.cpp
@@ -864,6 +864,8 @@ bool Image::copy(const Image& alt)
             setQuantum(alt.getQuantum());
         }
         resize(alt.width(),alt.height());
+        setTopIsLowIndex(alt.topIsLowIndex());
+
         int q1 = alt.getQuantum();
         int q2 = getQuantum();
         if (q1==0) { q1 = YARP_IMAGE_ALIGN; }
@@ -908,6 +910,7 @@ bool Image::copy(const Image& alt, size_t w, size_t h) {
     if (getPixelCode()==0) {
         setPixelCode(alt.getPixelCode());
         setQuantum(alt.getQuantum());
+        setTopIsLowIndex(alt.topIsLowIndex());
     }
     if (&alt==this) {
         FlexImage img;
@@ -919,6 +922,7 @@ bool Image::copy(const Image& alt, size_t w, size_t h) {
         FlexImage img;
         img.setPixelCode(getPixelCode());
         img.setQuantum(getQuantum());
+        img.setTopIsLowIndex(topIsLowIndex());
         img.copy(alt);
         return copy(img,w,h);
     }

--- a/src/libYARP_sig/src/yarp/sig/Image.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Image.cpp
@@ -54,11 +54,12 @@ inline bool readFromConnection(Image &dest, ImageNetworkHeader &header, Connecti
     //this check is redundant with assertion, I would remove it
     if (dest.getRawImageSize() != static_cast<size_t>(header.imgSize)) {
         printf("There is a problem reading an image\n");
-        printf("incoming: width %zu, height %zu, code %zu, quantum %zu, size %zu\n",
+        printf("incoming: width %zu, height %zu, code %zu, quantum %zu, topIsLow %zu, size %zu\n",
                static_cast<size_t>(header.width),
                static_cast<size_t>(header.height),
                static_cast<size_t>(header.id),
                static_cast<size_t>(header.quantum),
+               static_cast<size_t>(header.topIsLow),
                static_cast<size_t>(header.imgSize));
         printf("my space: width %zu, height %zu, code %d, quantum %zu, size %zu\n",
             dest.width(), dest.height(), dest.getPixelCode(), dest.getQuantum(), allocatedBytes);
@@ -696,6 +697,8 @@ bool Image::read(yarp::os::ConnectionReader& connection) {
         }
     }
 
+    setTopIsLowIndex(header.topIsLow == 0);
+
     // handle easy case, received and current image are compatible, no conversion needed
     if (getPixelCode() == header.id && q == static_cast<size_t>(header.quantum) && imgPixelSize == static_cast<size_t>(header.depth))
     {
@@ -723,6 +726,7 @@ bool Image::read(yarp::os::ConnectionReader& connection) {
         FlexImage flex;
         flex.setPixelCode(VOCAB_PIXEL_MONO);
         flex.setQuantum(header.quantum);
+        flex.setTopIsLowIndex(header.topIsLow == 0);
 
         bool ok = readFromConnection(flex, header, connection);
         if (!ok) {

--- a/src/libYARP_sig/src/yarp/sig/Image.h
+++ b/src/libYARP_sig/src/yarp/sig/Image.h
@@ -349,9 +349,7 @@ public:
      * false if image has origin at bottom left.
      *
      */
-    void setTopIsLowIndex(bool flag) {
-        topIsLow = flag;
-    }
+    void setTopIsLowIndex(bool flag);
 
 
     /**

--- a/src/libYARP_sig/src/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/src/yarp/sig/ImageNetworkHeader.h
@@ -12,6 +12,7 @@
 
 #include <yarp/conf/system.h>
 
+#include <yarp/os/NetInt16.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Bottle.h>
 
@@ -43,7 +44,8 @@ public:
     yarp::os::NetInt32 paramListLen;
     yarp::os::NetInt32 depth;
     yarp::os::NetInt32 imgSize;
-    yarp::os::NetInt32 quantum;
+    yarp::os::NetInt16 quantum;
+    yarp::os::NetInt16 topIsLow;
     yarp::os::NetInt32 width;
     yarp::os::NetInt32 height;
     yarp::os::NetInt32 paramBlobTag;
@@ -52,7 +54,7 @@ public:
     ImageNetworkHeader() : listTag(0), listLen(0), paramNameTag(0),
                            paramName(0), paramIdTag(0), id(0),
                            paramListTag(0), paramListLen(0), depth(0),
-                           imgSize(0), quantum(0), width(0),
+                           imgSize(0), quantum(0), topIsLow(0), width(0),
                            height(0), paramBlobTag(0), paramBlobLen(0) {}
 
     void setFromImage(const Image& image) {
@@ -63,10 +65,17 @@ public:
         paramIdTag = BOTTLE_TAG_VOCAB32;
         id = image.getPixelCode();
         paramListTag = BOTTLE_TAG_LIST + BOTTLE_TAG_INT32;
+        // WARNING This is 5 and not 6 because quantum and topIsLow are
+        //         transmitted in the same 32 bits for compatibility with
+        //         YARP 3.4 and older
         paramListLen = 5;
         depth = image.getPixelSize();
         imgSize = image.getRawImageSize();
-        quantum = image.getQuantum();
+        quantum = static_cast<yarp::os::NetInt16>(image.getQuantum());
+        // WARNING The topIsLowIndex field in the ImageNetworkHeader is `0` for
+        //         `true` and `1` for `false` for compatibility with YARP 3.4
+        //         and older
+        topIsLow = image.topIsLowIndex() ? 0 : 1;
         width = image.width();
         height = image.height();
         paramBlobTag = BOTTLE_TAG_BLOB;

--- a/src/yarpview/plugin/ImagePort.cpp
+++ b/src/yarpview/plugin/ImagePort.cpp
@@ -70,7 +70,15 @@ void InputCallback::onRead(yarp::sig::ImageOf<yarp::sig::PixelRgba> &img)
         j+=4;
     }*/
 
-    memcpy(tmpBuf,rawImg,imgSize);
+    if (img.topIsLowIndex()) {
+        memcpy(tmpBuf, rawImg, imgSize);
+    } else {
+        for(int x = 0; x < s.height(); x++) {
+            memcpy(tmpBuf + x * img.getRowSize(),
+                   rawImg + (s.height() - x - 1) * img.getRowSize(),
+                   img.getRowSize());
+        }
+    }
 
     //unmap the buffer
     frame.unmap();


### PR DESCRIPTION
This patch introduces a few fixes in the `topIsLow` flag handling in `yarp::sig::Image`.
This flag represent the scanline direction (top to bottom if true, bottom to top if false) of the image.
This is, in our use case, normally top to bottom, but there are a very limited number of exceptions (for example the [ovrheadset device](https://github.com/robotology/yarp-device-ovrheadset/blob/b310d7c8588ed0c74d2d167ea41c7d804d10aa18/src/devices/ovrheadset/OVRHeadset.cpp#L1134-L1136) is able to handle both cases), and there are a few cases when it is useful to have the origin in the bottom left corner (for example when working with opengl)

At the moment, whenever an image is sent through the network, it is copied to a top-left-origin image, therefore flipping any bottom-left-origin image, and therefore it is always sent through the network as top-left-origin image.
Flipping the image has advantages (for example, yarpview always receives the images in the right direction), but it is an expansive operation, and it introduces some logic in the network layer, which makes it different to work attached directly to the device, or to the network wrapper. This has therefore to be removed, in order to implement properly the nws/nwc architecture. 

The drawback is that I'm pretty sure that this flag is not checked almost anywhere, and in some cases there might be some users that will not handle this properly.

First of all, this flag is never forwarded through the network. This information has to be included in the ImageNetworkHeader, somehow, but this will cause a breaking change (See also #2587) in the protocol. In order to reduce the amount of breaking changes, since the quantum is transmitted using a 32bit integer, which is quite large for what it should contain, this field is reduced to 16 bit, and the remaining 16 bit are used for the `topIsLow` flag. The `topIsLow` flag is normally `true`, therefore we use an inverted convention here, `0` for `true`, `1` for `false`. This will reduce the number of breaking changes to the minumum.
Anyway, if an image with `topIsLow == false` is sent after this patch, a client running YARP 3.4 will receive a very unfortunate `quantum` and will probably crash. Therefore I'm planning to patch the yarp-3.4 branch, to discard the 16 bits that do not belong to the quantum. This will fix the image, but the user will probably have it upside down.


