### PR TITLE
Avoid copies between `cv::Mat` and `yarp::sig::Image` in opencv_grabber

### DIFF
--- a/doc/release/yarp_3_5/opencv_no_copy.md
+++ b/doc/release/yarp_3_5/opencv_no_copy.md
@@ -1,0 +1,9 @@
+opencv_no_copy {#yarp_3_5}
+-----------
+
+### Devices
+
+#### `opencv_grabber`
+
+* Efficiency has been improved as copies are (in most cases) no longer
+  performed in order to convert from OpenCV frames to YARP image structures.

--- a/doc/release/yarp_3_5/opencv_no_copy.md
+++ b/doc/release/yarp_3_5/opencv_no_copy.md
@@ -7,3 +7,5 @@ opencv_no_copy {#yarp_3_5}
 
 * Efficiency has been improved as copies are (in most cases) no longer
   performed in order to convert from OpenCV frames to YARP image structures.
+* Options `--flip_x`, `--flip_y` and `--transpose` are now also available
+  when reading from file (`--movie`).

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -99,18 +99,19 @@ bool OpenCVGrabber::open(Searchable & config) {
             double m_fps = config.check("framerate", Value(-1)).asFloat64();
             m_cap.set(cv::VideoCaptureProperties::CAP_PROP_FPS, m_fps);
         }
-
-        if (config.check("flip_x", "if present, flip the image along the x-axis")) {
-            m_flip_x = true;
-        }
-        if (config.check("flip_y", "if present, flip the image along the y-axis")) {
-            m_flip_y = true;
-        }
-        if (config.check("transpose", "if present, rotate the image along of 90 degrees")) {
-            m_transpose = true;
-        }
     }
 
+    if (config.check("flip_x", "if present, flip the image along the x-axis")) {
+        m_flip_x = true;
+    }
+
+    if (config.check("flip_y", "if present, flip the image along the y-axis")) {
+        m_flip_y = true;
+    }
+
+    if (config.check("transpose", "if present, rotate the image along of 90 degrees")) {
+        m_transpose = true;
+    }
 
     // Extract the desired image size from the configuration if
     // present, otherwise query the capture device
@@ -238,7 +239,7 @@ bool OpenCVGrabber::getImage(ImageOf<PixelRgb> & image) {
         m_h = frame.rows;
     }
 
-    if (fromFile && m_w > 0 && m_h > 0 && (frame.cols != m_w || frame.rows != m_h)) {
+    if (fromFile && (frame.cols != (!m_transpose ? m_w : m_h) || frame.rows != (!m_transpose ? m_h : m_w))) {
         if (!m_saidResize) {
             yCDebug(OPENCVGRABBER, "Software scaling from %dx%d to %dx%d", frame.cols, frame.rows, m_w, m_h);
             m_saidResize = true;

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -63,7 +63,6 @@ public:
     bool close() override;
 
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb> & image) override;
-    virtual bool sendImage(const cv::Mat & frame, yarp::sig::ImageOf<yarp::sig::PixelRgb> & image);
 
 
     /** Get the height of images a grabber produces.
@@ -83,9 +82,9 @@ public:
 protected:
 
     /** Width of the images a grabber produces. */
-    size_t m_w;
+    int m_w;
     /** Height of the images a grabber produces. */
-    size_t m_h;
+    int m_h;
 
     /** Whether to loop or not. */
     bool m_loop;


### PR DESCRIPTION
Resolves #2161. In contrast to the suggested solution, I am converting a `yarp::sig::Image` to a `cv::Mat` so that final allocation occurs at the YARP caller side (doing it on a local `cv::Mat` would produce memory corruption as soon as the execution flow exits `getImage`) without using YARP_cv at all since color conversion must take place after the frame is grabbed. As a side note, I noticed in-place `cv::cvtColor` produces bogus results (frames flash between BGR and RGB representations), hence the auxiliary `bgr` variable.

Disclaimer: copying still happens whenever frame transposition or resizing is requested.

In addition, I have enabled `--flip_x`, `--flip_y` and `--transpose` for data streams originating from a file on disk (using `--movie`), which also helped me test these changes.

