### PR TITLE
yarpidl_thrift: Fix services when the first argument is a vocab

### DIFF
--- a/doc/release/master/thrift_vocab_arg.md
+++ b/doc/release/master/thrift_vocab_arg.md
@@ -1,0 +1,10 @@
+thrift_vocab_arg {#master}
+----------------
+
+Important Changes
+-----------------
+
+### `yarpidl_thrift`
+
+* It's no longer possible to have service functions that starts with the same
+  name as a different one followed by `_` (for example `get` and `get_all`).

--- a/src/devices/ILocalization2DMsgs/idl_generated_code/ILocalization2DMsgs.cpp
+++ b/src/devices/ILocalization2DMsgs/idl_generated_code/ILocalization2DMsgs.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // start_localization_service_RPC helper class declaration
 class ILocalization2DMsgs_start_localization_service_RPC_helper :
         public yarp::os::Portable
@@ -612,7 +614,7 @@ bool ILocalization2DMsgs_start_localization_service_RPC_helper::Command::read(ya
 
 bool ILocalization2DMsgs_start_localization_service_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -745,7 +747,7 @@ bool ILocalization2DMsgs_stop_localization_service_RPC_helper::Command::read(yar
 
 bool ILocalization2DMsgs_stop_localization_service_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -878,7 +880,7 @@ bool ILocalization2DMsgs_get_localization_status_RPC_helper::Command::read(yarp:
 
 bool ILocalization2DMsgs_get_localization_status_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1011,7 +1013,7 @@ bool ILocalization2DMsgs_get_estimated_poses_RPC_helper::Command::read(yarp::os:
 
 bool ILocalization2DMsgs_get_estimated_poses_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1144,7 +1146,7 @@ bool ILocalization2DMsgs_get_current_position1_RPC_helper::Command::read(yarp::o
 
 bool ILocalization2DMsgs_get_current_position1_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1277,7 +1279,7 @@ bool ILocalization2DMsgs_get_current_position2_RPC_helper::Command::read(yarp::o
 
 bool ILocalization2DMsgs_get_current_position2_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1410,7 +1412,7 @@ bool ILocalization2DMsgs_get_estimated_odometry_RPC_helper::Command::read(yarp::
 
 bool ILocalization2DMsgs_get_estimated_odometry_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1556,7 +1558,7 @@ bool ILocalization2DMsgs_set_initial_pose1_RPC_helper::Command::read(yarp::os::i
 
 bool ILocalization2DMsgs_set_initial_pose1_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1714,7 +1716,7 @@ bool ILocalization2DMsgs_set_initial_pose2_RPC_helper::Command::read(yarp::os::i
 
 bool ILocalization2DMsgs_set_initial_pose2_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1953,6 +1955,9 @@ std::vector<std::string> ILocalization2DMsgs::help(const std::string& functionNa
 // read from ConnectionReader
 bool ILocalization2DMsgs::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 4;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -1960,12 +1965,12 @@ bool ILocalization2DMsgs::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == ILocalization2DMsgs_start_localization_service_RPC_helper::s_tag) {
             ILocalization2DMsgs_start_localization_service_RPC_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -2134,11 +2139,12 @@ bool ILocalization2DMsgs::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }

--- a/src/devices/IMap2DMsgs/idl_generated_code/IMap2DMsgs.cpp
+++ b/src/devices/IMap2DMsgs/idl_generated_code/IMap2DMsgs.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // clear_all_maps_RPC helper class declaration
 class IMap2DMsgs_clear_all_maps_RPC_helper :
         public yarp::os::Portable
@@ -2231,7 +2233,7 @@ bool IMap2DMsgs_clear_all_maps_RPC_helper::Command::read(yarp::os::idl::WireRead
 
 bool IMap2DMsgs_clear_all_maps_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2377,7 +2379,7 @@ bool IMap2DMsgs_store_map_RPC_helper::Command::read(yarp::os::idl::WireReader& r
 
 bool IMap2DMsgs_store_map_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2531,7 +2533,7 @@ bool IMap2DMsgs_get_map_RPC_helper::Command::read(yarp::os::idl::WireReader& rea
 
 bool IMap2DMsgs_get_map_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2672,7 +2674,7 @@ bool IMap2DMsgs_get_map_names_RPC_helper::Command::read(yarp::os::idl::WireReade
 
 bool IMap2DMsgs_get_map_names_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2818,7 +2820,7 @@ bool IMap2DMsgs_remove_map_RPC_helper::Command::read(yarp::os::idl::WireReader& 
 
 bool IMap2DMsgs_remove_map_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2976,7 +2978,7 @@ bool IMap2DMsgs_store_location_RPC_helper::Command::read(yarp::os::idl::WireRead
 
 bool IMap2DMsgs_store_location_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3142,7 +3144,7 @@ bool IMap2DMsgs_store_area_RPC_helper::Command::read(yarp::os::idl::WireReader& 
 
 bool IMap2DMsgs_store_area_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3308,7 +3310,7 @@ bool IMap2DMsgs_store_path_RPC_helper::Command::read(yarp::os::idl::WireReader& 
 
 bool IMap2DMsgs_store_path_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3470,7 +3472,7 @@ bool IMap2DMsgs_get_location_RPC_helper::Command::read(yarp::os::idl::WireReader
 
 bool IMap2DMsgs_get_location_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3624,7 +3626,7 @@ bool IMap2DMsgs_get_area_RPC_helper::Command::read(yarp::os::idl::WireReader& re
 
 bool IMap2DMsgs_get_area_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3778,7 +3780,7 @@ bool IMap2DMsgs_get_path_RPC_helper::Command::read(yarp::os::idl::WireReader& re
 
 bool IMap2DMsgs_get_path_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3919,7 +3921,7 @@ bool IMap2DMsgs_get_locations_list_RPC_helper::Command::read(yarp::os::idl::Wire
 
 bool IMap2DMsgs_get_locations_list_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4052,7 +4054,7 @@ bool IMap2DMsgs_get_areas_list_RPC_helper::Command::read(yarp::os::idl::WireRead
 
 bool IMap2DMsgs_get_areas_list_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4185,7 +4187,7 @@ bool IMap2DMsgs_get_paths_list_RPC_helper::Command::read(yarp::os::idl::WireRead
 
 bool IMap2DMsgs_get_paths_list_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4318,7 +4320,7 @@ bool IMap2DMsgs_get_all_locations_RPC_helper::Command::read(yarp::os::idl::WireR
 
 bool IMap2DMsgs_get_all_locations_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4451,7 +4453,7 @@ bool IMap2DMsgs_get_all_areas_RPC_helper::Command::read(yarp::os::idl::WireReade
 
 bool IMap2DMsgs_get_all_areas_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4584,7 +4586,7 @@ bool IMap2DMsgs_get_all_paths_RPC_helper::Command::read(yarp::os::idl::WireReade
 
 bool IMap2DMsgs_get_all_paths_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4734,7 +4736,7 @@ bool IMap2DMsgs_rename_location_RPC_helper::Command::read(yarp::os::idl::WireRea
 
 bool IMap2DMsgs_rename_location_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4896,7 +4898,7 @@ bool IMap2DMsgs_delete_location_RPC_helper::Command::read(yarp::os::idl::WireRea
 
 bool IMap2DMsgs_delete_location_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5050,7 +5052,7 @@ bool IMap2DMsgs_delete_path_RPC_helper::Command::read(yarp::os::idl::WireReader&
 
 bool IMap2DMsgs_delete_path_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5208,7 +5210,7 @@ bool IMap2DMsgs_rename_area_RPC_helper::Command::read(yarp::os::idl::WireReader&
 
 bool IMap2DMsgs_rename_area_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5374,7 +5376,7 @@ bool IMap2DMsgs_rename_path_RPC_helper::Command::read(yarp::os::idl::WireReader&
 
 bool IMap2DMsgs_rename_path_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5536,7 +5538,7 @@ bool IMap2DMsgs_delete_area_RPC_helper::Command::read(yarp::os::idl::WireReader&
 
 bool IMap2DMsgs_delete_area_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5677,7 +5679,7 @@ bool IMap2DMsgs_clear_all_locations_RPC_helper::Command::read(yarp::os::idl::Wir
 
 bool IMap2DMsgs_clear_all_locations_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5810,7 +5812,7 @@ bool IMap2DMsgs_clear_all_areas_RPC_helper::Command::read(yarp::os::idl::WireRea
 
 bool IMap2DMsgs_clear_all_areas_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -5943,7 +5945,7 @@ bool IMap2DMsgs_clear_all_paths_RPC_helper::Command::read(yarp::os::idl::WireRea
 
 bool IMap2DMsgs_clear_all_paths_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6076,7 +6078,7 @@ bool IMap2DMsgs_clear_all_maps_temporary_flags_RPC_helper::Command::read(yarp::o
 
 bool IMap2DMsgs_clear_all_maps_temporary_flags_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6222,7 +6224,7 @@ bool IMap2DMsgs_clear_map_temporary_flags_RPC_helper::Command::read(yarp::os::id
 
 bool IMap2DMsgs_clear_map_temporary_flags_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6376,7 +6378,7 @@ bool IMap2DMsgs_save_maps_collection_RPC_helper::Command::read(yarp::os::idl::Wi
 
 bool IMap2DMsgs_save_maps_collection_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6530,7 +6532,7 @@ bool IMap2DMsgs_load_maps_collection_RPC_helper::Command::read(yarp::os::idl::Wi
 
 bool IMap2DMsgs_load_maps_collection_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6684,7 +6686,7 @@ bool IMap2DMsgs_save_locations_and_extras_RPC_helper::Command::read(yarp::os::id
 
 bool IMap2DMsgs_save_locations_and_extras_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6838,7 +6840,7 @@ bool IMap2DMsgs_load_locations_and_extras_RPC_helper::Command::read(yarp::os::id
 
 bool IMap2DMsgs_load_locations_and_extras_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -6996,7 +6998,7 @@ bool IMap2DMsgs_save_map_to_disk_RPC_helper::Command::read(yarp::os::idl::WireRe
 
 bool IMap2DMsgs_save_map_to_disk_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -7158,7 +7160,7 @@ bool IMap2DMsgs_load_map_from_disk_RPC_helper::Command::read(yarp::os::idl::Wire
 
 bool IMap2DMsgs_load_map_from_disk_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -7312,7 +7314,7 @@ bool IMap2DMsgs_enable_maps_compression_RPC_helper::Command::read(yarp::os::idl:
 
 bool IMap2DMsgs_enable_maps_compression_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -7907,6 +7909,9 @@ std::vector<std::string> IMap2DMsgs::help(const std::string& functionName)
 // read from ConnectionReader
 bool IMap2DMsgs::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 6;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -7914,12 +7919,12 @@ bool IMap2DMsgs::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == IMap2DMsgs_clear_all_maps_RPC_helper::s_tag) {
             IMap2DMsgs_clear_all_maps_RPC_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -8478,11 +8483,12 @@ bool IMap2DMsgs::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }

--- a/src/devices/INavigation2DMsgs/idl_generated_code/INavigation2DMsgs.cpp
+++ b/src/devices/INavigation2DMsgs/idl_generated_code/INavigation2DMsgs.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // stop_navigation_RPC helper class declaration
 class INavigation2DMsgs_stop_navigation_RPC_helper :
         public yarp::os::Portable
@@ -1112,7 +1114,7 @@ bool INavigation2DMsgs_stop_navigation_RPC_helper::Command::read(yarp::os::idl::
 
 bool INavigation2DMsgs_stop_navigation_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1245,7 +1247,7 @@ bool INavigation2DMsgs_resume_navigation_RPC_helper::Command::read(yarp::os::idl
 
 bool INavigation2DMsgs_resume_navigation_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1391,7 +1393,7 @@ bool INavigation2DMsgs_suspend_navigation_RPC_helper::Command::read(yarp::os::id
 
 bool INavigation2DMsgs_suspend_navigation_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1532,7 +1534,7 @@ bool INavigation2DMsgs_recompute_current_navigation_path_RPC_helper::Command::re
 
 bool INavigation2DMsgs_recompute_current_navigation_path_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1665,7 +1667,7 @@ bool INavigation2DMsgs_get_navigation_status_RPC_helper::Command::read(yarp::os:
 
 bool INavigation2DMsgs_get_navigation_status_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1798,7 +1800,7 @@ bool INavigation2DMsgs_get_current_nav_waypoint_RPC_helper::Command::read(yarp::
 
 bool INavigation2DMsgs_get_current_nav_waypoint_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1944,7 +1946,7 @@ bool INavigation2DMsgs_get_all_navigation_waypoints_RPC_helper::Command::read(ya
 
 bool INavigation2DMsgs_get_all_navigation_waypoints_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2100,7 +2102,7 @@ bool INavigation2DMsgs_get_current_navigation_map_RPC_helper::Command::read(yarp
 
 bool INavigation2DMsgs_get_current_navigation_map_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2256,7 +2258,7 @@ bool INavigation2DMsgs_goto_target_by_absolute_location_RPC_helper::Command::rea
 
 bool INavigation2DMsgs_goto_target_by_absolute_location_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2414,7 +2416,7 @@ bool INavigation2DMsgs_goto_target_by_relative_location1_RPC_helper::Command::re
 
 bool INavigation2DMsgs_goto_target_by_relative_location1_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2584,7 +2586,7 @@ bool INavigation2DMsgs_goto_target_by_relative_location2_RPC_helper::Command::re
 
 bool INavigation2DMsgs_goto_target_by_relative_location2_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2741,7 +2743,7 @@ bool INavigation2DMsgs_get_absolute_location_of_current_target_RPC_helper::Comma
 
 bool INavigation2DMsgs_get_absolute_location_of_current_target_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2874,7 +2876,7 @@ bool INavigation2DMsgs_get_relative_location_of_current_target_RPC_helper::Comma
 
 bool INavigation2DMsgs_get_relative_location_of_current_target_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3024,7 +3026,7 @@ bool INavigation2DMsgs_goto_target_by_absolute_location_and_set_name_RPC_helper:
 
 bool INavigation2DMsgs_goto_target_by_absolute_location_and_set_name_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3198,7 +3200,7 @@ bool INavigation2DMsgs_apply_velocity_command_RPC_helper::Command::read(yarp::os
 
 bool INavigation2DMsgs_apply_velocity_command_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3363,7 +3365,7 @@ bool INavigation2DMsgs_get_last_velocity_command_RPC_helper::Command::read(yarp:
 
 bool INavigation2DMsgs_get_last_velocity_command_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3496,7 +3498,7 @@ bool INavigation2DMsgs_get_name_of_current_target_RPC_helper::Command::read(yarp
 
 bool INavigation2DMsgs_get_name_of_current_target_RPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3831,6 +3833,9 @@ std::vector<std::string> INavigation2DMsgs::help(const std::string& functionName
 // read from ConnectionReader
 bool INavigation2DMsgs::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 9;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -3838,12 +3843,12 @@ bool INavigation2DMsgs::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == INavigation2DMsgs_stop_navigation_RPC_helper::s_tag) {
             INavigation2DMsgs_stop_navigation_RPC_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -4132,11 +4137,12 @@ bool INavigation2DMsgs::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }

--- a/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.cpp
+++ b/src/devices/fakeBattery/idl_generated_code/FakeBatteryService.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // setBatteryVoltage helper class declaration
 class FakeBatteryService_setBatteryVoltage_helper :
         public yarp::os::Portable
@@ -864,7 +866,7 @@ bool FakeBatteryService_setBatteryVoltage_helper::Command::read(yarp::os::idl::W
 
 bool FakeBatteryService_setBatteryVoltage_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1004,7 +1006,7 @@ bool FakeBatteryService_setBatteryCurrent_helper::Command::read(yarp::os::idl::W
 
 bool FakeBatteryService_setBatteryCurrent_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1144,7 +1146,7 @@ bool FakeBatteryService_setBatteryCharge_helper::Command::read(yarp::os::idl::Wi
 
 bool FakeBatteryService_setBatteryCharge_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1284,7 +1286,7 @@ bool FakeBatteryService_setBatteryStatus_helper::Command::read(yarp::os::idl::Wi
 
 bool FakeBatteryService_setBatteryStatus_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1426,7 +1428,7 @@ bool FakeBatteryService_setBatteryInfo_helper::Command::read(yarp::os::idl::Wire
 
 bool FakeBatteryService_setBatteryInfo_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1566,7 +1568,7 @@ bool FakeBatteryService_setBatteryTemperature_helper::Command::read(yarp::os::id
 
 bool FakeBatteryService_setBatteryTemperature_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1693,7 +1695,7 @@ bool FakeBatteryService_getBatteryVoltage_helper::Command::read(yarp::os::idl::W
 
 bool FakeBatteryService_getBatteryVoltage_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1826,7 +1828,7 @@ bool FakeBatteryService_getBatteryCurrent_helper::Command::read(yarp::os::idl::W
 
 bool FakeBatteryService_getBatteryCurrent_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1959,7 +1961,7 @@ bool FakeBatteryService_getBatteryCharge_helper::Command::read(yarp::os::idl::Wi
 
 bool FakeBatteryService_getBatteryCharge_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2092,7 +2094,7 @@ bool FakeBatteryService_getBatteryStatus_helper::Command::read(yarp::os::idl::Wi
 
 bool FakeBatteryService_getBatteryStatus_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2227,7 +2229,7 @@ bool FakeBatteryService_getBatteryStatusString_helper::Command::read(yarp::os::i
 
 bool FakeBatteryService_getBatteryStatusString_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2360,7 +2362,7 @@ bool FakeBatteryService_getBatteryInfo_helper::Command::read(yarp::os::idl::Wire
 
 bool FakeBatteryService_getBatteryInfo_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2493,7 +2495,7 @@ bool FakeBatteryService_getBatteryTemperature_helper::Command::read(yarp::os::id
 
 bool FakeBatteryService_getBatteryTemperature_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2766,6 +2768,9 @@ std::vector<std::string> FakeBatteryService::help(const std::string& functionNam
 // read from ConnectionReader
 bool FakeBatteryService::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 1;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -2773,12 +2778,12 @@ bool FakeBatteryService::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == FakeBatteryService_setBatteryVoltage_helper::s_tag) {
             FakeBatteryService_setBatteryVoltage_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -3031,11 +3036,12 @@ bool FakeBatteryService::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }

--- a/src/devices/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.cpp
+++ b/src/devices/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // setTransformsRPC helper class declaration
 class FrameTransformStorageSetRPC_setTransformsRPC_helper :
         public yarp::os::Portable
@@ -348,7 +350,7 @@ bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Command::read(yarp::os
 
 bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -514,7 +516,7 @@ bool FrameTransformStorageSetRPC_setTransformRPC_helper::Command::read(yarp::os:
 
 bool FrameTransformStorageSetRPC_setTransformRPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -672,7 +674,7 @@ bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Command::read(yarp::
 
 bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -821,7 +823,7 @@ bool FrameTransformStorageSetRPC_clearAllRPC_helper::Command::read(yarp::os::idl
 
 bool FrameTransformStorageSetRPC_clearAllRPC_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -974,6 +976,9 @@ std::vector<std::string> FrameTransformStorageSetRPC::help(const std::string& fu
 // read from ConnectionReader
 bool FrameTransformStorageSetRPC::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 1;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -981,12 +986,12 @@ bool FrameTransformStorageSetRPC::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == FrameTransformStorageSetRPC_setTransformsRPC_helper::s_tag) {
             FrameTransformStorageSetRPC_setTransformsRPC_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -1080,11 +1085,12 @@ bool FrameTransformStorageSetRPC::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }

--- a/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
+++ b/src/libYARP_os/src/yarp/os/idl/WireReader.cpp
@@ -545,7 +545,7 @@ bool WireReader::isError()
     return reader.isError();
 }
 
-std::string WireReader::readTag()
+std::string WireReader::readTag(size_t len)
 {
     flush_if_needed = true;
     std::string str;
@@ -558,7 +558,7 @@ std::string WireReader::readTag()
     if (!is_vocab) {
         return str;
     }
-    while (is_vocab && state->len > 0) {
+    while (--len > 0 && is_vocab && state->len > 0) {
         if (state->code >= 0) {
             is_vocab = (state->code == BOTTLE_TAG_VOCAB32);
         } else {

--- a/src/libYARP_os/src/yarp/os/idl/WireReader.h
+++ b/src/libYARP_os/src/yarp/os/idl/WireReader.h
@@ -187,7 +187,7 @@ public:
 
     bool isError();
 
-    std::string readTag();
+    std::string readTag(size_t len = static_cast<size_t>(-1));
 
     void readListBegin(yarp::os::idl::WireState& nstate, std::uint32_t& len);
 

--- a/src/yarpdataplayer-console/idl_generated_code/yarpdataplayer_console_IDL.cpp
+++ b/src/yarpdataplayer-console/idl_generated_code/yarpdataplayer_console_IDL.cpp
@@ -12,6 +12,8 @@
 
 #include <yarp/os/idl/WireTypes.h>
 
+#include <algorithm>
+
 // step helper class declaration
 class yarpdataplayer_console_IDL_step_helper :
         public yarp::os::Portable
@@ -1497,7 +1499,7 @@ bool yarpdataplayer_console_IDL_step_helper::Command::read(yarp::os::idl::WireRe
 
 bool yarpdataplayer_console_IDL_step_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1643,7 +1645,7 @@ bool yarpdataplayer_console_IDL_setFrame_helper::Command::read(yarp::os::idl::Wi
 
 bool yarpdataplayer_console_IDL_setFrame_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1797,7 +1799,7 @@ bool yarpdataplayer_console_IDL_getFrame_helper::Command::read(yarp::os::idl::Wi
 
 bool yarpdataplayer_console_IDL_getFrame_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -1951,7 +1953,7 @@ bool yarpdataplayer_console_IDL_load_helper::Command::read(yarp::os::idl::WireRe
 
 bool yarpdataplayer_console_IDL_load_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2092,7 +2094,7 @@ bool yarpdataplayer_console_IDL_play_helper::Command::read(yarp::os::idl::WireRe
 
 bool yarpdataplayer_console_IDL_play_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2225,7 +2227,7 @@ bool yarpdataplayer_console_IDL_pause_helper::Command::read(yarp::os::idl::WireR
 
 bool yarpdataplayer_console_IDL_pause_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2358,7 +2360,7 @@ bool yarpdataplayer_console_IDL_stop_helper::Command::read(yarp::os::idl::WireRe
 
 bool yarpdataplayer_console_IDL_stop_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2504,7 +2506,7 @@ bool yarpdataplayer_console_IDL_enable_helper::Command::read(yarp::os::idl::Wire
 
 bool yarpdataplayer_console_IDL_enable_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2658,7 +2660,7 @@ bool yarpdataplayer_console_IDL_disable_helper::Command::read(yarp::os::idl::Wir
 
 bool yarpdataplayer_console_IDL_disable_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2799,7 +2801,7 @@ bool yarpdataplayer_console_IDL_getAllParts_helper::Command::read(yarp::os::idl:
 
 bool yarpdataplayer_console_IDL_getAllParts_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -2965,7 +2967,7 @@ bool yarpdataplayer_console_IDL_getPortName_helper::Command::read(yarp::os::idl:
 
 bool yarpdataplayer_console_IDL_getPortName_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3123,7 +3125,7 @@ bool yarpdataplayer_console_IDL_setPortName_helper::Command::read(yarp::os::idl:
 
 bool yarpdataplayer_console_IDL_setPortName_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3285,7 +3287,7 @@ bool yarpdataplayer_console_IDL_setSpeed_helper::Command::read(yarp::os::idl::Wi
 
 bool yarpdataplayer_console_IDL_setSpeed_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3426,7 +3428,7 @@ bool yarpdataplayer_console_IDL_getSpeed_helper::Command::read(yarp::os::idl::Wi
 
 bool yarpdataplayer_console_IDL_getSpeed_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3572,7 +3574,7 @@ bool yarpdataplayer_console_IDL_repeat_helper::Command::read(yarp::os::idl::Wire
 
 bool yarpdataplayer_console_IDL_repeat_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3721,7 +3723,7 @@ bool yarpdataplayer_console_IDL_setStrict_helper::Command::read(yarp::os::idl::W
 
 bool yarpdataplayer_console_IDL_setStrict_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -3870,7 +3872,7 @@ bool yarpdataplayer_console_IDL_forward_helper::Command::read(yarp::os::idl::Wir
 
 bool yarpdataplayer_console_IDL_forward_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4019,7 +4021,7 @@ bool yarpdataplayer_console_IDL_backward_helper::Command::read(yarp::os::idl::Wi
 
 bool yarpdataplayer_console_IDL_backward_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4155,7 +4157,7 @@ bool yarpdataplayer_console_IDL_getProgress_helper::Command::read(yarp::os::idl:
 
 bool yarpdataplayer_console_IDL_getProgress_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4288,7 +4290,7 @@ bool yarpdataplayer_console_IDL_getStatus_helper::Command::read(yarp::os::idl::W
 
 bool yarpdataplayer_console_IDL_getStatus_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4421,7 +4423,7 @@ bool yarpdataplayer_console_IDL_resume_helper::Command::read(yarp::os::idl::Wire
 
 bool yarpdataplayer_console_IDL_resume_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4554,7 +4556,7 @@ bool yarpdataplayer_console_IDL_quit_helper::Command::read(yarp::os::idl::WireRe
 
 bool yarpdataplayer_console_IDL_quit_helper::Command::readTag(yarp::os::idl::WireReader& reader)
 {
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(s_tag_len);
     if (reader.isError()) {
         return false;
     }
@@ -4981,6 +4983,9 @@ std::vector<std::string> yarpdataplayer_console_IDL::help(const std::string& fun
 // read from ConnectionReader
 bool yarpdataplayer_console_IDL::read(yarp::os::ConnectionReader& connection)
 {
+    constexpr size_t max_tag_len = 1;
+    size_t tag_len = 1;
+
     yarp::os::idl::WireReader reader(connection);
     reader.expectAccept();
     if (!reader.readListHeader()) {
@@ -4988,12 +4993,12 @@ bool yarpdataplayer_console_IDL::read(yarp::os::ConnectionReader& connection)
         return false;
     }
 
-    std::string tag = reader.readTag();
+    std::string tag = reader.readTag(1);
     bool direct = (tag == "__direct__");
     if (direct) {
-        tag = reader.readTag();
+        tag = reader.readTag(1);
     }
-    while (!reader.isError()) {
+    while (tag_len <= max_tag_len && !reader.isError()) {
         if (tag == yarpdataplayer_console_IDL_step_helper::s_tag) {
             yarpdataplayer_console_IDL_step_helper helper;
             if (!helper.cmd.readArgs(reader)) {
@@ -5357,11 +5362,12 @@ bool yarpdataplayer_console_IDL::read(yarp::os::ConnectionReader& connection)
             reader.fail();
             return false;
         }
-        std::string next_tag = reader.readTag();
+        std::string next_tag = reader.readTag(1);
         if (next_tag.empty()) {
             break;
         }
         tag.append("_").append(next_tag);
+        tag_len = std::count(tag.begin(), tag.end(), '_') + 1;
     }
     return false;
 }


### PR DESCRIPTION
WARNING: This makes it impossible to have a service function that starts
with the same name as a different function.