### PR TITLE
yarpidl_thrift: Fix malformed files when comments contain double quotes

### DIFF
--- a/src/yarpidl_thrift/src/t_yarp_generator.cc
+++ b/src/yarpidl_thrift/src/t_yarp_generator.cc
@@ -3720,7 +3720,7 @@ void t_yarp_generator::generate_service_helper_classes_decl(t_function* function
                     }
                     first = false;
                     f_cpp_ << '\n';
-                    f_cpp_ << indent_cpp() << "\"" << replaceInString(helpStr, "\"", "\\\"");
+                    f_cpp_ << indent_cpp() << "\"" << helpStr;
                 }
             }
             indent_down_cpp();

--- a/tests/yarpidl_thrift/demo/demo.thrift
+++ b/tests/yarpidl_thrift/demo/demo.thrift
@@ -13,7 +13,7 @@
 
 
 /**
- * Documentation for enumerator
+ * Documentation for "enumerator"
  */
 enum DemoEnum {
   /** thing 1 */
@@ -24,13 +24,13 @@ enum DemoEnum {
 }
 
 /**
- * Documentation for structure
+ * Documentation for "structure"
  */
 struct DemoStruct {
-  /** this is the x part */
+  /** this is the "x" part */
   1: i32 x = 0,
 
-  /** this is the y part */
+  /** this is the "y" part */
   2: i32 y
 }
 
@@ -43,10 +43,10 @@ struct DemoStructMap {
 }
 
 struct DemoStructExt {
-  /** this is the x part */
+  /** this is the "x" part */
   1: i32 x = 0,
 
-  /** this is the y part */
+  /** this is the "y" part */
   2: i32 y = 0,
 
   /** this is a list of ints */
@@ -68,10 +68,10 @@ struct TestSomeMoreTypes {
 }
 
 /**
- * Documentation for service
+ * Documentation for "service"
  */
 service Demo {
-  /** This function gets the answer */
+  /** This "function" gets the answer */
   i32 get_answer();
   bool set_answer(1:i32 rightAnswer)
   i32 add_one(1:i32 x);

--- a/tests/yarpidl_thrift/demo/main.cpp
+++ b/tests/yarpidl_thrift/demo/main.cpp
@@ -796,7 +796,7 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         bot.read(con.getReader());
         INFO("Structure specific help is " << bot.toString());
         std::string help = bot.toString();
-        CHECK(help.find("this is the x part") != std::string::npos);
+        CHECK(help.find("this is the \\\"x\\\" part") != std::string::npos);
     }
 
     SECTION("test primitives")


### PR DESCRIPTION
Fixes #2768