### PR TITLE
yarp_macos_duplicate_and_add_bundle: Do not try to set properties that contain HEADER_SETS in the name

### DIFF
--- a/cmake/YarpMacOSUtilities.cmake
+++ b/cmake/YarpMacOSUtilities.cmake
@@ -85,6 +85,11 @@ function(YARP_MACOS_DUPLICATE_AND_ADD_BUNDLE)
       elseif("${_prop_name}" MATCHES "IMPORTED_GLOBAL")
         # Remove other properties containing "IMPORTED_GLOBAL".
         list(REMOVE_ITEM _all_properties "${_prop_name}")
+      elseif("${_prop_name}" MATCHES "HEADER_SETS")
+        # Remove other properties containing "HEADER_SETS" as they are write only
+        # and in any case are not relevant for these kind of targets
+        # See https://github.com/robotology/robotology-superbuild/issues/1090
+        list(REMOVE_ITEM _all_properties "${_prop_name}")
       endif()
     endforeach()
 

--- a/doc/release/yarp_3_6/fixrobsup_1090.md
+++ b/doc/release/yarp_3_6/fixrobsup_1090.md
@@ -1,0 +1,4 @@
+fixrobsup_1090 {#yarp_3_6}
+-----------
+
+* yarp_macos_duplicate_and_add_bundle: Do not try to set properties that contain HEADER_SETS in the name (https://github.com/robotology/yarp/pull/2822). This fixes compatibility with CMake 3.23.1 on macOS.


### PR DESCRIPTION
This fixes compatibility with CMake 3.23.1 
Fix https://github.com/robotology/robotology-superbuild/issues/1090