### PR TITLE
Robotinterface dryrun and reverse shutdown action order

### DIFF
--- a/doc/release/master/robotinterface_dryrun.md
+++ b/doc/release/master/robotinterface_dryrun.md
@@ -1,0 +1,10 @@
+robotinterface_dryrun {#master}
+---------------------
+
+### `robotinterface`
+
+* Added `--dryrun` option to test the xml file without actually opening devices.
+* Added `reverse-shutdown-action-order` attribute for the `robot` tag.
+  This reverses the order of actions in shutdown and interrupt phase, making it
+  easier to write the actions when multiple attach and detach are involved.
+* All `robot` tag parameters are now passed to all devices.

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -41,10 +41,7 @@ yarp::os::LogStream operator<<(yarp::os::LogStream dbg, const yarp::robotinterfa
 class yarp::robotinterface::Robot::Private
 {
 public:
-    Private(Robot* /*parent*/) :
-            build(0),
-            currentPhase(ActionPhaseUnknown),
-            currentLevel(0)
+    Private(Robot* /*parent*/)
     {
     }
 
@@ -101,13 +98,13 @@ public:
     bool custom(const Device& device, const ParamList& params);
 
     std::string name;
-    unsigned int build;
+    unsigned int build {0};
     std::string portprefix;
     ParamList params;
     DeviceList devices;
     yarp::dev::PolyDriverList externalDevices;
-    yarp::robotinterface::ActionPhase currentPhase;
-    unsigned int currentLevel;
+    yarp::robotinterface::ActionPhase currentPhase {ActionPhaseUnknown};
+    unsigned int currentLevel {0};
 }; // class yarp::robotinterface::Robot::Private
 
 bool yarp::robotinterface::Robot::Private::hasDevice(const std::string& name) const
@@ -280,7 +277,7 @@ bool yarp::robotinterface::Robot::Private::configure(const yarp::robotinterface:
 }
 
 bool yarp::robotinterface::Robot::Private::calibrate(const yarp::robotinterface::Device& device,
-                                                                   const yarp::robotinterface::ParamList& params)
+                                                     const yarp::robotinterface::ParamList& params)
 {
     if (!yarp::robotinterface::hasParam(params, "target")) {
         yError() << "Action \"" << ActionTypeToString(ActionTypeCalibrate) << R"(" requires "target" parameter)";
@@ -298,7 +295,7 @@ bool yarp::robotinterface::Robot::Private::calibrate(const yarp::robotinterface:
 }
 
 bool yarp::robotinterface::Robot::Private::attach(const yarp::robotinterface::Device& device,
-                                                                const yarp::robotinterface::ParamList& params)
+                                                  const yarp::robotinterface::ParamList& params)
 {
     int check = 0;
     if (yarp::robotinterface::hasParam(params, "network")) {
@@ -618,10 +615,8 @@ bool yarp::robotinterface::Robot::enterPhase(yarp::robotinterface::ActionPhase p
     std::vector<unsigned int> levels = mPriv->getLevels(phase);
 
     bool ret = true;
-    for (std::vector<unsigned int>::const_iterator lit = levels.begin(); lit != levels.end(); ++lit) {
+    for (unsigned int level : levels) {
         // for each level
-        const unsigned int level = *lit;
-
         yInfo() << "Entering action level" << level << "of phase" << ActionPhaseToString(phase);
         mPriv->currentLevel = level;
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -193,7 +193,11 @@ bool yarp::robotinterface::Robot::Private::openDevices()
 {
     bool ret = true;
     for (auto& device : devices) {
-        yInfo() << "Opening device" << device.name();
+        for (auto& param : params) {
+            device.params().push_back(param);
+        }
+
+        yInfo() << "Opening device" << device.name() << "with parameters" << device.params();
 
         if (dryrun) {
             continue;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -28,6 +28,7 @@ public:
 
     void setVerbose(bool verbose);
     void setAllowDeprecatedDevices(bool allowDeprecatedDevices);
+    void setDryRun(bool dryrun);
 
     ParamList& params();
     DeviceList& devices();

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -29,6 +29,7 @@ public:
     void setVerbose(bool verbose);
     void setAllowDeprecatedDevices(bool allowDeprecatedDevices);
     void setDryRun(bool dryrun);
+    void setReverseShutdownActionOrder(bool reverseShutdownActionOrder);
 
     ParamList& params();
     DeviceList& devices();

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV1.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV1.h
@@ -23,11 +23,11 @@ public:
     ~XMLReaderFileV1() override;
 
     yarp::robotinterface::XMLReaderResult getRobotFromFile(const std::string& filename,
-                                                                         const yarp::os::Searchable& config,
-                                                                         bool verbose = false) override;
+                                                           const yarp::os::Searchable& config,
+                                                           bool verbose = false) override;
     yarp::robotinterface::XMLReaderResult getRobotFromString(const std::string& xmlString,
-                                                                           const yarp::os::Searchable& config,
-                                                                           bool verbose = false) override;
+                                                             const yarp::os::Searchable& config,
+                                                             bool verbose = false) override;
 
 private:
     class Private;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
@@ -257,6 +257,14 @@ yarp::robotinterface::XMLReaderResult yarp::robotinterface::impl::XMLReaderFileV
         result.robot.portprefix() = result.robot.name();
     }
 
+    // FIXME DTD >= 4 Make this the default behaviour
+    bool reverse = false;
+    if (robotElem->QueryBoolAttribute("reverse-shutdown-action-order", &reverse) == TIXML_WRONG_TYPE) {
+        SYNTAX_ERROR(robotElem->Row()) << R"(The "reverse-shutdown-action-order" attribute in the "robot" element should be a bool.)";
+        return yarp::robotinterface::XMLReaderResult::ParsingFailed();
+    }
+    result.robot.setReverseShutdownActionOrder(reverse);
+
     // yDebug() << "Found robot [" << robot.name() << "] build [" << robot.build() << "] portprefix [" << robot.portprefix() << "]";
 
     for (TiXmlElement* childElem = robotElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.h
@@ -23,11 +23,11 @@ public:
     ~XMLReaderFileV3() override;
 
     yarp::robotinterface::XMLReaderResult getRobotFromFile(const std::string& filename,
-                                                                         const yarp::os::Searchable& config,
-                                                                         bool verbose = false) override;
+                                                           const yarp::os::Searchable& config,
+                                                           bool verbose = false) override;
     yarp::robotinterface::XMLReaderResult getRobotFromString(const std::string& xmlString,
-                                                                           const yarp::os::Searchable& config,
-                                                                           bool verbose = false) override;
+                                                             const yarp::os::Searchable& config,
+                                                             bool verbose = false) override;
 
 private:
     class Private;

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileVx.h
@@ -24,11 +24,11 @@ public:
     bool verbose;
     virtual ~XMLReaderFileVx(){};
     virtual yarp::robotinterface::XMLReaderResult getRobotFromFile(const std::string& filename,
-                                                                                 const yarp::os::Searchable& config,
-                                                                                 bool verbose = false) = 0;
+                                                                   const yarp::os::Searchable& config,
+                                                                   bool verbose = false) = 0;
     virtual yarp::robotinterface::XMLReaderResult getRobotFromString(const std::string& xmlString,
-                                                                                   const yarp::os::Searchable& config,
-                                                                                   bool verbose = false) = 0;
+                                                                     const yarp::os::Searchable& config,
+                                                                     bool verbose = false) = 0;
 };
 
 } // namespace yarp::robotinterface::impl

--- a/src/yarprobotinterface/Module.cpp
+++ b/src/yarprobotinterface/Module.cpp
@@ -113,6 +113,8 @@ bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder& rf)
 
     bool verbosity = rf.check("verbose");
     bool deprecated = rf.check("allow-deprecated-dtd");
+    bool dryrun = rf.check("dryrun");
+
     yarp::robotinterface::XMLReader reader;
     reader.setVerbose(verbosity);
     reader.setEnableDeprecated(deprecated);
@@ -140,6 +142,7 @@ bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder& rf)
 
     mPriv->robot.setVerbose(verbosity);
     mPriv->robot.setAllowDeprecatedDevices(rf.check("allow-deprecated-devices"));
+    mPriv->robot.setDryRun(dryrun);
 
     std::string rpcPortName("/" + getName() + "/yarprobotinterface");
     mPriv->rpcPort.open(rpcPortName);

--- a/src/yarprobotinterface/tests/fakeFrameGrabber/fakeFrameGrabber.xml
+++ b/src/yarprobotinterface/tests/fakeFrameGrabber/fakeFrameGrabber.xml
@@ -25,7 +25,7 @@
     <device name="wrapper_left" type="grabberDual"> <!-- frameGrabber_nws_yarp -->
         <param name="name">/left</param>
         <param name="period">33</param>
-        <action phase="startup" level="10" type="attach">
+        <action phase="startup" level="5" type="attach">
             <param name="device"> grabber_left </param>
         </action>
         <action phase="shutdown" level="5" type="detach" />
@@ -37,6 +37,6 @@
         <action phase="startup" level="10" type="attach">
             <param name="device"> grabber_right </param>
         </action>
-        <action phase="shutdown" level="5" type="detach" />
+        <action phase="shutdown" level="10" type="detach" />
     </device>
 </devices>

--- a/src/yarprobotinterface/tests/fakeFrameGrabber/grabber.xml
+++ b/src/yarprobotinterface/tests/fakeFrameGrabber/grabber.xml
@@ -7,6 +7,6 @@
 
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<robot name="grabber" build="3" portprefix="grabber" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="grabber" build="3" portprefix="grabber" reverse-shutdown-action-order="true" xmlns:xi="http://www.w3.org/2001/XInclude">
     <xi:include href="./fakeFrameGrabber.xml" />
 </robot>


### PR DESCRIPTION
### `robotinterface`

* Added `--dryrun` option to test the xml file without actually opening devices.
* Added `reverse-shutdown-action-order` attribute for the `robot` tag.
  This reverses the order of actions in shutdown and interrupt phase, making it
  easier to write the actions when multiple attach and detach are involved.

![image](https://user-images.githubusercontent.com/1100056/140960265-1d028ce5-897c-4d03-b784-4e8989ce7217.png)

* All `robot` tag parameters are now passed to all devices.