### PR TITLE
Added error message for conf file

### DIFF
--- a/doc/release/yarp_3_7.md
+++ b/doc/release/yarp_3_7.md
@@ -17,6 +17,12 @@ Bug Fixes
 
 * Major improvements to Yarp documentation
 
+### Libraries
+
+#### `lib_yarp_os`
+
+* Yarp now displays an error message if it is unable to save its configuration file
+
 ### Devices
 
 #### `controlBoard_nws_yarp`

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdConf.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdConf.cpp
@@ -31,7 +31,9 @@ int Companion::cmdConf(int argc, char *argv[])
         } else {
             nc.setMode("yarp");
         }
-        nc.toFile();
+        if (!nc.toFile()) {
+            yCError(COMPANION, "Unable to write configuration file");
+        }
         nc.fromFile();
         Contact current = nc.getAddress();
         std::string currentMode = nc.getMode();
@@ -63,9 +65,13 @@ int Companion::cmdConf(int argc, char *argv[])
     }
     if (argc==1) {
         if (std::string(argv[0])=="--clean") {
-            nc.toFile(true);
-            yCInfo(COMPANION, "Cleared configuration file:");
-            yCInfo(COMPANION, "  %s", nc.getConfigFileName().c_str());
+            if (nc.toFile(true)) {
+                yCInfo(COMPANION, "Cleared configuration file:");
+                yCInfo(COMPANION, "  %s", nc.getConfigFileName().c_str());
+            }
+            else {
+                yCError(COMPANION, "Unable to clear configuration file");
+            }
             return 0;
         }
     }

--- a/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameClient.cpp
@@ -358,10 +358,17 @@ std::string NameClient::send(const std::string& cmd, bool multi, const ContactSt
             if (alt.isValid()) {
                 address = alt;
                 if (allowSaveScan) {
-                    reportSaveScan = true;
                     NameConfig nc;
                     nc.setAddress(alt);
-                    nc.toFile();
+                    if (nc.toFile())
+                    {
+                        yCInfo(NAMECLIENT, "New configuration stored to file");
+                        reportSaveScan = true;
+                    }
+                    else
+                    {
+                        yCError(NAMECLIENT, "Unable to write configuration");
+                    }
                 }
                 server = getAddress();
                 server.setTimeout(timeout);

--- a/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/NameConfig.cpp
@@ -192,10 +192,12 @@ Contact NameConfig::getAddress()
 bool NameConfig::writeConfig(const std::string& fileName, const std::string& text)
 {
     if (yarp::os::mkdir_p(fileName.c_str(), 1) != 0) {
+        yCError(NAMECONFIG, "Unable to create dir for file %s, check your permissions",fileName.c_str());
         return false;
     }
     FILE* fout = fopen(fileName.c_str(), "w");
     if (fout == nullptr) {
+        yCError(NAMECONFIG, "Unable to write file %s, check your permissions",fileName.c_str());
         return false;
     }
     fprintf(fout, "%s", text.c_str());


### PR DESCRIPTION
Yarp now displays an error message if it is unable to save its configuration file.
Fixes: https://github.com/robotology/yarp/issues/2662