### PR TITLE
Fixed python binding of IGazeControl storeContext()

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -1750,11 +1750,12 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 
     int storeContext() {
         int id;
+        int badContextId = -1000;
 
         if(self->storeContext(&id)) {
             return id;
         } else {
-            return -1; //On error return -1
+            return badContextId; //On error return the badContextId
         }
     }
 }

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -1750,7 +1750,7 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
 
     int storeContext() {
         int id;
-        
+
         if(self->storeContext(&id)) {
             return id;
         } else {

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -1719,13 +1719,13 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
     }
 
     double getNeckTrajTime() {
-              double result;
+        double result;
 
-              if(self->getNeckTrajTime(&result)) {
+        if(self->getNeckTrajTime(&result)) {
             return result;
         } else {
             return -1.0; //On error return -1.0
-          }
+        }
     }
 
     double getEyesTrajTime() {
@@ -1739,11 +1739,22 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
     }
 
     bool checkMotionDone() {
-          bool flag;
+        bool flag;
+
         if(self->checkMotionDone(&flag)) {
             return flag;
         } else {
             return false;
+        }
+    }
+
+    int storeContext() {
+        int id;
+        
+        if(self->storeContext(&id)) {
+            return id;
+        } else {
+            return -1; //On error return -1
         }
     }
 }

--- a/doc/release/yarp_3_7/py_bind_gazectrl.md
+++ b/doc/release/yarp_3_7/py_bind_gazectrl.md
@@ -1,0 +1,4 @@
+py-bind-gazectrl {#yarp_3_7}
+-----------
+
+*  IGazeControl.storeContext(): now the method is correctly exposed to Python, returning the ID instead of trying to modify a pointer to it.


### PR DESCRIPTION
The version of the method exposed to Python now returns the ID as output and takes no input, instead of expecting a pointer. A negative value (-1) represents an error in retrieving the ID.