### PR TITLE
mobileBaseVelocityControl_nws_yarp/ros improvements

### DIFF
--- a/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
+++ b/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
@@ -1,0 +1,12 @@
+streaming_MobileBaseVelocityControl_nws_yarp {#master}
+-----------
+
+Important Changes
+-----------------
+
+### Devices
+
+#### `MobileBaseVelocityControl_nws_yarp`
+* Added input streaming port as an alternative to rpc command `applyVelocityCommandRPC()`
+* Added `subdevice` option.
+* Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`

--- a/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
+++ b/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
@@ -9,9 +9,7 @@ Important Changes
 #### `MobileBaseVelocityControl_nws_yarp`
 * Added input streaming port as an alternative to rpc command `applyVelocityCommandRPC()`
 * Added `subdevice` option.
-* Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`
-
 
 #### `MobileBaseVelocityControl_nws_ros`
+* Removed periodic thread in favor of callback.
 * Added `subdevice` option.
-* Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`

--- a/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
+++ b/doc/release/master/streaming_MobileBaseVelocityControl_nws_yarp.md
@@ -10,3 +10,8 @@ Important Changes
 * Added input streaming port as an alternative to rpc command `applyVelocityCommandRPC()`
 * Added `subdevice` option.
 * Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`
+
+
+#### `MobileBaseVelocityControl_nws_ros`
+* Added `subdevice` option.
+* Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`

--- a/src/devices/mobileBaseVelocityControl/CMakeLists.txt
+++ b/src/devices/mobileBaseVelocityControl/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 
 
 
-yarp_prepare_plugin(mobileBaseVelocityControl_nwc_ros
+yarp_prepare_plugin(mobileBaseVelocityControl_nws_ros
   CATEGORY device
   TYPE MobileBaseVelocityControl_nws_ros
   INCLUDE MobileBaseVelocityControl_nws_ros.h

--- a/src/devices/mobileBaseVelocityControl/CMakeLists.txt
+++ b/src/devices/mobileBaseVelocityControl/CMakeLists.txt
@@ -116,7 +116,7 @@ yarp_prepare_plugin(mobileBaseVelocityControl_nws_ros
   DEFAULT ON
 )
 
-if(NOT SKIP_mobileBaseVelocityControl_nwc_ros)
+if(NOT SKIP_mobileBaseVelocityControl_nws_ros)
   yarp_add_plugin(yarp_mobileBaseVelocityControl_nws_ros)
 
   target_sources(yarp_mobileBaseVelocityControl_nws_ros

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.cpp
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.cpp
@@ -26,6 +26,41 @@ namespace {
 
 //------------------------------------------------------------------------------------------------------------------------------
 
+void commandSubscriber::init(yarp::dev::Nav2D::INavigation2DVelocityActions* _iNavVel)
+{
+    m_iNavVel = _iNavVel;
+}
+
+void commandSubscriber::deinit()
+{
+    m_iNavVel = nullptr;
+}
+
+commandSubscriber::commandSubscriber()
+{
+    //this->setStrict();
+    this->useCallback();
+}
+
+commandSubscriber::~commandSubscriber()
+{
+    this->close();
+}
+
+void commandSubscriber::onRead(yarp::rosmsg::geometry_msgs::Twist& v)
+{
+    if (m_iNavVel)
+    {
+        m_iNavVel->applyVelocityCommand(v.linear.x, v.linear.y, v.angular.z * 180 / M_PI);
+    }
+    else
+    {
+        yCError(MOBVEL_NWS_ROS, "Subdevice interface not yet initialized");
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+
 bool MobileBaseVelocityControl_nws_ros::open(yarp::os::Searchable& config)
 {
     if (config.check("node_name") == true)
@@ -36,24 +71,6 @@ bool MobileBaseVelocityControl_nws_ros::open(yarp::os::Searchable& config)
     if (config.check("topic_name") == true)
     {
         m_ros_topic_name = config.find("topic_name").asString();
-    }
-
-    m_ros_node = new yarp::os::Node (m_ros_node_name);
-
-    if (!m_ros_subscriber.topic(m_ros_topic_name))
-    {
-        yCError(MOBVEL_NWS_ROS) << " opening " << m_ros_topic_name << " Topic, check your yarp-ROS network configuration\n";
-        return false;
-    }
-
-    if (config.check("period"))
-    {
-        m_period = config.find("period").asFloat32();
-        this->setPeriod (m_period);
-    }
-    else
-    {
-        yCWarning(MOBVEL_NWS_ROS, "Using default period of %f s", m_period);
     }
 
     //attach subdevice if required
@@ -80,72 +97,50 @@ bool MobileBaseVelocityControl_nws_ros::open(yarp::os::Searchable& config)
         yCInfo(MOBVEL_NWS_ROS) << "Waiting for device to attach";
     }
 
+    //open the subscriber
+    m_ros_node = new yarp::os::Node(m_ros_node_name);
+    m_command_subscriber = new commandSubscriber();
+
+    if (!m_command_subscriber->topic(m_ros_topic_name))
+    {
+        yCError(MOBVEL_NWS_ROS) << " opening " << m_ros_topic_name << " Topic, check your yarp-ROS network configuration\n";
+        return false;
+    }
+
     return true;
 }
 
 bool MobileBaseVelocityControl_nws_ros::close()
 {
-    m_ros_subscriber.close();
-    delete m_ros_node;
+    if (m_command_subscriber) {delete m_command_subscriber;}
+    if (m_ros_node) {delete m_ros_node;}
     if (m_subdev.isValid()) { m_subdev.close(); }
     return true;
 }
 
-bool MobileBaseVelocityControl_nws_ros::threadInit()
-{
-    return true;
-}
-
-void  MobileBaseVelocityControl_nws_ros::run()
-{
-    if (yarp::rosmsg::geometry_msgs::Twist* rosTwist = m_ros_subscriber.read(false))
-    {
-        this->m_iNavVel->applyVelocityCommand(rosTwist->linear.x,
-                                              rosTwist->linear.y,
-                                              rosTwist->angular.z * 180 / M_PI);
-    }
-}
 
 bool MobileBaseVelocityControl_nws_ros::detach()
 {
-    m_iNavVel = nullptr;
+    m_command_subscriber->deinit();
     return true;
 }
 
 bool MobileBaseVelocityControl_nws_ros::attach(PolyDriver* driver)
 {
+    yarp::dev::Nav2D::INavigation2DVelocityActions* iNavVel=nullptr;
+
     if (driver->isValid())
     {
-        driver->view(m_iNavVel);
+        driver->view(iNavVel);
     }
 
-    if (nullptr == m_iNavVel)
+    if (nullptr == iNavVel)
     {
         yCError(MOBVEL_NWS_ROS, "Subdevice passed to attach method is invalid");
         return false;
     }
 
+    m_command_subscriber->init(iNavVel);
+
     return true;
-}
-
-bool MobileBaseVelocityControl_nws_ros::applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout)
-{
-    if (nullptr == m_iNavVel)
-    {
-        yCError(MOBVEL_NWS_ROS, "Unable to applyVelocityCommandRPC");
-        return false;
-    }
-
-    return m_iNavVel->applyVelocityCommand(x_vel, y_vel, theta_vel, timeout);
-}
-
-bool MobileBaseVelocityControl_nws_ros::getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel)
-{
-    if (nullptr == m_iNavVel)
-    {
-        yCError(MOBVEL_NWS_ROS, "Unable to getLastVelocityCommand");
-        return false;
-    }
-
-    return m_iNavVel->getLastVelocityCommand(x_vel, y_vel, theta_vel);
 }

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.cpp
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.cpp
@@ -87,7 +87,7 @@ bool MobileBaseVelocityControl_nws_ros::close()
 {
     m_ros_subscriber.close();
     delete m_ros_node;
-    if (m_subdev.isValid()) m_subdev.close();
+    if (m_subdev.isValid()) { m_subdev.close(); }
     return true;
 }
 

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
@@ -12,7 +12,6 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Subscriber.h>
-#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/INavigation2D.h>
 #include <yarp/os/Node.h>
@@ -35,44 +34,47 @@
   * |:--------------:|:--------------:|:-------:|:--------------:|:------------------------------:|:------------:|:-----------------------------------------------------------------:|:-----:|
   * | node_name      |      -         | string  | -              | /mobileBase_VelControl_nws_ros | No           | Full name of the opened ROS node                                  |       |
   * | topic_name     |     -          | string  | -              | /velocity_input                | No           | Full name of the opened ROS topic                                 |       |
-  * | period         |     -          | float   | s              | 0.010                          | No           | Thread period           |  |
   * | subdevice      |      -         | string  | -              |   -                            | No           | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
   */
 
+class commandSubscriber :
+    public yarp::os::Subscriber<yarp::rosmsg::geometry_msgs::Twist>
+{
+    public:
+    void init(yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel);
+    void deinit();
+
+    ~commandSubscriber ();
+    commandSubscriber ();
+    yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
+
+    using yarp::os::Subscriber<yarp::rosmsg::geometry_msgs::Twist>::onRead;
+    virtual void onRead (yarp::rosmsg::geometry_msgs::Twist& v) override;
+};
+
 class MobileBaseVelocityControl_nws_ros :
     public yarp::dev::DeviceDriver,
-    public yarp::os::PeriodicThread,
-    public yarp::dev::WrapperSingle,
-    public yarp::dev::Nav2D::INavigation2DVelocityActions
+    public yarp::dev::WrapperSingle
 {
 protected:
     std::string                   m_ros_node_name = "/mobileBase_VelControl_nws_ros";
     std::string                   m_ros_topic_name = "/velocity_input";
     yarp::os::Node*               m_ros_node = nullptr;
-    yarp::os::Subscriber<yarp::rosmsg::geometry_msgs::Twist> m_ros_subscriber;
+    commandSubscriber*            m_command_subscriber = nullptr;
 
-    double                        m_period;
-
-    yarp::dev::PolyDriver                           m_subdev;
-    yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
+    yarp::dev::PolyDriver         m_subdev;
 
 public:
-    MobileBaseVelocityControl_nws_ros(double tperiod = 0.010) : PeriodicThread(tperiod) { m_period =tperiod; };
+    virtual ~MobileBaseVelocityControl_nws_ros () {};
+    MobileBaseVelocityControl_nws_ros() {};
 
     /* DeviceDriver methods */
     bool open(yarp::os::Searchable& config) override;
     bool close() override;
 
-public:
-    //* INavigation2DVelocityActions methods */
-    bool applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout = 0.1) override;
-    bool getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel) override;
-
 private:
     bool detach() override;
     bool attach(yarp::dev::PolyDriver* driver) override;
-    bool threadInit() override;
-    void run() override;
 };
 
 #endif // YARP_DEV_MOBILEBASEVELOCITYCONTROL_NWS_ROS

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
@@ -41,7 +41,8 @@
 class MobileBaseVelocityControl_nws_ros :
     public yarp::dev::DeviceDriver,
     public yarp::os::PeriodicThread,
-    public yarp::dev::WrapperSingle
+    public yarp::dev::WrapperSingle,
+    public yarp::dev::Nav2D::INavigation2DVelocityActions
 {
 protected:
     std::string                   m_ros_node_name = "/mobileBase_VelControl_nws_ros";
@@ -50,6 +51,8 @@ protected:
     yarp::os::Subscriber<yarp::rosmsg::geometry_msgs::Twist> m_ros_subscriber;
 
     double                        m_period;
+
+    yarp::dev::PolyDriver                           m_subdev;
     yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
 
 public:
@@ -58,6 +61,11 @@ public:
     /* DeviceDriver methods */
     bool open(yarp::os::Searchable& config) override;
     bool close() override;
+
+public:
+    //* INavigation2DVelocityActions methods */
+    bool applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout = 0.1) override;
+    bool getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel) override;
 
 private:
     bool detach() override;

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_ros.h
@@ -36,6 +36,7 @@
   * | node_name      |      -         | string  | -              | /mobileBase_VelControl_nws_ros | No           | Full name of the opened ROS node                                  |       |
   * | topic_name     |     -          | string  | -              | /velocity_input                | No           | Full name of the opened ROS topic                                 |       |
   * | period         |     -          | float   | s              | 0.010                          | No           | Thread period           |  |
+  * | subdevice      |      -         | string  | -              |   -                            | No           | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
   */
 
 class MobileBaseVelocityControl_nws_ros :

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.cpp
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.cpp
@@ -113,7 +113,7 @@ bool MobileBaseVelocityControl_nws_yarp::close()
 {
     m_rpc_port_navigation_server.close();
     m_StreamingInput.close();
-    if (m_subdev.isValid()) m_subdev.close();
+    if (m_subdev.isValid()) { m_subdev.close(); }
     return true;
 }
 

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.cpp
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.cpp
@@ -140,30 +140,6 @@ bool MobileBaseVelocityControl_nws_yarp::attach(PolyDriver* driver)
     return true;
 }
 
-bool MobileBaseVelocityControl_nws_yarp::applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout)
-{
-    std::lock_guard <std::mutex> lg(m_mutex);
-    if (nullptr == m_iNavVel)
-    {
-        yCError(MOBVEL_NWS_YARP, "Unable to applyVelocityCommandRPC");
-        return false;
-    }
-
-    return m_iNavVel->applyVelocityCommand(x_vel, y_vel, theta_vel, timeout);
-}
-
-bool MobileBaseVelocityControl_nws_yarp::getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel)
-{
-    std::lock_guard <std::mutex> lg(m_mutex);
-    if (nullptr == m_iNavVel)
-    {
-        yCError(MOBVEL_NWS_YARP, "Unable to getLastVelocityCommand");
-        return false;
-    }
-
-    return m_iNavVel->getLastVelocityCommand(x_vel, y_vel, theta_vel);
-}
-
 bool MobileBaseVelocityControl_nws_yarp::applyVelocityCommandRPC(const double x_vel, const double y_vel, const double theta_vel, const double timeout)
 {
     std::lock_guard <std::mutex> lg(m_mutex);

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
@@ -33,6 +33,7 @@
  * | Parameter name | SubParameter   | Type    | Units | Default Value | Required | Description                                                       | Notes |
  * |:--------------:|:--------------:|:-------:|:-----:|:-------------:|:-------: |:-----------------------------------------------------------------:|:-----:|
  * | local          |      -         | string  | -     |   -           | Yes      | Full name of the port opened by the device. For both ports (i.e. :rpc, :i) the corresponding suffix is automatically added |       |
+ * | subdevice      |      -         | string  | -     |   -           | No       | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
  *
  * Example usage:
  * yarpdev --device mobileBaseVelocityControl_nws_yarp --subdevice velocityInputHandler --local /input1

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
@@ -15,6 +15,7 @@
 #include <yarp/dev/INavigation2D.h>
 #include <yarp/dev/WrapperSingle.h>
 #include "MobileBaseVelocityControlRPC.h"
+#include <yarp/dev/MobileBaseVelocity.h>
 
 #include <mutex>
 #include <string>
@@ -25,22 +26,42 @@
  * \section MobileBaseVelocityControl_nws_yarp
  *
  * \brief `MobileBaseVelocityControl_nws_yarp`: A device which allows a client to control the velocity of a mobile base from YARP.
+ * The device opens two ports: a streaming port `/exampleName:i` for receiving streaming commands, and a rpc port `/exampleName:rpc` for rpc connection with
+ * a `MobileBaseVelocityControl_nwc_yarp` client device.
  *
  *  Parameters required by this device are:
- * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
- * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
- * | local          |      -         | string  | -              |   -           | Yes          | Full port name opened by the device.                             |       |
- */
+ * | Parameter name | SubParameter   | Type    | Units | Default Value | Required | Description                                                       | Notes |
+ * |:--------------:|:--------------:|:-------:|:-----:|:-------------:|:-------: |:-----------------------------------------------------------------:|:-----:|
+ * | local          |      -         | string  | -     |   -           | Yes      | Full name of the port opened by the device. For both ports (i.e. :rpc, :i) the corresponding suffix is automatically added |       |
+ *
+ * Example usage:
+ * yarpdev --device mobileBaseVelocityControl_nws_yarp --subdevice velocityInputHandler --local /input1
+*/
+
+class VelocityInputPortProcessor : public yarp::os::BufferedPort<yarp::dev::MobileBaseVelocity>
+{
+public:
+    double m_timeout = 0.1;
+    yarp::dev::Nav2D::INavigation2DVelocityActions* m_iVel = nullptr;
+
+public:
+    using yarp::os::BufferedPort<yarp::dev::MobileBaseVelocity>::onRead;
+    void onRead(yarp::dev::MobileBaseVelocity& v) override;
+};
 
 class MobileBaseVelocityControl_nws_yarp:
         public yarp::dev::DeviceDriver,
         public yarp::dev::WrapperSingle,
-        public MobileBaseVelocityControlRPC
+        public MobileBaseVelocityControlRPC,
+        public yarp::dev::Nav2D::INavigation2DVelocityActions
 {
 protected:
     std::mutex                    m_mutex;
     yarp::os::Port                m_rpc_port_navigation_server;
+    VelocityInputPortProcessor    m_StreamingInput;
     std::string                   m_local_name;
+
+    yarp::dev::PolyDriver                           m_subdev;
     yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
 
 public:
@@ -50,6 +71,10 @@ public:
     bool close() override;
     bool detach() override;
     bool attach(yarp::dev::PolyDriver* driver) override;
+
+public:
+    bool applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout = 0.1) override;
+    bool getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel) override;
 
 public:
     bool applyVelocityCommandRPC(const double x_vel, const double y_vel, const double theta_vel, const double timeout) override;

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
@@ -73,10 +73,12 @@ public:
     bool attach(yarp::dev::PolyDriver* driver) override;
 
 public:
+    //* INavigation2DVelocityActions methods */
     bool applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout = 0.1) override;
     bool getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel) override;
 
 public:
+    //* MobileBaseVelocityControlRPC methods*/
     bool applyVelocityCommandRPC(const double x_vel, const double y_vel, const double theta_vel, const double timeout) override;
     return_getLastVelocityCommand getLastVelocityCommandRPC() override;
 };

--- a/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/mobileBaseVelocityControl/MobileBaseVelocityControl_nws_yarp.h
@@ -53,8 +53,7 @@ public:
 class MobileBaseVelocityControl_nws_yarp:
         public yarp::dev::DeviceDriver,
         public yarp::dev::WrapperSingle,
-        public MobileBaseVelocityControlRPC,
-        public yarp::dev::Nav2D::INavigation2DVelocityActions
+        public MobileBaseVelocityControlRPC
 {
 protected:
     std::mutex                    m_mutex;
@@ -72,11 +71,6 @@ public:
     bool close() override;
     bool detach() override;
     bool attach(yarp::dev::PolyDriver* driver) override;
-
-public:
-    //* INavigation2DVelocityActions methods */
-    bool applyVelocityCommand(double x_vel, double y_vel, double theta_vel, double timeout = 0.1) override;
-    bool getLastVelocityCommand(double& x_vel, double& y_vel, double& theta_vel) override;
 
 public:
     //* MobileBaseVelocityControlRPC methods*/


### PR DESCRIPTION
* Added input streaming port as an alternative to rpc command `applyVelocityCommandRPC()`
* Added `subdevice` option.
* Added the possibility to view the device through the interface `yarp::dev::Nav2D::INavigation2DVelocityActions`