### PR TITLE
Add implementation for friction parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Main project
 project(
   YARP
-  VERSION 3.6.101
+  VERSION 3.6.102
   LANGUAGES C CXX
 )
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")

--- a/doc/release/master/friction_parameters.md
+++ b/doc/release/master/friction_parameters.md
@@ -7,10 +7,10 @@ New Features
 ### Viscous and Coulomb Friction Parameters
 
 - Now ITorqueControl supports 4 new friction parameters:
-  - viscousUp
-  - viscousDown
-  - coulombUp
-  - coulombDown
+  - viscousPos
+  - viscousNeg
+  - coulombPos
+  - coulombNeg
 
 **Note:**
 These parameters are used to improve the way we model and compensate for the friction in the FW.

--- a/doc/release/master/friction_parameters.md
+++ b/doc/release/master/friction_parameters.md
@@ -1,0 +1,17 @@
+Friction parameters {#master}
+---------------------------------
+
+New Features
+------------
+
+### Viscous and Coulomb Friction Parameters
+
+- Now ITorqueControl supports 4 new friction parameters:
+  - viscousUp
+  - viscousDown
+  - coulombUp
+  - coulombDown
+
+**Note:**
+These parameters are used to improve the way we model and compensate for the friction in the FW.
+

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -478,8 +478,8 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
                 break;
             }
 
-            if (b->size() != 4) {
-                yCError(CONTROLBOARD, "received a SET VOCAB_MOTOR_PARAMS command not understood, size!=4");
+            if (b->size() != 8) {
+                yCError(CONTROLBOARD, "received a SET VOCAB_MOTOR_PARAMS command not understood, size != 8");
                 break;
             }
 
@@ -487,6 +487,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             params.bemf_scale = b->get(1).asFloat64();
             params.ktau = b->get(2).asFloat64();
             params.ktau_scale = b->get(3).asFloat64();
+            params.viscousUp = b->get(4).asFloat64();
+            params.viscousDown = b->get(5).asFloat64();
+            params.coulombUp = b->get(6).asFloat64();
+            params.coulombDown = b->get(7).asFloat64();
 
             *ok = rpc_ITorque->setMotorTorqueParams(joint, params);
         } break;
@@ -557,6 +561,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             b.addFloat64(params.bemf_scale);
             b.addFloat64(params.ktau);
             b.addFloat64(params.ktau_scale);
+            b.addFloat64(params.viscousUp);
+            b.addFloat64(params.viscousDown);
+            b.addFloat64(params.coulombUp);
+            b.addFloat64(params.coulombDown);
         } break;
         case VOCAB_RANGE: {
             *ok = rpc_ITorque->getTorqueRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -487,10 +487,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             params.bemf_scale = b->get(1).asFloat64();
             params.ktau = b->get(2).asFloat64();
             params.ktau_scale = b->get(3).asFloat64();
-            params.viscousUp = b->get(4).asFloat64();
-            params.viscousDown = b->get(5).asFloat64();
-            params.coulombUp = b->get(6).asFloat64();
-            params.coulombDown = b->get(7).asFloat64();
+            params.viscousPos = b->get(4).asFloat64();
+            params.viscousNeg = b->get(5).asFloat64();
+            params.coulombPos = b->get(6).asFloat64();
+            params.coulombNeg = b->get(7).asFloat64();
 
             *ok = rpc_ITorque->setMotorTorqueParams(joint, params);
         } break;
@@ -561,10 +561,10 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             b.addFloat64(params.bemf_scale);
             b.addFloat64(params.ktau);
             b.addFloat64(params.ktau_scale);
-            b.addFloat64(params.viscousUp);
-            b.addFloat64(params.viscousDown);
-            b.addFloat64(params.coulombUp);
-            b.addFloat64(params.coulombDown);
+            b.addFloat64(params.viscousPos);
+            b.addFloat64(params.viscousNeg);
+            b.addFloat64(params.coulombPos);
+            b.addFloat64(params.coulombNeg);
         } break;
         case VOCAB_RANGE: {
             *ok = rpc_ITorque->getTorqueRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2211,10 +2211,10 @@ bool RemoteControlBoard::setMotorTorqueParams(int j, const MotorTorqueParameters
     b.addFloat64(params.bemf_scale);
     b.addFloat64(params.ktau);
     b.addFloat64(params.ktau_scale);
-    b.addFloat64(params.viscousUp);
-    b.addFloat64(params.viscousDown);
-    b.addFloat64(params.coulombUp);
-    b.addFloat64(params.coulombDown);
+    b.addFloat64(params.viscousPos);
+    b.addFloat64(params.viscousNeg);
+    b.addFloat64(params.coulombPos);
+    b.addFloat64(params.coulombNeg);
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
@@ -2242,10 +2242,10 @@ bool RemoteControlBoard::getMotorTorqueParams(int j, MotorTorqueParameters *para
         params->bemf_scale  = l.get(1).asFloat64();
         params->ktau        = l.get(2).asFloat64();
         params->ktau_scale  = l.get(3).asFloat64();
-        params->viscousUp   = l.get(4).asFloat64();
-        params->viscousDown = l.get(5).asFloat64();
-        params->coulombUp   = l.get(6).asFloat64();
-        params->coulombDown = l.get(7).asFloat64();
+        params->viscousPos   = l.get(4).asFloat64();
+        params->viscousNeg = l.get(5).asFloat64();
+        params->coulombPos   = l.get(6).asFloat64();
+        params->coulombNeg = l.get(7).asFloat64();
         return true;
     }
     return false;

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2211,6 +2211,10 @@ bool RemoteControlBoard::setMotorTorqueParams(int j, const MotorTorqueParameters
     b.addFloat64(params.bemf_scale);
     b.addFloat64(params.ktau);
     b.addFloat64(params.ktau_scale);
+    b.addFloat64(params.viscousUp);
+    b.addFloat64(params.viscousDown);
+    b.addFloat64(params.coulombUp);
+    b.addFloat64(params.coulombDown);
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
@@ -2229,15 +2233,19 @@ bool RemoteControlBoard::getMotorTorqueParams(int j, MotorTorqueParameters *para
             return false;
         }
         Bottle& l = *lp;
-        if (l.size() != 4)
+        if (l.size() != 8)
         {
-            yCError(REMOTECONTROLBOARD, "getMotorTorqueParams return value not understood, size!=4");
+            yCError(REMOTECONTROLBOARD, "getMotorTorqueParams return value not understood, size != 8");
             return false;
         }
         params->bemf        = l.get(0).asFloat64();
         params->bemf_scale  = l.get(1).asFloat64();
         params->ktau        = l.get(2).asFloat64();
         params->ktau_scale  = l.get(3).asFloat64();
+        params->viscousUp   = l.get(4).asFloat64();
+        params->viscousDown = l.get(5).asFloat64();
+        params->coulombUp   = l.get(6).asFloat64();
+        params->coulombDown = l.get(7).asFloat64();
         return true;
     }
     return false;

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -191,12 +191,12 @@ private:
     int *_velocityTimeout;                      /** velocity shifts */
     double *_kbemf;                             /** back-emf compensation parameter */
     double *_ktau;                              /** motor torque constant */
-    double *_viscousUp;                         /** viscous up friction */
-    double *_viscousDown;                       /** viscous down friction */
-    double *_coulombUp;                         /** coulomb up friction */
-    double *_coulombDown;                       /** coulomb down friction */
     int *_kbemf_scale;                          /** back-emf compensation parameter */
     int *_ktau_scale;                           /** motor torque constant */
+    double *_viscousPos;                         /** viscous pos friction */
+    double *_viscousNeg;                       /** viscous neg friction */
+    double *_coulombPos;                         /** coulomb up friction */
+    double *_coulombNeg;                       /** coulomb neg friction */
     int * _filterType;                          /** the filter type (int value) used by the force control algorithm */
     int *_torqueSensorId;                       /** Id of associated Joint Torque Sensor */
     int *_torqueSensorChan;                     /** Channel of associated Joint Torque Sensor */
@@ -508,7 +508,7 @@ private:
     void cleanup();
     bool dealloc();
     bool parsePositionPidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[]);
-    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousUp[], double viscousDown[], double coulombUp[], double coulombDown[]);
+    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[]);
 
     bool parseImpedanceGroup_NewFormat(yarp::os::Bottle& pidsGroup, ImpedanceParameters vals[]);
 

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -191,6 +191,10 @@ private:
     int *_velocityTimeout;                      /** velocity shifts */
     double *_kbemf;                             /** back-emf compensation parameter */
     double *_ktau;                              /** motor torque constant */
+    double *_viscousUp;                         /** viscous up friction */
+    double *_viscousDown;                       /** viscous down friction */
+    double *_coulombUp;                         /** coulomb up friction */
+    double *_coulombDown;                       /** coulomb down friction */
     int *_kbemf_scale;                          /** back-emf compensation parameter */
     int *_ktau_scale;                           /** motor torque constant */
     int * _filterType;                          /** the filter type (int value) used by the force control algorithm */
@@ -504,7 +508,8 @@ private:
     void cleanup();
     bool dealloc();
     bool parsePositionPidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[]);
-    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[]);
+    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousUp[], double viscousDown[], double coulombUp[], double coulombDown[]);
+
     bool parseImpedanceGroup_NewFormat(yarp::os::Bottle& pidsGroup, ImpedanceParameters vals[]);
 
     bool extractGroup(yarp::os::Bottle &input, yarp::os::Bottle &out, const std::string &key1, const std::string &txt, int size);

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -40,10 +40,10 @@ public:
     double *dutycycleToPWMs;
     double *bemfToRaws;
     double *ktauToRaws;
-    double *viscousUpToRaws;
-    double *viscousDownToRaws;
-    double *coulombUpToRaws;
-    double *coulombDownToRaws;
+    double *viscousPosToRaws;
+    double *viscousNegToRaws;
+    double *coulombPosToRaws;
+    double *coulombNegToRaws;
 
     PidUnits* PosPid_units;
     PidUnits* VelPid_units;
@@ -64,10 +64,10 @@ public:
         dutycycleToPWMs(nullptr),
         bemfToRaws(nullptr),
         ktauToRaws(nullptr),
-        viscousUpToRaws(nullptr),
-        viscousDownToRaws(nullptr),
-        coulombUpToRaws(nullptr),
-        coulombDownToRaws(nullptr),
+        viscousPosToRaws(nullptr),
+        viscousNegToRaws(nullptr),
+        coulombPosToRaws(nullptr),
+        coulombNegToRaws(nullptr),
         PosPid_units(nullptr),
         VelPid_units(nullptr),
         CurPid_units(nullptr),
@@ -83,10 +83,10 @@ public:
         std::fill_n(dutycycleToPWMs, size, 1.0);
         std::fill_n(bemfToRaws, size, 1.0);
         std::fill_n(ktauToRaws, size, 1.0);
-        std::fill_n(viscousUpToRaws, size, 1.0);
-        std::fill_n(viscousDownToRaws, size, 1.0);
-        std::fill_n(coulombUpToRaws, size, 1.0);
-        std::fill_n(coulombDownToRaws, size, 1.0);
+        std::fill_n(viscousPosToRaws, size, 1.0);
+        std::fill_n(viscousNegToRaws, size, 1.0);
+        std::fill_n(coulombPosToRaws, size, 1.0);
+        std::fill_n(coulombNegToRaws, size, 1.0);
     }
 
     ~PrivateUnitsHandler()
@@ -106,10 +106,10 @@ public:
         checkAndDestroy<double>(dutycycleToPWMs);
         checkAndDestroy<double>(bemfToRaws);
         checkAndDestroy<double>(ktauToRaws);
-        checkAndDestroy<double>(viscousUpToRaws);
-        checkAndDestroy<double>(viscousDownToRaws);
-        checkAndDestroy<double>(coulombUpToRaws);
-        checkAndDestroy<double>(coulombDownToRaws);
+        checkAndDestroy<double>(viscousPosToRaws);
+        checkAndDestroy<double>(viscousNegToRaws);
+        checkAndDestroy<double>(coulombPosToRaws);
+        checkAndDestroy<double>(coulombNegToRaws);
     }
 
     void alloc(int n)
@@ -130,10 +130,10 @@ public:
         CurPid_units = new PidUnits[nj];
         bemfToRaws = new double[nj];
         ktauToRaws = new double[nj];
-        viscousUpToRaws = new double[nj];
-        viscousDownToRaws = new double[nj];
-        coulombUpToRaws = new double[nj];
-        coulombDownToRaws = new double[nj];
+        viscousPosToRaws = new double[nj];
+        viscousNegToRaws = new double[nj];
+        coulombPosToRaws = new double[nj];
+        coulombNegToRaws = new double[nj];
 
         yAssert(position_zeros != nullptr);
         yAssert(helper_ones != nullptr);
@@ -150,10 +150,10 @@ public:
         yAssert(CurPid_units != nullptr);
         yAssert(bemfToRaws != nullptr);
         yAssert(ktauToRaws != nullptr);
-        yAssert(viscousUpToRaws != nullptr);
-        yAssert(viscousDownToRaws != nullptr);
-        yAssert(coulombUpToRaws != nullptr);
-        yAssert(coulombDownToRaws != nullptr);
+        yAssert(viscousPosToRaws != nullptr);
+        yAssert(viscousNegToRaws != nullptr);
+        yAssert(coulombPosToRaws != nullptr);
+        yAssert(coulombNegToRaws != nullptr);
 
         pid_units[VOCAB_PIDTYPE_POSITION] = PosPid_units;
         pid_units[VOCAB_PIDTYPE_VELOCITY] = VelPid_units;
@@ -179,10 +179,10 @@ public:
         memcpy(this->CurPid_units, other.CurPid_units, sizeof(*other.CurPid_units)*nj);
         memcpy(this->bemfToRaws, other.bemfToRaws, sizeof(*other.bemfToRaws)*nj);
         memcpy(this->ktauToRaws, other.ktauToRaws, sizeof(*other.ktauToRaws)*nj);
-        memcpy(this->viscousUpToRaws, other.viscousUpToRaws, sizeof(*other.viscousUpToRaws)*nj);
-        memcpy(this->viscousDownToRaws, other.viscousDownToRaws, sizeof(*other.viscousDownToRaws)*nj);
-        memcpy(this->coulombUpToRaws, other.coulombUpToRaws, sizeof(*other.coulombUpToRaws)*nj);
-        memcpy(this->coulombDownToRaws, other.coulombDownToRaws, sizeof(*other.coulombDownToRaws)*nj);
+        memcpy(this->viscousPosToRaws, other.viscousPosToRaws, sizeof(*other.viscousPosToRaws)*nj);
+        memcpy(this->viscousNegToRaws, other.viscousNegToRaws, sizeof(*other.viscousNegToRaws)*nj);
+        memcpy(this->coulombPosToRaws, other.coulombPosToRaws, sizeof(*other.coulombPosToRaws)*nj);
+        memcpy(this->coulombNegToRaws, other.coulombNegToRaws, sizeof(*other.coulombNegToRaws)*nj);
     }
 };
 
@@ -782,27 +782,27 @@ void ControlBoardHelper::ktau_user2raw(double ktau_user, int j, double &ktau_raw
     k = toHw(j);
 }
 
-void ControlBoardHelper::viscousUp_user2raw(double viscousUp_user, int j, double &viscousUp_raw, int &k)
+void ControlBoardHelper::viscousPos_user2raw(double viscousPos_user, int j, double &viscousPos_raw, int &k)
 {
-    viscousUp_raw = viscousUp_user * mPriv->viscousUpToRaws[j];
+    viscousPos_raw = viscousPos_user * mPriv->viscousPosToRaws[j];
     k = toHw(j);
 }
 
-void ControlBoardHelper::viscousDown_user2raw(double viscousDown_user, int j, double &viscousDown_raw, int &k)
+void ControlBoardHelper::viscousNeg_user2raw(double viscousNeg_user, int j, double &viscousNeg_raw, int &k)
 {
-    viscousDown_raw = viscousDown_user * mPriv->viscousDownToRaws[j];
+    viscousNeg_raw = viscousNeg_user * mPriv->viscousNegToRaws[j];
     k = toHw(j);
 }
 
-void ControlBoardHelper::coulombUp_user2raw(double coulombUp_user, int j, double &coulombUp_raw, int &k)
+void ControlBoardHelper::coulombPos_user2raw(double coulombPos_user, int j, double &coulombPos_raw, int &k)
 {
-    coulombUp_raw = coulombUp_user * mPriv->coulombUpToRaws[j];
+    coulombPos_raw = coulombPos_user * mPriv->coulombPosToRaws[j];
     k = toHw(j);
 }
 
-void ControlBoardHelper::coulombDown_user2raw(double coulombDown_user, int j, double &coulombDown_raw, int &k)
+void ControlBoardHelper::coulombNeg_user2raw(double coulombNeg_user, int j, double &coulombNeg_raw, int &k)
 {
-    coulombDown_raw = coulombDown_user * mPriv->coulombDownToRaws[j];
+    coulombNeg_raw = coulombNeg_user * mPriv->coulombNegToRaws[j];
     k = toHw(j);
 }
 
@@ -828,48 +828,48 @@ double  ControlBoardHelper::ktau_user2raw(double ktau_user, int j)
     return ktau_user * mPriv->ktauToRaws[j];
 }
 
-double  ControlBoardHelper::viscousUp_user2raw(double viscousUp_user, int j)
+double  ControlBoardHelper::viscousPos_user2raw(double viscousPos_user, int j)
 {
-    return viscousUp_user * mPriv->viscousUpToRaws[j];
+    return viscousPos_user * mPriv->viscousPosToRaws[j];
 }
 
-double ControlBoardHelper::viscousDown_user2raw(double viscousDown_user, int j)
+double ControlBoardHelper::viscousNeg_user2raw(double viscousNeg_user, int j)
 {
-    return viscousDown_user * mPriv->viscousDownToRaws[j];
+    return viscousNeg_user * mPriv->viscousNegToRaws[j];
 }
 
-double ControlBoardHelper::coulombUp_user2raw(double coulombUp_user, int j)
+double ControlBoardHelper::coulombPos_user2raw(double coulombPos_user, int j)
 {
-    return coulombUp_user * mPriv->coulombUpToRaws[j];
+    return coulombPos_user * mPriv->coulombPosToRaws[j];
 }
 
-double ControlBoardHelper::coulombDown_user2raw(double coulombDown_user, int j)
+double ControlBoardHelper::coulombNeg_user2raw(double coulombNeg_user, int j)
 {
-    return coulombDown_user * mPriv->coulombDownToRaws[j];
+    return coulombNeg_user * mPriv->coulombNegToRaws[j];
 }
 
-void ControlBoardHelper::viscousUp_raw2user(double viscousUp_raw, int k_raw, double &viscousUp_user, int &j_user)
+void ControlBoardHelper::viscousPos_raw2user(double viscousPos_raw, int k_raw, double &viscousPos_user, int &j_user)
 {
     j_user = toUser(k_raw);
-    viscousUp_user = viscousUp_raw / mPriv->viscousUpToRaws[j_user];
+    viscousPos_user = viscousPos_raw / mPriv->viscousPosToRaws[j_user];
 }
 
-void ControlBoardHelper::viscousDown_raw2user(double viscousDown_raw, int k_raw, double &viscousDown_user, int &j_user)
+void ControlBoardHelper::viscousNeg_raw2user(double viscousNeg_raw, int k_raw, double &viscousNeg_user, int &j_user)
 {
     j_user = toUser(k_raw);
-    viscousDown_user = viscousDown_raw / mPriv->viscousDownToRaws[j_user];
+    viscousNeg_user = viscousNeg_raw / mPriv->viscousNegToRaws[j_user];
 }
 
-void ControlBoardHelper::coulombUp_raw2user(double coulombUp_raw, int k_raw, double &coulombUp_user, int &j_user)
+void ControlBoardHelper::coulombPos_raw2user(double coulombPos_raw, int k_raw, double &coulombPos_user, int &j_user)
 {
     j_user = toUser(k_raw);
-    coulombUp_user = coulombUp_raw / mPriv->coulombUpToRaws[j_user];
+    coulombPos_user = coulombPos_raw / mPriv->coulombPosToRaws[j_user];
 }
 
-void ControlBoardHelper::coulombDown_raw2user(double coulombDown_raw, int k_raw, double &coulombDown_user, int &j_user)
+void ControlBoardHelper::coulombNeg_raw2user(double coulombNeg_raw, int k_raw, double &coulombNeg_user, int &j_user)
 {
     j_user = toUser(k_raw);
-    coulombDown_user = coulombDown_raw / mPriv->coulombDownToRaws[j_user];
+    coulombNeg_user = coulombNeg_raw / mPriv->coulombNegToRaws[j_user];
 }
 
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -806,8 +806,6 @@ void ControlBoardHelper::coulombDown_user2raw(double coulombDown_user, int j, do
     k = toHw(j);
 }
 
-// RAW_2_USER
-
 void ControlBoardHelper::bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user)
 {
     j_user = toUser(k_raw);
@@ -828,6 +826,26 @@ double  ControlBoardHelper::bemf_user2raw(double bemf_user, int j)
 double  ControlBoardHelper::ktau_user2raw(double ktau_user, int j)
 {
     return ktau_user * mPriv->ktauToRaws[j];
+}
+
+double  ControlBoardHelper::viscousUp_user2raw(double viscousUp_user, int j)
+{
+    return viscousUp_user * mPriv->viscousUpToRaws[j];
+}
+
+double ControlBoardHelper::viscousDown_user2raw(double viscousDown_user, int j)
+{
+    return viscousDown_user * mPriv->viscousDownToRaws[j];
+}
+
+double ControlBoardHelper::coulombUp_user2raw(double coulombUp_user, int j)
+{
+    return coulombUp_user * mPriv->coulombUpToRaws[j];
+}
+
+double ControlBoardHelper::coulombDown_user2raw(double coulombDown_user, int j)
+{
+    return coulombDown_user * mPriv->coulombDownToRaws[j];
 }
 
 void ControlBoardHelper::viscousUp_raw2user(double viscousUp_raw, int k_raw, double &viscousUp_user, int &j_user)

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -40,6 +40,10 @@ public:
     double *dutycycleToPWMs;
     double *bemfToRaws;
     double *ktauToRaws;
+    double *viscousUpToRaws;
+    double *viscousDownToRaws;
+    double *coulombUpToRaws;
+    double *coulombDownToRaws;
 
     PidUnits* PosPid_units;
     PidUnits* VelPid_units;
@@ -60,6 +64,10 @@ public:
         dutycycleToPWMs(nullptr),
         bemfToRaws(nullptr),
         ktauToRaws(nullptr),
+        viscousUpToRaws(nullptr),
+        viscousDownToRaws(nullptr),
+        coulombUpToRaws(nullptr),
+        coulombDownToRaws(nullptr),
         PosPid_units(nullptr),
         VelPid_units(nullptr),
         CurPid_units(nullptr),
@@ -75,6 +83,10 @@ public:
         std::fill_n(dutycycleToPWMs, size, 1.0);
         std::fill_n(bemfToRaws, size, 1.0);
         std::fill_n(ktauToRaws, size, 1.0);
+        std::fill_n(viscousUpToRaws, size, 1.0);
+        std::fill_n(viscousDownToRaws, size, 1.0);
+        std::fill_n(coulombUpToRaws, size, 1.0);
+        std::fill_n(coulombDownToRaws, size, 1.0);
     }
 
     ~PrivateUnitsHandler()
@@ -94,6 +106,10 @@ public:
         checkAndDestroy<double>(dutycycleToPWMs);
         checkAndDestroy<double>(bemfToRaws);
         checkAndDestroy<double>(ktauToRaws);
+        checkAndDestroy<double>(viscousUpToRaws);
+        checkAndDestroy<double>(viscousDownToRaws);
+        checkAndDestroy<double>(coulombUpToRaws);
+        checkAndDestroy<double>(coulombDownToRaws);
     }
 
     void alloc(int n)
@@ -114,6 +130,10 @@ public:
         CurPid_units = new PidUnits[nj];
         bemfToRaws = new double[nj];
         ktauToRaws = new double[nj];
+        viscousUpToRaws = new double[nj];
+        viscousDownToRaws = new double[nj];
+        coulombUpToRaws = new double[nj];
+        coulombDownToRaws = new double[nj];
 
         yAssert(position_zeros != nullptr);
         yAssert(helper_ones != nullptr);
@@ -130,6 +150,10 @@ public:
         yAssert(CurPid_units != nullptr);
         yAssert(bemfToRaws != nullptr);
         yAssert(ktauToRaws != nullptr);
+        yAssert(viscousUpToRaws != nullptr);
+        yAssert(viscousDownToRaws != nullptr);
+        yAssert(coulombUpToRaws != nullptr);
+        yAssert(coulombDownToRaws != nullptr);
 
         pid_units[VOCAB_PIDTYPE_POSITION] = PosPid_units;
         pid_units[VOCAB_PIDTYPE_VELOCITY] = VelPid_units;
@@ -155,6 +179,10 @@ public:
         memcpy(this->CurPid_units, other.CurPid_units, sizeof(*other.CurPid_units)*nj);
         memcpy(this->bemfToRaws, other.bemfToRaws, sizeof(*other.bemfToRaws)*nj);
         memcpy(this->ktauToRaws, other.ktauToRaws, sizeof(*other.ktauToRaws)*nj);
+        memcpy(this->viscousUpToRaws, other.viscousUpToRaws, sizeof(*other.viscousUpToRaws)*nj);
+        memcpy(this->viscousDownToRaws, other.viscousDownToRaws, sizeof(*other.viscousDownToRaws)*nj);
+        memcpy(this->coulombUpToRaws, other.coulombUpToRaws, sizeof(*other.coulombUpToRaws)*nj);
+        memcpy(this->coulombDownToRaws, other.coulombDownToRaws, sizeof(*other.coulombDownToRaws)*nj);
     }
 };
 
@@ -754,6 +782,32 @@ void ControlBoardHelper::ktau_user2raw(double ktau_user, int j, double &ktau_raw
     k = toHw(j);
 }
 
+void ControlBoardHelper::viscousUp_user2raw(double viscousUp_user, int j, double &viscousUp_raw, int &k)
+{
+    viscousUp_raw = viscousUp_user * mPriv->viscousUpToRaws[j];
+    k = toHw(j);
+}
+
+void ControlBoardHelper::viscousDown_user2raw(double viscousDown_user, int j, double &viscousDown_raw, int &k)
+{
+    viscousDown_raw = viscousDown_user * mPriv->viscousDownToRaws[j];
+    k = toHw(j);
+}
+
+void ControlBoardHelper::coulombUp_user2raw(double coulombUp_user, int j, double &coulombUp_raw, int &k)
+{
+    coulombUp_raw = coulombUp_user * mPriv->coulombUpToRaws[j];
+    k = toHw(j);
+}
+
+void ControlBoardHelper::coulombDown_user2raw(double coulombDown_user, int j, double &coulombDown_raw, int &k)
+{
+    coulombDown_raw = coulombDown_user * mPriv->coulombDownToRaws[j];
+    k = toHw(j);
+}
+
+// RAW_2_USER
+
 void ControlBoardHelper::bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user)
 {
     j_user = toUser(k_raw);
@@ -775,6 +829,31 @@ double  ControlBoardHelper::ktau_user2raw(double ktau_user, int j)
 {
     return ktau_user * mPriv->ktauToRaws[j];
 }
+
+void ControlBoardHelper::viscousUp_raw2user(double viscousUp_raw, int k_raw, double &viscousUp_user, int &j_user)
+{
+    j_user = toUser(k_raw);
+    viscousUp_user = viscousUp_raw / mPriv->viscousUpToRaws[j_user];
+}
+
+void ControlBoardHelper::viscousDown_raw2user(double viscousDown_raw, int k_raw, double &viscousDown_user, int &j_user)
+{
+    j_user = toUser(k_raw);
+    viscousDown_user = viscousDown_raw / mPriv->viscousDownToRaws[j_user];
+}
+
+void ControlBoardHelper::coulombUp_raw2user(double coulombUp_raw, int k_raw, double &coulombUp_user, int &j_user)
+{
+    j_user = toUser(k_raw);
+    coulombUp_user = coulombUp_raw / mPriv->coulombUpToRaws[j_user];
+}
+
+void ControlBoardHelper::coulombDown_raw2user(double coulombDown_raw, int k_raw, double &coulombDown_user, int &j_user)
+{
+    j_user = toUser(k_raw);
+    coulombDown_user = coulombDown_raw / mPriv->coulombDownToRaws[j_user];
+}
+
 
 // *******************************************//
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -147,8 +147,16 @@ public:
     double ktau_user2raw(double ktau_user, int j);
     void bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k);
     void ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k);
+    void viscousUp_user2raw(double viscousUp_user, int j, double &viscousUp_raw, int &k);
+    void viscousDown_user2raw(double viscousDown_user, int j, double &viscousDown_raw, int &k);
+    void coulombUp_user2raw(double coulombUp_user, int j, double &coulombUp_raw, int &k);
+    void coulombDown_user2raw(double coulombDown_user, int j, double &coulombDown_raw, int &k);
     void bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user);
     void ktau_raw2user(double ktau_raw, int k_raw, double &ktau_user, int &j_user);
+    void viscousUp_raw2user(double viscousUp_raw, int k_raw, double &viscousUp_user, int &j_user);
+    void viscousDown_raw2user(double viscousDown_raw, int k_raw, double &viscousDown_user, int &j_user);
+    void coulombUp_raw2user(double coulombUp_raw, int k_raw, double &coulombUp_user, int &j_user);
+    void coulombDown_raw2user(double coulombDown_raw, int k_raw, double &coulombDown_user, int &j_user);
 
     int axes();
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -145,6 +145,11 @@ public:
     // *******************************************//
     double bemf_user2raw(double bemf_user, int j);
     double ktau_user2raw(double ktau_user, int j);
+    double viscousUp_user2raw(double viscousUp_user, int j);
+    double viscousDown_user2raw(double viscousDown_user, int j);
+    double coulombUp_user2raw(double coulombUp_user, int j);
+    double coulombDown_user2raw(double coulombDown_user, int j);
+
     void bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k);
     void ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k);
     void viscousUp_user2raw(double viscousUp_user, int j, double &viscousUp_raw, int &k);

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -145,23 +145,23 @@ public:
     // *******************************************//
     double bemf_user2raw(double bemf_user, int j);
     double ktau_user2raw(double ktau_user, int j);
-    double viscousUp_user2raw(double viscousUp_user, int j);
-    double viscousDown_user2raw(double viscousDown_user, int j);
-    double coulombUp_user2raw(double coulombUp_user, int j);
-    double coulombDown_user2raw(double coulombDown_user, int j);
+    double viscousPos_user2raw(double viscousPos_user, int j);
+    double viscousNeg_user2raw(double viscousNeg_user, int j);
+    double coulombPos_user2raw(double coulombPos_user, int j);
+    double coulombNeg_user2raw(double coulombNeg_user, int j);
 
     void bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k);
     void ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k);
-    void viscousUp_user2raw(double viscousUp_user, int j, double &viscousUp_raw, int &k);
-    void viscousDown_user2raw(double viscousDown_user, int j, double &viscousDown_raw, int &k);
-    void coulombUp_user2raw(double coulombUp_user, int j, double &coulombUp_raw, int &k);
-    void coulombDown_user2raw(double coulombDown_user, int j, double &coulombDown_raw, int &k);
+    void viscousPos_user2raw(double viscousPos_user, int j, double &viscousPos_raw, int &k);
+    void viscousNeg_user2raw(double viscousNeg_user, int j, double &viscousNeg_raw, int &k);
+    void coulombPos_user2raw(double coulombPos_user, int j, double &coulombPos_raw, int &k);
+    void coulombNeg_user2raw(double coulombNeg_user, int j, double &coulombNeg_raw, int &k);
     void bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user);
     void ktau_raw2user(double ktau_raw, int k_raw, double &ktau_user, int &j_user);
-    void viscousUp_raw2user(double viscousUp_raw, int k_raw, double &viscousUp_user, int &j_user);
-    void viscousDown_raw2user(double viscousDown_raw, int k_raw, double &viscousDown_user, int &j_user);
-    void coulombUp_raw2user(double coulombUp_raw, int k_raw, double &coulombUp_user, int &j_user);
-    void coulombDown_raw2user(double coulombDown_raw, int k_raw, double &coulombDown_user, int &j_user);
+    void viscousPos_raw2user(double viscousPos_raw, int k_raw, double &viscousPos_user, int &j_user);
+    void viscousNeg_raw2user(double viscousNeg_raw, int k_raw, double &viscousNeg_user, int &j_user);
+    void coulombPos_raw2user(double coulombPos_raw, int k_raw, double &coulombPos_user, int &j_user);
+    void coulombNeg_raw2user(double coulombNeg_raw, int k_raw, double &coulombNeg_user, int &j_user);
 
     int axes();
 

--- a/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
@@ -22,11 +22,11 @@ class YARP_dev_API yarp::dev::MotorTorqueParameters
     double bemf_scale;
     double ktau;
     double ktau_scale;
-    double viscousUp;
-    double viscousDown;
-    double coulombUp;
-    double coulombDown;
-    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousUp(0), viscousDown(0), coulombUp(0), coulombDown(0) {};
+    double viscousPos;
+    double viscousNeg;
+    double coulombPos;
+    double coulombNeg;
+    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousPos(0), viscousNeg(0), coulombPos(0), coulombNeg(0) {};
 };
 
 /**

--- a/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
@@ -22,7 +22,11 @@ class YARP_dev_API yarp::dev::MotorTorqueParameters
     double bemf_scale;
     double ktau;
     double ktau_scale;
-    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0) {};
+    double viscousUp;
+    double viscousDown;
+    double coulombUp;
+    double coulombDown;
+    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousUp(0), viscousDown(0), coulombUp(0), coulombDown(0) {};
 };
 
 /**

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -94,10 +94,10 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
     params_raw.bemf_scale = params.bemf_scale;
     params_raw.ktau_scale = params.ktau_scale;
 
-    castToMapper(helper)->viscousUp_user2raw(params.viscousUp, j, params_raw.viscousUp, k);
-    castToMapper(helper)->viscousDown_user2raw(params.viscousDown, j, params_raw.viscousDown, k);
-    castToMapper(helper)->coulombUp_user2raw(params.coulombUp, j, params_raw.coulombUp, k);
-    castToMapper(helper)->coulombDown_user2raw(params.coulombDown, j, params_raw.coulombDown, k);
+    castToMapper(helper)->viscousPos_user2raw(params.viscousPos, j, params_raw.viscousPos, k);
+    castToMapper(helper)->viscousNeg_user2raw(params.viscousNeg, j, params_raw.viscousNeg, k);
+    castToMapper(helper)->coulombPos_user2raw(params.coulombPos, j, params_raw.coulombPos, k);
+    castToMapper(helper)->coulombNeg_user2raw(params.coulombNeg, j, params_raw.coulombNeg, k);
 
     return iTorqueRaw->setMotorTorqueParamsRaw(k, params_raw);
 }
@@ -118,10 +118,10 @@ bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorque
         castToMapper(helper)->ktau_raw2user(params_raw.ktau, k, (*params).ktau, tmp_j);
         (*params).bemf_scale = params_raw.bemf_scale;
         (*params).ktau_scale = params_raw.ktau_scale;
-        castToMapper(helper)->viscousUp_raw2user(params_raw.viscousUp, k, (*params).viscousUp, tmp_j);
-        castToMapper(helper)->viscousDown_raw2user(params_raw.viscousDown, k, (*params).viscousDown, tmp_j);
-        castToMapper(helper)->coulombUp_raw2user(params_raw.coulombUp, k, (*params).coulombUp, tmp_j);
-        castToMapper(helper)->coulombDown_raw2user(params_raw.coulombDown, k, (*params).coulombDown, tmp_j);
+        castToMapper(helper)->viscousPos_raw2user(params_raw.viscousPos, k, (*params).viscousPos, tmp_j);
+        castToMapper(helper)->viscousNeg_raw2user(params_raw.viscousNeg, k, (*params).viscousNeg, tmp_j);
+        castToMapper(helper)->coulombPos_raw2user(params_raw.coulombPos, k, (*params).coulombPos, tmp_j);
+        castToMapper(helper)->coulombNeg_raw2user(params_raw.coulombNeg, k, (*params).coulombNeg, tmp_j);
     }
     return b;
 }

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -93,10 +93,11 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
     castToMapper(helper)->ktau_user2raw(params.ktau, j, params_raw.ktau, k);
     params_raw.bemf_scale = params.bemf_scale;
     params_raw.ktau_scale = params.ktau_scale;
-    params_raw.viscousUp = params.viscousUp;
-    params_raw.viscousDown = params.viscousDown;
-    params_raw.coulombUp = params.coulombUp;
-    params_raw.coulombDown = params.coulombDown;
+
+    castToMapper(helper)->viscousUp_user2raw(params.viscousUp, j, params_raw.viscousUp, k);
+    castToMapper(helper)->viscousDown_user2raw(params.viscousDown, j, params_raw.viscousDown, k);
+    castToMapper(helper)->coulombUp_user2raw(params.coulombUp, j, params_raw.coulombUp, k);
+    castToMapper(helper)->coulombDown_user2raw(params.coulombDown, j, params_raw.coulombDown, k);
 
     return iTorqueRaw->setMotorTorqueParamsRaw(k, params_raw);
 }
@@ -117,10 +118,10 @@ bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorque
         castToMapper(helper)->ktau_raw2user(params_raw.ktau, k, (*params).ktau, tmp_j);
         (*params).bemf_scale = params_raw.bemf_scale;
         (*params).ktau_scale = params_raw.ktau_scale;
-        (*params).viscousUp = params_raw.viscousUp;
-        (*params).viscousDown = params_raw.viscousDown;
-        (*params).coulombUp = params_raw.coulombUp;
-        (*params).coulombDown = params_raw.coulombDown;
+        castToMapper(helper)->viscousUp_raw2user(params_raw.viscousUp, k, (*params).viscousUp, tmp_j);
+        castToMapper(helper)->viscousDown_raw2user(params_raw.viscousDown, k, (*params).viscousDown, tmp_j);
+        castToMapper(helper)->coulombUp_raw2user(params_raw.coulombUp, k, (*params).coulombUp, tmp_j);
+        castToMapper(helper)->coulombDown_raw2user(params_raw.coulombDown, k, (*params).coulombDown, tmp_j);
     }
     return b;
 }

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -93,6 +93,10 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
     castToMapper(helper)->ktau_user2raw(params.ktau, j, params_raw.ktau, k);
     params_raw.bemf_scale = params.bemf_scale;
     params_raw.ktau_scale = params.ktau_scale;
+    params_raw.viscousUp = params.viscousUp;
+    params_raw.viscousDown = params.viscousDown;
+    params_raw.coulombUp = params.coulombUp;
+    params_raw.coulombDown = params.coulombDown;
 
     return iTorqueRaw->setMotorTorqueParamsRaw(k, params_raw);
 }
@@ -113,6 +117,10 @@ bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorque
         castToMapper(helper)->ktau_raw2user(params_raw.ktau, k, (*params).ktau, tmp_j);
         (*params).bemf_scale = params_raw.bemf_scale;
         (*params).ktau_scale = params_raw.ktau_scale;
+        (*params).viscousUp = params_raw.viscousUp;
+        (*params).viscousDown = params_raw.viscousDown;
+        (*params).coulombUp = params_raw.coulombUp;
+        (*params).coulombDown = params_raw.coulombDown;
     }
     return b;
 }

--- a/src/yarpmotorgui/piddlg.cpp
+++ b/src/yarpmotorgui/piddlg.cpp
@@ -53,6 +53,10 @@
 #define     TORQUE_BEMFSCALE    11
 #define     TORQUE_KTAUGAIN     12
 #define     TORQUE_KTAUSCALE    13
+#define     TORQUE_VISCOUSPOS   14
+#define     TORQUE_VISCOUSNEG   15
+#define     TORQUE_COULOMBPOS   16
+#define     TORQUE_COULOMBNEG   17
 
 #define     CURRENT_KP         0
 #define     CURRENT_KD         1
@@ -185,6 +189,16 @@ void PidDlg::initTorque(Pid myPid, MotorTorqueParameters TrqParam)
 
     ui->tableTorque->item(TORQUE_KTAUSCALE,0)->setText(QString("%1").arg((int)TrqParam.ktau_scale));
     ui->tableTorque->item(TORQUE_KTAUSCALE,1)->setText(QString("%1").arg((int)TrqParam.ktau_scale));
+
+    ui->tableTorque->item(TORQUE_VISCOUSPOS, 0)->setText(QString("%1").arg((double)TrqParam.viscousPos));
+    ui->tableTorque->item(TORQUE_VISCOUSPOS, 1)->setText(QString("%1").arg((double)TrqParam.viscousPos));
+    ui->tableTorque->item(TORQUE_VISCOUSNEG, 0)->setText(QString("%1").arg((double)TrqParam.viscousNeg));
+    ui->tableTorque->item(TORQUE_VISCOUSNEG, 1)->setText(QString("%1").arg((double)TrqParam.viscousNeg));
+
+    ui->tableTorque->item(TORQUE_COULOMBPOS, 0)->setText(QString("%1").arg((double)TrqParam.coulombPos));
+    ui->tableTorque->item(TORQUE_COULOMBPOS, 1)->setText(QString("%1").arg((double)TrqParam.coulombPos));
+    ui->tableTorque->item(TORQUE_COULOMBNEG, 0)->setText(QString("%1").arg((double)TrqParam.coulombNeg));
+    ui->tableTorque->item(TORQUE_COULOMBNEG, 1)->setText(QString("%1").arg((double)TrqParam.coulombNeg));
 
     ui->tableTorque->item(TORQUE_KI,0)->setText(QString("%1").arg((double)myPid.ki));
     ui->tableTorque->item(TORQUE_KI,1)->setText(QString("%1").arg((double)myPid.ki));
@@ -392,6 +406,10 @@ void PidDlg::onSend()
         newMotorTorqueParams.bemf_scale = ui->tableTorque->item(TORQUE_BEMFSCALE,1)->text().toDouble();
         newMotorTorqueParams.ktau = ui->tableTorque->item(TORQUE_KTAUGAIN,1)->text().toDouble();
         newMotorTorqueParams.ktau_scale = ui->tableTorque->item(TORQUE_KTAUSCALE,1)->text().toDouble();
+        newMotorTorqueParams.viscousPos = ui->tableTorque->item(TORQUE_VISCOUSPOS,1)->text().toDouble();
+        newMotorTorqueParams.viscousNeg = ui->tableTorque->item(TORQUE_VISCOUSNEG,1)->text().toDouble();
+        newMotorTorqueParams.coulombPos = ui->tableTorque->item(TORQUE_COULOMBPOS,1)->text().toDouble();
+        newMotorTorqueParams.coulombNeg = ui->tableTorque->item(TORQUE_COULOMBNEG,1)->text().toDouble();
         newPid.ki = ui->tableTorque->item(TORQUE_KI,1)->text().toDouble();
         newPid.scale = ui->tableTorque->item(TORQUE_SCALE,1)->text().toDouble();
         newPid.offset = ui->tableTorque->item(TORQUE_OFFSET,1)->text().toDouble();

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -918,22 +918,22 @@
          </row>
          <row>
           <property name="text">
-           <string>Torque ViscouUp</string>
+           <string>Torque ViscousPos</string>
           </property>
          </row>
          <row>
           <property name="text">
-           <string>Torque ViscouDown</string>
+           <string>Torque ViscousNeg</string>
           </property>
          </row>
          <row>
           <property name="text">
-           <string>Torque CoulombUp</string>
+           <string>Torque CoulombPos</string>
           </property>
          </row>
          <row>
           <property name="text">
-           <string>Torque CoulombDown</string>
+           <string>Torque CoulombNeg</string>
           </property>
          </row>
          <column>
@@ -1423,6 +1423,9 @@
           </property>
          </item>
          <item row="14" column="0">
+          <property name="text">
+           <string/>
+          </property>
           <property name="background">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -1443,9 +1446,17 @@
           </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="14" column="1">
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
           </property>
          </item>
          <item row="15" column="0">
+          <property name="text">
+           <string/>
+          </property>
           <property name="background">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -1466,9 +1477,17 @@
           </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="15" column="1">
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
           </property>
          </item>
          <item row="16" column="0">
+          <property name="text">
+           <string/>
+          </property>
           <property name="background">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -1491,7 +1510,15 @@
            <set>ItemIsEnabled</set>
           </property>
          </item>
+         <item row="16" column="1">
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
          <item row="17" column="0">
+          <property name="text">
+           <string/>
+          </property>
           <property name="background">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -1512,6 +1539,11 @@
           </property>
           <property name="flags">
            <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="17" column="1">
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
           </property>
          </item>
         </widget>

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -916,6 +916,26 @@
            <string>Torque Ktau Scale</string>
           </property>
          </row>
+         <row>
+          <property name="text">
+           <string>Torque ViscouUp</string>
+          </property>
+         </row>
+         <row>
+          <property name="text">
+           <string>Torque ViscouDown</string>
+          </property>
+         </row>
+         <row>
+          <property name="text">
+           <string>Torque CoulombUp</string>
+          </property>
+         </row>
+         <row>
+          <property name="text">
+           <string>Torque CoulombDown</string>
+          </property>
+         </row>
          <column>
           <property name="text">
            <string>Current</string>

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -32,7 +32,7 @@
       <string notr="true"/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabPosition">
       <attribute name="title">
@@ -1420,6 +1420,98 @@
           </property>
           <property name="flags">
            <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="14" column="0">
+          <property name="background">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>207</red>
+             <green>207</green>
+             <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="flags">
+           <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="15" column="0">
+          <property name="background">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>207</red>
+             <green>207</green>
+             <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="flags">
+           <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="16" column="0">
+          <property name="background">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>207</red>
+             <green>207</green>
+             <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="flags">
+           <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="17" column="0">
+          <property name="background">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>207</red>
+             <green>207</green>
+             <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="flags">
+           <set>ItemIsEnabled</set>
           </property>
          </item>
         </widget>

--- a/tests/libYARP_dev/CMakeLists.txt
+++ b/tests/libYARP_dev/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(harness_dev
     frameGrabberCropperTest.cpp
     frameGrabber_nws_yarpTest.cpp
     grabberDualTest.cpp
+    TorqueControlTest.cpp
 )
 
 target_link_libraries(harness_dev

--- a/tests/libYARP_dev/TorqueControlTest.cpp
+++ b/tests/libYARP_dev/TorqueControlTest.cpp
@@ -74,7 +74,7 @@ TEST_CASE("dev::TorqueControl", "[yarp::dev]")
 
         trq->setMotorTorqueParams(0, params);
         trq->getMotorTorqueParams(0, &res);
-        
+
         //CHECK(res.bemf == 0.1); // interface seems functional
         //CHECK(res.bemf_scale == 0.2); // interface seems functional
         //CHECK(res.ktau == 0.3); // interface seems functional

--- a/tests/libYARP_dev/TorqueControlTest.cpp
+++ b/tests/libYARP_dev/TorqueControlTest.cpp
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/dev/PolyDriver.h>
+
+#include <yarp/os/Network.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IMultipleWrapper.h>
+
+#include <string>
+
+#include <catch.hpp>
+#include <harness.h>
+
+using namespace yarp::os;
+using namespace yarp::dev;
+
+TEST_CASE("dev::TorqueControl", "[yarp::dev]")
+{
+    YARP_REQUIRE_PLUGIN("group", "device");
+    YARP_REQUIRE_PLUGIN("fakeMotionControl", "device");
+    YARP_REQUIRE_PLUGIN("controlBoard_nws_yarp", "device");
+    YARP_REQUIRE_PLUGIN("remote_controlboard", "device");
+
+    Network::setLocalMode(true);
+
+    SECTION("test the controlBoard_nws_yarp device")
+    {
+        PolyDriver dd;
+        Property p;
+        p.put("device","controlBoard_nws_yarp");
+        p.put("subdevice","fakeMotionControl");
+        p.put("name","/motor");
+        auto& pg = p.addGroup("GENERAL");
+        pg.put("Joints", 1);
+        bool result;
+        result = dd.open(p);
+        REQUIRE(result); // controlboardwrapper open reported successful
+
+        // Check if IMultipleWrapper interface is correctly found
+        yarp::dev::IMultipleWrapper * i_mwrapper=nullptr;
+        result = dd.view(i_mwrapper);
+        REQUIRE(result); // IMultipleWrapper view reported successful
+        REQUIRE(i_mwrapper != nullptr); // IMultipleWrapper pointer not null
+
+        PolyDriver dd2;
+        Property p2;
+        p2.put("device","remote_controlboard");
+        p2.put("remote","/motor");
+        p2.put("local","/motor/client");
+        p2.put("carrier","tcp");
+        p2.put("ignoreProtocolCheck","true");
+        result = dd2.open(p2);
+        REQUIRE(result); // remote_controlboard open reported successful
+
+        ITorqueControl *trq = nullptr;
+        result = dd2.view(trq);
+        REQUIRE(result); // interface reported
+
+        yarp::dev::MotorTorqueParameters params;
+        yarp::dev::MotorTorqueParameters res;
+
+        //params.bemf = 0.1;
+        //params.bemf_scale = 0.2;
+        //params.ktau = 0.3;
+        //params.ktau_scale = 0.4;
+        params.viscousUp = 0.5;
+        params.viscousDown = 0.6;
+        params.coulombUp = 0.7;
+        params.coulombDown = 0.8;
+
+        trq->setMotorTorqueParams(0, params);
+        trq->getMotorTorqueParams(0, &res);
+        
+        //CHECK(res.bemf == 0.1); // interface seems functional
+        //CHECK(res.bemf_scale == 0.2); // interface seems functional
+        //CHECK(res.ktau == 0.3); // interface seems functional
+        //CHECK(res.ktau_scale == 0.4); // interface seems functional
+        CHECK(res.viscousUp == 0.5); // interface seems functional
+        CHECK(res.viscousDown == 0.6); // interface seems functional
+        CHECK(res.coulombUp == 0.7); // interface seems functional
+        CHECK(res.coulombDown == 0.8); // interface seems functional
+        CHECK(dd.close()); // close dd reported successful
+        CHECK(dd2.close()); // close dd2 reported successful
+    }
+}

--- a/tests/libYARP_dev/TorqueControlTest.cpp
+++ b/tests/libYARP_dev/TorqueControlTest.cpp
@@ -67,10 +67,10 @@ TEST_CASE("dev::TorqueControl", "[yarp::dev]")
         //params.bemf_scale = 0.2;
         //params.ktau = 0.3;
         //params.ktau_scale = 0.4;
-        params.viscousUp = 0.5;
-        params.viscousDown = 0.6;
-        params.coulombUp = 0.7;
-        params.coulombDown = 0.8;
+        params.viscousPos = 0.5;
+        params.viscousNeg = 0.6;
+        params.coulombPos = 0.7;
+        params.coulombNeg = 0.8;
 
         trq->setMotorTorqueParams(0, params);
         trq->getMotorTorqueParams(0, &res);
@@ -79,10 +79,10 @@ TEST_CASE("dev::TorqueControl", "[yarp::dev]")
         //CHECK(res.bemf_scale == 0.2); // interface seems functional
         //CHECK(res.ktau == 0.3); // interface seems functional
         //CHECK(res.ktau_scale == 0.4); // interface seems functional
-        CHECK(res.viscousUp == 0.5); // interface seems functional
-        CHECK(res.viscousDown == 0.6); // interface seems functional
-        CHECK(res.coulombUp == 0.7); // interface seems functional
-        CHECK(res.coulombDown == 0.8); // interface seems functional
+        CHECK(res.viscousPos == 0.5); // interface seems functional
+        CHECK(res.viscousNeg == 0.6); // interface seems functional
+        CHECK(res.coulombPos == 0.7); // interface seems functional
+        CHECK(res.coulombNeg == 0.8); // interface seems functional
         CHECK(dd.close()); // close dd reported successful
         CHECK(dd2.close()); // close dd2 reported successful
     }


### PR DESCRIPTION
What's new in this PR:
- In [ITorqueControl.h][1] have been added 4 new friction parameters: `viscousUp`, `viscousDown`, `coulombUp`, `coulombDown`.
- the definitions of all the `get/set` functions have been updated accordingly.
- A new ControlTorqueTest source has been added to the test folder in order to validate the implementation of the new parameters

**Notes:**
- The implementation has been tested successfully with the new test provided with this PR.

### True positive detection ✅

![image](https://user-images.githubusercontent.com/18039045/154572956-d92016fc-7e6a-4d2f-ac9d-0989f4c7d07a.png)

### False positive detection ✅

![image](https://user-images.githubusercontent.com/18039045/154574580-bf9c63d4-dbb7-4e4b-bb6a-8af84d473f48.png)

[1]: (https://github.com/robotology/yarp/compare/master...sgiraz:master#diff-a6d521af362a51d273c0ced3cd303cf4d7eaf66795f7514c6b33f471ea962254)