### PR TITLE
yarp_tests_skipped incapsulation

### DIFF
--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -143,6 +143,10 @@ static void fini_NameStore()
 
 } // namespace
 
+void increment_tests_skipped()
+{
+    ++yarp_tests_skipped;
+}
 
 int main(int argc, char *argv[])
 {

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -14,11 +14,11 @@
 #include <iostream>
 #include <catch.hpp>
 
-extern int yarp_tests_skipped;
+void increment_tests_skipped();
 
 #define YARP_SKIP_TEST(...) \
 { \
-    ++yarp_tests_skipped; \
+    increment_tests_skipped(); \
     FAIL(__VA_ARGS__); \
 }
 


### PR DESCRIPTION
`yarp_tests_skipped` variable is now hidden inside `harness.cpp` and accessible only using `increment_tests_skipped()` function.
This allows easier export of library symbols.