### PR TITLE
Extra info for compression portmonitor

### DIFF
--- a/doc/release/master/debug_compression_info.md
+++ b/doc/release/master/debug_compression_info.md
@@ -1,0 +1,10 @@
+debug_compression {#master}
+-------------------------
+
+## Important Changes
+
+### portmonitors
+
+* added option `debug_compression_info` to `bottle_compression_zlib` portmonitor
+
+

--- a/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.cpp
+++ b/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.cpp
@@ -28,9 +28,55 @@ YARP_LOG_COMPONENT(BOTTLE_ZLIB_MONITOR,
 }
 
 
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
+    std::istringstream iss(s);
+    std::string item;
+    while (std::getline(iss, item, delim)) {
+        elements.push_back(item);
+    }
+}
+
+void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
+{
+    // Split command line string using '+' delimiter
+    std::vector<std::string> parameters;
+    split(carrierString, '+', parameters);
+
+    // Iterate over result strings
+    for (std::string param : parameters)
+    {
+        // If there is no '.', then the param is bad formatted, skip it.
+        auto pointPosition = param.find('.');
+        if (pointPosition == std::string::npos)
+        {
+            continue;
+        }
+
+        // Otherwise, separate key and value
+        std::string paramKey = param.substr(0, pointPosition);
+        yarp::os::Value paramValue;
+        std::string s = param.substr(pointPosition + 1, param.length());
+        paramValue.fromString(s.c_str());
+
+        //and append to the returned property
+        prop.put(paramKey, paramValue);
+    }
+    return;
+}
+
 bool BottleZlibMonitorObject::create(const yarp::os::Property& options)
 {
+    std::string options_string=options.toString();
     m_shouldCompress = (options.find("sender_side").asBool());
+
+    //parse the user parameters
+    yarp::os::Property m_user_params;
+
+    std::string str = options.find("carrier").asString();
+    getParamsFromCommandLine(str, m_user_params);
+    m_debug_compression_size = m_user_params.check("debug_compression_info");
+
     return true;
 }
 
@@ -92,7 +138,9 @@ yarp::os::Things& BottleZlibMonitorObject::update(yarp::os::Things& thing)
         size_t sizeCompressed = (sizeUncompressed * 1.1) + 12;
         unsigned char* compressedData = (unsigned char*) malloc (sizeCompressed);
 
+        double start_time = yarp::os::Time::now();
         bool ret= compressData(uncompressedData, sizeUncompressed, compressedData, sizeCompressed);
+        double end_time = yarp::os::Time::now();
         if(!ret)
         {
             yCError(BOTTLE_ZLIB_MONITOR, "Failed to compress, exiting...");
@@ -105,6 +153,14 @@ yarp::os::Things& BottleZlibMonitorObject::update(yarp::os::Things& thing)
         m_data.addInt32(sizeUncompressed);
         m_data.add(v);
         m_th.setPortWriter(&m_data);
+
+        if (m_debug_compression_size)
+        {
+            yCDebug(BOTTLE_ZLIB_MONITOR) << "uncompressed size:" << sizeUncompressed
+                                         << "compressed size" << sizeCompressed
+                                         << "ratio:" << (double)sizeUncompressed/(double)sizeCompressed <<":1"
+                                         << "time:" << end_time - start_time;
+        }
 
         free(compressedData);
    }
@@ -119,7 +175,9 @@ yarp::os::Things& BottleZlibMonitorObject::update(yarp::os::Things& thing)
 
        unsigned char* uncompressedData = (unsigned char*)malloc(sizeUncompressed);
 
+       double start_time = yarp::os::Time::now();
        bool ret = decompressData(CompressedData, sizeCompressed, uncompressedData, sizeUncompressed);
+       double end_time = yarp::os::Time::now();
        if(!ret)
        {
            yCError(BOTTLE_ZLIB_MONITOR, "Failed to decompress, exiting...");
@@ -129,6 +187,14 @@ yarp::os::Things& BottleZlibMonitorObject::update(yarp::os::Things& thing)
 
        m_data.fromBinary((const char*)(uncompressedData),sizeUncompressed);
        m_th.setPortWriter(&m_data);
+
+        if (m_debug_compression_size)
+        {
+            yCDebug(BOTTLE_ZLIB_MONITOR) << "uncompressed size:" << sizeUncompressed
+                                         << "compressed size" << sizeCompressed
+                                         << "ratio:" << (double)sizeUncompressed / (double)sizeCompressed << ":1"
+                                         << "time:" << end_time - start_time;
+        }
 
        free(uncompressedData);
    }

--- a/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.h
+++ b/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.h
@@ -16,6 +16,7 @@
   *
   * Example usage:
   * yarp connect /src /dest tcp+send.portmonitor+file.bottle_compression_zlib+recv.portmonitor+file.bottle_compression_zlib+type.dll
+  * yarp connect /src /dest tcp+send.portmonitor+file.bottle_compression_zlib+recv.portmonitor+file.bottle_compression_zlib+type.dll+debug_compression_info
   */
 class BottleZlibMonitorObject : public yarp::os::MonitorObject
 {
@@ -37,6 +38,7 @@ private:
     yarp::os::Things m_th;
     yarp::os::Bottle m_data;
     bool             m_shouldCompress;
+    bool             m_debug_compression_size = false;
 };
 
 #endif


### PR DESCRIPTION
Added option `debug_compression_info` to `bottle_compression_zlib` portmonitor