### PR TITLE
Simple fix of onHomeAllPartsToCustomPoistion

### DIFF
--- a/doc/release/yarp_3_7/fix_yarpmotorgui_customPosition_error_on_missingParts.md
+++ b/doc/release/yarp_3_7/fix_yarpmotorgui_customPosition_error_on_missingParts.md
@@ -1,0 +1,10 @@
+fix/yarpmotorgui/customPosition_error_on_missingParts {#yarp_3_7}
+-------------------
+
+### Tools
+
+#### `yarpmotorgui`
+
+* This pr solves the problem reported in issue [#issue2839](https://github.com/robotology/yarp/issues/2839). Now `yarpmotorgui` does not show the error dialog when setting only a subset of the
+available robot parts to a custom position
+

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -903,7 +903,9 @@ void MainWindow::onHomeAllPartsToCustomPosition(const yarp::os::Bottle& position
     {
         auto* scroll = (QScrollArea *)m_tabPanel->widget(i);
         auto* part = (PartItem*)scroll->widget();
-        if(!part)
+        QString currName = QString("/%1/%2").arg(QString(m_finder.find("robot").asString().c_str())).arg(part->getPartName());
+        bool partPresent = positionElement.check(currName.toStdString() + "_Position") && positionElement.check(currName.toStdString() + "_Velocity");
+        if(!part || ! partPresent)
         {
             continue;
         }


### PR DESCRIPTION
### Tools

#### `yarpmotorgui`

* This pr solves the problem reported in issue [#issue2839](https://github.com/robotology/yarp/issues/2839). Now `yarpmotorgui` does not show the error dialog when setting only a subset of the
available robot parts to a custom position