### PR TITLE
Do not use "in the past" in docs

### DIFF
--- a/doc/nws_and_nwc_architecture.md
+++ b/doc/nws_and_nwc_architecture.md
@@ -24,14 +24,14 @@ The following sections are supposed to give a rationale to the changes that are 
 
 ### YARP and ROS wrappers
 
-In the past, network wrappers were for YARP only.
+Before YARP 3 and earlier releases, network wrappers were for YARP only.
 Recently, with the introduction of YARP-ROS compatibility layer, wrappers started implementing also the compatibility with the ROS middleware, with tons of if and switch cases inside the code. Obviously, this doesn't scale to other middlewares.
 
 There is no limit to how many wrappers can be attached to a device. We are therefore currently working to split the wrappers in two separate wrappers (one for YARP and one for ROS) that can be attached to the same device. Unfortunately this has the limitation that only one of them can be launched using `yarpdev`, and in order to use both of them contemporarily, it is necessary to use `yarprobotinterface`. We are currently considering whether to modify `yarpdev` to support attaching multiple wrappers.
 
 ### Naming
 
-In the past (and at the time of writing), NWS have often been called including one or more of these terms:
+Before YARP 3.5, NWS have often been called including one or more of these terms:
 
 * Wrapper
 * Network Wrapper
@@ -60,7 +60,7 @@ We also decided to include in the name the middleware used underneath (even for 
 
 ### Logic inside the wrappers
 
-In the past (and at the time of writing), a few wrappers had "logic" inside. This means that using a device locally it is different, compared to using it remotely. This also means that a few wrappers, in order to avoid this differences, had to implement the same interfaces of the device wrapped.
+Before YARP 3.5, a few wrappers had "logic" inside. This means that using a device locally it is different, compared to using it remotely. This also means that a few wrappers, in order to avoid this differences, had to implement the same interfaces of the device wrapped.
 In order to make things as small and clear as possible, network wrappers should not have any logic inside, and instead a separate wrapper (note: not a **network** wrapper here) should be created, and the NWS should be attached to this device instead of to the actual device.
 NWS and NWC using a transport that is different from YARP, can require some conversion in order to match with the standards used by the middleware underneath. This kind of conversion is acceptable
 


### PR DESCRIPTION
As the documentation will be used also in the future, and in the past in 2023 will have a different meaning then now. 