### PR TITLE
Fixed topic_name append in controlboard_nws_ros

### DIFF
--- a/doc/release/yarp_3_5/controlboard_nws_ros_fix.md
+++ b/doc/release/yarp_3_5/controlboard_nws_ros_fix.md
@@ -1,0 +1,10 @@
+fix_ros_nws_controlboard {#yarp_3_5}
+-----------
+
+Important Changes
+-----------------
+
+### Devices
+
+#### controlboard_nws_ros
+* fixed topic name, now it doesn't append /joint_states to the name

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.cpp
@@ -103,7 +103,6 @@ bool ControlBoard_nws_ros::open(Searchable& config)
         yCError(CONTROLBOARD) << "topic_name must begin with an initial /";
         return false;
     }
-    topicName.append("/joint_states");
     yCInfo(CONTROLBOARD) << "topicName is " << topicName;
     // call ROS node/topic initialization
     node = new yarp::os::Node(nodeName);

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.h
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.h
@@ -37,7 +37,7 @@
  * | Parameter name  | SubParameter   | Type    | Units          | Default Value | Required                    | Description                                                       | Notes |
  * |:---------------:|:--------------:|:-------:|:--------------:|:-------------:|:--------------------------: |:-----------------------------------------------------------------:|:-----:|
  * | node_name       |      -         | string  | -              |   -           | Yes                         | set the name for ROS node                                         | must start with a leading '/' |
- * | topic_name      |      -         | string  | -              |   -           | Yes                         | set the name for ROS topic                                        | must start with a leading '/' |
+ * | topic_name      |      -         | string  | -              |   -           | Yes                         | set the name for ROS topic                                        | must start with a leading '/', recommended value is /joint_states |
  * | period          |      -         | double  | s              |   0.02        | No                          | refresh period of the broadcasted values in s                     | optional, default 20ms |
  * | subdevice       |      -         | string  | -              |   -           | No                          | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
  *


### PR DESCRIPTION
fix_ros_nws_controlboard {#yarp_3_5}
-----------

Important Changes
-----------------

### Devices

#### controlboard_nws_ros
* fixed topic name, now it doesn't append /joint_states to the name