### PR TITLE
Throttle error message on inconsistent encoder timestamps

### DIFF
--- a/doc/release/yarp_3_8/throttle_consistency_checker.md
+++ b/doc/release/yarp_3_8/throttle_consistency_checker.md
@@ -1,0 +1,8 @@
+throttle_consistency_checker {#yarp_3_8}
+-----------
+
+### Devices
+
+#### `controlBoard_nws_yarp`
+
+* The error message upon inconsistent encoder timestamps has been throttled.

--- a/src/devices/controlBoard_nws_yarp/ControlBoard_nws_yarp.cpp
+++ b/src/devices/controlBoard_nws_yarp/ControlBoard_nws_yarp.cpp
@@ -437,7 +437,7 @@ void ControlBoard_nws_yarp::run()
     // check we are not overflowing with input messages
     constexpr int reads_for_warning = 20;
     if (inputStreamingPort.getPendingReads() >= reads_for_warning) {
-        yCWarning(CONTROLBOARD) << "Number of streaming input messages to be read is " << inputStreamingPort.getPendingReads() << " and can overflow";
+        yCIWarning(CONTROLBOARD, id()) << "Number of streaming input messages to be read is" << inputStreamingPort.getPendingReads() << "and can overflow";
     }
 
     // handle stateExt first
@@ -513,8 +513,7 @@ void ControlBoard_nws_yarp::run()
     {
         if (std::abs(times[0] - tt) > 1.0)
         {
-            yCError(CONTROLBOARD, "Encoder Timestamps are not consistent! Data will not be published.");
-            yarp::sig::Vector _data(subdevice_joints);
+            yCIErrorThrottle(CONTROLBOARD, id(), 1.0) << "Encoder timestamps are not consistent! Data will not be published.";
             return;
         }
     }


### PR DESCRIPTION
As a follow-up to https://github.com/robotology/yarp/pull/2862, this patch throttles the error message printed whenever an inconsistency in encoder timestamps is detected. The "Encoder timestamps are not consistent! Data will not be published." is logged every few milliseconds and bloats the terminal. I'm using an arbitrary throttle of one second to mitigate this.

@randaz81 I think the nws_ros{.h,.cpp} files at src/devices/ControlBoardWrapper have been accidentally left out after https://github.com/robotology/yarp/pull/2845.  Perhaps you want to delete them first, then I can rebase this patch accordingly. As a side note, the consistency check patch from https://github.com/robotology/yarp/pull/2841 was applied to both nws_yarp and nws_ros in the ControlBoardWrapper directory, but the latter was copied into a different location using a version prior to said changes.

As commented in https://github.com/robotology/yarp/pull/2862, I'm still considering other ways to treat (or perhaps disable) consistency checking due to my particular use case.