### PR TITLE
wire_rep_utils cleanup

### DIFF
--- a/src/carriers/h264_carrier/CMakeLists.txt
+++ b/src/carriers/h264_carrier/CMakeLists.txt
@@ -27,7 +27,6 @@ if(NOT SKIP_h264)
     PRIVATE
       YARP::YARP_os
       YARP::YARP_sig
-      YARP::YARP_wire_rep_utils
   )
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
     YARP_os

--- a/src/carriers/h264_carrier/H264Stream.cpp
+++ b/src/carriers/h264_carrier/H264Stream.cpp
@@ -27,7 +27,6 @@ using namespace yarp::sig;
 
 H264Stream::H264Stream(h264Decoder_cfgParamters &config) :
         delegate(nullptr),
-        blobHeader{0,0,0},
         phase(0),
         cursor(nullptr),
         remaining(0),
@@ -123,7 +122,7 @@ yarp::conf::ssize_t H264Stream::read(Bytes& b)
         {
             phase = 4;
             cursor = nullptr;
-            remaining = blobHeader.blobLen;
+            remaining = 0;
         } else
         {
             phase = 0;

--- a/src/carriers/h264_carrier/H264Stream.h
+++ b/src/carriers/h264_carrier/H264Stream.h
@@ -9,7 +9,6 @@
 #include <yarp/os/impl/DgramTwoWayStream.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/ImageNetworkHeader.h>
-#include <yarp/wire_rep_utils/BlobNetworkHeader.h>
 #include "H264Decoder.h"
 #include <yarp/os/InputStream.h>
 
@@ -22,7 +21,6 @@ private:
     DgramTwoWayStream *delegate;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> img;
     yarp::sig::ImageNetworkHeader imgHeader;
-    yarp::wire_rep_utils::BlobNetworkHeader blobHeader;
     int phase;
     char *cursor;
     size_t remaining;

--- a/src/carriers/websocket/CMakeLists.txt
+++ b/src/carriers/websocket/CMakeLists.txt
@@ -45,12 +45,10 @@ if(NOT SKIP_websocket)
     PRIVATE
       YARP::YARP_os
       YARP::YARP_sig
-      YARP::YARP_wire_rep_utils
   )
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
       YARP_os
       YARP_sig
-      YARP_wire_rep_utils
   )
 
   yarp_install(


### PR DESCRIPTION
YARP_wire_rep_utils unnecessary dependency removed from h264 and websocket carriers.
No functional changes.