### PR TITLE
Add velocityThres param for torque control

### DIFF
--- a/doc/release/v3_7_0.md
+++ b/doc/release/v3_7_0.md
@@ -48,7 +48,7 @@ New Features
 
 #### `lib_yarp_dev`
 
-* ITorqueControl supports four new friction parameters: viscousPos, viscousNeg, coulombPos, coulombNeg.
+* ITorqueControl supports four new friction parameters: viscousPos, viscousNeg, coulombPos, coulombNeg, velocityThres.
   These parameters are used to improve the friction model (and its compensation at FW level).
 
 #### `lib_yarp_companion`

--- a/doc/release/v3_7_0.md
+++ b/doc/release/v3_7_0.md
@@ -48,7 +48,7 @@ New Features
 
 #### `lib_yarp_dev`
 
-* ITorqueControl supports four new friction parameters: viscousPos, viscousNeg, coulombPos, coulombNeg, velocityThres.
+* ITorqueControl supports four new friction parameters: viscousPos, viscousNeg, coulombPos, coulombNeg.
   These parameters are used to improve the friction model (and its compensation at FW level).
 
 #### `lib_yarp_companion`

--- a/doc/release/v3_8_1.md
+++ b/doc/release/v3_8_1.md
@@ -38,7 +38,7 @@ Removed use of highgui.h include file.
 #### `lib_yarp_dev`
 
 * ITorqueControl supports four a new friction parameters: velocityThresh.
-  This parameters is used to enable the new torque control law and fine tune the the friction compensation at FW level.
+  This parameters is used to enable the new torque control law and fine tune the friction compensation at FW level.
   
 Contributors
 ------------

--- a/doc/release/v3_8_1.md
+++ b/doc/release/v3_8_1.md
@@ -35,6 +35,11 @@ Fixed communication with serialPort_nwc_yarp.
 
 Removed use of highgui.h include file.
 
+#### `lib_yarp_dev`
+
+* ITorqueControl supports four a new friction parameters: velocityThresh.
+  This parameters is used to enable the new torque control law and fine tune the the friction compensation at FW level.
+  
 Contributors
 ------------
 

--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.cpp
@@ -730,16 +730,6 @@ bool DynamixelAX12FtdiDriver::setTorqueOffset(int j, double v) {
     return NOT_YET_IMPLEMENTED("setTorqueOffset");
 }
 
-bool DynamixelAX12FtdiDriver::getBemfParam(int j, double *bemf) {
-    yCError(DYNAMIXELAX12FTDIDRIVER, "Note: AX12 does not support torque control mode. This is only used to get torque feedback.");
-    return NOT_YET_IMPLEMENTED("getBemfParam");
-}
-
-bool DynamixelAX12FtdiDriver::setBemfParam(int j, double bemf) {
-    yCError(DYNAMIXELAX12FTDIDRIVER, "Note: AX12 does not support torque control mode. This is only used to get torque feedback.");
-    return NOT_YET_IMPLEMENTED("setBemfParam");
-}
-
 bool DynamixelAX12FtdiDriver::resetEncoder(int j) {
     return NOT_YET_IMPLEMENTED("resetEncoder");
 }

--- a/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
+++ b/src/devices/DynamixelAX12Ftdi/DynamixelAX12FtdiDriver.h
@@ -256,9 +256,6 @@ public:
     bool enableTorquePid(int j);
     bool setTorqueOffset(int j, double v);
 
-    bool getBemfParam(int j, double *bemf);
-    bool setBemfParam(int j, double bemf);
-
     bool resetEncoder(int j) override;
     bool resetEncoders() override;
 

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2207,8 +2207,6 @@ bool RemoteControlBoard::setMotorTorqueParams(int j, const MotorTorqueParameters
     cmd.addVocab32(VOCAB_MOTOR_PARAMS);
     cmd.addInt32(j);
     Bottle& b = cmd.addList();
-    b.addFloat64(params.bemf);
-    b.addFloat64(params.bemf_scale);
     b.addFloat64(params.ktau);
     b.addFloat64(params.ktau_scale);
     b.addFloat64(params.viscousPos);
@@ -2239,8 +2237,6 @@ bool RemoteControlBoard::getMotorTorqueParams(int j, MotorTorqueParameters *para
             yCError(REMOTECONTROLBOARD, "getMotorTorqueParams return value not understood, size != 8");
             return false;
         }
-        params->bemf        = l.get(0).asFloat64();
-        params->bemf_scale  = l.get(1).asFloat64();
         params->ktau        = l.get(2).asFloat64();
         params->ktau_scale  = l.get(3).asFloat64();
         params->viscousPos   = l.get(4).asFloat64();

--- a/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/RemoteControlBoard/RemoteControlBoard.cpp
@@ -2215,6 +2215,7 @@ bool RemoteControlBoard::setMotorTorqueParams(int j, const MotorTorqueParameters
     b.addFloat64(params.viscousNeg);
     b.addFloat64(params.coulombPos);
     b.addFloat64(params.coulombNeg);
+    b.addFloat64(params.velocityThres);
     bool ok = rpc_p.write(cmd, response);
     return CHECK_FAIL(ok, response);
 }
@@ -2246,6 +2247,7 @@ bool RemoteControlBoard::getMotorTorqueParams(int j, MotorTorqueParameters *para
         params->viscousNeg = l.get(5).asFloat64();
         params->coulombPos   = l.get(6).asFloat64();
         params->coulombNeg = l.get(7).asFloat64();
+        params->velocityThres = l.get(8).asFloat64();
         return true;
     }
     return false;

--- a/src/devices/controlBoard_nws_yarp/RPCMessagesParser.cpp
+++ b/src/devices/controlBoard_nws_yarp/RPCMessagesParser.cpp
@@ -482,8 +482,6 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
                 break;
             }
 
-            params.bemf = b->get(0).asFloat64();
-            params.bemf_scale = b->get(1).asFloat64();
             params.ktau = b->get(2).asFloat64();
             params.ktau_scale = b->get(3).asFloat64();
             params.viscousPos = b->get(4).asFloat64();
@@ -557,8 +555,6 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             // convert it back to yarp message
             Bottle& b = response.addList();
 
-            b.addFloat64(params.bemf);
-            b.addFloat64(params.bemf_scale);
             b.addFloat64(params.ktau);
             b.addFloat64(params.ktau_scale);
             b.addFloat64(params.viscousPos);

--- a/src/devices/controlBoard_nws_yarp/RPCMessagesParser.cpp
+++ b/src/devices/controlBoard_nws_yarp/RPCMessagesParser.cpp
@@ -490,6 +490,7 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             params.viscousNeg = b->get(5).asFloat64();
             params.coulombPos = b->get(6).asFloat64();
             params.coulombNeg = b->get(7).asFloat64();
+            params.velocityThres = b->get(8).asFloat64();
 
             *ok = rpc_ITorque->setMotorTorqueParams(joint, params);
         } break;
@@ -564,6 +565,7 @@ void RPCMessagesParser::handleTorqueMsg(const yarp::os::Bottle& cmd,
             b.addFloat64(params.viscousNeg);
             b.addFloat64(params.coulombPos);
             b.addFloat64(params.coulombNeg);
+            b.addFloat64(params.velocityThres);
         } break;
         case VOCAB_RANGE: {
             *ok = rpc_ITorque->getTorqueRange(cmd.get(3).asInt32(), &dtmp, &dtmp2);

--- a/src/devices/fakeMotionControl/fakeMotionControl.cpp
+++ b/src/devices/fakeMotionControl/fakeMotionControl.cpp
@@ -268,6 +268,7 @@ bool FakeMotionControl::alloc(int nj)
     _viscousNeg=allocAndCheck<double>(nj);
     _coulombPos=allocAndCheck<double>(nj);
     _coulombNeg=allocAndCheck<double>(nj);
+    _velocityThres=allocAndCheck<double>(nj);
 
     // Reserve space for data stored locally. values are initialized to 0
     _posCtrl_references = allocAndCheck<double>(nj);
@@ -344,6 +345,7 @@ bool FakeMotionControl::dealloc()
     checkAndDestroy(_viscousNeg);
     checkAndDestroy(_coulombPos);
     checkAndDestroy(_coulombNeg);
+    checkAndDestroy(_velocityThres);
     checkAndDestroy(_posCtrl_references);
     checkAndDestroy(_posDir_references);
     checkAndDestroy(_command_speeds);
@@ -446,6 +448,7 @@ FakeMotionControl::FakeMotionControl() :
     _viscousNeg             (nullptr),
     _coulombPos             (nullptr),
     _coulombNeg             (nullptr),
+    _velocityThres              (nullptr),
     _filterType             (nullptr),
     _torqueSensorId         (nullptr),
     _torqueSensorChan       (nullptr),
@@ -744,7 +747,7 @@ bool FakeMotionControl::parsePositionPidsGroup(Bottle& pidsGroup, Pid myPid[])
     return true;
 }
 
-bool FakeMotionControl::parseTorquePidsGroup(Bottle& pidsGroup, Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[])
+bool FakeMotionControl::parseTorquePidsGroup(Bottle& pidsGroup, Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[], double velocityThres[])
 {
     int j=0;
     Bottle xtmp;
@@ -866,6 +869,14 @@ bool FakeMotionControl::parseTorquePidsGroup(Bottle& pidsGroup, Pid myPid[], dou
     for (j=0; j<_njoints; j++) {
         coulombNeg[j] = xtmp.get(j+1).asFloat64();
     }
+
+    if (!extractGroup(pidsGroup, xtmp, "velocityThres", "velocity threshold parameter", _njoints)) {
+        return false;
+    }
+    for (j=0; j<_njoints; j++) {
+        threshold[j] = xtmp.get(j+1).asFloat64();
+    }
+
 
     //conversion from metric to machine units (if applicable)
 //     for (j=0; j<_njoints; j++)
@@ -2909,6 +2920,7 @@ bool FakeMotionControl::getMotorTorqueParamsRaw(int j, MotorTorqueParameters *pa
     params->viscousNeg = _viscousNeg[j];
     params->coulombPos = _coulombPos[j];
     params->coulombNeg = _coulombNeg[j];
+    params->velocityThres = _velocityThres[j];
     yCDebug(FAKEMOTIONCONTROL) << "getMotorTorqueParamsRaw" << params->bemf
                                                             << params->bemf_scale
                                                             << params->ktau
@@ -2916,7 +2928,8 @@ bool FakeMotionControl::getMotorTorqueParamsRaw(int j, MotorTorqueParameters *pa
                                                             << params->viscousPos
                                                             << params->viscousNeg
                                                             << params->coulombPos
-                                                            << params->coulombNeg;
+                                                            << params->coulombNeg
+                                                            << params->velocityThres;
     return true;
 }
 
@@ -2930,6 +2943,7 @@ bool FakeMotionControl::setMotorTorqueParamsRaw(int j, const MotorTorqueParamete
     _viscousNeg[j] = params.viscousNeg;
     _coulombPos[j] = params.coulombPos;
     _coulombNeg[j] = params.coulombNeg;
+    _velocityThres[j] = params.velocityThres;
     yCDebug(FAKEMOTIONCONTROL) << "setMotorTorqueParamsRaw" << params.bemf
                                                             << params.bemf_scale
                                                             << params.ktau
@@ -2937,7 +2951,8 @@ bool FakeMotionControl::setMotorTorqueParamsRaw(int j, const MotorTorqueParamete
                                                             << params.viscousPos
                                                             << params.viscousNeg
                                                             << params.coulombPos
-                                                            << params.coulombNeg;
+                                                            << params.coulombNeg
+                                                            << params.velocityThres;
     return true;
 }
 

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -189,9 +189,7 @@ private:
     double *_maxMotorVelocity;                  /** max motor velocity */
     int *_velocityShifts;                       /** velocity shifts */
     int *_velocityTimeout;                      /** velocity shifts */
-    double *_kbemf;                             /** back-emf compensation parameter */
     double *_ktau;                              /** motor torque constant */
-    int *_kbemf_scale;                          /** back-emf compensation parameter */
     int *_ktau_scale;                           /** motor torque constant */
     double *_viscousPos;                        /** viscous pos friction  */
     double *_viscousNeg;                        /** viscous neg friction  */
@@ -509,7 +507,7 @@ private:
     void cleanup();
     bool dealloc();
     bool parsePositionPidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[]);
-    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[], double velocityThres[]);
+    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[], double velocityThres[]);
 
     bool parseImpedanceGroup_NewFormat(yarp::os::Bottle& pidsGroup, ImpedanceParameters vals[]);
 

--- a/src/devices/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fakeMotionControl/fakeMotionControl.h
@@ -193,10 +193,11 @@ private:
     double *_ktau;                              /** motor torque constant */
     int *_kbemf_scale;                          /** back-emf compensation parameter */
     int *_ktau_scale;                           /** motor torque constant */
-    double *_viscousPos;                         /** viscous pos friction */
-    double *_viscousNeg;                       /** viscous neg friction */
-    double *_coulombPos;                         /** coulomb up friction */
-    double *_coulombNeg;                       /** coulomb neg friction */
+    double *_viscousPos;                        /** viscous pos friction  */
+    double *_viscousNeg;                        /** viscous neg friction  */
+    double *_coulombPos;                        /** coulomb up friction  */
+    double *_coulombNeg;                        /** coulomb neg friction */
+    double *_velocityThres;                     /** velocity threshold for torque control */
     int * _filterType;                          /** the filter type (int value) used by the force control algorithm */
     int *_torqueSensorId;                       /** Id of associated Joint Torque Sensor */
     int *_torqueSensorChan;                     /** Channel of associated Joint Torque Sensor */
@@ -508,7 +509,7 @@ private:
     void cleanup();
     bool dealloc();
     bool parsePositionPidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[]);
-    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[]);
+    bool parseTorquePidsGroup(yarp::os::Bottle& pidsGroup, yarp::dev::Pid myPid[], double kbemf[], double ktau[], int filterType[], double viscousPos[], double viscousNeg[], double coulombPos[], double coulombNeg[], double velocityThres[]);
 
     bool parseImpedanceGroup_NewFormat(yarp::os::Bottle& pidsGroup, ImpedanceParameters vals[]);
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -44,6 +44,7 @@ public:
     double *viscousNegToRaws;
     double *coulombPosToRaws;
     double *coulombNegToRaws;
+    double *velocityThresToRaws;
 
     PidUnits* PosPid_units;
     PidUnits* VelPid_units;
@@ -68,6 +69,7 @@ public:
         viscousNegToRaws(nullptr),
         coulombPosToRaws(nullptr),
         coulombNegToRaws(nullptr),
+        velocityThresToRaws(nullptr),
         PosPid_units(nullptr),
         VelPid_units(nullptr),
         CurPid_units(nullptr),
@@ -87,6 +89,7 @@ public:
         std::fill_n(viscousNegToRaws, size, 1.0);
         std::fill_n(coulombPosToRaws, size, 1.0);
         std::fill_n(coulombNegToRaws, size, 1.0);
+        std::fill_n(velocityThresToRaws, size, 1.0);
     }
 
     ~PrivateUnitsHandler()
@@ -110,6 +113,7 @@ public:
         checkAndDestroy<double>(viscousNegToRaws);
         checkAndDestroy<double>(coulombPosToRaws);
         checkAndDestroy<double>(coulombNegToRaws);
+        checkAndDestroy<double>(velocityThresToRaws);
     }
 
     void alloc(int n)
@@ -134,6 +138,7 @@ public:
         viscousNegToRaws = new double[nj];
         coulombPosToRaws = new double[nj];
         coulombNegToRaws = new double[nj];
+        velocityThresToRaws = new double[nj];
 
         yAssert(position_zeros != nullptr);
         yAssert(helper_ones != nullptr);
@@ -154,6 +159,7 @@ public:
         yAssert(viscousNegToRaws != nullptr);
         yAssert(coulombPosToRaws != nullptr);
         yAssert(coulombNegToRaws != nullptr);
+        yAssert(velocityThresToRaws != nullptr);
 
         pid_units[VOCAB_PIDTYPE_POSITION] = PosPid_units;
         pid_units[VOCAB_PIDTYPE_VELOCITY] = VelPid_units;
@@ -183,6 +189,7 @@ public:
         memcpy(this->viscousNegToRaws, other.viscousNegToRaws, sizeof(*other.viscousNegToRaws)*nj);
         memcpy(this->coulombPosToRaws, other.coulombPosToRaws, sizeof(*other.coulombPosToRaws)*nj);
         memcpy(this->coulombNegToRaws, other.coulombNegToRaws, sizeof(*other.coulombNegToRaws)*nj);
+        memcpy(this->velocityThresToRaws, other.velocityThresToRaws, sizeof(*other.velocityThresToRaws)*nj);
     }
 };
 
@@ -806,6 +813,12 @@ void ControlBoardHelper::coulombNeg_user2raw(double coulombNeg_user, int j, doub
     k = toHw(j);
 }
 
+void ControlBoardHelper::velocityThres_user2raw(double velocityThres_user, int j, double &velocityThres_raw, int &k)
+{
+    velocityThres_raw = velocityThres_user * mPriv->velocityThresToRaws[j];
+    k = toHw(j);
+}
+
 void ControlBoardHelper::bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user)
 {
     j_user = toUser(k_raw);
@@ -848,6 +861,11 @@ double ControlBoardHelper::coulombNeg_user2raw(double coulombNeg_user, int j)
     return coulombNeg_user * mPriv->coulombNegToRaws[j];
 }
 
+double ControlBoardHelper::velocityThres_user2raw(double velocityThres_user, int j)
+{
+    return velocityThres_user * mPriv->velocityThresToRaws[j];
+}
+
 void ControlBoardHelper::viscousPos_raw2user(double viscousPos_raw, int k_raw, double &viscousPos_user, int &j_user)
 {
     j_user = toUser(k_raw);
@@ -870,6 +888,12 @@ void ControlBoardHelper::coulombNeg_raw2user(double coulombNeg_raw, int k_raw, d
 {
     j_user = toUser(k_raw);
     coulombNeg_user = coulombNeg_raw / mPriv->coulombNegToRaws[j_user];
+}
+
+void ControlBoardHelper::velocityThres_raw2user(double velocityThres_raw, int k_raw, double &velocityThres_user, int &j_user)
+{
+    j_user = toUser(k_raw);
+    velocityThres_user = velocityThres_raw / mPriv->velocityThresToRaws[j_user];
 }
 
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.cpp
@@ -38,7 +38,6 @@ public:
     double *ampereToSensors;
     double *voltToSensors;
     double *dutycycleToPWMs;
-    double *bemfToRaws;
     double *ktauToRaws;
     double *viscousPosToRaws;
     double *viscousNegToRaws;
@@ -63,7 +62,6 @@ public:
         ampereToSensors(nullptr),
         voltToSensors(nullptr),
         dutycycleToPWMs(nullptr),
-        bemfToRaws(nullptr),
         ktauToRaws(nullptr),
         viscousPosToRaws(nullptr),
         viscousNegToRaws(nullptr),
@@ -83,7 +81,6 @@ public:
         std::fill_n(ampereToSensors, size, 1.0);
         std::fill_n(voltToSensors, size, 1.0);
         std::fill_n(dutycycleToPWMs, size, 1.0);
-        std::fill_n(bemfToRaws, size, 1.0);
         std::fill_n(ktauToRaws, size, 1.0);
         std::fill_n(viscousPosToRaws, size, 1.0);
         std::fill_n(viscousNegToRaws, size, 1.0);
@@ -107,7 +104,6 @@ public:
         checkAndDestroy<double>(ampereToSensors);
         checkAndDestroy<double>(voltToSensors);
         checkAndDestroy<double>(dutycycleToPWMs);
-        checkAndDestroy<double>(bemfToRaws);
         checkAndDestroy<double>(ktauToRaws);
         checkAndDestroy<double>(viscousPosToRaws);
         checkAndDestroy<double>(viscousNegToRaws);
@@ -132,7 +128,6 @@ public:
         VelPid_units = new PidUnits[nj];
         TrqPid_units = new PidUnits[nj];
         CurPid_units = new PidUnits[nj];
-        bemfToRaws = new double[nj];
         ktauToRaws = new double[nj];
         viscousPosToRaws = new double[nj];
         viscousNegToRaws = new double[nj];
@@ -153,7 +148,6 @@ public:
         yAssert(VelPid_units != nullptr);
         yAssert(TrqPid_units != nullptr);
         yAssert(CurPid_units != nullptr);
-        yAssert(bemfToRaws != nullptr);
         yAssert(ktauToRaws != nullptr);
         yAssert(viscousPosToRaws != nullptr);
         yAssert(viscousNegToRaws != nullptr);
@@ -183,7 +177,6 @@ public:
         memcpy(this->VelPid_units, other.VelPid_units, sizeof(*other.VelPid_units)*nj);
         memcpy(this->TrqPid_units, other.TrqPid_units, sizeof(*other.TrqPid_units)*nj);
         memcpy(this->CurPid_units, other.CurPid_units, sizeof(*other.CurPid_units)*nj);
-        memcpy(this->bemfToRaws, other.bemfToRaws, sizeof(*other.bemfToRaws)*nj);
         memcpy(this->ktauToRaws, other.ktauToRaws, sizeof(*other.ktauToRaws)*nj);
         memcpy(this->viscousPosToRaws, other.viscousPosToRaws, sizeof(*other.viscousPosToRaws)*nj);
         memcpy(this->viscousNegToRaws, other.viscousNegToRaws, sizeof(*other.viscousNegToRaws)*nj);
@@ -193,7 +186,7 @@ public:
     }
 };
 
-ControlBoardHelper::ControlBoardHelper(int n, const int *aMap, const double *angToEncs, const double *zs, const double *newtons, const double *amps, const double *volts, const double *dutycycles, const double *kbemf, const double *ktau)
+ControlBoardHelper::ControlBoardHelper(int n, const int *aMap, const double *angToEncs, const double *zs, const double *newtons, const double *amps, const double *volts, const double *dutycycles, const double *ktau)
 {
     yAssert(n>=0);         // if number of joints is negative complain!
     yAssert(aMap!=nullptr);      // at least the axisMap is required
@@ -218,9 +211,6 @@ ControlBoardHelper::ControlBoardHelper(int n, const int *aMap, const double *ang
     }
     if (dutycycles != nullptr) {
         memcpy(mPriv->dutycycleToPWMs, dutycycles, sizeof(double) * n);
-    }
-    if (kbemf != nullptr) {
-        memcpy(mPriv->bemfToRaws, kbemf, sizeof(double) * n);
     }
     if (ktau != nullptr) {
         memcpy(mPriv->ktauToRaws, ktau, sizeof(double) * n);
@@ -777,11 +767,6 @@ double ControlBoardHelper::PWM2dutycycle(double pwm_raw, int k_raw)
 }
 
 // *******************************************//
-void ControlBoardHelper::bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k)
-{
-    bemf_raw = bemf_user * mPriv->bemfToRaws[j];
-    k = toHw(j);
-}
 
 void ControlBoardHelper::ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k)
 {
@@ -819,21 +804,10 @@ void ControlBoardHelper::velocityThres_user2raw(double velocityThres_user, int j
     k = toHw(j);
 }
 
-void ControlBoardHelper::bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user)
-{
-    j_user = toUser(k_raw);
-    bemf_user = bemf_raw / mPriv->bemfToRaws[j_user];
-}
-
 void ControlBoardHelper::ktau_raw2user(double ktau_raw, int k_raw, double &ktau_user, int &j_user)
 {
     j_user = toUser(k_raw);
     ktau_user = ktau_raw / mPriv->ktauToRaws[j_user];
-}
-
-double  ControlBoardHelper::bemf_user2raw(double bemf_user, int j)
-{
-    return bemf_user * mPriv->bemfToRaws[j];
 }
 
 double  ControlBoardHelper::ktau_user2raw(double ktau_user, int j)

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -149,6 +149,7 @@ public:
     double viscousNeg_user2raw(double viscousNeg_user, int j);
     double coulombPos_user2raw(double coulombPos_user, int j);
     double coulombNeg_user2raw(double coulombNeg_user, int j);
+    double velocityThres_user2raw(double velocityThres_user, int j);
 
     void bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k);
     void ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k);
@@ -156,12 +157,14 @@ public:
     void viscousNeg_user2raw(double viscousNeg_user, int j, double &viscousNeg_raw, int &k);
     void coulombPos_user2raw(double coulombPos_user, int j, double &coulombPos_raw, int &k);
     void coulombNeg_user2raw(double coulombNeg_user, int j, double &coulombNeg_raw, int &k);
+    void velocityThres_user2raw(double velocityThres_user, int j, double &velocityThres_raw, int &k);
     void bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user);
     void ktau_raw2user(double ktau_raw, int k_raw, double &ktau_user, int &j_user);
     void viscousPos_raw2user(double viscousPos_raw, int k_raw, double &viscousPos_user, int &j_user);
     void viscousNeg_raw2user(double viscousNeg_raw, int k_raw, double &viscousNeg_user, int &j_user);
     void coulombPos_raw2user(double coulombPos_raw, int k_raw, double &coulombPos_user, int &j_user);
     void coulombNeg_raw2user(double coulombNeg_raw, int k_raw, double &coulombNeg_user, int &j_user);
+    void velocityThres_raw2user(double threshold_raw, int k_raw, double &velocityThres_user, int &j_user);
 
     int axes();
 

--- a/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
+++ b/src/libYARP_dev/src/yarp/dev/ControlBoardHelper.h
@@ -54,7 +54,7 @@ class ControlBoardHelper;
 class YARP_dev_API yarp::dev::ControlBoardHelper
 {
 public:
-    ControlBoardHelper(int n, const int *aMap, const double *angToEncs = nullptr, const double *zs = nullptr, const double *newtons = nullptr, const double *amps = nullptr, const double *volts = nullptr, const double *dutycycles = nullptr, const double *kbemf = nullptr, const double *ktau = nullptr);
+    ControlBoardHelper(int n, const int *aMap, const double *angToEncs = nullptr, const double *zs = nullptr, const double *newtons = nullptr, const double *amps = nullptr, const double *volts = nullptr, const double *dutycycles = nullptr, const double *ktau = nullptr);
     ~ControlBoardHelper();
     ControlBoardHelper(const ControlBoardHelper& other);
     ControlBoardHelper& operator = (const ControlBoardHelper & other);
@@ -143,7 +143,6 @@ public:
     double PWM2dutycycle(double pwm_raw, int k_raw);
 
     // *******************************************//
-    double bemf_user2raw(double bemf_user, int j);
     double ktau_user2raw(double ktau_user, int j);
     double viscousPos_user2raw(double viscousPos_user, int j);
     double viscousNeg_user2raw(double viscousNeg_user, int j);
@@ -151,14 +150,12 @@ public:
     double coulombNeg_user2raw(double coulombNeg_user, int j);
     double velocityThres_user2raw(double velocityThres_user, int j);
 
-    void bemf_user2raw(double bemf_user, int j, double &bemf_raw, int &k);
     void ktau_user2raw(double ktau_user, int j, double &ktau_raw, int &k);
     void viscousPos_user2raw(double viscousPos_user, int j, double &viscousPos_raw, int &k);
     void viscousNeg_user2raw(double viscousNeg_user, int j, double &viscousNeg_raw, int &k);
     void coulombPos_user2raw(double coulombPos_user, int j, double &coulombPos_raw, int &k);
     void coulombNeg_user2raw(double coulombNeg_user, int j, double &coulombNeg_raw, int &k);
     void velocityThres_user2raw(double velocityThres_user, int j, double &velocityThres_raw, int &k);
-    void bemf_raw2user(double bemf_raw, int k_raw, double &bemf_user, int &j_user);
     void ktau_raw2user(double ktau_raw, int k_raw, double &ktau_user, int &j_user);
     void viscousPos_raw2user(double viscousPos_raw, int k_raw, double &viscousPos_user, int &j_user);
     void viscousNeg_raw2user(double viscousNeg_raw, int k_raw, double &viscousNeg_user, int &j_user);

--- a/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
@@ -18,8 +18,6 @@ class MotorTorqueParameters;
 class YARP_dev_API yarp::dev::MotorTorqueParameters
 {
     public:
-    double bemf;
-    double bemf_scale;
     double ktau;
     double ktau_scale;
     double viscousPos;
@@ -27,7 +25,7 @@ class YARP_dev_API yarp::dev::MotorTorqueParameters
     double coulombPos;
     double coulombNeg;
     double velocityThres;
-    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousPos(0), viscousNeg(0), coulombPos(0), coulombNeg(0), velocityThres(0){};
+    MotorTorqueParameters() : ktau(0), ktau_scale(0), viscousPos(0), viscousNeg(0), coulombPos(0), coulombNeg(0), velocityThres(0){};
 };
 
 /**
@@ -85,14 +83,14 @@ public:
      */
     virtual bool setRefTorques(const int n_joint, const int *joints, const double *t) {return false;}  // this function has a default implementation to keep backward compatibility with existing devices
 
-    /** Get a subset of motor parameters (bemf, ktau etc) useful for torque control.
+    /** Get a subset of motor parameters (ktau etc) useful for torque control.
      * @param j joint number
      * @param params a struct containing the motor parameters to be retrieved
      * @return true/false on success/failure
      */
     virtual bool getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params) {return false;}
 
-    /** Set a subset of motor parameters (bemf, ktau etc) useful for torque control.
+    /** Set a subset of motor parameters (ktau etc) useful for torque control.
      * @param j joint number
      * @param params a struct containing the motor parameters to be set
      * @return true/false on success/failure
@@ -235,7 +233,6 @@ constexpr yarp::conf::vocab32_t VOCAB_TORQUE            = yarp::os::createVocab3
 constexpr yarp::conf::vocab32_t VOCAB_TORQUE_MODE       = yarp::os::createVocab32('t', 'r', 'q', 'd');
 constexpr yarp::conf::vocab32_t VOCAB_TRQS              = yarp::os::createVocab32('t', 'r', 'q', 's');
 constexpr yarp::conf::vocab32_t VOCAB_TRQ               = yarp::os::createVocab32('t', 'r', 'q');
-constexpr yarp::conf::vocab32_t VOCAB_BEMF              = yarp::os::createVocab32('b', 'm', 'f');
 constexpr yarp::conf::vocab32_t VOCAB_MOTOR_PARAMS      = yarp::os::createVocab32('m', 't', 'p', 's');
 constexpr yarp::conf::vocab32_t VOCAB_RANGES            = yarp::os::createVocab32('r', 'n', 'g', 's');
 constexpr yarp::conf::vocab32_t VOCAB_RANGE             = yarp::os::createVocab32('r', 'n', 'g');

--- a/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ITorqueControl.h
@@ -26,7 +26,8 @@ class YARP_dev_API yarp::dev::MotorTorqueParameters
     double viscousNeg;
     double coulombPos;
     double coulombNeg;
-    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousPos(0), viscousNeg(0), coulombPos(0), coulombNeg(0) {};
+    double velocityThres;
+    MotorTorqueParameters() : bemf(0), bemf_scale(0), ktau(0), ktau_scale(0), viscousPos(0), viscousNeg(0), coulombPos(0), coulombNeg(0), velocityThres(0){};
 };
 
 /**

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -25,13 +25,13 @@ ImplementTorqueControl::~ImplementTorqueControl()
     uninitialize();
 }
 
-bool ImplementTorqueControl::initialize(int size, const int *amap, const double *enc, const double *zos, const double *nw, const double* amps, const double* dutys, const double* bemfs, const double* ktaus)
+bool ImplementTorqueControl::initialize(int size, const int *amap, const double *enc, const double *zos, const double *nw, const double* amps, const double* dutys, const double* ktaus)
 {
     if (helper != nullptr) {
         return false;
     }
 
-    helper=(void *)(new ControlBoardHelper(size, amap, enc, zos, nw, amps, nullptr, dutys,bemfs,ktaus));
+    helper=(void *)(new ControlBoardHelper(size, amap, enc, zos, nw, amps, nullptr, dutys, ktaus));
     yAssert (helper != nullptr);
 
     intBuffManager = new yarp::dev::impl::FixedSizeBuffersManager<int> (size);
@@ -89,9 +89,7 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
     int k;
 
     yarp::dev::MotorTorqueParameters params_raw;
-    castToMapper(helper)->bemf_user2raw(params.bemf, j, params_raw.bemf, k);
     castToMapper(helper)->ktau_user2raw(params.ktau, j, params_raw.ktau, k);
-    params_raw.bemf_scale = params.bemf_scale;
     params_raw.ktau_scale = params.ktau_scale;
 
     castToMapper(helper)->viscousPos_user2raw(params.viscousPos, j, params_raw.viscousPos, k);
@@ -115,9 +113,7 @@ bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorque
     if (b)
     {
         *params = params_raw;
-        castToMapper(helper)->bemf_raw2user(params_raw.bemf, k, (*params).bemf, tmp_j);
         castToMapper(helper)->ktau_raw2user(params_raw.ktau, k, (*params).ktau, tmp_j);
-        (*params).bemf_scale = params_raw.bemf_scale;
         (*params).ktau_scale = params_raw.ktau_scale;
         castToMapper(helper)->viscousPos_raw2user(params_raw.viscousPos, k, (*params).viscousPos, tmp_j);
         castToMapper(helper)->viscousNeg_raw2user(params_raw.viscousNeg, k, (*params).viscousNeg, tmp_j);

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.cpp
@@ -98,6 +98,7 @@ bool ImplementTorqueControl::setMotorTorqueParams(int j,  const yarp::dev::Motor
     castToMapper(helper)->viscousNeg_user2raw(params.viscousNeg, j, params_raw.viscousNeg, k);
     castToMapper(helper)->coulombPos_user2raw(params.coulombPos, j, params_raw.coulombPos, k);
     castToMapper(helper)->coulombNeg_user2raw(params.coulombNeg, j, params_raw.coulombNeg, k);
+    castToMapper(helper)->velocityThres_user2raw(params.velocityThres, j, params_raw.velocityThres, k);
 
     return iTorqueRaw->setMotorTorqueParamsRaw(k, params_raw);
 }
@@ -122,6 +123,7 @@ bool ImplementTorqueControl::getMotorTorqueParams(int j,  yarp::dev::MotorTorque
         castToMapper(helper)->viscousNeg_raw2user(params_raw.viscousNeg, k, (*params).viscousNeg, tmp_j);
         castToMapper(helper)->coulombPos_raw2user(params_raw.coulombPos, k, (*params).coulombPos, tmp_j);
         castToMapper(helper)->coulombNeg_raw2user(params_raw.coulombNeg, k, (*params).coulombNeg, tmp_j);
+        castToMapper(helper)->velocityThres_raw2user(params_raw.velocityThres, k, (*params).velocityThres, tmp_j);
     }
     return b;
 }

--- a/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementTorqueControl.h
@@ -35,7 +35,7 @@ protected:
      * @param zos is an array containing the zeros of the encoders.
      * @return true if initialized succeeded, false if it wasn't executed, or assert.
      */
-    bool initialize (int size, const int *amap, const double *enc, const double *zos, const double *nw, const double* amps, const double* dutys, const double* bemfs, const double* ktaus);
+    bool initialize (int size, const int *amap, const double *enc, const double *zos, const double *nw, const double* amps, const double* dutys, const double* ktaus);
 
     /**
      * Clean up internal data and memory.

--- a/src/libYARP_dev/src/yarp/dev/tests/ITorqueControlTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/ITorqueControlTest.h
@@ -34,6 +34,7 @@ namespace yarp::dev::tests
         params.viscousNeg = 0.6;
         params.coulombPos = 0.7;
         params.coulombNeg = 0.8;
+        params.velocityThres = 0.9;
         b= itrq->setMotorTorqueParams(0, params);
         CHECK(b);
 
@@ -48,6 +49,7 @@ namespace yarp::dev::tests
         CHECK(res.viscousNeg == 0.6); // interface seems functional
         CHECK(res.coulombPos == 0.7); // interface seems functional
         CHECK(res.coulombNeg == 0.8); // interface seems functional
+        CHECK(res.velocityThres == 0.9); // interface seems functional
     }
 }
 

--- a/src/libYARP_dev/src/yarp/dev/tests/ITorqueControlTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/ITorqueControlTest.h
@@ -26,8 +26,6 @@ namespace yarp::dev::tests
         CHECK(ax != 0);
 
         yarp::dev::MotorTorqueParameters params;
-        //params.bemf = 0.1;
-        //params.bemf_scale = 0.2;
         //params.ktau = 0.3;
         //params.ktau_scale = 0.4;
         params.viscousPos = 0.5;
@@ -41,8 +39,6 @@ namespace yarp::dev::tests
         yarp::dev::MotorTorqueParameters res;
         b= itrq->getMotorTorqueParams(0, &res);
         CHECK(b);
-        //CHECK(res.bemf == 0.1); // interface seems functional
-        //CHECK(res.bemf_scale == 0.2); // interface seems functional
         //CHECK(res.ktau == 0.3); // interface seems functional
         //CHECK(res.ktau_scale == 0.4); // interface seems functional
         CHECK(res.viscousPos == 0.5); // interface seems functional

--- a/src/yarpmotorgui/piddlg.cpp
+++ b/src/yarpmotorgui/piddlg.cpp
@@ -49,15 +49,13 @@
 #define     TORQUE_STITCTIONUP  7
 #define     TORQUE_STICTIONDW   8
 #define     TORQUE_KFF          9
-#define     TORQUE_BEMFGAIN     10
-#define     TORQUE_BEMFSCALE    11
-#define     TORQUE_KTAUGAIN     12
-#define     TORQUE_KTAUSCALE    13
-#define     TORQUE_VISCOUSPOS   14
-#define     TORQUE_VISCOUSNEG   15
-#define     TORQUE_COULOMBPOS   16
-#define     TORQUE_COULOMBNEG   17
-#define     VELOCITY_THRESHOLD  18
+#define     TORQUE_KTAUGAIN     10
+#define     TORQUE_KTAUSCALE    11
+#define     TORQUE_VISCOUSPOS   12
+#define     TORQUE_VISCOUSNEG   13
+#define     TORQUE_COULOMBPOS   14
+#define     TORQUE_COULOMBNEG   15
+#define     VELOCITY_THRESHOLD  16
 
 #define     CURRENT_KP         0
 #define     CURRENT_KD         1
@@ -178,12 +176,6 @@ void PidDlg::initTorque(Pid myPid, MotorTorqueParameters TrqParam)
 
     ui->tableTorque->item(TORQUE_KD,0)->setText(QString("%1").arg((double)myPid.kd));
     ui->tableTorque->item(TORQUE_KD,1)->setText(QString("%1").arg((double)myPid.kd));
-
-    ui->tableTorque->item(TORQUE_BEMFGAIN,0)->setText(QString("%1").arg((double)TrqParam.bemf));
-    ui->tableTorque->item(TORQUE_BEMFGAIN,1)->setText(QString("%1").arg((double)TrqParam.bemf));
-
-    ui->tableTorque->item(TORQUE_BEMFSCALE,0)->setText(QString("%1").arg((int)TrqParam.bemf_scale));
-    ui->tableTorque->item(TORQUE_BEMFSCALE,1)->setText(QString("%1").arg((int)TrqParam.bemf_scale));
 
     ui->tableTorque->item(TORQUE_KTAUGAIN,0)->setText(QString("%1").arg((double)TrqParam.ktau));
     ui->tableTorque->item(TORQUE_KTAUGAIN,1)->setText(QString("%1").arg((double)TrqParam.ktau));
@@ -406,8 +398,6 @@ void PidDlg::onSend()
         newPid.kp = ui->tableTorque->item(TORQUE_KP,1)->text().toDouble();
         newPid.kff = ui->tableTorque->item(TORQUE_KFF,1)->text().toDouble();
         newPid.kd = ui->tableTorque->item(TORQUE_KD,1)->text().toDouble();
-        newMotorTorqueParams.bemf = ui->tableTorque->item(TORQUE_BEMFGAIN,1)->text().toDouble();
-        newMotorTorqueParams.bemf_scale = ui->tableTorque->item(TORQUE_BEMFSCALE,1)->text().toDouble();
         newMotorTorqueParams.ktau = ui->tableTorque->item(TORQUE_KTAUGAIN,1)->text().toDouble();
         newMotorTorqueParams.ktau_scale = ui->tableTorque->item(TORQUE_KTAUSCALE,1)->text().toDouble();
         newMotorTorqueParams.viscousPos = ui->tableTorque->item(TORQUE_VISCOUSPOS,1)->text().toDouble();

--- a/src/yarpmotorgui/piddlg.cpp
+++ b/src/yarpmotorgui/piddlg.cpp
@@ -57,6 +57,7 @@
 #define     TORQUE_VISCOUSNEG   15
 #define     TORQUE_COULOMBPOS   16
 #define     TORQUE_COULOMBNEG   17
+#define     VELOCITY_THRESHOLD  18
 
 #define     CURRENT_KP         0
 #define     CURRENT_KD         1
@@ -199,6 +200,9 @@ void PidDlg::initTorque(Pid myPid, MotorTorqueParameters TrqParam)
     ui->tableTorque->item(TORQUE_COULOMBPOS, 1)->setText(QString("%1").arg((double)TrqParam.coulombPos));
     ui->tableTorque->item(TORQUE_COULOMBNEG, 0)->setText(QString("%1").arg((double)TrqParam.coulombNeg));
     ui->tableTorque->item(TORQUE_COULOMBNEG, 1)->setText(QString("%1").arg((double)TrqParam.coulombNeg));
+
+    ui->tableTorque->item(VELOCITY_THRESHOLD, 0)->setText(QString("%1").arg((double)TrqParam.velocityThres));
+    ui->tableTorque->item(VELOCITY_THRESHOLD, 1)->setText(QString("%1").arg((double)TrqParam.velocityThres));
 
     ui->tableTorque->item(TORQUE_KI,0)->setText(QString("%1").arg((double)myPid.ki));
     ui->tableTorque->item(TORQUE_KI,1)->setText(QString("%1").arg((double)myPid.ki));
@@ -410,6 +414,7 @@ void PidDlg::onSend()
         newMotorTorqueParams.viscousNeg = ui->tableTorque->item(TORQUE_VISCOUSNEG,1)->text().toDouble();
         newMotorTorqueParams.coulombPos = ui->tableTorque->item(TORQUE_COULOMBPOS,1)->text().toDouble();
         newMotorTorqueParams.coulombNeg = ui->tableTorque->item(TORQUE_COULOMBNEG,1)->text().toDouble();
+        newMotorTorqueParams.velocityThres =  ui->tableTorque->item(VELOCITY_THRESHOLD,1)->text().toDouble();
         newPid.ki = ui->tableTorque->item(TORQUE_KI,1)->text().toDouble();
         newPid.scale = ui->tableTorque->item(TORQUE_SCALE,1)->text().toDouble();
         newPid.offset = ui->tableTorque->item(TORQUE_OFFSET,1)->text().toDouble();

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -898,16 +898,6 @@
          </row>
          <row>
           <property name="text">
-           <string>Torque Kbemf</string>
-          </property>
-         </row>
-         <row>
-          <property name="text">
-           <string>Torque Kbemf Scale</string>
-          </property>
-         </row>
-         <row>
-          <property name="text">
            <string>Torque Ktau</string>
           </property>
          </row>

--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -936,6 +936,11 @@
            <string>Torque CoulombNeg</string>
           </property>
          </row>
+         <row>
+          <property name="text">
+           <string>Velocity Threshold</string>
+          </property>
+         </row>
          <column>
           <property name="text">
            <string>Current</string>


### PR DESCRIPTION
**What's new:**
- Add a new `velocityThres` parameter for friction compensation used during torque control. This parameters is used to enable the new torque control law and fine-tune the friction compensation at FW level.
- Remove unused `bemf` and `bemf_scale` parameter from `MotorTorqueParameters`


> **Note**
> - Tested on a single joint setup
> - Not Tested on a real robot yet