### PR TITLE
Register bindings for new device interfaces

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -82,8 +82,9 @@
 %include <stdint.i>
 %include <std_vector.i>
 
-// Try to translate std::string to native equivalents
+// Try to translate std::string and std::pair to native equivalents
 %include "std_string.i"
+%include "std_pair.i"
 
 #if defined(SWIGCSHARP)
     // Get .NET pointers instead of swig generated types (useful when dealing with images)
@@ -427,6 +428,9 @@ MAKE_COMMS(Bottle)
 %include <yarp/dev/IRemoteVariables.h>
 %include <yarp/dev/IPidControl.h>
 %include <yarp/dev/IPositionDirect.h>
+%include <yarp/dev/ISpeechSynthesizer.h>
+%include <yarp/dev/ISpeechTranscription.h>
+%include <yarp/dev/ILLM.h>
 %include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
 #ifndef YARP_NO_DEPRECATED // Since YARP 3.5.0
@@ -440,6 +444,8 @@ MAKE_COMMS(Bottle)
 %template(SVector) std::vector<std::string>;
 %template(IVector) std::vector<int>;
 %template(ShortVector) std::vector<short int>;
+%template() std::pair<std::string, std::string>;
+%template(SPairVector) std::vector<std::pair<std::string, std::string>>;
 
 #ifdef SWIGMATLAB
   // Extend IVector for handling conversion of vectors from and to Matlab
@@ -818,6 +824,9 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
     CAST_POLYDRIVER_TO_INTERFACE(IPositionDirect)
     CAST_POLYDRIVER_TO_INTERFACE(IRemoteVariables)
     CAST_POLYDRIVER_TO_INTERFACE(IAxisInfo)
+    CAST_POLYDRIVER_TO_INTERFACE(ISpeechSynthesizer)
+    CAST_POLYDRIVER_TO_INTERFACE(ISpeechTranscription)
+    CAST_POLYDRIVER_TO_INTERFACE(ILLM)
 
 // These views are currently disabled in SWIG + java generator since they are
 // useless without the EXTENDED_ANALOG_SENSOR_INTERFACE part.
@@ -1540,6 +1549,44 @@ typedef yarp::os::BufferedPort<ImageRgbFloat> BufferedPortImageRgbFloat;
         bool result = self->isPidEnabled((yarp::dev::PidControlTypeEnum)pidtype, j, (bool*)(&data[0]));
         for (size_t i = 0; i < data.size(); i++) flag[i] = data[i] != 0;
         return result;
+    }
+}
+
+%extend yarp::dev::ISpeechSynthesizer {
+    bool getLanguage(std::vector<string>& language) {
+        return self->getLanguage(language[0]);
+    }
+
+    bool getVoice(std::vector<string>& voice) {
+        return self->getVoice(voice[0]);
+    }
+
+    bool getSpeed(std::vector<double>& speed) {
+        return self->getSpeed(speed[0]);
+    }
+
+    bool getPitch(std::vector<double>& pitch) {
+        return self->getPitch(pitch[0]);
+    }
+}
+
+%extend yarp::dev::ISpeechTranscription {
+    bool getLanguage(std::vector<string>& language) {
+        return self->getLanguage(language[0]);
+    }
+
+    bool transcribe(const yarp::sig::Sound& sound, std::vector<string>& transcription, std::vector<double>& score) {
+        return self->transcribe(sound, transcription[0], score[0]);
+    }
+}
+
+%extend yarp::dev::ILLM {
+    bool readPrompt(std::vector<string>& oPropmt) {
+        return self->readPrompt(oPropmt[0]);
+    }
+
+    bool ask(const std::string& question, std::vector<string>& answer) {
+        return self->ask(question, answer[0]);
     }
 }
 

--- a/src/libYARP_dev/src/yarp/dev/all.h
+++ b/src/libYARP_dev/src/yarp/dev/all.h
@@ -37,6 +37,9 @@
 #include <yarp/dev/ServiceInterfaces.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/ISpeechSynthesizer.h>
+#include <yarp/dev/ISpeechTranscription.h>
+#include <yarp/dev/ILLM.h>
 
 #ifndef YARP_NO_DEPRECATED // since YARP 3.5
 #define YARP_INCLUDING_DEPRECATED_HEADER_YARP_DEV_FRAMEGRABBER_H_ON_PURPOSE


### PR DESCRIPTION
Follow-up of https://github.com/robotology/yarp/pull/2978 and https://github.com/robotology/yarp/pull/2993. Successfully tested on Python and the corresponding fake device implementations. Incidentally, the new headers have been also added to `<yarp/dev/all.h>`.

Sample usage:

```py
import yarp

options = yarp.Property()
options.put('device', 'fakeLLMDevice')

dd = yarp.PolyDriver(options)
llm = dd.viewILLM()

llm.setPrompt('test')

vs = yarp.SVector(1)
vsp = yarp.SPairVector()

llm.readPrompt(vs) # `vs[0]` yields 'test'
llm.ask('blah blah blah', vs)

llm.getConversation(vsp)
# `vsp[0]` yields ('system', 'test')
# `vsp[1]` yields ('user', 'blah blah blah')
# `vsp[2]` yields ('assistant', 'Fatti non foste per viver come bruti ma per seguir virtute e canoscenza')

llm.deleteConversation()
```