### PR TITLE
New carrier option for yarp clients connections

### DIFF
--- a/doc/release/master/carrier_option.md
+++ b/doc/release/master/carrier_option.md
@@ -1,0 +1,5 @@
+carrier_option {#master}
+-----------------------
+
+### devices
+* Most of the clients/nwcs now implement options (e.g.`carrier') to set the carrier for the connection with the server

--- a/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
+++ b/src/devices/RGBDSensorClient/RGBDSensorClient.cpp
@@ -128,7 +128,7 @@ bool RGBDSensorClient::fromConfig(yarp::os::Searchable &config)
         image_carrier_type = config.find("ImageCarrier").asString();
     }
 
-    if (config.check("DepthCarrier", "carrier for the depth tream"))
+    if (config.check("DepthCarrier", "carrier for the depth stream"))
     {
         depth_carrier_type = config.find("DepthCarrier").asString();
     }

--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.cpp
@@ -167,6 +167,8 @@ bool Rangefinder2DClient::open(yarp::os::Searchable &config)
     local  = config.find("local").asString();
     remote = config.find("remote").asString();
 
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
+
     if (local=="")
     {
         yCError(RANGEFINDER2DCLIENT, "open() error you have to provide valid local name");
@@ -196,7 +198,7 @@ bool Rangefinder2DClient::open(yarp::os::Searchable &config)
         return false;
     }
 
-    bool ok=Network::connect(remote.c_str(), local.c_str(), "udp");
+    bool ok=Network::connect(remote.c_str(), local.c_str(), m_carrier);
     if (!ok)
     {
         yCError(RANGEFINDER2DCLIENT, "open() error could not connect to %s\n", remote.c_str());

--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
@@ -64,7 +64,15 @@ public:
 * @ingroup dev_impl_network_clients dev_impl_network_lidar
 *
 * \brief `Rangefinder2DClient`: The client side of any ILaserRangefinder2D capable device.
+*
 * Still single thread! concurrent access is unsafe.
+*
+*  Parameters required by this device are:
+* | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
+* |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+* | local          |      -         | string  | -              |   -           | Yes          | Full port name opened by the Rangefinder2DClient device.          |       |
+* | remote         |      -         | string  | -              |   -           | Yes          | Full port name of the port opened on the server side, to which the Rangefinder2DClient connects to.    |     |
+* | carrier        |     -          | string  | -              | tcp           | No           | The carier used for the connection with the server.               |       |
 */
 class Rangefinder2DClient:
         public yarp::dev::DeviceDriver,
@@ -76,6 +84,7 @@ protected:
     yarp::os::Port rpcPort;
     std::string local;
     std::string remote;
+    std::string m_carrier;
     yarp::os::Stamp lastTs; //used by IPreciselyTimed
     std::string deviceId;
 

--- a/src/devices/batteryClient/BatteryClient.cpp
+++ b/src/devices/batteryClient/BatteryClient.cpp
@@ -179,6 +179,7 @@ bool BatteryClient::open(yarp::os::Searchable &config)
     yCDebug(BATTERYCLIENT) << config.toString();
     local  = config.find("local").asString();
     remote = config.find("remote").asString();
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
 
     if (local=="")
     {
@@ -213,7 +214,7 @@ bool BatteryClient::open(yarp::os::Searchable &config)
         return false;
     }
 
-    bool ok=Network::connect(remote_stream.c_str(), local_stream.c_str(), "udp");
+    bool ok=Network::connect(remote_stream.c_str(), local_stream.c_str(), m_carrier);
     if (!ok)
     {
         yCError(BATTERYCLIENT, "open(): Could not connect %s -> %s", remote_stream.c_str(), local_stream.c_str());

--- a/src/devices/batteryClient/BatteryClient.h
+++ b/src/devices/batteryClient/BatteryClient.h
@@ -66,7 +66,15 @@ public:
 * @ingroup dev_impl_network_clients
 *
 * \brief `batteryClient`: The client side of any IBattery capable device.
+*
 * Still single thread! concurrent access is unsafe.
+*
+*  Parameters required by this device are:
+* | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
+* |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+* | local          |      -         | string  | -              |   -           | Yes          | Full port name opened by the batteryClient device.                |       |
+* | remote         |      -         | string  | -              |   -           | Yes          | Full port name of the port opened on the server side, to which the batteryClient connects to.    |     |
+* | carrier        |     -          | string  | -              | tcp           | No           | The carier used for the connection with the server.               |       |
 */
 class BatteryClient :
         public yarp::dev::DeviceDriver,
@@ -78,6 +86,7 @@ protected:
     yarp::os::Port rpcPort;
     std::string local;
     std::string remote;
+    std::string m_carrier;
     yarp::os::Stamp lastTs; //used by IPreciselyTimed
     std::string deviceId;
 

--- a/src/devices/localization2DClient/Localization2DClient.cpp
+++ b/src/devices/localization2DClient/Localization2DClient.cpp
@@ -30,6 +30,7 @@ bool Localization2DClient::open(yarp::os::Searchable &config)
 
     m_local_name = config.find("local").asString();
     m_remote_name = config.find("remote").asString();
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
 
     if (m_local_name == "")
     {
@@ -62,7 +63,7 @@ bool Localization2DClient::open(yarp::os::Searchable &config)
 
     /*
     //currently unused
-    bool ok=Network::connect(remote_streaming_name.c_str(), local_streaming_name.c_str(), "tcp");
+    bool ok=Network::connect(remote_streaming_name.c_str(), local_streaming_name.c_str(), m_carrier);
     if (!ok)
     {
         yCError(LOCALIZATION2DCLIENT, "open() error could not connect to %s", remote_streaming_name.c_str());
@@ -71,7 +72,7 @@ bool Localization2DClient::open(yarp::os::Searchable &config)
 
     bool ok = true;
 
-    ok = Network::connect(local_rpc, remote_rpc);
+    ok = Network::connect(local_rpc, remote_rpc, m_carrier);
     if (!ok)
     {
         yCError(LOCALIZATION2DCLIENT, "open() error could not connect to %s", remote_rpc.c_str());

--- a/src/devices/localization2DClient/Localization2DClient.h
+++ b/src/devices/localization2DClient/Localization2DClient.h
@@ -33,8 +33,9 @@
  *  Parameters required by this device are:
  * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
- * | local          |      -         | string  | -   |   -           | Yes          | Full port name opened by the Localization2DClient device.                             |       |
- * | remote         |      -         | string  | -   |   -           | Yes          | Full port name of the port opened on the server side, to which the Localization2DClient connects to.                           | E.g.(https://github.com/robotology/navigation/src/localizationServer)    |
+ * | local          |      -         | string  | -   |   -           | Yes          | Full port name opened by the Localization2DClient device.                    |       |
+ * | remote         |      -         | string  | -   |   -           | Yes          | Full port name of the port opened on the server side, to which the Localization2DClient connects to.   |     |
+ * | carrier        |     -          | string  | -   | tcp           | No           | The carier used for the connection with the server.                          |       |
  */
 class Localization2DClient :
         public yarp::dev::DeviceDriver,
@@ -45,6 +46,7 @@ protected:
     yarp::os::Port                m_rpc_port_localization_server;
     std::string         m_local_name;
     std::string         m_remote_name;
+    std::string         m_carrier;
 
 public:
     /* DeviceDriver methods */

--- a/src/devices/map2DClient/Map2DClient.cpp
+++ b/src/devices/map2DClient/Map2DClient.cpp
@@ -35,6 +35,7 @@ bool Map2DClient::open(yarp::os::Searchable &config)
 
     m_local_name       = config.find("local").asString();
     m_map_server       = config.find("remote").asString();
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
 
     if (m_local_name == "")
     {
@@ -60,7 +61,7 @@ bool Map2DClient::open(yarp::os::Searchable &config)
     }
 
     bool ok=false;
-    ok=Network::connect(local_rpc1, remote_rpc1);
+    ok=Network::connect(local_rpc1, remote_rpc1, m_carrier);
     if (!ok)
     {
         yCError(MAP2DCLIENT, "open() error could not connect to %s", remote_rpc1.c_str());

--- a/src/devices/map2DClient/Map2DClient.h
+++ b/src/devices/map2DClient/Map2DClient.h
@@ -32,6 +32,7 @@
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | local          |      -         | string  | -   |   -           | Yes          | Full port name opened by the Map2DClient device.                             |       |
  * | remote         |     -          | string  | -   |   -           | Yes          | Full port name of the port remotely opened by the Map2DServer, to which the Map2DClient connects to.           |  |
+ * | carrier        |     -          | string  | -   | tcp           | No           | The carier used for the connection with the server.          |  |
  */
 
 class Map2DClient :
@@ -42,6 +43,7 @@ protected:
     yarp::os::Port      m_rpcPort_to_Map2DServer;
     std::string         m_local_name;
     std::string         m_map_server;
+    std::string         m_carrier;
 
 public:
 

--- a/src/devices/map2DClient/Map2D_nwc_yarp.cpp
+++ b/src/devices/map2DClient/Map2D_nwc_yarp.cpp
@@ -31,6 +31,7 @@ bool Map2D_nwc_yarp::open(yarp::os::Searchable &config)
 
     m_local_name       = config.find("local").asString();
     m_map_server       = config.find("remote").asString();
+    m_carrier          = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
 
     if (m_local_name.empty())
     {
@@ -56,7 +57,7 @@ bool Map2D_nwc_yarp::open(yarp::os::Searchable &config)
     }
 
     bool ok=false;
-    ok=Network::connect(local_rpc1, remote_rpc1);
+    ok=Network::connect(local_rpc1, remote_rpc1, m_carrier);
     if (!ok)
     {
         yCError(MAP2D_NWC_YARP, "open() error could not connect to %s", remote_rpc1.c_str());

--- a/src/devices/map2DClient/Map2D_nwc_yarp.h
+++ b/src/devices/map2DClient/Map2D_nwc_yarp.h
@@ -32,6 +32,7 @@
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | local          |      -         | string  | -   |   -           | Yes          | Full port name opened by the Map2D_nwc_yarp device.                             |       |
  * | remote         |     -          | string  | -   |   -           | Yes          | Full port name of the port remotely opened by the Map2D_nws_yarp, to which the Map2D_nwc_yarp connects to.           |  |
+ * | carrier        |     -          | string  | -   | tcp           | No           | The carier used for the connection with the server.          |  |
  */
 
 class Map2D_nwc_yarp :
@@ -42,6 +43,7 @@ protected:
     yarp::os::Port      m_rpcPort_to_Map2D_nws;
     std::string         m_local_name;
     std::string         m_map_server;
+    std::string         m_carrier;
     IMap2DMsgs          m_map_RPC;
     std::mutex          m_mutex;
 

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nwc_yarp.cpp
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nwc_yarp.cpp
@@ -31,6 +31,7 @@ bool MobileBaseVelocityControl_nwc_yarp::open(yarp::os::Searchable &config)
 
     m_local_name = config.find("local").asString();
     m_server_name = config.find("server").asString();
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
 
     if (m_local_name.empty())
     {
@@ -58,7 +59,7 @@ bool MobileBaseVelocityControl_nwc_yarp::open(yarp::os::Searchable &config)
 
     bool ok = true;
 
-    ok = Network::connect(local_rpc_1, remote_rpc_1);
+    ok = Network::connect(local_rpc_1, remote_rpc_1, m_carrier);
     if (!ok)
     {
         yCError(MOBVEL_NWC_YARP, "open() error could not connect to %s", remote_rpc_1.c_str());

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nwc_yarp.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nwc_yarp.h
@@ -30,6 +30,7 @@
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
  * | local          |      -         | string  | -              |   -           | Yes          | Full port name opened by the device.                             |       |
  * | server         |     -          | string  | -              |   -           | Yes          | Full port name of the port remotely opened by the server, to which this client connects to.           |  |
+ * | carrier        |     -          | string  | -   | tcp           | No           | The carier used for the connection with the server.          |  |
  */
 
 class MobileBaseVelocityControl_nwc_yarp:
@@ -41,6 +42,7 @@ protected:
     yarp::os::Port                m_rpc_port;
     std::string                   m_local_name;
     std::string                   m_server_name;
+    std::string                   m_carrier;
     MobileBaseVelocityControlRPC  m_RPC;
 
 public:

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -39,6 +39,8 @@ void SensorStreamingDataInputPort::updateTimeoutStatus() const
 
 bool MultipleAnalogSensorsClient::open(yarp::os::Searchable& config)
 {
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
+
     m_externalConnection = config.check("externalConnection",yarp::os::Value(false)).asBool();
     if (!config.check("remote"))
     {
@@ -96,7 +98,7 @@ bool MultipleAnalogSensorsClient::open(yarp::os::Searchable& config)
 
     // Connect ports
     if (!m_externalConnection) {
-        ok = yarp::os::Network::connect(m_localRPCPortName, m_remoteRPCPortName);
+        ok = yarp::os::Network::connect(m_localRPCPortName, m_remoteRPCPortName, m_carrier);
         if (!ok) {
             yCError(MULTIPLEANALOGSENSORSCLIENT,
                     "Failure connecting port %s to %s.",
@@ -108,7 +110,7 @@ bool MultipleAnalogSensorsClient::open(yarp::os::Searchable& config)
         }
         m_RPCConnectionActive = true;
 
-        ok = yarp::os::Network::connect(m_remoteStreamingPortName, m_localStreamingPortName);
+        ok = yarp::os::Network::connect(m_remoteStreamingPortName, m_localStreamingPortName, m_carrier);
         if (!ok) {
             yCError(MULTIPLEANALOGSENSORSCLIENT,
                     "Failure connecting port %s to %s.",

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
@@ -49,6 +49,7 @@ public:
 * | local              |       -        | string  | -              |   -           | Yes          | Port prefix of the ports opened by this device.                                        |       |
 * | timeout            |       -        | double  | seconds        | 0.01          | No           | Timeout after which the device reports an error if no measurement was received.        |       |
 * | externalConnection |       -        | bool    | -              | false         | No           | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened | Use case: e.g yarpdataplayer source. Note that with this configuration some information like sensor name, frame name and sensor number will be not available.|
+* | carrier            |     -          | string  | -              | tcp           | No           | The carier used for the connection with the server.          |  |
 *
 */
 class MultipleAnalogSensorsClient :
@@ -70,6 +71,7 @@ class MultipleAnalogSensorsClient :
     std::string m_localStreamingPortName;
     std::string m_remoteRPCPortName;
     std::string m_remoteStreamingPortName;
+    std::string m_carrier;
     bool m_RPCConnectionActive{false};
     bool m_StreamingConnectionActive{false};
     bool m_externalConnection{false};

--- a/src/devices/navigation2DClient/Navigation2DClient.cpp
+++ b/src/devices/navigation2DClient/Navigation2DClient.cpp
@@ -36,6 +36,8 @@ bool Navigation2DClient::open(yarp::os::Searchable &config)
     m_map_locations_server_name = config.find("map_locations_server").asString();
     m_localization_server_name = config.find("localization_server").asString();
 
+    m_carrier = config.check("carrier", yarp::os::Value("tcp"), "the carrier used for the connection with the server").asString();
+
     if (m_local_name == "")
     {
         yCError(NAVIGATION2DCLIENT, "open() error you have to provide a valid 'local' param");
@@ -111,21 +113,21 @@ bool Navigation2DClient::open(yarp::os::Searchable &config)
 
     bool ok = true;
 
-    ok = Network::connect(local_rpc_1, remote_rpc_1);
+    ok = Network::connect(local_rpc_1, remote_rpc_1, m_carrier);
     if (!ok)
     {
         yCError(NAVIGATION2DCLIENT, "open() error could not connect to %s", remote_rpc_1.c_str());
         return false;
     }
 
-    ok = Network::connect(local_rpc_2, remote_rpc_2);
+    ok = Network::connect(local_rpc_2, remote_rpc_2, m_carrier);
     if (!ok)
     {
         yCError(NAVIGATION2DCLIENT, "open() error could not connect to %s", remote_rpc_2.c_str());
         return false;
     }
 
-    ok = Network::connect(local_rpc_3, remote_rpc_3);
+    ok = Network::connect(local_rpc_3, remote_rpc_3, m_carrier);
     if (!ok)
     {
         yCError(NAVIGATION2DCLIENT, "open() error could not connect to %s", remote_rpc_3.c_str());

--- a/src/devices/navigation2DClient/Navigation2DClient.h
+++ b/src/devices/navigation2DClient/Navigation2DClient.h
@@ -34,6 +34,7 @@
  * | navigation_server    |     -    | string  | -              |   -           | Yes          | Full port name of the port remotely opened by the Navigation server, to which the Navigation2DClient connects to.           |  |
  * | map_locations_server |     -    | string  | -              |   -           | Yes          | Full port name of the port remotely opened by the Map2DServer, to which the Navigation2DClient connects to.           |  |
  * | localization_server  |     -    | string  | -              |   -           | Yes          | Full port name of the port remotely opened by the Localization server, to which the Navigation2DClient connects to.           |  |
+ * | carrier        |     -          | string  | -              | tcp           | No           | The carier used for the connection with the server.          |  |
  */
 
 class Navigation2DClient:
@@ -52,6 +53,7 @@ protected:
     std::string                   m_map_locations_server_name;
     std::string                   m_localization_server_name;
     int                           m_period;
+    std::string                   m_carrier;
 
 private: //math stuff
     double                        normalize_angle(double angle);

--- a/src/yarplaserscannergui/main.cpp
+++ b/src/yarplaserscannergui/main.cpp
@@ -344,6 +344,7 @@ void display_help()
     yInfo() << "--period <double> the refresh period (default 50 ms)";
     yInfo() << "--aspect <0/1> draws line/points (default 0=lines)";
     yInfo() << "--sens_port <string> the name of the port used by Rangefinder2DClient to connect to the laser device. (mandatory)";
+    yInfo() << "--carrier <string> the name of the carrier used by Rangefinder2DClient for connection to the server";
     yInfo() << "--lidar_debug shows NaN values";
     yInfo() << "--local <string> the orefix for the client port. By default /laserScannerGui. Useful in case of multiple instances.";
     yInfo() << "";
@@ -382,6 +383,7 @@ int main(int argc, char *argv[])
     int period = rf.check("period",Value(50),"period [ms]").asInt32(); //ms
     int aspect = rf.check("aspect", Value(0), "0 draw lines, 1 draw points").asInt32();
     std::string laserport = rf.check("sens_port", Value("/laser:o"), "laser port name").asString();
+    std::string carrier  = rf.check("carrier", Value("tcp"), "Rangefinder2DClient connection carrier").asString();
     std::string localprefix = rf.check("local", Value("/laserScannerGui"), "prefix for the client port").asString();
     if (rf.check ("lidar_debug"))     { g_lidar_debug_nan = g_lidar_debug_inf = true;}
     if (rf.check ("lidar_debug_nan")) { g_lidar_debug_nan = true; }
@@ -403,6 +405,7 @@ int main(int argc, char *argv[])
     lasOptions.put("local", localprefix + "/laser:i");
     lasOptions.put("remote", laserport);
     lasOptions.put("period", "10");
+    lasOptions.put("carrier", carrier);
     bool b = drv->open(lasOptions);
     if (!b)
     {


### PR DESCRIPTION
* Most of the clients/nwcs now implement options to set the carrier for the connection with the server

Minor:
* yarplaserscannergui now implements the `carrier` option to control the connection type of the internal Rangefinder2DClient