### PR TITLE
sig/Image: Add move() and swap() methods

### DIFF
--- a/doc/release/master/image_move_swap.md
+++ b/doc/release/master/image_move_swap.md
@@ -1,0 +1,10 @@
+image_move_swap {#master}
+---------------
+
+## Libraries
+
+### `sig`
+
+#### Image
+
+* Added `move()` and `swap()` methods.

--- a/src/libYARP_sig/src/yarp/sig/Image.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Image.cpp
@@ -875,6 +875,36 @@ bool Image::copy(const Image& alt)
 }
 
 
+bool Image::move(Image&& alt) noexcept
+{
+    // Cannot move an image of the wrong type inside an ImageOf that does not
+    // support it.
+    yAssert(dynamic_cast<FlexImage*>(this) ||
+            getPixelCode() == alt.getPixelCode());
+    if (&alt != this) {
+        delete static_cast<ImageStorage*>(implementation);
+        implementation = std::exchange(alt.implementation, nullptr);
+        synchronize();
+    }
+    return true;
+}
+
+
+bool Image::swap(Image& alt)
+{
+    // Cannot swap two ImageOf of different type, or an image of the wrong type
+    // inside an ImageOf that does not support it.
+    yAssert((dynamic_cast<FlexImage*>(this) && dynamic_cast<FlexImage*>(&alt)) ||
+            getPixelCode() == alt.getPixelCode());
+    if (&alt != this) {
+        std::swap(alt.implementation, implementation);
+        synchronize();
+        alt.synchronize();
+    }
+    return true;
+}
+
+
 void Image::setExternal(const void *data, size_t imgWidth, size_t imgHeight) {
     if (imgQuantum==0) {
         imgQuantum = 1;

--- a/src/libYARP_sig/src/yarp/sig/Image.h
+++ b/src/libYARP_sig/src/yarp/sig/Image.h
@@ -147,6 +147,22 @@ public:
 
 
     /**
+     * move operator.
+     * Moves the content of another image.
+     * @param alt the image to move
+     */
+    bool move(Image&& alt) noexcept;
+
+
+    /**
+     * swap operator.
+     * Swap the content with another image.
+     * @param alt the image to swap with
+     */
+    bool swap(Image& alt);
+
+
+    /**
      * Gets width of image in pixels.
      * @return the width of the image in pixels (0 if no image present)
      */

--- a/tests/libYARP_sig/ImageTest.cpp
+++ b/tests/libYARP_sig/ImageTest.cpp
@@ -99,13 +99,16 @@ TEST_CASE("sig::ImageTest", "[yarp::sig]")
         CHECK(total == 0); // pixel assignment check
     }
 
-    SECTION("test image copying.")
+    SECTION("test Image::copy().")
     {
+        constexpr size_t width = 128;
+        constexpr size_t height = 64;
         ImageOf<PixelRgb> img1;
-        img1.resize(128,64);
-        for (size_t x=0; x<img1.width(); x++) {
-            for (size_t y=0; y<img1.height(); y++) {
-                PixelRgb& pixel = img1.pixel(x,y);
+        img1.resize(width, height);
+
+        for (size_t x = 0; x < img1.width(); x++) {
+            for (size_t y = 0; y < img1.height(); y++) {
+                PixelRgb& pixel = img1.pixel(x, y);
                 pixel.r = x;
                 pixel.g = y;
                 pixel.b = 42;
@@ -117,22 +120,114 @@ TEST_CASE("sig::ImageTest", "[yarp::sig]")
 
         CHECK(img1.width() == result.width()); // width check
         CHECK(img1.height() == result.height()); // height check
-        if (img1.width()==result.width() &&
-            img1.height()==result.height()) {
+        if (img1.width() == result.width() && img1.height() == result.height()) {
             int mismatch = 0;
-            for (size_t x=0; x<img1.width(); x++) {
-                for (size_t y=0; y<img1.height(); y++) {
-                    PixelRgb& pix0 = img1.pixel(x,y);
-                    PixelRgb& pix1 = result.pixel(x,y);
-                    if (pix0.r!=pix1.r ||
-                        pix0.g!=pix1.g ||
-                        pix0.b!=pix1.b) {
+            for (size_t x = 0; x < img1.width(); x++) {
+                for (size_t y = 0; y < img1.height(); y++) {
+                    PixelRgb& pix0 = img1.pixel(x, y);
+                    PixelRgb& pix1 = result.pixel(x, y);
+                    if (pix0.r != pix1.r || pix0.g != pix1.g || pix0.b != pix1.b) {
                         mismatch++;
                     }
                 }
             }
-            CHECK(mismatch==0); // pixel match check
+            CHECK(mismatch == 0); // pixel match check
         }
+    }
+
+    SECTION("test Image::move().")
+    {
+        constexpr size_t width = 128;
+        constexpr size_t height = 64;
+        ImageOf<PixelRgb> img1;
+        img1.resize(width, height);
+
+        for (size_t x = 0; x < img1.width(); x++) {
+            for (size_t y = 0; y < img1.height(); y++) {
+                PixelRgb& pixel = img1.pixel(x, y);
+                pixel.r = x;
+                pixel.g = y;
+                pixel.b = 42;
+            }
+        }
+
+        ImageOf<PixelRgb> result;
+        result.move(std::move(img1));
+
+        CHECK(result.width() == width); // width check
+        CHECK(result.height() == height); // height check
+        int mismatch = 0;
+        for (size_t x = 0; x < result.width(); x++) {
+            for (size_t y = 0; y < result.height(); y++) {
+                PixelRgb& pix = result.pixel(x, y);
+                if (pix.r != x || pix.g != y || pix.b != 42) {
+                    mismatch++;
+                }
+            }
+        }
+        CHECK(mismatch == 0); // pixel match check
+    }
+
+
+    SECTION("test Image::swap().")
+    {
+        constexpr size_t width1 = 128;
+        constexpr size_t height1 = 64;
+        ImageOf<PixelRgb> img1;
+        img1.resize(width1, height1);
+
+        for (size_t x = 0; x < img1.width(); x++) {
+            for (size_t y = 0; y < img1.height(); y++) {
+                PixelRgb& pixel = img1.pixel(x, y);
+                pixel.r = x;
+                pixel.g = y;
+                pixel.b = 42;
+            }
+        }
+
+        constexpr size_t width2 = 64;
+        constexpr size_t height2 = 32;
+        ImageOf<PixelRgb> img2;
+        img2.resize(width2, height2);
+
+        for (size_t x = 0; x < img2.width(); x++) {
+            for (size_t y = 0; y < img2.height(); y++) {
+                PixelRgb& pixel = img2.pixel(x, y);
+                pixel.r = y;
+                pixel.g = x;
+                pixel.b = 255 - 42;
+            }
+        }
+
+        img2.swap(img1);
+
+        // Check img1
+        int mismatch = 0;
+        CHECK(img1.width() == width2);
+        CHECK(img1.height() == height2);
+        for (size_t x = 0; x < img1.width(); x++) {
+            for (size_t y = 0; y < img1.height(); y++) {
+                PixelRgb& pix = img1.pixel(x, y);
+                if (pix.r != y || pix.g != x || pix.b != 255 - 42) {
+                    mismatch++;
+                }
+            }
+        }
+        CHECK(mismatch == 0); // pixel match check
+
+        // Check img2
+        mismatch = 0;
+        CHECK(img2.width() == width1);
+        CHECK(img2.height() == height1);
+        for (size_t x = 0; x < img2.width(); x++) {
+            for (size_t y = 0; y < img2.height(); y++) {
+                PixelRgb& pix = img2.pixel(x, y);
+                if (pix.r != x || pix.g != y || pix.b != 42) {
+                    mismatch++;
+                }
+            }
+        }
+        CHECK(mismatch == 0); // pixel match check
     }
 
     SECTION("test image zeroing.")


### PR DESCRIPTION
These 2 methods allow to swap or move 2 images of different type (like [`copy()`](https://yarp.it/git-master/classyarp_1_1sig_1_1Image.html#a7792cdf9c1192dabd7f8ad2332895897))

------

## Libraries

### `sig`

#### Image

* Added `move()` and `swap()` methods.