### PR TITLE
Add documentation on carrier option supported in remote_controlboard device

### DIFF
--- a/src/devices/RemoteControlBoard/RemoteControlBoard.h
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.h
@@ -60,6 +60,7 @@ class DiagnosticThread;
 * | remote         |       -        | string  | -     |   -           | Yes          | Prefix of the port to which to connect.        |       |
 * | local          |       -        | string  | -     |   -           | Yes          | Port prefix of the port opened by this device. |       |
 * | writeStrict    |       -        | string  | -     | See note      | No           |                                                |       |
+* | carrier        |       -        | string  | -     | udp           | No           | Specify the carrier used for reading state and sending references. This option does not change the carrier used by rpc, that is hardcoded to tcp. |       |
 *
 */
 class RemoteControlBoard :


### PR DESCRIPTION
The options are supported in the code (see https://github.com/robotology/yarp/blob/v3.6.0/src/devices/RemoteControlBoard/RemoteControlBoard.cpp#L236) but they were not documented.