### PR TITLE
[WIP] Option for fake devices to test failure

### DIFF
--- a/doc/release/master/fake_test_failure.md
+++ b/doc/release/master/fake_test_failure.md
@@ -1,0 +1,6 @@
+fake_test_failure {#master}
+-----------------------
+
+### devices
+* added option `test_open_failure` to all fake devices, in order to simulate a failure during the opening of the device.
+  Useful for debug purposes, especially when testing if the wrappers/nws behaves correctly if the attached device fails to open.

--- a/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
+++ b/src/devices/fakeAnalogSensor/fakeAnalogSensor.cpp
@@ -35,6 +35,12 @@ bool FakeAnalogSensor::open(yarp::os::Searchable& config)
     yCTrace(FAKEANALOGSENSOR);
     bool correct=true;
 
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEANALOGSENSOR) << "Open failed on user request";
+        return false;
+    }
+
     //debug
     fprintf(stderr, "%s\n", config.toString().c_str());
 

--- a/src/devices/fakeBattery/fakeBattery.cpp
+++ b/src/devices/fakeBattery/fakeBattery.cpp
@@ -34,6 +34,12 @@ FakeBattery::FakeBattery() :
 
 bool FakeBattery::open(yarp::os::Searchable& config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEBATTERY) << "Open failed on user request";
+        return false;
+    }
+
     double period = config.check("thread_period", Value(default_period), "Thread period (smaller implies faster charge/discharge)").asFloat64();
     setPeriod(period);
 

--- a/src/devices/fakeDepthCamera/fakeDepthCameraDriver.cpp
+++ b/src/devices/fakeDepthCamera/fakeDepthCameraDriver.cpp
@@ -38,6 +38,12 @@ fakeDepthCameraDriver::~fakeDepthCameraDriver() = default;
 
 bool fakeDepthCameraDriver::open(Searchable& config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEDEPTHCAMERA) << "Open failed on user request";
+        return false;
+    }
+
     Property cfg;
     cfg.fromString(config.toString());
     cfg.unput("device");

--- a/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
+++ b/src/devices/fakeFrameGrabber/FakeFrameGrabber.cpp
@@ -220,6 +220,13 @@ bool FakeFrameGrabber::close() {
 }
 
 bool FakeFrameGrabber::open(yarp::os::Searchable& config) {
+
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEFRAMEGRABBER) << "Open failed on user request";
+        return false;
+    }
+
     m_rpcPortName = config.check("fakeFrameGrabber_rpc_port", yarp::os::Value("/fakeFrameGrabber/rpc"), "rpc port for the fakeFrameGrabber").asString();
     w = config.check("width",yarp::os::Value(320),
                      "desired width of test image").asInt32();

--- a/src/devices/fakeIMU/fakeIMU.cpp
+++ b/src/devices/fakeIMU/fakeIMU.cpp
@@ -55,6 +55,12 @@ fakeIMU::~fakeIMU()
 
 bool fakeIMU::open(yarp::os::Searchable &config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEIMU) << "Open failed on user request";
+        return false;
+    }
+
     double period;
     if( config.check("period")) {
         period = config.find("period").asInt32() / 1000.0;

--- a/src/devices/fakeLaser/fakeLaser.cpp
+++ b/src/devices/fakeLaser/fakeLaser.cpp
@@ -33,6 +33,12 @@ using namespace yarp::dev::Nav2D;
 
 bool FakeLaser::open(yarp::os::Searchable& config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKE_LASER) << "Open failed on user request";
+        return false;
+    }
+
     m_info = "Fake Laser device for test/debugging";
     m_device_status = DEVICE_OK_STANBY;
 

--- a/src/devices/fakeLocalizerDevice/fakeLocalizerDev.cpp
+++ b/src/devices/fakeLocalizerDevice/fakeLocalizerDev.cpp
@@ -212,6 +212,12 @@ void fakeLocalizerThread::threadRelease()
 
 bool fakeLocalizer::open(yarp::os::Searchable& config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKELOCALIZER) << "Open failed on user request";
+        return false;
+    }
+
     yarp::os::Property p;
     locThread = new fakeLocalizerThread(0.010, p);
 

--- a/src/devices/fakeMicrophone/fakeMicrophone.cpp
+++ b/src/devices/fakeMicrophone/fakeMicrophone.cpp
@@ -42,6 +42,12 @@ fakeMicrophone::~fakeMicrophone()
 
 bool fakeMicrophone::open(yarp::os::Searchable &config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEMICROPHONE) << "Open failed on user request";
+        return false;
+    }
+
     if (config.check("help"))
     {
         yCInfo(FAKEMICROPHONE, "Some examples:");

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -494,6 +494,12 @@ void FakeMotionControl::threadRelease()
 
 bool FakeMotionControl::open(yarp::os::Searchable &config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEMOTIONCONTROL) << "Open failed on user request";
+        return false;
+    }
+
     std::string str;
 
 //     if (!config.findGroup("GENERAL").find("MotioncontrolVersion").isInt32())

--- a/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
+++ b/src/devices/fakeNavigationDevice/fakeNavigationDev.cpp
@@ -24,6 +24,12 @@ YARP_LOG_COMPONENT(FAKENAVIGATION, "yarp.device.fakeNavigation")
 
 bool fakeNavigation :: open(yarp::os::Searchable& config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKENAVIGATION) << "Open failed on user request";
+        return false;
+    }
+
 #if 1
 
     yCDebug(FAKENAVIGATION) << "config configuration: \n" << config.toString().c_str();

--- a/src/devices/fakeSpeaker/fakeSpeaker.cpp
+++ b/src/devices/fakeSpeaker/fakeSpeaker.cpp
@@ -37,6 +37,12 @@ fakeSpeaker::~fakeSpeaker()
 
 bool fakeSpeaker::open(yarp::os::Searchable &config)
 {
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKESPEAKER) << "Open failed on user request";
+        return false;
+    }
+
     if (config.check("help"))
     {
         yCInfo(FAKESPEAKER, "Some examples:");

--- a/src/devices/fakebot/FakeBot.cpp
+++ b/src/devices/fakebot/FakeBot.cpp
@@ -87,6 +87,13 @@ void scramble(unsigned char& ch, float f) {
 
 
 bool FakeBot::open(yarp::os::Searchable& config) {
+
+    if (config.check("test_open_failure"))
+    {
+        yCError(FAKEBOT) << "Open failed on user request";
+        return false;
+    }
+
     std::string backFile = config.check("background",Value("textures/back.ppm"),
                                         "background image to use").asString();
     if (backFile!="") {


### PR DESCRIPTION
Added option `test_open_failure` to all fake devices, in order to simulate a failure during the opening of the device.
Useful for debug purposes, especially when testing if the wrappers/nws behave correctly if the attached device fails to open.