### PR TITLE
Refactor audioPlayer and audioRecorder wrappers for yarprobotinterface compatibility

### DIFF
--- a/doc/release/master/refactor_audioWrappers_multiWrapperToSingleWrapper.md
+++ b/doc/release/master/refactor_audioWrappers_multiWrapperToSingleWrapper.md
@@ -1,0 +1,13 @@
+refactor_audioWrappers_multiWrapperToSingleWrapper {#master}
+-------------------
+
+### AudioRecorderWrapper and AudioPlayerWrapper
+
+#### `yarp::dev`
+
+The two wrappers have been modified in order to be compatible with `yarprobotinterface` without losing the
+compatibility with `yarpdev` and the `subdevice` option
+
+Now the two objects do not inherit from `yarp::dev::IMultipleWrapper` but from `yarp::dev::WrapperSingle`
+
+This modification has been done in order to allow the two wrappers to implement both the `IWrapper` and the `IMultipleWrapper` interfaces

--- a/src/devices/audioPlayerWrapper/AudioPlayerWrapper.h
+++ b/src/devices/audioPlayerWrapper/AudioPlayerWrapper.h
@@ -29,7 +29,7 @@
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/WrapperSingle.h>
 #include <yarp/dev/api.h>
 
 /**
@@ -52,7 +52,7 @@
 class AudioPlayerWrapper :
         public yarp::os::PeriodicThread,
         public yarp::dev::DeviceDriver,
-        public yarp::dev::IMultipleWrapper,
+        public yarp::dev::WrapperSingle,
         public yarp::os::PortReader
 {
 
@@ -77,13 +77,11 @@ public:
     /**
      * Specify which sensor this thread has to read from.
      */
-    bool attachAll(const yarp::dev::PolyDriverList &p) override;
-    bool detachAll() override;
-
-    void attach(yarp::dev::IAudioRender *irend);
-    void detach();
+    bool attach(yarp::dev::PolyDriver *driver) override;
+    bool detach() override;
 
     bool threadInit() override;
+    void afterStart(bool success) override;
     void threadRelease() override;
     void run() override;
 
@@ -96,6 +94,7 @@ private:
     yarp::os::BufferedPort<yarp::sig::Sound> m_audioInPort;
     std::string  m_statusPortName;
     yarp::os::Port m_statusPort;
+    yarp::os::Property m_config;
 
     yarp::dev::IAudioRender *m_irender = nullptr;
     yarp::os::Stamp m_lastStateStamp;

--- a/src/devices/audioRecorderWrapper/AudioRecorderWrapper.h
+++ b/src/devices/audioRecorderWrapper/AudioRecorderWrapper.h
@@ -13,7 +13,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/AudioGrabberInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/WrapperSingle.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/PeriodicThread.h>
@@ -45,12 +45,13 @@ class AudioRecorderDataThread;
 */
 class AudioRecorderWrapper :
         public yarp::dev::DeviceDriver,
-        public yarp::dev::IMultipleWrapper,
+        public yarp::dev::WrapperSingle,
         public yarp::os::PortReader
 {
 private:
     yarp::dev::PolyDriver          m_driver;
     yarp::dev::IAudioGrabberSound* m_mic = nullptr; //The microphone device
+    yarp::os::Property             m_config;
     double                         m_period;
     yarp::os::Port                 m_rpcPort;
     yarp::os::Port                 m_streamingPort;
@@ -84,11 +85,9 @@ public:
 
     bool open(yarp::os::Searchable& config) override;
     bool close() override;
-    bool attachAll(const yarp::dev::PolyDriverList &p) override;
-    bool detachAll() override;
 
-    void attach(yarp::dev::IAudioGrabberSound *igrab);
-    void detach();
+    bool attach(yarp::dev::PolyDriver* driver) override;
+    bool detach() override;
 
     bool read(yarp::os::ConnectionReader& connection) override;
     friend class AudioRecorderStatusThread;


### PR DESCRIPTION
### AudioRecorderWrapper and AudioPlayerWrapper

#### `yarp::dev`

The two wrappers have been modified in order to be compatible with `yarprobotinterface` without losing the
compatibility with `yarpdev` and the `subdevice` option

Now the two objects do not inherit from `yarp::dev::IMultipleWrapper` but from `yarp::dev::WrapperSingle`

This modification has been done in order to allow the two wrappers to implement both the `IWrapper` and the `IMultipleWrapper` interfaces