### PR TITLE
disabled failing test on windows

### DIFF
--- a/tests/libYARP_os/LogStreamTest.cpp
+++ b/tests/libYARP_os/LogStreamTest.cpp
@@ -1490,7 +1490,9 @@ TEST_CASE("os::LogStreamTest", "[yarp::os]")
 
         CNT yInfo() << "std::unordered_map:" << std::unordered_map<int, double> {{1, 1.1}, {2, 2.2}, {3, 3.3}};
 
+        #if defined(ENABLE_BROKEN_TESTS)
         CNT yInfo() << "C array:" << (double[]) {1.1, 2.2, 3.3};
+        #endif
 
         CNT yInfo() << "std::pair<int, double>" << std::pair<int, double> {1, 1.1};
 


### PR DESCRIPTION
there is a failing test on windows machines, the failure reason is the one below.
![Screenshot from 2021-12-07 09-33-41](https://user-images.githubusercontent.com/10057781/145057610-b4d639b7-c861-406b-bbba-d967bfd4ec27.png)
