### PR TITLE
Give Python3 headers more precedence over 3rd-party transitive deps

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -35,7 +35,14 @@ set_target_properties(${SWIG_MODULE_yarp_python_REAL_NAME}
   PROPERTIES
     OUTPUT_NAME "_yarp"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/python3"
+    # treat Python3_INCLUDE_DIRS as non-system so that it can be overriden
+    NO_SYSTEM_FROM_IMPORTED TRUE
 )
+
+# INCLUDE_DIRECTORIES might have gotten polluted by 3rd-party deps, make sure
+# the Python3 header path has more predecence by overriding the previous value
+# (set by `swig_link_libraries`) and prepending it to the search path
+target_include_directories(${SWIG_MODULE_yarp_python_REAL_NAME} BEFORE PRIVATE ${Python3_INCLUDE_DIRS})
 
 # installation path is determined reliably on most platforms using distutils
 execute_process(

--- a/doc/release/yarp_3_5/fix_python3_bionic
+++ b/doc/release/yarp_3_5/fix_python3_bionic
@@ -1,0 +1,6 @@
+fix_python3_bionic {#yarp_3_5}
+-----------
+
+### Bindings
+
+* Fixed compilation of Python3 bindings on certain configurations. (#2725)


### PR DESCRIPTION
On Bionic with VTK 6.3, Python 2.7 headers are added to the search path by `find_package` and given more precedence than Python 3 headers as provided by FindPython3.

Fixes https://github.com/robotology/yarp/issues/2725.