### PR TITLE
Merge `setAlignment` commands in yarpmotorgui

### DIFF
--- a/doc/release/yarp_3_8/yarpmotorgui_cpu.md
+++ b/doc/release/yarp_3_8/yarpmotorgui_cpu.md
@@ -1,0 +1,8 @@
+yarpmotorgui_cpu {#yarp_3_8}
+-----------
+
+### tools
+
+#### `yarpmotorgui`
+
+* Fixed an issue regarding high CPU usage (#2955).

--- a/src/yarpmotorgui/sliderWithTarget.cpp
+++ b/src/yarpmotorgui/sliderWithTarget.cpp
@@ -106,31 +106,25 @@ void SliderWithTarget::paintEvent(QPaintEvent *e)
         double value = this->value();
         double newX = ((double)w / (double)totValues) * ((double)value + abs(this->minimum()));
         QString label_text = QString("%L1").arg((double)value / sliderStep, 0, 'f', number_of_decimals);
-        int label_text_siz = label_text.size();
         sliderCurrentLabel->setText(label_text);
-        sliderCurrentLabel->setAlignment(Qt::AlignLeft);
-        sliderCurrentLabel->setAlignment(Qt::AlignVCenter);
+        sliderCurrentLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         //these adjustment are required to have the label properly aligned and
         //to avoid overflow
-        double newX2 = newX;
-        if (newX2<0) newX2 = 0;
-        if (newX2>w-30) newX2 = w-30;
-        sliderCurrentLabel->setGeometry(newX2, -10, 60, 20);
+        if (newX<0) newX = 0;
+        if (newX>w-30) newX = w-30;
+        sliderCurrentLabel->setGeometry(newX, -10, 60, 20);
     }
     if (enableViewTargetValue)
     {
         double newX = ((double)w / (double)totValues) * ((double)target + abs(this->minimum()));
         QString label_text = QString("Ref:%L1").arg((double)target, 0, 'f', number_of_decimals);
-        int label_text_siz = label_text.size();
         sliderTargetLabel->setText(label_text);
-        sliderCurrentLabel->setAlignment(Qt::AlignLeft);
-        sliderCurrentLabel->setAlignment(Qt::AlignVCenter);
+        sliderTargetLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         //these adjustment are required to have the label properly aligned and
         //to avoid overflow
-        double newX2 = newX;
-        if (newX2 < 0) newX2 = 0;
-        if (newX2 > w - 30) newX2 = w - 30;
-        sliderTargetLabel->setGeometry(newX2, +10, 60, 20);
+        if (newX < 0) newX = 0;
+        if (newX > w - 30) newX = w - 30;
+        sliderTargetLabel->setGeometry(newX, +10, 60, 20);
     }
     else
     {


### PR DESCRIPTION
Fixes https://github.com/robotology/yarp/issues/2955. Apparently, CPU usage skyrockets when these commands are split, and also the application segfaults on exit. I merged them following [the API docs](https://doc.qt.io/qt-5/qt.html#AlignmentFlag-enum) and verified that `Qt::AlignLeft` and `Qt::AlignVCenter` cope well together (had to check View > View Position Target Value).

cc @xEnVrE please give it a try on your end
cc @randaz81 regarding https://github.com/robotology/yarp/commit/54c1a6f2151984985a227ee9083aecf89402fcbb (https://github.com/robotology/yarp/pull/2947).