### PR TITLE
Timestamp for IRangefinder2D

### DIFF
--- a/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
+++ b/src/devices/Rangefinder2DClient/Rangefinder2DClient.h
@@ -55,7 +55,6 @@ public:
     // time is in ms
     void getEstFrequency(int &ite, double &av, double &min, double &max);
 
-    bool getData(yarp::sig::Vector &data);
     yarp::dev::IRangefinder2D::Device_status getStatus();
 
 };
@@ -115,14 +114,14 @@ public:
     * @param data a vector containing the measurement data, expressed in cartesian/polar format
     * @return true/false..
     */
-    bool getLaserMeasurement(std::vector<yarp::dev::LaserMeasurementData> &data) override;
+    bool getLaserMeasurement(std::vector<yarp::dev::LaserMeasurementData> &data, double* timestamp = nullptr) override;
 
     /**
     * Get the device measurements
     * @param ranges the vector containing the raw measurement data, as acquired by the device.
     * @return true/false.
     */
-    bool getRawData(yarp::sig::Vector &data) override;
+    bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
 
     /**
     * get the device status

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_ros.cpp
@@ -217,13 +217,15 @@ void Rangefinder2D_nws_ros::run()
         bool ret = true;
         IRangefinder2D::Device_status status;
         yarp::sig::Vector ranges;
-        ret &= sens_p->getRawData(ranges);
+        double synchronized_timestamp=0;
+        ret &= sens_p->getRawData(ranges, &synchronized_timestamp);
         ret &= sens_p->getDeviceStatus(status);
 
         if (ret)
         {
             if (iTimed) {
-                lastStateStamp = iTimed->getLastInputStamp();
+                //lastStateStamp = iTimed->getLastInputStamp();
+                lastStateStamp.update(synchronized_timestamp);
             } else {
                 lastStateStamp.update(yarp::os::Time::now());
             }

--- a/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.cpp
+++ b/src/devices/Rangefinder2DWrapper/Rangefinder2D_nws_yarp.cpp
@@ -380,13 +380,15 @@ void Rangefinder2D_nws_yarp::run()
         bool ret = true;
         IRangefinder2D::Device_status status;
         yarp::sig::Vector ranges;
-        ret &= sens_p->getRawData(ranges);
+        double synchronized_timestamp = 0;
+        ret &= sens_p->getRawData(ranges, &synchronized_timestamp);
         ret &= sens_p->getDeviceStatus(status);
 
         if (ret)
         {
             if (iTimed) {
-                lastStateStamp = iTimed->getLastInputStamp();
+                //lastStateStamp = iTimed->getLastInputStamp();
+                lastStateStamp.update(synchronized_timestamp);
             } else {
                 lastStateStamp.update(yarp::os::Time::now());
             }

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -331,7 +331,7 @@ bool laserHokuyo::setScanRate(double rate)
     return false;
 }
 
-bool laserHokuyo::getRawData(yarp::sig::Vector &out)
+bool laserHokuyo::getRawData(yarp::sig::Vector &out, double* timestamp)
 {
     if (internal_status != HOKUYO_STATUS_NOT_READY)
     {
@@ -346,7 +346,7 @@ bool laserHokuyo::getRawData(yarp::sig::Vector &out)
     return false;
 }
 
-bool laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data)
+bool laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
 {
     if (internal_status != HOKUYO_STATUS_NOT_READY)
     {

--- a/src/devices/laserHokuyo/laserHokuyo.h
+++ b/src/devices/laserHokuyo/laserHokuyo.h
@@ -104,8 +104,8 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector &data) override;
-    bool getLaserMeasurement(std::vector<LaserMeasurementData> &data) override;
+    bool getRawData(yarp::sig::Vector &data, double* timestamp) override;
+    bool getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp) override;
     bool getDeviceStatus     (Device_status &status) override;
     bool getDeviceInfo       (std::string &device_info) override;
     bool getDistanceRange    (double& min, double& max) override;

--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -267,7 +267,7 @@ bool RpLidar::setScanRate(double rate)
 }
 
 
-bool RpLidar::getRawData(yarp::sig::Vector &out)
+bool RpLidar::getRawData(yarp::sig::Vector &out, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(mutex);
     out = laser_data;
@@ -275,7 +275,7 @@ bool RpLidar::getRawData(yarp::sig::Vector &out)
     return true;
 }
 
-bool RpLidar::getLaserMeasurement(std::vector<LaserMeasurementData> &data)
+bool RpLidar::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(mutex);
 #ifdef LASER_DEBUG

--- a/src/devices/rpLidar/rpLidar.h
+++ b/src/devices/rpLidar/rpLidar.h
@@ -234,8 +234,8 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector &data) override;
-    bool getLaserMeasurement(std::vector<LaserMeasurementData> &data) override;
+    bool getRawData(yarp::sig::Vector &data, double* timestamp) override;
+    bool getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp) override;
     bool getDeviceStatus     (Device_status &status) override;
     bool getDeviceInfo       (std::string &device_info) override;
     bool getDistanceRange    (double& min, double& max) override;

--- a/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
+++ b/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
@@ -45,16 +45,18 @@ public:
     /**
     * Get the device measurements
     * @param data a vector containing the measurement data, expressed in cartesian/polar format
-    * @return true/false..
+    * @param timestamp the timestamp of the retrieved data.
+    * @return true/false
     */
-    virtual bool getLaserMeasurement(std::vector<LaserMeasurementData> &data) = 0;
+    virtual bool getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp = nullptr) = 0;
 
     /**
     * Get the device measurements
     * @param ranges the vector containing the raw measurement data, as acquired by the device.
+    * @param timestamp the timestamp of the retrieved data.
     * @return true/false.
     */
-    virtual bool getRawData(yarp::sig::Vector &data) = 0;
+    virtual bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) = 0;
 
     /**
     * get the device status

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
@@ -50,10 +50,14 @@ bool Lidar2DDeviceBase::getDeviceStatus(Device_status& status)
     return true;
 }
 
-bool Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out)
+bool Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     out = m_laser_data;
+    if (timestamp != nullptr)
+    {
+        *timestamp = m_timestamp.getTime();
+    }
     return true;
 }
 
@@ -71,7 +75,7 @@ bool Lidar2DDeviceBase::getDeviceInfo(std::string& device_info)
     return true;
 }
 
-bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& data)
+bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 #ifdef LASER_DEBUG
@@ -85,6 +89,10 @@ bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& d
     {
         double angle = (i / double(size) * laser_angle_of_view + m_min_angle) * DEG2RAD;
         data[i].set_polar(m_laser_data[i], angle);
+    }
+    if (timestamp!=nullptr)
+    {
+        *timestamp = m_timestamp.getTime();
     }
     return true;
 }

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
@@ -92,8 +92,8 @@ protected:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector& data) override;
-    bool getLaserMeasurement(std::vector<LaserMeasurementData>& data) override;
+    bool getRawData(yarp::sig::Vector& data, double* timestamp = nullptr) override;
+    bool getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp = nullptr) override;
     bool getDeviceStatus(Device_status& status) override;
     bool getDeviceInfo(std::string& device_info) override;
     bool getDistanceRange(double& min, double& max) override;


### PR DESCRIPTION
added timestamp to the following IRangefinder2D methods:
``` getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp = nullptr) ```
```getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) ```