### PR TITLE
Fix branch name in Python workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -141,7 +141,7 @@ jobs:
         if: |
           github.repository == 'robotology/yarp' &&
           ((github.event_name == 'release' && github.event.action == 'published') ||
-           (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+           (github.event_name == 'push' && github.ref == 'refs/heads/master'))
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Small but relevant copy-paste mistake from #2573 