### PR TITLE
added option `testdata_filename` to latency-test companion

### DIFF
--- a/doc/release/master/testdata_filename.md
+++ b/doc/release/master/testdata_filename.md
@@ -1,0 +1,10 @@
+testdata_filename {#master}
+-----------------------
+
+### tools
+
+#### `yarp`
+
+* Added option `testdata_filename` to latency-test companion.
+  It allows to load a file which will be transmitted over the network as benchmark.
+  Different files can be used to test latency when using a compression portmonitor (the compression factor will depend on the entropy of the file )


### PR DESCRIPTION
Added option `testdata_filename` to latency-test companion.
It allows to load a file that will be transmitted over the network as a benchmark.
Different files can be used to test latency when using a compression portmonitor (the compression factor will depend on the entropy of the file )
