### PR TITLE
Fix logger lost messages

### DIFF
--- a/doc/release/master/fix_logFowarder_lost_msgs.md
+++ b/doc/release/master/fix_logFowarder_lost_msgs.md
@@ -1,0 +1,10 @@
+fix_logForwarder_lost_msgs {#master}
+-----------------------
+
+## Libraries
+
+### `os`
+
+#### `Log`
+
+* LogForwarder: now using yarp::os::PortWriterBuffer to prevent message loss

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
@@ -46,8 +46,9 @@ yarp::os::impl::LogForwarder::LogForwarder()
     if (!outputPort.open(logPortName)) {
         printf("LogForwarder error while opening port %s\n", logPortName.c_str());
     }
-    outputPort.enableBackgroundWrite(true);
+
     outputPort.addOutput("/yarplogger", "fast_tcp");
+    outputPort_buffer.attach(outputPort);
 
     started = true;
 }
@@ -55,12 +56,12 @@ yarp::os::impl::LogForwarder::LogForwarder()
 void yarp::os::impl::LogForwarder::forward(const std::string& message)
 {
     mutex.lock();
-    static Bottle b;
+    Bottle& b = outputPort_buffer.get();
     b.clear();
     std::string port = "[" + outputPort.getName() + "]";
     b.addString(port);
     b.addString(message);
-    outputPort.write(b);
+    outputPort_buffer.write();
     mutex.unlock();
 }
 

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
@@ -9,6 +9,7 @@
 #include <yarp/os/api.h>
 
 #include <yarp/os/Port.h>
+#include <yarp/os/PortWriterBuffer.h>
 
 #include <mutex>
 #include <string>
@@ -31,6 +32,7 @@ private:
 
     std::mutex mutex;
     yarp::os::Port outputPort;
+    yarp::os::PortWriterBuffer<yarp::os::Bottle> outputPort_buffer;
     static bool started;
 };
 


### PR DESCRIPTION
A possible solution for issue https://github.com/robotology/yarp/issues/2643, already addressed by  PR https://github.com/robotology/yarp/pull/2667 , but using a different, not-blocking technique.

The performance of this solution still has to be investigated.