### PR TITLE
Improved tests and debug messages for frameTransformClient/Server

### DIFF
--- a/doc/release/master/improved_frameTransformClientTest.md
+++ b/doc/release/master/improved_frameTransformClientTest.md
@@ -1,0 +1,18 @@
+improved_frameTransformClientTest {#master}
+-------------------
+
+### Tests
+
+* improved frameTransformClientTest for better understanding issues in CI: now using new param FrameTransform_verbose_debug=1
+
+### Devices
+
+#### FrameTransformClient
+
+* added optional parameter --FrameTransform_verbose_debug
+
+#### `FrameTransformStorage` `FrameTransformContainer`
+
+* FrameTransformStorage, FrameTransformContainer now show advanced debug info when parameter FrameTransform_verbose_debug=1
+* all xml files now expose the parameter FrameTransform_verbose_debug (default = 0)
+

--- a/src/devices/frameTransformClient/FrameTransformClient.cpp
+++ b/src/devices/frameTransformClient/FrameTransformClient.cpp
@@ -297,8 +297,9 @@ bool FrameTransformClient::open(yarp::os::Searchable &config)
 {
     yCWarning(FRAMETRANSFORMCLIENT) << "The 'FrameTransformClient' device is experimental and could be modified without any warning";
 
+    std::string cfg_string = config.toString();
     yarp::os::Property cfg;
-    cfg.fromString(config.toString());
+    cfg.fromString(cfg_string);
 
     std::string configuration_to_open;
     std::string innerFilePath="config_xml/ftc_local_only.xml";
@@ -323,8 +324,16 @@ bool FrameTransformClient::open(yarp::os::Searchable &config)
     }
 
     std::string m_local_rpcUser = "/ftClient/rpc";
+
     if (cfg.check("local_rpc")) { m_local_rpcUser=cfg.find("local_rpc").toString();}
     cfg.unput("local_rpc");
+
+    if (config.check("FrameTransform_verbose_debug"))
+    {
+       yarp::os::Value vval = config.find("FrameTransform_verbose_debug");
+       cfg.put("FrameTransform_verbose_debug", vval);
+    }
+
     yarp::robotinterface::XMLReader reader;
     yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(configuration_to_open, cfg);
     yCAssert(FRAMETRANSFORMCLIENT, result.parsingIsSuccessful);
@@ -375,9 +384,13 @@ bool FrameTransformClient::open(yarp::os::Searchable &config)
 
 bool FrameTransformClient::close()
 {
+    this->askToStop();
+    m_rpc_InterfaceToUser.close();
+    yCDebug(FRAMETRANSFORMCLIENT, "rpc port closed");
+
     m_robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
     m_robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
-    m_rpc_InterfaceToUser.close();
+
     return true;
 }
 

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
@@ -11,6 +11,7 @@
     <param name="getDeviceName"> ftc_storage </param>
     <param name="setDeviceName"> ftc_mpxSet  </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
             <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_local_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_local_only.xml
@@ -11,6 +11,7 @@
     <param name="getDeviceName"> ftc_storage </param>
     <param name="setDeviceName"> ftc_storage </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <device name="ftc_storage" type="frameTransformStorage">
         </device>
     </devices>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_ros.xml
@@ -10,6 +10,7 @@
 <robot name="frameTransformClient" build="2" portprefix="frameTransformClient" xmlns:xi="http://www.w3.org/2001/XInclude">
     <param name="setDeviceName"> ftSet_nwc_ros  </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** ROS NWC **************** -->
         <device name="ftSet_nwc_ros" type="frameTransformSet_nwc_ros">
             <group name="GENERAL">

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_pub_yarp_only.xml
@@ -10,6 +10,7 @@
 <robot name="frameTransformClient" build="2" portprefix="frameTransformClient" xmlns:xi="http://www.w3.org/2001/XInclude">
     <param name="setDeviceName"> ftSet_nwc_yarp  </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
             <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_ros.xml
@@ -12,6 +12,7 @@
     <param name="setDeviceName"> ftc_mpxSet  </param>
     <devices>
         <!-- **************** ROS NWC **************** -->
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <device name="ftSet_nwc_ros" type="frameTransformSet_nwc_ros">
             <group name="GENERAL">
                 <param extern-name="ftSet_period" name="period"> 0.01 </param>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_ros.xml
@@ -10,6 +10,7 @@
 <robot name="frameTransformClient" build="2" portprefix="frameTransformClient" xmlns:xi="http://www.w3.org/2001/XInclude">
     <param name="getDeviceName"> ftc_storage </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** ROS NWC **************** -->
         <device name="ftGet_nwc_ros" type="frameTransformGet_nwc_ros">
             <group name="GENERAL">

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
@@ -10,6 +10,7 @@
 <robot name="frameTransformClient" build="2" portprefix="frameTransformClient" xmlns:xi="http://www.w3.org/2001/XInclude">
     <param name="getDeviceName"> ftc_storage </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWC **************** -->
         <device name="ftGet_nwc_yarp" type="frameTransformGet_nwc_yarp">
             <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
@@ -11,6 +11,7 @@
     <param name="getDeviceName"> ftc_storage </param>
     <param name="setDeviceName"> ftc_mpxSet  </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWC **************** -->
         <device name="ftSet_nwc_yarp" type="frameTransformSet_nwc_yarp">
             <param extern-name="ft_client_prefix" name="nwc_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
@@ -10,6 +10,7 @@
 <robot name="frameTransformClient" build="2" portprefix="frameTransformClient" xmlns:xi="http://www.w3.org/2001/XInclude">
     <param name="getDeviceName"> ftc_storage </param>
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
         </device>

--- a/src/devices/frameTransformServer/FrameTransformServer.cpp
+++ b/src/devices/frameTransformServer/FrameTransformServer.cpp
@@ -67,8 +67,9 @@ bool FrameTransformServer::open(yarp::os::Searchable &config)
 {
     yCWarning(FRAMETRANSFORMSERVER) << "The 'FrameTransformServer' device is experimental and could be modified without any warning";
 
+    std::string cfg_string = config.toString();
     yarp::os::Property cfg;
-    cfg.fromString(config.toString());
+    cfg.fromString(cfg_string);
 
     std::string configuration_to_open;
     std::string innerFilePath="config_xml/fts_yarp_only.xml";
@@ -96,6 +97,12 @@ bool FrameTransformServer::open(yarp::os::Searchable &config)
     if (cfg.check("local_rpc")) { m_local_rpcUser=cfg.find("local_rpc").toString();}
     cfg.unput("local_rpc");
 
+    if (config.check("FrameTransform_verbose_debug"))
+    {
+        yarp::os::Value vval = config.find("FrameTransform_verbose_debug");
+        cfg.put("FrameTransform_verbose_debug", vval);
+    }
+
     yarp::robotinterface::XMLReader reader;
     yarp::robotinterface::XMLReaderResult result = reader.getRobotFromString(configuration_to_open, cfg);
     yCAssert(FRAMETRANSFORMSERVER, result.parsingIsSuccessful);
@@ -122,9 +129,13 @@ bool FrameTransformServer::open(yarp::os::Searchable &config)
 
 bool FrameTransformServer::close()
 {
+    this->askToStop();
+    m_rpc_InterfaceToUser.close();
+    yCDebug(FRAMETRANSFORMSERVER, "rpc port closed");
+
     m_robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
     m_robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
-    m_rpc_InterfaceToUser.close();
+
     return true;
 }
 

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
@@ -9,6 +9,7 @@
 
 <robot name="frameTransformServer" build="2" portprefix="frameTransformServer" xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">
             <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
@@ -9,6 +9,7 @@
 
 <robot name="frameTransformServer" build="2" portprefix="frameTransformServer" xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
+        <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">
             <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -28,6 +28,13 @@ bool FrameTransformStorage::open(yarp::os::Searchable& config)
 {
     std::string sstr = config.toString();
 
+    if (config.check("FrameTransform_verbose_debug") &&
+        config.find("FrameTransform_verbose_debug").asInt32() == 1)
+    {
+        m_tf_container.m_verbose_debug=true;
+        m_tf_container.m_name = this->id() + ".container";
+    }
+
     yCTrace(FRAMETRANSFORSTORAGE);
     bool b = this->start();
     return b;

--- a/src/devices/frameTransformUtils/FrameTransformContainer.cpp
+++ b/src/devices/frameTransformUtils/FrameTransformContainer.cpp
@@ -18,16 +18,22 @@ using namespace yarp::math;
 namespace {
 YARP_LOG_COMPONENT(FRAMETRANSFORMCONTAINER, "yarp.device.frameTransformContainer")
 
-void invalidateTransform(yarp::math::FrameTransform& trf)
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+
+void FrameTransformContainer::invalidateTransform(yarp::math::FrameTransform& trf)
 {
     trf.timestamp = yarp::os::Time::now();
     trf.isStatic = false;
     trf.translation = { 0,0,0 };
     trf.rotation = { 0,0,0,0 };
+    if (m_verbose_debug)
+    {
+        yCIDebug(FRAMETRANSFORMCONTAINER, m_name) << "At time" << std::to_string(trf.timestamp)
+            << "deleted transform (marked invalid):" << trf.src_frame_id << "->" << trf.dst_frame_id << ", assigned timestamp" << std::to_string(trf.timestamp);
+    }
 }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------
 
 bool FrameTransformContainer::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
 {
@@ -161,6 +167,15 @@ bool FrameTransformContainer::checkAndRemoveExpired()
         if (curr_t - it->timestamp > m_timeout &&
             it->isStatic == false)
         {
+            if (m_verbose_debug)
+            {
+                if (it->isValid())
+                {yCIDebug(FRAMETRANSFORMCONTAINER, m_name) << "At time" << std::to_string(curr_t)
+                 <<"Transform expired:" << it->src_frame_id << "->" << it->dst_frame_id << "with timestamp" << std::to_string(it->timestamp);}
+                else
+                {yCIDebug(FRAMETRANSFORMCONTAINER, m_name) << "At time" << std::to_string(curr_t)
+                 << "Invalid transform expired:" << it->src_frame_id << "->"<< it->dst_frame_id << "with timestamp" << std::to_string(it->timestamp);}
+            }
             m_transforms.erase(it);
             goto check_vector;
         }

--- a/src/devices/frameTransformUtils/FrameTransformContainer.h
+++ b/src/devices/frameTransformUtils/FrameTransformContainer.h
@@ -86,6 +86,7 @@ public:
 
 protected:
     ContainerType m_transforms;
+    void invalidateTransform(yarp::math::FrameTransform& trf);
 
 public:
     mutable std::recursive_mutex  m_trf_mutex;
@@ -93,6 +94,8 @@ public:
 public:
     //non-static transforms older than value (seconds) will be removed by method checkAndRemoveExpired()
     double m_timeout = 0.2;
+    bool   m_verbose_debug = false;
+    std::string m_name;
 
 public:
     FrameTransformContainer() {}

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -17,6 +17,10 @@
 
 TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
 {
+    #if defined(DISABLE_FAILING_TESTS)
+        YARP_SKIP_TEST("Skipping failing tests")
+    #endif
+
     YARP_REQUIRE_PLUGIN("frameTransformClient", "device");
 
     yarp::os::Network::setLocalMode(true);

--- a/tests/libYARP_dev/FrameTransformClientTest.cpp
+++ b/tests/libYARP_dev/FrameTransformClientTest.cpp
@@ -20,14 +20,34 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
     YARP_REQUIRE_PLUGIN("frameTransformClient", "device");
 
     yarp::os::Network::setLocalMode(true);
+    const bool verboseDebug = true;
+
+    SECTION("test the frameTransformClient/Server open/close, case 0")
+    {
+        yarp::dev::PolyDriver pd;
+        yarp::os::Property p;
+
+        p.put("device", "frameTransformClient");
+        p.put("filexml_option", "ftc_local_only.xml");
+        REQUIRE(pd.open(p));
+        yarp::os::Time::delay(0.5);
+        REQUIRE(pd.close());
+
+        p.put("device", "frameTransformServer");
+        p.put("filexml_option", "fts_yarp_only.xml");
+        REQUIRE(pd.open(p));
+        yarp::os::Time::delay(0.5);
+        REQUIRE(pd.close());
+    }
 
     SECTION("test the frameTransformClient local only mode, case 1")
     {
-        yarp::dev::IFrameTransform* ift;
+        yarp::dev::IFrameTransform* ift = nullptr;
         yarp::dev::PolyDriver pd;
         yarp::os::Property p;
         p.put("device","frameTransformClient");
         p.put("filexml_option","ftc_local_only.xml");
+        if(verboseDebug) {p.put("FrameTransform_verbose_debug","1"); }
         REQUIRE(pd.open(p));
         REQUIRE(pd.view(ift));
 
@@ -38,11 +58,12 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
 
     SECTION("test the frameTransformClient local only mode, case 2")
     {
-        yarp::dev::IFrameTransform* ift;
+        yarp::dev::IFrameTransform* ift = nullptr;
         yarp::dev::PolyDriver pd;
         yarp::os::Property p;
         p.put("device", "frameTransformClient");
         p.put("filexml_option", "ftc_local_only.xml");
+        if (verboseDebug) { p.put("FrameTransform_verbose_debug", "1"); }
         REQUIRE(pd.open(p));
         REQUIRE(pd.view(ift));
 
@@ -57,13 +78,15 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
         yarp::os::Property server_prop;
         server_prop.put("device", "frameTransformServer");
         server_prop.put("filexml_option", "fts_yarp_only.xml");
+        if (verboseDebug) { server_prop.put("FrameTransform_verbose_debug", "1"); }
         REQUIRE(server_pd.open(server_prop));
 
-        yarp::dev::IFrameTransform* ift;
+        yarp::dev::IFrameTransform* ift = nullptr;
         yarp::dev::PolyDriver client_pd;
         yarp::os::Property client_prop;
         client_prop.put("device", "frameTransformClient");
         client_prop.put("filexml_option", "ftc_yarp_only.xml");
+        if (verboseDebug) { client_prop.put("FrameTransform_verbose_debug", "1"); }
         REQUIRE(client_pd.open(client_prop));
         REQUIRE(client_pd.view(ift));
 
@@ -79,13 +102,15 @@ TEST_CASE("dev::FrameTransformClientTest", "[yarp::dev]")
         yarp::os::Property server_prop;
         server_prop.put("device", "frameTransformServer");
         server_prop.put("filexml_option", "fts_yarp_only.xml");
+        if (verboseDebug) { server_prop.put("FrameTransform_verbose_debug", "1"); }
         REQUIRE(server_pd.open(server_prop));
 
-        yarp::dev::IFrameTransform* ift;
+        yarp::dev::IFrameTransform* ift = nullptr;
         yarp::dev::PolyDriver client_pd;
         yarp::os::Property client_prop;
         client_prop.put("device", "frameTransformClient");
         client_prop.put("filexml_option", "ftc_yarp_only.xml");
+        if (verboseDebug) { client_prop.put("FrameTransform_verbose_debug", "1"); }
         REQUIRE(client_pd.open(client_prop));
         REQUIRE(client_pd.view(ift));
 

--- a/tests/libYARP_dev/IFrameTransformTest.cpp
+++ b/tests/libYARP_dev/IFrameTransformTest.cpp
@@ -389,11 +389,17 @@ void exec_frameTransform_test_1(IFrameTransform* itf)
     {
         yInfo() << "Running Sub-test12";
         itf->clear();
+        yDebug() << "Creating Transform frame2 -> frame1 at time" << std::to_string(yarp::os::Time::now());
         CHECK(itf->setTransform("frame2", "frame1", m1));
-        yarp::os::Time::delay(0.050);
+        yDebug() << "Created at time" << std::to_string(yarp::os::Time::now());
+        yarp::os::Time::delay(0.040);
+        yDebug() << "Creating Transform frame3 -> frame2 at time" << std::to_string(yarp::os::Time::now());
         CHECK(itf->setTransform("frame3", "frame2", m2));
-        yarp::os::Time::delay(0.050);
+        yDebug() << "Created at time" << std::to_string(yarp::os::Time::now());
+        yarp::os::Time::delay(0.040);
+        yDebug() << "Creating Transform frame3 -> frame1 at time" << std::to_string(yarp::os::Time::now());
         CHECK_FALSE(itf->setTransform("frame3", "frame1", m1));
+        yDebug() << "Intentionally skipped at time" << std::to_string(yarp::os::Time::now());
         // itf->setTransform duplicate transform successfully skipped
 
         yarp::sig::Matrix mt1;


### PR DESCRIPTION
* improved frameTransformClientTest for better understanding issues in CI: now using new param FrameTransform_verbose_debug=1
* FrameTransformStorage, FrameTransformContainer show advanced debug info when FrameTransform_verbose_debug=1
* all xml files now expose the parameter FrameTransform_verbose_debug (default = 0)