### PR TITLE
robotinterface: Pass all parames inside a `devices` tag to all `device` inside that tag

### DIFF
--- a/doc/release/master/robotinterface_dryrun.md
+++ b/doc/release/master/robotinterface_dryrun.md
@@ -7,4 +7,5 @@ robotinterface_dryrun {#master}
 * Added `reverse-shutdown-action-order` attribute for the `robot` tag.
   This reverses the order of actions in shutdown and interrupt phase, making it
   easier to write the actions when multiple attach and detach are involved.
-* All `robot` tag parameters are now passed to all devices.
+* All `device` tag parameters are now passed to all devices defined inside that
+  tag.

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -193,10 +193,6 @@ bool yarp::robotinterface::Robot::Private::openDevices()
 {
     bool ret = true;
     for (auto& device : devices) {
-        for (auto& param : params) {
-            device.params().push_back(param);
-        }
-
         yInfo() << "Opening device" << device.name() << "with parameters" << device.params();
 
         if (dryrun) {

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
@@ -356,10 +356,25 @@ yarp::robotinterface::DeviceList yarp::robotinterface::impl::XMLReaderFileV3::Pr
     //const std::string &valueStr = devicesElem->ValueStr();
 
     yarp::robotinterface::DeviceList devices;
+    yarp::robotinterface::ParamList params;
+
     for (TiXmlElement* childElem = devicesElem->FirstChildElement(); childElem != nullptr; childElem = childElem->NextSiblingElement()) {
-        for (const auto& childDevice : readDevices(childElem, result)) {
-            devices.push_back(childDevice);
+        // FIXME Check DTD >= 3.2
+        // "subdevice" is not allowed in the "devices" tag
+        if (childElem->ValueStr() == "param" || childElem->ValueStr() == "group" || childElem->ValueStr() == "paramlist" || childElem->ValueStr() == "params") {
+            for (const auto& childParam : readParams(childElem, result)) {
+                params.push_back(childParam);
+            }
+        } else {
+            for (const auto& childDevice : readDevices(childElem, result)) {
+                devices.push_back(childDevice);
+            }
         }
+    }
+
+
+    for (auto& device : devices) {
+        device.params().insert(device.params().begin(), params.begin(), params.end());
     }
 
     return devices;


### PR DESCRIPTION
Revert the changes in ed063f3f4325f32b0abb6b4f2be2694831aa2993 that was doing the same thing for the `robot` tag, since this was used in other places, and some tags should not have been passed to the devices.