### PR TITLE
os/idl/WireReader: Fix reading an empty string as last argument

### DIFF
--- a/doc/release/yarp_3_5/fix_WireReader_readString.md
+++ b/doc/release/yarp_3_5/fix_WireReader_readString.md
@@ -1,0 +1,10 @@
+fix_WireReader_readString {#yarp_3_5}
+-------------------------
+
+### Libraries
+
+#### `os`
+
+##### `idl::WireReader`
+
+* Fixed reading empty string as latest argument.

--- a/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
+++ b/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
@@ -419,7 +419,7 @@ bool WireReader::readString(std::string& str, bool* is_vocab)
     if (reader.isError()) {
         return false;
     }
-    if (noMore()) {
+    if (len != 0 && noMore()) {
         return false;
     }
     str.resize(len);


### PR DESCRIPTION
### Libraries

#### `os`

##### `idl::WireReader`

* Fixed reading empty string as latest argument.