### PR TITLE
Map2dArea description

### DIFF
--- a/doc/release/master/Map2DArea_description.md
+++ b/doc/release/master/Map2DArea_description.md
@@ -9,3 +9,7 @@ Important Changes
 * `Map2DArea` has been refactored: it now inherits from the thrift defined type Map2DAreaData.thrift
 * `Map2DArea`, `Map2DLocation`, `Map2DPath` now include a `description` field which can be filled by the user for generic purposes
 * The documentation of the thrift types: `Map2DAreaData`, `Map2DLocationData`, `Map2DPathData` has been updated.
+
+### devices
+
+*  Updated `map2DStorage` device to support the new `v3` file format, which includes the description for Map2DLocation, Map2DArea and Map2DPath

--- a/doc/release/master/Map2DArea_description.md
+++ b/doc/release/master/Map2DArea_description.md
@@ -1,0 +1,11 @@
+Map2DArea_description {#master}
+-----------
+
+Important Changes
+-----------------
+
+### YARP_dev
+
+* `Map2DArea` has been refactored: it now inherits from the thrift defined type Map2DAreaData.thrift
+* `Map2DArea`, `Map2DLocation`, `Map2DPath` now include a `description` field which can be filled by the user for generic purposes
+* The documentation of the thrift types: `Map2DAreaData`, `Map2DLocationData`, `Map2DPathData` has been updated.

--- a/src/devices/map2DStorage/map2DStorage.h
+++ b/src/devices/map2DStorage/map2DStorage.h
@@ -105,6 +105,7 @@ public:
 private:
     bool priv_load_locations_and_areas_v1(std::ifstream& file);
     bool priv_load_locations_and_areas_v2(std::ifstream& file);
+    bool priv_load_locations_and_areas_v3(std::ifstream& file);
 
 private:
     yarp::os::ResourceFinder     m_rf_mapCollection;

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -266,6 +266,7 @@ set(YARP_dev_IDL
 if(TARGET YARP::YARP_math)
   list(APPEND YARP_dev_IDL
     idl/Map2DLocationData.thrift
+    idl/Map2DAreaData.thrift
     idl/Map2DPathData.thrift
   )
 endif()

--- a/src/libYARP_dev/src/idl/Map2DAreaData.thrift
+++ b/src/libYARP_dev/src/idl/Map2DAreaData.thrift
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+namespace yarp yarp.dev
+
+struct Vec2D {
+} (
+  yarp.name = "yarp::math::Vec2D<double>"
+  yarp.includefile="yarp/math/Vec2D.h"
+)
+
+struct Map2DAreaData
+{
+    /** name of the map */
+    1: string map_id;
+    /** list of points which define the vertices of the area */
+    2: list<Vec2D> points;
+    /** user defined string*/
+    3: string description;
+}
+(
+    yarp.api.include = "yarp/dev/api.h"
+    yarp.api.keyword = "YARP_dev_API"
+)

--- a/src/libYARP_dev/src/idl/Map2DLocationData.thrift
+++ b/src/libYARP_dev/src/idl/Map2DLocationData.thrift
@@ -7,10 +7,16 @@ namespace yarp yarp.dev
 
 struct Map2DLocationData
 {
+    /** name of the map */
     1: string map_id;
+    /** x position of the location [m], expressed in the map reference frame */
     2: double x;
+    /** y position of the location [m], expressed in the map reference frame  */
     3: double y;
+    /** orientation [deg] in the map reference frame */
     4: double theta;
+    /** user defined string*/
+    5: string description;
 }
 (
     yarp.api.include = "yarp/dev/api.h"

--- a/src/libYARP_dev/src/idl/Map2DPathData.thrift
+++ b/src/libYARP_dev/src/idl/Map2DPathData.thrift
@@ -5,17 +5,18 @@
 
 namespace yarp yarp.dev
 
-struct Map2DLocation
-{
-}
-(
+struct Map2DLocation {
+} (
   yarp.name = "yarp::dev::Nav2D::Map2DLocation"
   yarp.includefile="yarp/dev/Map2DLocation.h"
 )
 
 struct Map2DPathData
 {
+    /** list of waypoints which define the path*/
     1: list<Map2DLocation> waypoints;
+    /** user defined string*/
+    2: string description;
 }
 (
     yarp.api.include = "yarp/dev/api.h"

--- a/src/libYARP_dev/src/idl_generated_code/Map2DAreaData_index.txt
+++ b/src/libYARP_dev/src/idl_generated_code/Map2DAreaData_index.txt
@@ -1,0 +1,2 @@
+yarp/dev/Map2DAreaData.h
+yarp/dev/Map2DAreaData.cpp

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DAreaData.cpp
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DAreaData.cpp
@@ -8,32 +8,38 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
-#include <yarp/dev/Map2DPathData.h>
+#include <yarp/dev/Map2DAreaData.h>
 
 namespace yarp {
 namespace dev {
 
 // Default constructor
-Map2DPathData::Map2DPathData() :
+Map2DAreaData::Map2DAreaData() :
         WirePortable(),
-        waypoints(),
+        map_id(""),
+        points(),
         description("")
 {
 }
 
 // Constructor with field values
-Map2DPathData::Map2DPathData(const std::vector<yarp::dev::Nav2D::Map2DLocation>& waypoints,
+Map2DAreaData::Map2DAreaData(const std::string& map_id,
+                             const std::vector<yarp::math::Vec2D<double>>& points,
                              const std::string& description) :
         WirePortable(),
-        waypoints(waypoints),
+        map_id(map_id),
+        points(points),
         description(description)
 {
 }
 
 // Read structure on a Wire
-bool Map2DPathData::read(yarp::os::idl::WireReader& reader)
+bool Map2DAreaData::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_waypoints(reader)) {
+    if (!read_map_id(reader)) {
+        return false;
+    }
+    if (!read_points(reader)) {
         return false;
     }
     if (!read_description(reader)) {
@@ -43,19 +49,22 @@ bool Map2DPathData::read(yarp::os::idl::WireReader& reader)
 }
 
 // Read structure on a Connection
-bool Map2DPathData::read(yarp::os::ConnectionReader& connection)
+bool Map2DAreaData::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(2)) {
+    if (!reader.readListHeader(3)) {
         return false;
     }
     return read(reader);
 }
 
 // Write structure on a Wire
-bool Map2DPathData::write(const yarp::os::idl::WireWriter& writer) const
+bool Map2DAreaData::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_waypoints(writer)) {
+    if (!write_map_id(writer)) {
+        return false;
+    }
+    if (!write_points(writer)) {
         return false;
     }
     if (!write_description(writer)) {
@@ -65,17 +74,17 @@ bool Map2DPathData::write(const yarp::os::idl::WireWriter& writer) const
 }
 
 // Write structure on a Connection
-bool Map2DPathData::write(yarp::os::ConnectionWriter& connection) const
+bool Map2DAreaData::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(2)) {
+    if (!writer.writeListHeader(3)) {
         return false;
     }
     return write(writer);
 }
 
 // Convert to a printable string
-std::string Map2DPathData::toString() const
+std::string Map2DAreaData::toString() const
 {
     yarp::os::Bottle b;
     b.read(*this);
@@ -83,17 +92,17 @@ std::string Map2DPathData::toString() const
 }
 
 // Editor: default constructor
-Map2DPathData::Editor::Editor()
+Map2DAreaData::Editor::Editor()
 {
     group = 0;
     obj_owned = true;
-    obj = new Map2DPathData;
+    obj = new Map2DAreaData;
     dirty_flags(false);
     yarp().setOwner(*this);
 }
 
 // Editor: constructor with base class
-Map2DPathData::Editor::Editor(Map2DPathData& obj)
+Map2DAreaData::Editor::Editor(Map2DAreaData& obj)
 {
     group = 0;
     obj_owned = false;
@@ -102,7 +111,7 @@ Map2DPathData::Editor::Editor(Map2DPathData& obj)
 }
 
 // Editor: destructor
-Map2DPathData::Editor::~Editor()
+Map2DAreaData::Editor::~Editor()
 {
     if (obj_owned) {
         delete obj;
@@ -110,7 +119,7 @@ Map2DPathData::Editor::~Editor()
 }
 
 // Editor: edit
-bool Map2DPathData::Editor::edit(Map2DPathData& obj, bool dirty)
+bool Map2DAreaData::Editor::edit(Map2DAreaData& obj, bool dirty)
 {
     if (obj_owned) {
         delete this->obj;
@@ -122,71 +131,99 @@ bool Map2DPathData::Editor::edit(Map2DPathData& obj, bool dirty)
 }
 
 // Editor: validity check
-bool Map2DPathData::Editor::isValid() const
+bool Map2DAreaData::Editor::isValid() const
 {
     return obj != nullptr;
 }
 
 // Editor: state
-Map2DPathData& Map2DPathData::Editor::state()
+Map2DAreaData& Map2DAreaData::Editor::state()
 {
     return *obj;
 }
 
 // Editor: grouping begin
-void Map2DPathData::Editor::start_editing()
+void Map2DAreaData::Editor::start_editing()
 {
     group++;
 }
 
 // Editor: grouping end
-void Map2DPathData::Editor::stop_editing()
+void Map2DAreaData::Editor::stop_editing()
 {
     group--;
     if (group == 0 && is_dirty) {
         communicate();
     }
 }
-// Editor: waypoints setter
-void Map2DPathData::Editor::set_waypoints(const std::vector<yarp::dev::Nav2D::Map2DLocation>& waypoints)
+// Editor: map_id setter
+void Map2DAreaData::Editor::set_map_id(const std::string& map_id)
 {
-    will_set_waypoints();
-    obj->waypoints = waypoints;
-    mark_dirty_waypoints();
+    will_set_map_id();
+    obj->map_id = map_id;
+    mark_dirty_map_id();
     communicate();
-    did_set_waypoints();
+    did_set_map_id();
 }
 
-// Editor: waypoints setter (list)
-void Map2DPathData::Editor::set_waypoints(size_t index, const yarp::dev::Nav2D::Map2DLocation& elem)
+// Editor: map_id getter
+const std::string& Map2DAreaData::Editor::get_map_id() const
 {
-    will_set_waypoints();
-    obj->waypoints[index] = elem;
-    mark_dirty_waypoints();
-    communicate();
-    did_set_waypoints();
+    return obj->map_id;
 }
 
-// Editor: waypoints getter
-const std::vector<yarp::dev::Nav2D::Map2DLocation>& Map2DPathData::Editor::get_waypoints() const
-{
-    return obj->waypoints;
-}
-
-// Editor: waypoints will_set
-bool Map2DPathData::Editor::will_set_waypoints()
+// Editor: map_id will_set
+bool Map2DAreaData::Editor::will_set_map_id()
 {
     return true;
 }
 
-// Editor: waypoints did_set
-bool Map2DPathData::Editor::did_set_waypoints()
+// Editor: map_id did_set
+bool Map2DAreaData::Editor::did_set_map_id()
+{
+    return true;
+}
+
+// Editor: points setter
+void Map2DAreaData::Editor::set_points(const std::vector<yarp::math::Vec2D<double>>& points)
+{
+    will_set_points();
+    obj->points = points;
+    mark_dirty_points();
+    communicate();
+    did_set_points();
+}
+
+// Editor: points setter (list)
+void Map2DAreaData::Editor::set_points(size_t index, const yarp::math::Vec2D<double>& elem)
+{
+    will_set_points();
+    obj->points[index] = elem;
+    mark_dirty_points();
+    communicate();
+    did_set_points();
+}
+
+// Editor: points getter
+const std::vector<yarp::math::Vec2D<double>>& Map2DAreaData::Editor::get_points() const
+{
+    return obj->points;
+}
+
+// Editor: points will_set
+bool Map2DAreaData::Editor::will_set_points()
+{
+    return true;
+}
+
+// Editor: points did_set
+bool Map2DAreaData::Editor::did_set_points()
 {
     return true;
 }
 
 // Editor: description setter
-void Map2DPathData::Editor::set_description(const std::string& description)
+void Map2DAreaData::Editor::set_description(const std::string& description)
 {
     will_set_description();
     obj->description = description;
@@ -196,31 +233,31 @@ void Map2DPathData::Editor::set_description(const std::string& description)
 }
 
 // Editor: description getter
-const std::string& Map2DPathData::Editor::get_description() const
+const std::string& Map2DAreaData::Editor::get_description() const
 {
     return obj->description;
 }
 
 // Editor: description will_set
-bool Map2DPathData::Editor::will_set_description()
+bool Map2DAreaData::Editor::will_set_description()
 {
     return true;
 }
 
 // Editor: description did_set
-bool Map2DPathData::Editor::did_set_description()
+bool Map2DAreaData::Editor::did_set_description()
 {
     return true;
 }
 
 // Editor: clean
-void Map2DPathData::Editor::clean()
+void Map2DAreaData::Editor::clean()
 {
     dirty_flags(false);
 }
 
 // Editor: read
-bool Map2DPathData::Editor::read(yarp::os::ConnectionReader& connection)
+bool Map2DAreaData::Editor::read(yarp::os::ConnectionReader& connection)
 {
     if (!isValid()) {
         return false;
@@ -262,14 +299,25 @@ bool Map2DPathData::Editor::read(yarp::os::ConnectionReader& connection)
             if (!reader.readString(field)) {
                 return false;
             }
-            if (field == "waypoints") {
+            if (field == "map_id") {
                 if (!writer.writeListHeader(2)) {
                     return false;
                 }
-                if (!writer.writeString("std::vector<yarp::dev::Nav2D::Map2DLocation> waypoints")) {
+                if (!writer.writeString("std::string map_id")) {
                     return false;
                 }
-                if (!writer.writeString("list of waypoints which define the path")) {
+                if (!writer.writeString("name of the map")) {
+                    return false;
+                }
+            }
+            if (field == "points") {
+                if (!writer.writeListHeader(2)) {
+                    return false;
+                }
+                if (!writer.writeString("std::vector<yarp::math::Vec2D<double>> points")) {
+                    return false;
+                }
+                if (!writer.writeString("list of points which define the vertices of the area")) {
                     return false;
                 }
             }
@@ -285,11 +333,12 @@ bool Map2DPathData::Editor::read(yarp::os::ConnectionReader& connection)
                 }
             }
         }
-        if (!writer.writeListHeader(3)) {
+        if (!writer.writeListHeader(4)) {
             return false;
         }
         writer.writeString("*** Available fields:");
-        writer.writeString("waypoints");
+        writer.writeString("map_id");
+        writer.writeString("points");
         writer.writeString("description");
         return true;
     }
@@ -317,12 +366,18 @@ bool Map2DPathData::Editor::read(yarp::os::ConnectionReader& connection)
         if (!reader.readString(key)) {
             return false;
         }
-        if (key == "waypoints") {
-            will_set_waypoints();
-            if (!obj->nested_read_waypoints(reader)) {
+        if (key == "map_id") {
+            will_set_map_id();
+            if (!obj->nested_read_map_id(reader)) {
                 return false;
             }
-            did_set_waypoints();
+            did_set_map_id();
+        } else if (key == "points") {
+            will_set_points();
+            if (!obj->nested_read_points(reader)) {
+                return false;
+            }
+            did_set_points();
         } else if (key == "description") {
             will_set_description();
             if (!obj->nested_read_description(reader)) {
@@ -344,7 +399,7 @@ bool Map2DPathData::Editor::read(yarp::os::ConnectionReader& connection)
 }
 
 // Editor: write
-bool Map2DPathData::Editor::write(yarp::os::ConnectionWriter& connection) const
+bool Map2DAreaData::Editor::write(yarp::os::ConnectionWriter& connection) const
 {
     if (!isValid()) {
         return false;
@@ -356,17 +411,31 @@ bool Map2DPathData::Editor::write(yarp::os::ConnectionWriter& connection) const
     if (!writer.writeString("patch")) {
         return false;
     }
-    if (is_dirty_waypoints) {
+    if (is_dirty_map_id) {
         if (!writer.writeListHeader(3)) {
             return false;
         }
         if (!writer.writeString("set")) {
             return false;
         }
-        if (!writer.writeString("waypoints")) {
+        if (!writer.writeString("map_id")) {
             return false;
         }
-        if (!obj->nested_write_waypoints(writer)) {
+        if (!obj->nested_write_map_id(writer)) {
+            return false;
+        }
+    }
+    if (is_dirty_points) {
+        if (!writer.writeListHeader(3)) {
+            return false;
+        }
+        if (!writer.writeString("set")) {
+            return false;
+        }
+        if (!writer.writeString("points")) {
+            return false;
+        }
+        if (!obj->nested_write_points(writer)) {
             return false;
         }
     }
@@ -388,7 +457,7 @@ bool Map2DPathData::Editor::write(yarp::os::ConnectionWriter& connection) const
 }
 
 // Editor: send if possible
-void Map2DPathData::Editor::communicate()
+void Map2DAreaData::Editor::communicate()
 {
     if (group != 0) {
         return;
@@ -400,24 +469,35 @@ void Map2DPathData::Editor::communicate()
 }
 
 // Editor: mark dirty overall
-void Map2DPathData::Editor::mark_dirty()
+void Map2DAreaData::Editor::mark_dirty()
 {
     is_dirty = true;
 }
 
-// Editor: waypoints mark_dirty
-void Map2DPathData::Editor::mark_dirty_waypoints()
+// Editor: map_id mark_dirty
+void Map2DAreaData::Editor::mark_dirty_map_id()
 {
-    if (is_dirty_waypoints) {
+    if (is_dirty_map_id) {
         return;
     }
     dirty_count++;
-    is_dirty_waypoints = true;
+    is_dirty_map_id = true;
+    mark_dirty();
+}
+
+// Editor: points mark_dirty
+void Map2DAreaData::Editor::mark_dirty_points()
+{
+    if (is_dirty_points) {
+        return;
+    }
+    dirty_count++;
+    is_dirty_points = true;
     mark_dirty();
 }
 
 // Editor: description mark_dirty
-void Map2DPathData::Editor::mark_dirty_description()
+void Map2DAreaData::Editor::mark_dirty_description()
 {
     if (is_dirty_description) {
         return;
@@ -428,24 +508,63 @@ void Map2DPathData::Editor::mark_dirty_description()
 }
 
 // Editor: dirty_flags
-void Map2DPathData::Editor::dirty_flags(bool flag)
+void Map2DAreaData::Editor::dirty_flags(bool flag)
 {
     is_dirty = flag;
-    is_dirty_waypoints = flag;
+    is_dirty_map_id = flag;
+    is_dirty_points = flag;
     is_dirty_description = flag;
-    dirty_count = flag ? 2 : 0;
+    dirty_count = flag ? 3 : 0;
 }
 
-// read waypoints field
-bool Map2DPathData::read_waypoints(yarp::os::idl::WireReader& reader)
+// read map_id field
+bool Map2DAreaData::read_map_id(yarp::os::idl::WireReader& reader)
 {
-    waypoints.clear();
+    if (!reader.readString(map_id)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write map_id field
+bool Map2DAreaData::write_map_id(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeString(map_id)) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) map_id field
+bool Map2DAreaData::nested_read_map_id(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readString(map_id)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write (nested) map_id field
+bool Map2DAreaData::nested_write_map_id(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeString(map_id)) {
+        return false;
+    }
+    return true;
+}
+
+// read points field
+bool Map2DAreaData::read_points(yarp::os::idl::WireReader& reader)
+{
+    points.clear();
     uint32_t _size0;
     yarp::os::idl::WireState _etype3;
     reader.readListBegin(_etype3, _size0);
-    waypoints.resize(_size0);
+    points.resize(_size0);
     for (size_t _i4 = 0; _i4 < _size0; ++_i4) {
-        if (!reader.readNested(waypoints[_i4])) {
+        if (!reader.readNested(points[_i4])) {
             reader.fail();
             return false;
         }
@@ -454,13 +573,13 @@ bool Map2DPathData::read_waypoints(yarp::os::idl::WireReader& reader)
     return true;
 }
 
-// write waypoints field
-bool Map2DPathData::write_waypoints(const yarp::os::idl::WireWriter& writer) const
+// write points field
+bool Map2DAreaData::write_points(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(waypoints.size()))) {
+    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(points.size()))) {
         return false;
     }
-    for (const auto& _item5 : waypoints) {
+    for (const auto& _item5 : points) {
         if (!writer.writeNested(_item5)) {
             return false;
         }
@@ -471,16 +590,16 @@ bool Map2DPathData::write_waypoints(const yarp::os::idl::WireWriter& writer) con
     return true;
 }
 
-// read (nested) waypoints field
-bool Map2DPathData::nested_read_waypoints(yarp::os::idl::WireReader& reader)
+// read (nested) points field
+bool Map2DAreaData::nested_read_points(yarp::os::idl::WireReader& reader)
 {
-    waypoints.clear();
+    points.clear();
     uint32_t _size6;
     yarp::os::idl::WireState _etype9;
     reader.readListBegin(_etype9, _size6);
-    waypoints.resize(_size6);
+    points.resize(_size6);
     for (size_t _i10 = 0; _i10 < _size6; ++_i10) {
-        if (!reader.readNested(waypoints[_i10])) {
+        if (!reader.readNested(points[_i10])) {
             reader.fail();
             return false;
         }
@@ -489,13 +608,13 @@ bool Map2DPathData::nested_read_waypoints(yarp::os::idl::WireReader& reader)
     return true;
 }
 
-// write (nested) waypoints field
-bool Map2DPathData::nested_write_waypoints(const yarp::os::idl::WireWriter& writer) const
+// write (nested) points field
+bool Map2DAreaData::nested_write_points(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(waypoints.size()))) {
+    if (!writer.writeListBegin(BOTTLE_TAG_LIST, static_cast<uint32_t>(points.size()))) {
         return false;
     }
-    for (const auto& _item11 : waypoints) {
+    for (const auto& _item11 : points) {
         if (!writer.writeNested(_item11)) {
             return false;
         }
@@ -507,7 +626,7 @@ bool Map2DPathData::nested_write_waypoints(const yarp::os::idl::WireWriter& writ
 }
 
 // read description field
-bool Map2DPathData::read_description(yarp::os::idl::WireReader& reader)
+bool Map2DAreaData::read_description(yarp::os::idl::WireReader& reader)
 {
     if (!reader.readString(description)) {
         reader.fail();
@@ -517,7 +636,7 @@ bool Map2DPathData::read_description(yarp::os::idl::WireReader& reader)
 }
 
 // write description field
-bool Map2DPathData::write_description(const yarp::os::idl::WireWriter& writer) const
+bool Map2DAreaData::write_description(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeString(description)) {
         return false;
@@ -526,7 +645,7 @@ bool Map2DPathData::write_description(const yarp::os::idl::WireWriter& writer) c
 }
 
 // read (nested) description field
-bool Map2DPathData::nested_read_description(yarp::os::idl::WireReader& reader)
+bool Map2DAreaData::nested_read_description(yarp::os::idl::WireReader& reader)
 {
     if (!reader.readString(description)) {
         reader.fail();
@@ -536,7 +655,7 @@ bool Map2DPathData::nested_read_description(yarp::os::idl::WireReader& reader)
 }
 
 // write (nested) description field
-bool Map2DPathData::nested_write_description(const yarp::os::idl::WireWriter& writer) const
+bool Map2DAreaData::nested_write_description(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeString(description)) {
         return false;

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DAreaData.h
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DAreaData.h
@@ -8,37 +8,42 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
-#ifndef YARP_THRIFT_GENERATOR_STRUCT_MAP2DPATHDATA_H
-#define YARP_THRIFT_GENERATOR_STRUCT_MAP2DPATHDATA_H
+#ifndef YARP_THRIFT_GENERATOR_STRUCT_MAP2DAREADATA_H
+#define YARP_THRIFT_GENERATOR_STRUCT_MAP2DAREADATA_H
 
 #include <yarp/dev/api.h>
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
-#include <yarp/dev/Map2DLocation.h>
+#include <yarp/math/Vec2D.h>
 
 namespace yarp {
 namespace dev {
 
-class YARP_dev_API Map2DPathData :
+class YARP_dev_API Map2DAreaData :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
     /**
-     * list of waypoints which define the path
+     * name of the map
      */
-    std::vector<yarp::dev::Nav2D::Map2DLocation> waypoints;
+    std::string map_id;
+    /**
+     * list of points which define the vertices of the area
+     */
+    std::vector<yarp::math::Vec2D<double>> points;
     /**
      * user defined string
      */
     std::string description;
 
     // Default constructor
-    Map2DPathData();
+    Map2DAreaData();
 
     // Constructor with field values
-    Map2DPathData(const std::vector<yarp::dev::Nav2D::Map2DLocation>& waypoints,
+    Map2DAreaData(const std::string& map_id,
+                  const std::vector<yarp::math::Vec2D<double>>& points,
                   const std::string& description);
 
     // Read structure on a Wire
@@ -57,7 +62,7 @@ public:
     std::string toString() const;
 
     // If you want to serialize this class without nesting, use this helper
-    typedef yarp::os::idl::Unwrapped<Map2DPathData> unwrapped;
+    typedef yarp::os::idl::Unwrapped<Map2DAreaData> unwrapped;
 
     class Editor :
             public yarp::os::Wire,
@@ -68,7 +73,7 @@ public:
         Editor();
 
         // Editor: constructor with base class
-        Editor(Map2DPathData& obj);
+        Editor(Map2DAreaData& obj);
 
         // Editor: destructor
         ~Editor() override;
@@ -80,13 +85,13 @@ public:
         Editor& operator=(Editor&& rhs) = delete;
 
         // Editor: edit
-        bool edit(Map2DPathData& obj, bool dirty = true);
+        bool edit(Map2DAreaData& obj, bool dirty = true);
 
         // Editor: validity check
         bool isValid() const;
 
         // Editor: state
-        Map2DPathData& state();
+        Map2DAreaData& state();
 
         // Editor: start editing
         void start_editing();
@@ -110,12 +115,18 @@ public:
         }
 #endif // YARP_NO_DEPRECATED
 
-        // Editor: waypoints field
-        void set_waypoints(const std::vector<yarp::dev::Nav2D::Map2DLocation>& waypoints);
-        void set_waypoints(size_t index, const yarp::dev::Nav2D::Map2DLocation& elem);
-        const std::vector<yarp::dev::Nav2D::Map2DLocation>& get_waypoints() const;
-        virtual bool will_set_waypoints();
-        virtual bool did_set_waypoints();
+        // Editor: map_id field
+        void set_map_id(const std::string& map_id);
+        const std::string& get_map_id() const;
+        virtual bool will_set_map_id();
+        virtual bool did_set_map_id();
+
+        // Editor: points field
+        void set_points(const std::vector<yarp::math::Vec2D<double>>& points);
+        void set_points(size_t index, const yarp::math::Vec2D<double>& elem);
+        const std::vector<yarp::math::Vec2D<double>>& get_points() const;
+        virtual bool will_set_points();
+        virtual bool did_set_points();
 
         // Editor: description field
         void set_description(const std::string& description);
@@ -134,13 +145,14 @@ public:
 
     private:
         // Editor: state
-        Map2DPathData* obj;
+        Map2DAreaData* obj;
         bool obj_owned;
         int group;
 
         // Editor: dirty variables
         bool is_dirty;
-        bool is_dirty_waypoints;
+        bool is_dirty_map_id;
+        bool is_dirty_points;
         bool is_dirty_description;
         int dirty_count;
 
@@ -151,7 +163,8 @@ public:
         void mark_dirty();
 
         // Editor: mark dirty single fields
-        void mark_dirty_waypoints();
+        void mark_dirty_map_id();
+        void mark_dirty_points();
         void mark_dirty_description();
 
         // Editor: dirty_flags
@@ -159,11 +172,17 @@ public:
     };
 
 private:
-    // read/write waypoints field
-    bool read_waypoints(yarp::os::idl::WireReader& reader);
-    bool write_waypoints(const yarp::os::idl::WireWriter& writer) const;
-    bool nested_read_waypoints(yarp::os::idl::WireReader& reader);
-    bool nested_write_waypoints(const yarp::os::idl::WireWriter& writer) const;
+    // read/write map_id field
+    bool read_map_id(yarp::os::idl::WireReader& reader);
+    bool write_map_id(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_map_id(yarp::os::idl::WireReader& reader);
+    bool nested_write_map_id(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write points field
+    bool read_points(yarp::os::idl::WireReader& reader);
+    bool write_points(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_points(yarp::os::idl::WireReader& reader);
+    bool nested_write_points(const yarp::os::idl::WireWriter& writer) const;
 
     // read/write description field
     bool read_description(yarp::os::idl::WireReader& reader);
@@ -175,4 +194,4 @@ private:
 } // namespace yarp
 } // namespace dev
 
-#endif // YARP_THRIFT_GENERATOR_STRUCT_MAP2DPATHDATA_H
+#endif // YARP_THRIFT_GENERATOR_STRUCT_MAP2DAREADATA_H

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DLocationData.cpp
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DLocationData.cpp
@@ -19,7 +19,8 @@ Map2DLocationData::Map2DLocationData() :
         map_id(""),
         x(0),
         y(0),
-        theta(0)
+        theta(0),
+        description("")
 {
 }
 
@@ -27,12 +28,14 @@ Map2DLocationData::Map2DLocationData() :
 Map2DLocationData::Map2DLocationData(const std::string& map_id,
                                      const double x,
                                      const double y,
-                                     const double theta) :
+                                     const double theta,
+                                     const std::string& description) :
         WirePortable(),
         map_id(map_id),
         x(x),
         y(y),
-        theta(theta)
+        theta(theta),
+        description(description)
 {
 }
 
@@ -51,6 +54,9 @@ bool Map2DLocationData::read(yarp::os::idl::WireReader& reader)
     if (!read_theta(reader)) {
         return false;
     }
+    if (!read_description(reader)) {
+        return false;
+    }
     return !reader.isError();
 }
 
@@ -58,7 +64,7 @@ bool Map2DLocationData::read(yarp::os::idl::WireReader& reader)
 bool Map2DLocationData::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(4)) {
+    if (!reader.readListHeader(5)) {
         return false;
     }
     return read(reader);
@@ -79,6 +85,9 @@ bool Map2DLocationData::write(const yarp::os::idl::WireWriter& writer) const
     if (!write_theta(writer)) {
         return false;
     }
+    if (!write_description(writer)) {
+        return false;
+    }
     return !writer.isError();
 }
 
@@ -86,7 +95,7 @@ bool Map2DLocationData::write(const yarp::os::idl::WireWriter& writer) const
 bool Map2DLocationData::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(4)) {
+    if (!writer.writeListHeader(5)) {
         return false;
     }
     return write(writer);
@@ -277,6 +286,34 @@ bool Map2DLocationData::Editor::did_set_theta()
     return true;
 }
 
+// Editor: description setter
+void Map2DLocationData::Editor::set_description(const std::string& description)
+{
+    will_set_description();
+    obj->description = description;
+    mark_dirty_description();
+    communicate();
+    did_set_description();
+}
+
+// Editor: description getter
+const std::string& Map2DLocationData::Editor::get_description() const
+{
+    return obj->description;
+}
+
+// Editor: description will_set
+bool Map2DLocationData::Editor::will_set_description()
+{
+    return true;
+}
+
+// Editor: description did_set
+bool Map2DLocationData::Editor::did_set_description()
+{
+    return true;
+}
+
 // Editor: clean
 void Map2DLocationData::Editor::clean()
 {
@@ -327,39 +364,62 @@ bool Map2DLocationData::Editor::read(yarp::os::ConnectionReader& connection)
                 return false;
             }
             if (field == "map_id") {
-                if (!writer.writeListHeader(1)) {
+                if (!writer.writeListHeader(2)) {
                     return false;
                 }
                 if (!writer.writeString("std::string map_id")) {
                     return false;
                 }
+                if (!writer.writeString("name of the map")) {
+                    return false;
+                }
             }
             if (field == "x") {
-                if (!writer.writeListHeader(1)) {
+                if (!writer.writeListHeader(2)) {
                     return false;
                 }
                 if (!writer.writeString("double x")) {
                     return false;
                 }
+                if (!writer.writeString("x position of the location [m], expressed in the map reference frame")) {
+                    return false;
+                }
             }
             if (field == "y") {
-                if (!writer.writeListHeader(1)) {
+                if (!writer.writeListHeader(2)) {
                     return false;
                 }
                 if (!writer.writeString("double y")) {
                     return false;
                 }
+                if (!writer.writeString("y position of the location [m], expressed in the map reference frame")) {
+                    return false;
+                }
             }
             if (field == "theta") {
-                if (!writer.writeListHeader(1)) {
+                if (!writer.writeListHeader(2)) {
                     return false;
                 }
                 if (!writer.writeString("double theta")) {
                     return false;
                 }
+                if (!writer.writeString("orientation [deg] in the map reference frame")) {
+                    return false;
+                }
+            }
+            if (field == "description") {
+                if (!writer.writeListHeader(2)) {
+                    return false;
+                }
+                if (!writer.writeString("std::string description")) {
+                    return false;
+                }
+                if (!writer.writeString("user defined string")) {
+                    return false;
+                }
             }
         }
-        if (!writer.writeListHeader(5)) {
+        if (!writer.writeListHeader(6)) {
             return false;
         }
         writer.writeString("*** Available fields:");
@@ -367,6 +427,7 @@ bool Map2DLocationData::Editor::read(yarp::os::ConnectionReader& connection)
         writer.writeString("x");
         writer.writeString("y");
         writer.writeString("theta");
+        writer.writeString("description");
         return true;
     }
     bool nested = true;
@@ -417,6 +478,12 @@ bool Map2DLocationData::Editor::read(yarp::os::ConnectionReader& connection)
                 return false;
             }
             did_set_theta();
+        } else if (key == "description") {
+            will_set_description();
+            if (!obj->nested_read_description(reader)) {
+                return false;
+            }
+            did_set_description();
         } else {
             // would be useful to have a fallback here
         }
@@ -500,6 +567,20 @@ bool Map2DLocationData::Editor::write(yarp::os::ConnectionWriter& connection) co
             return false;
         }
     }
+    if (is_dirty_description) {
+        if (!writer.writeListHeader(3)) {
+            return false;
+        }
+        if (!writer.writeString("set")) {
+            return false;
+        }
+        if (!writer.writeString("description")) {
+            return false;
+        }
+        if (!obj->nested_write_description(writer)) {
+            return false;
+        }
+    }
     return !writer.isError();
 }
 
@@ -565,6 +646,17 @@ void Map2DLocationData::Editor::mark_dirty_theta()
     mark_dirty();
 }
 
+// Editor: description mark_dirty
+void Map2DLocationData::Editor::mark_dirty_description()
+{
+    if (is_dirty_description) {
+        return;
+    }
+    dirty_count++;
+    is_dirty_description = true;
+    mark_dirty();
+}
+
 // Editor: dirty_flags
 void Map2DLocationData::Editor::dirty_flags(bool flag)
 {
@@ -573,7 +665,8 @@ void Map2DLocationData::Editor::dirty_flags(bool flag)
     is_dirty_x = flag;
     is_dirty_y = flag;
     is_dirty_theta = flag;
-    dirty_count = flag ? 4 : 0;
+    is_dirty_description = flag;
+    dirty_count = flag ? 5 : 0;
 }
 
 // read map_id field
@@ -723,6 +816,44 @@ bool Map2DLocationData::nested_read_theta(yarp::os::idl::WireReader& reader)
 bool Map2DLocationData::nested_write_theta(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeFloat64(theta)) {
+        return false;
+    }
+    return true;
+}
+
+// read description field
+bool Map2DLocationData::read_description(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readString(description)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write description field
+bool Map2DLocationData::write_description(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeString(description)) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) description field
+bool Map2DLocationData::nested_read_description(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readString(description)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write (nested) description field
+bool Map2DLocationData::nested_write_description(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeString(description)) {
         return false;
     }
     return true;

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DLocationData.h
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/Map2DLocationData.h
@@ -24,10 +24,26 @@ class YARP_dev_API Map2DLocationData :
 {
 public:
     // Fields
+    /**
+     * name of the map
+     */
     std::string map_id;
+    /**
+     * x position of the location [m], expressed in the map reference frame
+     */
     double x;
+    /**
+     * y position of the location [m], expressed in the map reference frame
+     */
     double y;
+    /**
+     * orientation [deg] in the map reference frame
+     */
     double theta;
+    /**
+     * user defined string
+     */
+    std::string description;
 
     // Default constructor
     Map2DLocationData();
@@ -36,7 +52,8 @@ public:
     Map2DLocationData(const std::string& map_id,
                       const double x,
                       const double y,
-                      const double theta);
+                      const double theta,
+                      const std::string& description);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;
@@ -131,6 +148,12 @@ public:
         virtual bool will_set_theta();
         virtual bool did_set_theta();
 
+        // Editor: description field
+        void set_description(const std::string& description);
+        const std::string& get_description() const;
+        virtual bool will_set_description();
+        virtual bool did_set_description();
+
         // Editor: clean
         void clean();
 
@@ -152,6 +175,7 @@ public:
         bool is_dirty_x;
         bool is_dirty_y;
         bool is_dirty_theta;
+        bool is_dirty_description;
         int dirty_count;
 
         // Editor: send if possible
@@ -165,6 +189,7 @@ public:
         void mark_dirty_x();
         void mark_dirty_y();
         void mark_dirty_theta();
+        void mark_dirty_description();
 
         // Editor: dirty_flags
         void dirty_flags(bool flag);
@@ -194,6 +219,12 @@ private:
     bool write_theta(const yarp::os::idl::WireWriter& writer) const;
     bool nested_read_theta(yarp::os::idl::WireReader& reader);
     bool nested_write_theta(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write description field
+    bool read_description(yarp::os::idl::WireReader& reader);
+    bool write_description(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_description(yarp::os::idl::WireReader& reader);
+    bool nested_write_description(const yarp::os::idl::WireWriter& writer) const;
 };
 
 } // namespace yarp

--- a/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
@@ -38,15 +38,17 @@ int pnpoly(std::vector<yarp::math::Vec2D<double>> points, double testx, double t
     return c;
 }
 
-Map2DArea::Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points)
+Map2DArea::Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points, const std::string& desc)
 {
     map_id = map_name;
     points = area_points;
+    description = desc;
 }
 
-Map2DArea::Map2DArea(const std::string& map_name, const std::vector<Map2DLocation> area_points)
+Map2DArea::Map2DArea(const std::string& map_name, const std::vector<Map2DLocation> area_points, const std::string& desc)
 {
     map_id = map_name;
+    description = desc;
     for (auto it = area_points.begin(); it != area_points.end(); it++)
     {
 #if 0
@@ -69,68 +71,6 @@ Map2DArea::Map2DArea()
     map_id = "";
 }
 
-bool Map2DArea::read(yarp::os::ConnectionReader& connection)
-{
-    // auto-convert text mode interaction
-    connection.convertTextMode();
-
-    //[[maybe_unused]] int32_t dummy; //@@@FIXME To be used as soon as C++17 becomes available
-    int32_t dummy;
-
-    dummy = connection.expectInt32();
-    assert(dummy == BOTTLE_TAG_LIST);
-    dummy = connection.expectInt32();
-
-    dummy = connection.expectInt32();
-    assert(dummy == BOTTLE_TAG_STRING);
-    int string_size = connection.expectInt32();
-    this->map_id.resize(string_size);
-    connection.expectBlock(const_cast<char*>(this->map_id.data()), string_size);
-
-    dummy = connection.expectInt32();
-    assert(dummy == BOTTLE_TAG_INT32);
-    size_t siz = connection.expectInt32();
-
-    this->points.clear();
-    for (size_t i = 0; i < siz; i++)
-    {
-        dummy = connection.expectInt32();
-        assert(dummy == BOTTLE_TAG_FLOAT64);
-        double x = connection.expectFloat64();
-        dummy = connection.expectInt32();
-        assert(dummy == BOTTLE_TAG_FLOAT64);
-        double y = connection.expectFloat64();
-        this->points.push_back(yarp::math::Vec2D<double>(x, y));
-    }
-
-    return !connection.isError();
-}
-
-bool Map2DArea::write(yarp::os::ConnectionWriter& connection) const
-{
-    size_t siz = this->points.size();
-
-    connection.appendInt32(BOTTLE_TAG_LIST);
-    connection.appendInt32(2+siz*2);
-
-    connection.appendInt32(BOTTLE_TAG_STRING);
-    connection.appendString(map_id);
-
-    connection.appendInt32(BOTTLE_TAG_INT32);
-    connection.appendInt32(siz);
-
-    for (size_t i = 0; i < siz; i++)
-    {
-        connection.appendInt32(BOTTLE_TAG_FLOAT64);
-        connection.appendFloat64(this->points[i].x);
-        connection.appendInt32(BOTTLE_TAG_FLOAT64);
-        connection.appendFloat64(this->points[i].y);
-    }
-
-    connection.convertTextMode();
-    return !connection.isError();
-}
-
 std::string Map2DArea::toString() const
 {
     std::ostringstream stringStream;
@@ -141,6 +81,7 @@ std::string Map2DArea::toString() const
     {
         stringStream << " point " << i << "(" << points[i].x << "," << points[i].y << ")";
     }
+    stringStream << std::string("desc:") << description;
     return stringStream.str();
 }
 
@@ -266,6 +207,7 @@ bool  Map2DArea::getRandomLocation(Map2DLocation& loc)
 
 void Map2DArea::clear()
 {
+    this->description="";
     this->map_id = "";
     this->points.clear();
 }

--- a/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DArea.cpp
@@ -38,14 +38,14 @@ int pnpoly(std::vector<yarp::math::Vec2D<double>> points, double testx, double t
     return c;
 }
 
-Map2DArea::Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points, const std::string& desc)
+Map2DArea::Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>>& area_points, const std::string& desc)
 {
     map_id = map_name;
     points = area_points;
     description = desc;
 }
 
-Map2DArea::Map2DArea(const std::string& map_name, const std::vector<Map2DLocation> area_points, const std::string& desc)
+Map2DArea::Map2DArea(const std::string& map_name, const std::vector<Map2DLocation>& area_points, const std::string& desc)
 {
     map_id = map_name;
     description = desc;

--- a/src/libYARP_dev/src/yarp/dev/Map2DArea.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DArea.h
@@ -32,14 +32,14 @@ namespace yarp
                 * @param map_name: the name of the map the location refers to.
                 * @param area_points: a set of vertexes defining the area. At least three points are required to define a valid area.
                 */
-                Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points, const std::string& desc = "");
+                Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>>& area_points, const std::string& desc = "");
 
                 /**
                 * Constructor
                 * @param map_name: the name of the map the location refers to.
                 * @param area_points: a set of Map2DLocations defining the area. At least three points are required to define a valid area.
                 */
-                Map2DArea(const std::string& map_name, const std::vector<yarp::dev::Nav2D::Map2DLocation> area_points, const std::string& desc = "");
+                Map2DArea(const std::string& map_name, const std::vector<yarp::dev::Nav2D::Map2DLocation>& area_points, const std::string& desc = "");
 
                 /**
                 * Default constructor: the map name is empty, coordinates are set to zero.

--- a/src/libYARP_dev/src/yarp/dev/Map2DArea.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DArea.h
@@ -10,6 +10,7 @@
 #include <yarp/math/Vec2D.h>
 #include <yarp/dev/api.h>
 #include <yarp/dev/Map2DLocation.h>
+#include <yarp/dev/Map2DAreaData.h>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -23,25 +24,22 @@ namespace yarp
     {
         namespace Nav2D
         {
-            class YARP_dev_API Map2DArea : public yarp::os::Portable
+            class YARP_dev_API Map2DArea : public Map2DAreaData
             {
-            private:
-                yarp::dev::Nav2D::Map2DLocation helper_tmp_location;
-
             public:
                 /**
                 * Constructor
                 * @param map_name: the name of the map the location refers to.
                 * @param area_points: a set of vertexes defining the area. At least three points are required to define a valid area.
                 */
-                Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points);
+                Map2DArea(const std::string& map_name, const std::vector<yarp::math::Vec2D<double>> area_points, const std::string& desc = "");
 
                 /**
                 * Constructor
                 * @param map_name: the name of the map the location refers to.
                 * @param area_points: a set of Map2DLocations defining the area. At least three points are required to define a valid area.
                 */
-                Map2DArea(const std::string& map_name, const std::vector<yarp::dev::Nav2D::Map2DLocation> area_points);
+                Map2DArea(const std::string& map_name, const std::vector<yarp::dev::Nav2D::Map2DLocation> area_points, const std::string& desc = "");
 
                 /**
                 * Default constructor: the map name is empty, coordinates are set to zero.
@@ -113,22 +111,13 @@ namespace yarp
                 */
                 void clear();
 
-            public:
-                std::string map_id;
-                std::vector<yarp::math::Vec2D<double>> points;
-
-            public:
-                /*
-                * Read a map2DArea from a connection.
-                * return true iff a map2DArea was read correctly
-                */
-                bool read(yarp::os::ConnectionReader& connection) override;
-
                 /**
-                * Write a map2DArea to a connection.
-                * return true iff a map2DArea was written correctly
+                * Serialization methods
                 */
-                bool write(yarp::os::ConnectionWriter& connection) const override;
+                bool read(yarp::os::idl::WireReader& reader) override { return Map2DAreaData::read(reader); }
+                bool write(const yarp::os::idl::WireWriter& writer) const override { return Map2DAreaData::write(writer); }
+                bool read(yarp::os::ConnectionReader& reader) override { return Map2DAreaData::read(reader); }
+                bool write(yarp::os::ConnectionWriter& writer) const override { return Map2DAreaData::write(writer); }
             };
         }
     }

--- a/src/libYARP_dev/src/yarp/dev/Map2DLocation.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DLocation.h
@@ -49,7 +49,7 @@ namespace yarp
                 * @param inY: location coordinates w.r.t. map reference frame (expressed in meters)
                 * @param inT: location orientation w.r.t. map reference frame (expressed in degrees)
                 */
-                Map2DLocation(const std::string& map_name, yarp::dev::Nav2D::XYWorld location, const std::string& desc="")
+                Map2DLocation(const std::string& map_name, const yarp::dev::Nav2D::XYWorld& location, const std::string& desc="")
                 {
                     map_id = map_name;
                     x = location.x;

--- a/src/libYARP_dev/src/yarp/dev/Map2DLocation.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DLocation.h
@@ -32,12 +32,13 @@ namespace yarp
                 * @param inY: location coordinates w.r.t. map reference frame (expressed in meters)
                 * @param inT: location orientation w.r.t. map reference frame (expressed in degrees)
                 */
-                Map2DLocation(const std::string& map_name, const double& inX, const double& inY, const double& inT)
+                Map2DLocation(const std::string& map_name, const double& inX, const double& inY, const double& inT, const std::string& desc="")
                 {
                     map_id = map_name;
                     x = inX;
                     y = inY;
                     theta = inT;
+                    description = desc;
                 }
 
                 /**
@@ -48,12 +49,13 @@ namespace yarp
                 * @param inY: location coordinates w.r.t. map reference frame (expressed in meters)
                 * @param inT: location orientation w.r.t. map reference frame (expressed in degrees)
                 */
-                Map2DLocation(const std::string& map_name, yarp::dev::Nav2D::XYWorld location)
+                Map2DLocation(const std::string& map_name, yarp::dev::Nav2D::XYWorld location, const std::string& desc="")
                 {
                     map_id = map_name;
                     x = location.x;
                     y = location.y;
                     theta = 0;
+                    description = desc;
                 }
 
                 /**
@@ -62,6 +64,7 @@ namespace yarp
                 Map2DLocation()
                 {
                     map_id = "";
+                    description = "";
                     x = 0;
                     y = 0;
                     theta = 0;
@@ -77,6 +80,7 @@ namespace yarp
                     stringStream.precision(-1);
                     stringStream.width(-1);
                     stringStream << std::string("map_id:") << map_id << std::string(" x:") << x << std::string(" y:") << y << std::string(" theta:") << theta;
+                    stringStream << std::string("desc:") << description;
                     return stringStream.str();
                 }
 

--- a/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
@@ -59,7 +59,7 @@ void Map2DPath::clear()
     description = "";
 }
 
-Map2DPath::Map2DPath(const std::vector<Map2DLocation> map_waypoints, const std::string& desc)
+Map2DPath::Map2DPath(const std::vector<Map2DLocation>& map_waypoints, const std::string& desc)
 {
     description = desc;
     for (const auto& map_waypoint : map_waypoints)

--- a/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Map2DPath.cpp
@@ -49,16 +49,19 @@ std::string Map2DPath::toString() const
     {
         stringStream << " waypoint " << i << "(" << waypoints[i].map_id << " " << waypoints[i].x << "," << waypoints[i].y << "," << waypoints[i].theta << ")";
     }
+    stringStream << " desc: " << description;
     return stringStream.str();
 }
 
 void Map2DPath::clear()
 {
     this->waypoints.clear();
+    description = "";
 }
 
-Map2DPath::Map2DPath(const std::vector<Map2DLocation> map_waypoints)
+Map2DPath::Map2DPath(const std::vector<Map2DLocation> map_waypoints, const std::string& desc)
 {
+    description = desc;
     for (const auto& map_waypoint : map_waypoints)
     {
         waypoints.push_back(map_waypoint);

--- a/src/libYARP_dev/src/yarp/dev/Map2DPath.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DPath.h
@@ -27,7 +27,7 @@ namespace yarp
                 * Constructor
                 * @param area_points: a set of Map2DLocations defining the path.
                 */
-                Map2DPath(const std::vector<yarp::dev::Nav2D::Map2DLocation> map_waypoints, const std::string& desc = "");
+                Map2DPath(const std::vector<yarp::dev::Nav2D::Map2DLocation>& map_waypoints, const std::string& desc = "");
 
                 /**
                 * Default constructor: the map name is empty, coordinates are set to zero.

--- a/src/libYARP_dev/src/yarp/dev/Map2DPath.h
+++ b/src/libYARP_dev/src/yarp/dev/Map2DPath.h
@@ -27,7 +27,7 @@ namespace yarp
                 * Constructor
                 * @param area_points: a set of Map2DLocations defining the path.
                 */
-                Map2DPath(const std::vector<yarp::dev::Nav2D::Map2DLocation> map_waypoints);
+                Map2DPath(const std::vector<yarp::dev::Nav2D::Map2DLocation> map_waypoints, const std::string& desc = "");
 
                 /**
                 * Default constructor: the map name is empty, coordinates are set to zero.

--- a/tests/libYARP_dev/Navigation2DClientTest.cpp
+++ b/tests/libYARP_dev/Navigation2DClientTest.cpp
@@ -110,7 +110,7 @@ TEST_CASE("dev::Navigation2DClientTest", "[yarp::dev]")
             Map2DArea area_test("map_1", std::vector<Map2DLocation> {Map2DLocation("map_1", -10, -10, 0),
                 Map2DLocation("map_1", -10, +10, 0),
                 Map2DLocation("map_1", +10, +10, 0),
-                Map2DLocation("map_1", +10, -10, 0)});
+                Map2DLocation("map_1", +10, -10, 0)}, "this is a test area");
             bool b0, b1;
             b0 = imap->storeArea("area_test", area_test); CHECK(b0);
             b0 = imap->storeLocation("loc_test", loc_test); CHECK(b0);


### PR DESCRIPTION
* `Map2DArea` has been refactored: it now inherits from the thrift defined type Map2DAreaData.thrift
* `Map2DArea`, `Map2DLocation`, `Map2DPath` now include a `description` field which can be filled by the user for generic purposes
* The documentation of the thrift types: `Map2DAreaData`, `Map2DLocationData`, `Map2DPathData` has been updated.
* Updated `map2DStorage` device to support the new v3 file format, which includes the description for Locations, Areas and Paths. 

Example of file locations.ini:
```
Version:
3
Locations:
living_room testMap 2 0 0 test1
office testMap 0 0 0 test2
Areas:
area1 testMap 3 1 1 2 1 2 2 test3
area2 testMap 4 -1 -1 -2 -1 -2 -2 -3 -3 test4
Paths:
path1 (testMap 0 0 0) (testMap 1 1 1) test5

```