### PR TITLE
Check multiple analog sensor interfaces

### DIFF
--- a/doc/release/yarp_3_7.md
+++ b/doc/release/yarp_3_7.md
@@ -19,6 +19,10 @@ Bug Fixes
 
 * Migrate to use CMake's official `FindSQLite3.cmake` module.
 
+### Devices
+
+* `GenericSensorRosPublisher` (and derived devices): added checks if the interfaces are available in the Attach phase
+
 ### Libraries
 
 #### `lib_yarp_dev`

--- a/src/devices/multipleAnalogSensorsRosPublishers/GenericSensorRosPublisher.h
+++ b/src/devices/multipleAnalogSensorsRosPublishers/GenericSensorRosPublisher.h
@@ -214,6 +214,11 @@ bool GenericSensorRosPublisher<ROS_MSG>::attachAll(const yarp::dev::PolyDriverLi
 
     // View all the interfaces
     bool ok = viewInterfaces();
+    if (!ok)
+    {
+        yCError(GENERICSENSORROSPUBLISHER, "viewInterfaces() method failed.");
+        return false;
+    }
 
     // Set rate period
     ok &= this->setPeriod(m_periodInS);

--- a/src/devices/multipleAnalogSensorsRosPublishers/IMURosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/IMURosPublisher.cpp
@@ -15,13 +15,28 @@ bool IMURosPublisher::viewInterfaces()
 {
     // View all the interfaces
     bool ok = true;
-    ok &= m_poly->view(m_iThreeAxisGyroscopes);
-    ok &= m_poly->view(m_iThreeAxisLinearAccelerometers);
-    ok &= m_poly->view(m_iThreeAxisMagnetometers);
-    ok &= m_poly->view(m_iOrientationSensors);
-    if (m_iThreeAxisGyroscopes) {
-        m_iThreeAxisGyroscopes->getThreeAxisGyroscopeFrameName(m_sens_index, m_framename);
+    ok = m_poly->view(m_iThreeAxisGyroscopes);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IThreeAxisGyroscopes interface is not available";
+        return false;
     }
+    ok = m_poly->view(m_iThreeAxisLinearAccelerometers);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IThreeAxisLinearAccelerometers interface is not available";
+        return false;
+    }
+    ok = m_poly->view(m_iThreeAxisMagnetometers);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IThreeAxisMagnetometers interface is not available";
+        return false;
+    }
+    ok = m_poly->view(m_iOrientationSensors);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IOrientationSensors interface is not available";
+        return false;
+    }
+
+    ok = m_iThreeAxisGyroscopes->getThreeAxisGyroscopeFrameName(m_sens_index, m_framename);
     return ok;
 }
 

--- a/src/devices/multipleAnalogSensorsRosPublishers/MagneticFieldRosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/MagneticFieldRosPublisher.cpp
@@ -11,8 +11,13 @@ bool MagneticFieldRosPublisher::viewInterfaces()
 {
     // View all the interfaces
     bool ok = true;
-    ok &= m_poly->view(m_iThreeAxisMagnetometers);
-    m_iThreeAxisMagnetometers->getThreeAxisMagnetometerFrameName(0, m_framename);
+    ok = m_poly->view(m_iThreeAxisMagnetometers);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IThreeAxisMagnetometers interface is not available";
+        return false;
+    }
+
+    ok = m_iThreeAxisMagnetometers->getThreeAxisMagnetometerFrameName(0, m_framename);
     return ok;
 }
 

--- a/src/devices/multipleAnalogSensorsRosPublishers/PoseStampedRosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/PoseStampedRosPublisher.cpp
@@ -17,9 +17,17 @@ bool PoseStampedRosPublisher::viewInterfaces()
 {
     // View all the interfaces
     bool ok = true;
-    ok &= m_poly->view(m_iOrientationSensors);
-    ok &= m_poly->view(m_iPositionSensors);
-    m_iPositionSensors->getPositionSensorFrameName(m_sens_index, m_framename);
+    ok = m_poly->view(m_iOrientationSensors);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IOrientationSensors interface is not available";
+        return false;
+    }
+    ok = m_poly->view(m_iPositionSensors);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "IPositionSensors interface is not available";
+        return false;
+    }
+    ok = m_iPositionSensors->getPositionSensorFrameName(m_sens_index, m_framename);
     return ok;
 }
 

--- a/src/devices/multipleAnalogSensorsRosPublishers/TemperatureRosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/TemperatureRosPublisher.cpp
@@ -11,8 +11,13 @@ bool TemperatureRosPublisher::viewInterfaces()
 {
     // View all the interfaces
     bool ok = true;
-    ok &= m_poly->view(m_ITemperature);
-    m_ITemperature->getTemperatureSensorFrameName(0,m_framename);
+    ok = m_poly->view(m_ITemperature);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "ITemperatureSensors interface is not available";
+        return false;
+    }
+
+    ok = m_ITemperature->getTemperatureSensorFrameName(0,m_framename);
     return ok;
 }
 

--- a/src/devices/multipleAnalogSensorsRosPublishers/WrenchStampedRosPublisher.cpp
+++ b/src/devices/multipleAnalogSensorsRosPublishers/WrenchStampedRosPublisher.cpp
@@ -11,7 +11,12 @@ bool WrenchStampedRosPublisher::viewInterfaces()
 {
     // View all the interfaces
     bool ok = m_poly->view(m_iFTsens);
-    m_iFTsens->getSixAxisForceTorqueSensorFrameName(m_sens_index, m_framename);
+    if (!ok) {
+        yCError(GENERICSENSORROSPUBLISHER) << "ISixAxisForceTorqueSensors interface is not available";
+        return false;
+    }
+
+    ok = m_iFTsens->getSixAxisForceTorqueSensorFrameName(m_sens_index, m_framename);
     return ok;
 }
 


### PR DESCRIPTION
`GenericSensorRosPublisher` (and derived devices): added checks if the interfaces are available in the Attach phase.  This prevents a segfault if the attached device does not implement the required interface.