### PR TITLE
Fix retrieval of gearbox ratio in controlBoardRemapper

### DIFF
--- a/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/devices/ControlBoardRemapper/ControlBoardRemapper.cpp
@@ -2074,7 +2074,7 @@ bool ControlBoardRemapper::setTemperatureLimit (int m, const double val)
 
 bool ControlBoardRemapper::getGearboxRatio(int m, double* val)
 {
-    int off = (int)remappedControlBoards.lut[m].subControlBoardIndex;
+    int off = (int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
     size_t subIndex = remappedControlBoards.lut[m].subControlBoardIndex;
 
     RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);
@@ -2094,7 +2094,7 @@ bool ControlBoardRemapper::getGearboxRatio(int m, double* val)
 
 bool ControlBoardRemapper::setGearboxRatio(int m, const double val)
 {
-    int off = (int)remappedControlBoards.lut[m].subControlBoardIndex;
+    int off = (int)remappedControlBoards.lut[m].axisIndexInSubControlBoard;
     size_t subIndex = remappedControlBoards.lut[m].subControlBoardIndex;
 
     RemappedSubControlBoard *p = remappedControlBoards.getSubControlBoard(subIndex);


### PR DESCRIPTION
This PR fixes a bug that arises when a user tries to get the gearbox ratio when a part uses the remapper. 

For example, let two sets of joints of a specific part have the following parameters:

```
set_1:
joint indices (0 1 2)
gear ratios (10 20 30)

set_2:
joint indices (3 4 5)
gear ratios (30 40 50)

remapper:
set_1 (0 2 0 2)
set_2 (3 5 0 2)
```

Without the fix, trying to get the gearbox ratio of all the robot part returns: `(10 10 10 40 40 40)`, because the index of the subcontrolboard is used. 
Instead, with the fix it should of course be: `(10 20 30 40 50 60)`.

The fix was successfully tested on iCub3.

Targeting yarp 3.7 as it's a bugfix, not sure if it's the correct branch.

cc @pattacini 