### PR TITLE
Joint item slider Target box position fixed

### DIFF
--- a/doc/release/yarp_3_6/fix_yarpmotorgui_setPointBox.md
+++ b/doc/release/yarp_3_6/fix_yarpmotorgui_setPointBox.md
@@ -1,0 +1,10 @@
+fix_yarpmotorgui_setPointBox {#yarp_3_6}
+-------------------
+
+### Tools
+
+#### `yarpmotorgui`
+
+* The target box for the joints sliders now lands where expected (see [#issue2824](https://github.com/robotology/yarp/issues/2824) for further details).
+  The the `target` value for the slider was not being multiplied by the `sliderStep` value when computing the new X value for the `target box` rectangle.
+

--- a/src/yarpmotorgui/sliderWithTarget.cpp
+++ b/src/yarpmotorgui/sliderWithTarget.cpp
@@ -96,7 +96,7 @@ void SliderWithTarget::paintEvent(QPaintEvent *e)
     if (enableViewTargetBox)
     {
         QPainter p(this);
-        double newX = ((double)w / (double)totValues) * ((double)target + abs(this->minimum()));
+        double newX = ((double)w / (double)totValues) * (target*sliderStep + abs(this->minimum()));
         QRect r(newX, 17, 30, 15);
         p.fillRect(r, QBrush(QColor(128, 128, 255, 128)));
         p.drawRect(r);


### PR DESCRIPTION
### Tools

#### `yarpmotorgui`

* The target box for the joints sliders now lands where expected (see [#issue2824](https://github.com/robotology/yarp/issues/2824) for further details).
  The the `target` value for the slider was not being multiplied by the `sliderStep` value when computing the new X value for the `target box` rectangle.