### PR TITLE
Refresh timestamps on consistency check failure

### DIFF
--- a/doc/release/yarp_3_7/cbw_consistency_timestamps.md
+++ b/doc/release/yarp_3_7/cbw_consistency_timestamps.md
@@ -1,0 +1,9 @@
+cbw_consistency_timestamps {#yarp_3_7}
+-----------
+
+### Devices
+
+#### `controlBoard_nws_yarp`
+
+* Encoder timestamps are now queried by the consistency checker on failure,
+  thus allowing to recover once the hardware is available again.

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
@@ -440,23 +440,6 @@ void ControlBoard_nws_yarp::run()
         yCWarning(CONTROLBOARD) << "Number of streaming input messages to be read is " << inputStreamingPort.getPendingReads() << " and can overflow";
     }
 
-    // Check if the encoders timestamps are consistent.
-    for (double tt : times)
-    {
-        if (std::abs(times[0] - tt) > 1.0)
-        {
-            yCError(CONTROLBOARD, "Encoder Timestamps are not consistent! Data will not be published.");
-            yarp::sig::Vector _data(subdevice_joints);
-            // update `times` for the next iteration
-            iEncodersTimed->getEncodersTimed(_data.data(), times.data());
-            return;
-        }
-    }
-
-    // Update the port envelope time by averaging all timestamps
-    time.update(std::accumulate(times.begin(), times.end(), 0.0) / subdevice_joints);
-    yarp::os::Stamp averageTime = time;
-
     // handle stateExt first
     jointData& data = extendedOutputState_buffer.get();
 
@@ -524,6 +507,21 @@ void ControlBoard_nws_yarp::run()
     } else {
         data.interactionMode_isValid = false;
     }
+
+    // Check if the encoders timestamps are consistent.
+    for (double tt : times)
+    {
+        if (std::abs(times[0] - tt) > 1.0)
+        {
+            yCError(CONTROLBOARD, "Encoder Timestamps are not consistent! Data will not be published.");
+            yarp::sig::Vector _data(subdevice_joints);
+            return;
+        }
+    }
+
+    // Update the port envelope time by averaging all timestamps
+    time.update(std::accumulate(times.begin(), times.end(), 0.0) / subdevice_joints);
+    yarp::os::Stamp averageTime = time;
 
     extendedOutputStatePort.setEnvelope(averageTime);
     extendedOutputState_buffer.write();

--- a/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
+++ b/src/devices/ControlBoardWrapper/ControlBoard_nws_yarp.cpp
@@ -14,7 +14,7 @@
 #include <yarp/dev/impl/jointData.h>
 
 #include <numeric>
-#include <math.h>
+#include <cmath>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -441,12 +441,14 @@ void ControlBoard_nws_yarp::run()
     }
 
     // Check if the encoders timestamps are consistent.
-    double tt = *times.data();
-    for (auto it = times.begin(); it != times.end(); it++)
+    for (double tt : times)
     {
-        if (fabs(tt - *it) > 1.0)
+        if (std::abs(times[0] - tt) > 1.0)
         {
             yCError(CONTROLBOARD, "Encoder Timestamps are not consistent! Data will not be published.");
+            yarp::sig::Vector _data(subdevice_joints);
+            // update `times` for the next iteration
+            iEncodersTimed->getEncodersTimed(_data.data(), times.data());
             return;
         }
     }


### PR DESCRIPTION
This bugfix is a follow-up to https://github.com/robotology/yarp/pull/2841 (cc @randaz81). The `run` loop is stuck on the consistency check after raising an error since there is no way to refresh the `times` vector again, thus rendering the state ports unusable from that point onwards. Our robot is capable of recovery on comms failure (which happens quite often) on any joint, therefore patch https://github.com/robotology/yarp/pull/2841 forces us to restart the control board. This didn't happen prior to YARP 3.7.

I might suggest later a way to disable or configure this consistency checker differently. Anyway, I believe this patch targets a bug and should be addressed first.