### PR TITLE
Fixed time stamp in static transforms

### DIFF
--- a/doc/release/yarp_3_5/fix_frameTransformSet_nws_ros_timestamp_value.md
+++ b/doc/release/yarp_3_5/fix_frameTransformSet_nws_ros_timestamp_value.md
@@ -1,0 +1,8 @@
+fix_frameTransformSet_nws_ros_timestamp_value {#yarp_3_5}
+-------------------
+
+### Devices
+
+#### `frameTransformSet_nws_ros`
+
+* Fixed bug in `frameTransformSet_nws_ros::yarpTransformToROSTransform`. The time stamps of the static transforms were wrongly set to yarp::os::Time::now()

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_ros.cpp
@@ -176,8 +176,8 @@ bool FrameTransformSet_nwc_ros::setTransform(const yarp::math::FrameTransform& t
 void  FrameTransformSet_nwc_ros::yarpTransformToROSTransform(const yarp::math::FrameTransform &input, yarp::rosmsg::geometry_msgs::TransformStamped& output)
 {
     output.child_frame_id = input.dst_frame_id;
-    output.header.frame_id = input.src_frame_id;;
-    output.header.stamp = input.isStatic ? yarp::os::Time::now() : input.timestamp; ; //@@@check timestamp of static transform?
+    output.header.frame_id = input.src_frame_id;
+    output.header.stamp = input.timestamp;
     output.transform.rotation.x = input.rotation.x();
     output.transform.rotation.y = input.rotation.y();
     output.transform.rotation.z = input.rotation.z();


### PR DESCRIPTION
#### `frameTransformSet_nws_ros`

* Fixed bug in `frameTransformSet_nws_ros::yarpTransformToROSTransform`. The time stamps of the static transforms were wrongly set to yarp::os::Time::now()