### PR TITLE
Update nightly-merge.yml

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Nightly Merge
-      uses: robotology/gh-action-nightly-merge@v1.3.1
+      uses: robotology/gh-action-nightly-merge@v1.3.3
       with:
         stable_branch: 'yarp-3.6'
         development_branch: 'master'


### PR DESCRIPTION
The `nightly-merge` workflows are failing, preventing the scheduled merge of `yarp-3.6` into `master`.

Recently, @traversaro updated the underlying GH action, which should solve the problem.