### PR TITLE
Feature: frameTransform custom config

### DIFF
--- a/doc/release/master/fix_frameTransformSet_nwc_ros.md
+++ b/doc/release/master/fix_frameTransformSet_nwc_ros.md
@@ -1,0 +1,9 @@
+feature_frameTransform_custom_config {#master}
+-------------------
+
+### Devices
+
+#### `frameTransformServer` `frameTransformClient`
+
+* Added the option to use an extern xml file (by providing its absolute path) to configure the `frameTransformServer` and the `frameTransformClient` devices.
+* **NB:** this function is intended for TEST ONLY

--- a/src/devices/frameTransformClient/FrameTransformClient.cpp
+++ b/src/devices/frameTransformClient/FrameTransformClient.cpp
@@ -11,11 +11,12 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
-
 #include <yarp/math/Math.h>
 
 #include <cmrc/cmrc.hpp>
 #include <mutex>
+#include <fstream>
+
 CMRC_DECLARE(frameTransformRC);
 
 using namespace yarp::dev;
@@ -301,19 +302,29 @@ bool FrameTransformClient::open(yarp::os::Searchable &config)
 
     std::string configuration_to_open;
     std::string innerFilePath="config_xml/ftc_local_only.xml";
-    auto fs = cmrc::frameTransformRC::get_filesystem();
-    if(cfg.check("filexml_option")) { innerFilePath="config_xml/"+cfg.find("filexml_option").toString();}
-    cfg.unput("filexml_option");
-    auto xmlFile = fs.open(innerFilePath);
-    for(const auto& lemma : xmlFile)
+    if(cfg.check("testxml_option"))
     {
-        configuration_to_open += lemma;
+        innerFilePath = cfg.find("testxml_option").asString();
+        std::ifstream xmlFile(innerFilePath);
+        std::stringstream stream_file;
+        stream_file << xmlFile.rdbuf();
+        configuration_to_open = stream_file.str();
+    }
+    else
+    {
+        auto fs = cmrc::frameTransformRC::get_filesystem();
+        if(cfg.check("filexml_option")) { innerFilePath="config_xml/"+cfg.find("filexml_option").toString();}
+        cfg.unput("filexml_option");
+        auto xmlFile = fs.open(innerFilePath);
+        for(const auto& lemma : xmlFile)
+        {
+            configuration_to_open += lemma;
+        }
     }
 
     std::string m_local_rpcUser = "/ftClient/rpc";
     if (cfg.check("local_rpc")) { m_local_rpcUser=cfg.find("local_rpc").toString();}
     cfg.unput("local_rpc");
-
     yarp::robotinterface::XMLReader reader;
     yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(configuration_to_open, cfg);
     yCAssert(FRAMETRANSFORMCLIENT, result.parsingIsSuccessful);

--- a/src/devices/frameTransformClient/FrameTransformClient.h
+++ b/src/devices/frameTransformClient/FrameTransformClient.h
@@ -44,10 +44,11 @@ const int MAX_PORTS = 5;
  * (For more information, go to \ref FrameTransform)
  *
  *   Parameters required by this device are:
- * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                                             |
- * |:----------------:|:--------------------:|:-------:|:--------------:|:---------------------:|:-----------: |:---------------------------------------------------------------------------------------:|
- * | filexml_option   | -                    | string  | -              | ftc_local_only.xml    | no           | The name of the xml file containing the needed client configuration                     |
- * | period           | -                    | float   | -              | 10ms                  | no           | The period for publishing individual tfs on port                                        |
+ * | Parameter name   | SubParameter         | Type    | Units          | Default Value         | Required     | Description                                                                                                |
+ * |:----------------:|:--------------------:|:-------:|:--------------:|:---------------------:|:-----------: |:----------------------------------------------------------------------------------------------------------:|
+ * | filexml_option   | -                    | string  | -              | ftc_local_only.xml    | no           | The name of the xml file containing the needed client configuration                                        |
+ * | testxml_option   | -                    | string  | -              | -                     | no           | NB: FOR TEST ONLY. The absolute path of the xml file containing the configuration to test                  |
+ * | period           | -                    | float   | -              | 10ms                  | no           | The period for publishing individual tfs on port                                                           |
  * | ft_client_prefix | -                    | string  | -              | ""                    | no           | A prefix to add to the names of all the ports opened by the NWCs instantiated by the frameTransformClient  |
  * | ft_server_prefix | -                    | string  | -              | ""                    | no           | The prefix added to all the names of the ports opened by the NWSs instantiated by the frameTransformServer |
  *

--- a/src/devices/frameTransformServer/FrameTransformServer.cpp
+++ b/src/devices/frameTransformServer/FrameTransformServer.cpp
@@ -13,6 +13,7 @@
 
 #include <cmrc/cmrc.hpp>
 #include <mutex>
+#include <fstream>
 CMRC_DECLARE(frameTransformServerRC);
 
 using namespace yarp::dev;
@@ -71,13 +72,24 @@ bool FrameTransformServer::open(yarp::os::Searchable &config)
 
     std::string configuration_to_open;
     std::string innerFilePath="config_xml/fts_yarp_only.xml";
-    auto fs = cmrc::frameTransformServerRC::get_filesystem();
-    if(cfg.check("filexml_option")) { innerFilePath="config_xml/"+cfg.find("filexml_option").toString();}
-    cfg.unput("filexml_option");
-    auto xmlFile = fs.open(innerFilePath);
-    for(const auto& lemma : xmlFile)
+    if(cfg.check("testxml_option"))
     {
-        configuration_to_open += lemma;
+        innerFilePath = cfg.find("testxml_option").asString();
+        std::ifstream xmlFile(innerFilePath);
+        std::stringstream stream_file;
+        stream_file << xmlFile.rdbuf();
+        configuration_to_open = stream_file.str();
+    }
+    else
+    {
+        auto fs = cmrc::frameTransformServerRC::get_filesystem();
+        if(cfg.check("filexml_option")) { innerFilePath="config_xml/"+cfg.find("filexml_option").toString();}
+        cfg.unput("filexml_option");
+        auto xmlFile = fs.open(innerFilePath);
+        for(const auto& lemma : xmlFile)
+        {
+            configuration_to_open += lemma;
+        }
     }
 
     std::string m_local_rpcUser = "/ftServer/rpc";

--- a/src/devices/frameTransformServer/FrameTransformServer.h
+++ b/src/devices/frameTransformServer/FrameTransformServer.h
@@ -45,6 +45,7 @@ const int MAX_PORTS = 5;
  * | Parameter name   | SubParameter         | Type    | Units          | Default Value        | Required     | Description                                                                                               |
  * |:----------------:|:--------------------:|:-------:|:--------------:|:--------------------:|:-----------: |:---------------------------------------------------------------------------------------------------------:|
  * | filexml_option   | -                    | string  | -              | fts_yarp_only.xml    | no           | The name of the xml file containing the needed server configuration                                       |
+ * | testxml_option   | -                    | string  | -              | -                    | no           | NB: FOR TEST ONLY. The absolute path of the xml file containing the configuration to test                 |
  * | ft_server_prefix | -                    | string  | -              | ""                   | no           | A prefix to add to the names of all the ports opened by the NWSs instantiated by the frameTransformServer |
  *
  * Example of command line:


### PR DESCRIPTION
* Added the option to use an extern xml file (by providing its absolute path) to configure the `frameTransformServer` and the `frameTransformClient` devices.
* **NB:** this function is intended for TEST ONLY