### PR TITLE
Fix yarpmanager white spaces check in ports names and ports names color

### DIFF
--- a/doc/release/yarp_3_5/fix_yarpmanager_white_spaces_and_colors_port_names.md
+++ b/doc/release/yarp_3_5/fix_yarpmanager_white_spaces_and_colors_port_names.md
@@ -1,0 +1,14 @@
+fix_yarpmanager_white_spaces_and_colors_port_names {#yarp_3_5}
+-------------------
+
+### Tools + Libraries
+
+#### `yarpmanager` + `manager`
+
+* Targeted issue: port names containing trailing or leading white spaces not targeted as `non-existing` but throwing an error
+when trying to connect.
+* Now `yarpmanager` shows an error message in its `Message` text box when a port name listed in the `Connection list` widget
+contains white spaces. For simplicity's sake the error is thrown for spaces in any position, not only leading or trailing
+* This has been done by adding a check in the [Manager::existPortFrom](https://github.com/robotology/yarp/blob/2aeab6c8e4babe651febc2ea755a5409f4cfeda7/src/libYARP_manager/src/yarp/manager/manager.cpp#L731) and [Manager::existPortTo](https://github.com/robotology/yarp/blob/2aeab6c8e4babe651febc2ea755a5409f4cfeda7/src/libYARP_manager/src/yarp/manager/manager.cpp#L745) functions
+* Also, fixed the color of port names in the `Connections list` widget. If a port name is edited by the user, the new name
+is automatically checked and if the port exists, the color is changed to green, if it doesn't the color is changed to red.

--- a/src/libYARP_manager/src/yarp/manager/manager.cpp
+++ b/src/libYARP_manager/src/yarp/manager/manager.cpp
@@ -735,8 +735,15 @@ bool Manager::existPortFrom(unsigned int id)
         logger->addError("Connection id is out of range.");
         return false;
     }
+    std::string portName(connections[id].from());
+    if(portName.find(' ') != std::string::npos)
+    {
+        std::string message = "Port name \"" + portName + "\" contains spaces.";
+        logger->addError(message.c_str());
+        return false;
+    }
 
-    bool exists = connector.exists(connections[id].from());
+    bool exists = connector.exists(portName.c_str());
     connections[id].setFromExists(exists);
     return exists;
 }
@@ -749,8 +756,15 @@ bool Manager::existPortTo(unsigned int id)
         logger->addError("Connection id is out of range.");
         return false;
     }
+    std::string portName(connections[id].to());
+    if(portName.find(' ') != std::string::npos)
+    {
+        std::string message = "Port name \"" + portName + "\" contains spaces.";
+        logger->addError(message.c_str());
+        return false;
+    }
 
-    bool exists = connector.exists(connections[id].to());
+    bool exists = connector.exists(portName.c_str());
     connections[id].setToExists(exists);
     return exists;
 }

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -777,6 +777,7 @@ void ApplicationViewWidget::onItemChanged(QTreeWidgetItem *it,int col)
             }
         }
         ui->connectionList->blockSignals(false);
+        disconnect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
         break;
     }
     case yarp::manager::MODULE:
@@ -784,7 +785,6 @@ void ApplicationViewWidget::onItemChanged(QTreeWidgetItem *it,int col)
     default:
         break;
     }
-    disconnect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
 }
 
 /*! \brief Return the editable state of an item

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -742,9 +742,49 @@ void ApplicationViewWidget::onItemDoubleClicked(QTreeWidgetItem *it,int col)
     Qt::ItemFlags tmp = it->flags();
     if (isEditable(it, col)) {
         it->setFlags(tmp | Qt::ItemIsEditable);
+        disconnect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
+        connect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
     } else if (tmp & Qt::ItemIsEditable) {
         it->setFlags(tmp ^ Qt::ItemIsEditable);
+        disconnect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
+        connect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
     }
+}
+
+/*! \brief Called when an item has been changed by the user */
+void ApplicationViewWidget::onItemChanged(QTreeWidgetItem *it,int col)
+{
+    yarp::manager::NodeType type = (yarp::manager::NodeType)it->data(0,Qt::UserRole).toInt();
+    switch (type) {
+    case yarp::manager::INOUTD:{
+        ui->connectionList->blockSignals(true);
+        if (col == 3) {
+            updateConnectionItem(it);
+            bool res = safeManager.existPortFrom(it->text(1).toInt());
+            it->setForeground(3,QColor(res ? "#008C00" : "#BF0303"));
+            if (!res)
+            {
+                reportErrors();
+            }
+        }
+        if (col == 4) {
+            updateConnectionItem(it);
+            bool res = safeManager.existPortTo(it->text(1).toInt());
+            it->setForeground(3,QColor(res ? "#008C00" : "#BF0303"));
+            if (!res)
+            {
+                reportErrors();
+            }
+        }
+        ui->connectionList->blockSignals(false);
+        break;
+    }
+    case yarp::manager::MODULE:
+    case yarp::manager::RESOURCE:
+    default:
+        break;
+    }
+    disconnect(ui->connectionList,SIGNAL(itemChanged(QTreeWidgetItem*,int)),this,SLOT(onItemChanged(QTreeWidgetItem*,int)));
 }
 
 /*! \brief Return the editable state of an item
@@ -1520,44 +1560,50 @@ void ApplicationViewWidget::updateConnection(int index, std::vector<int>& CIDs)
 {
     QTreeWidgetItem *it = ui->connectionList->topLevelItem(index);
     if (it->isSelected()) {
-        auto* box = qobject_cast<QComboBox*>(ui->connectionList->itemWidget((QTreeWidgetItem *)it, 5));
-        QString carrier, modifier;
-        if (box)
-        {
-            carrier = box->currentText();
+        updateConnectionItem(it);
 
-        }
-        else
-        {
-            carrier=it->text(5);
-        }
-
-        //checking if in the carrier has been added a modifier
-
-        size_t pos = carrier.toStdString().find('+');
-        if(pos != std::string::npos)
-        {
-            modifier = carrier.mid(pos);
-            QStringList myStringList = carrier.split('+');
-            carrier = myStringList.first();
-            box->setCurrentText(carrier);
-            it->setText(6,modifier);
-        }
-
-        // scan the available carriers in the system where yarpmanager is launched.
-        scanAvailableCarriers(carrier);
-        carrier = carrier + it->text(6); //adding modifier.
         CIDs.push_back(it->text(1).toInt());
-        safeManager.updateConnection(it->text(1).toInt(),
-                                 it->text(3).toLatin1().data(),
-                                 it->text(4).toLatin1().data(),
-                                 carrier.toLatin1().data());
 
         it->setText(2,"waiting");
         it->setIcon(0,QIcon(":/refresh22.svg"));
         it->setForeground(2,QColor("#000000"));
     }
 
+}
+
+void ApplicationViewWidget::updateConnectionItem(QTreeWidgetItem *it)
+{
+    auto* box = qobject_cast<QComboBox*>(ui->connectionList->itemWidget((QTreeWidgetItem *)it, 5));
+    QString carrier, modifier;
+    if (box)
+    {
+        carrier = box->currentText();
+
+    }
+    else
+    {
+        carrier=it->text(5);
+    }
+
+    //checking if in the carrier has been added a modifier
+
+    size_t pos = carrier.toStdString().find('+');
+    if(pos != std::string::npos)
+    {
+        modifier = carrier.mid(pos);
+        QStringList myStringList = carrier.split('+');
+        carrier = myStringList.first();
+        box->setCurrentText(carrier);
+        it->setText(6,modifier);
+    }
+
+    // scan the available carriers in the system where yarpmanager is launched.
+    scanAvailableCarriers(carrier);
+    carrier = carrier + it->text(6); //adding modifier.
+    safeManager.updateConnection(it->text(1).toInt(),
+                                 it->text(3).toLatin1().data(),
+                                 it->text(4).toLatin1().data(),
+                                 carrier.toLatin1().data());
 }
 
 /*! \brief Select/deselect all connections

--- a/src/yarpmanager/src-manager/applicationviewwidget.h
+++ b/src/yarpmanager/src-manager/applicationviewwidget.h
@@ -106,6 +106,7 @@ private:
     void selectAllNestedApplicationModule(QTreeWidgetItem *it, bool check);
     bool scanAvailableCarriers(QString carrier, bool isConnection = true);
     void updateConnection(int index, std::vector<int> &CIDs);
+    void updateConnectionItem(QTreeWidgetItem *it);
 
 
 
@@ -172,6 +173,7 @@ private slots:
     void selectAllConnections();
     void selectAllResources();
     void onItemDoubleClicked(QTreeWidgetItem*,int);
+    void onItemChanged(QTreeWidgetItem*,int);
     bool onRun();
     bool onStop();
     bool onKill();


### PR DESCRIPTION
### Tools + Libraries

#### `yarpmanager` + `manager`

* Targeted issue: port names containing trailing or leading white spaces not targeted as `non-existing` but throwing an error
when trying to connect.
* Now `yarpmanager` shows an error message in its `Message` text box when a port name listed in the `Connection list` widget contains white spaces. For simplicity's sake the error is thrown for spaces in any position, not only leading or trailing
* This has been done by adding a check in the [Manager::existPortFrom](https://github.com/robotology/yarp/blob/2aeab6c8e4babe651febc2ea755a5409f4cfeda7/src/libYARP_manager/src/yarp/manager/manager.cpp#L731) and [Manager::existPortTo](https://github.com/robotology/yarp/blob/2aeab6c8e4babe651febc2ea755a5409f4cfeda7/src/libYARP_manager/src/yarp/manager/manager.cpp#L745) functions
* Also, fixed the color of port names in the `Connections list` widget. If a port name is edited by the user, the new name
is automatically checked and if the port exists, the color is changed to green, if it doesn't the color is changed to red.
