### PR TITLE
yarp_dev_tests

### DIFF
--- a/doc/release/master/yarp_dev_tests.md
+++ b/doc/release/master/yarp_dev_tests.md
@@ -1,0 +1,9 @@
+exposed_yarp_dev_tests {#master}
+-----------
+
+### `tests`
+
+#### `yarp_dev_tests`
+
+* A new library `yarp_dev_tests`: is now exported.
+  It contains common sources to test yarp device through lib_yarpdev (also outside yarp repo).

--- a/src/devices/ControlBoardRemapper/tests/CMakeLists.txt
+++ b/src/devices/ControlBoardRemapper/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_controlBoardRemapper)
 

--- a/src/devices/ControlBoardWrapper/tests/CMakeLists.txt
+++ b/src/devices/ControlBoardWrapper/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_controlBoardWrapper)
 

--- a/src/devices/ControlBoard_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/ControlBoard_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_controlBoard_nws_yarp)
 

--- a/src/devices/RGBDSensorClient/tests/CMakeLists.txt
+++ b/src/devices/RGBDSensorClient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_RGBDSensorClient)
 

--- a/src/devices/RGBDSensor_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/RGBDSensor_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_RGBDSensor_nws_yarp)
 

--- a/src/devices/Rangefinder2DClient/tests/CMakeLists.txt
+++ b/src/devices/Rangefinder2DClient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Rangefinder2DClient)
 

--- a/src/devices/Rangefinder2D_nwc_yarp/tests/CMakeLists.txt
+++ b/src/devices/Rangefinder2D_nwc_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_rangefinder2D_nwc_yarp)
 

--- a/src/devices/Rangefinder2D_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/Rangefinder2D_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_rangefinder2D_nws_yarp)
 

--- a/src/devices/RemoteControlBoard/tests/CMakeLists.txt
+++ b/src/devices/RemoteControlBoard/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_RemoteControlBoard)
 

--- a/src/devices/RobotDescriptionClient/tests/CMakeLists.txt
+++ b/src/devices/RobotDescriptionClient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_robotDescriptionClient)
 

--- a/src/devices/RobotDescriptionServer/tests/CMakeLists.txt
+++ b/src/devices/RobotDescriptionServer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_robotDescriptionServer)
 

--- a/src/devices/fakeDepthCamera/tests/CMakeLists.txt
+++ b/src/devices/fakeDepthCamera/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeDepthCamera)
 

--- a/src/devices/fakeFrameGrabber/tests/CMakeLists.txt
+++ b/src/devices/fakeFrameGrabber/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeFrameGrabber)
 

--- a/src/devices/fakeIMU/tests/CMakeLists.txt
+++ b/src/devices/fakeIMU/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeImu)
 

--- a/src/devices/fakeLaser/tests/CMakeLists.txt
+++ b/src/devices/fakeLaser/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeLaser)
 

--- a/src/devices/fakeLaserWithMotor/tests/CMakeLists.txt
+++ b/src/devices/fakeLaserWithMotor/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeLaserWithMotor)
 

--- a/src/devices/fakeMotionControl/tests/CMakeLists.txt
+++ b/src/devices/fakeMotionControl/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeMotionControl)
 

--- a/src/devices/fakeNavigationDevice/tests/CMakeLists.txt
+++ b/src/devices/fakeNavigationDevice/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_fakeNavigation)
 

--- a/src/devices/frameGrabberCropper/tests/CMakeLists.txt
+++ b/src/devices/frameGrabberCropper/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_frameGrabberCropper)
 

--- a/src/devices/frameGrabber_nwc_yarp/tests/CMakeLists.txt
+++ b/src/devices/frameGrabber_nwc_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_frameGrabber_nwc_yarp)
 

--- a/src/devices/frameGrabber_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/frameGrabber_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_frameGrabber_nws_yarp)
 

--- a/src/devices/frameTransformClient/tests/CMakeLists.txt
+++ b/src/devices/frameTransformClient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_FrameTransformClient)
 

--- a/src/devices/frameTransformServer/tests/CMakeLists.txt
+++ b/src/devices/frameTransformServer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_FrameTransformServer)
 

--- a/src/devices/map2DStorage/tests/CMakeLists.txt
+++ b/src/devices/map2DStorage/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Map2DStorage)
 

--- a/src/devices/map2D_nwc_yarp/tests/CMakeLists.txt
+++ b/src/devices/map2D_nwc_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Map2Dnwc)
 

--- a/src/devices/map2D_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/map2D_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Map2Dnws)
 

--- a/src/devices/multipleanalogsensorsclient/tests/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsclient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_multipleanalogsensorsclient)
 

--- a/src/devices/multipleanalogsensorsserver/tests/CMakeLists.txt
+++ b/src/devices/multipleanalogsensorsserver/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_multipleanalogsensorsserver)
 

--- a/src/devices/navigation2D_nwc_yarp/tests/CMakeLists.txt
+++ b/src/devices/navigation2D_nwc_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Navigation2Dnwc)
 

--- a/src/devices/navigation2D_nws_yarp/tests/CMakeLists.txt
+++ b/src/devices/navigation2D_nws_yarp/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_Navigation2Dnws)
 

--- a/src/devices/transformClient/tests/CMakeLists.txt
+++ b/src/devices/transformClient/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_TransformerClient)
 

--- a/src/devices/transformServer/tests/CMakeLists.txt
+++ b/src/devices/transformServer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ function(yarp_catch_discover_tests _target)
 endfunction()
 #########################################################################
 
-find_package(YARP::YARP_dev_tests)
+
 
 add_executable(harness_dev_TransformerServer)
 

--- a/src/libYARP_dev/CMakeLists.txt
+++ b/src/libYARP_dev/CMakeLists.txt
@@ -10,3 +10,8 @@ yarp_install_basic_package_files(YARP_dev
   DEPENDENCIES ${YARP_dev_PUBLIC_DEPS}
   PRIVATE_DEPENDENCIES ${YARP_dev_PRIVATE_DEPS}
 )
+
+yarp_install_basic_package_files(YARP_dev_tests
+  DEPENDENCIES ${YARP_dev_tests_PUBLIC_DEPS}
+  PRIVATE_DEPENDENCIES ${YARP_dev_tests_PRIVATE_DEPS}
+)

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -397,53 +397,62 @@ set(YARP_dev_PRIVATE_DEPS ${YARP_dev_PRIVATE_DEPS} PARENT_SCOPE)
 add_library(YARP_dev_tests)
 add_library(YARP::YARP_dev_tests ALIAS YARP_dev_tests)
 
+set(YARP_dev_test_HDRS
+    yarp/dev/tests/IDummyTest.h
+    yarp/dev/tests/IPositionControlTest.h
+    yarp/dev/tests/ITorqueControlTest.h
+    yarp/dev/tests/IAxisInfoTest.h
+    yarp/dev/tests/IRGBDSensorTest.h
+)
+
+set(YARP_dev_test_SRCS
+    yarp/dev/tests/IDummyTest.cpp
+    yarp/dev/tests/IPositionControlTest.cpp
+    yarp/dev/tests/ITorqueControlTest.cpp
+    yarp/dev/tests/IAxisInfoTest.cpp
+    yarp/dev/tests/IRGBDSensorTest.cpp
+)
+
 if(TARGET YARP::YARP_math)
-target_sources(YARP_dev_tests
-  PRIVATE
-      yarp/dev/tests/IFrameGrabberImageTest.cpp
+  list(APPEND YARP_dev_test_HDRS
       yarp/dev/tests/IFrameGrabberImageTest.h
-      yarp/dev/tests/IRgbVisualParamsTest.cpp
       yarp/dev/tests/IRgbVisualParamsTest.h
-      yarp/dev/tests/IFrameTransformTest.cpp
       yarp/dev/tests/IFrameTransformTest.h
-      yarp/dev/tests/IMap2DTest.cpp
       yarp/dev/tests/IMap2DTest.h
-      yarp/dev/tests/INavigation2DTest.cpp
       yarp/dev/tests/INavigation2DTest.h
-      yarp/dev/tests/IDummyTest.cpp
       yarp/dev/tests/IDummyTest.h
-      yarp/dev/tests/IRangefinder2DTest.cpp
       yarp/dev/tests/IRangefinder2DTest.h
-      yarp/dev/tests/IPositionControlTest.cpp
       yarp/dev/tests/IPositionControlTest.h
-      yarp/dev/tests/ITorqueControlTest.cpp
       yarp/dev/tests/ITorqueControlTest.h
-      yarp/dev/tests/IAxisInfoTest.cpp
       yarp/dev/tests/IAxisInfoTest.h
-      yarp/dev/tests/IOrientationSensorsTest.cpp
       yarp/dev/tests/IOrientationSensorsTest.h
-      yarp/dev/tests/IRGBDSensorTest.cpp
       yarp/dev/tests/IRGBDSensorTest.h
-)
-else()
-target_sources(YARP_dev_tests
-  PRIVATE
+      )
+  list(APPEND YARP_dev_test_SRCS
+      yarp/dev/tests/IFrameGrabberImageTest.cpp
+      yarp/dev/tests/IRgbVisualParamsTest.cpp
+      yarp/dev/tests/IFrameTransformTest.cpp
+      yarp/dev/tests/INavigation2DTest.cpp
       yarp/dev/tests/IDummyTest.cpp
-      yarp/dev/tests/IDummyTest.h
+      yarp/dev/tests/IRangefinder2DTest.cpp
       yarp/dev/tests/IPositionControlTest.cpp
-      yarp/dev/tests/IPositionControlTest.h
       yarp/dev/tests/ITorqueControlTest.cpp
-      yarp/dev/tests/ITorqueControlTest.h
       yarp/dev/tests/IAxisInfoTest.cpp
-      yarp/dev/tests/IAxisInfoTest.h
+      yarp/dev/tests/IOrientationSensorsTest.cpp
       yarp/dev/tests/IRGBDSensorTest.cpp
-      yarp/dev/tests/IRGBDSensorTest.h
-)
+      yarp/dev/tests/IMap2DTest.cpp
+      )
 endif()
 
 target_include_directories(YARP_dev_tests
   PRIVATE
     ${CMAKE_SOURCE_DIR}/extern/catch2
+)
+
+target_sources(YARP_dev_tests
+  PRIVATE
+    ${YARP_dev_test_SRCS}
+    ${YARP_dev_test_HDRS}
 )
 
 target_compile_definitions(YARP_dev_tests PUBLIC YARP_dev_EXPORTS=1)
@@ -453,7 +462,7 @@ target_link_libraries(YARP_dev_tests PRIVATE YARP_dev)
 target_compile_features(YARP_dev_tests PRIVATE cxx_std_17)
 
 set_property (
-TARGET YARP_dev_tests
+  TARGET YARP_dev_tests
   PROPERTY FOLDER "Test"
 )
 
@@ -462,5 +471,27 @@ set_property(
   PROPERTY
     PUBLIC_HEADER
       ${YARP_dev_HDRS}
-      yarp/dev/tests/IMap2DTest.h
+      ${YARP_dev_test_HDRS}
+)
+
+set_property(TARGET YARP_dev_tests PROPERTY VERSION ${YARP_VERSION_SHORT})
+set_property(TARGET YARP_dev_tests PROPERTY SOVERSION ${YARP_SOVERSION})
+set_property(TARGET YARP_dev_tests PROPERTY FOLDER "Test")
+
+ install(
+  TARGETS YARP_dev_tests
+  EXPORT YARP_dev_tests
+  RUNTIME
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT YARP_dev_tests
+  LIBRARY
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    COMPONENT YARP_dev_tests
+    NAMELINK_COMPONENT YARP_dev_tests-dev
+  ARCHIVE
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    COMPONENT YARP_dev_tests-dev
+  PUBLIC_HEADER
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/yarp/dev/tests"
+    COMPONENT YARP_dev_tests-dev
 )


### PR DESCRIPTION
A new library `yarp_dev_tests`: is now exported. It contains common sources to test yarp devices through lib_yarpdev (also outside yarp repo).