### PR TITLE
yarp::sig::Sound refactor

### DIFF
--- a/doc/release/yarp_3_9_master/master.md
+++ b/doc/release/yarp_3_9_master/master.md
@@ -27,3 +27,7 @@ Added new device `LLM_nws_yarp`, thrift interface `ILLMMsgs`, fakeDevice `fakeLL
 # LLM_nwc_yarp
 
 Added new device `LLM_nwc_yarp`.
+
+# yarp::sig::Sound
+
+`yarp::sig::sound` refactored to avoid the internal use (private implementation) of yarp::sig::Image data type.

--- a/src/libYARP_sig/src/yarp/sig/Sound.h
+++ b/src/libYARP_sig/src/yarp/sig/Sound.h
@@ -263,9 +263,8 @@ public:
 
 private:
     void init(size_t bytesPerSample);
-    void synchronize();
 
-    void *implementation;
+    void *implementation =nullptr;
     size_t m_samples;
     size_t m_channels;
     size_t m_bytesPerSample;


### PR DESCRIPTION
`yarp::sig::sound` refactored to avoid the internal use (private implementation) of yarp::sig::Image data type.