### PR TITLE
fixed bug in XMLReaderFileV3

### DIFF
--- a/doc/release/yarp_3_5/fix_libYARP_robotinterface_XMLReaderFileV3.md
+++ b/doc/release/yarp_3_5/fix_libYARP_robotinterface_XMLReaderFileV3.md
@@ -1,0 +1,14 @@
+fix_libYARP_robotinterface_XMLReaderFileV3 {#yarp_3_5}
+-------------------
+
+## Libraries
+
+### `robotinterface`
+
+#### `XMLReadefFileV3`
+
+
+* Fixed bug in `yarp::robotinterface::impl::XMLReaderFileV3::Private::readParamTag`.
+* The value passed to the `yarprobotinterface` executable using the correspondent `extern-name` (and stored in a `yarp::os::Value`) where
+converted to `std::string` by the aforementioned function using the `yarp::os::Value::asString` instead of `yarp::os::Value::toString`.  
+This resulted in empty strings every time a value with a type different from `std::string` was converted.

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
@@ -417,7 +417,7 @@ yarp::robotinterface::Param yarp::robotinterface::impl::XMLReaderFileV3::Private
     std::string extern_name;
     if (paramElem->QueryStringAttribute("extern-name", &extern_name) == TIXML_SUCCESS && config && config->check(extern_name)) {
         // FIXME Check DTD >= 3.1
-        param.value() = config->find(extern_name).asString();
+        param.value() = config->find(extern_name).toString();
     } else {
         param.value() = valueText;
     }


### PR DESCRIPTION
## Libraries

### `robotinterface`

#### `XMLReadefFileV3`


* Fixed bug in `yarp::robotinterface::impl::XMLReaderFileV3::Private::readParamTag`.
* The value passed to the `yarprobotinterface` executable using the correspondent `extern-name` (and stored in a `yarp::os::Value`) where
converted to `std::string` by the aforementioned function using the `yarp::os::Value::asString` instead of `yarp::os::Value::toString`.  
This resulted in empty strings every time a value with a type different from `std::string` was converted.