### PR TITLE
Yarpmotorgui with displayed hardware faults messages 

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -416,6 +416,7 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/ControlBoardPid.h>
 %include <yarp/dev/IControlMode.h>
 %include <yarp/dev/IInteractionMode.h>
+%include <yarp/dev/IJointFault.h>
 %include <yarp/dev/IEncodersTimed.h>
 %include <yarp/dev/IMotor.h>
 %include <yarp/dev/IMotorEncoders.h>
@@ -815,6 +816,7 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
     CAST_POLYDRIVER_TO_INTERFACE(IImpedanceControl)
     CAST_POLYDRIVER_TO_INTERFACE(ITorqueControl)
     CAST_POLYDRIVER_TO_INTERFACE(IControlMode)
+    CAST_POLYDRIVER_TO_INTERFACE(IJointFault)
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.0.0
     yarp::dev::IControlMode *viewIControlMode2() {
@@ -1234,6 +1236,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 
     bool getVelLimits(int axis, std::vector<double>& min, std::vector<double>& max) {
         return self->getVelLimits(axis, &min[0], &max[0]);
+    }
+}
+
+%extend yarp::dev::IJointFault {
+    bool getLastJointFault(int j, std::vector<int>& fault, std::vector<std::string>& message) {
+        return self->getLastJointFault(j, fault[0], message[0]);
     }
 }
 

--- a/doc/release/master/yarpmotogui_hwfault.md
+++ b/doc/release/master/yarpmotogui_hwfault.md
@@ -16,6 +16,10 @@ yarpmotorgui_hwfault {#master}
 
 * ControlBoard_nws_yarp now implements IJointFault
 
+#### ControlBoardRemapper
+
+* ControlBoardRemapper now implements IJointFault
+
 #### fakeMotionControl
 
 * fakeMotionControl now simulates an hardware fault when it receives a TorqueCommand > 1Nm

--- a/doc/release/master/yarpmotogui_hwfault.md
+++ b/doc/release/master/yarpmotogui_hwfault.md
@@ -1,0 +1,32 @@
+yarpmotorgui_hwfault {#master}
+-----------------------
+
+### libyarp_dev
+
+* Added new interface IJointFault with method: IJointFault::getLastJointFault(int j, int& fault, std::string& message)
+
+### devices
+
+
+#### RemoteControlBoard
+
+* RemoteControlBoard now implements IJointFault
+
+#### ControlBoard_nws_yarp
+
+* ControlBoard_nws_yarp now implements IJointFault
+
+#### fakeMotionControl
+
+* fakeMotionControl now simulates an hardware fault when it receives a TorqueCommand > 1Nm
+
+### GUIs
+
+#### yarpmotorgui
+
+* Modified yarpmotorgui to support a new page "Hardware Fault" which displays the internal hardware error
+
+
+
+
+

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -1623,6 +1623,26 @@ bool ControlBoardRemapper::stop(const int n_joints, const int *joints)
     return ret;
 }
 
+/* IJointFaultControl */
+bool ControlBoardRemapper::getLastJointFault(int j, int& fault, std::string& message)
+{
+    int off = (int)remappedControlBoards.lut[j].axisIndexInSubControlBoard;
+    size_t subIndex = remappedControlBoards.lut[j].subControlBoardIndex;
+
+    RemappedSubControlBoard* p = remappedControlBoards.getSubControlBoard(subIndex);
+
+    if (!p)
+    {
+        return false;
+    }
+
+    if (p->iFault)
+    {
+        return p->iFault->getLastJointFault(off, fault, message);
+    }
+
+    return false;
+}
 
 /* IVelocityControl */
 

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapper.h
@@ -88,7 +88,8 @@ class ControlBoardRemapper :
         public yarp::dev::IAxisInfo,
         public yarp::dev::IPreciselyTimed,
         public yarp::dev::IInteractionMode,
-        public yarp::dev::IRemoteVariables {
+        public yarp::dev::IRemoteVariables,
+        public yarp::dev::IJointFault {
 private:
     std::vector<std::string> axesNames;
     RemappedControlBoards remappedControlBoards;
@@ -301,6 +302,10 @@ public:
     bool stop() override;
 
     bool stop(const int n_joints, const int *joints) override;
+
+    /* IJointFault */
+
+    bool getLastJointFault(int j, int& fault, std::string& message) override;
 
     /* IVelocityControl */
     bool velocityMove(int j, double v) override;

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -112,6 +112,7 @@ bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string
         subdevice->view(iVar);
         subdevice->view(iPwm);
         subdevice->view(iCurr);
+        subdevice->view(iFault);
     }
     else
     {
@@ -164,8 +165,13 @@ bool RemappedSubControlBoard::attach(yarp::dev::PolyDriver *d, const std::string
         yCWarning(CONTROLBOARDREMAPPER) << "ICurrentControl not valid interface";
     }
 
+    if ((iFault == nullptr) && (_subDevVerbose))
+    {
+        yCWarning(CONTROLBOARDREMAPPER) << "IJointFault not valid interface";
+    }
 
-    // checking minimum set of intefaces required
+
+    // checking minimum set of interfaces required
     if( !(pos) )
     {
         yCError(CONTROLBOARDREMAPPER, "IPositionControl interface was not found in subdevice. Quitting");

--- a/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.h
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapperHelpers.h
@@ -64,6 +64,7 @@ public:
     yarp::dev::IRemoteVariables      *iVar;
     yarp::dev::IPWMControl           *iPwm;
     yarp::dev::ICurrentControl       *iCurr;
+    yarp::dev::IJointFault           *iFault;
 
     RemappedSubControlBoard();
 

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
@@ -207,6 +207,12 @@ bool ControlBoard_nws_yarp::setDevice(yarp::dev::DeviceDriver* driver, bool owne
     subdevice_ptr = driver;
     subdevice_owned = owned;
 
+    // yarp::dev::IJointFault* iJointFault{nullptr};
+    subdevice_ptr->view(iJointFault);
+    if (!iJointFault) {
+        yCWarning(CONTROLBOARD, "Part <%s>: iJointFault interface was not found in subdevice.", partName.c_str());
+    }
+
     // yarp::dev::IPidControl* iPidControl{nullptr};
     subdevice_ptr->view(iPidControl);
     if (!iPidControl) {
@@ -386,6 +392,7 @@ void ControlBoard_nws_yarp::closeDevice()
     iRemoteVariables = nullptr;
     iPWMControl = nullptr;
     iCurrentControl = nullptr;
+    iJointFault = nullptr;
 }
 
 bool ControlBoard_nws_yarp::attach(yarp::dev::PolyDriver* poly)

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.h
@@ -111,6 +111,7 @@ private:
     yarp::dev::IRemoteVariables* iRemoteVariables{nullptr};
     yarp::dev::IPWMControl* iPWMControl{nullptr};
     yarp::dev::ICurrentControl* iCurrentControl{nullptr};
+    yarp::dev::IJointFault* iJointFault{ nullptr };
 
     bool setDevice(yarp::dev::DeviceDriver* device, bool owned);
     bool openAndAttachSubDevice(yarp::os::Property& prop);

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.h
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.h
@@ -73,6 +73,7 @@ protected:
     yarp::dev::IRemoteVariables* rpc_IVar {nullptr};
     yarp::dev::ICurrentControl* rpc_ICurrent {nullptr};
     yarp::dev::IPWMControl* rpc_IPWM {nullptr};
+    yarp::dev::IJointFault* rpc_IJointFault{ nullptr };
     yarp::sig::Vector tmpVect;
     yarp::os::Stamp lastRpcStamp;
     std::mutex mutex;
@@ -99,6 +100,11 @@ public:
                          yarp::os::Bottle& response,
                          bool* rec,
                          bool* ok);
+
+    void handleJointFaultMsg(const yarp::os::Bottle& cmd,
+                              yarp::os::Bottle& response,
+                              bool* rec,
+                              bool* ok);
 
     void handleControlModeMsg(const yarp::os::Bottle& cmd,
                               yarp::os::Bottle& response,

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -1885,6 +1885,30 @@ bool RemoteControlBoard::stop()
 
 // END IPositionControl
 
+// BEGIN IJoint Fault
+bool RemoteControlBoard::getLastJointFault(int j, int& fault, std::string& message)
+{
+    Bottle cmd, response;
+
+    cmd.addVocab32(VOCAB_GET);
+    cmd.addVocab32(VOCAB_IJOINTFAULT);
+    cmd.addVocab32(VOCAB_JF_GET_JOINTFAULT);
+    cmd.addInt32(j);
+
+    bool ok = rpc_p.write(cmd, response);
+
+    std::string ss = response.toString();
+
+    if (CHECK_FAIL(ok, response))
+    {
+        fault = response.get(1).asInt32();
+        message = response.get(2).asString();
+        return true;
+    }
+    return false;
+}
+// END IJointFault
+
 // BEGIN IVelocityControl
 
 bool RemoteControlBoard::velocityMove(int j, double v)

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.h
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.h
@@ -30,6 +30,7 @@
 #include <yarp/dev/IRemoteVariables.h>
 #include <yarp/dev/IPWMControl.h>
 #include <yarp/dev/ICurrentControl.h>
+#include <yarp/dev/IJointFault.h>
 #include <yarp/dev/ControlBoardHelpers.h>
 
 #include "stateExtendedReader.h"
@@ -82,7 +83,8 @@ class RemoteControlBoard :
         public yarp::dev::IRemoteCalibrator,
         public yarp::dev::IRemoteVariables,
         public yarp::dev::IPWMControl,
-        public yarp::dev::ICurrentControl
+        public yarp::dev::ICurrentControl,
+        public yarp::dev::IJointFault
 {
 protected:
     yarp::os::Port rpc_p;
@@ -381,6 +383,9 @@ public:
     bool stop(int j) override;
     bool stop(const int len, const int *val1) override;
     bool stop() override;
+
+    // IJointFault
+    bool getLastJointFault(int j, int& fault, std::string& message) override;
 
     // IVelocityControl
     bool velocityMove(int j, double v) override;

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -59,6 +59,7 @@ set(YARP_dev_HDRS
   yarp/dev/IImpedanceControl.h
   yarp/dev/IInteractionMode.h
   yarp/dev/IJoypadController.h
+  yarp/dev/IJointFault.h
   yarp/dev/IMotor.h
   yarp/dev/IMotorEncoders.h
   yarp/dev/IMultipleWrapper.h
@@ -90,6 +91,7 @@ set(YARP_dev_HDRS
   yarp/dev/ImplementEncodersTimed.h
   yarp/dev/ImplementImpedanceControl.h
   yarp/dev/ImplementInteractionMode.h
+  yarp/dev/ImplementJointFault.h
   yarp/dev/ImplementMotor.h
   yarp/dev/ImplementMotorEncoders.h
   yarp/dev/ImplementPWMControl.h
@@ -206,6 +208,7 @@ set(YARP_dev_SRCS
   yarp/dev/ImplementEncodersTimed.cpp
   yarp/dev/ImplementImpedanceControl.cpp
   yarp/dev/ImplementInteractionMode.cpp
+  yarp/dev/ImplementJointFault.cpp
   yarp/dev/ImplementMotor.cpp
   yarp/dev/ImplementMotorEncoders.cpp
   yarp/dev/ImplementPWMControl.cpp

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
@@ -36,6 +36,7 @@
 #include <yarp/dev/IAxisInfo.h>
 #include <yarp/dev/IControlLimits.h>
 #include <yarp/dev/IControlMode.h>
+#include <yarp/dev/IJointFault.h>
 
 #include <yarp/dev/ControlBoardVocabs.h>
 

--- a/src/libYARP_dev/src/yarp/dev/IJointFault.h
+++ b/src/libYARP_dev/src/yarp/dev/IJointFault.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_DEV_IJOINTFAULT_H
+#define YARP_DEV_IJOINTFAULT_H
+
+#include <yarp/os/Vocab.h>
+#include <yarp/dev/api.h>
+
+namespace yarp::dev {
+class IJointFaultRaw;
+class IJointFault;
+}
+
+/**
+ * @ingroup dev_iface_motor
+ *
+ * Interface for getting info about the fault which may occur on a robot.
+ */
+class YARP_dev_API yarp::dev::IJointFault
+{
+public:
+    virtual ~IJointFault(){}
+    virtual bool getLastJointFault(int j, int& fault, std::string& message)=0;
+};
+
+/**
+ * @ingroup dev_iface_motor
+ *
+ * Interface for getting info about the fault which may occur on a robot.
+ */
+class YARP_dev_API yarp::dev::IJointFaultRaw
+{
+public:
+    virtual ~IJointFaultRaw(){}
+    virtual bool getLastJointFaultRaw(int j, int& mode, std::string& message)=0;
+};
+
+constexpr yarp::conf::vocab32_t  VOCAB_IJOINTFAULT             =    yarp::os::createVocab32('i','j','f','l');
+constexpr yarp::conf::vocab32_t  VOCAB_JF_GET_JOINTFAULT       =    yarp::os::createVocab32('j','h','f','l');
+
+#endif // YARP_DEV_IJOINTFAULT_H

--- a/src/libYARP_dev/src/yarp/dev/ImplementJointFault.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementJointFault.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/dev/ImplementJointFault.h>
+#include <yarp/dev/ControlBoardHelper.h>
+#include <yarp/dev/impl/FixedSizeBuffersManager.h>
+
+#include <cstdio>
+using namespace yarp::dev;
+using namespace yarp::os;
+
+#define JOINTIDCHECK if (j >= castToMapper(helper)->axes()){yError("joint id out of bound"); return false;}
+
+ImplementJointFault::ImplementJointFault(IJointFaultRaw *r):
+    helper(nullptr),
+    raw(r)
+{}
+
+bool ImplementJointFault::initialize(int size, const int *amap)
+{
+    if (helper != nullptr) {
+        return false;
+    }
+
+    helper=(void *)(new ControlBoardHelper(size, amap));
+    yAssert (helper != nullptr);
+
+    return true;
+}
+
+ImplementJointFault::~ImplementJointFault()
+{
+    uninitialize();
+}
+
+bool ImplementJointFault::uninitialize ()
+{
+    if (helper!=nullptr)
+    {
+        delete castToMapper(helper);
+        helper=nullptr;
+    }
+
+    return true;
+}
+
+bool ImplementJointFault::getLastJointFault(int j, int& fault, std::string& message)
+{
+    JOINTIDCHECK
+    int k=castToMapper(helper)->toHw(j);
+    return raw->getLastJointFaultRaw(k, fault, message);
+}

--- a/src/libYARP_dev/src/yarp/dev/ImplementJointFault.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementJointFault.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_DEV_IMPLEMENTJOINTFAULT_H
+#define YARP_DEV_IMPLEMENTJOINTFAULT_H
+
+#include <yarp/dev/IJointFault.h>
+#include <yarp/dev/api.h>
+
+namespace yarp::dev {
+class ImplementJointFault;
+}
+
+class YARP_dev_API yarp::dev::ImplementJointFault: public IJointFault
+{
+protected:
+    yarp::dev::IJointFaultRaw *raw;
+    void *helper;
+
+    /**
+     * Initialize the internal data and alloc memory.
+     * @param size is the number of controlled axes the driver deals with.
+     * @param amap is a lookup table mapping axes onto physical drivers.
+     * @return true if initialized succeeded, false if it wasn't executed, or assert.
+     */
+    bool initialize (int size, const int *amap);
+
+    /**
+     * Clean up internal data and memory.
+     * @return true if uninitialization is executed, false otherwise.
+     */
+    bool uninitialize ();
+
+public:
+    /* Constructor.
+     * @param y is the pointer to the class instance inheriting from this
+     *  implementation.
+     */
+    ImplementJointFault(yarp::dev::IJointFaultRaw *y);
+
+    /**
+     * Destructor. Perform uninitialize if needed.
+     */
+    virtual ~ImplementJointFault();
+
+    bool getLastJointFault(int j, int& fault, std::string& message) override;
+
+};
+
+#endif // YARP_DEV_IMPLEMENTJOINTFAULT_H

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -428,6 +428,7 @@ void JointItem::setUnits(yarp::dev::JointTypeEnum t)
         ui->labelPWMposUnits->setText(pos_metric_revolute);
         ui->labelCurrentposUnits->setText(pos_metric_revolute);
         ui->labelVelocityposUnits->setText(pos_metric_revolute);
+        ui->labelFaultposUnits->setText(pos_metric_revolute);
 
         ui->labelIdletrqUnits->setText(trq_metric_revolute);
         ui->labelPositiontrqUnits->setText(trq_metric_revolute);
@@ -466,6 +467,7 @@ void JointItem::setUnits(yarp::dev::JointTypeEnum t)
         ui->labelPWMposUnits->setText(pos_metric_prism);
         ui->labelCurrentposUnits->setText(pos_metric_prism);
         ui->labelVelocityposUnits->setText(pos_metric_prism);
+        ui->labelFaultposUnits->setText(pos_metric_prism);
 
         ui->labelIdletrqUnits->setText(trq_metric_prism);
         ui->labelPositiontrqUnits->setText(trq_metric_prism);
@@ -1485,6 +1487,10 @@ void JointItem::setPosition(double val)
 
     if(ui->stackedWidget->currentIndex() == IDLE){
         ui->editIdleJointPos->setText(sVal);
+    }
+
+    if (ui->stackedWidget->currentIndex() == HW_FAULT) {
+        ui->editFaultJointPos->setText(sVal);
     }
 
     if(ui->stackedWidget->currentIndex() == POSITION){

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -79,6 +79,7 @@ JointItem::JointItem(int index,QWidget *parent) :
     TORQUE          = 5;
     PWM             = 6;
     CURRENT         = 7;
+    HW_FAULT        = 8;
 
 
 
@@ -1420,6 +1421,12 @@ void JointItem::updateSliderCurrent(double val)
     ui->sliderCurrentOutput->setValue(val);
 }
 
+void JointItem::updateJointFault(int i, std::string message)
+{
+    ui->labelFaultCodeEntry->setText(QString::fromStdString(std::to_string(i)));
+    ui->labelFaultMessageEntry->setText(QString::fromStdString(message));
+}
+
 void JointItem::updateSliderTorque(double val)
 {
     if(sliderTorquePressed){
@@ -1777,15 +1784,24 @@ void JointItem::setJointInternalState(int mode)
     if(ui->stackedWidget->widget(mode)){
         QVariant variant = ui->comboMode->itemData(mode,Qt::BackgroundRole);
         QColor c;
-        switch(internalState){
-            case Disconnected:{
+        switch(internalState)
+       {
+            case Disconnected:
                 c = disconnectColor;
                 break;
-            }
-            case HwFault:{
+            case HwFault:
+                ui->groupBox->setTitle(QString("JOINT %1 (%2) -  HARDWARE FAULT").arg(jointIndex).arg(jointName));
+                ui->stackedWidget->setEnabled(false);
+                //ui->buttonsContainer->setEnabled(false);
+                ui->buttonHome->setEnabled(false);
+                ui->buttonCalib->setEnabled(false);
+                ui->buttonRun->setEnabled(false);
+                ui->comboMode->setEnabled(false);
+                ui->comboInteraction->setEnabled(false);
+                ui->buttonIdle->setEnabled(true);
+                ui->buttonPid->setEnabled(true);
                 c = hwFaultColor;
                 break;
-            }
             case Unknown:
             case NotConfigured:
             case Configured:
@@ -1921,22 +1937,7 @@ void JointItem::setJointState(JointState newState)
         break;
     }
     case HwFault:{
-        ui->groupBox->setTitle(QString("JOINT %1 (%2) -  HARDWARE FAULT").arg(jointIndex).arg(jointName));
-        ui->stackedWidget->setEnabled(false);
-        //ui->buttonsContainer->setEnabled(false);
-        ui->buttonHome->setEnabled(false);
-        ui->buttonCalib->setEnabled(false);
-        ui->buttonRun->setEnabled(false);
-        ui->comboMode->setEnabled(false);
-        ui->comboInteraction->setEnabled(false);
-        ui->buttonIdle->setEnabled(true);
-        ui->buttonPid->setEnabled(true);
-
-        int index = ui->stackedWidget->currentIndex();
-        if(ui->stackedWidget->widget(index)){
-            QColor c = hwFaultColor;
-            setStyleSheet(QString("font: 8pt; background-color: rgb(%1,%2,%3); color: rgb(35, 38, 41);").arg(c.red()).arg(c.green()).arg(c.blue()));
-        }
+        setJointInternalState(HW_FAULT);
         break;
     }
     case Disconnected:{

--- a/src/yarpmotorgui/jointitem.h
+++ b/src/yarpmotorgui/jointitem.h
@@ -50,6 +50,7 @@ class JointItem : public QWidget
     void setCurrent(double meas);
     void setRefCurrent(double ref);
     void updateMotionDone(bool done);
+    void updateJointFault(int i, std::string message);
     void setJointName(QString name);
     QString getJointName();
     int getJointIndex();
@@ -149,6 +150,7 @@ private:
     int     TORQUE;
     int     PWM;
     int     CURRENT;
+    int     HW_FAULT;
 
     int shiftPositions;
 

--- a/src/yarpmotorgui/jointitem.ui
+++ b/src/yarpmotorgui/jointitem.ui
@@ -439,7 +439,7 @@ QSlider::groove:horizontal:disabled {
  }</string>
         </property>
         <property name="currentIndex">
-         <number>5</number>
+         <number>8</number>
         </property>
         <widget class="QWidget" name="pageIdle">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -2416,6 +2416,81 @@ QSlider::groove:horizontal:disabled {
               <widget class="QLineEdit" name="editCurrentDuty">
                <property name="styleSheet">
                 <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="pageFault">
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <layout class="QFormLayout" name="formLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="LabelFaultCode">
+              <property name="text">
+               <string>Fault Code:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="labelFaultCodeEntry">
+              <property name="text">
+               <string>TextLabel</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="LabelFaultMessage">
+              <property name="text">
+               <string>Fault Message:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="labelFaultMessageEntry">
+              <property name="text">
+               <string>TextLabel</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_8">
+             <property name="leftMargin">
+              <number>2</number>
+             </property>
+             <property name="rightMargin">
+              <number>2</number>
+             </property>
+             <item row="0" column="2">
+              <widget class="QLabel" name="labelFaultposUnits">
+               <property name="text">
+                <string>deg</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="editFaultJointPos">
+               <property name="styleSheet">
+                <string notr="true">background-color: rgb(255, 255, 255); color: rgb(35, 38, 41);</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelFaultJointPos">
+               <property name="text">
+                <string>Encoder:</string>
                </property>
               </widget>
              </item>

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -149,6 +149,7 @@ private:
     IControlCalibration    *m_ical;
     IControlMode           *m_ictrlmode;
     IInteractionMode        *m_iinteract;
+    IJointFault             *m_ijointfault;
     IRemoteCalibrator   *m_iremCalib;
     int m_slow_k;
 


### PR DESCRIPTION
See discussion: https://github.com/robotology/community/discussions/561

* Modified yarpmotorgui to support a new page "Hardware Fault" which displays the internal hardware error
* Added new interface IJointFault with method: IJointFault::getLastJointFault(int j, int& fault, std::string& message)
* IJointFault is now implemented by RemoteControlBoard and ControlBoard_nws_yarp
* fakeMotionControl.cpp now simulates an hardware fault when it receives a TorqueCommand > 1Nm

