### PR TITLE
Fix handling of `IRemoteVariables` messages via RPC

### DIFF
--- a/doc/release/yarp_3_7/cbw_remote_vars.md
+++ b/doc/release/yarp_3_7/cbw_remote_vars.md
@@ -1,0 +1,8 @@
+cbw_remote_vars {#yarp_3_7}
+-------------------
+
+### Devices
+
+#### `controlBoard_nws_yarp`
+
+* Fix handling of `IRemoteVariables` messages via RPC.

--- a/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
+++ b/src/devices/ControlBoardWrapper/RPCMessagesParser.cpp
@@ -1232,10 +1232,10 @@ void RPCMessagesParser::handlePWMMsg(const yarp::os::Bottle& cmd, yarp::os::Bott
 
 void RPCMessagesParser::handleRemoteVariablesMsg(const yarp::os::Bottle& cmd, yarp::os::Bottle& response, bool* rec, bool* ok)
 {
-    yCTrace(CONTROLBOARD, "Handling IRemoteCalibrator message");
+    yCTrace(CONTROLBOARD, "Handling IRemoteVariables message");
 
-    if (!rpc_IRemoteCalibrator) {
-        yCError(CONTROLBOARD, "controlBoardWrapper: I do not have a valid IRemoteCalibrator interface");
+    if (!rpc_IVar) {
+        yCError(CONTROLBOARD, "controlBoardWrapper: I do not have a valid IRemoteVariables interface");
         *ok = false;
         return;
     }


### PR DESCRIPTION
Bugfix: a wrong pointer check could prevent from parsing remote `IRemoteVariables` commands.