### PR TITLE
sig/Image: Fix topIsLow handling in YARP 3.4

### DIFF
--- a/doc/release/yarp_3_4/fix_topIsLow_yarp-3.4.md
+++ b/doc/release/yarp_3_4/fix_topIsLow_yarp-3.4.md
@@ -1,0 +1,17 @@
+fix_topIsLow_yarp-3.4 {#yarp_3_4}
+---------------------
+
+## Libraries
+
+### `sig`
+
+#### `Image`
+
+* Fixed compatibility with images with topIsLow==false sent by YARP 3.5.
+
+
+## GUIs
+
+### `yarpview`
+
+* Fixed upside down image when topIsLow is false (Qt >= 5.3.2 only).

--- a/src/libYARP_sig/src/yarp/sig/Image.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Image.cpp
@@ -54,11 +54,12 @@ inline bool readFromConnection(Image &dest, ImageNetworkHeader &header, Connecti
     //this check is redundant with assertion, I would remove it
     if (dest.getRawImageSize() != static_cast<size_t>(header.imgSize)) {
         printf("There is a problem reading an image\n");
-        printf("incoming: width %zu, height %zu, code %zu, quantum %zu, size %zu\n",
+        printf("incoming: width %zu, height %zu, code %zu, quantum %zu, topIsLow %zu, size %zu\n",
                static_cast<size_t>(header.width),
                static_cast<size_t>(header.height),
                static_cast<size_t>(header.id),
                static_cast<size_t>(header.quantum),
+               static_cast<size_t>(header.topIsLow),
                static_cast<size_t>(header.imgSize));
         printf("my space: width %zu, height %zu, code %d, quantum %zu, size %zu\n",
             dest.width(), dest.height(), dest.getPixelCode(), dest.getQuantum(), allocatedBytes);
@@ -696,6 +697,8 @@ bool Image::read(yarp::os::ConnectionReader& connection) {
         }
     }
 
+    setTopIsLowIndex(header.topIsLow == 0);
+
     // handle easy case, received and current image are compatible, no conversion needed
     if (getPixelCode() == header.id && q == static_cast<size_t>(header.quantum) && imgPixelSize == static_cast<size_t>(header.depth))
     {
@@ -723,6 +726,7 @@ bool Image::read(yarp::os::ConnectionReader& connection) {
         FlexImage flex;
         flex.setPixelCode(VOCAB_PIXEL_MONO);
         flex.setQuantum(header.quantum);
+        flex.setTopIsLowIndex(header.topIsLow == 0);
 
         bool ok = readFromConnection(flex, header, connection);
         if (!ok) {
@@ -760,6 +764,7 @@ bool Image::read(yarp::os::ConnectionReader& connection) {
     FlexImage flex;
     flex.setPixelCode(header.id);
     flex.setQuantum(header.quantum);
+    flex.setTopIsLowIndex(header.topIsLow == 0);
     ok = readFromConnection(flex, header, connection);
     if (ok) {
         copy(flex);

--- a/src/libYARP_sig/src/yarp/sig/ImageNetworkHeader.h
+++ b/src/libYARP_sig/src/yarp/sig/ImageNetworkHeader.h
@@ -12,6 +12,7 @@
 
 #include <yarp/conf/system.h>
 
+#include <yarp/os/NetInt16.h>
 #include <yarp/os/NetInt32.h>
 #include <yarp/os/Bottle.h>
 
@@ -43,7 +44,8 @@ public:
     yarp::os::NetInt32 paramListLen;
     yarp::os::NetInt32 depth;
     yarp::os::NetInt32 imgSize;
-    yarp::os::NetInt32 quantum;
+    yarp::os::NetInt16 quantum;
+    yarp::os::NetInt16 topIsLow;
     yarp::os::NetInt32 width;
     yarp::os::NetInt32 height;
     yarp::os::NetInt32 paramBlobTag;
@@ -52,7 +54,7 @@ public:
     ImageNetworkHeader() : listTag(0), listLen(0), paramNameTag(0),
                            paramName(0), paramIdTag(0), id(0),
                            paramListTag(0), paramListLen(0), depth(0),
-                           imgSize(0), quantum(0), width(0),
+                           imgSize(0), quantum(0), topIsLow(0), width(0),
                            height(0), paramBlobTag(0), paramBlobLen(0) {}
 
     void setFromImage(const Image& image) {
@@ -63,10 +65,16 @@ public:
         paramIdTag = BOTTLE_TAG_VOCAB;
         id = image.getPixelCode();
         paramListTag = BOTTLE_TAG_LIST + BOTTLE_TAG_INT32;
+        // WARNING This is 5 and not 6 because quantum and topIsLow are
+        //         transmitted in the same 32 bits for compatibility with
+        //         YARP 3.4 and older
         paramListLen = 5;
         depth = image.getPixelSize();
         imgSize = image.getRawImageSize();
-        quantum = image.getQuantum();
+        quantum = static_cast<yarp::os::NetInt16>(image.getQuantum());
+        // WARNING The topIsLowIndex is always 0 for compatibility between
+        //         YARP 3.4 and YARP 3.5
+        topIsLow = 0;
         width = image.width();
         height = image.height();
         paramBlobTag = BOTTLE_TAG_BLOB;

--- a/src/yarpview/plugin/ImagePort.cpp
+++ b/src/yarpview/plugin/ImagePort.cpp
@@ -82,7 +82,15 @@ void InputCallback::onRead(yarp::sig::ImageOf<yarp::sig::PixelRgba> &img)
     }*/
 
 #if QT_VERSION >= 0x050302
-    memcpy(tmpBuf,rawImg,imgSize);
+    if (img.topIsLowIndex()) {
+        memcpy(tmpBuf, rawImg, imgSize);
+    } else {
+        for(int x = 0; x < s.height(); x++) {
+            memcpy(tmpBuf + x * img.getRowSize(),
+                   rawImg + (s.height() - x - 1) * img.getRowSize(),
+                   img.getRowSize());
+        }
+    }
 #else
     for(int x =0; x < s.height(); x++) {
         memcpy(tmpBuf + x * (img.width() * img.getPixelSize()),


### PR DESCRIPTION
As explained in #2609 and #2587, this patch restores compatibility in the protocol, when an image with `topIsLow==false` is sent by YARP 3.5.

---

## Libraries

### `sig`

#### `Image`

* Fixed compatibility with images with topIsLow==false sent by YARP 3.5.


## GUIs

### `yarpview`

* Fixed upside down image when topIsLow is false (Qt >= 5.3.2 only).