### PR TITLE
multipleanalogsensorsserver: Improve message in case a sensor is not published due to non-OK status

### DIFF
--- a/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -104,7 +104,8 @@ class MultipleAnalogSensorsServer :
                            const std::vector< SensorMetadata >& metadataVector,
                            std::vector< SensorMeasurement >& streamingDataVector,
                            yarp::dev::MAS_status (Interface::*getStatusMethodPtr)(size_t) const,
-                           bool (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const);
+                           bool (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const,
+                           const char* sensorType);
 
 
 public:


### PR DESCRIPTION
Before, only a sensor name was printed, now also the sensor type and the non-OK status that resulted in an error.