### PR TITLE
Fix segmentation fault bug in multipleanalogsensorsserver YARP device

### DIFF
--- a/doc/release/yarp_3_8/master.md
+++ b/doc/release/yarp_3_8/master.md
@@ -1,6 +1,11 @@
-# Navigation2D nws 
+# Navigation2D nws
 
 Added a status:o port to the navigation server.
+
+# multipleanalogsensorsserver
+
+Fixed bug that resulted in a segmentation fault if one of the device to which
+`multipleanalogsensorsserver` was attached did not resized the measure vector.
 
 # Tests
 yarp tests moved from `tests` folder to individual library folders (e.g. libYARP_XXX)

--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -83,12 +83,29 @@ class MultipleAnalogSensorsServer :
                                             size_t (Interface::*getNrOfSensorsMethodPtr)() const,
                                             bool (Interface::*getNameMethodPtr)(size_t, std::string&) const);
 
+
+    // Helper methods to resize measure buffers
+    template<typename Interface>
+    bool resizeMeasureVectors(Interface* wrappedDeviceInterface,
+                              const std::vector< SensorMetadata >& metadataVector,
+                              std::vector< SensorMeasurement >& streamingDataVector,
+                              size_t (Interface::*getMeasureSizePtr)(size_t) const);
+    template<typename Interface>
+    bool resizeMeasureVectors(Interface* wrappedDeviceInterface,
+                              const std::vector< SensorMetadata >& metadataVector,
+                              std::vector< SensorMeasurement >& streamingDataVector,
+                              size_t measureSize);
+    bool resizeAllMeasureVectors(SensorStreamingData& streamingData);
+
+
+    // Helper method used to copy the sensor measure to the measure buffers
     template<typename Interface>
     bool genericStreamData(Interface* wrappedDeviceInterface,
                            const std::vector< SensorMetadata >& metadataVector,
                            std::vector< SensorMeasurement >& streamingDataVector,
                            yarp::dev::MAS_status (Interface::*getStatusMethodPtr)(size_t) const,
                            bool (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const);
+
 
 public:
     MultipleAnalogSensorsServer();

--- a/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
@@ -580,7 +580,7 @@ public:
      * Get the last reading of the specified sensor.
      *
      * @param[in] sens_index The index of the specified sensor (should be between 0 and getNrOfSkinPatches()-1).
-     * @param[out] out The requested measure. The vector should be getNrOfSkinPatches(sens_index)-dimensional.
+     * @param[out] out The requested measure. The vector should be getSkinPatchSize(sens_index)-dimensional.
      *                 The measure is expressed in implementation-specific unit of measure.
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      */


### PR DESCRIPTION
The bug occured once one of the device that was wrapped by multipleanalogsensorsserver did not resize the measure vector passed in the `get<...>Measure` call, for example because no sensor measurements were available.

The problem is solved by properly resizing the buffers before populating them, without relying on the wrapped device to do the necessary resizing.