### PR TITLE
[ISSUE-2889] SWIG leak on yarp::os::Type

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -44,6 +44,7 @@
 
 %import <yarp/os/api.h>
 
+
 // YARP_sig
 %{
 #include <yarp/sig/api.h>
@@ -366,6 +367,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %include <yarp/os/LogStream.h>
 %include <yarp/os/Wire.h>
 %include <yarp/os/WireLink.h>
+%include <yarp/os/Type.h>
 
 %define MAKE_COMMS(name)
 %feature("notabstract") yarp::os::BufferedPort<name>;

--- a/doc/release/master/yarp_python_bindings_update.md
+++ b/doc/release/master/yarp_python_bindings_update.md
@@ -1,0 +1,8 @@
+yarp_python_bindings {#master}
+------------------------------
+
+Branch: [fbrand-new:bugfix/is-2889](https://github.com/fbrand-new/yarp/tree/bugfix/is-2889)
+
+### `Bindings`
+
+* Added explicit include of os/Type.h in bindings file to fix swig complain about missing destructor [#2889](https://github.com/robotology/yarp/issues/2889)


### PR DESCRIPTION
Fixes bug described in https://github.com/robotology/yarp/issues/2889.

Thanks @PeterBowman for the hint!

