### PR TITLE
Use `mkdir_p` instead of `mkdir` w/ `getHomeContextPath` and `getHomeRobotPath`

### DIFF
--- a/doc/release/yarp_3_5/ResourceFinder_fix.md
+++ b/doc/release/yarp_3_5/ResourceFinder_fix.md
@@ -1,0 +1,12 @@
+ResourceFinder_fix {#yarp_3_5}
+-----------
+
+Important Changes
+-----------------
+
+### Libraries
+
+##### `ResourceFinder`
+
+* Use `mkdir_p` instead of `mkdir` when calling `getHomeContextPath` and `getHomeRobotPath`
+  to correctly create the missing paths. 

--- a/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
+++ b/src/libYARP_os/src/yarp/os/ResourceFinder.cpp
@@ -685,10 +685,10 @@ public:
 
         std::string parentPath = getPath(yarp::conf::dirs::yarpdatahome(), "contexts", "", "");
         if (yarp::os::stat(parentPath.c_str()) != 0) {
-            yarp::os::mkdir(parentPath.c_str());
+            yarp::os::mkdir_p(parentPath.c_str());
         }
 
-        if (yarp::os::mkdir(path.c_str()) < 0 && errno != EEXIST) {
+        if (yarp::os::mkdir_p(path.c_str()) < 0 && errno != EEXIST) {
             yCWarning(RESOURCEFINDER, "Could not create %s directory", path.c_str());
         }
         return path;
@@ -715,10 +715,10 @@ public:
 
         std::string parentPath = getPath(yarp::conf::dirs::yarpdatahome(), "robots", "", "");
         if (yarp::os::stat(parentPath.c_str()) != 0) {
-            yarp::os::mkdir(parentPath.c_str());
+            yarp::os::mkdir_p(parentPath.c_str());
         }
 
-        if (yarp::os::mkdir(path.c_str()) < 0 && errno != EEXIST) {
+        if (yarp::os::mkdir_p(path.c_str()) < 0 && errno != EEXIST) {
             yCWarning(RESOURCEFINDER, "Could not create %s directory", path.c_str());
         }
         return path;


### PR DESCRIPTION
This PR fixes #2676.

I've tested it successfully ✔️ 

I'm proposing this change back to yarp-3.4 to then easily port it forward as for Distro 2021.08 we would likely need to rely on a fixed `yarp-3.4.6`.

I've tried to fill in the mandatory fields for describing the fix by taking inspiration from supporting files done for other old mods.
Tell me if I'm required to do anything else.