### PR TITLE
devices/controlBoard_nws_ros: Do not append /joint_states to the topic name

### DIFF
--- a/doc/release/yarp_3_5/fix_joint_states_topic.md
+++ b/doc/release/yarp_3_5/fix_joint_states_topic.md
@@ -1,0 +1,8 @@
+fix_joint_states_topic {#yarp_3_5}
+----------------------
+
+## Devices
+
+### `controlBoard_nws_ros`
+
+* `/joint_states` is no longer appended to the topic name.

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_ros.cpp
@@ -103,7 +103,6 @@ bool ControlBoard_nws_ros::open(Searchable& config)
         yCError(CONTROLBOARD) << "topic_name must begin with an initial /";
         return false;
     }
-    topicName.append("/joint_states");
     yCInfo(CONTROLBOARD) << "topicName is " << topicName;
     // call ROS node/topic initialization
     node = new yarp::os::Node(nodeName);


### PR DESCRIPTION
## Devices

### `controlBoard_nws_ros`

* `/joint_states` is no longer appended to the topic name.