### PR TITLE
Sound filters

### DIFF
--- a/cmake/FindSOXR.cmake
+++ b/cmake/FindSOXR.cmake
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FindSOXR
+-----------
+
+Try to find the SOXR library.
+Once done this will define the following variables::
+
+ SOXR_FOUND         - System has SOXR
+ SOXR_INCLUDE_DIRS  - SOXR include directory
+ SOXR_LIBRARIES     - SOXR libraries
+ SOXR_DEFINITIONS   - Additional compiler flags for SOXR
+ SOXR_VERSION       - SOXR version
+ SOXR_MAJOR_VERSION - SOXR major version
+ SOXR_MINOR_VERSION - SOXR minor version
+ SOXR_PATCH_VERSION - SOXR patch version
+#]=======================================================================]
+
+include(StandardFindModule)
+standard_find_module(SOXR soxr
+                     SKIP_CMAKE_CONFIG)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+    set_package_properties(SOXR PROPERTIES DESCRIPTION "The SoX Resampler library `libsoxr' performs one-dimensional sample-rate conversion"
+                                              URL "https://sourceforge.net/projects/soxr/")
+endif()

--- a/cmake/FindSOXR.cmake
+++ b/cmake/FindSOXR.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
 #[=======================================================================[.rst:

--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -387,6 +387,9 @@ checkandset_dependency(GObject)
 find_package(GLIB2 QUIET)
 checkandset_dependency(GLIB2)
 
+find_package(SOXR QUIET)
+checkandset_dependency(SOXR)
+
 set(GStreamer_REQUIRED_VERSION 1.4)
 find_package(GStreamer ${GStreamer_REQUIRED_VERSION} QUIET)
 checkandset_dependency(GStreamer)

--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -665,6 +665,7 @@ print_dependency(Libv4l2)
 print_dependency(Libv4lconvert)
 print_dependency(Fuse)
 print_dependency(ZLIB)
+print_dependency(SOXR)
 
 ################################################################################
 # Print information for user

--- a/doc/release/master/soundFilters.md
+++ b/doc/release/master/soundFilters.md
@@ -1,0 +1,6 @@
+soundFilters {#master}
+-----------------------
+
+### yarp::sig
+* added new files `yarp::sig::SoundFilters.h`, `yarp::sig::SoundFilters.cpp`
+* added new method `yarp::sig::soundfilters::resample()`

--- a/src/libYARP_sig/src/CMakeLists.txt
+++ b/src/libYARP_sig/src/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 if(YARP_HAS_SOXR)
   target_include_directories(YARP_sig SYSTEM PRIVATE ${SOXR_INCLUDE_DIR})
   target_compile_definitions(YARP_sig PRIVATE YARP_HAS_SOXR)
-  target_link_libraries(YARP_sig PRIVATE ${SOXR_LIBRARY})
+  target_link_libraries(YARP_sig PRIVATE ${SOXR_LIBRARIES})
   list(APPEND YARP_sig_PRIVATE_DEPS SOXR)
 endif()
 

--- a/src/libYARP_sig/src/CMakeLists.txt
+++ b/src/libYARP_sig/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(YARP_sig_HDRS
   yarp/sig/PointCloudUtils-inl.h
   yarp/sig/Sound.h
   yarp/sig/SoundFile.h
+  yarp/sig/SoundFilters.h
   yarp/sig/SoundFileMp3.h
   yarp/sig/SoundFileWav.h
   yarp/sig/Vector.h
@@ -45,6 +46,7 @@ set(YARP_sig_SRCS
   yarp/sig/PointCloudBase.cpp
   yarp/sig/PointCloudUtils.cpp
   yarp/sig/Sound.cpp
+  yarp/sig/SoundFilters.cpp
   yarp/sig/SoundFile.cpp
   yarp/sig/SoundFileMp3.cpp
   yarp/sig/SoundFileWav.cpp
@@ -114,6 +116,13 @@ if(YARP_HAS_JPEG)
   target_compile_definitions(YARP_sig PRIVATE YARP_HAS_JPEG)
   target_link_libraries(YARP_sig PRIVATE ${JPEG_LIBRARY})
   list(APPEND YARP_sig_PRIVATE_DEPS JPEG)
+endif()
+
+if(YARP_HAS_SOXR)
+  target_include_directories(YARP_sig SYSTEM PRIVATE ${SOXR_INCLUDE_DIR})
+  target_compile_definitions(YARP_sig PRIVATE YARP_HAS_SOXR)
+  target_link_libraries(YARP_sig PRIVATE ${SOXR_LIBRARY})
+  list(APPEND YARP_sig_PRIVATE_DEPS SOXR)
 endif()
 
 if(YARP_HAS_ZLIB)

--- a/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/sig/SoundFilters.h>
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+
+using namespace yarp::os;
+using namespace yarp::sig;
+using namespace yarp::sig::soundfilters;
+
+namespace
+{
+    YARP_LOG_COMPONENT(SOUNDFILTERS, "yarp.sig.SoundFilters")
+}
+
+#if defined (YARP_HAS_SOXR)
+#include <soxr.h>
+#endif
+
+//#######################################################################################################
+
+bool yarp::sig::soundfilters::resample(yarp::sig::Sound& snd, size_t frequency)
+{
+#if !defined (YARP_HAS_SOXR)
+
+    yCError(SOUNDFILTERS) << "libsoxr not available";
+    return false;
+#else
+    //configuration
+    soxr_io_spec_t tit;
+    tit.itype = SOXR_INT16_I;
+    tit.otype = SOXR_INT16_I;
+    tit.scale = 1.0;
+
+    double irate = snd.getFrequency();
+    double orate = double(frequency);
+    size_t ilen = snd.getSamples();
+    yarp::sig::Sound::audio_sample* arri = new yarp::sig::Sound::audio_sample[ilen];
+
+    //copy from sound to buffer
+    for (size_t t = 0; t < ilen; t++)
+    {
+        for (size_t c = 0; c < 1; c++)
+        {
+            arri[t] = snd.getSafe(t, c);
+        }
+    }
+
+    size_t olen = (size_t)(ilen * orate / irate + .5);
+    yarp::sig::Sound::audio_sample* arro = new yarp::sig::Sound::audio_sample[olen];
+
+    //resample
+    size_t odone;
+    soxr_error_t error = soxr_oneshot(irate, orate, 1,            // Rates and # of channels
+        arri, ilen, NULL,           // Input
+        arro, olen, &odone,         // Output
+        &tit, NULL, NULL);          // Configuration
+    if (error != 0)
+    {
+        yCError(SOUNDFILTERS) << "libsoxr resample failed";
+        delete[]arri;
+        delete[]arro;
+    }
+
+    //copy from buffer to sound
+    snd.setFrequency(size_t(orate));
+    snd.resize(olen);
+    for (size_t t = 0; t < olen; t++)
+    {
+        for (size_t c = 0; c < 1; c++)
+        {
+            snd.setSafe(arro[t], t, c);
+        }
+    }
+
+    //clear buffer
+    delete[]arri;
+    delete[]arro;
+
+    return true;
+#endif
+}

--- a/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -87,7 +87,7 @@ bool yarp::sig::soundfilters::resample(yarp::sig::Sound& snd, size_t frequency)
 
     //resample
     size_t odone;
-    soxr_error_t error = soxr_oneshot(irate, orate, ,            // Rates and # of channels
+    soxr_error_t error = soxr_oneshot(irate, orate, ichans,            // Rates and # of channels
         arri, ilen, NULL,           // Input
         arro, olen, &odone,         // Output
         &tit, NULL, NULL);          // Configuration

--- a/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundFilters.cpp
@@ -25,6 +25,27 @@ namespace
 
 bool yarp::sig::soundfilters::resample(yarp::sig::Sound& snd, size_t frequency)
 {
+    if (frequency == 0)
+    {
+        yCError(SOUNDFILTERS) << "invalid frequency value = 0";
+        return false;
+    }
+    if (snd.getChannels() != 1)
+    {
+        yCError(SOUNDFILTERS) << "only 1 channel is currently supported";
+        return false;
+    }
+    if (snd.getSamples() == 0)
+    {
+        yCError(SOUNDFILTERS) << "empty sound received?!";
+        return false;
+    }
+    if (snd.getFrequency() == frequency)
+    {
+        yCWarning(SOUNDFILTERS) << "no resampling needed";
+        return true;
+    }
+
 #if !defined (YARP_HAS_SOXR)
 
     yCError(SOUNDFILTERS) << "libsoxr not available";

--- a/src/libYARP_sig/src/yarp/sig/SoundFilters.h
+++ b/src/libYARP_sig/src/yarp/sig/SoundFilters.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/libYARP_sig/src/yarp/sig/SoundFilters.h
+++ b/src/libYARP_sig/src/yarp/sig/SoundFilters.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_SIG_SOUNDFILTERS_H
+#define YARP_SIG_SOUNDFILTERS_H
+
+#include <yarp/sig/Sound.h>
+
+namespace yarp {
+    namespace sig{
+        namespace soundfilters {
+            /**
+             * Resample a sound
+             * @param snd the sound to resample
+             * @param frequency the output frequency
+             * @return true on success
+             */
+            bool YARP_sig_API resample(yarp::sig::Sound& snd, size_t frequency);
+        }
+    }
+}
+
+#endif // YARP_SIG_SOUNDFILTERS_H


### PR DESCRIPTION
* added new files `yarp::sig::SoundFilters.h`, `yarp::sig::SoundFilters.cpp`
* added new method `yarp::sig::soundfilters::resample()`
* requires libsoxr.  `cmake/FindSOXR.cmake` temporary added. The file will be removed when ycm 0.14 is released.