### PR TITLE
Deprecate *Int and *Double methods in favour of *Int32 and *Float64

### DIFF
--- a/doc/release/master/deprecated_internal.md
+++ b/doc/release/master/deprecated_internal.md
@@ -1,0 +1,35 @@
+deprecated_internal {#master}
+-------------------
+
+# Important Changes
+
+## Libraries
+
+### `os`
+
+#### `Bottle`
+
+* `BOTTLE_TAG_INT` is deprecated in favour of `BOTTLE_TAG_INT32`
+* `BOTTLE_TAG_DOUBLE` is deprecated in favour of `BOTTLE_TAG_FLOAT64`
+* `BOTTLE_TAG_VOCAB` is deprecated in favour of `BOTTLE_TAG_VOCAB32`
+* `addInt` is deprecated in favour of `addInt32`
+* `addDouble` is deprecated in favour of `addFloat64`
+
+#### `ConnectionReader`
+
+* `expectInt` is deprecated in favour of `expectInt32`
+* `expectDouble` is deprecated in favour of `expectFloat64`
+
+#### `ConnectionWriter`
+
+* `appendInt` is deprecated in favour of `appendInt32`
+* `appendDouble` is deprecated in favour of `appendFloat64`
+
+#### `Value`
+
+* `isInt` is deprecated in favour of `isInt32`
+* `isDouble` is deprecated in favour of `isFloat64`
+* `asInt` is deprecated in favour of `asInt32`
+* `asDouble` is deprecated in favour of `asFloat64`
+* `makeInt` is deprecated in favour of `makeInt32`
+* `makeDouble` is deprecated in favour of `makeFloat64`

--- a/src/libYARP_os/src/yarp/os/Bottle.h
+++ b/src/libYARP_os/src/yarp/os/Bottle.h
@@ -30,13 +30,13 @@
 #define BOTTLE_TAG_LIST 256        // 0000 0001 0000 0000
 #define BOTTLE_TAG_DICT 512        // 0000 0010 0000 0000
 
-YARP_DEPRECATED_INTERNAL_MSG("Use BOTTLE_TAG_INT32 instead") // Since YARP 3.0.0
+YARP_DEPRECATED_MSG("Use BOTTLE_TAG_INT32 instead") // Since YARP 3.5.0
 constexpr std::int32_t BOTTLE_TAG_DOUBLE = BOTTLE_TAG_FLOAT64;
 
-YARP_DEPRECATED_INTERNAL_MSG("Use BOTTLE_TAG_FLOAT64 instead") // Since YARP 3.0.0
+YARP_DEPRECATED_MSG("Use BOTTLE_TAG_FLOAT64 instead") // Since YARP 3.5.0
 constexpr std::int32_t BOTTLE_TAG_INT = BOTTLE_TAG_INT32;
 
-YARP_DEPRECATED_INTERNAL_MSG("Use BOTTLE_TAG_VOCAB32 instead") // Since YARP 3.5.0
+YARP_DEPRECATED_MSG("Use BOTTLE_TAG_VOCAB32 instead") // Since YARP 3.5.0
 constexpr std::int32_t BOTTLE_TAG_VOCAB = BOTTLE_TAG_VOCAB32;
 
 namespace yarp {
@@ -155,7 +155,7 @@ public:
      * @param x the integer to add.
      * @warning Unsafe, sizeof(int) is platform dependent. Use addInt32 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use addInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use addInt32 instead") // Since YARP 3.5.0
     inline void addInt(int x)
     {
         addInt32(static_cast<std::int32_t>(x));
@@ -203,7 +203,7 @@ public:
      * @param x the number to add.
      * @warning Unsafe, sizeof(double) is platform dependent. Use addFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use addFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use addFloat64 instead") // Since YARP 3.5.0
     inline void addDouble(double x)
     {
         addFloat64(static_cast<yarp::conf::float64_t>(x));

--- a/src/libYARP_os/src/yarp/os/ConnectionReader.h
+++ b/src/libYARP_os/src/yarp/os/ConnectionReader.h
@@ -81,7 +81,7 @@ public:
      * @return the integer read from the connection
      * @warning Unsafe, sizeof(int) is platform dependent. Use expectInt32 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use expectInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use expectInt32 instead") // Since YARP 3.5.0
     virtual int expectInt() final
     {
         return static_cast<int>(expectInt32());
@@ -116,7 +116,7 @@ public:
      * @return the floating point number read from the connection
      * @warning Unsafe, sizeof(double) is platform dependent. Use expectFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use expectFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use expectFloat64 instead") // Since YARP 3.5.0
     virtual double expectDouble()
     {
         return static_cast<double>(expectFloat64());

--- a/src/libYARP_os/src/yarp/os/ConnectionWriter.h
+++ b/src/libYARP_os/src/yarp/os/ConnectionWriter.h
@@ -61,7 +61,7 @@ public:
      * @param data the integer to send
      * @warning Unsafe, sizeof(int) is platform dependent. Use appendInt32 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use appendInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use appendInt32 instead") // Since YARP 3.5.0
     virtual void appendInt(int data) final
     {
         appendInt32(static_cast<std::int32_t>(data));
@@ -98,7 +98,7 @@ public:
      * @param data the floating point number to send
      * @warning Unsafe, sizeof(double) is platform dependent. Use appendFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use appendFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use appendFloat64 instead") // Since YARP 3.5.0
     virtual void appendDouble(double data)
     {
         appendFloat64(static_cast<yarp::conf::float64_t>(data));

--- a/src/libYARP_os/src/yarp/os/Value.h
+++ b/src/libYARP_os/src/yarp/os/Value.h
@@ -112,7 +112,7 @@ public:
      * @return true iff value is an integer
      * @warning Unsafe, sizeof(int) is platform dependent. Use isInt32 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use isInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use isInt32 instead") // Since YARP 3.5.0
     inline virtual bool isInt() const final
     {
         return isInt32();
@@ -152,7 +152,7 @@ public:
      * @return true iff value is a floating point number
      * @warning Unsafe, sizeof(double) is platform dependent. Use isFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use isFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use isFloat64 instead") // Since YARP 3.5.0
     inline virtual bool isDouble() const final
     {
         return isFloat64();
@@ -220,7 +220,7 @@ public:
      * Otherwise returns 0.
      * @warning Unsafe, sizeof(int) is platform dependent. Use asInt32 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use asInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use asInt32 instead") // Since YARP 3.5.0
     inline virtual int asInt() const final
     {
         return static_cast<int>(asInt32());
@@ -277,7 +277,7 @@ public:
      * Otherwise returns 0.
      * @warning Unsafe, sizeof(double) is platform dependent. Use asFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use asFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use asFloat64 instead") // Since YARP 3.5.0
     inline virtual double asDouble() const final
     {
         return static_cast<double>(asFloat64());
@@ -420,7 +420,7 @@ public:
      * @return an integer Value
      * @warning Unsafe, sizeof(int) is platform dependent. Use makeInt instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use makeInt32 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use makeInt32 instead") // Since YARP 3.5.0
     inline static Value* makeInt(int x)
     {
         return makeInt32(static_cast<std::int32_t>(x));
@@ -460,7 +460,7 @@ public:
      * @return a floating point Value
      * @warning Unsafe, sizeof(double) is platform dependent. Use makeFloat64 instead.
      */
-    YARP_DEPRECATED_INTERNAL_MSG("Use makeFloat64 instead") // Since YARP 3.0.0
+    YARP_DEPRECATED_MSG("Use makeFloat64 instead") // Since YARP 3.5.0
     inline static Value* makeDouble(double x)
     {
         return makeFloat64(static_cast<yarp::conf::float64_t>(x));


### PR DESCRIPTION
These methods have been deprecated internally since YARP 3.0, and their use has been discouraged since then.

These are quite used, and that's the reason why I was asked not to deprecate them at the time, but since these methods will disappear in YARP 4, I think it is is better to have them deprecated for some time, rather than having an error when migrating from YARP 3 to YARP 4.

CC @traversaro, @pattacini, @vtikha, @Nicogene 

---

# Important Changes

## Libraries

### `os`

#### `Bottle`

* `BOTTLE_TAG_INT` is deprecated in favour of `BOTTLE_TAG_INT32`
* `BOTTLE_TAG_DOUBLE` is deprecated in favour of `BOTTLE_TAG_FLOAT64`
* `BOTTLE_TAG_VOCAB` is deprecated in favour of `BOTTLE_TAG_VOCAB32`
* `addInt` is deprecated in favour of `addInt32`
* `addDouble` is deprecated in favour of `addFloat64`

#### `ConnectionReader`

* `expectInt` is deprecated in favour of `expectInt32`
* `expectDouble` is deprecated in favour of `expectFloat64`

#### `ConnectionWriter`

* `appendInt` is deprecated in favour of `appendInt32`
* `appendDouble` is deprecated in favour of `appendFloat64`

#### `Value`

* `isInt` is deprecated in favour of `isInt32`
* `isDouble` is deprecated in favour of `isFloat64`
* `asInt` is deprecated in favour of `asInt32`
* `asDouble` is deprecated in favour of `asFloat64`
* `makeInt` is deprecated in favour of `makeInt32`
* `makeDouble` is deprecated in favour of `makeFloat64`