### PR TITLE
Fix for frameTransformClient part2

### DIFF
--- a/doc/release/yarp_3_5/fix_frameTransformClient_part2.md
+++ b/doc/release/yarp_3_5/fix_frameTransformClient_part2.md
@@ -1,0 +1,38 @@
+fix_frameTransformClient_part2 {#yarp_3_5}
+-------------------
+
+### Devices
+
+#### `FrameTransformClient`
+
+* timestamp is now set also for static_transforms
+
+#### `FrameTransformSetMultiplexer`
+
+* fixed race condition issue in `deleteTransform()` method.
+
+#### `FrameTransformStorage`
+
+* fixed race condition issue: added extra mutex to protect the periodicThread from set/get/delete operations
+* the periodic thread can be now stopped/started on request by
+  methods `IFrameTransformStorageUtils::stopStorageThread` and `IFrameTransformStorageUtils::startStorageThread`.
+
+#### `FrameTransformContainer`
+
+* added new iterator class. It iterates only on valid transforms.
+* when a transform is deleted, it is marked as invalid. The transform is then removed
+  during the next iteration of the checkAndRemoveExpired()
+
+### lib_yarpDev
+
+* added methods `startStorageThread()` and `stopStorageThread()` to interface `yarp::dev::IFrameTransformStorageUtils`
+
+### lib_yarpMath
+
+* added method `yarp::math::Quaternion::isValid()`
+* added method `yarp::math::FrameTransform::isValid()`
+
+### tests
+
+* Test `FrameTransformClientTest` has been improved.
+

--- a/src/devices/frameTransformClient/FrameTransformClient.cpp
+++ b/src/devices/frameTransformClient/FrameTransformClient.cpp
@@ -691,7 +691,7 @@ bool FrameTransformClient::setTransformStatic(const std::string &target_frame_id
     tf.src_frame_id = source_frame_id;
     tf.dst_frame_id = target_frame_id;
     tf.isStatic = true;
-    tf.timestamp=-1;
+    tf.timestamp= yarp::os::Time::now();
 
     if (m_ift_set)
     {

--- a/src/devices/frameTransformGet/FrameTransformGetMultiplexer.h
+++ b/src/devices/frameTransformGet/FrameTransformGetMultiplexer.h
@@ -43,8 +43,6 @@ public:
     // yarp::dev::IFrameTransformStorageGet
     bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
-    // yarp::os::PeriodicThread
-
 private:
     int    m_verbose{4};
     std::vector<IFrameTransformStorageGet*> m_iFrameTransformStorageGetList;

--- a/src/devices/frameTransformSet/FrameTransformSetMultiplexer.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSetMultiplexer.cpp
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/*
- * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
- * SPDX-License-Identifier: BSD-3-Clause
- */
-
 #include "FrameTransformSetMultiplexer.h"
 
 #include <yarp/os/LogComponent.h>
@@ -54,7 +49,11 @@ bool FrameTransformSetMultiplexer::attachAll(const yarp::dev::PolyDriverList& de
         yarp::dev::PolyDriver* polyDriverLocal = devices2attach[i]->poly;
         if (polyDriverLocal->isValid())
         {
-            yarp::dev::IFrameTransformStorageSet* iFrameTransformStorageSet=nullptr;
+            yarp::dev::IFrameTransformStorageSet*   iFrameTransformStorageSet=nullptr;
+            yarp::dev::IFrameTransformStorageUtils* iFrameTransformStorageUtils=nullptr;
+
+            //all attached devices must have iFrameTransformStorageSet interface while
+            //only FrameTransformStorage have iFrameTransformStorageUtils
             if (polyDriverLocal->view(iFrameTransformStorageSet) && iFrameTransformStorageSet!=nullptr)
             {
                 m_iFrameTransformStorageSetList.push_back(iFrameTransformStorageSet);
@@ -64,6 +63,10 @@ bool FrameTransformSetMultiplexer::attachAll(const yarp::dev::PolyDriverList& de
                 yCError(FRAMETRANSFORMSETMULTIPLEXER) << "failed to attach all the devices";
                 return false;
             }
+
+            //attempt to iFrameTransformStorageUtils
+            polyDriverLocal->view(iFrameTransformStorageUtils);
+            m_iFrameTransformStorageUtilsList.push_back(iFrameTransformStorageUtils);
         }
         else
         {
@@ -108,21 +111,31 @@ bool FrameTransformSetMultiplexer::setTransform(const yarp::math::FrameTransform
 
 bool FrameTransformSetMultiplexer::deleteTransform(std::string t1, std::string t2)
 {
+    //stopThreads();
+
+    bool frame_deleted = true;
+
     for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
     {
-        if (m_iFrameTransformStorageSetList[i] != nullptr) {
-            m_iFrameTransformStorageSetList[i]->deleteTransform(t1,t2);
+        if (m_iFrameTransformStorageSetList[i] != nullptr)
+        {
+            frame_deleted &= m_iFrameTransformStorageSetList[i]->deleteTransform(t1,t2);
         }
         else {
             yCError(FRAMETRANSFORMSETMULTIPLEXER) << "pointer to interface IFrameTransformStorageSet not valid";
             return false;
         }
     }
-    return true;
+
+    //startThreads();
+
+    return frame_deleted;
 }
 
 bool FrameTransformSetMultiplexer::clearAll()
 {
+    //stopThreads();
+
     for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
     {
         if (m_iFrameTransformStorageSetList[i] != nullptr) {
@@ -133,5 +146,28 @@ bool FrameTransformSetMultiplexer::clearAll()
             return false;
         }
     }
+
+    //startThreads();
+
     return true;
+}
+
+void FrameTransformSetMultiplexer::stopThreads()
+{
+    for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
+    {
+        if (m_iFrameTransformStorageUtilsList[i] != nullptr) {
+            m_iFrameTransformStorageUtilsList[i]->stopStorageThread();
+        }
+    }
+}
+
+void FrameTransformSetMultiplexer::startThreads()
+{
+    for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
+    {
+        if (m_iFrameTransformStorageUtilsList[i] != nullptr) {
+            m_iFrameTransformStorageUtilsList[i]->startStorageThread();
+        }
+    }
 }

--- a/src/devices/frameTransformSet/FrameTransformSetMultiplexer.h
+++ b/src/devices/frameTransformSet/FrameTransformSetMultiplexer.h
@@ -46,9 +46,13 @@ public:
     virtual bool deleteTransform(std::string t1, std::string t2) override;
     virtual bool clearAll() override;
 
+    void startThreads();
+    void stopThreads();
+
 private:
     int    m_verbose{4};
-    std::vector<IFrameTransformStorageSet*> m_iFrameTransformStorageSetList;
+    std::vector<yarp::dev::IFrameTransformStorageSet*> m_iFrameTransformStorageSetList;
+    std::vector<yarp::dev::IFrameTransformStorageUtils*> m_iFrameTransformStorageUtilsList;
     std::vector<std::vector<yarp::math::FrameTransform>> m_transformVector;
     std::vector<std::mutex> m_mutexSettingFromAttachedDevices;
 };

--- a/src/devices/frameTransformStorage/FrameTransformStorage.h
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.h
@@ -61,6 +61,8 @@ public:
     bool size(size_t& size) const override;
     bool clearAll() override;
     bool getInternalContainer(FrameTransformContainer*&  container) override;
+    bool startStorageThread() override;
+    bool stopStorageThread() override;
 
     //wrapper and interfaces
     bool attach(yarp::dev::PolyDriver* driver) override;

--- a/src/devices/frameTransformUtils/FrameTransformContainer.h
+++ b/src/devices/frameTransformUtils/FrameTransformContainer.h
@@ -31,6 +31,59 @@ class FrameTransformContainer :
 {
     using ContainerType = std::vector<yarp::math::FrameTransform>;
 
+public:
+    struct Iterator
+    {
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = ContainerType::difference_type;
+        using value_type = ContainerType::value_type;
+        using pointer = ContainerType::iterator;
+        using reference = value_type&;
+
+        //constructor
+        Iterator(ContainerType& data, ContainerType::iterator ptr) :
+            m_data(data),
+            m_ptr(ptr)
+        {
+            while (m_ptr != m_data.end() && !m_ptr->isValid()) {
+                ++m_ptr;
+            }
+        }
+
+        reference operator*() const { return *m_ptr; }
+        pointer operator->() { return m_ptr; }
+
+        // Prefix increment
+        Iterator& operator++()
+        {
+            do {
+                ++m_ptr;
+            } while (m_ptr != m_data.end() && !m_ptr->isValid());
+            return *this;
+        }
+
+        // Postfix increment
+        Iterator operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+
+        friend bool operator== (const Iterator& a, const Iterator& b) { return a.m_ptr == b.m_ptr; };
+        friend bool operator!= (const Iterator& a, const Iterator& b) { return a.m_ptr != b.m_ptr; };
+
+    private:
+        ContainerType::iterator m_ptr;
+        ContainerType& m_data;
+    };
+
+public:
+    Iterator begin()
+    {
+        return Iterator(m_transforms, m_transforms.begin());
+    }
+
+    Iterator end()
+    {
+        return Iterator(m_transforms, m_transforms.end());
+    }
+
 protected:
     ContainerType m_transforms;
 
@@ -62,11 +115,6 @@ public:
     //other
     bool checkAndRemoveExpired();
     bool checkAndRemoveExpired() const;
-    ContainerType::iterator begin() {return m_transforms.begin();}
-    ContainerType::iterator end()   {return m_transforms.end();}
-
-    //yarp::math::FrameTransform& operator[]   (std::size_t idx) { return m_transforms[idx]; }
-    //bool     delete_transform(int id);
 };
 
 #endif // YARP_DEV_FRAMETRANSFORM_UTILS_H

--- a/src/devices/transformClient/transformClient.cpp
+++ b/src/devices/transformClient/transformClient.cpp
@@ -837,7 +837,7 @@ bool TransformClient::setTransformStatic(const std::string &target_frame_id, con
     b.addVocab32(VOCAB_TRANSFORM_SET);
     b.addString(source_frame_id);
     b.addString(target_frame_id);
-    b.addFloat64(-1);
+    b.addFloat64(-1);  //transform lifetime
     b.addFloat64(tf.translation.tX);
     b.addFloat64(tf.translation.tY);
     b.addFloat64(tf.translation.tZ);

--- a/src/libYARP_dev/src/yarp/dev/IFrameTransformStorage.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameTransformStorage.h
@@ -78,7 +78,6 @@ public:
     * @return true/false
     */
     virtual bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const = 0;
-
 };
 
 /**
@@ -94,6 +93,10 @@ public:
     virtual bool size (size_t& size) const =0;
 
     virtual bool getInternalContainer(FrameTransformContainer*& container)  =0;
+
+    virtual bool startStorageThread() = 0;
+
+    virtual bool stopStorageThread() = 0;
 };
 
 #endif // YARP_DEV_IFRAMETRANSFORM_STORAGE_H

--- a/src/libYARP_math/src/yarp/math/FrameTransform.cpp
+++ b/src/libYARP_math/src/yarp/math/FrameTransform.cpp
@@ -38,6 +38,14 @@ yarp::math::FrameTransform::FrameTransform (const std::string& parent,
 {
 }
 
+bool yarp::math::FrameTransform::isValid() const
+{
+    //if (isStatic==false && timestamp < 0 ) { return false; }
+    //if (std::isnan(timestamp)) { return false; }
+    if (rotation.isValid()==false) { return false;}
+    return true;
+}
+
 yarp::math::FrameTransform::~FrameTransform() = default;
 
 void yarp::math::FrameTransform::transFromVec(double X, double Y, double Z)

--- a/src/libYARP_math/src/yarp/math/FrameTransform.h
+++ b/src/libYARP_math/src/yarp/math/FrameTransform.h
@@ -38,6 +38,8 @@ public:
 
     Quaternion rotation;
 
+    bool isValid() const;
+
     FrameTransform();
 
     FrameTransform(const std::string& parent,

--- a/src/libYARP_math/src/yarp/math/Quaternion.cpp
+++ b/src/libYARP_math/src/yarp/math/Quaternion.cpp
@@ -54,6 +54,15 @@ double* Quaternion::data()
     return internal_data;
 }
 
+bool Quaternion::isValid() const
+{
+    if (internal_data[0] == 0 &&
+        internal_data[1] == 0 &&
+        internal_data[2] == 0 &&
+        internal_data[3] == 0) {return false;}
+    return true;
+}
+
 yarp::sig::Vector Quaternion::toVector()  const
 {
     yarp::sig::Vector v(4);

--- a/src/libYARP_math/src/yarp/math/Quaternion.h
+++ b/src/libYARP_math/src/yarp/math/Quaternion.h
@@ -51,6 +51,11 @@ public:
     void normalize();
 
     /**
+    * Check if the quaternion is valid.
+    */
+    bool isValid() const;
+
+    /**
     * Computes the inverse of the quaternion.
     */
     Quaternion inverse() const;

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -21,7 +21,6 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
 
     yarp::os::Network::setLocalMode(true);
 
-#if defined(ENABLE_BROKEN_TESTS)
     SECTION("test the frameTransformClient local only mode, case 1")
     {
         yarp::dev::IFrameTransform* ift;
@@ -96,6 +95,5 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
         REQUIRE(server_pd.close());
     }
 
-#endif
     yarp::os::Network::setLocalMode(false);
 }


### PR DESCRIPTION
### Devices

#### `FrameTransformClient`

* timestamp is now set also for static_transforms

#### `FrameTransformSetMultiplexer`

* fixed race condition issue in `deleteTransform()` method.

#### `FrameTransformStorage`

* fixed race condition issue: added extra mutex to protect the periodicThread from set/get/delete operations
* the periodic thread can be now stopped/started on request by
  methods `IFrameTransformStorageUtils::stopStorageThread` and `IFrameTransformStorageUtils::startStorageThread`.

#### `FrameTransformContainer`

* added new iterator class. It iterates only on valid transforms.
* when a transform is deleted, it is marked as invalid. The transform is then removed
  during the next iteration of the checkAndRemoveExpired()

### lib_yarpDev

* added methods `startStorageThread()` and `stopStorageThread()` to interface `yarp::dev::IFrameTransformStorageUtils`

### lib_yarpMath

* added method `yarp::math::Quaternion::isValid()`
* added method `yarp::math::FrameTransform::isValid()`

### tests

* Test `FrameTransformClientTest` has been improved.