### PR TITLE
Relax requirement on timestamp consistency checker

### DIFF
--- a/doc/release/master/nws_yarp_consistency.md
+++ b/doc/release/master/nws_yarp_consistency.md
@@ -1,0 +1,15 @@
+nws_yarp_consistency {#master}
+-------------------
+
+### Devices
+
+#### `controlBoard_nws_yarp`
+
+* A consistency checker prevented from broadcasting any motor state if, among
+  the latest retrieved encoder timestamps, there were two whose difference was
+  greater than one second. This helped to obtain a sensible average timestamp
+  for consumers (such as remotecontrolboard), but was too conservative if state
+  was expected to be published anyway as long as there is at least one subdevice
+  still reporting valid data. This has been changed to compare against the
+  current timestamp instead, and thus support the latter scenario.
+


### PR DESCRIPTION
Don't account for inconsistent timestamps (e.g due to disconnection or hardware error) as long as there is at least one subdevice still reporting current data. Use valid timestamps only for obtaining the average timestamp used as envelope in broadcast state messages.

Also, throttle the inconsistency error message to avoid flooding logs.