### PR TITLE
portmonitor `image_rotation`

### DIFF
--- a/doc/release/master/portmoinitor_imagerotation.md
+++ b/doc/release/master/portmoinitor_imagerotation.md
@@ -1,0 +1,9 @@
+portmonitor_imagerotation {#master}
+-----------
+
+### `portmonitor`
+
+#### `image_rotation`
+
+* added new portmonitor `image_rotation`
+

--- a/src/portmonitors/CMakeLists.txt
+++ b/src/portmonitors/CMakeLists.txt
@@ -16,6 +16,7 @@ yarp_begin_plugin_library(yarppm
   add_subdirectory(depthimage_to_rgb)
   add_subdirectory(depthimage_to_vector)
   add_subdirectory(image_compression_ffmpeg)
+  add_subdirectory(image_rotation)
   add_subdirectory(rpc_monitor)
   add_subdirectory(segmentationimage_to_rgb)
   add_subdirectory(sound_compression_mp3)

--- a/src/portmonitors/image_rotation/CMakeLists.txt
+++ b/src/portmonitors/image_rotation/CMakeLists.txt
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+yarp_prepare_plugin(image_rotation
+  TYPE ImageRotation
+  INCLUDE imageRotation.h
+  CATEGORY portmonitor
+  DEPENDS "ENABLE_yarpcar_portmonitor"
+)
+
+if(SKIP_image_rotation)
+  return()
+endif()
+
+yarp_add_plugin(yarp_pm_image_rotation)
+
+target_sources(yarp_pm_image_rotation
+  PRIVATE
+    imageRotation.cpp
+    imageRotation.h
+)
+target_link_libraries(yarp_pm_image_rotation
+  PRIVATE
+    YARP::YARP_os
+    YARP::YARP_sig
+    YARP::YARP_cv
+)
+list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+  YARP_os
+  YARP_sig
+)
+
+ target_include_directories(yarp_pm_image_rotation SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS})
+ target_link_libraries(yarp_pm_image_rotation PRIVATE ${OpenCV_LIBRARIES})
+
+yarp_install(
+  TARGETS yarp_pm_image_rotation
+  EXPORT YARP_${YARP_PLUGIN_MASTER}
+  COMPONENT ${YARP_PLUGIN_MASTER}
+  LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+  ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+  YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+)
+
+set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+set_property(TARGET yarp_pm_image_rotation PROPERTY FOLDER "Plugins/Port Monitor")

--- a/src/portmonitors/image_rotation/imageRotation.cpp
+++ b/src/portmonitors/image_rotation/imageRotation.cpp
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "imageRotation.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/sig/Image.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/videoio/videoio.hpp>
+
+using namespace yarp::os;
+using namespace yarp::sig;
+
+namespace {
+YARP_LOG_COMPONENT(IMAGEROTATION,
+                   "yarp.carrier.portmonitor.image_rotation",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)
+}
+
+bool ImageRotation::create(const yarp::os::Property& options)
+{
+    //parse the user parameters
+    yarp::os::Property m_user_params;
+    yCDebug(IMAGEROTATION) << "user params:" << options.toString();
+    std::string str = options.find("carrier").asString();
+    getParamsFromCommandLine(str, m_user_params);
+    yCDebug(IMAGEROTATION) << "parsed params:" << m_user_params.toString();
+
+    if (m_user_params.check("options_rotate"))
+    {
+        m_options_rotate_str = m_user_params.find("options_rotate").asString();
+    }
+    if (m_options_rotate_str == std::string("rotate_cw"))
+    {
+        m_rot_flags = cv::ROTATE_90_CLOCKWISE;
+    }
+    else if (m_options_rotate_str == std::string("rotate_ccw"))
+    {
+        m_rot_flags = cv::ROTATE_90_COUNTERCLOCKWISE;
+    }
+    else
+   {
+        yCDebug(IMAGEROTATION) << "Invalid value of `options` parameter";
+        return false;
+    }
+    return true;
+}
+
+void ImageRotation::destroy()
+{
+}
+
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
+    std::istringstream iss(s);
+    std::string item;
+    while (std::getline(iss, item, delim)) {
+        elements.push_back(item);
+    }
+}
+
+void ImageRotation::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
+{
+    // Split command line string using '+' delimiter
+    std::vector<std::string> parameters;
+    split(carrierString, '+', parameters);
+
+    // Iterate over result strings
+    for (std::string param : parameters)
+    {
+        // If there is no '.', then the param is bad formatted, skip it.
+        auto pointPosition = param.find('.');
+        if (pointPosition == std::string::npos)
+        {
+            continue;
+        }
+
+        // Otherwise, separate key and value
+        std::string paramKey = param.substr(0, pointPosition);
+        yarp::os::Value paramValue;
+        std::string s = param.substr(pointPosition + 1, param.length());
+        paramValue.fromString(s.c_str());
+
+        //and append to the returned property
+        prop.put(paramKey, paramValue);
+    }
+    return;
+}
+
+bool ImageRotation::setparam(const yarp::os::Property& params)
+{
+    return false;
+}
+
+bool ImageRotation::getparam(yarp::os::Property& params)
+{
+    return false;
+}
+
+bool ImageRotation::accept(yarp::os::Things& thing)
+{
+    auto* img = thing.cast_as<yarp::sig::FlexImage>();
+    if(img == nullptr)
+    {
+        yCError(IMAGEROTATION, "Expected type FlexImage but got wrong data type!");
+        return false;
+    }
+    if (img->getPixelCode() != VOCAB_PIXEL_RGB &&
+        img->getPixelCode() != VOCAB_PIXEL_MONO_FLOAT)
+    {
+        yCError(IMAGEROTATION, "Expected type FlexImage but got wrong data type!");
+        return false;
+    }
+    return true;
+}
+
+yarp::os::Things& ImageRotation::update(yarp::os::Things& thing)
+{
+    yarp::sig::FlexImage* flximg = thing.cast_as<yarp::sig::FlexImage >();
+    if (flximg->getPixelCode() == VOCAB_PIXEL_RGB)
+    {
+        m_cvInImage = yarp::cv::toCvMat(*flximg);
+
+        m_outImgRgb.resize(flximg->width(), flximg->height());
+        m_outImgRgb.zero();
+
+        //double angle = 90;
+        //cv::Point2f center((flximg->width() - 1) / 2.0, (flximg->height() - 1) / 2.0);
+        //cv::Mat rotation_matix = getRotationMatrix2D(center, angle, 1.0);
+        //cv::warpAffine(cvInImage, cvOutImage, rotation_matix, cvInImage.size());
+
+        cv::rotate(m_cvInImage, m_cvOutImage, m_rot_flags);
+
+        m_outImgRgb = yarp::cv::fromCvMat<yarp::sig::PixelRgb>(m_cvOutImage);
+        m_th.setPortWriter(&m_outImgRgb);
+    }
+    else if (flximg->getPixelCode() == VOCAB_PIXEL_MONO_FLOAT)
+    {
+        m_cvInImage = yarp::cv::toCvMat(*flximg);
+
+        m_outImgFloat.resize(flximg->width(), flximg->height());
+        m_outImgFloat.zero();
+
+        //double angle = 90;
+        //cv::Point2f center((flximg->width() - 1) / 2.0, (flximg->height() - 1) / 2.0);
+        //cv::Mat rotation_matix = getRotationMatrix2D(center, angle, 1.0);
+        //cv::warpAffine(cvInImage, cvOutImage, rotation_matix, cvInImage.size());
+
+        cv::rotate(m_cvInImage, m_cvOutImage, m_rot_flags);
+
+        m_outImgFloat = yarp::cv::fromCvMat<yarp::sig::PixelFloat>(m_cvOutImage);
+        m_th.setPortWriter(&m_outImgFloat);
+    }
+    else
+    {
+        yCError(IMAGEROTATION, "Invalid Image type!");
+    }
+    return m_th;
+}

--- a/src/portmonitors/image_rotation/imageRotation.h
+++ b/src/portmonitors/image_rotation/imageRotation.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_PORTMONITOR_IMAGEROTATION_H
+#define YARP_PORTMONITOR_IMAGEROTATION_H
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Things.h>
+#include <yarp/os/MonitorObject.h>
+#include <yarp/sig/Image.h>
+#include <yarp/cv/Cv.h>
+
+ /**
+  * @ingroup portmonitors_lists
+  * \brief `image_rotation`: Documentation to be added
+  * example usage:
+  * yarp connect /grabber/depth:o /yarpview/img:i tcp+recv.portmonitor+type.dll+file.image_rotation
+  * yarp connect /grabber/depth:o /yarpview/img:i tcp+recv.portmonitor+type.dll+file.image_rotation+options_rotate.rotate_ccw
+  */
+class ImageRotation : public yarp::os::MonitorObject
+{
+public:
+    bool create(const yarp::os::Property& options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property& params) override;
+    bool getparam(yarp::os::Property& params) override;
+
+    bool accept(yarp::os::Things& thing) override;
+    yarp::os::Things& update(yarp::os::Things& thing) override;
+
+    void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop);
+
+private:
+
+    yarp::os::Bottle m_bt;
+    yarp::os::Things m_th;
+    yarp::sig::ImageOf<yarp::sig::PixelFloat> m_outImgFloat;
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> m_outImgRgb;
+
+    std::string m_options_rotate_str = "rotate_cw";
+    cv::RotateFlags m_rot_flags;
+    cv::Mat m_cvInImage;
+    cv::Mat m_cvOutImage;
+};
+
+#endif  // YARP_PORTMONITOR_IMAGEROTATION_H


### PR DESCRIPTION
added new portmonitor `image_rotation`

e.g.
`yarp connect /grabber/depth:o /yarpview/img:i tcp+recv.portmonitor+type.dll+file.image_rotation+options_rotate.rotate_ccw`