### PR TITLE
Actually return a reference in `VectorOf<T>::emplace_back`

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -322,6 +322,14 @@ Bug Fixes
 * Fixed build of lidar sdk with clang.
 
 
+### Libraries
+
+#### `sig`
+
+* Fixed `VectorOf<T>::emplace_back` returning `void`. Now it returns a
+  reference to the new element as expected.
+
+
 ### GUIs
 
 #### `yarplogger`

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -267,7 +267,7 @@ public:
     template<typename... _Args>
     inline T& emplace_back(_Args&&... args)
     {
-        bytes.emplace_back(std::forward<_Args>(args)...);
+        return bytes.emplace_back(std::forward<_Args>(args)...);
     }
 
     /**


### PR DESCRIPTION
This method was not returning anything contrary to what was stated in the documentation. Actually, it would have made sense to return `void` due to the signature of `std::vector<T>::emplace_back` in previous standards. In C++17 and later (hence I wouldn't think of backporting this as-is to yarp-3.5), it does return a reference instead: [cppreference.com](https://en.cppreference.com/w/cpp/container/vector/emplace_back).

Affects YARP 3.4.0+: https://github.com/robotology/yarp/pull/2195.