### PR TITLE
YARP_priv_SQLite3 fix

### DIFF
--- a/doc/release/master/extern_sqlite3_fix.md
+++ b/doc/release/master/extern_sqlite3_fix.md
@@ -1,0 +1,9 @@
+extern_sqlite3_fix {#master}
+-----------
+
+### `extern`
+
+#### `sqlite3`
+
+* Migration from sqlite to sqlite3. Fixed issue preventing extern/sqlite3 (i.e. YARP_priv_SQLite3) to be correctly found 
+as a dependency by other projects.

--- a/extern/sqlite/CMakeLists.txt
+++ b/extern/sqlite/CMakeLists.txt
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # SQLite
-project(YARP_priv_sqlite)
+project(YARP_priv_sqlite3)
 
-add_library(YARP_priv_sqlite STATIC)
+add_library(YARP_priv_sqlite3 STATIC)
 
 set(sqlite_SRCS
   sqlite/shell.c
@@ -20,27 +20,27 @@ if(MSVC)
   set_source_files_properties(sqlite/sqlite3.c PROPERTIES COMPILE_FLAGS "/wd4996")
 endif()
 
-target_sources(YARP_priv_sqlite PRIVATE ${sqlite_SRCS})
+target_sources(YARP_priv_sqlite3 PRIVATE ${sqlite_SRCS})
 
-target_include_directories(YARP_priv_sqlite PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sqlite>)
+target_include_directories(YARP_priv_sqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sqlite>)
 
-target_compile_definitions(YARP_priv_sqlite PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
+target_compile_definitions(YARP_priv_sqlite3 PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
 
 if(UNIX)
-  target_link_libraries(YARP_priv_sqlite PRIVATE pthread)
+  target_link_libraries(YARP_priv_sqlite3 PRIVATE pthread)
 endif(UNIX)
 
-set_property(TARGET YARP_priv_sqlite PROPERTY FOLDER "Libraries/External")
+set_property(TARGET YARP_priv_sqlite3 PROPERTY FOLDER "Libraries/External")
 
 
 set(SQLite3_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/sqlite PARENT_SCOPE)
-set(SQLite3_LIBRARIES YARP_priv_sqlite PARENT_SCOPE)
+set(SQLite3_LIBRARIES YARP_priv_sqlite3 PARENT_SCOPE)
 set(SQLite3_DEFINITIONS "" PARENT_SCOPE)
 
 install(
-  TARGETS YARP_priv_sqlite
-  EXPORT YARP_priv_sqlite
-  COMPONENT YARP_priv_sqlite
+  TARGETS YARP_priv_sqlite3
+  EXPORT YARP_priv_sqlite3
+  COMPONENT YARP_priv_sqlite3
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -48,5 +48,5 @@ install(
 
 if(NOT CREATE_SHARED_LIBS)
   include(YarpInstallBasicPackageFiles)
-  yarp_install_basic_package_files(YARP_priv_sqlite)
+  yarp_install_basic_package_files(YARP_priv_sqlite3)
 endif()


### PR DESCRIPTION
Migration from sqlite to sqlite3. Fixed issue preventing extern/sqlite3 (i.e. YARP_priv_SQLite3) to be correctly found
as a dependency by other projects. Thanks @traversaro for finding the issue.