### PR TITLE
New companion command `yarp split`

### DIFF
--- a/doc/module_executables/cmd_yarpscope.dox
+++ b/doc/module_executables/cmd_yarpscope.dox
@@ -8,8 +8,10 @@
 
 \section yarpscope_intro Description
 This simple graphical user interface allows one to visualize on a plot the
-content of a YARP port. The input port is assumed to contain a vector of
-numbers.
+content of a YARP port. The input port is assumed to contain a single vector of
+numbers. If you want to plot complex data, i.e. a nested bottle, you might want to
+check the command `yarp split` to pre-process the data and subdivide the bottle into
+multiple vectors.
 
  - The main window can contain one or more plots.
  - Each plot can contain one or more graphs.

--- a/doc/release/master/companion_split.md
+++ b/doc/release/master/companion_split.md
@@ -1,0 +1,7 @@
+companion_split {#master}
+-----------
+
+### `lib_yarp_companion`
+
+* Added companion command `yarp split`. The command splits an heterogeneous nested bottle received from a port into multiple ports.
+

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(YARP_companion_IMPL_SRCS
   yarp/companion/impl/Companion.cmdRpc.cpp
   yarp/companion/impl/Companion.cmdRpcServer.cpp
   yarp/companion/impl/Companion.cmdSample.cpp
+  yarp/companion/impl/Companion.cmdSplit.cpp
   yarp/companion/impl/Companion.cmdStats.cpp
   yarp/companion/impl/Companion.cmdTerminate.cpp
   yarp/companion/impl/Companion.cmdTime.cpp

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdSplit.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdSplit.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/companion/impl/Companion.h>
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Contactable.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/Semaphore.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/os/TypedReaderCallback.h>
+#include <yarp/os/Value.h>
+
+using yarp::companion::impl::Companion;
+using yarp::os::Bottle;
+using yarp::os::BufferedPort;
+using yarp::os::Contactable;
+using yarp::os::NetworkBase;
+using yarp::os::Property;
+using yarp::os::Semaphore;
+using yarp::os::Stamp;
+using yarp::os::TypedReaderCallback;
+using yarp::os::Value;
+
+namespace {
+class inPortProcessor :  public TypedReaderCallback<Bottle>
+{
+public:
+    Semaphore*   sema{nullptr};
+    Contactable* port{nullptr};
+    std::mutex   mutex;
+    Bottle       value;
+    size_t       value_size{0};
+    Stamp        stamp;
+
+    inPortProcessor() = default;
+
+    void init(Contactable& port, Semaphore& sema)
+    {
+        this->port = &port;
+        this->sema = &sema;
+    }
+
+    using yarp::os::TypedReaderCallback<Bottle>::onRead;
+    void onRead(Bottle& datum) override
+    {
+        mutex.lock();
+        value = datum;
+        value_size= value.size();
+        port->getEnvelope(stamp);
+        mutex.unlock();
+        sema->post();
+    }
+};
+} // namespace
+
+int Companion::cmdSplit(int argc, char *argv[])
+{
+    BufferedPort<Bottle >*  outPort = nullptr;
+    BufferedPort<Bottle >   inPort;
+    inPortProcessor*        inData = nullptr;
+
+    //a simple help
+    if (argc == 0)
+    {
+        yCInfo(COMPANION, "This is yarp split. Please provide the name of the port to process, e.g:");
+        yCInfo(COMPANION, "  yarp split /port1");
+        return -1;
+    }
+
+    //some options
+    std::string portname = argv[0];
+    Property options;
+    options.fromCommand(argc, argv, false);
+    std::string carrier = options.check("carrier", Value("udp")).asString().c_str();
+
+    //initializations
+    inData  = new inPortProcessor;
+    Semaphore product(0);
+    inData->init(inPort, product);
+    inPort.useCallback(*inData);
+
+    //open the input port and try the connection to the remote
+    inPort.open("...");
+    bool b = yarp::os::NetworkBase::connect(portname, inPort.getName().c_str(), carrier, false);
+    if (!b)
+    {
+        yCError(COMPANION, "Failed to connect.");
+        return -1;
+    }
+
+    yCInfo(COMPANION, "Waiting for data..");
+    size_t siz = 0;
+    while(true)
+    {
+        //wait for new data to be received
+        product.wait();
+        while (product.check()) {
+            product.wait();
+        }
+
+        //open some ports. The number depends on the first received data.
+        if (outPort == nullptr)
+        {
+            inData->mutex.lock();
+            siz = inData->value_size;
+            inData->mutex.unlock();
+            if (siz != 0)
+            {
+                yCInfo(COMPANION, std::string("Received a Bottle of "+std::to_string(siz)+" elements.").c_str());
+                outPort = new BufferedPort<Bottle> [siz];
+                for (size_t i = 0; i < siz; i++)
+                {
+                    std::string portName = portname+"/split" + std::to_string(i) +":o";
+                    outPort[i].open(portName);
+                }
+                yCInfo(COMPANION, "Ready");
+            }
+            else
+            {
+                yCError(COMPANION, "Data with invalid size received.");
+            }
+        }
+
+        //Check if the data size is not constant
+        inData->mutex.lock();
+        if (inData->value_size != siz)
+        {
+            yCError(COMPANION, "Data with invalid size received.");
+        }
+        inData->mutex.unlock();
+
+        //write data on each single port
+        for (size_t i = 0; i < siz; i++)
+        {
+            if (outPort[i].getOutputCount() > 0)
+            {
+                Bottle& b = outPort[i].prepare();
+                b.clear();
+                inData->mutex.lock();
+                b.add(inData->value.get(i));
+                outPort[i].setEnvelope(inData->stamp);
+                inData->mutex.unlock();
+                outPort[i].write();
+            }
+        }
+    }
+    yCInfo(COMPANION, "Complete.");
+
+    //cleanup
+    delete [] outPort;
+    delete inData;
+    return 0;
+}

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cpp
@@ -159,6 +159,7 @@ Companion::Companion() :
     add("rpc",             &Companion::cmdRpc,            "write commands to a port, and read replies");
     add("rpcserver",       &Companion::cmdRpcServer,      "make a test RPC server to receive and reply to Bottle-format messages");
     add("sample",          &Companion::cmdSample,         "drop or duplicate messages to achieve a constant frame-rate");
+    add("split",           &Companion::cmdSplit,          "splits data received in a bottle onto multiple ports, one for each element");
     add("stats",           &Companion::cmdStats,          "print statics about the data received from a specific port");
     add("priority-sched",  &Companion::cmdPrioritySched,  "set/get the thread policy and priority for a given connection");
     add("terminate",       &Companion::cmdTerminate,      "terminate a yarp-terminate-aware process by name");

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -128,6 +128,9 @@ public:
     // Defined in Companion.cmdStats.cpp
     int cmdStats(int argc, char* argv[]);
 
+    // Defined in Companion.cmdSplit.cpp
+    int cmdSplit(int argc, char* argv[]);
+
     // Defined in Companion.cmdTerminate.cpp
     int cmdTerminate(int argc, char *argv[]);
 


### PR DESCRIPTION
Added companion command `yarp split`. The command splits a heterogeneous nested bottle received from a port into multiple ports.