### PR TITLE
Improve joints tree view in yarpmotorgui

### DIFF
--- a/src/yarpmotorgui/CMakeLists.txt
+++ b/src/yarpmotorgui/CMakeLists.txt
@@ -19,6 +19,8 @@ if(YARP_COMPILE_yarpmotorgui)
     sliderOptions.cpp
     sliderWithTarget.cpp
     startdlg.cpp
+    jointItemTree.cpp
+    partItemTree.cpp
   )
   set(yarpmotorgui_HDRS
     flowlayout.h
@@ -32,6 +34,8 @@ if(YARP_COMPILE_yarpmotorgui)
     yarpmotorgui.h
     sequencewindow.h
     startdlg.h
+    jointItemTree.h
+    partItemTree.h
   )
   set(yarpmotorgui_QRC_FILES
     res.qrc
@@ -43,6 +47,7 @@ if(YARP_COMPILE_yarpmotorgui)
     sequencewindow.ui
     startdlg.ui
     sliderOptions.ui
+    jointItemTree.ui
   )
 
   qt5_add_resources(yarpmotorgui_QRC_GEN_SRCS ${yarpmotorgui_QRC_FILES})

--- a/src/yarpmotorgui/jointItemTree.cpp
+++ b/src/yarpmotorgui/jointItemTree.cpp
@@ -14,6 +14,32 @@ JointItemTree::JointItemTree(int index, QWidget *parent) :
 {
     m_ui->setupUi(this);
     setAttribute(Qt::WA_StyledBackground, true);
+
+    this->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    connect(this, SIGNAL(customContextMenuRequested(QPoint)),
+            this, SLOT(onShowContextMenu(QPoint)));
+
+    m_rightClickMenuTitle = new QAction(this);
+    m_rightClickMenuTitle->setEnabled(false);
+    m_rightClickMenu.addAction(m_rightClickMenuTitle);
+    m_rightClickMenu.addSeparator();
+
+    QAction* homeAction = new QAction("Home joint", this);
+    connect(homeAction, SIGNAL(triggered()), this, SLOT(onHomeClicked()));
+    m_rightClickMenu.addAction(homeAction);
+
+    QAction* idleAction = new QAction("Idle joint", this);
+    connect(idleAction, SIGNAL(triggered()), this, SLOT(onIdleClicked()));
+    m_rightClickMenu.addAction(idleAction);
+
+    QAction* runAction = new QAction("Run joint", this);
+    connect(runAction, SIGNAL(triggered()), this, SLOT(onRunClicked()));
+    m_rightClickMenu.addAction(runAction);
+
+    QAction* pidAction = new QAction("Show joint PID", this);
+    connect(pidAction, SIGNAL(triggered()), this, SLOT(onPIDClicked()));
+    m_rightClickMenu.addAction(pidAction);
 }
 
 JointItemTree::~JointItemTree()
@@ -64,4 +90,30 @@ void JointItemTree::setDesiredSize(int w, int h)
 {
     m_desiredWidth = w;
     m_desiredHeight = h;
+}
+
+void JointItemTree::onShowContextMenu(QPoint pos)
+{
+    m_rightClickMenuTitle->setText(m_ui->jointName->text() + " menu");
+    m_rightClickMenu.exec(mapToGlobal(pos));
+}
+
+void JointItemTree::onHomeClicked()
+{
+    emit sig_homeClicked(m_index);
+}
+
+void JointItemTree::onRunClicked()
+{
+    emit sig_runClicked(m_index);
+}
+
+void JointItemTree::onIdleClicked()
+{
+    emit sig_idleClicked(m_index);
+}
+
+void JointItemTree::onPIDClicked()
+{
+    emit sig_PIDClicked(m_index);
 }

--- a/src/yarpmotorgui/jointItemTree.cpp
+++ b/src/yarpmotorgui/jointItemTree.cpp
@@ -7,9 +7,10 @@
 #include "jointItemTree.h"
 #include "ui_jointItemTree.h"
 
-JointItemTree::JointItemTree(QWidget *parent) :
+JointItemTree::JointItemTree(int index, QWidget *parent) :
     QWidget(parent),
-    m_ui(new Ui::jointItemTree)
+    m_ui(new Ui::jointItemTree),
+    m_index(index)
 {
     m_ui->setupUi(this);
     setAttribute(Qt::WA_StyledBackground, true);
@@ -37,6 +38,11 @@ void JointItemTree::setColor(const QColor &color, const QColor &background)
             .arg(color.red()).arg(color.green()).arg(color.blue())
             .arg(background.red()).arg(background.green()).arg(background.blue());
     setStyleSheet(stileSheet);
+}
+
+void JointItemTree::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    emit sig_jointClicked(m_index);
 }
 
 QSize JointItemTree::sizeHint() const

--- a/src/yarpmotorgui/jointItemTree.cpp
+++ b/src/yarpmotorgui/jointItemTree.cpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "jointItemTree.h"
+#include "ui_jointItemTree.h"
+
+JointItemTree::JointItemTree(QWidget *parent) :
+    QWidget(parent),
+    m_ui(new Ui::jointItemTree)
+{
+    m_ui->setupUi(this);
+}
+
+JointItemTree::~JointItemTree()
+{
+    delete m_ui;
+}
+
+QLabel *JointItemTree::jointLabel()
+{
+    return m_ui->jointName;
+}
+
+QLabel *JointItemTree::modeLabel()
+{
+    return m_ui->jointMode;
+}
+
+void JointItemTree::setColor(const QColor &color, const QColor &background)
+{
+//    setAutoFillBackground(true);
+//    setStyleSheet(QString("color: rbg(%1, %2, %3); background-color:  rbg(%4, %5, %6);").arg(color.red())
+//                  .arg(color.green())
+//                  .arg(color.blue())
+//                  .arg(background.red())
+//                  .arg(background.green())
+//                  .arg(background.blue()));
+}

--- a/src/yarpmotorgui/jointItemTree.cpp
+++ b/src/yarpmotorgui/jointItemTree.cpp
@@ -33,12 +33,10 @@ QLabel *JointItemTree::modeLabel()
 void JointItemTree::setColor(const QColor &color, const QColor &background)
 {
     setAutoFillBackground(true);
-    setStyleSheet(QString("color: rbg(%1, %2, %3); background-color:  rbg(%4, %5, %6);").arg(color.red())
-                  .arg(color.green())
-                  .arg(color.blue())
-                  .arg(background.red())
-                  .arg(background.green())
-                  .arg(background.blue()));
+    QString stileSheet = QString("color: rgb(%1, %2, %3); background-color: rgb(%4, %5, %6)")
+            .arg(color.red()).arg(color.green()).arg(color.blue())
+            .arg(background.red()).arg(background.green()).arg(background.blue());
+    setStyleSheet(stileSheet);
 }
 
 QSize JointItemTree::sizeHint() const

--- a/src/yarpmotorgui/jointItemTree.cpp
+++ b/src/yarpmotorgui/jointItemTree.cpp
@@ -12,6 +12,7 @@ JointItemTree::JointItemTree(QWidget *parent) :
     m_ui(new Ui::jointItemTree)
 {
     m_ui->setupUi(this);
+    setAttribute(Qt::WA_StyledBackground, true);
 }
 
 JointItemTree::~JointItemTree()
@@ -31,11 +32,32 @@ QLabel *JointItemTree::modeLabel()
 
 void JointItemTree::setColor(const QColor &color, const QColor &background)
 {
-//    setAutoFillBackground(true);
-//    setStyleSheet(QString("color: rbg(%1, %2, %3); background-color:  rbg(%4, %5, %6);").arg(color.red())
-//                  .arg(color.green())
-//                  .arg(color.blue())
-//                  .arg(background.red())
-//                  .arg(background.green())
-//                  .arg(background.blue()));
+    setAutoFillBackground(true);
+    setStyleSheet(QString("color: rbg(%1, %2, %3); background-color:  rbg(%4, %5, %6);").arg(color.red())
+                  .arg(color.green())
+                  .arg(color.blue())
+                  .arg(background.red())
+                  .arg(background.green())
+                  .arg(background.blue()));
+}
+
+QSize JointItemTree::sizeHint() const
+{
+    QSize size = QWidget::sizeHint();
+    if (m_desiredWidth > 0)
+    {
+        size.setWidth(m_desiredWidth);
+    }
+    if (m_desiredHeight > 0)
+    {
+        size.setHeight(m_desiredHeight);
+    }
+
+    return size;
+}
+
+void JointItemTree::setDesiredSize(int w, int h)
+{
+    m_desiredWidth = w;
+    m_desiredHeight = h;
 }

--- a/src/yarpmotorgui/jointItemTree.h
+++ b/src/yarpmotorgui/jointItemTree.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifndef JOINTITEMTREE_H
+#define JOINTITEMTREE_H
+
+#include <QWidget>
+#include <QLabel>
+#include <QColor>
+
+namespace Ui {
+class jointItemTree;
+}
+
+class JointItemTree : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit JointItemTree(QWidget *parent = nullptr);
+    ~JointItemTree();
+
+    QLabel* jointLabel();
+
+    QLabel* modeLabel();
+
+    void setColor(const QColor& color, const QColor& background);
+
+private:
+    Ui::jointItemTree *m_ui;
+};
+
+#endif // JOINTITEMTREE_H

--- a/src/yarpmotorgui/jointItemTree.h
+++ b/src/yarpmotorgui/jointItemTree.h
@@ -20,7 +20,7 @@ class JointItemTree : public QWidget
     Q_OBJECT
 
 public:
-    explicit JointItemTree(QWidget *parent = nullptr);
+    explicit JointItemTree(int index, QWidget *parent = nullptr);
     ~JointItemTree();
 
     QLabel* jointLabel();
@@ -29,14 +29,21 @@ public:
 
     void setColor(const QColor& color, const QColor& background);
 
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+
     QSize sizeHint() const override;
 
     void setDesiredSize(int w, int h);
+
+signals:
+
+    void sig_jointClicked(int index);
 
 private:
     Ui::jointItemTree *m_ui;
     int m_desiredHeight{-1};
     int m_desiredWidth{-1};
+    int m_index;
 };
 
 #endif // JOINTITEMTREE_H

--- a/src/yarpmotorgui/jointItemTree.h
+++ b/src/yarpmotorgui/jointItemTree.h
@@ -10,6 +10,7 @@
 #include <QWidget>
 #include <QLabel>
 #include <QColor>
+#include <QMenu>
 
 namespace Ui {
 class jointItemTree;
@@ -39,8 +40,30 @@ signals:
 
     void sig_jointClicked(int index);
 
+    void sig_homeClicked(int index);
+
+    void sig_runClicked(int index);
+
+    void sig_idleClicked(int index);
+
+    void sig_PIDClicked(int index);
+
+public slots:
+
+    void onShowContextMenu(QPoint pos);
+
+    void onHomeClicked();
+
+    void onRunClicked();
+
+    void onIdleClicked();
+
+    void onPIDClicked();
+
 private:
     Ui::jointItemTree *m_ui;
+    QMenu m_rightClickMenu;
+    QAction* m_rightClickMenuTitle;
     int m_desiredHeight{-1};
     int m_desiredWidth{-1};
     int m_index;

--- a/src/yarpmotorgui/jointItemTree.h
+++ b/src/yarpmotorgui/jointItemTree.h
@@ -12,6 +12,8 @@
 #include <QColor>
 #include <QMenu>
 
+#include "jointitem.h"
+
 namespace Ui {
 class jointItemTree;
 }
@@ -24,11 +26,13 @@ public:
     explicit JointItemTree(int index, QWidget *parent = nullptr);
     ~JointItemTree();
 
-    QLabel* jointLabel();
+    void setJointName(const QString& name);
 
-    QLabel* modeLabel();
+    QString jointName() const;
 
-    void setColor(const QColor& color, const QColor& background);
+    void setJointMode(const JointItem::JointState& mode);
+
+    JointItem::JointState jointMode() const;
 
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
@@ -61,12 +65,21 @@ public slots:
     void onPIDClicked();
 
 private:
+
+    void setColor(const QColor& color, const QColor& background);
+
     Ui::jointItemTree *m_ui;
     QMenu m_rightClickMenu;
     QAction* m_rightClickMenuTitle;
+    QAction* m_homeAction;
+    QAction* m_idleAction;
+    QAction* m_runAction;
+    QAction* m_pidAction;
     int m_desiredHeight{-1};
     int m_desiredWidth{-1};
     int m_index;
+    bool m_modeSet{false};
+    JointItem::JointState m_mode{JointItem::Idle};
 };
 
 #endif // JOINTITEMTREE_H

--- a/src/yarpmotorgui/jointItemTree.h
+++ b/src/yarpmotorgui/jointItemTree.h
@@ -29,8 +29,14 @@ public:
 
     void setColor(const QColor& color, const QColor& background);
 
+    QSize sizeHint() const override;
+
+    void setDesiredSize(int w, int h);
+
 private:
     Ui::jointItemTree *m_ui;
+    int m_desiredHeight{-1};
+    int m_desiredWidth{-1};
 };
 
 #endif // JOINTITEMTREE_H

--- a/src/yarpmotorgui/jointItemTree.ui
+++ b/src/yarpmotorgui/jointItemTree.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>131</width>
-    <height>101</height>
+    <width>112</width>
+    <height>81</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,10 +21,6 @@
   </property>
   <property name="autoFillBackground">
    <bool>true</bool>
-  </property>
-  <property name="styleSheet">
-   <string notr="true">background-color: rgb(138, 226, 52);
-color: rgb(0, 0, 0);</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -44,10 +40,16 @@ color: rgb(0, 0, 0);</string>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::NoTextInteraction</set>
+     </property>
     </widget>
    </item>
    <item>
     <widget class="Line" name="line">
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -61,17 +63,11 @@ color: rgb(0, 0, 0);</string>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="autoFillBackground">
-      <bool>true</bool>
-     </property>
      <property name="text">
       <string>JointMode</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
-     </property>
-     <property name="margin">
-      <number>10</number>
      </property>
      <property name="textInteractionFlags">
       <set>Qt::NoTextInteraction</set>

--- a/src/yarpmotorgui/jointItemTree.ui
+++ b/src/yarpmotorgui/jointItemTree.ui
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>jointItemTree</class>
+ <widget class="QWidget" name="jointItemTree">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>131</width>
+    <height>101</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="autoFillBackground">
+   <bool>true</bool>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">background-color: rgb(138, 226, 52);
+color: rgb(0, 0, 0);</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QLabel" name="jointName">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>JointName</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="jointMode">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>JointMode</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="margin">
+      <number>10</number>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::NoTextInteraction</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -22,6 +22,38 @@ void JointItem::resetTarget()
     ui->sliderMixedPosition->resetTarget();
 }
 
+void JointItem::home()
+{
+    if (this->internalState == Velocity)
+    {
+       velocityTimer.stop();
+    }
+    emit homeClicked(this);
+}
+
+void JointItem::run()
+{
+    if (this->internalState == Velocity)
+    {
+       velocityTimer.stop();
+    }
+    emit runClicked(this);
+}
+
+void JointItem::idle()
+{
+    if (this->internalState == Velocity)
+    {
+       velocityTimer.stop();
+    }
+    emit idleClicked(this);
+}
+
+void JointItem::showPID()
+{
+    emit pidClicked(this);
+}
+
 void JointItem::updateTrajectoryPositionTarget(double val)
 {
     ui->sliderTrajectoryPosition->updateSliderTarget(val);
@@ -2099,34 +2131,22 @@ void JointItem::onCalibClicked()
 
 void JointItem::onHomeClicked()
 {
-    if (this->internalState == Velocity)
-    {
-       velocityTimer.stop();
-    }
-    emit homeClicked(this);
+    home();
 }
 
 void JointItem::onIdleClicked()
 {
-    if (this->internalState == Velocity)
-    {
-       velocityTimer.stop();
-    }
-    emit idleClicked(this);
+    idle();
 }
 
 void JointItem::onRunClicked()
 {
-    if (this->internalState == Velocity)
-    {
-       velocityTimer.stop();
-    }
-    emit runClicked(this);
+    run();
 }
 
 void JointItem::onPidClicked()
 {
-    emit pidClicked(this);
+    showPID();
 }
 
 void JointItem::sequenceActivated()

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -1130,6 +1130,7 @@ int JointItem::getJointIndex()
 void JointItem::installFilter()
 {
     auto* filter = new WheelEventFilter();
+    filter->setParent(this);
     ui->comboMode->installEventFilter(filter);
     ui->comboInteraction->installEventFilter(filter);
 

--- a/src/yarpmotorgui/jointitem.cpp
+++ b/src/yarpmotorgui/jointitem.cpp
@@ -54,6 +54,140 @@ void JointItem::showPID()
     emit pidClicked(this);
 }
 
+QColor JointItem::GetModeColor(JointState mode)
+{
+    QColor output;
+    switch (mode) {
+    case JointItem::Idle:{
+        output = idleColor;
+        break;
+    }
+    case JointItem::Position:{
+        output = positionColor;
+        break;
+    }
+    case JointItem::PositionDirect:{
+        output = positionDirectColor;
+        break;
+    }
+    case JointItem::Mixed:{
+        output = mixedColor;
+        break;
+    }
+    case JointItem::Velocity:{
+        output = velocityColor;
+        break;
+    }
+    case JointItem::Torque:{
+        output = torqueColor;
+        break;
+    }
+    case JointItem::Pwm:{
+        output = pwmColor;
+        break;
+    }
+    case JointItem::Current:{
+        output = currentColor;
+        break;
+    }
+
+    case JointItem::Disconnected:{
+        output = disconnectColor;
+        break;
+    }
+    case JointItem::HwFault:{
+        output = hwFaultColor;
+        break;
+    }
+    case JointItem::Calibrating:{
+        output = calibratingColor;
+        break;
+    }
+    case JointItem::NotConfigured:{
+        output = calibratingColor;
+        break;
+    }
+    case JointItem::Configured:{
+        output = calibratingColor;
+        break;
+    }
+
+    default:
+        output = calibratingColor;
+        break;
+    }
+
+    return output;
+
+}
+
+QString JointItem::GetModeString(JointState mode)
+{
+    QString output;
+    switch (mode) {
+    case JointItem::Idle:{
+        output = "Idle";
+        break;
+    }
+    case JointItem::Position:{
+        output = "Position";
+        break;
+    }
+    case JointItem::PositionDirect:{
+        output = "Position Direct";
+        break;
+    }
+    case JointItem::Mixed:{
+        output = "Mixed";
+        break;
+    }
+    case JointItem::Velocity:{
+        output = "Velocity";
+        break;
+    }
+    case JointItem::Torque:{
+        output = "Torque";
+        break;
+    }
+    case JointItem::Pwm:{
+        output = "PWM";
+        break;
+    }
+    case JointItem::Current:{
+        output = "Current";
+        break;
+    }
+
+    case JointItem::Disconnected:{
+        output = "Disconnected";
+        break;
+    }
+    case JointItem::HwFault:{
+        output = "Hardware Fault";
+        break;
+    }
+    case JointItem::Calibrating:{
+        output = "Calibrating";
+        break;
+    }
+    case JointItem::NotConfigured:{
+        output = "Not Configured";
+        break;
+    }
+    case JointItem::Configured:{
+        output = "Configured";
+        break;
+    }
+
+    default:
+        output = "Unknown";
+        break;
+    }
+
+    return output;
+
+}
+
 void JointItem::updateTrajectoryPositionTarget(double val)
 {
     ui->sliderTrajectoryPosition->updateSliderTarget(val);

--- a/src/yarpmotorgui/jointitem.h
+++ b/src/yarpmotorgui/jointitem.h
@@ -98,6 +98,11 @@ class JointItem : public QWidget
     void disableTrajectoryVelocitySliderDouble();
     void resetTarget();
 
+    void home();
+    void run();
+    void idle();
+    void showPID();
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
 

--- a/src/yarpmotorgui/jointitem.h
+++ b/src/yarpmotorgui/jointitem.h
@@ -103,6 +103,9 @@ class JointItem : public QWidget
     void idle();
     void showPID();
 
+    static QColor GetModeColor(JointState mode);
+    static QString GetModeString(JointState mode);
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
 

--- a/src/yarpmotorgui/jointitem.ui
+++ b/src/yarpmotorgui/jointitem.ui
@@ -2438,7 +2438,7 @@ QSlider::groove:horizontal:disabled {
             <item row="0" column="1">
              <widget class="QLabel" name="labelFaultCodeEntry">
               <property name="text">
-               <string>TextLabel</string>
+               <string>UNKNOWN</string>
               </property>
              </widget>
             </item>
@@ -2452,7 +2452,7 @@ QSlider::groove:horizontal:disabled {
             <item row="1" column="1">
              <widget class="QLabel" name="labelFaultMessageEntry">
               <property name="text">
-               <string>TextLabel</string>
+               <string>UNKNOWN</string>
               </property>
              </widget>
             </item>

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -519,7 +519,17 @@ void MainWindow::onJointClicked(int partIndex, int jointIndex)
     m_tabPanel->setCurrentIndex(partIndex);
     auto* scroll = (QScrollArea *)m_tabPanel->widget(partIndex);
     auto* part = (PartItem*)scroll->widget();
-    scroll->ensureWidgetVisible(part->getJointWidget(jointIndex));
+    auto* partWidget = part->getJointWidget(jointIndex);
+    scroll->ensureWidgetVisible(partWidget);
+    m_glowEffect->setEnabled(false);
+    partWidget->setGraphicsEffect(m_glowEffect);
+    m_glowEffect->setEnabled(true);
+    m_glowTimer.start();
+}
+
+void MainWindow::onGlowTimerExpired()
+{
+    m_glowEffect->setEnabled(false);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -738,6 +748,17 @@ bool MainWindow::init(QStringList enabledParts,
     onViewCurrents(currentVisible);
     onViewMotorPositions(motorPosVisible);
     onViewDutyCycles(dutyVisible);
+
+    m_glowEffect = new QGraphicsDropShadowEffect(this);
+    m_glowEffect->setOffset(.0);
+    m_glowEffect->setBlurRadius(40.0);
+    m_glowEffect->setColor(Qt::yellow);
+
+    m_glowTimer.setInterval(2000);
+    m_glowTimer.setSingleShot(true);
+
+    connect(&m_glowTimer, SIGNAL(timeout()), this, SLOT(onGlowTimerExpired()));
+
     return true;
 }
 

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -318,7 +318,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(enableControlCurrent, SIGNAL(triggered(bool)), this, SLOT(onEnableControlCurrent(bool)));
     connect(sliderOptions, SIGNAL(triggered()), this, SLOT(onSliderOptionsClicked()));
 
-    connect(this,SIGNAL(internalClose()),this,SLOT(close()),Qt::QueuedConnection);
+    connect(this,SIGNAL(sig_internalClose()),this,SLOT(close()),Qt::QueuedConnection);
 
 
     m_timer.setInterval(200);

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -514,6 +514,14 @@ void MainWindow::onSetTrqSliderOptionMW(int choice, double val)
     emit sig_setTrqSliderOptionMW(choice, val);
 }
 
+void MainWindow::onJointClicked(int partIndex, int jointIndex)
+{
+    m_tabPanel->setCurrentIndex(partIndex);
+    auto* scroll = (QScrollArea *)m_tabPanel->widget(partIndex);
+    auto* part = (PartItem*)scroll->widget();
+    scroll->ensureWidgetVisible(part->getJointWidget(jointIndex));
+}
+
 void MainWindow::closeEvent(QCloseEvent *event)
 {
 
@@ -618,7 +626,7 @@ bool MainWindow::init(QStringList enabledParts,
     m_ui->treeViewMode->setModel(modesTreeModel);
     m_ui->treeViewMode->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
     m_ui->treeViewMode->setUniformRowHeights(false);
-    m_ui->treeViewMode->setAnimated(false); //Animations look weird with the custom widgets
+    m_ui->treeViewMode->setAnimated(false); //Animations look weird with a custom widget as a leaf element
 
     QStandardItem *parentItem = modesTreeModel->invisibleRootItem();
 
@@ -666,7 +674,7 @@ bool MainWindow::init(QStringList enabledParts,
             connect(this, SIGNAL(sig_enableControlCurrent(bool)), part, SLOT(onEnableControlCurrent(bool)));
 
             scroll->setWidget(part);
-            m_tabPanel->addTab(scroll, part_name.c_str());
+            int tabIndex = m_tabPanel->addTab(scroll, part_name.c_str());
             if (part_id == 0)
             {
                 QString auxName = part_name.c_str();
@@ -686,7 +694,8 @@ bool MainWindow::init(QStringList enabledParts,
             partTreeItem->appendRow(partTreeItemChild);
 
             auto index = partTreeItemChild->index();
-            auto* partTreeWidget = new PartItemTree(m_ui->treeViewMode);
+            auto* partTreeWidget = new PartItemTree(tabIndex, m_ui->treeViewMode);
+            connect(partTreeWidget, SIGNAL(sig_jointClicked(int,int)), this, SLOT(onJointClicked(int,int)));
             m_ui->treeViewMode->setIndexWidget(index, partTreeWidget);
 
             part->setTreeWidgetItem(partTreeWidget);

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -515,13 +515,17 @@ void MainWindow::onSetTrqSliderOptionMW(int choice, double val)
 
 void MainWindow::onJointClicked(int partIndex, int jointIndex)
 {
+    if (!m_tabPanel){
+        return;
+    }
+
     m_tabPanel->setCurrentIndex(partIndex);
     auto* scroll = (QScrollArea *)m_tabPanel->widget(partIndex);
     auto* part = (PartItem*)scroll->widget();
-    auto* partWidget = part->getJointWidget(jointIndex);
-    scroll->ensureWidgetVisible(partWidget);
+    auto* jointWidget = part->getJointWidget(jointIndex);
+    scroll->ensureWidgetVisible(jointWidget);
     m_glowEffect->setEnabled(false);
-    partWidget->setGraphicsEffect(m_glowEffect);
+    jointWidget->setGraphicsEffect(m_glowEffect);
     m_glowEffect->setEnabled(true);
     m_glowTimer.start();
 }
@@ -529,6 +533,42 @@ void MainWindow::onJointClicked(int partIndex, int jointIndex)
 void MainWindow::onGlowTimerExpired()
 {
     m_glowEffect->setEnabled(false);
+}
+
+void MainWindow::onJointHomeFromTree(int partIndex, int jointIndex)
+{
+    if (!m_tabPanel){
+        return;
+    }
+
+    getJointWidget(partIndex, jointIndex)->home();
+}
+
+void MainWindow::onJointRunFromTree(int partIndex, int jointIndex)
+{
+    if (!m_tabPanel){
+        return;
+    }
+
+    getJointWidget(partIndex, jointIndex)->run();
+}
+
+void MainWindow::onJointIdleFromTree(int partIndex, int jointIndex)
+{
+    if (!m_tabPanel){
+        return;
+    }
+
+    getJointWidget(partIndex, jointIndex)->idle();
+}
+
+void MainWindow::onJointPIDFromTree(int partIndex, int jointIndex)
+{
+    if (!m_tabPanel){
+        return;
+    }
+
+    getJointWidget(partIndex, jointIndex)->showPID();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -708,6 +748,11 @@ bool MainWindow::init(QStringList enabledParts,
             auto index = partTreeItemChild->index();
             auto* partTreeWidget = new PartItemTree(tabIndex, m_ui->treeViewMode);
             connect(partTreeWidget, SIGNAL(sig_jointClicked(int,int)), this, SLOT(onJointClicked(int,int)));
+            connect(partTreeWidget, SIGNAL(sig_homeClicked(int,int)), this, SLOT(onJointHomeFromTree(int,int)));
+            connect(partTreeWidget, SIGNAL(sig_runClicked(int,int)), this, SLOT(onJointRunFromTree(int,int)));
+            connect(partTreeWidget, SIGNAL(sig_idleClicked(int,int)), this, SLOT(onJointIdleFromTree(int,int)));
+            connect(partTreeWidget, SIGNAL(sig_PIDClicked(int,int)), this, SLOT(onJointPIDFromTree(int,int)));
+
             m_ui->treeViewMode->setIndexWidget(index, partTreeWidget);
 
             part->setTreeWidgetItem(partTreeWidget);
@@ -1320,6 +1365,13 @@ QColor MainWindow::getColorMode(int m)
     }
 
     return mode;
+}
+
+JointItem *MainWindow::getJointWidget(int partIndex, int jointIndex)
+{
+    auto* scroll = (QScrollArea *)m_tabPanel->widget(partIndex);
+    auto* part = (PartItem*)scroll->widget();
+    return part->getJointWidget(jointIndex);
 }
 
 QString MainWindow::getStringMode(int m)

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -1373,7 +1373,7 @@ void MainWindow::updateModesTree(PartItem *part)
             jointNode->jointLabel()->setText(QString("%1 - %2").arg(i).arg(name));
             jointNode->modeLabel()->setText(mode);
             QColor c = getColorMode(modes.at(i));
-            jointNode->setColor(QColor(Qt::black), c);
+            jointNode->setColor(QColor(35, 38, 41), c);
 
 //            if(c == hwFaultColor){
 //                parentNode->setData(0,Qt::UserRole,TREEMODE_WARN);
@@ -1386,7 +1386,6 @@ void MainWindow::updateModesTree(PartItem *part)
 //                parentNode->setIcon(0,QIcon(":/apply.svg"));
 //            }
         }
-        parentNode->uniformLayout();
     } else {
         bool foundFaultPart = false;
         for(int i=0;i<parentNode->numberOfJoints();i++){
@@ -1409,7 +1408,7 @@ void MainWindow::updateModesTree(PartItem *part)
 //            if(parentNode->isExpanded()){
                 if(jointNode->modeLabel()->text() != mode){
                     jointNode->modeLabel()->setText(mode);
-                    jointNode->setColor(QColor(Qt::black), c);
+                    jointNode->setColor(QColor(35, 38, 41), c);
                 }
 //            }
         }

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -685,6 +685,7 @@ bool MainWindow::init(QStringList enabledParts,
         auto* robot_top = new QStandardItem(QString(robot.first.c_str()));
         robot_top->setEditable(false);
         parentItem->appendRow(robot_top);
+        m_ui->treeViewMode->setExpanded(robot_top->index(), true);
         robot.second.tree_pointer = robot_top;
     }
 
@@ -736,7 +737,7 @@ bool MainWindow::init(QStringList enabledParts,
             QStandardItem *tp = robots[i_parts.second.robot_name].tree_pointer;
             partTreeItem->setEditable(false);
             tp->appendRow(partTreeItem);
-            m_ui->treeViewMode->setExpanded(partTreeItem->index(), true);
+            m_ui->treeViewMode->setExpanded(partTreeItem->index(), false);
             partTreeItem->setBackground(Qt::white);
             partTreeItem->setIcon(m_okIcon);
 
@@ -1458,6 +1459,8 @@ void MainWindow::updateModesTree(PartItem *part)
             auto* jointNode = partWidget->addJoint();
             jointNode->jointLabel()->setText(QString("%1 - %2").arg(i).arg(name));
         }
+        m_ui->treeViewMode->setExpanded(parentNode->index(), true); //Expand only after having filled each part
+        emit m_ui->treeViewMode->model()->layoutChanged({parentNode->index()}); //Notify that the layout changed to avoid whitespaces
     }
 
     bool foundFaultPart = false;

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -681,6 +681,8 @@ bool MainWindow::init(QStringList enabledParts,
             tp->appendRow(partTreeItem);
             m_ui->treeViewMode->setExpanded(partTreeItem->index(), true);
             auto* partTreeItemChild = new QStandardItem();
+            partTreeItemChild->setEditable(false);
+            partTreeItemChild->setEnabled(false);
             partTreeItem->appendRow(partTreeItemChild);
 
             auto index = partTreeItemChild->index();
@@ -1384,6 +1386,7 @@ void MainWindow::updateModesTree(PartItem *part)
 //                parentNode->setIcon(0,QIcon(":/apply.svg"));
 //            }
         }
+        parentNode->uniformLayout();
     } else {
         bool foundFaultPart = false;
         for(int i=0;i<parentNode->numberOfJoints();i++){

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -18,6 +18,7 @@
 #include <QTreeView>
 #include <QGraphicsDropShadowEffect>
 #include <QTimer>
+#include <QIcon>
 
 #include "partitem.h"
 #include "sliderOptions.h"
@@ -85,6 +86,7 @@ private:
     QAction *m_script1;
     QGraphicsDropShadowEffect *m_glowEffect;
     QTimer m_glowTimer;
+    QIcon m_okIcon, m_warningIcon;
 
 private:
     void updateModesTree(PartItem *part);

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -21,6 +21,7 @@
 #include <QIcon>
 
 #include "partitem.h"
+#include "jointitem.h"
 #include "sliderOptions.h"
 
 #include <vector>
@@ -92,6 +93,7 @@ private:
     void updateModesTree(PartItem *part);
     QString getStringMode(int mode);
     QColor getColorMode(int m);
+    JointItem* getJointWidget(int partIndex, int jointIndex);
 private slots:
     void onSequenceActivated();
     void onSequenceStopped();
@@ -136,6 +138,10 @@ private slots:
     void onSetTrqSliderOptionMW(int, double);
     void onJointClicked(int partIndex, int jointIndex);
     void onGlowTimerExpired();
+    void onJointHomeFromTree(int partIndex, int jointIndex);
+    void onJointRunFromTree(int partIndex, int jointIndex);
+    void onJointIdleFromTree(int partIndex, int jointIndex);
+    void onJointPIDFromTree(int partIndex, int jointIndex);
 
 signals:
     void sig_enableControlVelocity(bool);

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -128,6 +128,7 @@ private slots:
     void onSetPosSliderOptionMW(int, double);
     void onSetVelSliderOptionMW(int, double);
     void onSetTrqSliderOptionMW(int, double);
+    void onJointClicked(int partIndex, int jointIndex);
 
 signals:
     void sig_enableControlVelocity(bool);

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -16,6 +16,8 @@
 #include <QAction>
 #include <QMutex>
 #include <QTreeView>
+#include <QGraphicsDropShadowEffect>
+#include <QTimer>
 
 #include "partitem.h"
 #include "sliderOptions.h"
@@ -81,6 +83,8 @@ private:
     QAction *m_idleSinglePart;
     QAction *m_script2;
     QAction *m_script1;
+    QGraphicsDropShadowEffect *m_glowEffect;
+    QTimer m_glowTimer;
 
 private:
     void updateModesTree(PartItem *part);
@@ -129,6 +133,7 @@ private slots:
     void onSetVelSliderOptionMW(int, double);
     void onSetTrqSliderOptionMW(int, double);
     void onJointClicked(int partIndex, int jointIndex);
+    void onGlowTimerExpired();
 
 signals:
     void sig_enableControlVelocity(bool);

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -91,8 +91,6 @@ private:
 
 private:
     void updateModesTree(PartItem *part);
-    QString getStringMode(int mode);
-    QColor getColorMode(int m);
     JointItem* getJointWidget(int partIndex, int jointIndex);
 private slots:
     void onSequenceActivated();

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -15,12 +15,13 @@
 #include <QTimer>
 #include <QAction>
 #include <QMutex>
-#include <QTreeWidget>
+#include <QTreeView>
 
 #include "partitem.h"
 #include "sliderOptions.h"
 
 #include <vector>
+#include <unordered_map>
 
 namespace Ui {
 class MainWindow;
@@ -147,14 +148,14 @@ signals:
 
 };
 
-class ModesTreeWidget : public QTreeWidget
+class ModesTreeWidget : public QTreeView
 {
     Q_OBJECT
 
 public:
     ModesTreeWidget(QWidget * parent = 0);
 
-
+    void resizeEvent(QResizeEvent *event) override;
 };
 
 #endif // MAINWINDOW_H

--- a/src/yarpmotorgui/mainwindow.ui
+++ b/src/yarpmotorgui/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>MainWindow</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../yarplogger/res.qrc">
     <normaloff>:/logo.svg</normaloff>:/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -45,38 +45,34 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="ModesTreeWidget" name="treeWidgetMode">
+      <widget class="ModesTreeWidget" name="treeViewMode">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="maximumSize">
         <size>
-         <width>300</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
        </property>
+       <property name="rootIsDecorated">
+        <bool>true</bool>
+       </property>
        <property name="animated">
         <bool>true</bool>
        </property>
-       <attribute name="headerDefaultSectionSize">
+       <property name="headerHidden">
+        <bool>true</bool>
+       </property>
+       <attribute name="headerMinimumSectionSize">
         <number>150</number>
        </attribute>
-       <column>
-        <property name="text">
-         <string>Parts</string>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string>Mode</string>
-        </property>
-       </column>
       </widget>
       <widget class="QWidget" name="mainContainer" native="true"/>
      </widget>
@@ -174,10 +170,12 @@
  <customwidgets>
   <customwidget>
    <class>ModesTreeWidget</class>
-   <extends>QTreeWidget</extends>
+   <extends>QTreeView</extends>
    <header>mainwindow.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../yarplogger/res.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/yarpmotorgui/mainwindow.ui
+++ b/src/yarpmotorgui/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>MainWindow</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../yarplogger/res.qrc">
+   <iconset>
     <normaloff>:/logo.svg</normaloff>:/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -174,8 +174,6 @@
    <header>mainwindow.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../yarplogger/res.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "partItemTree.h"
+#include <iostream>
+
+PartItemTree::PartItemTree(QWidget *parent) : QWidget(parent)
+{
+    m_layout = new FlowLayout(1, 1, 1);
+    setLayout(m_layout);
+    setFocusPolicy(Qt::FocusPolicy::NoFocus);
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+}
+
+int PartItemTree::numberOfJoints() const
+{
+    return m_layout->count();
+}
+
+JointItemTree *PartItemTree::addJoint()
+{
+    JointItemTree* added = new JointItemTree(this);
+    m_layout->addWidget(added);
+    return added;
+}
+
+JointItemTree *PartItemTree::getJoint(int index)
+{
+    if (index < 0 || index >= numberOfJoints())
+    {
+        return nullptr;
+    }
+
+    return (JointItemTree*)m_layout->itemAt(index)->widget();
+}
+
+QSize PartItemTree::sizeHint() const
+{
+    QSize initialHint = QWidget::sizeHint();
+    return QSize(initialHint.width(), m_layout->heightForWidth(width()));
+}

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -23,6 +23,11 @@ JointItemTree *PartItemTree::addJoint()
 {
     JointItemTree* added = new JointItemTree(m_layout->count(), this);
     connect(added, SIGNAL(sig_jointClicked(int)), this, SLOT(onJointClicked(int)));
+    connect(added, SIGNAL(sig_homeClicked(int)), this, SLOT(onHomeClicked(int)));
+    connect(added, SIGNAL(sig_runClicked(int)), this, SLOT(onRunClicked(int)));
+    connect(added, SIGNAL(sig_idleClicked(int)), this, SLOT(onIdleClicked(int)));
+    connect(added, SIGNAL(sig_PIDClicked(int)), this, SLOT(onPIDClicked(int)));
+
     m_layout->addWidget(added);
     return added;
 }
@@ -89,4 +94,24 @@ void PartItemTree::resizeEvent(QResizeEvent *event)
 void PartItemTree::onJointClicked(int index)
 {
     emit sig_jointClicked(m_index, index);
+}
+
+void PartItemTree::onHomeClicked(int index)
+{
+    emit sig_homeClicked(m_index, index);
+}
+
+void PartItemTree::onRunClicked(int index)
+{
+    emit sig_runClicked(m_index, index);
+}
+
+void PartItemTree::onIdleClicked(int index)
+{
+    emit sig_idleClicked(m_index, index);
+}
+
+void PartItemTree::onPIDClicked(int index)
+{
+    emit sig_PIDClicked(m_index, index);
 }

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -79,3 +79,8 @@ void PartItemTree::uniformLayout()
 
     m_layout->activate(); //Update the layout
 }
+
+void PartItemTree::resizeEvent(QResizeEvent *event)
+{
+    uniformLayout();
+}

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -9,7 +9,7 @@
 
 PartItemTree::PartItemTree(QWidget *parent) : QWidget(parent)
 {
-    m_layout = new FlowLayout(1, 1, 1);
+    m_layout = new FlowLayout(5, 5, 5);
     setLayout(m_layout);
     setFocusPolicy(Qt::FocusPolicy::NoFocus);
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
@@ -41,4 +41,41 @@ QSize PartItemTree::sizeHint() const
 {
     QSize initialHint = QWidget::sizeHint();
     return QSize(initialHint.width(), m_layout->heightForWidth(width()));
+}
+
+void PartItemTree::uniformLayout()
+{
+    if (m_layout->count() == 0)
+    {
+        return;
+    }
+
+    m_layout->activate(); //To make sure that the widgets have already the appropriate size
+
+    int maxWidth = m_layout->itemAt(0)->widget()->width();
+    int maxHeight = m_layout->itemAt(0)->widget()->height();
+
+    for (int i = 1; i < m_layout->count(); ++i)
+    {
+        int width = m_layout->itemAt(i)->widget()->width();
+        int height = m_layout->itemAt(i)->widget()->height();
+
+        if (width > maxWidth)
+        {
+            maxWidth = width;
+        }
+
+        if (height > maxHeight)
+        {
+            maxHeight = height;
+        }
+    }
+
+    for (int i = 0; i < m_layout->count(); ++i)
+    {
+        JointItemTree* item = (JointItemTree*)(m_layout->itemAt(i)->widget());
+        item->setDesiredSize(maxWidth, maxHeight);
+    }
+
+    m_layout->activate(); //Update the layout
 }

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -5,9 +5,8 @@
  */
 
 #include "partItemTree.h"
-#include <iostream>
 
-PartItemTree::PartItemTree(QWidget *parent) : QWidget(parent)
+PartItemTree::PartItemTree(int index, QWidget *parent) : QWidget(parent), m_index(index)
 {
     m_layout = new FlowLayout(5, 5, 5);
     setLayout(m_layout);
@@ -22,7 +21,8 @@ int PartItemTree::numberOfJoints() const
 
 JointItemTree *PartItemTree::addJoint()
 {
-    JointItemTree* added = new JointItemTree(this);
+    JointItemTree* added = new JointItemTree(m_layout->count(), this);
+    connect(added, SIGNAL(sig_jointClicked(int)), this, SLOT(onJointClicked(int)));
     m_layout->addWidget(added);
     return added;
 }
@@ -83,4 +83,9 @@ void PartItemTree::uniformLayout()
 void PartItemTree::resizeEvent(QResizeEvent *event)
 {
     uniformLayout();
+}
+
+void PartItemTree::onJointClicked(int index)
+{
+    emit sig_jointClicked(m_index, index);
 }

--- a/src/yarpmotorgui/partItemTree.cpp
+++ b/src/yarpmotorgui/partItemTree.cpp
@@ -83,6 +83,7 @@ void PartItemTree::uniformLayout()
 void PartItemTree::resizeEvent(QResizeEvent *event)
 {
     uniformLayout();
+    QWidget::resizeEvent(event);
 }
 
 void PartItemTree::onJointClicked(int index)

--- a/src/yarpmotorgui/partItemTree.h
+++ b/src/yarpmotorgui/partItemTree.h
@@ -28,7 +28,9 @@ public:
 
     JointItemTree* getJoint(int index);
 
-    virtual QSize sizeHint() const override;
+    QSize sizeHint() const override;
+
+    void uniformLayout();
 };
 
 #endif // PARTITEMTREE_H

--- a/src/yarpmotorgui/partItemTree.h
+++ b/src/yarpmotorgui/partItemTree.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifndef PARTITEMTREE_H
+#define PARTITEMTREE_H
+
+#include <QWidget>
+#include <unordered_map>
+
+
+#include "jointItemTree.h"
+#include "flowlayout.h"
+
+class PartItemTree : public QWidget
+{
+    Q_OBJECT
+    FlowLayout *m_layout;
+
+public:
+    explicit PartItemTree(QWidget *parent = nullptr);
+
+    int numberOfJoints() const;
+
+    JointItemTree* addJoint();
+
+    JointItemTree* getJoint(int index);
+
+    virtual QSize sizeHint() const override;
+};
+
+#endif // PARTITEMTREE_H

--- a/src/yarpmotorgui/partItemTree.h
+++ b/src/yarpmotorgui/partItemTree.h
@@ -39,9 +39,25 @@ public slots:
 
     void onJointClicked(int index);
 
+    void onHomeClicked(int index);
+
+    void onRunClicked(int index);
+
+    void onIdleClicked(int index);
+
+    void onPIDClicked(int index);
+
 signals:
 
     void sig_jointClicked(int partIndex, int jointIndex);
+
+    void sig_homeClicked(int partIndex, int jointIndex);
+
+    void sig_runClicked(int partIndex, int jointIndex);
+
+    void sig_idleClicked(int partIndex, int jointIndex);
+
+    void sig_PIDClicked(int partIndex, int jointIndex);
 
 };
 

--- a/src/yarpmotorgui/partItemTree.h
+++ b/src/yarpmotorgui/partItemTree.h
@@ -18,9 +18,10 @@ class PartItemTree : public QWidget
 {
     Q_OBJECT
     FlowLayout *m_layout;
+    int m_index;
 
 public:
-    explicit PartItemTree(QWidget *parent = nullptr);
+    explicit PartItemTree(int index, QWidget *parent = nullptr);
 
     int numberOfJoints() const;
 
@@ -33,6 +34,15 @@ public:
     void uniformLayout();
 
     void resizeEvent(QResizeEvent *event) override;
+
+public slots:
+
+    void onJointClicked(int index);
+
+signals:
+
+    void sig_jointClicked(int partIndex, int jointIndex);
+
 };
 
 #endif // PARTITEMTREE_H

--- a/src/yarpmotorgui/partItemTree.h
+++ b/src/yarpmotorgui/partItemTree.h
@@ -31,6 +31,8 @@ public:
     QSize sizeHint() const override;
 
     void uniformLayout();
+
+    void resizeEvent(QResizeEvent *event) override;
 };
 
 #endif // PARTITEMTREE_H

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -1081,6 +1081,11 @@ QString PartItem::getJointName(int joint)
     return jointWidget->getJointName();
 }
 
+QWidget *PartItem::getJointWidget(int jointIndex)
+{
+    return m_layout->itemAt(jointIndex)->widget();
+}
+
 void PartItem::resizeEvent(QResizeEvent *event)
 {
     if(!isVisible()){

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -51,7 +51,6 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
     m_part_motorPositionVisible(false),
     m_part_dutyVisible(false),
     m_part_currentVisible(false),
-    m_interactionModes(nullptr),
     m_finder(&_finder),
     m_iMot(nullptr),
     m_iinfo(nullptr),
@@ -180,7 +179,7 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
             m_dutyCycles[i] = std::nan("");
         }
         m_done = new bool[number_of_joints];
-        m_interactionModes = new yarp::dev::InteractionModeEnum[number_of_joints];
+        m_interactionModes.resize(number_of_joints);
 
         bool ret = false;
         SystemClock::delaySystem(0.050);
@@ -337,6 +336,8 @@ PartItem::~PartItem()
 
     if (m_partsdd){
         m_partsdd->close();
+        delete m_partsdd;
+        m_partsdd = nullptr;
     }
 
     if (m_controlModes) { delete[] m_controlModes; m_controlModes = nullptr; }
@@ -2299,7 +2300,7 @@ bool PartItem::updatePart()
     //    if(ret==false){
     //        LOG_ERROR("ictrl->getControlMode failed\n" );
     //    }
-    ret = m_iinteract->getInteractionModes(m_interactionModes);
+    ret = m_iinteract->getInteractionModes(m_interactionModes.data());
     if(ret==false){
         LOG_ERROR("iint->getInteractionlMode failed\n" );
     }

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -1082,9 +1082,9 @@ QString PartItem::getJointName(int joint)
     return jointWidget->getJointName();
 }
 
-QWidget *PartItem::getJointWidget(int jointIndex)
+JointItem *PartItem::getJointWidget(int jointIndex)
 {
-    return m_layout->itemAt(jointIndex)->widget();
+    return (JointItem*)m_layout->itemAt(jointIndex)->widget();
 }
 
 void PartItem::resizeEvent(QResizeEvent *event)

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -1069,6 +1069,18 @@ void PartItem::resizeWidget(int w)
     }
 }
 
+QString PartItem::getJointName(int joint)
+{
+    if (joint < 0 || joint >= m_layout->count())
+    {
+        return "";
+    }
+
+    auto* jointWidget = (JointItem*)m_layout->itemAt(joint)->widget();
+
+    return jointWidget->getJointName();
+}
+
 void PartItem::resizeEvent(QResizeEvent *event)
 {
     if(!isVisible()){
@@ -2081,12 +2093,12 @@ void PartItem::onSetTrqSliderOptionPI(int mode, double step)
         }
     }
 }
-QTreeWidgetItem *PartItem::getTreeWidgetModeNode()
+PartItemTree *PartItem::getTreeWidgetItem()
 {
     return m_node;
 }
 
-void PartItem::setTreeWidgetModeNode(QTreeWidgetItem *node)
+void PartItem::setTreeWidgetItem(PartItemTree *node)
 {
     m_node = node;
 }

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -2104,9 +2104,19 @@ PartItemTree *PartItem::getTreeWidgetItem()
     return m_node;
 }
 
+QStandardItem *PartItem::getParentItem()
+{
+    return m_parentItem;
+}
+
 void PartItem::setTreeWidgetItem(PartItemTree *node)
 {
     m_node = node;
+}
+
+void PartItem::setParentItem(QStandardItem *item)
+{
+    m_parentItem = item;
 }
 
 QList<int> PartItem::getPartMode()

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -1070,9 +1070,14 @@ void PartItem::resizeWidget(int w)
     }
 }
 
+int PartItem::getNumberOfJoints()
+{
+    return m_layout->count();
+}
+
 QString PartItem::getJointName(int joint)
 {
-    if (joint < 0 || joint >= m_layout->count())
+    if (joint < 0 || joint >= getNumberOfJoints())
     {
         return "";
     }
@@ -2119,9 +2124,9 @@ void PartItem::setParentItem(QStandardItem *item)
     m_parentItem = item;
 }
 
-QList<int> PartItem::getPartMode()
+QList<JointItem::JointState> PartItem::getPartMode()
 {
-    QList <int> modes;
+    QList <JointItem::JointState> modes;
 
     for (int k = 0; k < m_layout->count(); k++){
         switch (m_controlModes[k])

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -74,9 +74,11 @@ public:
     bool checkAndGo();
     void stopSequence();
     void setTreeWidgetItem(PartItemTree *node);
+    void setParentItem(QStandardItem* item);
     void loadSequence();
     void saveSequence(QString global_filename);
     PartItemTree *getTreeWidgetItem();
+    QStandardItem* getParentItem();
     QString getPartName();
     QList<int> getPartMode();
     void resizeWidget(int w);
@@ -109,6 +111,7 @@ private:
     QTimer m_runTimeTimer;
     QTimer m_cycleTimer;
     QTimer m_cycleTimeTimer;
+    QStandardItem* m_parentItem;
 
     QList<SequenceItem> m_runValues;
     QList<SequenceItem> m_runTimeValues;

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -83,7 +83,7 @@ public:
     QList<int> getPartMode();
     void resizeWidget(int w);
     QString getJointName(int joint);
-    QWidget* getJointWidget(int jointIndex);
+    JointItem* getJointWidget(int jointIndex);
 
 
 private:

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -29,6 +29,7 @@
 #include <QWidget>
 #include <QTimer>
 #include <QStandardItem>
+#include <vector>
 
 
 
@@ -129,7 +130,7 @@ private:
     bool    m_part_motorPositionVisible;
     bool    m_part_dutyVisible;
     bool    m_part_currentVisible;
-    yarp::dev::InteractionModeEnum* m_interactionModes;
+    std::vector<yarp::dev::InteractionModeEnum> m_interactionModes;
 
     ResourceFinder* m_finder;
     PolyDriver*     m_partsdd;

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -80,8 +80,9 @@ public:
     PartItemTree *getTreeWidgetItem();
     QStandardItem* getParentItem();
     QString getPartName();
-    QList<int> getPartMode();
+    QList<JointItem::JointState> getPartMode();
     void resizeWidget(int w);
+    int getNumberOfJoints();
     QString getJointName(int joint);
     JointItem* getJointWidget(int jointIndex);
 

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -80,6 +80,8 @@ public:
     QList<int> getPartMode();
     void resizeWidget(int w);
     QString getJointName(int joint);
+    QWidget* getJointWidget(int jointIndex);
+
 
 private:
     void fixedTimeMove(SequenceItem sequence);

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -12,6 +12,7 @@
 #include "jointitem.h"
 #include "piddlg.h"
 #include "yarpmotorgui.h"
+#include "partItemTree.h"
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Port.h>
@@ -27,6 +28,7 @@
 
 #include <QWidget>
 #include <QTimer>
+#include <QStandardItem>
 
 
 
@@ -70,13 +72,14 @@ public:
     void calibratePart();
     bool checkAndGo();
     void stopSequence();
-    void setTreeWidgetModeNode(QTreeWidgetItem *node);
+    void setTreeWidgetItem(PartItemTree *node);
     void loadSequence();
     void saveSequence(QString global_filename);
-    QTreeWidgetItem *getTreeWidgetModeNode();
+    PartItemTree *getTreeWidgetItem();
     QString getPartName();
     QList<int> getPartMode();
     void resizeWidget(int w);
+    QString getJointName(int joint);
 
 private:
     void fixedTimeMove(SequenceItem sequence);
@@ -86,7 +89,7 @@ protected:
     void changeEvent(QEvent *event) override;
 
 private:
-    QTreeWidgetItem *m_node;
+    PartItemTree *m_node;
     FlowLayout *m_layout;
     SequenceWindow *m_sequenceWindow;
     QString m_robotPartPort;


### PR DESCRIPTION
This PR edits the tree view as follows:
- it shows each joint name
- the joint name and mode are in a separate widget
- each part uses a flow layout to have all the joints fitting in the screen
- when double click in a joint on the tree, the focus automatically moves to the corresponding joint in the tab view
- with a right click on the joint in the tree it is possible to home, idle, run or show the PID dialog of the corresponding joint.