### PR TITLE
Fix compilation error as std::nan is used without cmath

### DIFF
--- a/src/devices/odometry2D_nws_ros/Odometry2D_nws_ros.cpp
+++ b/src/devices/odometry2D_nws_ros/Odometry2D_nws_ros.cpp
@@ -7,7 +7,7 @@
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Stamp.h>
-#include <math.h>
+#include <cmath>
 
 YARP_LOG_COMPONENT(ODOMETRY2D_NWS_ROS, "yarp.devices.Odometry2D_nws_ros")
 


### PR DESCRIPTION
Fix regression in https://github.com/robotology/yarp/pull/2854 . `std::isnan` is used, but `math.h` is included, instead of `cmath` that actually defines `std::isnan`.