### PR TITLE
sensorMeasurements_to_vector portmonitor

### DIFF
--- a/.ci/initial-cache.gh.linux.cmake
+++ b/.ci/initial-cache.gh.linux.cmake
@@ -112,5 +112,6 @@ set(ENABLE_yarpmod_grabber ON CACHE BOOL "")
 set(ENABLE_yarpmod_test_segfault ON CACHE BOOL "")
 set(ENABLE_yarpmod_test_nop ON CACHE BOOL "")
 set(ENABLE_yarpcar_websocket ON CACHE BOOL "")
+set(ENABLE_yarpmod_fakePositionSensor ON CACHE BOOL "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/bindings-cache.cmake)

--- a/.ci/initial-cache.gh.macos.cmake
+++ b/.ci/initial-cache.gh.macos.cmake
@@ -32,5 +32,6 @@ set(ENABLE_yarpmod_fakeLaser ON CACHE BOOL "")
 set(ENABLE_yarpmod_rpLidar ON CACHE BOOL "")
 set(ENABLE_yarpmod_laserHokuyo ON CACHE BOOL "")
 set(ENABLE_yarpcar_websocket ON CACHE BOOL "")
+set(ENABLE_yarpmod_fakePositionSensor ON CACHE BOOL "")
 
 set(Qt5_DIR "/usr/local/opt/qt5/lib/cmake/Qt5")

--- a/.ci/initial-cache.gh.windows.cmake
+++ b/.ci/initial-cache.gh.windows.cmake
@@ -26,4 +26,5 @@ set(ENABLE_yarpmod_fakeLaser ON CACHE BOOL "")
 set(ENABLE_yarpmod_rpLidar ON CACHE BOOL "")
 set(ENABLE_yarpmod_laserHokuyo ON CACHE BOOL "")
 set(ENABLE_yarpcar_websocket ON CACHE BOOL "")
+set(ENABLE_yarpmod_fakePositionSensor ON CACHE BOOL "")
 

--- a/doc/release/master/sensorMeas_to_vec.md
+++ b/doc/release/master/sensorMeas_to_vec.md
@@ -1,0 +1,6 @@
+seansorMeas_to_vec {#master}
+------------------
+
+### PortMonitors
+
+* added new portmonitor `sensorMeasurements_to_vector` which converts a 6D Pose from a `SensorStreamingData` data type to a `yarp::sig::Vector` data type

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -22,6 +22,7 @@ yarp_begin_plugin_library(yarpmod
   add_subdirectory(fakeBattery)
   add_subdirectory(fakeIMU)
   add_subdirectory(fakeOdometry)
+  add_subdirectory(fakePositionSensor)
   add_subdirectory(frameTransformClient)
   add_subdirectory(frameTransformGet)
   add_subdirectory(frameTransformServer)

--- a/src/devices/fakePositionSensor/CMakeLists.txt
+++ b/src/devices/fakePositionSensor/CMakeLists.txt
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+yarp_prepare_plugin(fakePositionSensor
+  CATEGORY device
+  TYPE FakePositionSensor
+  INCLUDE fakePositionSensor.h
+  EXTRA_CONFIG
+    WRAPPER=multipleanalogsensorsserver
+)
+
+if(ENABLE_fakePositionSensor)
+  yarp_add_plugin(yarp_fakePositionSensor)
+
+  target_sources(yarp_fakePositionSensor
+    PRIVATE
+      fakePositionSensor.cpp
+      fakePositionSensor.h
+  )
+
+  target_link_libraries(yarp_fakePositionSensor
+    PRIVATE
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+  )
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+    YARP_os
+    YARP_sig
+    YARP_dev
+  )
+
+  yarp_install(
+    TARGETS yarp_fakePositionSensor
+    EXPORT YARP_${YARP_PLUGIN_MASTER}
+    COMPONENT ${YARP_PLUGIN_MASTER}
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_fakePositionSensor PROPERTY FOLDER "Plugins/Device/Fake")
+endif()

--- a/src/devices/fakePositionSensor/fakePositionSensor.cpp
+++ b/src/devices/fakePositionSensor/fakePositionSensor.cpp
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fakePositionSensor.h"
+
+#include <yarp/os/Time.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+
+using namespace yarp::dev;
+
+namespace {
+YARP_LOG_COMPONENT(FAKE_POSITION_SENSOR, "yarp.device.fakePositionSensor")
+}
+
+FakePositionSensor::FakePositionSensor(double period) : PeriodicThread(period),
+        m_mutex(),
+        m_channelsNum(1)
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+}
+
+FakePositionSensor::~FakePositionSensor()
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+}
+
+bool FakePositionSensor::open(yarp::os::Searchable& config)
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+    bool correct=true;
+
+    //debug
+    fprintf(stderr, "%s\n", config.toString().c_str());
+
+    if (!correct)
+    {
+        yCError(FAKE_POSITION_SENSOR) << "Insufficient parameters to FakePositionSensor\n";
+        return false;
+    }
+
+    if (config.check("sensor_period"))
+    {
+        double period=config.find("sensor_period").asFloat32();
+        setPeriod(period);
+    }
+
+    //create the data vector:
+    this->m_channelsNum = 1;
+    m_orientation_sensors.resize(m_channelsNum);
+    m_position_sensors.resize(m_channelsNum);
+
+    return PeriodicThread::start();
+}
+
+bool FakePositionSensor::close()
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+    //stop the thread
+    PeriodicThread::stop();
+
+    return true;
+}
+
+bool FakePositionSensor::threadInit()
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+    return true;
+}
+
+void FakePositionSensor::run()
+{
+    m_mutex.lock();
+
+    // Do fake stuff
+    double timeNow = yarp::os::Time::now();
+
+    for (size_t i = 0; i < m_position_sensors.size(); i++)
+    {
+        m_position_sensors[i].m_timestamp = timeNow;
+        m_position_sensors[i].m_status = yarp::dev::MAS_status::MAS_OK;
+        for (auto it= m_position_sensors[i].m_data.begin(); it != m_position_sensors[i].m_data.end(); it++)
+        {
+            *it = *it + 0.001;
+        }
+    }
+    for (size_t i = 0; i < m_orientation_sensors.size(); i++)
+    {
+        m_orientation_sensors[i].m_timestamp = timeNow;
+        m_orientation_sensors[i].m_status = yarp::dev::MAS_status::MAS_OK;
+        for (auto it = m_orientation_sensors[i].m_data.begin(); it != m_orientation_sensors[i].m_data.end(); it++)
+        {
+            *it = *it - 0.001;
+        }
+    }
+
+    m_mutex.unlock();
+}
+
+void FakePositionSensor::threadRelease()
+{
+    yCTrace(FAKE_POSITION_SENSOR);
+}
+
+
+size_t FakePositionSensor::getNrOfPositionSensors() const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    return m_position_sensors.size();
+}
+
+yarp::dev::MAS_status FakePositionSensor::getPositionSensorStatus(size_t sens_index) const
+{
+    std::lock_guard<std::mutex> myLockGuard (m_mutex);
+    if (sens_index >= m_position_sensors.size()) return yarp::dev::MAS_status::MAS_UNKNOWN;
+    return m_position_sensors[sens_index].m_status;
+}
+
+bool FakePositionSensor::getPositionSensorName(size_t sens_index, std::string& name) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_position_sensors.size()) return false;
+    name = m_position_sensors[sens_index].m_name;
+    return true;
+}
+
+bool FakePositionSensor::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_position_sensors.size()) return false;
+    frameName = m_position_sensors[sens_index].m_framename;
+    return true;
+}
+
+bool FakePositionSensor::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_position_sensors.size()) return false;
+    timestamp = m_position_sensors[sens_index].m_timestamp;
+    xyz = m_position_sensors[sens_index].m_data;
+    return true;
+}
+
+size_t FakePositionSensor::getNrOfOrientationSensors() const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    return m_orientation_sensors.size();
+}
+
+yarp::dev::MAS_status FakePositionSensor::getOrientationSensorStatus(size_t sens_index) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_orientation_sensors.size()) return yarp::dev::MAS_status::MAS_UNKNOWN;
+    return m_orientation_sensors[sens_index].m_status;
+}
+
+bool FakePositionSensor::getOrientationSensorName(size_t sens_index, std::string& name) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_orientation_sensors.size()) return false;
+    name = m_orientation_sensors[sens_index].m_name;
+    return true;
+}
+
+bool FakePositionSensor::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_orientation_sensors.size()) return false;
+    frameName = m_orientation_sensors[sens_index].m_framename;
+    return true;
+}
+
+bool FakePositionSensor::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
+{
+    std::lock_guard<std::mutex> myLockGuard(m_mutex);
+    if (sens_index >= m_orientation_sensors.size()) return false;
+    timestamp = m_orientation_sensors[sens_index].m_timestamp;
+    xyz = m_orientation_sensors[sens_index].m_data;
+    return true;
+}

--- a/src/devices/fakePositionSensor/fakePositionSensor.h
+++ b/src/devices/fakePositionSensor/fakePositionSensor.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_DEVICE_FAKE_POSITIONSENSOR
+#define YARP_DEVICE_FAKE_POSITIONSENSOR
+
+#include <yarp/os/PeriodicThread.h>
+
+#include <yarp/dev/all.h>
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+
+#include <mutex>
+
+/**
+*
+* @ingroup dev_impl_fake dev_impl_media dev_impl_analog_sensors
+*
+* \brief `fakePositionSensor`: Fake position sensor device for testing purpose and reference for new similar devices
+*
+* Parameters accepted in the config argument of the open method:
+* | Parameter name | Type   | Units   | Default Value | Required | Description | Notes |
+* |:--------------:|:------:|:-------:|:-------------:|:--------:|:-----------:|:-----:|
+* | sensor_period  | double | seconds |   0.01        | No       | Period over which the measurement is updated.  |       |
+*/
+
+class FakePositionSensor :
+        public yarp::dev::DeviceDriver,
+        public yarp::os::PeriodicThread,
+        public yarp::dev::IPositionSensors,
+        public yarp::dev::IOrientationSensors
+{
+private:
+
+    mutable std::mutex      m_mutex;
+    unsigned int            m_channelsNum;
+
+    struct myfakesensor
+    {
+        std::string             m_name = "mySensor";
+        std::string             m_framename = "myFrame";
+        yarp::dev::MAS_status   m_status = yarp::dev::MAS_status::MAS_OK;
+        double                  m_timestamp = 0.0;
+        yarp::sig::Vector       m_data;
+
+        myfakesensor()
+        {
+            m_data.resize(3);
+            m_data[0] = 1.0;
+            m_data[1] = 2.0;
+            m_data[2] = 3.0;
+        }
+    };
+
+    std::vector<myfakesensor>     m_position_sensors;
+    std::vector<myfakesensor>     m_orientation_sensors;
+
+public:
+    FakePositionSensor(double period = 0.05);
+
+    ~FakePositionSensor();
+
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+    //Interfaces
+    size_t getNrOfPositionSensors() const override;
+    yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
+    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
+    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+
+    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
+    bool getOrientationSensorName(size_t sens_index, std::string& name) const override;
+    bool getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+
+    // RateThread interface
+    void run() override;
+    bool threadInit() override;
+    void threadRelease() override;
+};
+
+
+#endif  // YARP_DEVICE_FAKE_POSITIONSENSOR

--- a/src/portmonitors/CMakeLists.txt
+++ b/src/portmonitors/CMakeLists.txt
@@ -19,21 +19,22 @@ yarp_begin_plugin_library(yarppm
   add_subdirectory(segmentationimage_to_rgb)
   add_subdirectory(sound_compression_mp3)
   add_subdirectory(soundfilter_resample)
+  add_subdirectory(sensorMeasurements_to_vector)
 yarp_end_plugin_library(yarppm QUIET)
 add_library(YARP::yarppm ALIAS yarppm)
 
 install(
   TARGETS yarppm
-  EXPORT YARP_yarppm
-  COMPONENT yarppm
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        EXPORT YARP_yarppm
+        COMPONENT yarppm
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 include(YarpInstallBasicPackageFiles)
 yarp_install_basic_package_files(YARP_yarppm
-  DEPENDENCIES ${YARP_yarppm_PUBLIC_DEPS}
+                                 DEPENDENCIES ${YARP_yarppm_PUBLIC_DEPS}
   PRIVATE_DEPENDENCIES ${YARP_yarppm_PRIVATE_DEPS}
 )
 

--- a/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
+++ b/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
-# All rights reserved.
-#
-# This software may be modified and distributed under the terms of the
-# BSD-3-Clause license. See the accompanying LICENSE file for details.
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 yarp_prepare_plugin(sensorMeasurements_to_vector
   TYPE SensorMeasurements_to_vector
@@ -24,7 +21,7 @@ target_sources(yarp_pm_sensorMeasurements_to_vector
 )
 
 target_sources(yarp_pm_sensorMeasurements_to_vector PRIVATE $<TARGET_OBJECTS:multipleAnalogSensorsSerializations>)
-  
+
 target_include_directories(yarp_pm_sensorMeasurements_to_vector PRIVATE $<TARGET_PROPERTY:multipleAnalogSensorsSerializations,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_link_libraries(yarp_pm_sensorMeasurements_to_vector

--- a/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
+++ b/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(sensorMeasurements_to_vector
+  TYPE SensorMeasurements_to_vector
+  INCLUDE SM_to_vec.h
+  CATEGORY portmonitor
+  DEPENDS "ENABLE_yarpcar_portmonitor"
+)
+
+if(SKIP_sensorMeasurements_to_vector)
+  return()
+endif()
+
+yarp_add_plugin(yarp_pm_sensorMeasurements_to_vector)
+
+target_sources(yarp_pm_sensorMeasurements_to_vector
+  PRIVATE
+    SM_to_vec.cpp
+    SM_to_vec.h
+)
+
+target_sources(yarp_pm_sensorMeasurements_to_vector PRIVATE $<TARGET_OBJECTS:multipleAnalogSensorsSerializations>)
+  
+target_include_directories(yarp_pm_sensorMeasurements_to_vector PRIVATE $<TARGET_PROPERTY:multipleAnalogSensorsSerializations,INTERFACE_INCLUDE_DIRECTORIES>)
+
+target_link_libraries(yarp_pm_sensorMeasurements_to_vector
+  PRIVATE
+    YARP::YARP_os
+    YARP::YARP_sig
+)
+list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+  YARP_os
+  YARP_sig
+)
+
+yarp_install(
+  TARGETS yarp_pm_sensorMeasurements_to_vector
+  EXPORT YARP_${YARP_PLUGIN_MASTER}
+  COMPONENT ${YARP_PLUGIN_MASTER}
+  LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+  ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+  YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+)
+
+set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+set_property(TARGET yarp_pm_sensorMeasurements_to_vector PROPERTY FOLDER "Plugins/Port Monitor")

--- a/src/portmonitors/sensorMeasurements_to_vector/README.md
+++ b/src/portmonitors/sensorMeasurements_to_vector/README.md
@@ -1,0 +1,15 @@
+
+sensorMeasurements_to_vector plugin
+======================================================================
+Portmonitor plugin for converting a sensorMeasurements to yarp::sig::Vector
+Note: This plugin is experimental and could be modified without any warning.
+Note: This plugin should be considered an example. User are encouraged to take inspiration from it and adapt it to their needs.
+      Only OrientationSensors, PositionSensors data types are supported. The plugin can be extended to support other data types.   Some restriction are apply on the size of the input data type vector. The output is a vector with a fixed size of six elements.
+      The plugin can be extended to support vectors of different sizes.
+
+Usage:
+-----
+
+yarpdev --device fakePositionSensor --name /tracking --period 10
+yarp read ... /in
+yarp connect yarp connect /tracking/measures:o /in tcp+recv.portmonitor+type.dll+file.sensorMeasurements_to_vector

--- a/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.cpp
+++ b/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.cpp
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
- * All rights reserved.
- *
- * This software may be modified and distributed under the terms of the
- * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "SM_to_vec.h"

--- a/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.cpp
+++ b/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include "SM_to_vec.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <yarp/os/LogComponent.h>
+#include "SensorStreamingData.h"
+
+using namespace yarp::os;
+using namespace yarp::sig;
+
+namespace {
+YARP_LOG_COMPONENT(SM2VEC,
+                   "yarp.carrier.portmonitor.sensorMeasurements_to_vector",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)
+}
+
+
+bool SensorMeasurements_to_vector::create(const yarp::os::Property& options)
+{
+    return true;
+}
+
+void SensorMeasurements_to_vector::destroy()
+{
+}
+
+bool SensorMeasurements_to_vector::setparam(const yarp::os::Property& params)
+{
+    return false;
+}
+
+bool SensorMeasurements_to_vector::getparam(yarp::os::Property& params)
+{
+    return false;
+}
+
+bool SensorMeasurements_to_vector::accept(yarp::os::Things& thing)
+{
+    SensorStreamingData* ssd = thing.cast_as<SensorStreamingData>();
+    if(ssd == nullptr ||
+       ssd->OrientationSensors.measurements.size() != 1 ||
+       ssd->OrientationSensors.measurements[0].measurement.size() != 3 ||
+       ssd->PositionSensors.measurements.size() != 1 ||
+       ssd->PositionSensors.measurements[0].measurement.size() != 3)
+    {
+        yCError(SM2VEC, "SensorMeasurements_to_vector: received invalid data type!");
+        return false;
+    }
+
+    out.resize(3 + 3);
+    return true;
+}
+
+yarp::os::Things& SensorMeasurements_to_vector::update(yarp::os::Things& thing)
+{
+    SensorStreamingData* ssd = thing.cast_as<SensorStreamingData>();
+    const size_t sensor_id = 0;
+    if (ssd)
+    {
+        out[0] = ssd->PositionSensors.measurements[sensor_id].measurement[0];
+        out[1] = ssd->PositionSensors.measurements[sensor_id].measurement[1];
+        out[2] = ssd->PositionSensors.measurements[sensor_id].measurement[2];
+        out[3] = ssd->OrientationSensors.measurements[sensor_id].measurement[0];
+        out[4] = ssd->OrientationSensors.measurements[sensor_id].measurement[1];
+        out[5] = ssd->OrientationSensors.measurements[sensor_id].measurement[2];
+    }
+
+    th.setPortWriter(&out);
+    return th;
+}

--- a/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.h
+++ b/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_CARRIER_SM2VEC_CONVERTER_H
+#define YARP_CARRIER_SM2VEC_CONVERTER_H
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Things.h>
+#include <yarp/os/MonitorObject.h>
+#include <yarp/sig/Vector.h>
+
+//example usage:
+//yarp connect /tracking/measures:o /in tcp+recv.portmonitor+type.dll+file.sensorMeasurements_to_vector
+
+class SensorMeasurements_to_vector : public yarp::os::MonitorObject
+{
+    yarp::sig::Vector    out;
+    yarp::os::Things     th;
+
+public:
+    bool create(const yarp::os::Property& options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property& params) override;
+    bool getparam(yarp::os::Property& params) override;
+
+    bool accept(yarp::os::Things& thing) override;
+    yarp::os::Things& update(yarp::os::Things& thing) override;
+};
+
+#endif  // YARP_CARRIER_SM2VEC_CONVERTER_H

--- a/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.h
+++ b/src/portmonitors/sensorMeasurements_to_vector/SM_to_vec.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
- * All rights reserved.
- *
- * This software may be modified and distributed under the terms of the
- * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef YARP_CARRIER_SM2VEC_CONVERTER_H


### PR DESCRIPTION
added new portmonitor `sensorMeasurements_to_vector` which converts a 6D Pose from a `SensorStreamingData` data type to a `yarp::sig::Vector` data type. The port monitor can be extended (writing simple additional code) to support different use cases.

Usage Example:
`yarp connect /tracking/measures:o /in tcp+recv.portmonitor+type.dll+file.sensorMeasurements_to_vector`
 