### PR TITLE
Fix Fixed symbol lookup runtime error in plugins using FFMPEG

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -359,7 +359,7 @@ checkandset_dependency(OpenGL)
 find_package(FTDI QUIET)
 checkandset_dependency(FTDI)
 
-find_package(FFMPEG COMPONENTS avcodec avutil OPTIONAL_COMPONENTS avformat avdevice QUIET)
+find_package(FFMPEG COMPONENTS avcodec avutil OPTIONAL_COMPONENTS avformat avdevice swscale QUIET)
 checkandset_dependency(FFMPEG)
 
 find_package(SDL QUIET)

--- a/doc/release/yarp_3_5/fix_ffmpeg.md
+++ b/doc/release/yarp_3_5/fix_ffmpeg.md
@@ -1,0 +1,19 @@
+fix_ffmpeg {#yarp_3_5}
+----------
+
+### Port Monitors
+
+#### `image_compression_ffmpeg`
+
+* Fixed symbol lookup runtime error.
+
+
+### Devices
+
+#### `ffmpeg_grabber`
+
+* Fixed symbol lookup runtime error.
+
+#### `ffmpeg_writer`
+
+* Fixed symbol lookup runtime error.

--- a/src/devices/ffmpeg/CMakeLists.txt
+++ b/src/devices/ffmpeg/CMakeLists.txt
@@ -8,14 +8,14 @@ yarp_prepare_plugin(ffmpeg_grabber
   INCLUDE FfmpegGrabber.h
   EXTRA_CONFIG
     WRAPPER=grabberDual
-  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND"
+  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_swscale_FOUND"
 )
 
 yarp_prepare_plugin(ffmpeg_writer
   CATEGORY device
   TYPE FfmpegWriter
   INCLUDE FfmpegWriter.h
-  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND"
+  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_swscale_FOUND"
 )
 
 if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
@@ -48,12 +48,14 @@ if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
       ${FFMPEG_avcodec_INCLUDE_DIRS}
       ${FFMPEG_avformat_INCLUDE_DIRS}
       ${FFMPEG_avdevice_INCLUDE_DIRS}
+      ${FFMPEG_swscale_INCLUDE_DIRS}
   )
   target_link_libraries(yarp_ffmpeg
     PRIVATE
       ${FFMPEG_avcodec_LIBRARIES}
       ${FFMPEG_avformat_LIBRARIES}
       ${FFMPEG_avdevice_LIBRARIES}
+      ${FFMPEG_swscale_LIBRARIES}
   )
   # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets
 

--- a/src/portmonitors/image_compression_ffmpeg/CMakeLists.txt
+++ b/src/portmonitors/image_compression_ffmpeg/CMakeLists.txt
@@ -5,7 +5,7 @@ yarp_prepare_plugin(image_compression_ffmpeg
   TYPE FfmpegMonitorObject
   INCLUDE ffmpegPortmonitor.h
   CATEGORY portmonitor
-  DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_FFMPEG"
+  DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_FFMPEG;FFMPEG_swscale_FOUND"
 )
 
 if(SKIP_image_compression_ffmpeg)
@@ -30,8 +30,16 @@ list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
   YARP_sig
 )
 
-target_include_directories(yarp_pm_image_compression_ffmpeg SYSTEM PRIVATE ${FFMPEG_avcodec_INCLUDE_DIRS})
-target_link_libraries(yarp_pm_image_compression_ffmpeg PRIVATE ${FFMPEG_avcodec_LIBRARIES})
+target_include_directories(yarp_pm_image_compression_ffmpeg
+  SYSTEM PRIVATE
+    ${FFMPEG_avcodec_INCLUDE_DIRS}
+    ${FFMPEG_swscale_INCLUDE_DIRS}
+)
+target_link_libraries(yarp_pm_image_compression_ffmpeg
+  PRIVATE
+    ${FFMPEG_avcodec_LIBRARIES}
+    ${FFMPEG_swscale_LIBRARIES}
+)
 # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets
 
 yarp_install(


### PR DESCRIPTION
### Port Monitors

#### `image_compression_ffmpeg`

* Fixed symbol lookup runtime error.


### Devices

#### `ffmpeg_grabber`

* Fixed symbol lookup runtime error.

#### `ffmpeg_writer`

* Fixed symbol lookup runtime error.