### PR TITLE
FrameTransform architecture components refactoring

### DIFF
--- a/doc/release/yarp_3_5/refactor_frameTransformComponents.md
+++ b/doc/release/yarp_3_5/refactor_frameTransformComponents.md
@@ -1,0 +1,15 @@
+refactor_frameTransformComponents {#yarp-3.5}
+-------------------
+
+### FrameTransform architecture components
+
+#### `yarp::dev`
+
+The following components have been refactored in order to easily manage ports names and avoid errors in doing so:
+* frameTransformSet_nwc_yarp
+* frameTransformSet_nws_yarp
+* frameTransformGet_nwc_yarp
+* frameTransformSet_nws_yarp
+
+The xml files containing the configurations for the `frameTransformClient` and the `frameTransformServer` have been updated
+accordingly.

--- a/src/devices/frameTransformClient/FrameTransformClient.h
+++ b/src/devices/frameTransformClient/FrameTransformClient.h
@@ -44,10 +44,12 @@ const int MAX_PORTS = 5;
  * (For more information, go to \ref FrameTransform)
  *
  *   Parameters required by this device are:
- * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                          |
- * |:----------------:|:--------------------:|:-------:|:--------------:|:---------------------:|:-----------: |:--------------------------------------------------------------------:|
- * | filexml_option   | -                    | string  | -              | ftc_local_only.xml    | no           | The name of the xml file containing the needed client configuration  |
- * | period           | -                    | float   | -              | 10ms                  | no           | The period for publishing individual tfs on port                     |
+ * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                                             |
+ * |:----------------:|:--------------------:|:-------:|:--------------:|:---------------------:|:-----------: |:---------------------------------------------------------------------------------------:|
+ * | filexml_option   | -                    | string  | -              | ftc_local_only.xml    | no           | The name of the xml file containing the needed client configuration                     |
+ * | period           | -                    | float   | -              | 10ms                  | no           | The period for publishing individual tfs on port                                        |
+ * | ft_client_prefix | -                    | string  | -              | ""                    | no           | A prefix to add to the names of all the ports opened by the NWCs instantiated by the frameTransformClient  |
+ * | ft_server_prefix | -                    | string  | -              | ""                    | no           | The prefix added to all the names of the ports opened by the NWSs instantiated by the frameTransformServer |
  *
  * Example of command line:
  * \code{.unparsed}

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
@@ -13,12 +13,15 @@
     <devices>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
-            <param extern-name="ftSet_client_port" name="rpc_port_client"> /frameTransformSet/clientRPC </param>
-            <param extern-name="ftSet_server_port" name="rpc_port_server"> /frameTransformSet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
         </device>
         <device name="ftGet_nwc_yarp" type="frameTransformGet_nwc_yarp">
-            <param extern-name="ftGet_client_port" name="rpc_port_client"> /frameTransformGet/clientRPC </param>
-            <param extern-name="ftGet_server_port" name="rpc_port_server"> /frameTransformGet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
+            <param extern-name="ftGet_client_enable_stream" name="streaming_enabled"> true </param>
+            <param extern-name="ft_client_prefix" name="input_streaming_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
         </device>
         <!-- **************** ROS NWC **************** -->
         <device name="ftSet_nwc_ros" type="frameTransformSet_nwc_ros">

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_yarp_only.xml
@@ -12,8 +12,8 @@
     <devices>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
-            <param extern-name="ftSet_client_port" name="rpc_port_client"> /frameTransformSet/clientRPC </param>
-            <param extern-name="ftSet_server_port" name="rpc_port_server"> /frameTransformSet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
         </device>
     </devices>
 </robot>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
@@ -12,8 +12,11 @@
     <devices>
         <!-- **************** YARP NWC **************** -->
         <device name="ftGet_nwc_yarp" type="frameTransformGet_nwc_yarp">
-            <param extern-name="ftGet_client_port" name="rpc_port_client"> /frameTransformGet/clientRPC </param>
-            <param extern-name="ftGet_server_port" name="rpc_port_server"> /frameTransformGet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
+            <param extern-name="ftGet_client_enable_stream" name="streaming_enabled"> true </param>
+            <param extern-name="ft_client_prefix" name="input_streaming_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
@@ -13,12 +13,15 @@
     <devices>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
-            <param extern-name="ftSet_client_port" name="rpc_port_client"> /frameTransformSet/clientRPC </param>
-            <param extern-name="ftSet_server_port" name="rpc_port_server"> /frameTransformSet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
         </device>
         <device name="ftGet_nwc_yarp" type="frameTransformGet_nwc_yarp">
-            <param extern-name="ftGet_client_port" name="rpc_port_client"> /frameTransformGet/clientRPC </param>
-            <param extern-name="ftGet_server_port" name="rpc_port_server"> /frameTransformGet/serverRPC </param>
+            <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
+            <param extern-name="ftGet_client_enable_stream" name="streaming_enabled"> true </param>
+            <param extern-name="ft_client_prefix" name="input_streaming_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
@@ -16,7 +16,7 @@
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">
             <group name="GENERAL">
-                <param extern-name="ftSet_rpc_port" name="rpc_port"> /frameTransformSet/rpc </param>
+                <param extern-name="ft_client_prefix" name="nws_thrift_port_prefix">""</param>
             </group>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
@@ -55,7 +55,7 @@ class FrameTransformGet_nwc_yarp:
         DataReader() = default;
 
         using               yarp::os::BufferedPort<return_getAllTransforms>::onRead;
-        virtual void        onRead(return_getAllTransforms& v) override;
+        void        onRead(return_getAllTransforms& v) override;
         bool                getData(return_getAllTransforms& data);
     };
 
@@ -71,21 +71,25 @@ public:
     bool  open(yarp::os::Searchable &params) override;
     bool  close() override;
 
-    // yarp::os::PeriodicThread
-    bool m_streaming_port_enabled = false;
-    std::string    m_streaming_port_name{ "/frameTransformGet/tf:i" };
-    DataReader*    m_dataReader =nullptr;
-
     // yarp::dev::IFrameTransformStorageGet
     bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
 private:
-    int    m_verbose{4};
+    int            m_verbose{4};
+    std::string    m_deviceName{"frameTransformGet_nwc_yarp"};
+    std::string    m_defaultConfigPrefix{"/frameTransformClient"};
+    std::string    m_defaultServerPrefix{"/frameTransformServer/frameTransformGet_nws_yarp"};
+
+    //streaming port
+    bool           m_streaming_port_enabled = false;
+    std::string    m_streaming_input_port_name;
+    std::string    m_streaming_output_port_name;
+    DataReader*    m_dataReader =nullptr;
 
     // for the RPC with the NWS
-    yarp::os::Port      m_thrift_rpcPort;
-    std::string         m_thrift_rpcPort_Name{"/frameTransformGet/clientRPC"};
-    std::string         m_thrift_server_rpcPort_Name{"/frameTransformGet/serverRPC"};
+    yarp::os::Port                      m_thrift_rpcPort;
+    std::string                         m_thrift_rpcPort_Name;
+    std::string                         m_thrift_server_rpcPort_Name;
     mutable FrameTransformStorageGetRPC m_frameTransformStorageGetRPC;
 
 };

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
@@ -27,19 +27,73 @@
  * For further information see \subpage FrameTransform.
 
  *   Parameters required by this device are:
- * | Parameter name  | SubParameter            | Type    | Units          | Default Value                   | Required     | Description                            |
- * |:---------------:|:-----------------------:|:-------:|:--------------:|:-------------------------------:|:-----------: |:--------------------------------------:|
- * | rpc_port_client |      -                  | string  | -              |   /frameTransformGet/clientRPC  | No           | name of the port on which rpc calls should be made |
- * | rpc_port_server |      -                  | string  | -              |   /frameTransformGet/serverRPC  | No           | name of the port on which rpc calls should be made |
- * | streaming_port_client |      -            | string  | -              |   /frameTransformGet/tf:i       | No           | name of the port on which the tfs are received (if the port is enabled) |
- * | streaming_enabled |      -                | bool    | -              |   false                         | No           | if enabled, tfs are received from the streaming port instead of using RPCs |
+ * | Parameter name               | SubParameter | Type    | Units  | Default Value  | Required  | Description                                                                                                                                                                        |
+ * |:----------------------------:|:-------------|:-------:|:------:|:--------------:|:------- -:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+ * | default-client               | -            | bool    | -      | true           | No        | tells whether or not the nwc is instantiated by the frameTransformClient device. If true, "/frameTransformClient" will appended to the port name prefix                            |
+ * | default-server               | -            | bool    | -      | true           | No        | tells whether or not the nws is instantiated by the frameTransformServer device. If true, "/frameTransformServer/frameTransformGet_nws_yarp" will appended to the port name prefix |
+ * | nwc_thrift_port_prefix       | -            | string  | -      | ""             | No        | a prefix for the nwc thrift rpc port name                                                                                                                                          |
+ * | nws_thrift_port_prefix       | -            | string  | -      | ""             | No        | a prefix for the nws thrift rpc port name                                                                                                                                          |
+ * | input_streaming_port_prefix  | -            | string  | -      | -              | No        | a prefix for the input streaming port name (if the port is enabled)                                                                                                                |
+ * | output_streaming_port_prefix | -            | string  | -      | -              | No        | a prefix for the output streaming port name (if the port is enabled)                                                                                                               |
+ * | streaming_enabled            | -            | bool    | -      | false          | No        | if enabled, tfs are received from the streaming port instead of using RPCs                                                                                                         |
+ *
+ * \section FrameTransformGet_nwc_yarp_port_example Port names examples
+ * Here follow some examples of port names obtained with different parameters configurations
+ * -# With
+ *      - default-client = true
+ *      - nwc_thrift_port_prefix = ""\n
+ *        The frameTransformGet_nwc_yarp thrift port name will be: `/frameTransformClient/frameTransformGet_nwc_yarp/thrift`
+ * -# With
+ *      - default-client = true
+ *      - nwc_thrift_port_prefix = "/cer"\n
+ *        The frameTransformGet_nwc_yarp thrift port name will be: `/cer/frameTransformClient/frameTransformGet_nwc_yarp/thrift`
+ * -# With
+ *      - default-client = false
+ *      - nwc_thrift_port_prefix = "/cer"\n
+ *        The frameTransformGet_nwc_yarp thrift port name will be: `/cer/frameTransformGet_nwc_yarp/thrift`
+ * -# With
+ *      - default-server = true
+ *      - nws_thrift_port_prefix = ""\n
+ *        The name of the thrift port the frameTransformGet_nwc_yarp thrift port will connect to will be: `/frameTransformServer/frameTransformGet_nws_yarp/thrift`
+ * -# With
+ *      - default-server = true
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The name of the thrift port the frameTransformGet_nwc_yarp thrift port will connect to will be: `/cer/frameTransformServer/frameTransformGet_nws_yarp/thrift`
+ * -# With
+ *      - default-server = false
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The name of the thrift port the frameTransformGet_nwc_yarp thrift port will connect to will be: `/cer/thrift`
+ * -# With
+ *      - default-client = true
+ *      - input_streaming_port_prefix = ""\n
+ *        The name of the frameTransformGet_nwc_yarp input port for the tf stream will be: `/frameTransformClient/frameTransformGet_nwc_yarp/tf:i`
+ * -# With
+ *      - default-client = true
+ *      - input_streaming_port_prefix = "/cer"\n
+ *        The name of the frameTransformGet_nwc_yarp input port for the tf stream will be: `/cer/frameTransformClient/frameTransformGet_nwc_yarp/tf:i`
+ * -# With
+ *      - default-client = false
+ *      - input_streaming_port_prefix = "/cer"\n
+ *        The name of the frameTransformGet_nwc_yarp input port for the tf stream will be: `/cer/frameTransformGet_nwc_yarp/tf:i`
+ * -# With
+ *      - default-server = true
+ *      - output_streaming_port_prefix = ""\n
+ *        The name of the output port for the tf stream the nwc will connect to will be: `/frameTransformServer/frameTransformGet_nws_yarp/tf:o`
+ * -# With
+ *      - default-server = true
+ *      - output_streaming_port_prefix = "/cer"\n
+ *        The name of the output port for the tf stream the nwc will connect to will be: `/cer/frameTransformServer/frameTransformGet_nws_yarp/tf:o`
+ * -# With
+ *      - default-server = false
+ *      - output_streaming_port_prefix = "/cer"\n
+ *        The name of the output port for the tf stream the nwc will connect to will be: `/cer/tf:o`
  *
  * \section FrameTransformGet_nwc_yarp_device_configuration Example of configuration file using .ini format.
  *
  * \code{.unparsed}
- * device FrameTransformGet_nwc_yarp
- * rpc_port_client /frameTransformGet/clientRPC
- * rpc_port_server /frameTransformGet/clientRPC
+ * device frameTransformGet_nwc_yarp
+ * nwc_thrift_port_prefix /local
+ * nws_thrift_port_prefix /cer
  * \endcode
  */
 class FrameTransformGet_nwc_yarp:

--- a/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
@@ -62,9 +62,6 @@ public:
     bool threadInit() override;
     void threadRelease() override;
     void run() override;
-    bool m_streaming_port_enabled = true;
-    yarp::os::Port m_streaming_port;
-    std::string    m_streaming_port_name{ "/frameTransformGet/tf:o" };
 
     // yarp::dev::DeviceDriver
     bool  open(yarp::os::Searchable &params) override;
@@ -80,14 +77,19 @@ public:
 private:
     // mutable std::vector<std::mutex> m_PolyDriver_mutex;
     // double m_period{const_default_thread_period};
-    int    m_verbose{4};
+    bool            m_streaming_port_enabled = true;
+    int             m_verbose{4};
+    yarp::os::Port  m_streaming_port;
+    std::string     m_streaming_port_name;
+    std::string     m_defaultConfigPrefix{"/frameTransformServer"};
+    std::string     m_deviceName{"frameTransformGet_nws_yarp"};
 
     // for requesting the transforms to FrameTransformStorageGetMultiplexer
     yarp::dev::IFrameTransformStorageGet* m_iFrameTransformStorageGet = nullptr;
 
     // for the RPC with the NWC
-    yarp::os::Port      m_thrift_rpcPort;
-    std::string         m_thrift_rpcPort_Name{"/frameTransformGet/serverRPC"};
+    yarp::os::Port  m_thrift_rpcPort;
+    std::string     m_thrift_rpcPort_Name;
 };
 
 #endif   // YARP_DEV_FRAMETRANSFORMGET_NWS_YARP_H

--- a/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nws_yarp.h
@@ -28,18 +28,47 @@
  * For further information see \subpage FrameTransform.
  *
  *   Parameters required by this device are:
- * | Parameter name  | SubParameter            | Type    | Units          | Default Value                   | Required     | Description                            |
- * |:---------------:|:-----------------------:|:-------:|:--------------:|:-------------------------------:|:-----------: |:--------------------------------------:|
- * | rpc_port_server |      -                  | string  | -              |   /frameTransformGet/serverRPC  | No           | name of the port on which rpc calls should be made |
- * | streaming_port_server |      -            | string  | -              |   /frameTransformGet/tf:o       | No           | name of the port on which the tfs are published periodically |
- * | streaming_enabled |      -                | bool    | -              |   true                          | No           | enable/disable the tf publishing on the streaming port |
- * | period |                                  | float   | s              |   0.010                         | No           | It affects the period of thread publishing transforms on the streaming port |
+ * | Parameter name               | SubParameter            | Type    | Units          | Default Value  | Required  | Description                                                                                                                                             |
+ * |:----------------------------:|:-----------------------:|:-------:|:--------------:|:--------------:|:------- -:|:-------------------------------------------------------------------------------------------------------------------------------------------------------:|
+ * | default-config               |      -                  | bool    | -              | true           | No        | tells whether or not the nws is instanciated by the frameTransformServer device. If true, "/frameTransformServer" will appended to the port name prefix |
+ * | nws_thrift_port_prefix       |      -                  | string  | -              | ""             | No        | a prefix for the nws thrift rpc port name                                                                                                               |
+ * | output_streaming_port_prefix |      -                  | string  | -              | ""             | No        | a prefix for the output streaming port name                                                                                                             |
+ * | streaming_enabled            |      -                  | bool    | -              | true           | No        | enable/disable the tf publishing on the streaming port                                                                                                  |
+ * | period                       |                         | float   | s              | 0.010          | No        | It affects the period of thread publishing transforms on the streaming port                                                                             |
+ *
+ * \section FrameTransformGet_nwc_yarp_port_example Port names examples
+ * Here follow some examples of port names obtained with different parameters configurations
+ * -# With
+ *      - default-config = true
+ *      - nws_thrift_port_prefix = ""\n
+ *        The frameTransformGet_nws_yarp thrift port name will be: `/frameTransformServer/frameTransformGet_nws_yarp/thrift`
+ * -# With
+ *      - default-config = true
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The frameTransformGet_nws_yarp thrift port name will be: `/cer/frameTransformServer/frameTransformGet_nws_yarp/thrift`
+ * -# With
+ *      - default-config = false
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The frameTransformGet_nws_yarp thrift port name will be: `/cer/frameTransformGet_nws_yarp/thrift`
+ * -# With
+ *      - default-config = true
+ *      - output_streaming_port_prefix = ""\n
+ *        The name of the frameTransformGet_nws_yarp output port for the tf stream will be: `/frameTransformServer/frameTransformGet_nws_yarp/tf:o`
+ * -# With
+ *      - default-config = true
+ *      - output_streaming_port_prefix = "/cer"\n
+ *        The name of the frameTransformGet_nws_yarp output port for the tf stream will be: `/cer/frameTransformServer/frameTransformGet_nws_yarp/tf:o`
+ * -# With
+ *      - default-config = false
+ *      - output_streaming_port_prefix = "/cer"\n
+ *        The name of the frameTransformGet_nws_yarp output port for the tf stream will be: `/cer/frameTransformGet_nws_yarp/tf:o`
  *
  * \section FrameTransformGet_nws_yarp_device_configuration Example of configuration file using .ini format.
  *
  * \code{.unparsed}
- * device FrameTransformGet_nws_yarp
- * rpc_port_server /frameTransformGet/serverRPC
+ * device frameTransformGet_nws_yarp
+ * default-config true
+ * thrift_port_prefix /cer
  * \endcode
  */
 

--- a/src/devices/frameTransformServer/FrameTransformServer.h
+++ b/src/devices/frameTransformServer/FrameTransformServer.h
@@ -42,9 +42,10 @@ const int MAX_PORTS = 5;
  * \brief A server to manage FrameTransforms for a robot (see \ref FrameTransform)
  *
  *   Parameters required by this device are:
- * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                          |
- * |:----------------:|:--------------------:|:-------:|:--------------:|:---------------------:|:-----------: |:--------------------------------------------------------------------:|
- * | filexml_option   | -                    | string  | -              | fts_yarp_only.xml    | no           | The name of the xml file containing the needed server configuration  |
+ * | Parameter name   | SubParameter         | Type    | Units          | Default Value        | Required     | Description                                                                                               |
+ * |:----------------:|:--------------------:|:-------:|:--------------:|:--------------------:|:-----------: |:---------------------------------------------------------------------------------------------------------:|
+ * | filexml_option   | -                    | string  | -              | fts_yarp_only.xml    | no           | The name of the xml file containing the needed server configuration                                       |
+ * | ft_server_prefix | -                    | string  | -              | ""                   | no           | A prefix to add to the names of all the ports opened by the NWSs instantiated by the frameTransformServer |
  *
  * Example of command line:
  * \code{.unparsed}

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
@@ -11,7 +11,7 @@
     <devices>
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">
-            <param extern-name="ftSet_server_port" name="rpc_port_server"> /frameTransformSet/serverRPC </param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicestorage"> ftc_storage </elem>
@@ -20,7 +20,8 @@
             <action phase="shutdown" level="5" type="detach" />
         </device>
         <device name="ftGet_nws_yarp" type="frameTransformGet_nws_yarp">
-            <param extern-name="ftGet_server_port" name="rpc_port_server"> /frameTransformGet/serverRPC </param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicestorage"> ftc_storage </elem>

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
@@ -11,7 +11,7 @@
     <devices>
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">
-            <param extern-name="ftSet_server_port" name="rpc_port_server"> /frameTransformSet/serverRPC </param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicestorage"> ftc_storage </elem>
@@ -20,7 +20,8 @@
             <action phase="shutdown" level="5" type="detach" />
         </device>
         <device name="ftGet_nws_yarp" type="frameTransformGet_nws_yarp">
-            <param extern-name="ftGet_server_port" name="rpc_port_server"> /frameTransformGet/serverRPC </param>
+            <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
+            <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicestorage"> ftc_storage </elem>

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.cpp
@@ -28,19 +28,40 @@ bool FrameTransformSet_nwc_yarp::open(yarp::os::Searchable& config)
         yCError(FRAMETRANSFORMSETNWCYARP,"Error! YARP Network is not initialized");
         return false;
     }
+    std::string prefix;
+    //checking default config params
+    bool default_config = true;
+    if(config.check("default-client")) {
+        default_config = config.find("default-client").asString() == "true";
+    }
+    bool default_server = true;
+    if(config.check("default-server")) {
+        default_server = config.find("default-server").asString() == "true";
+    }
     // client port configuration
-    if (config.check("rpc_port_client")){
-        m_thriftPortName = config.find("rpc_port_client").asString();
-    } else {
-        yCWarning(FRAMETRANSFORMSETNWCYARP) << "no rpc_port_client param found, using default one: " << m_thriftPortName;
+    if (config.check("nwc_thrift_port_prefix")){
+        prefix = config.find("nwc_thrift_port_prefix").asString() + (default_config ? m_defaultConfigPrefix : "");
+        if(prefix[0] != '/') {prefix = "/"+prefix;}
+        m_thriftPortName = prefix + "/" + m_deviceName + "/thrift";
+    }
+    else {
+        prefix =  default_config ? m_defaultConfigPrefix : "";
+        m_thriftPortName = prefix + "/" + m_deviceName + "/thrift";
+        yCWarning(FRAMETRANSFORMSETNWCYARP) << "no nwc_thrift_port_prefix param found. The resulting port name will be: " << m_thriftPortName;
     }
 
     //server port configuration
-    if (config.check("rpc_port_server")){
-        m_thrift_server_rpcPort_Name = config.find("rpc_port_server").asString();
-    } else {
-        yCWarning(FRAMETRANSFORMSETNWCYARP) << "no rpc_port_server param found, using default one " << m_thrift_server_rpcPort_Name;
+    if (config.check("nws_thrift_port_prefix")){
+        prefix = config.find("nws_thrift_port_prefix").asString() + (default_server ? m_defaultServerPrefix : "");
+        if(prefix[0] != '/') {prefix = "/"+prefix;}
+        m_thrift_server_rpcPort_Name = prefix + "/thrift";
     }
+    else {
+        prefix =  default_server ? m_defaultServerPrefix : "";
+        m_thrift_server_rpcPort_Name = prefix + "/thrift";
+        yCWarning(FRAMETRANSFORMSETNWCYARP) << "no nws_thrift_port_prefix param found. The resulting port name will be: " << m_thrift_server_rpcPort_Name;
+    }
+
     // rpc inizialisation
     if(!m_thriftPort.open(m_thriftPortName))
     {

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
@@ -24,17 +24,46 @@
  * This device is paired with its server called FrameTransformSet_nws_yarp.
  *
  *   Parameters required by this device are:
- * | Parameter name  | SubParameter            | Type    | Units          | Default Value                   | Required     | Description                            |
- * |:---------------:|:-----------------------:|:-------:|:--------------:|:-------------------------------:|:-----------: |:--------------------------------------:|
- * | rpc_port_client |      -                  | string  | -              |   /frameTransformGet/clientRPC  | No           | port on which rpc calls should be made |
- * | rpc_port_server |      -                  | string  | -              |   /frameTransformGet/serverRPC  | No           | port on which rpc calls should be made |
+ * | Parameter name               | SubParameter | Type    | Units  | Default Value  | Required  | Description                                                                                                                                                                        |
+ * |:----------------------------:|:-------------|:-------:|:------:|:--------------:|:------- -:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+ * | default-client               | -            | bool    | -      | true           | No        | tells whether or not the nwc is instantiated by the frameTransformClient device. If true, "/frameTransformClient" will appended to the port name prefix                            |
+ * | default-server               | -            | bool    | -      | true           | No        | tells whether or not the nws is instantiated by the frameTransformServer device. If true, "/frameTransformServer/frameTransformSet_nws_yarp" will appended to the port name prefix |
+ * | nwc_thrift_port_prefix       | -            | string  | -      | ""             | No        | a prefix for the nwc thrift rpc port name                                                                                                                                          |
+ * | nws_thrift_port_prefix       | -            | string  | -      | ""             | No        | a prefix for the nws thrift rpc port name                                                                                                                                          |
+ *
+ * \section FrameTransformGet_nwc_yarp_port_example Port names examples
+ * Here follow some examples of port names obtained with different parameters configurations
+ * -# With
+ *      - default-client = true
+ *      - nwc_thrift_port_prefix = ""\n
+ *        The frameTransformSet_nwc_yarp thrift port name will be: `/frameTransformClient/frameTransformSet_nwc_yarp/thrift`
+ * -# With
+ *      - default-client = true
+ *      - nwc_thrift_port_prefix = "/cer"\n
+ *        The frameTransformSet_nwc_yarp thrift port name will be: `/cer/frameTransformClient/frameTransformSet_nwc_yarp/thrift`
+ * -# With
+ *      - default-client = false
+ *      - nwc_thrift_port_prefix = "/cer"\n
+ *        The frameTransformSet_nwc_yarp thrift port name will be: `/cer/frameTransformSet_nwc_yarp/thrift`
+ * -# With
+ *      - default-server = true
+ *      - nws_thrift_port_prefix = ""\n
+ *       The name of the thrift port the frameTransformSet_nwc_yarp thrift port will connect to will be: `/frameTransformServer/frameTransformSet_nws_yarp/thrift`
+ * -# With
+ *      - default-server = true
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The name of the thrift port the frameTransformSet_nwc_yarp thrift port will connect to will be: `/cer/frameTransformServer/frameTransformSet_nws_yarp/thrift`
+ * -# With
+ *      - default-server = false
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The name of the thrift port the frameTransformSet_nwc_yarp thrift port will connect to will be: `/cer/thrift`
  *
  * \section FrameTransformSet_nwc_yarp_example Example of configuration file using .ini format.
  *
  * \code{.unparsed}
- * device FrameTransformGet_nwc_yarp
- * rpc_port_client /frameTransformGet/clientRPC
- * rpc_port_server /frameTransformGet/clientRPC
+ * device frameTransformSet_nwc_yarp
+ * nwc_thrift_port_prefix /local
+ * nws_thrift_port_prefix /cer
  * \endcode
  */
 

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
@@ -51,17 +51,20 @@ public:
     bool close() override;
 
     //FrameTransformStorageSetRPC functions
-    virtual bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    virtual bool setTransform(const yarp::math::FrameTransform& transform) override;
-    virtual bool deleteTransform(std::string t1, std::string t2) override;
-    virtual bool clearAll() override;
+    bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    bool setTransform(const yarp::math::FrameTransform& transform) override;
+    bool deleteTransform(std::string t1, std::string t2) override;
+    bool clearAll() override;
 
 private:
     mutable std::mutex          m_trf_mutex;
     mutable std::mutex          m_pd_mutex;
-    std::string                 m_thriftPortName{"/frameTransformSet/clientRPC"};
+    std::string                 m_deviceName{"frameTransformSet_nwc_yarp"};
+    std::string                 m_defaultConfigPrefix{"/frameTransformClient"};
+    std::string                 m_defaultServerPrefix{"/frameTransformServer/frameTransformSet_nws_yarp"};
+    std::string                 m_thriftPortName;
+    std::string                 m_thrift_server_rpcPort_Name;
     yarp::os::Port              m_thriftPort;
-    std::string                 m_thrift_server_rpcPort_Name{"/frameTransformSet/serverRPC"};
     FrameTransformStorageSetRPC m_setRPC;
 };
 

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.cpp
@@ -27,7 +27,25 @@ bool FrameTransformSet_nws_yarp::open(yarp::os::Searchable& config)
         yCError(FRAMETRANSFORMSETNWSYARP,"Error! YARP Network is not initialized");
         return false;
     }
-    if (config.check("rpc_port_server"))       {m_thriftPortName = config.find("rpc_port_server").asString();}
+
+    std::string prefix;
+    //checking default config param
+    bool default_config = true;
+    if(config.check("default-config")) {
+        default_config = config.find("default-config").asString() == "true";
+    }
+    // configuration
+    if (config.check("nws_thrift_port_prefix")){
+        prefix = config.find("nws_thrift_port_prefix").asString() + (default_config ? m_defaultConfigPrefix : "");
+        if(prefix[0] != '/') {prefix = "/"+prefix;}
+        m_thriftPortName = prefix + "/" + m_deviceName + "/thrift";
+    }
+    else {
+        prefix =  default_config ? m_defaultConfigPrefix : "";
+        m_thriftPortName = prefix + "/" + m_deviceName + "/thrift";
+        yCWarning(FRAMETRANSFORMSETNWSYARP) << "no nws_thrift_port_prefix param found. The resulting port name will be: " << m_thriftPortName;
+    }
+
     if(!m_thriftPort.open(m_thriftPortName))
     {
         yCError(FRAMETRANSFORMSETNWSYARP,"Could not open \"%s\" port",m_thriftPortName.c_str());

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
@@ -25,15 +25,32 @@
  * This device is paired with its server called FrameTransformSet_nwc_yarp.
  *
  *   Parameters required by this device are:
- * | Parameter name  | SubParameter            | Type    | Units          | Default Value                   | Required     | Description                            |
- * |:---------------:|:-----------------------:|:-------:|:--------------:|:-------------------------------:|:-----------: |:--------------------------------------:|
- * | rpc_port_server |      -                  | string  | -              |   /frameTransformGet/serverRPC  | No           | port on which rpc calls should be made |
+ * | Parameter name               | SubParameter            | Type    | Units          | Default Value  | Required  | Description                                                                                                                                             |
+ * |:----------------------------:|:-----------------------:|:-------:|:--------------:|:--------------:|:------- -:|:-------------------------------------------------------------------------------------------------------------------------------------------------------:|
+ * | default-config               |      -                  | bool    | -              | true           | No        | tells whether or not the nws is instanciated by the frameTransformServer device. If true, "/frameTransformServer" will appended to the port name prefix |
+ * | nws_thrift_port_prefix       |      -                  | string  | -              | ""             | No        | a prefix for the nws thrift rpc port name                                                                                                               |
+ *
+ * \section FrameTransformGet_nwc_yarp_port_example Port names examples
+ * Here follow some examples of port names obtained with different parameters configurations
+ * -# With
+ *      - default-config = true
+ *      - nws_thrift_port_prefix = ""\n
+ *        The frameTransformSet_nws_yarp thrift port name will be: `/frameTransformServer/frameTransformSet_nws_yarp/thrift`
+ * -# With
+ *      - default-config = true
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The frameTransformSet_nws_yarp thrift port name will be: `/cer/frameTransformServer/frameTransformSet_nws_yarp/thrift`
+ * -# With
+ *      - default-config = false
+ *      - nws_thrift_port_prefix = "/cer"\n
+ *        The frameTransformSet_nws_yarp thrift port name will be: `/cer/frameTransformSet_nws_yarp/thrift`
  *
  * \section FrameTransformSet_nws_yarp_example Example of configuration file using .ini format.
  *
  * \code{.unparsed}
  * device frameTransformSet_nws_yarp
- * rpc_port_server /frameTransformGet/serverRPC
+ * default-config true
+ * nws_thrift_port_prefix /cer
  * \endcode
  */
 

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
@@ -63,8 +63,10 @@ public:
 private:
     mutable std::mutex                      m_pd_mutex;
     mutable std::mutex                      m_trf_mutex;
+    std::string                             m_defaultConfigPrefix{"/frameTransformServer"};
+    std::string                             m_deviceName{"frameTransformSet_nws_yarp"};
     yarp::dev::PolyDriver*                  m_pDriver{nullptr};
-    std::string                             m_thriftPortName{"/frameTransformGet/serverRPC"};
+    std::string                             m_thriftPortName;
     yarp::os::Port                          m_thriftPort;
     yarp::dev::IFrameTransformStorageSet*   m_iSetIf   {nullptr};
     yarp::dev::IFrameTransformStorageUtils* m_iUtilsIf {nullptr};


### PR DESCRIPTION
The following components have been refactored in order to easily manage ports names and avoid errors in doing so:
* frameTransformSet_nwc_yarp
* frameTransformSet_nws_yarp
* frameTransformGet_nwc_yarp
* frameTransformSet_nws_yarp

The xml files containing the configurations for the `frameTransformClient` and the `frameTransformServer` have been updated
accordingly.