### PR TITLE
Remove delay in DgramTwoWayStream::interrupt

### DIFF
--- a/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/DgramTwoWayStream.cpp
@@ -639,9 +639,6 @@ void DgramTwoWayStream::interrupt()
                 tmp.write(empty.bytes());
                 tmp.flush();
                 tmp.close();
-                if (happy) {
-                    yarp::os::SystemClock::delaySystem(0.25);
-                }
             }
             yCDebug(DGRAMTWOWAYSTREAM, "dgram interrupt done");
         }


### PR DESCRIPTION
Fix https://github.com/robotology/yarp/issues/2814 .