### PR TITLE
[Draft] ffmpeg deprecation cleanup 

### DIFF
--- a/src/devices/ffmpeg/FfmpegGrabber.cpp
+++ b/src/devices/ffmpeg/FfmpegGrabber.cpp
@@ -119,7 +119,6 @@ public:
     {
         // Get a pointer to the codec context for the video stream
         pCodecCtx=pFormatCtx->streams[index]->codec;
-
         // Find the decoder for the video stream
         pCodec = avcodec_find_decoder(pFormatCtx->streams[index]->codecpar->codec_id);
         if(pCodec==nullptr) {
@@ -150,13 +149,13 @@ public:
         }
 
         // Determine required buffer size and allocate buffer
-        int numBytes=avpicture_get_size(AV_PIX_FMT_RGB24, pCodecCtx->width,
-                                        pCodecCtx->height);
+        int numBytes=av_image_get_buffer_size(AV_PIX_FMT_RGB24, pCodecCtx->width,
+                                              pCodecCtx->height, 1);
         buffer=new uint8_t[numBytes];
 
         // Assign appropriate parts of buffer to image planes in pFrameRGB
-        avpicture_fill((AVPicture *)pFrameRGB, buffer, AV_PIX_FMT_RGB24,
-                       pCodecCtx->width, pCodecCtx->height);
+        av_image_fill_arrays(pFrameRGB->data, pFrameRGB->linesize, buffer,
+                             AV_PIX_FMT_RGB24, pCodecCtx->width, pCodecCtx->height, 1);
         return true;
     }
 
@@ -270,11 +269,11 @@ public:
                                                  nullptr, nullptr, nullptr);
             }
             if (img_convert_ctx!=nullptr) {
-                sws_scale(img_convert_ctx, ((AVPicture*)pFrame)->data,
-                          ((AVPicture*)pFrame)->linesize, 0,
+                sws_scale(img_convert_ctx, pFrame->data,
+                          pFrame->linesize, 0,
                           pCodecCtx->height,
-                          ((AVPicture*)pFrameRGB)->data,
-                          ((AVPicture*)pFrameRGB)->linesize);
+                          pFrameRGB->data,
+                          pFrameRGB->linesize);
             } else {
                 yCFatal(FFMPEGGRABBER, "Software scaling not working");
             }

--- a/src/devices/ffmpeg/FfmpegWriter.cpp
+++ b/src/devices/ffmpeg/FfmpegWriter.cpp
@@ -612,12 +612,10 @@ bool FfmpegWriter::delayedOpen(yarp::os::Searchable & config) {
     }
 
     /* allocate the output media context */
-    oc = avformat_alloc_context();
-    if (!oc) {
+    int ret = avformat_alloc_output_context2(&oc, fmt, NULL, filename.c_str());
+    if (ret < 0) {
         yCFatal(FFMPEGWRITER, "Memory error");
     }
-    oc->oformat = fmt;
-    snprintf(oc->filename, sizeof(oc->filename), "%s", filename.c_str());
 
     /* add the audio and video streams using the default format codecs
        and initialize the codecs */

--- a/src/devices/ffmpeg/FfmpegWriter.cpp
+++ b/src/devices/ffmpeg/FfmpegWriter.cpp
@@ -391,14 +391,14 @@ static AVFrame *alloc_picture(int pix_fmt, int width, int height)
     if (!picture) {
         return nullptr;
     }
-    size = avpicture_get_size((AVPixelFormat)pix_fmt, width, height);
+    size = av_image_get_buffer_size((AVPixelFormat)pix_fmt, width, height, 1);
     picture_buf = (uint8_t*)av_malloc(size);
     if (!picture_buf) {
         av_free(picture);
         return nullptr;
     }
-    avpicture_fill((AVPicture *)picture, picture_buf,
-                   (AVPixelFormat)pix_fmt, width, height);
+    av_image_fill_arrays(picture->data, picture->linesize, picture_buf,
+                   (AVPixelFormat)pix_fmt, width, height,1);
     return picture;
 }
 
@@ -475,8 +475,8 @@ void FfmpegWriter::write_video_frame(AVFormatContext *oc, AVStream *st,
 
     if (c->pix_fmt != AV_PIX_FMT_RGB24) {
         fill_rgb_image(tmp_picture, frame_count, c->width, c->height, img);
-        stable_img_convert((AVPicture *)picture, c->pix_fmt,
-                           (AVPicture *)tmp_picture, AV_PIX_FMT_RGB24,
+        stable_img_convert(picture, c->pix_fmt,
+                           tmp_picture, AV_PIX_FMT_RGB24,
                            c->width, c->height);
     } else {
         fill_rgb_image(picture, frame_count, c->width, c->height, img);

--- a/src/devices/ffmpeg/ffmpeg_api.cpp
+++ b/src/devices/ffmpeg/ffmpeg_api.cpp
@@ -7,8 +7,8 @@
 #include "ffmpeg_api.h"
 
 
-int stable_img_convert (AVPicture *dst, int dst_pix_fmt,
-                        const AVPicture *src, int src_pix_fmt,
+int stable_img_convert (AVFrame *dst, int dst_pix_fmt,
+                        const AVFrame *src, int src_pix_fmt,
                         int src_width, int src_height) {
   static struct SwsContext *img_convert_ctx = nullptr;
   if (img_convert_ctx==nullptr) {
@@ -26,16 +26,16 @@ int stable_img_convert (AVPicture *dst, int dst_pix_fmt,
       /*
       printf("software scale: %ld %ld/%ld %d/%d %d\n",
              (long int)img_convert_ctx,
-             (long int)(((AVPicture*)src)->data),
-             (long int)(((AVPicture*)dst)->data),
-             ((AVPicture*)src)->linesize[0],
-             ((AVPicture*)dst)->linesize[0],
+             (long int)(src->data),
+             (long int)(dst->data),
+             src->linesize[0],
+             dst->linesize[0],
              src_height);
       */
 
-      sws_scale(img_convert_ctx, ((AVPicture*)src)->data,
-                ((AVPicture*)src)->linesize, 0, src_height,
-                ((AVPicture*)dst)->data, ((AVPicture*)dst)->linesize);
+      sws_scale(img_convert_ctx, src->data,
+                src->linesize, 0, src_height,
+                dst->data, dst->linesize);
       //printf("software scale done\n");
   } else {
     fprintf(stderr,"image conversion failed\n");

--- a/src/devices/ffmpeg/ffmpeg_api.h
+++ b/src/devices/ffmpeg/ffmpeg_api.h
@@ -41,8 +41,9 @@ extern "C" {
 #  define av_dict_set_int(x, k, v, f) { char buf[256]; sprintf(buf,"%d",v); av_dict_set(x, k ,buf, 0); }
 #endif
 
-int stable_img_convert (AVPicture *dst, int dst_pix_fmt,
-                        const AVPicture *src, int src_pix_fmt,
+
+int stable_img_convert (AVFrame *dst, int dst_pix_fmt,
+                        const AVFrame *src, int src_pix_fmt,
                         int src_width, int src_height);
 
 


### PR DESCRIPTION
Work in progress, for now cleaning up the deprecations, eventually this should fix https://github.com/robotology/yarp/issues/2885 . I open this PR to use the CI to make sure that this is compiling fine against all the ffmpeg versions tested in the CI.

Detailed changes with motivations for the changes:

* [substitute AVPicture with AVFrame](https://github.com/robotology/yarp/commit/ff705bfb8ed8bb6616f48f8fb088e0279549d15b): See https://github.com/FFmpeg/FFmpeg/blob/n4.4.3/libavcodec/avpicture.c#L40 for the original implementation of the function substituted