### PR TITLE
Added brief tag and nws-nwc sections

### DIFF
--- a/doc/dev_all.dox
+++ b/doc/dev_all.dox
@@ -145,10 +145,50 @@ Concrete device drivers that implement sets of interfaces.
 /**
 \ingroup dev_impl
 
-\defgroup dev_impl_wrapper Network Servers (Wrappers)
+\defgroup dev_impl_wrapper Network Servers (Wrappers - pre NWC/NWS architecture)
 
 These devices take implementations of existing interfaces and wrap them
 up to work across the network.
+
+*/
+
+/**
+\ingroup dev_impl
+
+\defgroup dev_impl_nws_yarp YARP Network Wrapper Servers (NWS)
+
+These devices take implementations of existing interfaces and wrap them
+up to work across the YARP network (see \ref nws_and_nwc_architecture).
+
+*/
+
+/**
+\ingroup dev_impl
+
+\defgroup dev_impl_nws_ros ROS Network Wrapper Servers (NWS)
+
+These devices take implementations of existing interfaces and wrap them
+up to work across the ROS network (see \ref nws_and_nwc_architecture).
+
+*/
+
+/**
+\ingroup dev_impl
+
+\defgroup dev_impl_nwc_yarp YARP Network Wrapper Clients (NWC)
+
+These devices connects to their NWS counterpart through YARP network and expose a yarp::dev interface
+(see \ref nws_and_nwc_architecture).
+
+*/
+
+/**
+\ingroup dev_impl
+
+\defgroup dev_impl_nwc_ros ROS Network Wrapper Clients (NWC)
+
+These devices connects to ROS network and expose a yarp::dev interface
+(see \ref nws_and_nwc_architecture).
 
 */
 
@@ -156,7 +196,7 @@ up to work across the network.
 /**
 \ingroup dev_impl
 
-\defgroup dev_impl_network_clients Network Clients
+\defgroup dev_impl_network_clients Network Clients (pre NWC/NWS architecture)
 
 These devices are meant to communicate to YARP ports opened by \ref dev_impl_wrapper
 to provide device interfaces in a transparent way over a YARP network.

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.h
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.h
@@ -30,7 +30,7 @@
 
 
 /**
- *  @ingroup dev_impl_wrapper
+ *  @ingroup dev_impl_nws_ros
  *
  * \brief `controlBoard_nws_ros`: A controlBoard network wrapper server for ROS.
  *

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
@@ -48,7 +48,7 @@
 
 
 /**
- * @ingroup dev_impl_wrapper
+ * @ingroup dev_impl_nws_yarp
  *
  * \brief `controlBoard_nws_yarp`: A controlBoard network wrapper server for YARP.
  *

--- a/src/devices/RGBDSensorWrapper/RgbdSensor_nws_ros.h
+++ b/src/devices/RGBDSensorWrapper/RgbdSensor_nws_ros.h
@@ -49,10 +49,10 @@ namespace RGBDImpl
 }
 
 /**
- *  @ingroup dev_impl_wrapper
+ *  @ingroup dev_impl_nws_ros
  *
  * \section RgbdSensor_nws_ros_device_parameters Description of input parameters
- * A Network grabber for kinect-like devices.
+ * \brief `rgbdSensor_nws_ros`: A Network grabber for kinect-like devices.
  * This device will produce two streams of data through different ports, one for the color frame and the other one
  * for depth image following Framegrabber and IDepthSensor interfaces specification respectively.
  * See they documentation for more details about each interface.

--- a/src/devices/RGBDSensorWrapper/RgbdSensor_nws_yarp.h
+++ b/src/devices/RGBDSensorWrapper/RgbdSensor_nws_yarp.h
@@ -67,10 +67,10 @@ public:
 } // RGBDImpl
 
 /**
- *  @ingroup dev_impl_wrapper
+ *  @ingroup dev_impl_nws_yarp
  *
  * \section RgbdSensor_nws_yarp_device_parameters Description of input parameters
- * A Network grabber for kinect-like devices.
+ * \brief `rgbdSensor_nws_yarp`: A Network grabber for kinect-like devices.
  * This device will produce two streams of data through different ports, one for the color frame and the other one
  * for depth image following Framegrabber and IDepthSensor interfaces specification respectively.
  * See they documentation for more details about each interface.

--- a/src/devices/RGBDToPointCloudSensorWrapper/CMakeLists.txt
+++ b/src/devices/RGBDToPointCloudSensorWrapper/CMakeLists.txt
@@ -6,23 +6,23 @@
 
 
 ## ROS WRAPPER #################################################################### START #
-yarp_prepare_plugin(RGBDToPointCloudSensor_nws_ros
+yarp_prepare_plugin(rgbdToPointCloudSensor_nws_ros
                     CATEGORY device
                     TYPE RGBDToPointCloudSensor_nws_ros
                     INCLUDE RGBDToPointCloudSensor_nws_ros.h
-                    EXTRA_CONFIG WRAPPER=RGBDToPointCloudSensor_nws_ros
+                    EXTRA_CONFIG WRAPPER=rgbdToPointCloudSensor_nws_ros
                     DEFAULT ON)
 
-if(NOT SKIP_RGBDToPointCloudSensor_nws_ros)
-  yarp_add_plugin(RGBDToPointCloudSensor_nws_ros)
+if(NOT SKIP_rgbdToPointCloudSensor_nws_ros)
+  yarp_add_plugin(yarp_rgbdToPointCloudSensor_nws_ros)
 
-  target_sources(RGBDToPointCloudSensor_nws_ros PRIVATE RGBDToPointCloudSensor_nws_ros.cpp
+  target_sources(yarp_rgbdToPointCloudSensor_nws_ros PRIVATE RGBDToPointCloudSensor_nws_ros.cpp
                                                  RGBDToPointCloudSensor_nws_ros.h)
-  target_sources(RGBDToPointCloudSensor_nws_ros PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
+  target_sources(yarp_rgbdToPointCloudSensor_nws_ros PRIVATE $<TARGET_OBJECTS:RGBDRosConversionUtils>)
 
-  target_include_directories(RGBDToPointCloudSensor_nws_ros PRIVATE $<TARGET_PROPERTY:RGBDRosConversionUtils,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_include_directories(yarp_rgbdToPointCloudSensor_nws_ros PRIVATE $<TARGET_PROPERTY:RGBDRosConversionUtils,INTERFACE_INCLUDE_DIRECTORIES>)
 
-  target_link_libraries(RGBDToPointCloudSensor_nws_ros PRIVATE YARP::YARP_os
+  target_link_libraries(yarp_rgbdToPointCloudSensor_nws_ros PRIVATE YARP::YARP_os
                                                         YARP::YARP_sig
                                                         YARP::YARP_dev
                                                         YARP::YARP_rosmsg)
@@ -32,7 +32,7 @@ if(NOT SKIP_RGBDToPointCloudSensor_nws_ros)
                                                       YARP_dev
                                                       YARP_rosmsg)
 
-  yarp_install(TARGETS RGBDToPointCloudSensor_nws_ros
+  yarp_install(TARGETS yarp_rgbdToPointCloudSensor_nws_ros
                EXPORT YARP_${YARP_PLUGIN_MASTER}
                COMPONENT ${YARP_PLUGIN_MASTER}
                LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
@@ -41,6 +41,6 @@ if(NOT SKIP_RGBDToPointCloudSensor_nws_ros)
 
   set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
 
-  set_property(TARGET RGBDToPointCloudSensor_nws_ros PROPERTY FOLDER "Plugins/Device")
+  set_property(TARGET yarp_rgbdToPointCloudSensor_nws_ros PROPERTY FOLDER "Plugins/Device")
 endif()
 ## ROS WRAPPER ###################################################################### END #

--- a/src/devices/RGBDToPointCloudSensorWrapper/RGBDToPointCloudSensor_nws_ros.h
+++ b/src/devices/RGBDToPointCloudSensorWrapper/RGBDToPointCloudSensor_nws_ros.h
@@ -43,10 +43,11 @@ namespace RGBDToPointCloudImpl{
     const std::string pointCloudTopicName_param     = "pointCloudTopicName";
 }
 /**
- *  @ingroup dev_impl_wrapper
+ *  @ingroup dev_impl_nws_ros
  *
  * \section RGBDToPointCloudSensor_nws_ros_device_parameters Description of input parameters
- * A Network grabber for kinect-like devices.
+ *
+ * \brief `RGBDToPointCloudSensor_nws_ros`: A Network grabber for kinect-like devices.
  * This device will produce one stream of data for the point cloud
  * derived fron the combination of the data derived from Framegrabber and IDepthSensor interfaces.
  * See they documentation for more details about each interface.

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.h
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.h
@@ -57,10 +57,11 @@
 
 
   /**
-   *  @ingroup dev_impl_wrapper dev_impl_network_wrapper dev_impl_lidar
+   *  @ingroup dev_impl_nws_ros dev_impl_lidar
    *
    * \section Rangefinder2D_nws_ros_device_parameters Description of input parameters
-   * A Network grabber for 2D Rangefinder devices.
+   *
+   * \brief `rangefinder2D_nws_ros`: A Network grabber for 2D Rangefinder devices.
    * This device will publish data on the specified ROS topic.
    *
    * This device does not accepts YARP RPC commands, it is dedicated only to data publishing.

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.h
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.h
@@ -49,10 +49,10 @@
 #define DEFAULT_THREAD_PERIOD 0.02 //s
 
   /**
-   *  @ingroup dev_impl_wrapper dev_impl_network_wrapper dev_impl_lidar
+   *  @ingroup dev_impl_nws_yarp dev_impl_lidar
    *
    * \section rangefinder2D_nws_yarp_device_parameters Description of input parameters
-   * A Network grabber for 2D Rangefinder devices.
+   * \brief `rangefinder2D_nws_yarp`: A Network grabber for 2D Rangefinder devices.
    * This device will stream data on the specified YARP ports.
    *
    * This device is paired with its YARP client called Rangefinder2DClient to receive the data streams and perform RPC operations.

--- a/src/devices/RemoteFrameGrabber/FrameGrabber_nwc_yarp.h
+++ b/src/devices/RemoteFrameGrabber/FrameGrabber_nwc_yarp.h
@@ -78,7 +78,7 @@ private:
 
 
 /**
- * @ingroup dev_impl_network_clients
+ * @ingroup dev_impl_nwc_yarp
  *
  * \section frameGrabber_nws_yarp
  *

--- a/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_ros.h
+++ b/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_ros.h
@@ -27,8 +27,11 @@
 #include <yarp/rosmsg/sensor_msgs/Image.h>
 
 /**
- *  @ingroup dev_impl_wrapper
+ * @ingroup dev_impl_nws_ros
  *
+ * \section FrameGrabber_nws_ros_device_parameters Description of input parameters
+ *
+ * \brief `frameGrabber_nws_ros`: A ROS NWS for camera devices.
  *  Parameters required by this device are:
  * | Parameter name  | Type   | Units   | Default Value | Required  | Description                              | Notes |
  * |:---------------:|:------:|:-------:|:-------------:|:--------: |:----------------------------------------:|:-----:|

--- a/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_yarp.h
+++ b/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_yarp.h
@@ -30,7 +30,7 @@
 
 
 /**
- * @ingroup dev_impl_wrapper
+ * @ingroup dev_impl_nws_yarp
  *
  * \brief `frameGrabber_nws_yarp`: A YARP NWS for camera devices.
  *

--- a/src/devices/frameTransformClient/FrameTransformClient.h
+++ b/src/devices/frameTransformClient/FrameTransformClient.h
@@ -53,7 +53,8 @@ const int MAX_PORTS = 5;
  *
  * \section FrameTransformClient_device_parameters Description of input parameters
  *
- * \brief A client to manage FrameTransforms for a robot (see \ref FrameTransform)
+ * \brief `frameTransformClient`: A client to manage FrameTransforms for a robot
+ * (For more information, go to \ref FrameTransform)
  *
  *   Parameters required by this device are:
  * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                          |

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.h
@@ -36,7 +36,9 @@
 #define ROSTOPICNAME_TF_STATIC "/tf_static"
 
 /**
- * @brief A ros network wrapper client that receives frame transforms from a ros topic and makes them available through an IFrameTransformStorageGet interface. See \subpage FrameTransform for additional info.
+ * @ingroup dev_impl_nwc_ros
+ *
+ * @brief `frameTransformGet_nwc_ros`: A ros network wrapper client that receives frame transforms from a ros topic and makes them available through an IFrameTransformStorageGet interface. See \subpage FrameTransform for additional info.
  *
  * \section FrameTransformGet_nwc_ros_device_parameters Parameters
  *

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
@@ -16,7 +16,9 @@
 #include <FrameTransformStorageGetRPC.h>
 
 /**
- * @brief A network wrapper client which converts the input retrieved from a FrameTransformStorageGetRPC thrift interface to an IFrameTransformStorageGet interface.
+ * @ingroup dev_impl_nwc_yarp
+ *
+ * @brief `frameTransformGet_nwc_yarp`: A network wrapper client which converts the input retrieved from a FrameTransformStorageGetRPC thrift interface to an IFrameTransformStorageGet interface.
  *
  * \section FrameTransformGet_nwc_yarp_device_parameters Parameters
  * This device is paired with its server called FrameTransformGet_nws_yarp.

--- a/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
@@ -18,7 +18,9 @@
 
 // TODO FIXME STE need to check subdevice option
 /**
- * @brief A network wrapper client which converts the input retrieved from an IFrameTransformStorageGet interface to a FrameTransformStorageGetRPC thrift interface.
+ * @ingroup dev_impl_nws_yarp
+ *
+ * @brief `frameTransformGet_nws_yarp`: A network wrapper client which converts the input retrieved from an IFrameTransformStorageGet interface to a FrameTransformStorageGetRPC thrift interface.
  *
  * \section FrameTransformGet_nws_yarp_device_parameters Parameters
  * this device listens on a FrameTransformStorageGetRPC interface for an RPC and then forwards the request to an IFrameTransformStorageGet interface (device attached)

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.h
@@ -36,7 +36,9 @@
 #define ROSTOPICNAME_TF_STATIC "/tf_static"
 
 /**
- * @brief A network wrapper client which publishes the transforms received on the yarp::dev::IFrameTransformStorageSet interface to a ROS topic.
+ * @ingroup dev_impl_nwc_ros
+ *
+ * @brief `frameTransformSet_nwc_ros`: A network wrapper client which publishes the transforms received on the yarp::dev::IFrameTransformStorageSet interface to a ROS topic.
  *
  * \section FrameTransformSet_nwc_ros_device_parameters Parameters
  *

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
@@ -19,7 +19,9 @@
 #include <map>
 
 /**
- * @brief A network wrapper client which publishes the transforms received on the thrift interface FrameTransformStorageSetRPC to yarp::dev::IFrameTransformStorageSet interface.
+ * @ingroup dev_impl_nwc_yarp
+ *
+ * @brief `frameTransformSet_nwc_yarp`: A network wrapper client which publishes the transforms received on the thrift interface FrameTransformStorageSetRPC to yarp::dev::IFrameTransformStorageSet interface.
  *
  * \section FrameTransformSet_nwc_yarp_device_parameters Parameters
  * This device is paired with its server called FrameTransformSet_nws_yarp.

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
@@ -20,8 +20,9 @@
 #include <map>
 
 /**
- * @brief A network wrapper client which publishes the transforms received on the yarp::dev::IFrameTransformStorageSet interface to thrift interface FrameTransformStorageSetRPC interface.
-
+ * @ingroup dev_impl_nws_yarp
+ *
+ * @brief `frameTransformSet_nws_yarp`: A network wrapper client which publishes the transforms received on the yarp::dev::IFrameTransformStorageSet interface to thrift interface FrameTransformStorageSetRPC interface.
  *
  * \section FrameTransformSet_nws_yarp_device_parameters Parameters
  * This device is paired with its server called FrameTransformSet_nwc_yarp.

--- a/src/devices/frameTransformStorage/FrameTransformStorage.h
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.h
@@ -36,7 +36,7 @@
 /**
  *  @ingroup dev_impl_other
  *
- * \brief A class that keeps a \ref FrameTransformContainer updated by receiving transformations
+ * \brief `frameTransformStorage`: A class that keeps a \ref FrameTransformContainer updated by receiving transformations
  *  through the \ref yarp::dev::IFrameTransformStorageSet interface and periodically querying a set of attached
  *  devices that expose the \ref yarp::dev::IFrameTransformStorageGet interface.
  *  It also exposes the \ref yarp::dev::IFrameTransformStorageGet interface to allow stored transformations retrieval

--- a/src/devices/frameTransformUtils/FrameTransformContainer.h
+++ b/src/devices/frameTransformUtils/FrameTransformContainer.h
@@ -32,7 +32,7 @@
 /**
  *  @ingroup dev_impl_other
  *
- * \brief A class that contains a vector of frame transformations and exposes
+ * \brief `FrameTransformContainer`: A class that contains a vector of frame transformations and exposes
  *  \ref yarp::dev::IFrameTransformStorageSet and \ref yarp::dev::IFrameTransformStorageGet
  *  interfaces in order to allow external access to it.
  *

--- a/src/devices/localization2DServer/Localization2D_nws_ros.h
+++ b/src/devices/localization2DServer/Localization2D_nws_ros.h
@@ -39,26 +39,26 @@
 #include <math.h>
 
  /**
- * @ingroup dev_impl_network_wrapper dev_impl_navigation
- *
- * \section Localization2D_nws_ros
- *
- * \brief `Localization2D_nws_ros`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
- *
- *
- *  Parameters required by this device are:
- * | Parameter name   | Type    | Units          | Default Value            | Required     | Description                                                        | Notes |
- * |:----------------:|:-------:|:--------------:|:------------------------:|:-----------: |:-----------------------------------------------------------------: |:-----:|
- * | period           | double  | s              | 0.01                     | No           | The period of the working thread                                   |       |
- * | yarp_base_name   | string  |  -             |                          | Yes          | The name of the server, used as a prefix for the opened yarp ports | By default ports opened are: /xxx/rpc |
- * | publish_odometry | bool    |  -             | true                     | No           | Periodically publish odometry data over the network                | -     |
- * | publish_tf       | bool    |  -             | true                     | No           | Periodically publish tf data over the network                      | -     |
- * | parent_frame_id  | string  |  -             | odom                     | No           | The name of the of the parent frame published in the /tf topic     | -     |
- * | child_frame_id   | string  |  -             | base_link                | No           | The name of the of the child frame published in the /tf topic      | -     |
- * | topic_name       | string  |  -             |                          | Yes          | The name of the of the odometry topic                              | -     |
- * | node_name        | string  |  -             |                          | Yes          | The name of the of the ROS node                                    | -     |
- * | subdevice        | string  |  -             |  -                       | Yes          | The name of the of Localization device to be used                  | -     |
- */
+  * @ingroup dev_impl_nws_ros dev_impl_navigation
+  *
+  * \section Localization2D_nws_ros
+  *
+  * \brief `localization2D_nws_ros`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
+  *
+  *
+  *  Parameters required by this device are:
+  * | Parameter name   | Type    | Units          | Default Value            | Required     | Description                                                        | Notes |
+  * |:----------------:|:-------:|:--------------:|:------------------------:|:-----------: |:-----------------------------------------------------------------: |:-----:|
+  * | period           | double  | s              | 0.01                     | No           | The period of the working thread                                   |       |
+  * | yarp_base_name   | string  |  -             |                          | Yes          | The name of the server, used as a prefix for the opened yarp ports | By default ports opened are: /xxx/rpc |
+  * | publish_odometry | bool    |  -             | true                     | No           | Periodically publish odometry data over the network                | -     |
+  * | publish_tf       | bool    |  -             | true                     | No           | Periodically publish tf data over the network                      | -     |
+  * | parent_frame_id  | string  |  -             | odom                     | No           | The name of the of the parent frame published in the /tf topic     | -     |
+  * | child_frame_id   | string  |  -             | base_link                | No           | The name of the of the child frame published in the /tf topic      | -     |
+  * | topic_name       | string  |  -             |                          | Yes          | The name of the of the odometry topic                              | -     |
+  * | node_name        | string  |  -             |                          | Yes          | The name of the of the ROS node                                    | -     |
+  * | subdevice        | string  |  -             |  -                       | Yes          | The name of the of Localization device to be used                  | -     |
+  */
 class Localization2D_nws_ros :
         public yarp::dev::DeviceDriver,
         public yarp::os::PeriodicThread,

--- a/src/devices/localization2DServer/Localization2D_nws_yarp.h
+++ b/src/devices/localization2DServer/Localization2D_nws_yarp.h
@@ -37,11 +37,11 @@
 #include <math.h>
 
  /**
- * @ingroup dev_impl_network_wrapper dev_impl_navigation
+ * @ingroup dev_impl_nws_yarp dev_impl_navigation
  *
  * \section Localization2D_nws_yarp
  *
- * \brief `Localization2D_nws_yarp`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
+ * \brief `localization2D_nws_yarp`: A localization server which can be wrap multiple algorithms and devices to provide robot localization in a 2D World.
  *
  *
  *  Parameters required by this device are:

--- a/src/devices/map2DServer/Map2D_nws_ros.h
+++ b/src/devices/map2DServer/Map2D_nws_ros.h
@@ -54,11 +54,11 @@
 #include <yarp/rosmsg/nav_msgs/OccupancyGrid.h>
 
 /**
- *  @ingroup dev_impl_wrapper dev_impl_navigation
+ *  @ingroup dev_impl_nws_ros dev_impl_navigation
  *
  * \section Map2D_nws_ros
  *
- * \brief `Map2D_nws_ros`: A device capable of read/save collections of maps from disk, and make them accessible to any Map2DClient device.
+ * \brief `map2D_nws_ros`: A device capable of read/save collections of maps from disk, and make them accessible to any Map2DClient device.
  *
  *  Parameters required by this device are:
  * | Parameter name | SubParameter           | Type    | Units          | Default Value    | Required     | Description                                                       | Notes |

--- a/src/devices/map2DServer/Map2D_nws_yarp.h
+++ b/src/devices/map2DServer/Map2D_nws_yarp.h
@@ -48,11 +48,11 @@
 #include <yarp/dev/api.h>
 
 /**
- *  @ingroup dev_impl_wrapper dev_impl_navigation
+ *  @ingroup dev_impl_nws_yarp dev_impl_navigation
  *
  * \section Map2D_nws_yarp
  *
- * \brief `Map2D_nws_yarp`: A device capable of read/save collections of maps from disk, and make them accessible to any Map2DClient device.
+ * \brief `map2D_nws_yarp`: A device capable of read/save collections of maps from disk, and make them accessible to any Map2DClient device.
  *
  *  Parameters required by this device are:
  * | Parameter name | SubParameter   | Type    | Units          | Default Value    | Required     | Description                                                       | Notes |


### PR DESCRIPTION
Four new sections in the doxygen library have been added for NWS and NWC (both YARP and ROS). Missing `\brief` sections have been added to the documentation of a set of yarp devices