### PR TITLE
multipleanalogsensorsremapper: Add more verbosity when sensor name is not found

### DIFF
--- a/doc/release/yarp_3_7/adddebugremap.md
+++ b/doc/release/yarp_3_7/adddebugremap.md
@@ -1,0 +1,4 @@
+adddebugremap {#yarp_3_7}
+-----------
+
+*  multipleanalogsensorsremapper: Add more verbosity when sensor name is not found.

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -200,6 +200,11 @@ bool MultipleAnalogSensorsRemapper::genericAttachAll(const MAS_SensorType sensor
         if (sensorLocationMap.find(name) == sensorLocationMap.end())
         {
             yCError(MULTIPLEANALOGSENSORSREMAPPER) << "Impossible to find sensor name" << name << ", exiting.";
+            yCError(MULTIPLEANALOGSENSORSREMAPPER) << "    Names of available sensors are:";
+            for(auto& availableDevice: sensorLocationMap)
+            {
+                yCError(MULTIPLEANALOGSENSORSREMAPPER) << "    * " << availableDevice->first;
+            }
             return false;
         }
 

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -203,7 +203,7 @@ bool MultipleAnalogSensorsRemapper::genericAttachAll(const MAS_SensorType sensor
             yCError(MULTIPLEANALOGSENSORSREMAPPER) << "    Names of available sensors are:";
             for(auto& availableDevice: sensorLocationMap)
             {
-                yCError(MULTIPLEANALOGSENSORSREMAPPER) << "    * " << availableDevice->first;
+                yCError(MULTIPLEANALOGSENSORSREMAPPER) << "    * " << availableDevice.first;
             }
             return false;
         }


### PR DESCRIPTION
When the `multipleanalogsensorsremapper` complains that the name is not found, it is important to also print the available names, to make sure that the users have a precise idea of why the provided name is not ok. 

This was quite useful when debugging https://github.com/robotology/gazebo-yarp-plugins/pull/633 .