### PR TITLE
CI path cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,13 +857,6 @@ jobs:
           else()
             file(APPEND "${_env_script}" "set(ENV{PATH} \"\$ENV{PATH};C:\\\\robotology\\\\vcpkg\\\\installed\\\\x64-windows\\\\debug\\\\bin\")\n")
           endif()
-
-          # Append output bin directory to the PATH
-          if("${{ matrix.config.cmake_generator }}" MATCHES "Visual Studio")
-            file(APPEND "${_env_script}" "set(ENV{PATH} \"\$ENV{PATH};\$ENV{GITHUB_WORKSPACE}\\\\build\\\\bin\\\\${{ matrix.config.build_type }}\")\n")
-          elseif("${{ matrix.config.cmake_generator }}" MATCHES "Ninja")
-            file(APPEND "${_env_script}" "set(ENV{PATH} \"\$ENV{PATH};\$ENV{GITHUB_WORKSPACE}\\\\build\\\\bin\")\n")
-          endif()
         endif()
 
         file(APPEND "${_env_script}" "set(ENV{CC} ${{ matrix.config.cc }})\n")


### PR DESCRIPTION
CI cleanup: removed build/bin from the PATH environment variable since it is no more needed after https://github.com/robotology/yarp/pull/2943