### PR TITLE
Add mapsOfLists.thrift to avoid regressions in thrift generation of map containg lists

### DIFF
--- a/tests/yarpidl_thrift/demo/CMakeLists.txt
+++ b/tests/yarpidl_thrift/demo/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/catch2)
 set(IDL_FILES
   annotated.thrift
   demo.thrift
+  mapOfLists.thrift
   namespaced.thrift
   objects3D.thrift
   wrapping.thrift

--- a/tests/yarpidl_thrift/demo/mapOfLists.thrift
+++ b/tests/yarpidl_thrift/demo/mapOfLists.thrift
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+struct MapOfLists
+{
+    1: map<string, list<double>> vectors;
+}


### PR DESCRIPTION
PR that adds a regression test related to https://github.com/robotology/yarp/issues/2787 .