### PR TITLE
dev/DeviceResponder: Change debug line to trace

### DIFF
--- a/src/libYARP_dev/src/yarp/dev/DeviceDriver.cpp
+++ b/src/libYARP_dev/src/yarp/dev/DeviceDriver.cpp
@@ -69,7 +69,7 @@ bool DeviceResponder::read(ConnectionReader& connection)
     if (!cmd.read(connection)) {
         return false;
     }
-    yCDebug(DEVICERESPONDER, "Command received: %s", cmd.toString().c_str());
+    yCTrace(DEVICERESPONDER, "Command received: %s", cmd.toString().c_str());
     respond(cmd, response);
     if (response.size() >= 1) {
         ConnectionWriter* writer = connection.getWriter();
@@ -89,7 +89,7 @@ bool DeviceResponder::read(ConnectionReader& connection)
                 response.write(*writer);
             }
 
-            yCDebug(DEVICERESPONDER, "Response sent: %s", response.toString().c_str());
+            yCTrace(DEVICERESPONDER, "Response sent: %s", response.toString().c_str());
         }
     } else {
         ConnectionWriter* writer = connection.getWriter();


### PR DESCRIPTION
YARP 3.4 backport of https://github.com/robotology/yarp/commit/d02db0521aae86537aa5ada8bc17ce661d2cb3e3 . 

Fix https://github.com/robotology/yarp/issues/2630 .