### PR TITLE
Yarp log label

### DIFF
--- a/doc/release/master/yarp_log_label.md
+++ b/doc/release/master/yarp_log_label.md
@@ -1,0 +1,15 @@
+yarp_log_label {#master}
+-----------
+
+Important Changes
+-----------------
+
+### YARP_os
+
+* yarp::os::LogForwarder now checks the environment variable `YARP_LOG_PROCESS_LABEL`. 
+  If found, the label is appended to the executable name in the log port name. e.g. /log/hostname/yarpdev[mylabel]/123123
+
+### YARP_run
+
+* yarprun now checks the environment variable `YARP_LOG_PROCESS_LABEL`. 
+  If found, the label is appended to the executable name in the log port name. e.g. /log/yaprunname/yarpdev[mylabel]/123123

--- a/doc/yarp_env_variables.md
+++ b/doc/yarp_env_variables.md
@@ -18,7 +18,7 @@ Logger and print configuration
 | `YARP_TRACE_ENABLE`           | If this variable exists and is set to 1, it enables the YARP trace prints. Otherwise disable the trace prints. | \ref yarp_log |
 | `YARP_DEBUG_ENABLE`           | If this variable exists and is set to 0, it disables the YARP debug prints. Otherwise leaves them enabled. | \ref yarp_log |
 | `YARP_FORWARD_LOG_ENABLE`     | If this variable exists and is set to 1, enables the forwarding of log over ports to be used by the yarplogger. Otherwise disable the forwarding. | \ref yarp_log |
-
+| `YARP_LOG_PROCESS_LABEL`      | If this variable exists and is set to a string, the specified label is attached to the log port to better specify the name of the process to which the log belongs to. | \ref yarp_log |
 
 Directories
 ===========

--- a/doc/yarp_logging.md
+++ b/doc/yarp_logging.md
@@ -16,6 +16,9 @@ YARP is also able to detect if it is running on a console or inside
 [yarplogger](@ref yarplogger) (using the `--log` option), and change its
 output accordingly, so that the extra information is forwarded properly.
 
+When the log is forwarded over the network, the logging process opens a yarp port
+with the following syntax: `/log/hostname/processname/pid`. 
+NOTE: If yarprun is used, hostname is replaced by the name of yarprun server.
 
 ## Log Levels
 
@@ -438,6 +441,18 @@ colored character instead of the log level.
 
 If `YARP_VERBOSE_OUTPUT` is set to `1`, YARP will print several extra
 information for each log line.
+
+User can set 'YARP_LOG_PROCESS_LABEL` to specify a string which can help in identifying the
+process which is currently broadcasting the log over the network. 
+The string will be appended after the process name in the log port and included between
+two square brackets, i.e. `/log/hostname/processname[user_label]/pid`. 
+A typical use case for this environment variable is when multiple [yarprobotinterface](@ref yarprobotinterface)
+and/or [yarpdev](@ref yarpdev) are running simultaneously. In this case, the name log ports are 
+difficult to interpret, since the process name alone is not enough to identify them.
+In this case the user can set a custom label for each of them to better distinguish them
+in the [yarplogger](@ref yarplogger) gui.
+`YARP_LOG_PROCESS_LABEL` can be easily set for each individual process, via [yarpmanager](@ref yarpmanager),
+using the `environment` section.
 
 `YARP_FORWARD_LOG_ENABLE` can be used to enable the forwarding of the log to
 [yarplogger](@ref yarplogger).

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
@@ -13,6 +13,8 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/impl/PlatformLimits.h>
 
+#include <yarp/conf/environment.h>
+
 #include <sstream>
 
 bool yarp::os::impl::LogForwarder::started{false};
@@ -31,9 +33,16 @@ yarp::os::impl::LogForwarder::LogForwarder()
     yarp::os::gethostname(hostname, HOST_NAME_MAX);
 
     yarp::os::SystemInfo::ProcessInfo processInfo = yarp::os::SystemInfo::getProcessInfo();
+    std::string proc_label = yarp::conf::environment::get_string("YARP_LOG_PROCESS_LABEL");
 
     outputPort.setWriteOnly();
-    std::string logPortName = "/log/" + std::string(hostname) + "/" + processInfo.name.substr(processInfo.name.find_last_of("\\/") + 1) + "/" + std::to_string(processInfo.pid);
+    std::string logPortName = "/log/" + std::string(hostname) +
+                              "/" + processInfo.name.substr(processInfo.name.find_last_of("\\/") + 1);
+
+    if (proc_label!="") { logPortName += "[" + proc_label + "]"; }
+
+    logPortName += "/" + std::to_string(processInfo.pid);
+
     if (!outputPort.open(logPortName)) {
         printf("LogForwarder error while opening port %s\n", logPortName.c_str());
     }

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -133,6 +133,19 @@ static bool fileExists(const char *fname)
     }
 }
 
+static std::string getProcLabel(const yarp::os::Bottle& msg)
+{
+    auto ss = yarp::conf::string::split(msg.find("env").asString(), ';');
+    for (const auto& s_iter : ss)
+    {
+        auto sss = yarp::conf::string::split(s_iter, '=');
+        if (sss.size() == 2 && sss[0] == "YARP_LOG_PROCESS_LABEL")
+        {
+            return sss[1];
+        }
+    }
+    return "";
+}
 
 /////////
 int yarp::run::Run::main(int argc, char *argv[])
@@ -1953,20 +1966,6 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
     fprintf(stderr, "%s", out.c_str());
 
     return cmd_process_info.dwProcessId;
-}
-
-std::string getProcLabel (const yarp::os::Bottle& msg)
-{
-    auto ss = yarp::conf::string::split(msg.find("env").asString(), ';');
-    for (const auto& s_iter : ss)
-    {
-        auto sss = yarp::conf::string::split(s_iter, '=');
-        if (sss.size() == 2 && sss[0] == "YARP_LOG_PROCESS_LABEL")
-        {
-            return sss[1];
-        }
-    }
-    return "";
 }
 
 int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -1955,8 +1955,24 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
     return cmd_process_info.dwProcessId;
 }
 
+std::string getProcLabel (const yarp::os::Bottle& msg)
+{
+    auto ss = yarp::conf::string::split(msg.find("env").asString(), ';');
+    for (const auto& s_iter : ss)
+    {
+        auto sss = yarp::conf::string::split(s_iter, '=');
+        if (sss.size() == 2 && sss[0] == "YARP_LOG_PROCESS_LABEL")
+        {
+            return sss[1];
+        }
+    }
+    return "";
+}
+
 int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
 {
+    std::string proc_label = getProcLabel(msg);
+
     std::string strAlias=msg.find("as").asString();
     std::string portName="/log";
     portName+=mPortName+"/";
@@ -1964,6 +1980,7 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
     command = command.substr(0, command.find(' '));
     command = command.substr(command.find_last_of("\\/") + 1);
     portName+=command;
+    if (proc_label != "") { portName += "[" + proc_label + "]"; }
 
     // PIPES
     SECURITY_ATTRIBUTES pipe_sec_attr;
@@ -2908,6 +2925,8 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
 
 int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
 {
+    std::string proc_label = getProcLabel(msg);
+
     std::string strAlias=msg.find("as").asString();
     std::string strCmd=msg.find("cmd").asString();
 
@@ -2919,7 +2938,7 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
     command = command.substr(command.find_last_of("\\/") + 1);
 
     portName+=command;
-
+    if (proc_label != "") { portName += "[" + proc_label + "]"; }
 
 
     int  pipe_cmd_to_stdout[2];


### PR DESCRIPTION
You can now use the new environment variable `YARP_LOG_PROCESS_LABEL` to set an extra label which helps in identifying the name of the process which is performing the log