### PR TITLE
yarpdataplayer high-rate fix

### DIFF
--- a/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
+++ b/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
@@ -650,10 +650,9 @@ void DataplayerWorker::run()
             ret = sendImages(part, frame);
         }
         else if (strcmp(utilities->partDetails[part].type.c_str(), "Bottle") == 0)  {
-            ret = sendBottle(part, frame);
-            // the above line can be safely replaced with sendGenericData<Bottle>.
-            // I kept it for no particular reason, thinking that maybe it could be convenient (later)
-            // to process Bottles in a different way.
+            ret = sendGenericData<Bottle>(part, frame);
+            //the above line could be replaced with sendBottle(part, frame) if 
+            //specifically different behaviour is required for a bottle.
         }
         else if (strcmp(utilities->partDetails[part].type.c_str(), "sensor_msgs/LaserScan") == 0)  {
             ret = sendGenericData<yarp::rosmsg::sensor_msgs::LaserScan>(part, frame);
@@ -720,6 +719,10 @@ int DataplayerWorker::sendBottle(int part, int frame)
 
     Bottle& outBot = the_port->prepare();
     outBot = tmp;
+
+    /* Note: sendBottle differs from sendGenericData as the envelope is a single
+             timestamp, ionstead of the standard yarp::os::Stamp which includes
+             also the sequence number */
 
     //propagate timestamp
     std::string time = yarp::conf::numeric::to_string(utilities->partDetails[part].timestamp[frame]);
@@ -1053,43 +1056,48 @@ void DataplayerEngine::stepFromCmd()
 /**********************************************************/
 void DataplayerEngine::runNormally()
 {
-    for (int i=0; i < this->numPart; i++){
-        bool isActive = this->isPartActive[i];
-        if ( this->utilities->partDetails[i].currFrame <= this->utilities->partDetails[i].maxFrame ){
-            if ( this->virtualTime >= this->utilities->partDetails[i].timestamp[ this->utilities->partDetails[i].currFrame ] ){
-                if ( this->initTime > 300 && this->virtualTime < this->utilities->partDetails[i].timestamp[this->utilities->partDetails[i].timestamp.length()-1]){
-                    this->initTime = 0;
-                }
-                if (!this->utilities->partDetails[i].hasNotified){
-                    this->utilities->partDetails[i].worker->sendData(this->utilities->partDetails[i].currFrame, isActive, this->virtualTime );
-                    this->utilities->partDetails[i].currFrame++;
-                }
-            }
-        } else {
-            if (this->utilities->repeat) {
-                this->initThread();
-                this->utilities->partDetails[i].worker->init();
-            } else {
-                if ( !this->utilities->partDetails[i].hasNotified ) {
-                    if (utilities->verbose){
-                        yInfo() << "partID:" << i << "has finished";
-                    }
-                    this->utilities->partDetails[i].hasNotified = true;
-                }
+    for (int i=0; i < this->numPart; i++) {
+        //get a reference to the part we are interested in
+        PartsData &this_part = this->utilities->partDetails[i];
 
+        //if we have alredy stopped we have nothing to do
+        if(this_part.hasNotified)
+            continue;
+        
+        //if this port is not active, keep progressing though the frames without
+        //sending, so if the part activates it is in synch
+        bool isActive = this->isPartActive[i];
+
+        //send all available frames up to the current virtualTime
+        while (this_part.currFrame <= this_part.maxFrame &&
+            this->virtualTime >= this_part.timestamp[this_part.currFrame]) {
+            this_part.worker->sendData(this_part.currFrame++, isActive, this->virtualTime);
+        }
+
+        //if we have sent all frames perform reset/stop
+        if(this_part.currFrame > this_part.maxFrame) {
+            if (this->utilities->repeat) {
+                //restart the part
+                this->initThread();
+                this_part.worker->init();
+            } else {
+                //this part has finished
+                if (utilities->verbose) {
+                    yInfo() << "partID:" << i << "has finished";
+                }
+                this_part.hasNotified = true;
+
+                //perform a check to see if ALL parts have finished
                 int stopAll = 0;
                 for (int x=0; x < this->numPart; x++){
-                    if (this->utilities->partDetails[x].hasNotified){
-                        stopAll++;
+                    stopAll += this->utilities->partDetails[x].hasNotified ? 1 : 0;
+                }
+                if (stopAll == this->numPart) {
+                    if (utilities->verbose) {
+                        yInfo() << "All parts have Finished!";
                     }
-
-                    if (stopAll == this->numPart){
-                        if (utilities->verbose) {
-                            yInfo() << "All parts have Finished!";
-                        }
-                        this->utilities->stopAtEnd();
-                        this->allPartsStatus = true;
-                    }
+                    this->utilities->stopAtEnd();
+                    this->allPartsStatus = true;
                 }
             }
         }
@@ -1097,7 +1105,6 @@ void DataplayerEngine::runNormally()
 
     this->virtualTime += this->diff_seconds() * this->utilities->speed;
     this->tick();
-    this->initTime++;
 }
 
 /**********************************************************/

--- a/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
+++ b/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp
@@ -651,7 +651,7 @@ void DataplayerWorker::run()
         }
         else if (strcmp(utilities->partDetails[part].type.c_str(), "Bottle") == 0)  {
             ret = sendGenericData<Bottle>(part, frame);
-            //the above line could be replaced with sendBottle(part, frame) if 
+            //the above line could be replaced with sendBottle(part, frame) if
             //specifically different behaviour is required for a bottle.
         }
         else if (strcmp(utilities->partDetails[part].type.c_str(), "sensor_msgs/LaserScan") == 0)  {
@@ -1063,7 +1063,7 @@ void DataplayerEngine::runNormally()
         //if we have alredy stopped we have nothing to do
         if(this_part.hasNotified)
             continue;
-        
+
         //if this port is not active, keep progressing though the frames without
         //sending, so if the part activates it is in synch
         bool isActive = this->isPartActive[i];

--- a/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.h
+++ b/src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.h
@@ -265,7 +265,7 @@ protected:
     public:
         void SetDataplayerEngine(DataplayerEngine &dataplayerEngine)
         { this->dataplayerEngine = &dataplayerEngine; }
-        dataplayer_thread (double _period=0.002);
+        dataplayer_thread (double _period=0.0001);
 
         bool        threadInit() override;
         void        run() override;

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -94,43 +94,52 @@ void QEngine::stepFromCmd()
 void QEngine::runNormally()
 {
     for (int i=0; i < this->numPart; i++){
-        bool isActive = ((MainWindow*)gui)->getPartActivation(qutils->partDetails[i].name.c_str());
-        if ( qutils->partDetails[i].currFrame <= qutils->partDetails[i].maxFrame ){
-            if ( this->virtualTime >= qutils->partDetails[i].timestamp[ qutils->partDetails[i].currFrame ] ){
-                if ( this->initTime > 300 && this->virtualTime < qutils->partDetails[i].timestamp[qutils->partDetails[i].timestamp.length()-1]){
-                    emit qutils->updateGuiThread();
-                    this->initTime = 0;
-                }
-                if (!qutils->partDetails[i].hasNotified){
-                    qutils->partDetails[i].worker->sendData(qutils->partDetails[i].currFrame, isActive, this->virtualTime );
-                    qutils->partDetails[i].currFrame++;
-                }
-            }
-        } else {
+        //get a reference to the part we are interested in
+        yarp::yarpDataplayer::PartsData &this_part = qutils->partDetails[i];
+
+        //if we have alredy stopped we have nothing to do
+        if(this_part.hasNotified)
+            continue;
+            
+        //if this port is not active, keep progressing though the frames without
+        //sending, so if the part activates it is in synch
+        bool isActive = ((MainWindow*)gui)->getPartActivation(this_part.name.c_str());
+
+        //send all available frames up to the current virtualTime
+        while (this_part.currFrame <= this_part.maxFrame &&
+            this->virtualTime >= this_part.timestamp[this_part.currFrame]) {
+            this_part.worker->sendData(this_part.currFrame++, isActive, this->virtualTime);
+        }
+
+        //check if to update the Gui
+        if (this->initTime > 300 && this->virtualTime < this_part.timestamp[this_part.timestamp.length() - 1]) {
+            emit qutils->updateGuiThread();
+            this->initTime = 0;
+        }
+
+        //if we have sent all frames perform reset/stop
+        if(this_part.currFrame > this_part.maxFrame) {
             if (qutils->repeat) {
                 this->initThread();
-                qutils->partDetails[i].worker->init();
+                this_part.worker->init();
             } else {
-                if ( !qutils->partDetails[i].hasNotified ) {
-                    yInfo() << "partID: " <<  i << " has finished";
-                    qutils->partDetails[i].hasNotified = true;
-                }
+                yInfo() << "partID: " <<  i << " has finished";
+                this_part.hasNotified = true;
 
+                //perform a check to see if ALL parts have finished
                 int stopAll = 0;
                 for (int x=0; x < this->numPart; x++){
-                    if (qutils->partDetails[x].hasNotified){
-                        stopAll++;
-                    }
+                    stopAll += qutils->partDetails[x].hasNotified ? 1 : 0;
+                }
 
-                    if (stopAll == this->numPart){
-                        yInfo() << "All parts have Finished!";
-                        if (qutils->partDetails[i].currFrame > 1) {
-                            emit qutils->updateGuiThread();
-                        }
-                        qutils->stopAtEnd();
-                        qutils->resetButton();
-                        allPartsStatus = true;
+                if (stopAll == this->numPart){
+                    yInfo() << "All parts have Finished!";
+                    if (this_part.currFrame > 1) {
+                        emit qutils->updateGuiThread();
                     }
+                    qutils->stopAtEnd();
+                    qutils->resetButton();
+                    allPartsStatus = true;
                 }
             }
         }

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -146,7 +146,7 @@ void QEngine::runNormally()
 
     //10 Hz gui update
     static double gui_tic = 0.0;
-    if(this->virtualTime < gui_tic || this->virtualTime - gui_tic > 0.1) { 
+    if(this->virtualTime < gui_tic || this->virtualTime - gui_tic > 0.1) {
          emit qutils->updateGuiThread();
          gui_tic = this->virtualTime;
     }

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -100,7 +100,7 @@ void QEngine::runNormally()
         //if we have alredy stopped we have nothing to do
         if(this_part.hasNotified)
             continue;
-            
+
         //if this port is not active, keep progressing though the frames without
         //sending, so if the part activates it is in synch
         bool isActive = ((MainWindow*)gui)->getPartActivation(this_part.name.c_str());


### PR DESCRIPTION
This pull request applies a bug-fix and an update for high-frequency to `yarpdataplayer`.

`src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp#L653`

The function `sendBottle(part, frame)` sends the envelope as a `Bottle(timestamp)` which is inconsistent with `yarpdatadumper` which saves the envelope as a `yarp::os::Stamp` - i.e. sequence number and timestamp. This causes invalid envelopes when reading the envelopes sent by `yarpdatadumper` as a `Stamp`.

The function is changed to `sendGenericData<Bottle>(part, frame)` as it sends the envelope as a `Stamp` by default. In the comments of the code it suggests that the functions are "identical" and therefore this was probably something overlooked, and not intentional.

This bug completely breaks all timestamps for EDPR when using `yarpdataplayer`, but I'm not sure if others have normalised using only timestamps when reading `Bottle`s from `yarpdataplayer`. However, it is inconsistent with all other functions.

`src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.h#L268`

Update the thread rate of the periodic_thread to have higher temporal resolution - `2 ms` -> `0.1 ms`. In particular for event-camera datasets which can have sub millisecond packet resolution. Higher thread rate did not affect slow datasets, it may increase processing, but the CPU utilisation was `<1%` under both thread rate values. 

 `src/libYARP_dataplayer/src/yarp/dataplayer/YarpDataplayer.cpp`

`src/yarpdataplayer/src/worker.cpp`

`runNormally()` is performed in both these threads for GUI v.s. non-GUI operation. I've updated in both locations to change an 
`if(...)` -> sends only a single frame on any periodic_thread update. Multiple packets can "build-up" for high-frequency datasets or if the periodic_thread is delayed from the OS - to -
`while(..)` -> sends **all** frames of data that have not yet been sent and should have given the `virtualTime`. This change keeps multiple parts in synch much more robustly.

It made sense to restructure the `runNormally()` function to de-clutter the change in logic required to perform this change.
