### PR TITLE
Fix yarp_add_idl use when cross-compiling

### DIFF
--- a/cmake/YarpIDL.cmake
+++ b/cmake/YarpIDL.cmake
@@ -565,8 +565,18 @@ function(YARP_ADD_IDL var)
       message(FATAL_ERROR "Unknown extension ${ext}. Supported extensions are .thrift, .msg, and .srv")
     endif()
 
-    # FIXME This should handle cross-compiling
-    set(YARPIDL_${family}_COMMAND YARP::yarpidl_${family})
+    if (CMAKE_CROSSCOMPILING)
+      find_program(YARPIDL_${_family}_LOCATION
+        NAMES yarpidl_${_family}
+        HINTS ${YARP_IDL_BINARY_HINT} # This is a list of directories defined
+                                      # in YarpOptions.cmake (for YARP) or in
+                                      # YARPConfig.cmake for dependencies
+        NO_DEFAULT_PATH
+      )
+      set(YARPIDL_${family}_COMMAND YARPIDL_${_family}_LOCATION)
+    else()
+      set(YARPIDL_${family}_COMMAND YARP::yarpidl_${family})
+    endif()
 
     # Set output directories and remove extra "/" and ensure that the directory
     # exists.
@@ -603,7 +613,9 @@ function(YARP_ADD_IDL var)
     endforeach()
 
     if(NOT "${output}" STREQUAL "")
-      set(depends ${YARPIDL_${family}_COMMAND})
+      if(TARGET ${YARPIDL_${family}_COMMAND})
+        set(depends ${YARPIDL_${family}_COMMAND})
+      endif()
       if(NOT native)
         list(APPEND depends ${file})
       endif()

--- a/cmake/YarpIDL.cmake
+++ b/cmake/YarpIDL.cmake
@@ -566,14 +566,14 @@ function(YARP_ADD_IDL var)
     endif()
 
     if (CMAKE_CROSSCOMPILING)
-      find_program(YARPIDL_${_family}_LOCATION
-        NAMES yarpidl_${_family}
+      find_program(YARPIDL_${family}_LOCATION
+        NAMES yarpidl_${family}
         HINTS ${YARP_IDL_BINARY_HINT} # This is a list of directories defined
                                       # in YarpOptions.cmake (for YARP) or in
                                       # YARPConfig.cmake for dependencies
         NO_DEFAULT_PATH
       )
-      set(YARPIDL_${family}_COMMAND YARPIDL_${_family}_LOCATION)
+      set(YARPIDL_${family}_COMMAND ${YARPIDL_${family}_LOCATION})
     else()
       set(YARPIDL_${family}_COMMAND YARP::yarpidl_${family})
     endif()


### PR DESCRIPTION
In YARP are two CMake macros to run yarpidl programs, `yarp_idl_to_dir` and `yarp_add_idl`. 

When cross-compiling (for exmaple for Android or iOS) , it is not possible for `yarp_idl_to_dir` and `yarp_add_idl` to call the `yarpidl_rosmsg` and `yarpidl_thrift` provided by the YARP that is used for linking the program, as that version tipically does not work for the system on which we are cross-compiling. For this reason, it is important that there is a way for users to specify manually the `yarpidl_rosmsg` and `yarpidl_thrift` executables that `yarp_idl_to_dir` and `yarp_add_idl` use.

Even before this PR, `yarp_idl_to_dir` works fine with cross-compilaton by specifing the CMake cache variables `YARPIDL_thrift_LOCATION` and `YARPIDL_rosmsg_LOCATION`. If this variables are not set, the one provided by the YARP used to link the applications are used instead.

Before this PR, `yarp_add_idl` was not using the executable specified in the `YARPIDL_thrift_LOCATION` and `YARPIDL_rosmsg_LOCATION` variable, while after this PR also `yarp_add_idl` works fine in cross-compilation.