### PR TITLE
Improve yarpmotorgui open speed

### DIFF
--- a/doc/release/master/yarpmotorgui_open_speedup.md
+++ b/doc/release/master/yarpmotorgui_open_speedup.md
@@ -1,0 +1,14 @@
+yarpmotorgui_open_speedup {#master}
+---------------------------------
+
+
+
+Branch: [S-Dafarra:yarpmotorgui_speedup](https://github.com/S-Dafarra/yarp/tree/yarpmotorgui_speedup)
+
+#### `yarpmotorgui`
+
+* Improved the initialization time of ``yarpmotorgui`` by:
+  * removing useless code
+  * using a dummy port to check conflicts with other ``yarpmotorgui`` instances
+  * parallelize the opening of the different robot part via ``std::async``
+

--- a/src/yarpmotorgui/CMakeLists.txt
+++ b/src/yarpmotorgui/CMakeLists.txt
@@ -109,6 +109,7 @@ if(YARP_COMPILE_yarpmotorgui)
       YARP::YARP_dev
       Qt5::Widgets
       Qt5::Gui
+      Threads::Threads
   )
 
   install(TARGETS yarpmotorgui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/yarpmotorgui/mainwindow.cpp
+++ b/src/yarpmotorgui/mainwindow.cpp
@@ -623,6 +623,26 @@ bool MainWindow::init(QStringList enabledParts,
         int              partindex;
     };
 
+    //checking existence of the port
+    int ind = 0;
+    QString portPrefix = QString("/yarpmotorgui%1").arg(ind);
+
+    //   NameClient &nic=NameClient::getNameClient();
+    yDebug("Checking the existence of: %s \n", portPrefix.toLatin1().data());
+    Contact adr=Network::queryName(portPrefix.toLatin1().data());
+
+    while(adr.isValid()){
+        ind++;
+
+        portPrefix = QString("/yarpmotorgui%1").arg(ind);
+        yDebug("Checking the existence of: %s \n", portPrefix.toLatin1().data());
+        adr=Network::queryName(portPrefix.toLatin1().data());
+    }
+
+    m_testNamePort.open(portPrefix.toLatin1().data()); //This port is needed only to register a name in the nameserver,
+                                                       //so that other instances of yarpmotorgui will use a different port name
+    m_testNamePort.setWriteOnly();
+
     std::map<std::string, robot_type> robots;
     std::map<std::string, part_type> parts;
 
@@ -672,7 +692,7 @@ bool MainWindow::init(QStringList enabledParts,
         std::string robot_name_without_slash = i_parts.second.robot_name_without_slash;
         std::string part_name_without_slash = i_parts.second.part_name_without_slash;
         int         part_id = i_parts.second.partindex;
-        part = new PartItem(robot_name_without_slash.c_str(), part_id, part_name_without_slash.c_str(), finder, debug_param_enabled, speedview_param_enabled, enable_calib_all, scroll);
+        part = new PartItem(robot_name_without_slash.c_str(), portPrefix, part_id, part_name_without_slash.c_str(), finder, debug_param_enabled, speedview_param_enabled, enable_calib_all, scroll);
 
         if(part && !part->getInterfaceError())
         {

--- a/src/yarpmotorgui/mainwindow.h
+++ b/src/yarpmotorgui/mainwindow.h
@@ -8,6 +8,7 @@
 #define MAINWINDOW_H
 
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/os/Port.h>
 
 #include <QMainWindow>
 #include <QResizeEvent>
@@ -60,6 +61,7 @@ private:
     ResourceFinder   m_finder;
     std::string      m_user_script1;
     std::string      m_user_script2;
+    Port             m_testNamePort;
 
     QAction *m_goAll;
     QAction *m_runAllSeq;

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -22,7 +22,10 @@
 #include <cmath>
 #include <cstdio>
 
-PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& _finder,
+PartItem::PartItem(QString robotName,
+                   QString portPrefix,
+                   int id, QString partName,
+                   ResourceFinder& _finder,
                    bool debug_param_enabled,
                    bool speedview_param_enabled,
                    bool enable_calib_all, QWidget *parent) :
@@ -67,37 +70,12 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
     if (partName.at(0) == '/') {
         partName.remove(0, 1);
     }
-    m_robotPartPort = QString("/%1/%2").arg(robotName).arg(partName);
+    m_robotPartPort = QString("/%1/%2").arg(robotName, partName);
     m_partName = partName;
     m_robotName = robotName;
 
     //checking existence of the port
-    int ind = 0;
-    QString portLocalName = QString("/yarpmotorgui%1/%2").arg(ind).arg(m_robotPartPort);
-
-
-    QString nameToCheck = portLocalName;
-    nameToCheck += "/rpc:o";
-
-    //   NameClient &nic=NameClient::getNameClient();
-    yDebug("Checking the existence of: %s \n", nameToCheck.toLatin1().data());
-    //                    Address adr=nic.queryName(nameToCheck.c_str());
-
-    Contact adr=Network::queryName(nameToCheck.toLatin1().data());
-
-    //Contact c = yarp::os::Network::queryName(portLocalName.c_str());
-    yDebug("ADDRESS is: %s \n", adr.toString().c_str());
-
-    while(adr.isValid()){
-        ind++;
-
-        portLocalName = QString("/yarpmotorgui%1/%2").arg(ind).arg(m_robotPartPort);
-
-        nameToCheck = portLocalName;
-        nameToCheck += "/rpc:o";
-        // adr=nic.queryName(nameToCheck.c_str());
-        adr=Network::queryName(nameToCheck.toLatin1().data());
-    }
+    QString portLocalName = QString("%1%2").arg(portPrefix, m_robotPartPort);
 
     m_interfaceError = false;
 
@@ -124,7 +102,7 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
         yDebug("Setting a valid finder \n");
     }
 
-    QString sequence_portname = QString("/yarpmotorgui/%1/sequence:o").arg(partName);
+    QString sequence_portname = QString("%1/sequence:o").arg(portLocalName);
     m_sequence_port.open(sequence_portname.toLatin1().data());
 
     initInterfaces();
@@ -227,9 +205,6 @@ PartItem::PartItem(QString robotName, int id, QString partName, ResourceFinder& 
             yarp::dev::JointTypeEnum jtype = yarp::dev::VOCAB_JOINTTYPE_REVOLUTE;
             m_iinfo->getJointType(k, jtype);
 
-            Pid myPid(0,0,0,0,0,0);
-            yarp::os::SystemClock::delaySystem(0.005);
-            m_iPid->getPid(VOCAB_PIDTYPE_POSITION, k, &myPid);
 
             auto* joint = new JointItem(k);
             joint->setJointName(jointname.c_str());

--- a/src/yarpmotorgui/partitem.cpp
+++ b/src/yarpmotorgui/partitem.cpp
@@ -24,18 +24,23 @@
 
 PartItem::PartItem(QString robotName,
                    QString portPrefix,
-                   int id, QString partName,
-                   ResourceFinder& _finder,
+                   int id,
+                   QString partName,
                    bool debug_param_enabled,
                    bool speedview_param_enabled,
-                   bool enable_calib_all, QWidget *parent) :
+                   bool enable_calib_all,
+                   QWidget *parent) :
     QWidget(parent),
     m_sequenceWindow(nullptr),
+    m_portPrefix(portPrefix),
     m_partId(id),
     m_mixedEnabled(false),
     m_positionDirectEnabled(false),
     m_pwmEnabled(false),
     m_currentEnabled(false),
+    m_debugParamEnabled(debug_param_enabled),
+    m_speedviewParamEnabled(speedview_param_enabled),
+    m_enableCalibAll(enable_calib_all),
     m_currentPidDlg(nullptr),
     m_controlModes(nullptr),
     m_refTrajectorySpeeds(nullptr),
@@ -54,7 +59,6 @@ PartItem::PartItem(QString robotName,
     m_part_dutyVisible(false),
     m_part_currentVisible(false),
     m_interactionModes(nullptr),
-    m_finder(&_finder),
     m_iMot(nullptr),
     m_iinfo(nullptr),
     m_slow_k(0)
@@ -73,207 +77,6 @@ PartItem::PartItem(QString robotName,
     m_robotPartPort = QString("/%1/%2").arg(robotName, partName);
     m_partName = partName;
     m_robotName = robotName;
-
-    //checking existence of the port
-    QString portLocalName = QString("%1%2").arg(portPrefix, m_robotPartPort);
-
-    m_interfaceError = false;
-
-    // Initializing the polydriver options and instantiating the polydrivers
-    m_partOptions.put("local", portLocalName.toLatin1().data());
-    m_partOptions.put("device", "remote_controlboard");
-    m_partOptions.put("remote", m_robotPartPort.toLatin1().data());
-    m_partOptions.put("carrier", "udp");
-
-    m_partsdd = new PolyDriver();
-
-    // Opening the drivers
-    m_interfaceError = !openPolyDrivers();
-    if (m_interfaceError == true)
-    {
-        yError("Opening PolyDriver for part %s failed...", m_robotPartPort.toLatin1().data());
-        QMessageBox::critical(nullptr, "Error opening a device", QString("Error while opening device for part ").append(m_robotPartPort.toLatin1().data()));
-    }
-
-    /*********************************************************************/
-    /**************** PartMover Content **********************************/
-
-    if (!m_finder->isNull()){
-        yDebug("Setting a valid finder \n");
-    }
-
-    QString sequence_portname = QString("%1/sequence:o").arg(portLocalName);
-    m_sequence_port.open(sequence_portname.toLatin1().data());
-
-    initInterfaces();
-    openInterfaces();
-
-    if (m_interfaceError == false)
-    {
-        int i = 0;
-        std::string jointname;
-        int number_of_joints;
-        m_iPos->getAxes(&number_of_joints);
-
-        m_controlModes = new int[number_of_joints]; //for (i = 0; i < number_of_joints; i++) m_controlModes = 0;
-        m_refTrajectorySpeeds = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_refTrajectorySpeeds[i] = std::nan("");
-        }
-        m_refTrajectoryPositions = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_refTrajectoryPositions[i] = std::nan("");
-        }
-        m_refTorques = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_refTorques[i] = std::nan("");
-        }
-        m_refVelocitySpeeds = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_refVelocitySpeeds[i] = std::nan("");
-        }
-        m_torques = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_torques[i] = std::nan("");
-        }
-        m_positions = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_positions[i] = std::nan("");
-        }
-        m_speeds = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_speeds[i] = std::nan("");
-        }
-        m_currents = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_currents[i] = std::nan("");
-        }
-        m_motorPositions = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_motorPositions[i] = std::nan("");
-        }
-        m_dutyCycles = new double[number_of_joints];
-        for (i = 0; i < number_of_joints; i++) {
-            m_dutyCycles[i] = std::nan("");
-        }
-        m_done = new bool[number_of_joints];
-        m_interactionModes = new yarp::dev::InteractionModeEnum[number_of_joints];
-
-        bool ret = false;
-        SystemClock::delaySystem(0.050);
-        do {
-            ret = m_iencs->getEncoders(m_positions);
-            if (!ret) {
-                yError("%s iencs->getEncoders() failed, retrying...\n", partName.toLatin1().data());
-                SystemClock::delaySystem(0.050);
-            }
-        } while (!ret);
-
-        yInfo("%s iencs->getEncoders() ok!\n", partName.toLatin1().data());
-
-        double min_pos = 0;
-        double max_pos = 100;
-        double min_vel = 0;
-        double max_vel = 100;
-        double min_cur = -2.0;
-        double max_cur = +2.0;
-        for (int k = 0; k<number_of_joints; k++)
-        {
-            bool bpl = m_iLim->getLimits(k, &min_pos, &max_pos);
-            bool bvl = m_iLim->getVelLimits(k, &min_vel, &max_vel);
-            bool bcr = m_iCur->getCurrentRange(k, &min_cur, &max_cur);
-            if (bpl == false)
-            {
-                yError() << "Error while getting position limits, part " << partName.toStdString() << " joint " << k;
-            }
-            if (bvl == false || (min_vel == 0 && max_vel == 0))
-            {
-                yError() << "Error while getting velocity limits, part " << partName.toStdString() << " joint " << k;
-            }
-            if (bcr == false || (min_cur == 0 && max_cur == 0))
-            {
-                yError() << "Error while getting current range, part " << partName.toStdString() << " joint " << k;
-            }
-
-            QSettings settings("YARP", "yarpmotorgui");
-            double max_slider_vel = settings.value("velocity_slider_limit", 100.0).toDouble();
-            if (max_vel > max_slider_vel) {
-                max_vel = max_slider_vel;
-            }
-
-            m_iinfo->getAxisName(k, jointname);
-            yarp::dev::JointTypeEnum jtype = yarp::dev::VOCAB_JOINTTYPE_REVOLUTE;
-            m_iinfo->getJointType(k, jtype);
-
-
-            auto* joint = new JointItem(k);
-            joint->setJointName(jointname.c_str());
-            joint->setPWMRange(-100.0, 100.0);
-            joint->setCurrentRange(min_cur, max_cur);
-            m_layout->addWidget(joint);
-            joint->setPositionRange(min_pos, max_pos);
-            joint->setVelocityRange(min_vel, max_vel);
-            joint->setTrajectoryVelocityRange(max_vel);
-            joint->setTorqueRange(5.0);
-            joint->setUnits(jtype);
-            joint->enableControlPositionDirect(m_positionDirectEnabled);
-            joint->enableControlMixed(m_mixedEnabled);
-            joint->enableControlPWM(m_pwmEnabled);
-            joint->enableControlCurrent(m_currentEnabled);
-
-            int val_pos_choice = settings.value("val_pos_choice", 0).toInt();
-            int val_trq_choice = settings.value("val_trq_choice", 0).toInt();
-            int val_vel_choice = settings.value("val_vel_choice", 0).toInt();
-            double val_pos_custom_step = settings.value("val_pos_custom_step", 1.0).toDouble();
-            double val_trq_custom_step = settings.value("val_trq_custom_step", 1.0).toDouble();
-            double val_vel_custom_step = settings.value("val_vel_custom_step", 1.0).toDouble();
-            onSetPosSliderOptionPI(val_pos_choice, val_pos_custom_step);
-            onSetVelSliderOptionPI(val_vel_choice, val_vel_custom_step);
-            onSetTrqSliderOptionPI(val_trq_choice, val_trq_custom_step);
-            onSetCurSliderOptionPI(val_trq_choice, val_trq_custom_step);
-
-            joint->setEnabledOptions(debug_param_enabled,
-                                     speedview_param_enabled,
-                                     enable_calib_all);
-
-            connect(joint, SIGNAL(changeMode(int,JointItem*)), this, SLOT(onJointChangeMode(int,JointItem*)));
-            connect(joint, SIGNAL(changeInteraction(int,JointItem*)), this, SLOT(onJointInteraction(int,JointItem*)));
-            connect(joint, SIGNAL(sliderTrajectoryPositionCommand(double, int)), this, SLOT(onSliderTrajectoryPositionCommand(double, int)));
-            connect(joint, SIGNAL(sliderTrajectoryVelocityCommand(double, int)), this, SLOT(onSliderTrajectoryVelocityCommand(double, int)));
-            connect(joint, SIGNAL(sliderMixedPositionCommand(double, int)), this, SLOT(onSliderMixedPositionCommand(double, int)));
-            connect(joint, SIGNAL(sliderMixedVelocityCommand(double, int)), this, SLOT(onSliderMixedVelocityCommand(double, int)));
-            connect(joint, SIGNAL(sliderTorqueCommand(double, int)), this, SLOT(onSliderTorqueCommand(double, int)));
-            connect(joint, SIGNAL(sliderDirectPositionCommand(double, int)), this, SLOT(onSliderDirectPositionCommand(double, int)));
-            connect(joint, SIGNAL(sliderPWMCommand(double, int)), this, SLOT(onSliderPWMCommand(double, int)));
-            connect(joint, SIGNAL(sliderCurrentCommand(double, int)), this, SLOT(onSliderCurrentCommand(double, int)));
-            connect(joint, SIGNAL(sliderVelocityCommand(double, int)), this, SLOT(onSliderVelocityCommand(double, int)));
-            connect(joint, SIGNAL(homeClicked(JointItem*)),this,SLOT(onHomeClicked(JointItem*)));
-            connect(joint, SIGNAL(idleClicked(JointItem*)),this,SLOT(onIdleClicked(JointItem*)));
-            connect(joint, SIGNAL(runClicked(JointItem*)),this,SLOT(onRunClicked(JointItem*)));
-            connect(joint, SIGNAL(pidClicked(JointItem*)),this,SLOT(onPidClicked(JointItem*)));
-            connect(joint, SIGNAL(calibClicked(JointItem*)),this,SLOT(onCalibClicked(JointItem*)));
-        }
-    }
-
-    /*********************************************************************/
-    /*********************************************************************/
-
-    m_cycleTimer.setSingleShot(true);
-    m_cycleTimer.setTimerType(Qt::PreciseTimer);
-    connect(&m_cycleTimer, SIGNAL(timeout()), this, SLOT(onCycleTimerTimeout()), Qt::QueuedConnection);
-
-    m_cycleTimeTimer.setSingleShot(true);
-    m_cycleTimeTimer.setTimerType(Qt::PreciseTimer);
-    connect(&m_cycleTimeTimer, SIGNAL(timeout()), this, SLOT(onCycleTimeTimerTimeout()), Qt::QueuedConnection);
-
-
-    m_runTimeTimer.setSingleShot(true);
-    m_runTimeTimer.setTimerType(Qt::PreciseTimer);
-    connect(&m_runTimeTimer, SIGNAL(timeout()), this, SLOT(onRunTimerTimeout()), Qt::QueuedConnection);
-
-    m_runTimer.setSingleShot(true);
-    m_runTimer.setTimerType(Qt::PreciseTimer);
-    connect(&m_runTimer, SIGNAL(timeout()), this, SLOT(onRunTimeout()), Qt::QueuedConnection);
 }
 
 PartItem::~PartItem()
@@ -330,6 +133,211 @@ PartItem::~PartItem()
     if (m_interactionModes) { delete [] m_interactionModes; m_interactionModes = nullptr; }
 }
 
+void PartItem::initializeYarpConnections()
+{
+    //checking existence of the port
+    QString portLocalName = QString("%1%2").arg(m_portPrefix, m_robotPartPort);
+
+    m_interfaceError = false;
+
+    // Initializing the polydriver options and instantiating the polydrivers
+    m_partOptions.put("local", portLocalName.toLatin1().data());
+    m_partOptions.put("device", "remote_controlboard");
+    m_partOptions.put("remote", m_robotPartPort.toLatin1().data());
+    m_partOptions.put("carrier", "udp");
+
+    m_partsdd = new PolyDriver();
+
+    // Opening the drivers
+    m_interfaceError = !openPolyDrivers();
+    if (m_interfaceError == true)
+    {
+        return;
+    }
+
+    /*********************************************************************/
+    /**************** PartMover Content **********************************/
+
+    QString sequence_portname = QString("%1/sequence:o").arg(portLocalName);
+    m_sequence_port.open(sequence_portname.toLatin1().data());
+
+    initInterfaces();
+    openInterfaces();
+
+    if (m_interfaceError == false)
+    {
+        int i = 0;
+        int number_of_joints;
+        m_iPos->getAxes(&number_of_joints);
+
+        m_controlModes = new int[number_of_joints]; //for (i = 0; i < number_of_joints; i++) m_controlModes = 0;
+        m_refTrajectorySpeeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTrajectorySpeeds[i] = std::nan("");
+        }
+        m_refTrajectoryPositions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTrajectoryPositions[i] = std::nan("");
+        }
+        m_refTorques = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refTorques[i] = std::nan("");
+        }
+        m_refVelocitySpeeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_refVelocitySpeeds[i] = std::nan("");
+        }
+        m_torques = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_torques[i] = std::nan("");
+        }
+        m_positions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_positions[i] = std::nan("");
+        }
+        m_speeds = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_speeds[i] = std::nan("");
+        }
+        m_currents = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_currents[i] = std::nan("");
+        }
+        m_motorPositions = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_motorPositions[i] = std::nan("");
+        }
+        m_dutyCycles = new double[number_of_joints];
+        for (i = 0; i < number_of_joints; i++) {
+            m_dutyCycles[i] = std::nan("");
+        }
+        m_done = new bool[number_of_joints];
+        m_interactionModes = new yarp::dev::InteractionModeEnum[number_of_joints];
+
+        bool ret = false;
+        SystemClock::delaySystem(0.050);
+        do {
+            ret = m_iencs->getEncoders(m_positions);
+            if (!ret) {
+                yError("%s iencs->getEncoders() failed, retrying...\n", m_partName.toLatin1().data());
+                SystemClock::delaySystem(0.050);
+            }
+        } while (!ret);
+
+        yInfo("%s iencs->getEncoders() ok!\n", m_partName.toLatin1().data());
+
+        for (int k = 0; k < number_of_joints; ++k)
+        {
+            JointInfo addedJoint;
+            m_iinfo->getAxisName(k, addedJoint.name);
+            bool bpl = m_iLim->getLimits(k, &addedJoint.minPosition, &addedJoint.maxPosition);
+            bool bvl = m_iLim->getVelLimits(k, &addedJoint.minVelocity, &addedJoint.maxVelocity);
+            bool bcr = m_iCur->getCurrentRange(k, &addedJoint.minCurrent, &addedJoint.maxCurrent);
+            if (bpl == false)
+            {
+                yError() << "Error while getting position limits, part " << m_partName.toStdString() << " joint " << k;
+            }
+            if (bvl == false || (addedJoint.minVelocity == 0 && addedJoint.maxVelocity == 0))
+            {
+                yError() << "Error while getting velocity limits, part " << m_partName.toStdString() << " joint " << k;
+            }
+            if (bcr == false || (addedJoint.minCurrent == 0 && addedJoint.maxCurrent == 0))
+            {
+                yError() << "Error while getting current range, part " << m_partName.toStdString() << " joint " << k;
+            }
+
+            m_iinfo->getJointType(k, addedJoint.jointType);
+            m_jointsInfo.push_back(addedJoint);
+        }
+    }
+}
+
+void PartItem::initializeJointWidgets()
+{
+    if (m_interfaceError == false)
+    {
+        QSettings settings("YARP", "yarpmotorgui");
+        double max_slider_vel = settings.value("velocity_slider_limit", 100.0).toDouble();
+
+
+        for (int k = 0; k < m_jointsInfo.size(); k++)
+        {
+            JointInfo& jointInfo = m_jointsInfo[k];
+
+            if (jointInfo.maxVelocity > max_slider_vel) {
+                jointInfo.maxVelocity = max_slider_vel;
+            }
+
+            auto* joint = new JointItem(k);
+            joint->setJointName(jointInfo.name.c_str());
+            joint->setPWMRange(-100.0, 100.0);
+            joint->setCurrentRange(jointInfo.minCurrent, jointInfo.maxCurrent);
+            m_layout->addWidget(joint);
+            joint->setPositionRange(jointInfo.minPosition, jointInfo.maxPosition);
+            joint->setVelocityRange(jointInfo.minVelocity, jointInfo.maxVelocity);
+            joint->setTrajectoryVelocityRange(jointInfo.maxVelocity);
+            joint->setTorqueRange(5.0);
+            joint->setUnits(jointInfo.jointType);
+            joint->enableControlPositionDirect(m_positionDirectEnabled);
+            joint->enableControlMixed(m_mixedEnabled);
+            joint->enableControlPWM(m_pwmEnabled);
+            joint->enableControlCurrent(m_currentEnabled);
+
+            int val_pos_choice = settings.value("val_pos_choice", 0).toInt();
+            int val_trq_choice = settings.value("val_trq_choice", 0).toInt();
+            int val_vel_choice = settings.value("val_vel_choice", 0).toInt();
+            double val_pos_custom_step = settings.value("val_pos_custom_step", 1.0).toDouble();
+            double val_trq_custom_step = settings.value("val_trq_custom_step", 1.0).toDouble();
+            double val_vel_custom_step = settings.value("val_vel_custom_step", 1.0).toDouble();
+            onSetPosSliderOptionPI(val_pos_choice, val_pos_custom_step);
+            onSetVelSliderOptionPI(val_vel_choice, val_vel_custom_step);
+            onSetTrqSliderOptionPI(val_trq_choice, val_trq_custom_step);
+            onSetCurSliderOptionPI(val_trq_choice, val_trq_custom_step);
+
+            joint->setEnabledOptions(m_debugParamEnabled,
+                                     m_speedviewParamEnabled,
+                                     m_enableCalibAll);
+
+            connect(joint, SIGNAL(changeMode(int,JointItem*)), this, SLOT(onJointChangeMode(int,JointItem*)));
+            connect(joint, SIGNAL(changeInteraction(int,JointItem*)), this, SLOT(onJointInteraction(int,JointItem*)));
+            connect(joint, SIGNAL(sliderTrajectoryPositionCommand(double, int)), this, SLOT(onSliderTrajectoryPositionCommand(double, int)));
+            connect(joint, SIGNAL(sliderTrajectoryVelocityCommand(double, int)), this, SLOT(onSliderTrajectoryVelocityCommand(double, int)));
+            connect(joint, SIGNAL(sliderMixedPositionCommand(double, int)), this, SLOT(onSliderMixedPositionCommand(double, int)));
+            connect(joint, SIGNAL(sliderMixedVelocityCommand(double, int)), this, SLOT(onSliderMixedVelocityCommand(double, int)));
+            connect(joint, SIGNAL(sliderTorqueCommand(double, int)), this, SLOT(onSliderTorqueCommand(double, int)));
+            connect(joint, SIGNAL(sliderDirectPositionCommand(double, int)), this, SLOT(onSliderDirectPositionCommand(double, int)));
+            connect(joint, SIGNAL(sliderPWMCommand(double, int)), this, SLOT(onSliderPWMCommand(double, int)));
+            connect(joint, SIGNAL(sliderCurrentCommand(double, int)), this, SLOT(onSliderCurrentCommand(double, int)));
+            connect(joint, SIGNAL(sliderVelocityCommand(double, int)), this, SLOT(onSliderVelocityCommand(double, int)));
+            connect(joint, SIGNAL(homeClicked(JointItem*)),this,SLOT(onHomeClicked(JointItem*)));
+            connect(joint, SIGNAL(idleClicked(JointItem*)),this,SLOT(onIdleClicked(JointItem*)));
+            connect(joint, SIGNAL(runClicked(JointItem*)),this,SLOT(onRunClicked(JointItem*)));
+            connect(joint, SIGNAL(pidClicked(JointItem*)),this,SLOT(onPidClicked(JointItem*)));
+            connect(joint, SIGNAL(calibClicked(JointItem*)),this,SLOT(onCalibClicked(JointItem*)));
+        }
+    }
+
+    /*********************************************************************/
+    /*********************************************************************/
+
+    m_cycleTimer.setSingleShot(true);
+    m_cycleTimer.setTimerType(Qt::PreciseTimer);
+    connect(&m_cycleTimer, SIGNAL(timeout()), this, SLOT(onCycleTimerTimeout()), Qt::QueuedConnection);
+
+    m_cycleTimeTimer.setSingleShot(true);
+    m_cycleTimeTimer.setTimerType(Qt::PreciseTimer);
+    connect(&m_cycleTimeTimer, SIGNAL(timeout()), this, SLOT(onCycleTimeTimerTimeout()), Qt::QueuedConnection);
+
+
+    m_runTimeTimer.setSingleShot(true);
+    m_runTimeTimer.setTimerType(Qt::PreciseTimer);
+    connect(&m_runTimeTimer, SIGNAL(timeout()), this, SLOT(onRunTimerTimeout()), Qt::QueuedConnection);
+
+    m_runTimer.setSingleShot(true);
+    m_runTimer.setTimerType(Qt::PreciseTimer);
+    connect(&m_runTimer, SIGNAL(timeout()), this, SLOT(onRunTimeout()), Qt::QueuedConnection);
+}
+
 bool PartItem::openPolyDrivers()
 {
     m_partsdd->open(m_partOptions);
@@ -353,7 +361,7 @@ bool PartItem::openPolyDrivers()
 
 void PartItem::initInterfaces()
 {
-    yDebug("Initializing interfaces...");
+    yDebug("Initializing %s interfaces...", getPartName().toStdString().c_str());
     //default value for unopened interfaces
     m_iPos = nullptr;
     m_iVel = nullptr;
@@ -376,7 +384,7 @@ void PartItem::initInterfaces()
 
 bool PartItem::openInterfaces()
 {
-    yDebug("Opening interfaces...");
+    yDebug("Opening %s interfaces...", getPartName().toStdString().c_str());
     bool ok = false;
 
     if (m_partsdd->isValid()) {
@@ -487,6 +495,16 @@ bool PartItem::getInterfaceError()
 QString PartItem::getPartName()
 {
     return m_partName;
+}
+
+QString PartItem::getRobotName()
+{
+    return m_robotName;
+}
+
+int PartItem::getPartIndex()
+{
+    return m_partId;
 }
 
 void PartItem::onSliderPWMCommand(double pwmVal, int index)

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -41,6 +41,7 @@ class PartItem : public QWidget
     Q_OBJECT
 public:
     explicit PartItem(QString robotName,
+                      QString portPrefix,
                       int partId,
                       QString partName,
                       ResourceFinder& _finder,

--- a/src/yarpmotorgui/partitem.h
+++ b/src/yarpmotorgui/partitem.h
@@ -44,7 +44,6 @@ public:
                       QString portPrefix,
                       int partId,
                       QString partName,
-                      ResourceFinder& _finder,
                       bool debug_param_enabled,
                       bool speedview_param_enabled,
                       bool enable_calib_all,
@@ -52,30 +51,27 @@ public:
 
 
     ~PartItem();
-    bool openPolyDrivers();
-    void initInterfaces();
-    bool openInterfaces();
+    void initializeYarpConnections();
+    void initializeJointWidgets();
     bool getInterfaceError();
     void openSequenceWindow();
     void closeSequenceWindow();
-    bool cycleAllSeq();
     bool checkAndRunAllSeq();
     bool checkAndRunTimeAllSeq();
     bool checkAndCycleAllSeq();
     bool checkAndCycleTimeAllSeq();
     void runPart();
     void idlePart();
-    bool homeJoint(int joint);
     bool homePart();
     bool homeToCustomPosition(const yarp::os::Bottle& positionElement);
     void calibratePart();
     bool checkAndGo();
     void stopSequence();
-    void setTreeWidgetModeNode(QTreeWidgetItem *node);
     void loadSequence();
     void saveSequence(QString global_filename);
-    QTreeWidgetItem *getTreeWidgetModeNode();
     QString getPartName();
+    QString getRobotName();
+    int getPartIndex();
     const QVector<JointItem::JointState>& getPartModes();
     void resizeWidget(int w);
     int getNumberOfJoints();
@@ -85,22 +81,43 @@ public:
 
 private:
     void fixedTimeMove(SequenceItem sequence);
+    bool openPolyDrivers();
+    void initInterfaces();
+    bool openInterfaces();
+    bool homeJoint(int joint);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
     void changeEvent(QEvent *event) override;
 
 private:
+
+    struct JointInfo
+    {
+        std::string name;
+        double minPosition{0};
+        double maxPosition{0};
+        double minVelocity{0};
+        double maxVelocity{0};
+        double minCurrent{0};
+        double maxCurrent{0};
+        yarp::dev::JointTypeEnum jointType{yarp::dev::VOCAB_JOINTTYPE_REVOLUTE};
+    };
+
     FlowLayout *m_layout;
     SequenceWindow *m_sequenceWindow;
     QString m_robotPartPort;
     QString m_robotName;
     QString m_partName;
+    QString m_portPrefix;
     int     m_partId;
     bool   m_mixedEnabled;
     bool   m_positionDirectEnabled;
     bool   m_pwmEnabled;
     bool   m_currentEnabled;
+    bool   m_debugParamEnabled;
+    bool   m_speedviewParamEnabled;
+    bool   m_enableCalibAll;
     PidDlg *m_currentPidDlg;
     Stamp  m_sequence_port_stamp;
     QTimer m_runTimer;
@@ -130,8 +147,8 @@ private:
     bool    m_part_currentVisible;
     yarp::dev::InteractionModeEnum* m_interactionModes;
     QVector<JointItem::JointState> m_modesList;
+    QVector<JointInfo> m_jointsInfo;
 
-    ResourceFinder* m_finder;
     PolyDriver*     m_partsdd;
     Property        m_partOptions;
     Port            m_sequence_port;


### PR DESCRIPTION
During the XPrize finals, we noticed that the ``yarpmotorgui`` can take some time to start.

I check the code and I found that there are some checks on whether there are other ``yarpmotogui`` opened. See for example https://github.com/robotology/yarp/blob/76fe34dfd5bb6b07557a816116cf48ae35a0e279/src/yarpmotorgui/partitem.cpp#L86

My guess is that this call can be costly in case of a delayed network.

Moreover, there was a useless call to get each joint position PID: https://github.com/robotology/yarp/blob/76fe34dfd5bb6b07557a816116cf48ae35a0e279/src/yarpmotorgui/partitem.cpp#L230-L232

Finally, there are some delays to make sure that the reading of the joint values is valid: https://github.com/robotology/yarp/blob/76fe34dfd5bb6b07557a816116cf48ae35a0e279/src/yarpmotorgui/partitem.cpp#L184-L194

Hence, with this PR:
- I have added a dummy port such that the check to avoid conflicts is done only once, instead of multiple times per part.
- I have removed the useless PID request.
- I have parallelized the opening of the different parts using [``std::async``](https://en.cppreference.com/w/cpp/thread/async)

I have measured the initialization time before and after when opening ``yarpmotorgui`` with the robot on Gazebo in my PC (so all local communication), and the improvement was more than half a second.