### PR TITLE
multipleanalogsensorsserver: Fix segmentation fault for sensors different from gyroscopes

### DIFF
--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -501,7 +501,7 @@ bool MultipleAnalogSensorsServer::genericStreamData(Interface* wrappedDeviceInte
             {
                 yCError(MULTIPLEANALOGSENSORSSERVER,
                         "Failure in reading data from sensor %s, no data will be sent on the port.",
-                        m_sensorMetadata.ThreeAxisGyroscopes[i].name.c_str());
+                        metadataVector[i].name.c_str());
                 return false;
             }
         }


### PR DESCRIPTION
Not sure why this ended up not to be included in https://github.com/robotology/yarp/pull/2967, for sure I had it during the testing.