### PR TITLE
Deprecated devices warnings

### DIFF
--- a/doc/release/master/deprecated_devices_warnings.md
+++ b/doc/release/master/deprecated_devices_warnings.md
@@ -1,0 +1,20 @@
+deprecated_devices_warning {#master}
+--------------------------
+
+* The following devices are now deprecated:
+  * `test_grabber`
+  * `fakeMotor`
+  * `test_motor`
+  * `fakebot`
+
+* The following devices will be replaced by NWS/NWC in the next release, and
+  print a warning when opened:
+  * `controlboardwrapper2` (replaced by `controlboardremapper` + `controlBoard_nws_yarp`)
+  * `RGBDSensorWrapper` (replaced by `rgbdSensor_nws_yarp`)
+  * `Rangefinder2DWrapper` (replaced by `rangefinder2D_nws_yarp`)
+  * `grabberDual` (replaced by `frameGrabber_nws_yarp`, and eventually `frameGrabberCropper`)
+  * `inertial` (replaced by `multipleanalogsensorsremapper` + `multipleanalogsensorsserver` + `IMURosPublisher`)
+  * `localization2DServer` (replaced by `localization2D_nws_yarp`)
+  * `map2DServer` (replaced by `map2D_nws_yarp`)
+  * `transformClient` (replaced by `frameTransformClient`)
+  * `transformServer` (replaced by `frameTransformServer`)

--- a/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoardWrapper.cpp
@@ -340,6 +340,10 @@ bool ControlBoardWrapper::initialize_YARP(yarp::os::Searchable& prop)
 
 bool ControlBoardWrapper::open(Searchable& config)
 {
+    yCWarning(CONTROLBOARD) << "The 'controlboardwrapper2' device is deprecated in favour of 'controlboardremapper' + 'controlBoard_nws_yarp'.";
+    yCWarning(CONTROLBOARD) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(CONTROLBOARD) << "Please update your scripts.";
+
     Property prop;
     prop.fromString(config.toString());
 

--- a/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
+++ b/src/devices/RGBDSensorWrapper/RGBDSensorWrapper.cpp
@@ -198,6 +198,10 @@ RGBDSensorWrapper::~RGBDSensorWrapper()
 
 bool RGBDSensorWrapper::open(yarp::os::Searchable &config)
 {
+    yCWarning(RGBDSENSORWRAPPER) << "The 'RGBDSensorWrapper' device is deprecated in favour of 'rgbdSensor_nws_yarp'.";
+    yCWarning(RGBDSENSORWRAPPER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(RGBDSENSORWRAPPER) << "Please update your scripts.";
+
 //     DeviceResponder::makeUsage();
 //     addUsage("[set] [bri] $fBrightness", "set brightness");
 //     addUsage("[set] [expo] $fExposure", "set exposure");

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2DWrapper.cpp
@@ -472,6 +472,10 @@ std::string Rangefinder2DWrapper::getId()
 
 bool Rangefinder2DWrapper::open(yarp::os::Searchable &config)
 {
+    yCWarning(RANGEFINDER2DWRAPPER) << "The 'Rangefinder2DWrapper' device is deprecated in favour of 'rangefinder2D_nws_yarp'.";
+    yCWarning(RANGEFINDER2DWRAPPER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(RANGEFINDER2DWRAPPER) << "Please update your scripts.";
+
     Property params;
     params.fromString(config.toString());
 

--- a/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
+++ b/src/devices/ServerFrameGrabberDual/ServerFrameGrabberDual.cpp
@@ -137,6 +137,11 @@ bool ServerGrabber::close() {
 }
 
 bool ServerGrabber::open(yarp::os::Searchable& config) {
+
+    yCWarning(SERVERGRABBER) << "The 'grabberDual' device is deprecated in favour of 'frameGrabber_nws_yarp' (and eventually 'frameGrabberCropper').";
+    yCWarning(SERVERGRABBER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(SERVERGRABBER) << "Please update your scripts.";
+
     if (param.active) {
         yCError(SERVERGRABBER, "Did you just try to open the same ServerGrabber twice?");
         return false;

--- a/src/devices/ServerInertial/ServerInertial.cpp
+++ b/src/devices/ServerInertial/ServerInertial.cpp
@@ -273,6 +273,10 @@ bool ServerInertial::openAndAttachSubDevice(yarp::os::Property& prop)
  */
 bool ServerInertial::open(yarp::os::Searchable& config)
 {
+    yCWarning(SERVERINERTIAL) << "The 'inertial' device is deprecated in favour of 'multipleanalogsensorsremapper' + 'multipleanalogsensorsserver' + 'IMURosPublisher'.";
+    yCWarning(SERVERINERTIAL) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(SERVERINERTIAL) << "Please update your scripts.";
+
     Property prop;
     prop.fromString(config.toString());
 

--- a/src/devices/fakeFrameGrabber/CMakeLists.txt
+++ b/src/devices/fakeFrameGrabber/CMakeLists.txt
@@ -11,20 +11,13 @@ yarp_prepare_plugin(fakeFrameGrabber
                     EXTRA_CONFIG WRAPPER=grabberDual
                     DEFAULT ON)
 
-# As discussed in #2308 test_grabber should be renamed fakeFrameGrabber
-#
-# For now, we just add a warning, but in one of the next releases,
-# test_grabber will become also a DeprecatedDevice, therefore it will not be
-# possible to launch it without --allow-deprecated-devices
-#
-# When this is deprecated/removed, also the
-# data/yarpmanager/tests/xml/modules/test_grabber.xml file should be updated
 yarp_prepare_plugin(test_grabber
                     CATEGORY device
                     TYPE TestFrameGrabber
                     INCLUDE FakeFrameGrabber.h
                     EXTRA_CONFIG WRAPPER=grabberDual
-                    DEFAULT ON)
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.5
 
 if(ENABLE_fakeFrameGrabber)
   yarp_add_plugin(yarp_fakeFrameGrabber)

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -919,9 +919,3 @@ bool FakeFrameGrabber::makeSimpleBayer(
 
     return true;
 }
-
-bool TestFrameGrabber::open(yarp::os::Searchable& config)
-{
-    yCWarning(FAKEFRAMEGRABBER, "'test_grabber' was renamed 'fakeFrameGrabber'. The old name is still supported for compatibility, but it will be deprecated and removed in a future release. Please update your scripts");
-    return FakeFrameGrabber::open(config);
-}

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.h
@@ -38,7 +38,11 @@
  * interfaces.
  */
 class FakeFrameGrabber :
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5`
+        virtual public yarp::dev::DeviceDriver,
+#else
         public yarp::dev::DeviceDriver,
+#endif
         public yarp::dev::IFrameGrabberImage,
         public yarp::dev::IFrameGrabberImageRaw,
         public yarp::dev::IFrameGrabberControls,
@@ -220,11 +224,12 @@ private:
     void printTime(unsigned char* pixbuf, size_t pixbuf_w, size_t pixbuf_h, size_t x, size_t y, char* s, size_t size);
 };
 
-
-class TestFrameGrabber : public FakeFrameGrabber
+#ifndef YARP_NO_DEPRECATED // Since YARP 3.5
+class TestFrameGrabber :
+        public yarp::dev::DeprecatedDeviceDriver,
+        public FakeFrameGrabber
 {
-public:
-    bool open(yarp::os::Searchable& config) override;
 };
+#endif // YARP_NO_DEPRECATED
 
 #endif // YARP_FAKEFRAMEGRABBER_FAKEFRAMEGRABBER_H

--- a/src/devices/fakeMotor/CMakeLists.txt
+++ b/src/devices/fakeMotor/CMakeLists.txt
@@ -9,7 +9,8 @@ yarp_prepare_plugin(fakeMotor
                     TYPE FakeMotor
                     INCLUDE FakeMotor.h
                     EXTRA_CONFIG WRAPPER=controlboardwrapper2
-                    DEFAULT OFF)
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.5
 
 # As discussed in #2308 test_motor should be renamed fakeMotor
 #
@@ -21,7 +22,8 @@ yarp_prepare_plugin(test_motor
                     TYPE TestMotor
                     INCLUDE FakeMotor.h
                     EXTRA_CONFIG WRAPPER=controlboardwrapper2
-                    DEFAULT OFF)
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.5
 
 if(NOT SKIP_fakeMotor)
   yarp_add_plugin(yarp_fakeMotor)

--- a/src/devices/fakebot/CMakeLists.txt
+++ b/src/devices/fakebot/CMakeLists.txt
@@ -8,7 +8,9 @@
 yarp_prepare_plugin(fakebot
                     CATEGORY device
                     TYPE FakeBot
-                    INCLUDE FakeBot.h)
+                    INCLUDE FakeBot.h
+                    DEFAULT OFF
+                    DEPENDS "NOT YARP_NO_DEPRECATED") # DEPRECATED Since YARP 3.5
 
 if(NOT SKIP_fakebot)
   yarp_add_plugin(yarp_fakebot)

--- a/src/devices/fakebot/FakeBot.h
+++ b/src/devices/fakebot/FakeBot.h
@@ -24,7 +24,7 @@ YARP_DECLARE_LOG_COMPONENT(FAKEBOT)
  * \brief `fakebot`: Documentation to be added
  */
 class FakeBot :
-        public yarp::dev::DeviceDriver,
+        public yarp::dev::DeprecatedDeviceDriver,
         public yarp::dev::IPositionControl,
         public yarp::dev::IVelocityControl,
         public yarp::dev::IAmplifierControl,

--- a/src/devices/localization2DServer/Localization2DServer.cpp
+++ b/src/devices/localization2DServer/Localization2DServer.cpp
@@ -117,6 +117,10 @@ bool Localization2DServer::detachAll()
 
 bool Localization2DServer::open(Searchable& config)
 {
+    yCWarning(LOCALIZATION2DSERVER) << "The 'localization2DServer' device is deprecated in favour of 'localization2D_nws_yarp'.";
+    yCWarning(LOCALIZATION2DSERVER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(LOCALIZATION2DSERVER) << "Please update your scripts.";
+
     Property params;
     params.fromString(config.toString().c_str());
     yCDebug(LOCALIZATION2DSERVER) << "Configuration: \n" << config.toString().c_str();

--- a/src/devices/map2DServer/Map2DServer.cpp
+++ b/src/devices/map2DServer/Map2DServer.cpp
@@ -916,6 +916,10 @@ bool Map2DServer::loadMaps(std::string mapsfile)
 
 bool Map2DServer::open(yarp::os::Searchable &config)
 {
+    yCWarning(MAP2DSERVER) << "The 'map2DServer' device is deprecated in favour of 'map2D_nws_yarp'.";
+    yCWarning(MAP2DSERVER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(MAP2DSERVER) << "Please update your scripts.";
+
     Property params;
     params.fromString(config.toString());
 

--- a/src/devices/transformClient/transformClient.cpp
+++ b/src/devices/transformClient/transformClient.cpp
@@ -395,6 +395,10 @@ bool TransformClient::read(yarp::os::ConnectionReader& connection)
 
 bool TransformClient::open(yarp::os::Searchable &config)
 {
+    yCWarning(TRANSFORMCLIENT) << "The 'transformClient' device is deprecated in favour of 'frameTransformClient'.";
+    yCWarning(TRANSFORMCLIENT) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(TRANSFORMCLIENT) << "Please update your scripts.";
+
     m_local_name.clear();
     m_remote_name.clear();
 

--- a/src/devices/transformServer/transformServer.cpp
+++ b/src/devices/transformServer/transformServer.cpp
@@ -688,6 +688,10 @@ bool TransformServer::parseStartingTf(yarp::os::Searchable &config)
 
 bool TransformServer::open(yarp::os::Searchable &config)
 {
+    yCWarning(TRANSFORMSERVER) << "The 'transformServer' device is deprecated in favour of 'frameTransformServer'.";
+    yCWarning(TRANSFORMSERVER) << "The old device is no longer supported, and it will be deprecated in YARP 3.6 and removed in YARP 4.";
+    yCWarning(TRANSFORMSERVER) << "Please update your scripts.";
+
     Property params;
     params.fromString(config.toString());
 

--- a/src/libYARP_dev/src/yarp/dev/DeviceDriver.h
+++ b/src/libYARP_dev/src/yarp/dev/DeviceDriver.h
@@ -115,7 +115,7 @@ public:
  * Deprecated device drivers cannot be opened as PolyDriver unless the
  * "allow-deprecated-devices" option is passed in the configuration.
  */
-class YARP_dev_API yarp::dev::DeprecatedDeviceDriver : public yarp::dev::DeviceDriver
+class YARP_dev_API yarp::dev::DeprecatedDeviceDriver : virtual public yarp::dev::DeviceDriver
 {
 };
 


### PR DESCRIPTION
* The following devices are now deprecated:
  * `test_grabber`
  * `fakeMotor`
  * `test_motor`
  * `fakebot`

* The following devices will be replaced by NWS/NWC in the next release, and
  print a warning when opened:
  * `controlboardwrapper2` (replaced by `controlboardremapper` + `controlBoard_nws_yarp`)
  * `RGBDSensorWrapper` (replaced by `rgbdSensor_nws_yarp`)
  * `Rangefinder2DWrapper` (replaced by `rangefinder2D_nws_yarp`)
  * `grabberDual` (replaced by `frameGrabber_nws_yarp`, and eventually `frameGrabberCropper`)
  * `inertial` (replaced by `multipleanalogsensorsremapper` + `multipleanalogsensorsserver` + `IMURosPublisher`)
  * `localization2DServer` (replaced by `localization2D_nws_yarp`)
  * `map2DServer` (replaced by `map2D_nws_yarp`)
  * `transformClient` (replaced by `frameTransformClient`)
  * `transformServer` (replaced by `frameTransformServer`)