### PR TITLE
Enable compilation of `libYARP_math` in the Python wheels

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -88,7 +88,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: "AUDITWHEEL_PLAT=manylinux_2_24_x86_64 CC=clang-7 CXX=clang++-7"
           CIBW_BEFORE_ALL_LINUX: |
               apt-get update &&\
-              apt-get install -y libace-dev &&\
+              apt-get install -y libace-dev libeigen3-dev &&\
               # Use clang: http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1684
               apt-get install -y clang-7
           CIBW_TEST_COMMAND: "python -c 'import yarp; yarp.Bottle()'"

--- a/doc/release/yarp_3_5/yarp_math_in_wheel.md
+++ b/doc/release/yarp_3_5/yarp_math_in_wheel.md
@@ -1,0 +1,8 @@
+yarp_math_in_wheel {#yarp_3_5}
+-----------
+
+### Bindings
+
+#### Python
+
+* Enable compilation of `libYARP_math` in the Python wheels

--- a/scripts/pip/setup.py
+++ b/scripts/pip/setup.py
@@ -58,6 +58,7 @@ setup(
                 "-DYARP_COMPILE_GUIS:BOOL=OFF",
                 "-DYARP_COMPILE_TESTS:BOOL=OFF",
                 "-DYARP_COMPILE_UNMAINTAINED:BOOL=OFF",
+                "-DYARP_COMPILE_libYARP_math:BOOL=ON",
             ]
             + CIBW_CMAKE_OPTIONS,
         )


### PR DESCRIPTION
Eigen was missing in the debian container used to build the PEP600 wheels, and `libYARP_math` automatically disabled by CMake. This PR adds the target to the process, hopefully fixing https://github.com/dic-iit/bipedal-locomotion-framework/pull/296#issuecomment-911429287.