### PR TITLE
FrameGrabber_nwc_yarp: fix bug that forces images to be sent through RPC calls

### DIFF
--- a/doc/release/yarp_3_8/fix_frameGrabber_nwc_RPC_port_bug.md
+++ b/doc/release/yarp_3_8/fix_frameGrabber_nwc_RPC_port_bug.md
@@ -1,0 +1,6 @@
+fix_frameGrabber_nwc_RPC_port_bug {#yarp-3.8}
+---
+
+#### `frameGrabber_nwc_yarp`
+
+* Fix bug that forces images to be sent through RPC calls

--- a/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
+++ b/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
@@ -202,6 +202,10 @@ bool FrameGrabber_nwc_yarp::open(yarp::os::Searchable& config)
         if (!streamReceiver.open(local, remote, carrier)) {
             return false;
         }
+        FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelRgb>>::setStreamReceiver(&streamReceiver);
+        FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelMono>, VOCAB_FRAMEGRABBER_IMAGERAW>::setStreamReceiver(&streamReceiver);
+        FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelFloat>>::setStreamReceiver(&streamReceiver);
+        FrameGrabberOf_ForwarderWithStream<yarp::sig::FlexImage>::setStreamReceiver(&streamReceiver);
     }
 
     std::string rpc_local = local + "/rpc_client";
@@ -219,11 +223,6 @@ bool FrameGrabber_nwc_yarp::open(yarp::os::Searchable& config)
     } else {
         yCInfo(FRAMEGRABBER_NWC_YARP) << "No remote specified. Waiting for connection";
     }
-
-    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelRgb>>::setStreamReceiver(&streamReceiver);
-    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelMono>, VOCAB_FRAMEGRABBER_IMAGERAW>::setStreamReceiver(&streamReceiver);
-    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelFloat>>::setStreamReceiver(&streamReceiver);
-    FrameGrabberOf_ForwarderWithStream<yarp::sig::FlexImage>::setStreamReceiver(&streamReceiver);
 
     return true;
 }

--- a/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
+++ b/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
@@ -220,6 +220,11 @@ bool FrameGrabber_nwc_yarp::open(yarp::os::Searchable& config)
         yCInfo(FRAMEGRABBER_NWC_YARP) << "No remote specified. Waiting for connection";
     }
 
+    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelRgb>>::setStreamReceiver(&streamReceiver);
+    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelMono>, VOCAB_FRAMEGRABBER_IMAGERAW>::setStreamReceiver(&streamReceiver);
+    FrameGrabberOf_ForwarderWithStream<yarp::sig::ImageOf<yarp::sig::PixelFloat>>::setStreamReceiver(&streamReceiver);
+    FrameGrabberOf_ForwarderWithStream<yarp::sig::FlexImage>::setStreamReceiver(&streamReceiver);
+
     return true;
 }
 


### PR DESCRIPTION
Together with @traversaro and @HosameldinMohamed, we found out that the `frameGrabber_nwc_yarp` is using an RPC port to get the image of a camera because `m_streamerReceiver` is not defined; we added the function `setStreamReceiver` and in this way, the object `m_streamerReceiver` is defined and we avoid continuously calling the function [getImage](https://github.com/robotology/yarp/blob/99f5a8a2c728b50300d02bada44fe8fc85df5636/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp#L145C115-L145C115) which uses an RPC port to receive the image and it slows the process.