### PR TITLE
Change build path for yarp tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,13 +26,6 @@ endif()
 
 
 #########################################################################
-# Control where test libraries and executables are placed during the build
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/tests")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/tests")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/tests")
-
-
-#########################################################################
 # Prepare 'build_generator' and 'build_options' variables
 # for tests in subdirectories
 set(build_generator --build-generator "${CMAKE_GENERATOR}")


### PR DESCRIPTION
Tests are no longer placed in /build/tests folder.
Instead, they are now placed into /build folder.
This is required to fix some CI issues, i.e. the tests placed into /build/tests were not able to find some yarp libraries without appending the /build folder to path (in Win32)
Discussed with @traversaro 