### PR TITLE
Fix log under yarprun always verbose 

### DIFF
--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -718,7 +718,7 @@ void yarp::os::impl::LogPrivate::do_log(yarp::os::Log::LogType type,
                                         double externaltime,
                                         const LogComponent& comp)
 {
-    auto* print_cb = yarprun_format ? yarp::os::impl::LogPrivate::print_callback : comp.printCallback(type);
+    auto* print_cb = (yarprun_format && comp != log_internal_component) ? yarp::os::impl::LogPrivate::print_callback : comp.printCallback(type);
     if (print_cb) {
         print_cb(type, msg, file, line, func, systemtime, networktime, externaltime, comp.name());
     } else {

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
@@ -22,19 +22,9 @@ std::atomic<yarp::os::Log::LogType> minimumOsPrintLevel(
 
 } // namespace
 
-void yarp::os::impl::LogComponent::print_callback(yarp::os::Log::LogType type,
-                                                  const char* msg,
-                                                  const char* file,
-                                                  const unsigned int line,
-                                                  const char* func,
-                                                  double systemtime,
-                                                  double networktime,
-                                                  double externaltime,
-                                                  const char* comp_name)
+yarp::os::Log::LogType yarp::os::impl::LogComponent::minimumLogType()
 {
-    if (type >= minimumOsPrintLevel.load()) {
-        yarp::os::Log::printCallback()(type, msg, file, line, func, systemtime, networktime, externaltime, comp_name);
-    }
+    return minimumOsPrintLevel.load();
 }
 
 void yarp::os::impl::LogComponent::setMinumumLogType(yarp::os::Log::LogType minumumLogType)

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.cpp
@@ -5,7 +5,7 @@
 
 #include <yarp/os/impl/LogComponent.h>
 
-#include <yarp/os/Os.h>
+#include <yarp/conf/environment.h>
 
 #include <atomic>
 #include <cstring>
@@ -13,34 +13,8 @@
 
 namespace {
 
-inline bool from_env(const char* name, bool defaultvalue)
-{
-    const char *strvalue = std::getenv(name);
-
-    if(!strvalue) { return defaultvalue; }
-
-    if(strcmp(strvalue, "1") == 0) { return true; }
-    if(strcmp(strvalue, "true") == 0) { return true; }
-    if(strcmp(strvalue, "True") == 0) { return true; }
-    if(strcmp(strvalue, "TRUE") == 0) { return true; }
-    if(strcmp(strvalue, "on") == 0) { return true; }
-    if(strcmp(strvalue, "On") == 0) { return true; }
-    if(strcmp(strvalue, "ON") == 0) { return true; }
-
-    if(strcmp(strvalue, "0") == 0) { return false; }
-    if(strcmp(strvalue, "false") == 0) { return false; }
-    if(strcmp(strvalue, "False") == 0) { return false; }
-    if(strcmp(strvalue, "FALSE") == 0) { return false; }
-    if(strcmp(strvalue, "off") == 0) { return false; }
-    if(strcmp(strvalue, "Off") == 0) { return false; }
-    if(strcmp(strvalue, "OFF") == 0) { return false; }
-
-    return defaultvalue;
-}
-
-std::atomic<bool> quiet(from_env("YARP_QUIET", false));
-std::atomic<bool> verbose(from_env("YARP_VERBOSE", false) &&
-                                !quiet.load());
+std::atomic<bool> quiet(yarp::conf::environment::get_bool("YARP_QUIET", false));
+std::atomic<bool> verbose(yarp::conf::environment::get_bool("YARP_VERBOSE", false) && !quiet.load());
 
 std::atomic<yarp::os::Log::LogType> minimumOsPrintLevel(
     (quiet.load() ? yarp::os::Log::WarningType :

--- a/src/libYARP_os/src/yarp/os/impl/LogComponent.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogComponent.h
@@ -24,6 +24,7 @@ void print_callback(yarp::os::Log::LogType type,
                     double externaltime,
                     const char* comp_name);
 
+yarp::os::Log::LogType minimumLogType();
 void setMinumumLogType(yarp::os::Log::LogType minumumLogType);
 
 } // namespace LogComponent
@@ -35,9 +36,9 @@ void setMinumumLogType(yarp::os::Log::LogType minumumLogType);
     const yarp::os::LogComponent& name() \
     { \
         static const yarp::os::LogComponent component(name_string, \
-                                                      yarp::os::Log::TraceType, \
+                                                      yarp::os::impl::LogComponent::minimumLogType(), \
                                                       yarp::os::Log::LogTypeReserved, \
-                                                      yarp::os::impl::LogComponent::print_callback, \
+                                                      yarp::os::Log::defaultPrintCallback(), \
                                                       nullptr); \
         return component; \
     }
@@ -46,9 +47,9 @@ void setMinumumLogType(yarp::os::Log::LogType minumumLogType);
     yarp::os::LogComponent& name() \
     { \
         static yarp::os::LogComponent component(name_string, \
-                                                yarp::os::Log::TraceType, \
+                                                yarp::os::impl::LogComponent::minimumLogType(), \
                                                 yarp::os::Log::LogTypeReserved, \
-                                                yarp::os::impl::LogComponent::print_callback, \
+                                                yarp::os::Log::defaultPrintCallback(), \
                                                 nullptr); \
         return component; \
     }


### PR DESCRIPTION
After 9a16a9a056469779f5c7ea9e00a13f7e000575e9 the custom print callback is no longer called when running under yarprun