### PR TITLE
Fix logger lost messages V2

### DIFF
--- a/doc/release/master/fix_logFowarder_lost_msgs_v2.md
+++ b/doc/release/master/fix_logFowarder_lost_msgs_v2.md
@@ -1,0 +1,10 @@
+fix_logForwarder_lost_msgs_v2 {#master}
+-----------------------
+
+## Libraries
+
+### `os`
+
+#### `Log`
+
+* LogForwarder: now using a separated thread (`class ThreadedPort`) to prevent the loss of log messages during stress condition

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
@@ -9,11 +9,35 @@
 #include <yarp/os/api.h>
 
 #include <yarp/os/Port.h>
+#include <yarp/os/PortWriterBuffer.h>
 
 #include <mutex>
 #include <string>
+#include <yarp/os/PeriodicThread.h>
+
+#include <yarp/os/BufferedPort.h>
+#include <list>
 
 namespace yarp::os::impl {
+
+class ThreadedPort : public yarp::os::PeriodicThread
+{
+    std::mutex mut;
+    yarp::os::BufferedPort<yarp::os::Bottle>* m_port = nullptr;
+    std::list<yarp::os::Bottle> messages;
+
+    void process();
+
+public:
+    void run() override;
+    void attach(yarp::os::BufferedPort<yarp::os::Bottle>* port);
+    void insert(const yarp::os::Bottle& bot);
+    void terminate();
+public:
+    ThreadedPort();
+};
+
+//----------------------------------------------------------------
 
 class YARP_os_impl_API LogForwarder
 {
@@ -29,8 +53,8 @@ private:
     LogForwarder(LogForwarder const&) = delete;
     LogForwarder& operator=(LogForwarder const&) = delete;
 
-    std::mutex mutex;
-    yarp::os::Port outputPort;
+    ThreadedPort   tport;
+    yarp::os::BufferedPort<yarp::os::Bottle> outputPort;
     static bool started;
 };
 


### PR DESCRIPTION
LogForwarder: now using a separated thread (`class ThreadedPort`) to prevent the loss of log messages during stress condition