### PR TITLE
devices/frameGrabber_nws_ros: Fix 'frame_id' parameter

### DIFF
--- a/doc/release/yarp_3_5/fix_frameGrabber_nws_ros_frame_id.md
+++ b/doc/release/yarp_3_5/fix_frameGrabber_nws_ros_frame_id.md
@@ -1,0 +1,8 @@
+fix_frameGrabber_nws_ros_frame_id {#yarp_3_5}
+---------------------------------
+
+## Devices
+
+### `frameGrabber_nws_ros`
+
+* The `frame_id` parameter is no longer required to start with `/`.

--- a/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_ros.cpp
+++ b/src/devices/ServerFrameGrabberDual/FrameGrabber_nws_ros.cpp
@@ -129,10 +129,6 @@ bool FrameGrabber_nws_ros::open(yarp::os::Searchable& config)
         return false;
     }
     m_frameId = config.find("frame_id").asString();
-    if (m_frameId.c_str()[0] != '/') {
-        yCError(FRAMEGRABBER_NWS_ROS) << "Missing '/' in frame_id parameter";
-        return false;
-    }
 
     // Check "subdevice" option and eventually open the device
     isSubdeviceOwned = config.check("subdevice");


### PR DESCRIPTION
## Devices

### `frameGrabber_nws_ros`

* The `frame_id` parameter is no longer required to start with `/`.