### PR TITLE
Fix Visual Studio 2019 CI Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
           }
         - {
             id: '23',
-            os: windows-latest,
+            os: windows-2019,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
@@ -537,7 +537,7 @@ jobs:
           }
         - {
             id: '24',
-            os: windows-latest,
+            os: windows-2019,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
@@ -550,7 +550,7 @@ jobs:
           }
         - {
             id: '25',
-            os: windows-latest,
+            os: windows-2019,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
@@ -562,7 +562,7 @@ jobs:
           }
         - {
             id: '26',
-            os: windows-latest,
+            os: windows-2019,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",


### PR DESCRIPTION
As documented in https://github.com/actions/virtual-environments/issues/4856, the `windows-latest` image now contains Visual Studio 2022, and so the jobs that expect that it contains `Visual Studio 2019` are failing. This PR fixes those jobs by switching them to use `windows-2019` that still contains `Visual Studio 2019` .