### PR TITLE
opencv_grabber: Remove use of highgui include

### DIFF
--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -26,8 +26,8 @@
 
 #include <cstring> // memcpy
 
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/videoio/videoio.hpp>
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgproc.hpp>
 
 
 using yarp::dev::DeviceDriver;

--- a/src/devices/opencv/OpenCVGrabber.cpp
+++ b/src/devices/opencv/OpenCVGrabber.cpp
@@ -26,7 +26,6 @@
 
 #include <cstring> // memcpy
 
-#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/videoio/videoio.hpp>
 

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -20,6 +20,8 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
 
+#include <opencv2/videoio.hpp>
+
 /**
  * @ingroup dev_impl_media
  *

--- a/src/devices/opencv/OpenCVGrabber.h
+++ b/src/devices/opencv/OpenCVGrabber.h
@@ -20,8 +20,6 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
 
-#include <opencv2/highgui/highgui.hpp>
-
 /**
  * @ingroup dev_impl_media
  *


### PR DESCRIPTION
I was testing compilation of YARP against an opencv without highgui, and the compilation failed even if highgui is not actually used in `opencv_grabber`.