### PR TITLE
Fix Python workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -83,7 +83,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse scripts/pip
         env:
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64
+          CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_ENVIRONMENT_LINUX: "AUDITWHEEL_PLAT=manylinux_2_24_x86_64 CC=clang-7 CXX=clang++-7"
           CIBW_BEFORE_ALL_LINUX: |


### PR DESCRIPTION
- Switching to stable releases of `cibuildwheel`. @drdanz not sure which branch to target, feel free to rebase.
- The next `cibuildwheel` version will enable[^1] by default `musllinux` support. Since we don't need to build wheels for it, I disabled it explicitly in the configuration so that this workflow doesn't break again in the same way as soon as the next stable release of cibuildwheel is released.
- I took advantage to enable Python 3.10 support since it has been recently released.

[^1]: https://github.com/pypa/cibuildwheel/releases/tag/v2.2.0a1