### PR TITLE
mitigating yarpdataplayer GUI race condition

### DIFF
--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -960,7 +960,7 @@ void MainWindow::onMenuPlayBackStop()
             setFrameRate(qutilities->partDetails[i].name.c_str(), 0);
         }
         setPlayProgress(0);
-        
+
         ui->playButton->setIcon(QIcon(":/play.svg"));
         disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPause()));
         disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPlay()));

--- a/src/yarpdataplayer/src/mainwindow.cpp
+++ b/src/yarpdataplayer/src/mainwindow.cpp
@@ -932,10 +932,6 @@ void MainWindow::resetButtonOnStop()
 void MainWindow::onMenuPlayBackStop()
 {
     if (subDirCnt > 0){
-        ui->playButton->setIcon(QIcon(":/play.svg"));
-        disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPause()));
-        disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPlay()));
-        connect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPlay()));
 
         if (verbose){
             yInfo() << "asking the threads to stop...";
@@ -964,6 +960,11 @@ void MainWindow::onMenuPlayBackStop()
             setFrameRate(qutilities->partDetails[i].name.c_str(), 0);
         }
         setPlayProgress(0);
+        
+        ui->playButton->setIcon(QIcon(":/play.svg"));
+        disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPause()));
+        disconnect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPlay()));
+        connect(ui->playButton,SIGNAL(clicked()),this,SLOT(onMenuPlayBackPlay()));
     }
 }
 

--- a/src/yarpdataplayer/src/worker.cpp
+++ b/src/yarpdataplayer/src/worker.cpp
@@ -130,7 +130,7 @@ void QEngine::runNormally()
 
                 if (stopAll == this->numPart){
                     yInfo() << "All parts have Finished!";
-                    if (this_part.currFrame > 1) {
+                    if (this_part.currFrame > 1  && this->isRunning()) {
                         emit qutils->updateGuiThread();
                     }
                     qutils->stopAtEnd();
@@ -146,7 +146,7 @@ void QEngine::runNormally()
 
     //10 Hz gui update
     static double gui_tic = 0.0;
-    if(this->virtualTime < gui_tic || this->virtualTime - gui_tic > 0.1) {
+    if(this->virtualTime < gui_tic || this->virtualTime - gui_tic > 0.1 && this->isRunning()) {
          emit qutils->updateGuiThread();
          gui_tic = this->virtualTime;
     }


### PR DESCRIPTION
There seems to be a race condition in the `yarpdataplayer` GUI that causes the GUI to lock-up sometimes when pressing the stop button. I found it is the case when the worker thread is asked to `stop()` and is waiting to `join()`, that the thread is also often still waiting to return from an `updateGuiThread()`, which for some reason never happens. The race condition probably occurs more often after the GUI updates at a fast rate #2946 

To mitigate this 
  - `updateGUIThread()` is only called if the worker thread is still running (`worker.cpp`)
  - the worker thread is stopped before other operations that modify the GUI preventing both threads from attempting to update the GUI simultaneously (`mainwindow.cpp`)