### PR TITLE
Fix regression in https://github.com/robotology/yarp/pull/2852 that created problem if no system SQLite was installed

### DIFF
--- a/.ci/initial-cache.gh.macos.cmake
+++ b/.ci/initial-cache.gh.macos.cmake
@@ -12,8 +12,8 @@ set(YARP_COMPILE_libYARP_math ON CACHE BOOL "")
 # Avoid building Qt5 guis twice on macOS.
 set(YARP_DISABLE_MACOS_BUNDLES ON CACHE BOOL "")
 
-# Disable system SQLite (workaround for #2247)
-set(YARP_USE_SYSTEM_SQLite OFF CACHE BOOL "")
+# Disable system SQLite3 (workaround for #2247)
+set(YARP_USE_SYSTEM_SQLite3 OFF CACHE BOOL "")
 
 set(ENABLE_yarpcar_human ON CACHE BOOL "")
 set(ENABLE_yarppm_depthimage_to_mono ON CACHE BOOL "")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ if(YARP_BUILD_TinyXML)
 endif()
 
 # SQLite
-if(YARP_BUILD_SQLite)
+if(YARP_BUILD_SQLite3)
   add_subdirectory(sqlite)
   set(SQLite3_INCLUDE_DIRS ${SQLite3_INCLUDE_DIRS} PARENT_SCOPE)
   set(SQLite3_LIBRARIES ${SQLite3_LIBRARIES} PARENT_SCOPE)


### PR DESCRIPTION
There were two points where https://github.com/robotology/yarp/pull/2852 did not changed from `SQLite`  to `SQLite3`.

Fix https://github.com/robotology/yarp/issues/2859 .

fyi @randaz81 @pattacini 