### PR TITLE
Fix C-style array initialization in LogStreamTest

### DIFF
--- a/tests/libYARP_os/LogStreamTest.cpp
+++ b/tests/libYARP_os/LogStreamTest.cpp
@@ -1490,7 +1490,7 @@ TEST_CASE("os::LogStreamTest", "[yarp::os]")
 
         CNT yInfo() << "std::unordered_map:" << std::unordered_map<int, double> {{1, 1.1}, {2, 2.2}, {3, 3.3}};
 
-        CNT yInfo() << "C array:" << (double[]) {1.1, 2.2, 3.3};
+        CNT yInfo() << "C array:" << std::array<double, 3> {1.1, 2.2, 3.3}.data();
 
         CNT yInfo() << "std::pair<int, double>" << std::pair<int, double> {1, 1.1};
 


### PR DESCRIPTION
Illegal cast caught by MSVC (error C4576). Follows up https://github.com/robotology/yarp/commit/0394d6967991bd25bde2a314110d949293fa387a.