### PR TITLE
os/impl/LogForwarder: Do not use a static Bottle

### DIFF
--- a/doc/release/yarp_3_5/LogForwarder_static_Bottle.md
+++ b/doc/release/yarp_3_5/LogForwarder_static_Bottle.md
@@ -1,0 +1,9 @@
+LogForwarder_static_Bottle {#yarp-3.5}
+--------------------------
+
+### Libraries
+
+#### `os`
+
+* The `LogForwarder` no longer skips messages when messages are sent too
+  quickly (#2643).

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
@@ -8,7 +8,8 @@
 
 #include <yarp/os/api.h>
 
-#include <yarp/os/Port.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
 
 #include <mutex>
 #include <string>
@@ -32,7 +33,7 @@ private:
     LogForwarder& operator=(LogForwarder const&) = delete;
 
     std::mutex mutex;
-    yarp::os::Port outputPort;
+    yarp::os::BufferedPort<yarp::os::Bottle> outputPort;
     static bool started;
 };
 


### PR DESCRIPTION
When the `forward` method is called twice, the `Bottle::clear()` method could be called before the message is sent, hence deleting the bottle being sent.

This fixes the `LogForwarder` skipping messages when messages are sent too quickly (Fixes #2643).

----

### Libraries

#### `os`

* The `LogForwarder` no longer skips messages when messages are sent too
  quickly (#2643).