### PR TITLE
added device for synchronization

### DIFF
--- a/doc/release/master/systemReady.md
+++ b/doc/release/master/systemReady.md
@@ -1,0 +1,7 @@
+systemReady {#master}
+-----------------------
+
+### yarp
+#### devices
+* added systemReady device that opens some ports when called. It is useful for synchronize processes opened with yarprobotinterface and yarpmanager to avoid crashes when some processes are not started
+

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -102,6 +102,7 @@ yarp_begin_plugin_library(yarpmod
   add_subdirectory(mobileBaseVelocityControlMsgs)
   add_subdirectory(odometry2D)
   add_subdirectory(systemReady)
+  add_subdirectory(awaitSystemReady)
 
 
   add_subdirectory(portaudio) # DEPRECATED Since YARP 3.2

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -101,6 +101,7 @@ yarp_begin_plugin_library(yarpmod
   add_subdirectory(mobileBaseVelocityControl)
   add_subdirectory(mobileBaseVelocityControlMsgs)
   add_subdirectory(odometry2D)
+  add_subdirectory(systemReady)
 
 
   add_subdirectory(portaudio) # DEPRECATED Since YARP 3.2

--- a/src/devices/awaitSystemReady/AwaitSystemReady_nws_yarp.cpp
+++ b/src/devices/awaitSystemReady/AwaitSystemReady_nws_yarp.cpp
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "AwaitSystemReady_nws_yarp.h"
+#include <yarp/os/Network.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+
+YARP_LOG_COMPONENT(AWAITSYSTEMREADY_NWS_YARP, "yarp.devices.AwaitSystemReady_nws_yarp")
+
+AwaitSystemReady_nws_yarp::AwaitSystemReady_nws_yarp()
+{
+}
+
+bool AwaitSystemReady_nws_yarp::open(yarp::os::Searchable &config)
+{
+    if (config.check("PORT_LIST")) {
+        // skips the first one since it is PORT_LIST
+        yarp::os::Bottle port_list = config.findGroup("PORT_LIST").tail();
+        for (int index = 0; index < port_list.size(); index++) {
+            std::string current_port_property = port_list.get(index).toString();
+            std::string token;
+            int pos;
+            char delimiter = ' ';
+            pos = current_port_property.find(delimiter);
+            token = current_port_property.substr(0, pos);
+            std::string current_port_name = port_list.find(token).asString();
+            yarp::os::NetworkBase::waitPort(current_port_name);
+        }
+        return true;
+    }
+    yCError(AWAITSYSTEMREADY_NWS_YARP) << "missing PORT_LIST group";
+    return false;
+}
+
+
+bool AwaitSystemReady_nws_yarp::close()
+{
+    return true;
+}

--- a/src/devices/awaitSystemReady/AwaitSystemReady_nws_yarp.h
+++ b/src/devices/awaitSystemReady/AwaitSystemReady_nws_yarp.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_AWAITSYSTEMREADY_NWS_YARP_H
+
+#include <yarp/dev/DeviceDriver.h>
+
+
+/**
+ * @ingroup dev_impl_network_servers
+ *
+ * \section AwaitSystemReady_nws_yarp Device description
+ * \brief `AwaitSystemReady_nws_yarp`: A yarp nws to wait port for synchronization:
+ *  it waits for the specified ports inside the PORT_LIST group.
+ *  Related to SystemReady_nws_yarp.
+ *
+ * Parameters required by this device are:
+ * | Parameter name      | SubParameter            | Type    | Units          | Default Value | Required                       | Description                                          |
+ * |:-------------------:|:-----------------------:|:-------:|:--------------:|:-------------:|:-----------------------------: |:-----------------------------------------------------|
+ * | PORT_NAME           |      -                  | group   |                |               | Yes                            | the group inside which port names are located        |
+ *
+ * example of xml file with a fake odometer
+ *
+ * \code{.unparsed}
+ * <?xml version="1.0" encoding="UTF-8" ?>
+ * <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+ * <robot name="awaitSystemReady" build="2" portprefix="test" xmlns:xi="http://www.w3.org/2001/XInclude">
+ * <devices>
+ *   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="awaitSystemReady_nws_yarp" type="awaitSystemReady_nws_yarp">
+ *     <group name="PORT_LIST">
+ *       <param name="pippo_port">/pippo</param>
+ *       <param name="pluto_port">/pluto</param>
+ *     </group>
+ *   </device>
+ * </devices>
+ * </robot>
+ * \endcode
+ *
+ */
+
+class AwaitSystemReady_nws_yarp :
+        public yarp::dev::DeviceDriver
+{
+public:
+    AwaitSystemReady_nws_yarp();
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable &params) override;
+    bool close() override;
+
+};
+
+#endif // YARP_AWAITSYSTEMREADY_NWS_YARP_H

--- a/src/devices/awaitSystemReady/CMakeLists.txt
+++ b/src/devices/awaitSystemReady/CMakeLists.txt
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+yarp_prepare_plugin(awaitSystemReady_nws_yarp
+  CATEGORY device
+  TYPE AwaitSystemReady_nws_yarp
+  INCLUDE AwaitSystemReady_nws_yarp.h
+  EXTRA_CONFIG
+    WRAPPER=awaitSystemReady_nws_yarp
+  DEFAULT ON
+)
+
+if(NOT SKIP_awaitSystemReady_nws_yarp)
+  yarp_add_plugin(yarp_awaitSystemReady_nws_yarp)
+
+  target_sources(yarp_awaitSystemReady_nws_yarp
+    PRIVATE
+          AwaitSystemReady_nws_yarp.cpp
+          AwaitSystemReady_nws_yarp.h
+  )
+
+  target_link_libraries(yarp_awaitSystemReady_nws_yarp
+    PRIVATE
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+  )
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+    YARP_os
+    YARP_sig
+    YARP_dev
+  )
+
+  yarp_install(
+    TARGETS yarp_awaitSystemReady_nws_yarp
+    EXPORT YARP_${YARP_PLUGIN_MASTER}
+    COMPONENT ${YARP_PLUGIN_MASTER}
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_awaitSystemReady_nws_yarp PROPERTY FOLDER "Plugins/Device/NWS")
+endif()

--- a/src/devices/systemReady/CMakeLists.txt
+++ b/src/devices/systemReady/CMakeLists.txt
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+yarp_prepare_plugin(systemReady_nws_yarp
+  CATEGORY device
+  TYPE SystemReady_nws_yarp
+  INCLUDE SystemReady_nws_yarp.h
+  EXTRA_CONFIG
+    WRAPPER=systemReady_nws_yarp
+  DEFAULT ON
+)
+
+if(NOT SKIP_systemReady_nws_yarp)
+  yarp_add_plugin(yarp_systemReady_nws_yarp)
+
+  target_sources(yarp_systemReady_nws_yarp
+    PRIVATE
+      SystemReady_nws_yarp.cpp
+      SystemReady_nws_yarp.h
+  )
+
+  target_link_libraries(yarp_systemReady_nws_yarp
+    PRIVATE
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+  )
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+    YARP_os
+    YARP_sig
+    YARP_dev
+  )
+
+  yarp_install(
+    TARGETS yarp_systemReady_nws_yarp
+    EXPORT YARP_${YARP_PLUGIN_MASTER}
+    COMPONENT ${YARP_PLUGIN_MASTER}
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_systemReady_nws_yarp PROPERTY FOLDER "Plugins/Device/NWS")
+endif()
+

--- a/src/devices/systemReady/CMakeLists.txt
+++ b/src/devices/systemReady/CMakeLists.txt
@@ -45,4 +45,3 @@ if(NOT SKIP_systemReady_nws_yarp)
 
   set_property(TARGET yarp_systemReady_nws_yarp PROPERTY FOLDER "Plugins/Device/NWS")
 endif()
-

--- a/src/devices/systemReady/SystemReady_nws_yarp.cpp
+++ b/src/devices/systemReady/SystemReady_nws_yarp.cpp
@@ -27,12 +27,12 @@ bool SystemReady_nws_yarp::open(yarp::os::Searchable &config)
             token = current_port_property.substr(0, pos);
             std::string current_port_name = port_list.find(token).asString();
             yarp::os::Port* current_port = new yarp::os::Port;
+            port_pointers_list.push_back(current_port);
             if(!current_port->open(current_port_name)){
                 yCError(SYSTEMREADY_NWS_YARP) << "error opening " << current_port_name;
                 close();
                 return false;
             }
-            port_pointers_list.push_back(current_port);
         }
         return true;
     }
@@ -45,6 +45,7 @@ bool SystemReady_nws_yarp::close()
 {
     for (auto elem: port_pointers_list){
         elem->close();
+        delete elem;
     }
     port_pointers_list.clear();
     return true;

--- a/src/devices/systemReady/SystemReady_nws_yarp.cpp
+++ b/src/devices/systemReady/SystemReady_nws_yarp.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "SystemReady_nws_yarp.h"
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+
+YARP_LOG_COMPONENT(SYSTEMREADY_NWS_YARP, "yarp.devices.SystemReady_nws_yarp")
+
+SystemReady_nws_yarp::SystemReady_nws_yarp()
+{
+}
+
+bool SystemReady_nws_yarp::open(yarp::os::Searchable &config)
+{
+    if (config.check("PORT_LIST")) {
+        yarp::os::Bottle port_list = config.findGroup("PORT_LIST");
+        // skips the first one since it is PORT_LIST
+        for (int index = 1; index < port_list.size(); index++) {
+            std::string current_port_property = port_list.get(index).toString();
+            std::string token;
+            int pos;
+            char delimiter = ' ';
+            pos = current_port_property.find(delimiter);
+            token = current_port_property.substr(0, pos);
+            std::string current_port_name = port_list.find(token).asString();
+            yCError(SYSTEMREADY_NWS_YARP) << port_list.get(index).asList()[0].toString();
+            yCError(SYSTEMREADY_NWS_YARP) << current_port_property;
+            yCError(SYSTEMREADY_NWS_YARP) << token;
+            yCError(SYSTEMREADY_NWS_YARP) << port_list.find(token).asString();
+            yarp::os::Port* current_port = new yarp::os::Port;
+            current_port->open(current_port_name);
+            port_pointers_list.push_back(current_port);
+        }
+        return true;
+    }
+    return false;
+}
+
+
+bool SystemReady_nws_yarp::close()
+{
+    for (auto elem: port_pointers_list){
+        elem->close();
+        delete elem;
+    }
+}

--- a/src/devices/systemReady/SystemReady_nws_yarp.h
+++ b/src/devices/systemReady/SystemReady_nws_yarp.h
@@ -12,7 +12,7 @@
 
 
 /**
- * @ingroup dev_impl_network_clients dev_impl_navigation
+ * @ingroup dev_impl_network_servers
  *
  * \section SystemReady_nws_yarp_parameters Device description
  * \brief `SystemReady_nws_yarp`: A yarp nws to open port for synchronization:

--- a/src/devices/systemReady/SystemReady_nws_yarp.h
+++ b/src/devices/systemReady/SystemReady_nws_yarp.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_SYSTEMREADY_NWS_YARP_H
+#define YARP_SYSTEMREADY_NWS_YARP_H
+
+#include <yarp/sig/Vector.h>
+#include <yarp/dev/DeviceDriver.h>
+
+
+/**
+ * @ingroup dev_impl_network_clients dev_impl_navigation
+ *
+ * \section SystemReady_nws_yarp_parameters Device description
+ * \brief `SystemReady_nws_yarp`: A yarp nws to open port for synchronization:
+ *  it opens the specified ports inside the PORT_LIST group.
+ *  Related to awaitSystemReady_nws_yarp.
+ *
+ * Parameters required by this device are:
+ * | Parameter name      | SubParameter            | Type    | Units          | Default Value | Required                       | Description                                          |
+ * |:-------------------:|:-----------------------:|:-------:|:--------------:|:-------------:|:-----------------------------: |:-----------------------------------------------------|
+ * | PORT_NAME           |      -                  | group   |                |               | Yes                            | the group inside which port names are located        |
+ *
+ * example of xml file with a fake odometer
+ *
+ * \code{.unparsed}
+ * <?xml version="1.0" encoding="UTF-8" ?>
+ * <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+ * <robot name="fakeOdometry" build="2" portprefix="test" xmlns:xi="http://www.w3.org/2001/XInclude">
+ * <devices>
+ *   <device xmlns:xi="http://www.w3.org/2001/XInclude" name="systemReady_nws_yarp" type="systemReady_nws_yarp">
+ *     <group name="PORT_LIST">
+ *       <param name="pippo_port">/pippo</param>
+ *       <param name="pluto_port">/pluto</param>
+ *     </group>
+ *   </device>
+ * </devices>
+ * </robot>
+ * \endcode
+ *
+ */
+
+class SystemReady_nws_yarp :
+        public yarp::dev::DeviceDriver
+{
+public:
+    SystemReady_nws_yarp();
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable &params) override;
+    bool close() override;
+
+private:
+    std::vector<yarp::os::Port*> port_pointers_list;
+
+};
+
+#endif // YARP_SYSTEMREADY_NWS_YARP_H

--- a/src/devices/systemReady/SystemReady_nws_yarp.h
+++ b/src/devices/systemReady/SystemReady_nws_yarp.h
@@ -6,7 +6,8 @@
 #ifndef YARP_SYSTEMREADY_NWS_YARP_H
 #define YARP_SYSTEMREADY_NWS_YARP_H
 
-#include <yarp/sig/Vector.h>
+#include <vector>
+#include <yarp/os/Port.h>
 #include <yarp/dev/DeviceDriver.h>
 
 


### PR DESCRIPTION

systemReady {#master}
-----------------------

### yarp
#### devices
* added systemReady device that opens some ports when called. It is useful for synchronize processes opened with yarprobotinterface and yarpmanager to avoid crashes when some processes are not started

