### PR TITLE
improved frameGrabber_nwc test / fix for method getImageCropped()

### DIFF
--- a/src/devices/JoypadControlServer/tests/joypadControlServer_test.cpp
+++ b/src/devices/JoypadControlServer/tests/joypadControlServer_test.cpp
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <yarp/dev/IFrameGrabberImage.h>
-#include <yarp/dev/IRgbVisualParams.h>
-
-#include <yarp/dev/tests/IFrameGrabberImageTest.h>
-#include <yarp/dev/tests/IRgbVisualParamsTest.h>
-
 #include <yarp/os/Network.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Vector.h>

--- a/src/devices/battery_nws_yarp/tests/battery_nws_yarp_test.cpp
+++ b/src/devices/battery_nws_yarp/tests/battery_nws_yarp_test.cpp
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <yarp/dev/IFrameGrabberImage.h>
-#include <yarp/dev/IRgbVisualParams.h>
-
-#include <yarp/dev/tests/IFrameGrabberImageTest.h>
-#include <yarp/dev/tests/IRgbVisualParamsTest.h>
-
 #include <yarp/os/Network.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Vector.h>

--- a/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.h
+++ b/src/devices/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.h
@@ -77,9 +77,16 @@ private:
 /**
  * @ingroup dev_impl_nwc_yarp
  *
- * \section frameGrabber_nws_yarp
+ * \section frameGrabber_nwc_yarp
  *
- * \brief `frameGrabber_nws_yarp`: Connect to a frameGrabber_nws_yarp.
+ * \brief `frameGrabber_nwc_yarp`: The client of a frameGrabber_nws_yarp.
+ *  Parameters required by this device are:
+ * | Parameter name | SubParameter   | Type    | Units          | Default Value | Required     | Description                                                       | Notes |
+ * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:-----------: |:-----------------------------------------------------------------:|:-----:|
+ * | local          |      -         | string  | -              |   -           | Yes          | Prefix of the ports opened locally by the nwc for streaming and rpc operations    |       |
+ * | remote         |      -         | string  | -              |   -           | Yes          | Name of the remote rpc port opened by the nws                     |       |
+ * | carrier        |      -         | string  | -              |   fast_tcp    | No           | Protocol used for connection with the nws streaming port          |       |
+ * | no_stream      |      -         | bool    | -              |   false       | No           | Full port name of the port remotely opened by the Navigation server, to which the Navigation2D_nwc_yarp connects to.           |  |
  */
 class FrameGrabber_nwc_yarp :
         public yarp::dev::DeviceDriver,

--- a/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage-inl.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameGrabberImage-inl.h
@@ -25,7 +25,12 @@ bool IFrameGrabberOf<ImageType>::getImageCrop(cropType_id_t cropType,
             return false;
         }
         ImageType full;
-        getImage(full);
+        bool b = getImage(full);
+        if (!b || full.width() == 0 || full.height() == 0)
+        {
+            yCError(IFRAMEGRABBEROF, "GetImageCrop failed: No image received");
+            return false;
+        }
 
         if (!yarp::sig::utils::cropRect(full, vertices[0], vertices[1], image)) {
             yCError(IFRAMEGRABBEROF, "GetImageCrop failed: utils::cropRect error: (%d, %d) (%d, %d)",


### PR DESCRIPTION
This PR is triggered by https://github.com/robotology/yarp/pull/2990. The fix on the image stream made visible a severe memory error on the method `getImageCropped()` which was not detected when the method was called in RPC mode. The issue is under investigation.
@davidegorbani