### PR TITLE
Fix IOdometry2D added missing timestamp

### DIFF
--- a/doc/release/yarp_3_7/fixodometryTimestamp.md
+++ b/doc/release/yarp_3_7/fixodometryTimestamp.md
@@ -1,0 +1,4 @@
+fixOdometryTimestamp {#yarp_3_7}
+-----------
+
+* added missing timestamp to `IOdometry2D::getOdometry()` method

--- a/src/devices/fakeOdometry/FakeOdometry.cpp
+++ b/src/devices/fakeOdometry/FakeOdometry.cpp
@@ -42,7 +42,7 @@ void FakeOdometry::run()
     m_odometryData.odom_x = m_odometryData.odom_x + m_period * m_odometryData.base_vel_x;
     m_odometryData.odom_y =  m_odometryData.odom_y + m_period * m_odometryData.base_vel_y;
     m_odometryData.odom_theta = m_odometryData.odom_theta + m_period * m_odometryData.base_vel_theta;
-
+    m_timestamp = yarp::os::Time::now();
 }
 
 
@@ -75,7 +75,7 @@ bool FakeOdometry::close()
 }
 
 
-bool FakeOdometry::getOdometry(yarp::dev::OdometryData& odom)
+bool FakeOdometry::getOdometry(yarp::dev::OdometryData& odom, double* timestamp)
 {
     std::lock_guard lock(m_odometry_mutex);
     odom.odom_x = m_odometryData.odom_x;
@@ -87,6 +87,10 @@ bool FakeOdometry::getOdometry(yarp::dev::OdometryData& odom)
     odom.odom_vel_x  = m_odometryData.odom_vel_x;
     odom.odom_vel_y = m_odometryData.odom_vel_y;
     odom.odom_vel_theta = m_odometryData.odom_vel_theta;
+    if (timestamp!=nullptr)
+    {
+        *timestamp = m_timestamp;
+    }
     return true;
 }
 

--- a/src/devices/fakeOdometry/FakeOdometry.h
+++ b/src/devices/fakeOdometry/FakeOdometry.h
@@ -70,7 +70,7 @@ public:
     bool close() override;
 
     // IOdometry2D
-    bool   getOdometry(yarp::dev::OdometryData& odom) override;
+    bool   getOdometry(yarp::dev::OdometryData& odom, double* timestamp=nullptr) override;
     bool   resetOdometry() override;
 
 private:
@@ -78,6 +78,7 @@ private:
 
     std::mutex m_odometry_mutex;
     double m_period;
+    double m_timestamp=0;
 };
 
 #endif // YARP_FAKEODOMETRY_H

--- a/src/devices/odometry2D_nws_ros/Odometry2D_nws_ros.h
+++ b/src/devices/odometry2D_nws_ros/Odometry2D_nws_ros.h
@@ -9,6 +9,7 @@
 #include <yarp/os/Node.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Publisher.h>
+#include <yarp/os/Stamp.h>
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IOdometry2D.h>
@@ -119,8 +120,8 @@ private:
     std::string m_baseFrame;
     bool m_enable_publish_tf = true;
 
-    // stamp count for timestamp
-    size_t m_stampCount{0};
+    // timestamp
+    yarp::os::Stamp m_lastStateStamp;
 
     // period for thread
     double m_period{DEFAULT_THREAD_PERIOD};

--- a/src/devices/odometry2D_nws_yarp/Odometry2D_nws_yarp.h
+++ b/src/devices/odometry2D_nws_yarp/Odometry2D_nws_yarp.h
@@ -7,6 +7,7 @@
 #define YARP_ODOMETRY2D_NWS_YARP_H
 
 #include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Stamp.h>
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IOdometry2D.h>
@@ -120,6 +121,9 @@ private:
 
     // thread
     double m_period{DEFAULT_THREAD_PERIOD};
+
+    // timestamp
+    yarp::os::Stamp m_lastStateStamp;
 
     //interfaces
     yarp::dev::PolyDriver m_driver;

--- a/src/libYARP_dev/src/yarp/dev/IOdometry2D.h
+++ b/src/libYARP_dev/src/yarp/dev/IOdometry2D.h
@@ -31,7 +31,7 @@ public:
     * @param odom the odometry.
     * @return true/false
     */
-    virtual bool   getOdometry(yarp::dev::OdometryData& odom) = 0;
+    virtual bool   getOdometry(yarp::dev::OdometryData& odom, double* timestamp = nullptr) = 0;
 
     /**
     * Resets the odometry of the robot to zero

--- a/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
+++ b/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
@@ -44,7 +44,7 @@ public:
 
     /**
     * Get the device measurements
-    * @param data a vector containing the measurement data, expressed in cartesian/polar format
+    * @param data a vector containing the measurement data, expressed in Cartesian/polar format
     * @param timestamp the timestamp of the retrieved data.
     * @return true/false
     */
@@ -98,15 +98,15 @@ public:
     virtual bool setScanLimits(double min, double max) = 0;
 
     /**
-    * get the angular step between two measurments.
-    * @param step the angular step between two measurments
+    * get the angular step between two measurements.
+    * @param step the angular step between two measurements
     * @return true/false.
     */
     virtual bool getHorizontalResolution(double& step) = 0;
 
     /**
-    * get the angular step between two measurments (if available)
-    * @param step the angular step between two measurments
+    * get the angular step between two measurements (if available)
+    * @param step the angular step between two measurements
     * @return true/false on success/failure.
     */
     virtual bool setHorizontalResolution(double step) = 0;
@@ -126,7 +126,7 @@ public:
     virtual bool setScanRate(double rate) = 0;
 
     /**
-    * get the device hardware charactestics
+    * get the device hardware characteristics
     * @param device_info string containing the device infos
     * @return true/false.
     */


### PR DESCRIPTION
added timestamp to IOdometry2D::getOdometry() method