### PR TITLE
Categories refactoring for yapr::dev: interfaces documentation

### DIFF
--- a/doc/module_yarp_dev/module_yarpdev.dox
+++ b/doc/module_yarp_dev/module_yarpdev.dox
@@ -31,6 +31,15 @@ Motor control and monitoring.
 
 */
 
+/**
+\ingroup dev_iface_motor
+
+\defgroup dev_iface_motor_raw Raw Motor Interfaces
+
+Motor control and monitoring (Raw version).
+
+*/
+
 
 /**
 \ingroup dev_iface
@@ -79,6 +88,15 @@ The interfaces in this group are to be implemented by devices who are meant to m
 \ingroup dev_iface
 
 \defgroup dev_iface_other Other Device Interfaces
+
+Sundry, miscellaneous.
+
+*/
+
+/**
+\ingroup dev_iface_other
+
+\defgroup dev_iface_other_raw Other Device Interfaces (Raw version)
 
 Sundry, miscellaneous.
 

--- a/doc/release/yarp_3_8/refactor_doc_libYARP_dev.md
+++ b/doc/release/yarp_3_8/refactor_doc_libYARP_dev.md
@@ -1,0 +1,37 @@
+refactor_doc_libYARP_dev {#yarp-3.8}
+-------------------
+
+### libYARP_dev interfaces doxygen tags
+
+#### `yarp::dev`
+
+- Added missing doxygen tags to:
+  - IAudioRender (`dev_iface_media`)
+  - ICalibrator (`dev_iface_motor`)
+  - IFrameGrabberControlsDC1394 (`dev_iface_media`)
+  - IFrameGrabberOf (`dev_iface_media`)
+  - IHapticDevice (`dev_iface_other`)
+  - IRemoteCalibrator (`dev_iface_motor`)
+  - IVisualServoing (`dev_iface_other`)
+- Created new `raw` tag inside `dev_iface_motor` and `dev_iface_other` to separate raw interfaces from the others.
+- Interfaces affected by this change (for some of them the tag was added since it was missing and for the other ones it was changes to the `raw` *sub-tag*):
+  - IAmplifierControlRaw (`dev_iface_motor_raw` - added)
+  - IAxisInfoRaw (`dev_iface_motor_raw` - added)
+  - IControlCalibrationRaw (`dev_iface_motor_raw` - added)
+  - IControlLimitsRaw (`dev_iface_motor_raw` - added)
+  - IControlModeRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - ICurrentControlRaw (`dev_iface_motor_raw` - added)
+  - IEncodersRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IEncodersTimedRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IInteractionModeRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IJointFaultRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IMotorRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IMotorEncodersRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IPWMControlRaw (`dev_iface_motor_raw` - added)
+  - IPidControlRaw (`dev_iface_motor_raw` - added)
+  - IPositionControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IPositionDirectRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IRemoteVariablesRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - ITorqueControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IVelocityControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
+  - IVirtualAnalogSensorRaw (`dev_iface_other_raw` - changed from `dev_iface_other`)

--- a/src/libYARP_dev/src/yarp/dev/IAmplifierControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IAmplifierControl.h
@@ -165,6 +165,7 @@ public:
 };
 
 /**
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for control devices, amplifier commands.
  */

--- a/src/libYARP_dev/src/yarp/dev/IAudioRender.h
+++ b/src/libYARP_dev/src/yarp/dev/IAudioRender.h
@@ -13,6 +13,12 @@
 
 namespace yarp::dev {
 
+/**
+ * @ingroup dev_iface_media
+ *
+ * Interface for rendering a YARP-format sound and controlling its reproduction ona device
+ */
+
 class YARP_dev_API IAudioRender
 {
 public:

--- a/src/libYARP_dev/src/yarp/dev/IAxisInfo.h
+++ b/src/libYARP_dev/src/yarp/dev/IAxisInfo.h
@@ -64,8 +64,10 @@ public:
 };
 
 /**
-* Interface for getting information about specific axes, if available.
-*/
+ * @ingroup dev_iface_motor_raw
+ *
+ * Interface for getting information about specific axes, if available.
+ */
 class YARP_dev_API yarp::dev::IAxisInfoRaw
 {
 public:

--- a/src/libYARP_dev/src/yarp/dev/ICalibrator.h
+++ b/src/libYARP_dev/src/yarp/dev/ICalibrator.h
@@ -11,6 +11,12 @@
 
 namespace yarp::dev {
 
+/**
+ * @ingroup dev_iface_motor
+ *
+ * Interface for a calibrator device.
+ */
+
 class YARP_dev_API ICalibrator
 {
 public:

--- a/src/libYARP_dev/src/yarp/dev/IControlCalibration.h
+++ b/src/libYARP_dev/src/yarp/dev/IControlCalibration.h
@@ -36,6 +36,7 @@ struct YARP_dev_API yarp::dev::CalibrationParameters
 };
 
 /**
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for control devices, calibration commands.
  */

--- a/src/libYARP_dev/src/yarp/dev/IControlLimits.h
+++ b/src/libYARP_dev/src/yarp/dev/IControlLimits.h
@@ -70,6 +70,8 @@ public:
 };
 
 /**
+ * @ingroup dev_iface_motor_raw
+ *
  * Interface for control devices. Limits commands.
  */
 class YARP_dev_API yarp::dev::IControlLimitsRaw

--- a/src/libYARP_dev/src/yarp/dev/IControlMode.h
+++ b/src/libYARP_dev/src/yarp/dev/IControlMode.h
@@ -90,7 +90,7 @@ public:
 
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for setting control mode in control board. See IControlMode for
  * more documentation.

--- a/src/libYARP_dev/src/yarp/dev/ICurrentControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ICurrentControl.h
@@ -102,6 +102,7 @@ public:
 };
 
 /**
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for control boards implementing current control.
  */

--- a/src/libYARP_dev/src/yarp/dev/IEncoders.h
+++ b/src/libYARP_dev/src/yarp/dev/IEncoders.h
@@ -15,7 +15,7 @@ class IEncoders;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Control board, encoder interface.
  */

--- a/src/libYARP_dev/src/yarp/dev/IEncodersTimed.h
+++ b/src/libYARP_dev/src/yarp/dev/IEncodersTimed.h
@@ -15,7 +15,7 @@ class IEncodersTimedRaw;
 }
 
 /**
- * \ingroup dev_iface_motor
+ * \ingroup dev_iface_motor_raw
  *
  * \brief Control board, extend encoder raw interface adding timestamps.
  */

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberControlsDC1394.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberControlsDC1394.h
@@ -11,6 +11,11 @@
 
 namespace yarp::dev {
 
+/**
+ * @ingroup dev_iface_media
+ *
+ * Control interface for frame grabber devices that conform to the 1394-based Digital Camera Specifications.
+ */
 class YARP_dev_API IFrameGrabberControlsDC1394
 {
 public:

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage.h
@@ -46,6 +46,11 @@ public:
     virtual int width() const = 0;
 };
 
+/**
+ * @ingroup dev_iface_media
+ *
+ * Read a YARP-format image (of a specific type) from a device.
+ */
 template <typename ImageType>
 class IFrameGrabberOf :
         public IFrameGrabberImageBase

--- a/src/libYARP_dev/src/yarp/dev/IHapticDevice.h
+++ b/src/libYARP_dev/src/yarp/dev/IHapticDevice.h
@@ -19,6 +19,8 @@ class IHapticDevice;
 
 
 /**
+ * @ingroup dev_iface_other
+ *
  * A generic interface for an haptic device.
  */
 class YARP_dev_API yarp::dev::IHapticDevice

--- a/src/libYARP_dev/src/yarp/dev/IInteractionMode.h
+++ b/src/libYARP_dev/src/yarp/dev/IInteractionMode.h
@@ -108,7 +108,7 @@ public:
 
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface settings the way the robot interacts with the environment: basic interaction types are Stiff and Compliant.
  * This setting is intended to work in conjunction with other settings like position or velocity control.

--- a/src/libYARP_dev/src/yarp/dev/IJointFault.h
+++ b/src/libYARP_dev/src/yarp/dev/IJointFault.h
@@ -27,7 +27,7 @@ public:
 };
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for getting info about the fault which may occur on a robot.
  */

--- a/src/libYARP_dev/src/yarp/dev/IMotor.h
+++ b/src/libYARP_dev/src/yarp/dev/IMotor.h
@@ -16,7 +16,7 @@ class IMotor;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Control board, encoder interface.
  */

--- a/src/libYARP_dev/src/yarp/dev/IMotorEncoders.h
+++ b/src/libYARP_dev/src/yarp/dev/IMotorEncoders.h
@@ -15,7 +15,7 @@ class IMotorEncoders;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Control board, encoder interface.
  */

--- a/src/libYARP_dev/src/yarp/dev/IPWMControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IPWMControl.h
@@ -76,9 +76,10 @@ public:
 };
 
 /**
-*
-* Interface for controlling an axis, by sending directly a PWM reference signal to a motor.
-*/
+ * @ingroup dev_iface_motor_raw
+ *
+ * Interface for controlling an axis, by sending directly a PWM reference signal to a motor.
+ */
 class YARP_dev_API yarp::dev::IPWMControlRaw
 {
 public:

--- a/src/libYARP_dev/src/yarp/dev/IPidControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IPidControl.h
@@ -19,6 +19,8 @@ class IPidControl;
 
 
 /**
+ * @ingroup dev_iface_motor_raw
+ *
  * Interface for a generic control board device implementing a PID controller.
  */
 class YARP_dev_API yarp::dev::IPidControlRaw

--- a/src/libYARP_dev/src/yarp/dev/IPositionControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IPositionControl.h
@@ -16,7 +16,7 @@ class IPositionControl;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for a generic control board device implementing position control in encoder
  * coordinates.

--- a/src/libYARP_dev/src/yarp/dev/IPositionDirect.h
+++ b/src/libYARP_dev/src/yarp/dev/IPositionDirect.h
@@ -16,7 +16,7 @@ class IPositionDirectRaw;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for a generic control board device implementing position control.
  * This interface is used to send high frequency streaming commands to the boards, the aim

--- a/src/libYARP_dev/src/yarp/dev/IRemoteCalibrator.h
+++ b/src/libYARP_dev/src/yarp/dev/IRemoteCalibrator.h
@@ -12,6 +12,8 @@
 namespace yarp::dev {
 
 /**
+ * @ingroup dev_iface_motor
+ *
  * IRemoteCalibrator interface is meant to remotize the access of the calibration device
  * in order to allow users to remotely call the calibration procedure for
  * a single joint or the whole device and let the calibrator do the job.

--- a/src/libYARP_dev/src/yarp/dev/IRemoteVariables.h
+++ b/src/libYARP_dev/src/yarp/dev/IRemoteVariables.h
@@ -18,7 +18,7 @@ class IRemoteVariables;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * IRemoteVariablesRaw interface.
  */

--- a/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
@@ -130,7 +130,7 @@ public:
 };
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for control boards implementing torque control.
  */

--- a/src/libYARP_dev/src/yarp/dev/IVelocityControl.h
+++ b/src/libYARP_dev/src/yarp/dev/IVelocityControl.h
@@ -16,7 +16,7 @@ class IVelocityControlRaw;
 }
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_motor_raw
  *
  * Interface for control boards implementig velocity control in encoder coordinates.
  */

--- a/src/libYARP_dev/src/yarp/dev/IVirtualAnalogSensor.h
+++ b/src/libYARP_dev/src/yarp/dev/IVirtualAnalogSensor.h
@@ -67,7 +67,7 @@ public:
 };
 
 /**
-* @ingroup dev_iface_other
+* @ingroup dev_iface_other_raw
 *
 * A generic interface to a virtual sensors. A virtual sensor is any device that
 * can generate values used as a measure by robot

--- a/src/libYARP_dev/src/yarp/dev/IVisualServoing.h
+++ b/src/libYARP_dev/src/yarp/dev/IVisualServoing.h
@@ -19,7 +19,7 @@ class IVisualServoing;
 
 
 /**
- * @ingroup dev_iface_motor
+ * @ingroup dev_iface_other
  *
  * \brief Interface for visual servoing controllers.
  */

--- a/src/libYARP_dev/src/yarp/dev/IVisualServoing.h
+++ b/src/libYARP_dev/src/yarp/dev/IVisualServoing.h
@@ -18,7 +18,9 @@ class IVisualServoing;
 }
 
 
-/*!
+/**
+ * @ingroup dev_iface_motor
+ *
  * \brief Interface for visual servoing controllers.
  */
 class YARP_dev_API yarp::dev::IVisualServoing


### PR DESCRIPTION
### libYARP_dev interfaces doxygen tags

#### `yarp::dev`

- Added missing doxygen tags to:
  - IAudioRender (`dev_iface_media`)
  - ICalibrator (`dev_iface_motor`)
  - IFrameGrabberControlsDC1394 (`dev_iface_media`)
  - IFrameGrabberOf (`dev_iface_media`)
  - IHapticDevice (`dev_iface_other`)
  - IRemoteCalibrator (`dev_iface_motor`)
  - IVisualServoing (`dev_iface_other`)
- Created new `raw` tag inside `dev_iface_motor` and `dev_iface_other` to separate raw interfaces from the others.
- Interfaces affected by this change (for some of them the tag was added since it was missing and for the other ones it was changes to the `raw` *sub-tag*):
  - IAmplifierControlRaw (`dev_iface_motor_raw` - added)
  - IAxisInfoRaw (`dev_iface_motor_raw` - added)
  - IControlCalibrationRaw (`dev_iface_motor_raw` - added)
  - IControlLimitsRaw (`dev_iface_motor_raw` - added)
  - IControlModeRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - ICurrentControlRaw (`dev_iface_motor_raw` - added)
  - IEncodersRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IEncodersTimedRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IInteractionModeRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IJointFaultRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IMotorRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IMotorEncodersRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IPWMControlRaw (`dev_iface_motor_raw` - added)
  - IPidControlRaw (`dev_iface_motor_raw` - added)
  - IPositionControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IPositionDirectRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IRemoteVariablesRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - ITorqueControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IVelocityControlRaw (`dev_iface_motor_raw` - changed from `dev_iface_motor`)
  - IVirtualAnalogSensorRaw (`dev_iface_other_raw` - changed from `dev_iface_other`)