### PR TITLE
yarp read once

### DIFF
--- a/doc/release/master/read_just_once.md
+++ b/doc/release/master/read_just_once.md
@@ -1,0 +1,9 @@
+read_just_once {#master}
+---------------------------------
+
+New Features
+------------
+
+### lib_yarp_companion
+
+* added `once` option to companion command `yarp read`

--- a/src/libYARP_companion/src/yarp/companion/impl/BottleReader.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/BottleReader.h
@@ -38,6 +38,7 @@ private:
     bool raw;
     bool env;
     std::string::size_type trim;
+    bool justOnce;
     Contact address;
 public:
     Port core;
@@ -46,12 +47,14 @@ public:
         raw = false;
         env = false;
         trim = std::string::npos;
+        justOnce = false;
         core.setReader(*this);
         core.setReadOnly();
     }
 
-    void open(const char *name, bool showEnvelope, int trim_at = -1) {
+    void open(const char *name, bool showEnvelope, bool _justonce, int trim_at = -1) {
         env = showEnvelope;
+        justOnce = _justonce;
         trim = (trim_at > 0 ? static_cast<std::string::size_type>(trim_at) : std::string::npos);
         if (core.open(name)) {
             Companion::setActivePort(&core);
@@ -99,6 +102,10 @@ public:
                 showEnvelope();
                 yCInfo(COMPANION, "%s", bot.toString().substr(0, trim).c_str());
                 fflush(stdout);
+            }
+            if (justOnce) {
+                //this will close everything and terminate the execution after the first received data
+                done.post();
             }
             return true;
         }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
@@ -29,12 +29,12 @@ using yarp::os::NetworkBase;
  * @param trim number of characters of the string that should be printed
  * @return 0 on success, non-zero on failure
  */
-int Companion::read(const char *name, const char *src, bool showEnvelope, int trim)
+int Companion::read(const char *name, const char *src, bool showEnvelope, bool justOnce, int trim)
 {
     Companion::installHandler();
     BottleReader reader;
     applyArgs(reader.core);
-    reader.open(name, showEnvelope, trim);
+    reader.open(name, showEnvelope, justOnce, trim);
     if (src != nullptr) {
         ContactStyle style;
         style.quiet = false;
@@ -52,7 +52,7 @@ int Companion::cmdRead(int argc, char *argv[])
 {
     if (argc<1) {
         yCError(COMPANION, "Usage:");
-        yCError(COMPANION, "  yarp read <port> [remote port] [envelope] [trim [length]]");
+        yCError(COMPANION, "  yarp read <port> [remote port] [envelope] [trim [length]] [once]");
         return 1;
     }
 
@@ -60,6 +60,7 @@ int Companion::cmdRead(int argc, char *argv[])
     const char *src = nullptr;
     bool showEnvelope = false;
     size_t trim = -1;
+    bool justOnce = false;
     while (argc>1) {
         if (strcmp(argv[1], "envelope")==0) {
             showEnvelope = true;
@@ -72,7 +73,11 @@ int Companion::cmdRead(int argc, char *argv[])
                 static constexpr int default_trim = 80;
                 trim = default_trim;
             }
-        } else {
+        }
+        else if (strcmp(argv[1], "once") == 0) {
+            justOnce = true;
+        }
+        else {
             src = argv[1];
         }
         argc--;
@@ -86,6 +91,5 @@ int Companion::cmdRead(int argc, char *argv[])
         yCError(COMPANION) << "Port"<< name << "already exists! Do you mean yarp read ..."<< name <<"?";
         return 1;
     }
-
-    return read(name, src, showEnvelope, trim);
+    return read(name, src, showEnvelope, justOnce, trim);
 }

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdReadWrite.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdReadWrite.cpp
@@ -25,7 +25,7 @@ int Companion::cmdReadWrite(int argc, char *argv[])
 
     Companion::installHandler();
     BottleReader reader;
-    reader.open(read_port_name, false);
+    reader.open(read_port_name, false, false);
 
     int ret = write(write_port_name, 1, (char**)&verbatim);
 

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -102,7 +102,7 @@ public:
     int cmdPrioritySched(int argc, char *argv[]);
 
     // Defined in Companion.cmdRead.cpp
-    int read(const char *name, const char *src = nullptr, bool showEnvelope = false, int trim = -1);
+    int read(const char *name, const char *src = nullptr, bool showEnvelope = false, bool justOnce = false, int trim = -1);
     int cmdRead(int argc, char *argv[]);
 
     // Defined in Companion.cmdReadWrite.cpp


### PR DESCRIPTION
added `once` option to companion command `yarp read`.
The `yarp read` terminates after the first received bottle.