### PR TITLE
Fixed regression in yarpmotorgui when part is not available.

### DIFF
--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -51,6 +51,7 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
     m_part_motorPositionVisible(false),
     m_part_dutyVisible(false),
     m_part_currentVisible(false),
+    m_interactionModes(nullptr),
     m_finder(&_finder),
     m_iMot(nullptr),
     m_iinfo(nullptr),


### PR DESCRIPTION
This regression was added with https://github.com/robotology/yarp/pull/2774/commits/d28d58e647995c2eff4043404d05fa4f016e8547. I forgot to add a proper initialization for the raw vector, so the corresponding delete could have caused a crash.

This is happening when a [art fails to open.

cc @randaz81 @drdanz 