### PR TITLE
new portmonitor bottle_compression_zilib

### DIFF
--- a/doc/release/master/bottle_compression_zlib.md
+++ b/doc/release/master/bottle_compression_zlib.md
@@ -1,0 +1,10 @@
+bottle_compression_zlib {#master}
+-------------------------
+
+## Important Changes
+
+### portmonitors
+
+* added new portmonitor `bottle_compression_zlib` to compress bottles (or yarp data types which can be converted to bottle)
+
+

--- a/src/portmonitors/CMakeLists.txt
+++ b/src/portmonitors/CMakeLists.txt
@@ -9,6 +9,7 @@ yarp_begin_plugin_library(yarppm
   OPTION YARP_COMPILE_PORTMONITOR_PLUGINS
   DEFAULT ON
 )
+  add_subdirectory(bottle_compression_zlib)
   add_subdirectory(depthimage_compression_zfp)
   add_subdirectory(depthimage_compression_zlib)
   add_subdirectory(depthimage_to_mono)

--- a/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.h
+++ b/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_ZLIB_CARRIER_ZFPPORTMONITOR_H
+#define YARP_ZLIB_CARRIER_ZFPPORTMONITOR_H
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Things.h>
+#include <yarp/sig/Image.h>
+#include <yarp/os/MonitorObject.h>
+
+ /**
+  * \brief `bottle_compression_zlib_portmonitor`: Portmonitor plugin for compression and decompression of bottles (or yarp data types castable to bottle) using zlib library.
+  *
+  * Example usage:
+  * yarp connect /src /dest tcp+send.portmonitor+file.bottle_compression_zlib+recv.portmonitor+file.bottle_compression_zlib+type.dll
+  */
+class BottleZlibMonitorObject : public yarp::os::MonitorObject
+{
+public:
+    bool create(const yarp::os::Property& options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property& params) override;
+    bool getparam(yarp::os::Property& params) override;
+
+    bool accept(yarp::os::Things& thing) override;
+    yarp::os::Things& update(yarp::os::Things& thing) override;
+
+protected:
+    int compressData  (const unsigned char* in, const size_t& in_size, unsigned char* out, size_t& out_size);
+    int decompressData(const unsigned char* in, const size_t& in_size, unsigned char* out, size_t& out_size);
+
+private:
+    yarp::os::Things m_th;
+    yarp::os::Bottle m_data;
+    bool             m_shouldCompress;
+};
+
+#endif

--- a/src/portmonitors/bottle_compression_zlib/CMakeLists.txt
+++ b/src/portmonitors/bottle_compression_zlib/CMakeLists.txt
@@ -1,26 +1,26 @@
 # SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
-yarp_prepare_plugin(depthimage_compression_zlib
-  TYPE DepthImageZlibMonitorObject
-  INCLUDE DepthImageZlibPortmonitor.h
+yarp_prepare_plugin(bottle_compression_zlib
+  TYPE BottleZlibMonitorObject
+  INCLUDE BottleZlibPortmonitor.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_ZLIB"
 )
 
-if(SKIP_depthimage_compression_zlib)
+if(SKIP_bottle_compression_zlib)
   return()
 endif()
 
-yarp_add_plugin(yarp_pm_depthimage_compression_zlib)
+yarp_add_plugin(yarp_pm_bottle_compression_zlib)
 
-target_sources(yarp_pm_depthimage_compression_zlib
+target_sources(yarp_pm_bottle_compression_zlib
   PRIVATE
-    DepthImageZlibPortmonitor.cpp
-    DepthImageZlibPortmonitor.h
+    BottleZlibPortmonitor.cpp
+    BottleZlibPortmonitor.h
 )
 
-target_link_libraries(yarp_pm_depthimage_compression_zlib
+target_link_libraries(yarp_pm_bottle_compression_zlib
   PRIVATE
     YARP::YARP_os
     YARP::YARP_sig
@@ -30,12 +30,12 @@ list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
   YARP_sig
 )
 
-target_include_directories(yarp_pm_depthimage_compression_zlib SYSTEM PRIVATE ${ZLIB_INCLUDE_DIRS})
-target_link_libraries(yarp_pm_depthimage_compression_zlib PRIVATE ${ZLIB_LIBRARIES})
+target_include_directories(yarp_pm_bottle_compression_zlib SYSTEM PRIVATE ${ZLIB_INCLUDE_DIRS})
+target_link_libraries(yarp_pm_bottle_compression_zlib PRIVATE ${ZLIB_LIBRARIES})
 # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ZLIB) (not using targets)
 
 yarp_install(
-  TARGETS yarp_pm_depthimage_compression_zlib
+  TARGETS yarp_pm_bottle_compression_zlib
   EXPORT YARP_${YARP_PLUGIN_MASTER}
   COMPONENT ${YARP_PLUGIN_MASTER}
   LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
@@ -45,4 +45,4 @@ yarp_install(
 
 set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
 
-set_property(TARGET yarp_pm_depthimage_compression_zlib PROPERTY FOLDER "Plugins/Port Monitor")
+set_property(TARGET yarp_pm_bottle_compression_zlib PROPERTY FOLDER "Plugins/Port Monitor")

--- a/src/portmonitors/bottle_compression_zlib/README.md
+++ b/src/portmonitors/bottle_compression_zlib/README.md
@@ -1,0 +1,9 @@
+
+bottle_compression_zlib_portmonitor plugin
+======================================================================
+Portmonitor plugin for compression and decompression of bottles (or yarp data types castable to bottle) using zlib library.
+
+Usage:
+-----
+
+yarp connect /src /dest tcp+send.portmonitor+file.bottle_compression_zlib+recv.portmonitor+file.bottle_compression_zlib+type.dll

--- a/src/portmonitors/depthimage_compression_zlib/DepthImageZlibPortmonitor.cpp
+++ b/src/portmonitors/depthimage_compression_zlib/DepthImageZlibPortmonitor.cpp
@@ -1,0 +1,196 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "DepthImageZlibPortmonitor.h"
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/sig/Image.h>
+
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+
+#include <zlib.h>
+
+using namespace yarp::os;
+using namespace yarp::sig;
+
+namespace {
+YARP_LOG_COMPONENT(DEPTHIMAGE_ZLIB_MONITOR,
+                   "yarp.carrier.portmonitor.depthimage_zlib",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)
+}
+
+
+bool DepthImageZlibMonitorObject::create(const yarp::os::Property& options)
+{
+    m_shouldCompress = (options.find("sender_side").asBool());
+    return true;
+}
+
+void DepthImageZlibMonitorObject::destroy()
+{
+}
+
+bool DepthImageZlibMonitorObject::setparam(const yarp::os::Property& params)
+{
+    return false;
+}
+
+bool DepthImageZlibMonitorObject::getparam(yarp::os::Property& params)
+{
+    return false;
+}
+
+bool DepthImageZlibMonitorObject::accept(yarp::os::Things& thing)
+{
+    if(m_shouldCompress)
+    {
+        //sender side / compressor
+        auto* b = thing.cast_as<ImageOf<PixelFloat>>();
+        if(b == nullptr)
+        {
+            yCError(DEPTHIMAGE_ZLIB_MONITOR, "Expected type ImageOf<PixelFloat> in sender side, but got wrong data type!");
+            return false;
+        }
+    }
+    else
+    {
+        //receiver side / decompressor
+        auto* b = thing.cast_as<Bottle>();
+        if(b == nullptr)
+        {
+            yCError(DEPTHIMAGE_ZLIB_MONITOR, "Expected type Bottle in receiver side, but got wrong data type!");
+            return false;
+        }
+    }
+    return true;
+}
+
+yarp::os::Things& DepthImageZlibMonitorObject::update(yarp::os::Things& thing)
+{
+   if(m_shouldCompress)
+   {
+        //sender side / compressor
+       //it receives an image, it sends a bottle to the network
+        auto* b = thing.cast_as<ImageOf<PixelFloat>>();
+
+        size_t sizeUncompressed= b->getRawImageSize();
+        const unsigned char* uncompressedData = b->getRawImage();
+
+        size_t sizeCompressed = (sizeUncompressed * 1.1) + 12;
+        unsigned char* compressedData = (unsigned char*) malloc (sizeCompressed);
+
+        bool ret= compressData(uncompressedData, sizeUncompressed, compressedData, sizeCompressed);
+        if(!ret)
+        {
+            yCError(DEPTHIMAGE_ZLIB_MONITOR, "Failed to compress, exiting...");
+            free(compressedData);
+            return thing;
+        }
+
+        m_data.clear();
+        Value v(compressedData, sizeCompressed);
+        m_data.addInt32(b->width());
+        m_data.addInt32(b->height());
+        m_data.addInt32(sizeCompressed);
+        m_data.addInt32(sizeUncompressed);
+        m_data.add(v);
+        m_th.setPortWriter(&m_data);
+
+        free(compressedData);
+   }
+   else
+   {
+       //receiver side / decompressor
+       //it receives a bottle from the network, it creates an image
+       Bottle* b= thing.cast_as<Bottle>();
+
+       size_t w = b->get(0).asInt32();
+       size_t h = b->get(1).asInt32();
+       size_t check_sizeCompressed = b->get(2).asInt32();
+       size_t check_sizeUncompressed = b->get(3).asInt32();
+       size_t sizeCompressed=b->get(4).asBlobLength();
+       const unsigned char* CompressedData = (const unsigned char*) b->get(4).asBlob();
+
+       size_t sizeUncompressed = w * h * 4;
+       if (check_sizeUncompressed != sizeUncompressed ||
+           check_sizeCompressed != sizeCompressed)
+       {
+           yCError(DEPTHIMAGE_ZLIB_MONITOR, "Invalid data received: wrong blob size?");
+           return thing;
+       }
+       unsigned char* uncompressedData = (unsigned char*)malloc(sizeUncompressed);
+
+       bool ret = decompressData(CompressedData, sizeCompressed, uncompressedData, sizeUncompressed);
+       if(!ret)
+       {
+           yCError(DEPTHIMAGE_ZLIB_MONITOR, "Failed to decompress, exiting...");
+           free(uncompressedData);
+           return thing;
+       }
+
+       m_imageOut.resize(w, h);
+       memcpy(m_imageOut.getRawImage(), uncompressedData, sizeUncompressed);
+       m_th.setPortWriter(&m_imageOut);
+
+       free(uncompressedData);
+   }
+
+    return m_th;
+}
+
+int DepthImageZlibMonitorObject::compressData(const unsigned char* in, const size_t& in_size, unsigned char* out, size_t& out_size)
+{
+    int z_result = compress((Bytef*)out, (uLongf*)&out_size, (Bytef*)in, in_size);
+    switch (z_result)
+    {
+    case Z_OK:
+        break;
+
+    case Z_MEM_ERROR:
+        yCError(DEPTHIMAGE_ZLIB_MONITOR, "zlib compression: out of memory");
+        return false;
+        break;
+
+    case Z_BUF_ERROR:
+        yCError(DEPTHIMAGE_ZLIB_MONITOR, "zlib compression: output buffer wasn't large enough");
+        return false;
+        break;
+    }
+
+    return true;
+}
+
+int DepthImageZlibMonitorObject::decompressData(const unsigned char* in, const size_t& in_size, unsigned char* out, size_t& out_size)
+{
+    int z_result = uncompress((Bytef*)out, (uLongf*)&out_size, (const Bytef*)in, in_size);
+    switch (z_result)
+    {
+    case Z_OK:
+        break;
+
+    case Z_MEM_ERROR:
+        yCError(DEPTHIMAGE_ZLIB_MONITOR, "zlib compression: out of memory");
+        return false;
+        break;
+
+    case Z_BUF_ERROR:
+        yCError(DEPTHIMAGE_ZLIB_MONITOR, "zlib compression: output buffer wasn't large enough");
+        return false;
+        break;
+
+    case Z_DATA_ERROR:
+        yCError(DEPTHIMAGE_ZLIB_MONITOR, "zlib compression: file contains corrupted data");
+        return false;
+        break;
+    }
+
+    return true;
+}

--- a/src/portmonitors/depthimage_compression_zlib/DepthImageZlibPortmonitor.h
+++ b/src/portmonitors/depthimage_compression_zlib/DepthImageZlibPortmonitor.h
@@ -11,8 +11,12 @@
 #include <yarp/sig/Image.h>
 #include <yarp/os/MonitorObject.h>
 
-
-class ZlibMonitorObject : public yarp::os::MonitorObject
+ /**
+  * \brief `depthimage_compression_zlib_portmonitor`: Portmonitor plugin for compression and decompression of depth images using zlib library.
+  * Example usage:
+  * yarp connect /depthCamera/depthImage:o /view tcp+send.portmonitor+file.depthimage_compression_zlib+recv.portmonitor+file.depthimage_compression_zlib+type.dll
+  */
+class DepthImageZlibMonitorObject : public yarp::os::MonitorObject
 {
 public:
     bool create(const yarp::os::Property& options) override;


### PR DESCRIPTION
added new portmonitor `bottle_compression_zlib` to compress bottles (or other yarp data types which can be automatically casted to bottle)