### PR TITLE
Fixed issues with FrameTransformGet_nwc_ros and FrameTransformStorage

### DIFF
--- a/doc/release/yarp_3_5/fix_frameTransform_ros_ports_and_storage_attach.md
+++ b/doc/release/yarp_3_5/fix_frameTransform_ros_ports_and_storage_attach.md
@@ -1,0 +1,11 @@
+bugfix/frameTransform/ros_ports_and_storage_attach {#yarp_3_5}
+-------------------
+
+### Devices
+
+### Bug fix
+
+#### `frameTransformGet_nwc_ros` + `frameTransformStorage`
+
+* Fixed a little but crucial issue in `frameTransformGet_nwc_ros`: `setStrict` was not being called for the subscribers ports for the `/tf` and `/tf_static` topics and that was causing a loss of frameTransforms in more than one occasion
+* Fixed an issue with `frameTransformStorage` attach function that did not performed the view on the `iFrameTransformStorageGet` interface and did not return `true` when successful

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.cpp
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_ros.cpp
@@ -70,11 +70,13 @@ bool FrameTransformGet_nwc_ros::open(yarp::os::Searchable& config)
             yCError(FRAMETRANSFORGETNWCROS) << "Unable to publish data on " << m_topic << " topic, check your yarp-ROS network configuration";
             return false;
         }
+        m_rosSubscriberPort_tf_timed.setStrict();
         if (!m_rosSubscriberPort_tf_static.topic(m_topic_static))
         {
             yCError(FRAMETRANSFORGETNWCROS) << "Unable to publish data on " << m_topic_static << " topic, check your yarp-ROS network configuration";
             return false;
         }
+        m_rosSubscriberPort_tf_static.setStrict();
     }
     else
     {
@@ -83,9 +85,9 @@ bool FrameTransformGet_nwc_ros::open(yarp::os::Searchable& config)
         return false;
     }
 
-    start();
+    bool resp = start();
 
-    return true;
+    return resp;
 }
 
 bool FrameTransformGet_nwc_ros::close()

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -93,6 +93,11 @@ bool FrameTransformStorage::attach(yarp::dev::PolyDriver* driver)
     if (driver->isValid())
     {
         pDriver = driver;
+        pDriver->view(iGetIf);
+        if(iGetIf)
+        {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
* Fixed a little but crucial issue in `frameTransformGet_nwc_ros`: `setStrict` was not being called for the subscribers ports for the `/tf` and `/tf_static` topics and that was causing a loss of frameTransforms in more than one occasion
* Fixed an issue with `frameTransformStorage` attach function that did not performed the view on the `iFrameTransformStorageGet` interface and did not return `true` when successful