### PR TITLE
Update nightly-merge.yml

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -19,6 +19,9 @@ jobs:
         stable_branch: 'yarp-3.6'
         development_branch: 'master'
         allow_ff: false
+        user_name: 'robotology-bot'
+        user_email: 'robotology@iit.it'
+        push_token: 'bot_TOKEN'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+        BOT_TOKEN: ${{ secrets.ROBOTOLOGY_BOT_TOKEN }}

--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -21,7 +21,7 @@ jobs:
         allow_ff: false
         user_name: 'robotology-bot'
         user_email: 'robotology@iit.it'
-        push_token: 'bot_TOKEN'
+        push_token: 'BOT_TOKEN'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_TOKEN: ${{ secrets.ROBOTOLOGY_BOT_TOKEN }}

--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -19,9 +19,6 @@ jobs:
         stable_branch: 'yarp-3.6'
         development_branch: 'master'
         allow_ff: false
-        user_name: 'Daniele E. Domenichelli (Nightly Merge Action)'
-        user_email: 'daniele.domenichelli@iit.it'
-        push_token: 'drdanz_TOKEN'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        drdanz_TOKEN: ${{ secrets.drdanz_TOKEN }}
+        


### PR DESCRIPTION
In retrospective wrt #2832, there could be a problem with credentials as well.
See https://github.com/robotology/yarp/runs/6220596862?check_suite_focus=true#step:4:61.

Hence, this PR promotes default values for certain fields as per the main documentation at https://github.com/robotology/gh-action-nightly-merge.