### PR TITLE
Fix compilation against graphviz 3 on Windows

### DIFF
--- a/doc/release/yarp_3_7/fixgraphviz3.md
+++ b/doc/release/yarp_3_7/fixgraphviz3.md
@@ -1,0 +1,4 @@
+fixgraphviz3 {#yarp_3_7}
+-----------
+
+* Fix compilation against graphviz 3 on Windows. To work correctly, the fix requires that YCM >= 0.14.2 is used.

--- a/extern/qgv/CMakeLists.txt
+++ b/extern/qgv/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(YARP_priv_qgvcore PUBLIC Qt5::Widgets)
 
 target_include_directories(YARP_priv_qgvcore PRIVATE ${Graphviz_INCLUDE_DIR})
 target_link_libraries(YARP_priv_qgvcore PRIVATE ${Graphviz_LIBRARIES})
+if(Graphviz_DEFINITIONS)
+  target_compile_definitions(YARP_priv_qgvcore PRIVATE ${Graphviz_DEFINITIONS})
+endif()
 
 set_property(TARGET YARP_priv_qgvcore PROPERTY FOLDER "Libraries/External")
 


### PR DESCRIPTION
Since version 3, Graphviz requires downstream users to define `GVDLL`  to link correctly on Windows when using a Graphviz shared library. This change (together with upcoming YCM release 0.14.2: https://github.com/robotology/ycm/pull/414) fixes the compilation of YARP against graphviz 3. 
If an older YCM version is used, nothing happens (so there is no need to bump the required YCM version).