### PR TITLE
[yarpdataplayer] Remove inertial ports for robot and iCubGui from the example app

### DIFF
--- a/data/yarpdataplayer/scripts/yarpdatadumper.xml.template
+++ b/data/yarpdataplayer/scripts/yarpdatadumper.xml.template
@@ -19,13 +19,6 @@
     </module>
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /data/inertial</parameters>
-        <node>computer1</node>
-        <stdio></stdio>
-        <tag>yarpdatadumper</tag>
-    </module>
-    <module>
-        <name>yarpdatadumper</name>
         <parameters>--name /data/torso</parameters>
         <node>computer1</node>
         <stdio></stdio>
@@ -73,11 +66,6 @@
         <stdio></stdio>
         <tag>yarpdatadumper</tag>
     </module>
-    <connection>
-        <from>/icub/inertial</from>
-        <to>/data/inertial</to>
-        <protocol>udp</protocol>
-    </connection>
     <connection>
         <from>/icub/head/state:o</from>
         <to>/data/head</to>

--- a/data/yarpdataplayer/scripts/yarpdatadumperExample.xml
+++ b/data/yarpdataplayer/scripts/yarpdatadumperExample.xml
@@ -18,13 +18,6 @@
     </module>
     <module>
         <name>yarpdatadumper</name>
-        <parameters>--name /data/inertial</parameters>
-        <node>localhost</node>
-        <stdio></stdio>
-        <tag>yarpdatadumper</tag>
-    </module>
-    <module>
-        <name>yarpdatadumper</name>
         <parameters>--name /data/torso</parameters>
         <node>computer1</node>
         <stdio></stdio>
@@ -72,11 +65,6 @@
         <stdio></stdio>
         <tag>yarpdatadumper</tag>
     </module>
-    <connection>
-        <from>/icub/inertial</from>
-        <to>/data/inertial</to>
-        <protocol>udp</protocol>
-    </connection>
     <connection>
         <from>/icub/head/state:o</from>
         <to>/data/head</to>

--- a/data/yarpdataplayer/scripts/yarpdataplayer.xml.template
+++ b/data/yarpdataplayer/scripts/yarpdataplayer.xml.template
@@ -51,11 +51,6 @@
         <protocol>udp</protocol>
     </connection>
     <connection>
-        <from>/icub/inertial</from>
-        <to>/iCubGui/inertial:i</to>
-        <protocol>udp</protocol>
-    </connection>
-    <connection>
         <from>/icub/left_arm/state:o</from>
         <to>/iCubGui/left_arm:i</to>
         <protocol>udp</protocol>

--- a/data/yarpdataplayer/scripts/yarpdataplayerExample.xml
+++ b/data/yarpdataplayer/scripts/yarpdataplayerExample.xml
@@ -50,11 +50,6 @@
         <protocol>udp</protocol>
     </connection>
     <connection>
-        <from>/icub/inertial</from>
-        <to>/iCubGui/inertial:i</to>
-        <protocol>udp</protocol>
-    </connection>
-    <connection>
         <from>/icub/left_arm/state:o</from>
         <to>/iCubGui/left_arm:i</to>
         <protocol>udp</protocol>

--- a/doc/release/yarp_3_8/yarpdataplayer_cleanup_inertial_portnames.md
+++ b/doc/release/yarp_3_8/yarpdataplayer_cleanup_inertial_portnames.md
@@ -1,0 +1,6 @@
+[pattacini:yarp-3.8](https://github.com/pattacini/yarp/tree/yarp-3.8) {#yarp_3_8}
+---
+
+#### `yarpdataplayer`
+
+* Removed robot and iCubGui inertial ports from the example app as the GUI is unable to handle the MAS client.


### PR DESCRIPTION
~~This patch follows up on https://github.com/orgs/robotology/discussions/638#discussioncomment-6248267 and aims to update the names of the inertial ports in the `yarpdataplayer` example application.~~

---

> **Note**
Actually, the `yarpdataplayer` is unable to deal with the MAS client, hence we cleaned up those ports.
See https://github.com/robotology/yarp/pull/2979#issuecomment-1602476624.