### PR TITLE
Allow chaining `yarp::sig::VectorOf<T>` to LogStream

### DIFF
--- a/doc/release/master/000_master.md
+++ b/doc/release/master/000_master.md
@@ -1,14 +1,14 @@
-YARP <yarp-3.7> (UNRELEASED)                                         {#yarp_3_7}
+YARP <yarp-3.8> (UNRELEASED)                                         {#yarp_3_8}
 ============================
 
 [TOC]
 
-YARP <yarp-3.7> Release Notes
+YARP <yarp-3.8> Release Notes
 =============================
 
-
 A (partial) list of bug fixed and issues resolved in this release can be found
-[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.7%22).
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.8%22).
+
 
 Deprecation and Behaviour Changes
 ---------------------------------
@@ -17,3 +17,12 @@ Deprecation and Behaviour Changes
 
 * Removed devices rpLidar, rpLidar2, rpLidar3, and the corresponding sdk in extern/rplidar.
   The devices can be now found in https://github.com/robotology/yarp-device-rplidar
+
+New Features
+------------
+
+### Libraries
+
+#### `lib_yarp_os`
+
+* `yarp::os::LogStream` now can chain instances of `yarp::sig::VectorOf<T>`.

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -119,6 +119,7 @@ private:
     std::vector<T> bytes;
 
 public:
+    using value_type     =  T;
     using iterator       =  typename std::vector<T>::iterator;
     using const_iterator =  typename std::vector<T>::const_iterator;
 

--- a/tests/libYARP_os/LogStreamTest.cpp
+++ b/tests/libYARP_os/LogStreamTest.cpp
@@ -11,6 +11,8 @@
 
 #include <yarp/os/impl/LogForwarder.h>
 
+#include <yarp/sig/Vector.h>
+
 #include <array>
 #include <deque>
 #include <forward_list>
@@ -1471,6 +1473,8 @@ TEST_CASE("os::LogStreamTest", "[yarp::os]")
     SECTION("Test containers, C arrays and tuples")
     {
         CNT_RESET
+
+        CNT yInfo() << "yarp::sig::Vector:" << yarp::sig::Vector {1.1, 2.2, 3.3};
 
         CNT yInfo() << "std::array:" << std::array<double, 3> {1.1, 2.2, 3.3};
 


### PR DESCRIPTION
Follow-up to https://github.com/robotology/yarp/pull/2758. Similarly to STL containers, C arrays, pairs and tuples, now `yarp::sig::VectorOf<T>` is also chainable to stream logging macros, e.g.:

```cxx
yarp::sig::Vector v {1.23, 5.0};
yInfo() << v;
```

(Disclaimer: one can obviously call `v.toString()` instead; this patch harmonizes YARP and STL vectors, though.)