### PR TITLE
Link against frameTransformRC via `target_link_libraries`

### DIFF
--- a/src/devices/frameTransformClient/CMakeLists.txt
+++ b/src/devices/frameTransformClient/CMakeLists.txt
@@ -7,7 +7,6 @@
 include(CMakeRC)
 
 cmrc_add_resource_library(frameTransformRC
-                          NAMESPACE frameTransformRC
                           WHENCE robotinterface_xml
                           PREFIX config_xml
                           robotinterface_xml/ftc_full_ros.xml
@@ -40,9 +39,9 @@ if(NOT SKIP_frameTransformClient)
                                                           YARP::YARP_sig
                                                           YARP::YARP_dev
                                                           YARP::YARP_math
-                                                          YARP::YARP_robotinterface)
-  target_sources(yarp_frameTransformClient PRIVATE $<TARGET_OBJECTS:frameTransformRC>)
-  target_include_directories(yarp_frameTransformClient PRIVATE $<TARGET_PROPERTY:frameTransformRC,INTERFACE_INCLUDE_DIRECTORIES>)
+                                                          YARP::YARP_robotinterface
+                                                          frameTransformRC)
+
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_sig
                                                       YARP_dev


### PR DESCRIPTION
On latest YARP master (unreleased 3.5), a CMake 3.12 configure run throws the following error ([logs](https://github.com/roboticslab-uc3m/vision/runs/2976739659#step:11:539)):

```
CMake Error at src/devices/frameTransformClient/CMakeLists.txt:44 (target_sources):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:frameTransformRC>

  Objects of target "frameTransformRC" referenced but is not an OBJECT
  library.
```

The offending line is:

https://github.com/robotology/yarp/blob/d0058d144991446df133c540a662371fafddbde5/src/devices/frameTransformClient/CMakeLists.txt#L44

According to CMake docs, `$<TARGET_OBJECTS:...>` requires an `OBJECT` target. However, the target created by `cmrc_add_resource_library` a few lines earlier is a `STATIC` library ([ref](https://github.com/vector-of-bool/cmrc/blob/e7ba9e9417960b2a5cefc9e79e8af8b06bfde3d1/CMakeRC.cmake#L468-L471)). For some reason, this generator expression does accept `STATIC` targets in recent CMake releases (tested at CMake 3.16.3), but it fails as expected for the minimum required CMake 3.12 version (tested at CMake 3.12.4).

I believe this instruction was somewhat inspired by the way "FrameTransformUtils" was referenced at line 36, which is in fact an `OBJECT` library. I think the simplest way to handle "frameTransformRC" is via `target_link_libraries`. That being said, this target does not register any interface include directory (regarding the now-deleted and superseded `target_include_directories` command).

Follows up https://github.com/robotology/yarp/pull/2624 (cc @elandini84). I'm also removing the `NAMESPACE` option to `cmrc_add_resource_library` since it defaults to the target name anyway ("frameTransformRC", [ref](https://github.com/vector-of-bool/cmrc/blob/e7ba9e9417960b2a5cefc9e79e8af8b06bfde3d1/CMakeRC.cmake#L406), [docs](https://github.com/vector-of-bool/cmrc/tree/e7ba9e9417960b2a5cefc9e79e8af8b06bfde3d1#usage)).