### PR TITLE
[2966] Bugfix for yarprun stdio

### DIFF
--- a/doc/release/yarp_3_8/yarprun_stdio_fix.md
+++ b/doc/release/yarp_3_8/yarprun_stdio_fix.md
@@ -1,0 +1,6 @@
+yarprun_stdio_fix {#yarp-3.8}
+---
+
+### `lib_YARP_run`
+
+* Fixed stdin in `yarprun --cmd <cmd> --stdio` 

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -2615,6 +2615,7 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
 
         if (IS_NEW_PROCESS(pid_stdin)) // STDIN IMPLEMENTED HERE
         {
+            yarp::conf::environment::set_string("YARP_QUIET", "1");
             REDIRECT_TO(STDOUT_FILENO, pipe_stdin_to_cmd[WRITE_TO_PIPE]);
             REDIRECT_TO(STDERR_FILENO, pipe_stdin_to_cmd[WRITE_TO_PIPE]);
 


### PR DESCRIPTION
Opened in #2966. This line prevents /stdin port to write info messages thus polluting the stdin of the cmd run by yarprun --cmd <cmd> --stdio.