### PR TITLE
MultipleAnalogSensorsClient: Increase default timeout parameter to 0.02 seconds

### DIFF
--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -64,7 +64,7 @@ bool MultipleAnalogSensorsClient::open(yarp::os::Searchable& config)
     std::string local = config.find("local").asString();
 
     // Optional timeout parameter
-    m_streamingPort.timeoutInSeconds = config.check("timeout", yarp::os::Value(0.01), "Timeout parameter").asFloat64();
+    m_streamingPort.timeoutInSeconds = config.check("timeout", yarp::os::Value(0.02), "Timeout parameter").asFloat64();
 
     m_localRPCPortName = local + "/rpc:i";
     m_localStreamingPortName = local + "/measures:i";

--- a/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
+++ b/src/devices/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
@@ -47,7 +47,7 @@ public:
 * |:------------------:|:--------------:|:-------:|:--------------:|:-------------:|:------------:|:--------------------------------------------------------------------------------------:|:-----:|
 * | remote             |       -        | string  | -              |   -           | Yes          | Prefix of the ports to which to connect, opened by MultipleAnalogSensorsServer device. |       |
 * | local              |       -        | string  | -              |   -           | Yes          | Port prefix of the ports opened by this device.                                        |       |
-* | timeout            |       -        | double  | seconds        | 0.01          | No           | Timeout after which the device reports an error if no measurement was received.        |       |
+* | timeout            |       -        | double  | seconds        | 0.02          | No           | Timeout after which the device reports an error if no measurement was received.        |       |
 * | externalConnection |       -        | bool    | -              | false         | No           | If set to true, the connection to the rpc port of the MAS server is skipped and it is possible to connect to the data source externally after being opened | Use case: e.g yarpdataplayer source. Note that with this configuration some information like sensor name, frame name and sensor number will be not available.|
 * | carrier            |     -          | string  | -              | tcp           | No           | The carier used for the connection with the server.          |  |
 *


### PR DESCRIPTION
The previous one was `0.01` but since almost all our sensors has a period ~ `0.01` this made  trigger a lot of timeout errors

cc @traversaro @pattacini @davidetome 