### PR TITLE
ffmpeg_grabber: Fix linking errors on Windows

### DIFF
--- a/doc/release/yarp_3_7/fixffmpegwin.md
+++ b/doc/release/yarp_3_7/fixffmpegwin.md
@@ -1,0 +1,4 @@
+fixffmpegwin {#yarp_3_7}
+-----------
+
+*  ffmpeg_grabber: Fix linking problems on Windows.

--- a/src/devices/ffmpeg/CMakeLists.txt
+++ b/src/devices/ffmpeg/CMakeLists.txt
@@ -8,14 +8,14 @@ yarp_prepare_plugin(ffmpeg_grabber
   INCLUDE FfmpegGrabber.h
   EXTRA_CONFIG
     WRAPPER=grabberDual
-  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_swscale_FOUND"
+  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avcodec_FOUND;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_avutil_FOUND;FFMPEG_swscale_FOUND"
 )
 
 yarp_prepare_plugin(ffmpeg_writer
   CATEGORY device
   TYPE FfmpegWriter
   INCLUDE FfmpegWriter.h
-  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_swscale_FOUND"
+  DEPENDS "YARP_HAS_FFMPEG;FFMPEG_avcodec_FOUND;FFMPEG_avformat_FOUND;FFMPEG_avdevice_FOUND;FFMPEG_avutil_FOUND;FFMPEG_swscale_FOUND"
 )
 
 if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
@@ -48,6 +48,7 @@ if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
       ${FFMPEG_avcodec_INCLUDE_DIRS}
       ${FFMPEG_avformat_INCLUDE_DIRS}
       ${FFMPEG_avdevice_INCLUDE_DIRS}
+      ${FFMPEG_avutil_INCLUDE_DIRS}
       ${FFMPEG_swscale_INCLUDE_DIRS}
   )
   target_link_libraries(yarp_ffmpeg
@@ -55,6 +56,7 @@ if(NOT SKIP_ffmpeg_grabber OR NOT SKIP_ffmpeg_writer)
       ${FFMPEG_avcodec_LIBRARIES}
       ${FFMPEG_avformat_LIBRARIES}
       ${FFMPEG_avdevice_LIBRARIES}
+      ${FFMPEG_avutil_LIBRARIES}
       ${FFMPEG_swscale_LIBRARIES}
   )
   # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets

--- a/src/portmonitors/image_compression_ffmpeg/CMakeLists.txt
+++ b/src/portmonitors/image_compression_ffmpeg/CMakeLists.txt
@@ -5,7 +5,7 @@ yarp_prepare_plugin(image_compression_ffmpeg
   TYPE FfmpegMonitorObject
   INCLUDE ffmpegPortmonitor.h
   CATEGORY portmonitor
-  DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_FFMPEG;FFMPEG_swscale_FOUND"
+  DEPENDS "ENABLE_yarpcar_portmonitor;YARP_HAS_FFMPEG;FFMPEG_avcodec_FOUND;FFMPEG_avutil_FOUND;FFMPEG_swscale_FOUND"
 )
 
 if(SKIP_image_compression_ffmpeg)
@@ -33,11 +33,13 @@ list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
 target_include_directories(yarp_pm_image_compression_ffmpeg
   SYSTEM PRIVATE
     ${FFMPEG_avcodec_INCLUDE_DIRS}
+    ${FFMPEG_avutil_INCLUDE_DIRS}
     ${FFMPEG_swscale_INCLUDE_DIRS}
 )
 target_link_libraries(yarp_pm_image_compression_ffmpeg
   PRIVATE
     ${FFMPEG_avcodec_LIBRARIES}
+    ${FFMPEG_avutil_LIBRARIES}
     ${FFMPEG_swscale_LIBRARIES}
 )
 # list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS FFMPEG) # Not using targets


### PR DESCRIPTION
Without this patch, compilation against ffmpeg 4 on Windows is failing with error:
~~~
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_freep referenced in function "protected: int __cdecl FfmpegMonitorObject::compress(class yarp
::sig::Image *,struct AVPacket *)" (?compress@FfmpegMonitorObject@@IEAAHPEAVImage@sig@yarp@@PEAUAVPacket@@@Z) [C:\src\yarp\builddev\src\portmonitors\image_compres
sion_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_buffer_create referenced in function "public: virtual class yarp::os::Things & __cdecl Ffmpeg
MonitorObject::update(class yarp::os::Things &)" (?update@FfmpegMonitorObject@@UEAAAEAVThings@os@yarp@@AEAV234@@Z) [C:\src\yarp\builddev\src\portmonitors\image_co
mpression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_buffer_default_free referenced in function "public: virtual class yarp::os::Things & __cdecl
FfmpegMonitorObject::update(class yarp::os::Things &)" (?update@FfmpegMonitorObject@@UEAAAEAVThings@os@yarp@@AEAV234@@Z) [C:\src\yarp\builddev\src\portmonitors\im
age_compression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_frame_alloc referenced in function "protected: int __cdecl FfmpegMonitorObject::compress(clas
s yarp::sig::Image *,struct AVPacket *)" (?compress@FfmpegMonitorObject@@IEAAHPEAVImage@sig@yarp@@PEAUAVPacket@@@Z) [C:\src\yarp\builddev\src\portmonitors\image_c
ompression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_frame_free referenced in function "protected: int __cdecl FfmpegMonitorObject::compress(class
 yarp::sig::Image *,struct AVPacket *)" (?compress@FfmpegMonitorObject@@IEAAHPEAVImage@sig@yarp@@PEAUAVPacket@@@Z) [C:\src\yarp\builddev\src\portmonitors\image_co
mpression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_opt_set referenced in function "protected: int __cdecl FfmpegMonitorObject::setCommandLinePar
ams(void)" (?setCommandLineParams@FfmpegMonitorObject@@IEAAHXZ) [C:\src\yarp\builddev\src\portmonitors\image_compression_ffmpeg\yarp_pm_image_compression_ffmpeg.v
cxproj]
ffmpegPortmonitor.obj : error LNK2019: unresolved external symbol av_image_alloc referenced in function "protected: int __cdecl FfmpegMonitorObject::compress(clas
s yarp::sig::Image *,struct AVPacket *)" (?compress@FfmpegMonitorObject@@IEAAHPEAVImage@sig@yarp@@PEAUAVPacket@@@Z) [C:\src\yarp\builddev\src\portmonitors\image_c
ompression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
C:\src\yarp\builddev\lib\yarp\Release\yarp_pm_image_compression_ffmpeg.dll : fatal error LNK1120: 7 unresolved externals [C:\src\yarp\builddev\src\portmonitors\im
age_compression_ffmpeg\yarp_pm_image_compression_ffmpeg.vcxproj]
~~~