### PR TITLE
Added --title option to yarpview

### DIFF
--- a/doc/release/master/feature_yarpview_titleOption.md
+++ b/doc/release/master/feature_yarpview_titleOption.md
@@ -1,0 +1,9 @@
+feature_yarpview_titleOption {#master}
+---------------
+
+### Tools
+
+#### `yarpview`
+
+* Added the possibility to set a custom title for `yarpview` by passing `--title` + *custom title* to the executable
+* If the `title` argument is not passed `yarpview` window title will be assigned as it has been until now

--- a/src/yarpview/plugin/VideoSurface.qml
+++ b/src/yarpview/plugin/VideoSurface.qml
@@ -31,6 +31,7 @@ Rectangle {
     signal synchRate(bool check);
     signal autosize(bool check);
     signal setName(string name);
+    signal setTitle(string inputTitle);
     signal saveSetClosed(bool check);
     signal saveSingleClosed(bool check);
     signal rightClickEnabled(bool enabled);
@@ -70,7 +71,13 @@ Rectangle {
         }
 
         onSetName:{
-            setName(name)
+            setName(name);
+        }
+
+        onSetTitle:{
+            if(inputTitle.length > 0) {
+                setTitle(inputTitle);
+            }
         }
 
         onWidthChanged:{

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -350,8 +350,11 @@ void QtYARPView::printHelp()
 {
     qDebug("yarpview usage:");
     qDebug("  --name: input port name (default: /yarpview/img:i)");
-    qDebug("  --title: A title for the yarpview window (default: input port name");
-    qDebug("           if in compact mode, otherwise it will be \"YARP Qt Image Viewer\")");
+    qDebug("  --title: A title for the yarpview window");
+    qDebug("           (default");
+    qDebug("             - compact flag enabled: input port name");
+    qDebug("             - compact flag disabled: \"YARP Qt Image Viewer\"");
+    qDebug("           )");
     qDebug("  --x: x position of the window in the screen");
     qDebug("  --y: y position of the window in the screen");
     qDebug("  --w: width of the window");

--- a/src/yarpview/plugin/qtyarpview.cpp
+++ b/src/yarpview/plugin/qtyarpview.cpp
@@ -277,6 +277,15 @@ void QtYARPView::setOptions(yarp::os::Searchable& options) {
         qsnprintf(_options.m_portName, 256, "%s", val->asString().c_str());
         qDebug("%s", val->asString().c_str());
     }
+    if (options.check("Title",val)||options.check("title",val)) {
+        qsnprintf(_options.m_title, 256, "%s", val->asString().c_str());
+        qDebug("%s", val->asString().c_str());
+    }
+    else{
+        if(options.check("compact")){
+            qsnprintf(_options.m_title, 256, "%s", _options.m_portName);
+        }
+    }
     if (options.check("NetName",val)||options.check("n",val)) {
         qsnprintf(_options.m_networkName, 256, "%s", val->asString().c_str());
     }
@@ -341,6 +350,8 @@ void QtYARPView::printHelp()
 {
     qDebug("yarpview usage:");
     qDebug("  --name: input port name (default: /yarpview/img:i)");
+    qDebug("  --title: A title for the yarpview window (default: input port name");
+    qDebug("           if in compact mode, otherwise it will be \"YARP Qt Image Viewer\")");
     qDebug("  --x: x position of the window in the screen");
     qDebug("  --y: y position of the window in the screen");
     qDebug("  --w: width of the window");
@@ -363,6 +374,7 @@ void QtYARPView::setOptionsToDefault()
     // Options defaults
     _options.m_refreshTime = 100;
     qsnprintf(_options.m_portName, 256, "%s","/yarpview/img:i");
+    qsnprintf(_options.m_title, 256, "%s","");
     qsnprintf(_options.m_networkName, 256, "%s", "default");
     qsnprintf(_options.m_outPortName, 256, "%s","/yarpview/o:point");
     qsnprintf(_options.m_outRightPortName, 256, "%s","/yarpview/r:o:point");
@@ -397,6 +409,7 @@ bool QtYARPView::openPorts()
     ptr_inputPort->setReadOnly();
     ret= ptr_inputPort->open(_options.m_portName);
     emit setName(ptr_inputPort->getName().c_str());
+    emit setTitle(_options.m_title);
 
     if (!ret){
         qDebug("Error: port failed to open, quitting.");

--- a/src/yarpview/plugin/qtyarpview.h
+++ b/src/yarpview/plugin/qtyarpview.h
@@ -28,6 +28,7 @@ struct mOptions
 {
     unsigned int    m_refreshTime;
     char            m_portName[256];
+    char            m_title[256];
     char            m_networkName[256];
     int             m_windWidth;
     int             m_windHeight;
@@ -134,6 +135,7 @@ signals:
     void synchRate(bool check);
     void autosize(bool check);
     void setName(QString name);
+    void setTitle(QString inputTitle);
 private slots:
     void onSendFps(double portAvg, double portMin, double portMax, double dispAvg, double dispMin, double dispMax);
     void onWindowSizeChangeRequested();

--- a/src/yarpview/src/qml/QtYARPView/main.qml
+++ b/src/yarpview/src/qml/QtYARPView/main.qml
@@ -76,6 +76,9 @@ ApplicationWindow {
         onSetName:{
             statusBar.setName(name)
         }
+        onSetTitle:{
+            window.title=inputTitle
+        }
         onSaveSetClosed:{
             menu.saveSetChecked(check);
         }

--- a/src/yarpview/src/qml/QtYARPView/mainCompact.qml
+++ b/src/yarpview/src/qml/QtYARPView/mainCompact.qml
@@ -60,8 +60,8 @@ ApplicationWindow {
                 menu.enableAutosize(check)
             }
         }
-        onSetName:{
-            title = name
+        onSetTitle:{
+            window.title=inputTitle
         }
     }
 }


### PR DESCRIPTION
### Tools

#### `yarpview`

* Added the possibility to set a custom title for `yarpview` by passing `--title` + *custom title* to the executable
* If the `title` argument is not passed `yarpview` window title will be assigned as it has been until now

---

 * This PR is linked to issue [#2894](https://github.com/robotology/yarp/issues/2894)