### PR TITLE
fix ControlBoard_nws_yarp closure segfault 

### DIFF
--- a/doc/release/yarp_3_5/fix_cb_nws_yarp.md
+++ b/doc/release/yarp_3_5/fix_cb_nws_yarp.md
@@ -1,0 +1,8 @@
+fix_cb_nws_yarp {#yarp_3_5}
+----------
+
+### Devices
+
+#### `ControlBoard_nws_yarp`
+
+* Fixed segfault if the device to which the nws attempts to attach was not successfully opened.

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
@@ -88,7 +88,7 @@ private:
     yarp::os::Stamp time; // envelope to attach to the state port
 
     yarp::dev::DeviceDriver* subdevice_ptr{nullptr};
-    bool subdevice_owned {true};
+    bool subdevice_owned = false;
     size_t subdevice_joints {0};
     bool subdevice_ready = false;
 


### PR DESCRIPTION
Fixed segfault if the device to which the nws attempts to attach was  not successfully opened