### PR TITLE
Fixed bug in frameTransformStorage

### DIFF
--- a/doc/release/yarp_3_5/fix_frameTransformStorage_start.md
+++ b/doc/release/yarp_3_5/fix_frameTransformStorage_start.md
@@ -1,0 +1,8 @@
+fix_frameTransformStorage_start {#yarp_3_5}
+-------------------
+
+### Devices
+
+#### `frameTransformStorage`
+
+* Fixed bug in `frameTransformStorage`. The device did not call its `start` method after successfully attaching to a `yarp::dev::IFrameTransformStorageGet` interface. Therefore the device was not able to update its `FrameTransformContainer` storage by querying the device it was attached to.

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -76,6 +76,10 @@ bool FrameTransformStorage::detach()
     std::lock_guard <std::mutex> lg(m_pd_mutex);
     iGetIf = nullptr;
     pDriver = nullptr;
+    if(isRunning())
+    {
+        stop();
+    }
     return true;
 }
 
@@ -87,6 +91,7 @@ bool FrameTransformStorage::attach(yarp::dev::PolyDriver* driver)
         pDriver = driver;
         if (pDriver->view(iGetIf) && iGetIf!=nullptr)
         {
+            start();
             return true;
         }
     }


### PR DESCRIPTION
* Fixed bug in `frameTransformStorage`. The device did not call its `start` method after successfully attaching to a `yarp::dev::IFrameTransformStorageGet` interface. Therefore the device was not able to update its `FrameTransformContainer` storage by querying the device it was attached to.