### PR TITLE
Removed subdevice parameter in device wrappers implementations

### DIFF
--- a/src/devices/controlBoardRemapper/ControlBoardRemapper.cpp
+++ b/src/devices/controlBoardRemapper/ControlBoardRemapper.cpp
@@ -308,7 +308,7 @@ bool ControlBoardRemapper::attachAllUsingAxesNames(const PolyDriverList& polylis
         if( !iencs ||
             !iaxinfos )
         {
-            yCError(CONTROLBOARDREMAPPER) << "subdevice" << deviceKey << "does not implemented the required IAxisInfo or IEncoders interfaces";
+            yCError(CONTROLBOARDREMAPPER) << "sub-device" << deviceKey << "does not implemented the required IAxisInfo or IEncoders interfaces";
             return false;
         }
 
@@ -317,7 +317,7 @@ bool ControlBoardRemapper::attachAllUsingAxesNames(const PolyDriverList& polylis
 
         if( !ok )
         {
-            yCError(CONTROLBOARDREMAPPER) << "subdevice" << deviceKey << "does not implemented the required getAxes method";
+            yCError(CONTROLBOARDREMAPPER) << "sub-device" << deviceKey << "does not implemented the required getAxes method";
             return false;
         }
 
@@ -330,7 +330,7 @@ bool ControlBoardRemapper::attachAllUsingAxesNames(const PolyDriverList& polylis
 
             if( !ok )
             {
-                yCError(CONTROLBOARDREMAPPER) << "subdevice" << deviceKey << "does not implemented the required getAxisName method";
+                yCError(CONTROLBOARDREMAPPER) << "sub-device" << deviceKey << "does not implemented the required getAxisName method";
                 return false;
             }
 

--- a/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros.xml
+++ b/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros.xml
@@ -16,7 +16,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -28,7 +28,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />

--- a/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros2.xml
+++ b/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros2.xml
@@ -15,7 +15,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -26,7 +26,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -39,7 +39,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -51,7 +51,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />

--- a/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros2b.xml
+++ b/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/ros2b.xml
@@ -15,7 +15,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -26,7 +26,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -51,7 +51,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -65,7 +65,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />

--- a/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/yarp.xml
+++ b/src/devices/fake/fakeLaserWithMotor/robotinterface_xml/yarp.xml
@@ -15,7 +15,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -26,7 +26,7 @@
             <param name="period">    0.01   </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevice"> lidarmotor </elem>
+                    <elem name="subdev"> lidarmotor </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />

--- a/src/devices/fake/fakeMotionControl/fakeMotionControl.h
+++ b/src/devices/fake/fakeMotionControl/fakeMotionControl.h
@@ -73,15 +73,13 @@ struct ImpedanceParameters
 /**
  * @ingroup dev_impl_fake dev_impl_motor
  *
- * \brief `fakeMotionControl`: Documentation to be added
- *
- * The aim of this device is to mimic the expected behavior of a
+ * \brief `fakeMotionControl`: The aim of this device is to mimic the expected behavior of a
  * real motion control device to help testing the high level software.
  *
  * This device is implementing last version of interfaces and it is compatible
  * with controlBoard_nws_yarp device.
  *
- * WIP - it is very basic now, not all interfaces are implemented yet.
+ * WIP - Some interfaces could be not implemented.
  */
 class FakeMotionControl :
         public yarp::dev::DeviceDriver,

--- a/src/devices/fake/fakeMotionControlMicro/fakeMotionControlMicro.h
+++ b/src/devices/fake/fakeMotionControlMicro/fakeMotionControlMicro.h
@@ -20,15 +20,9 @@
 /**
  * @ingroup dev_impl_fake dev_impl_motor
  *
- * \brief `fakeMotionControlMicro`: Documentation to be added
+ * \brief `fakeMotionControlMicro`: This device implements a minimal subset of mandatory interfaces
+ * to run with controlBoard_nws_yarp. It is thus a smaller, limited version than fakeMotionControl.
  *
- * The aim of this device is to mimic the expected behavior of a
- * real motion control device to help testing the high level software.
- *
- * This device is implementing last version of interfaces and it is compatible
- * with controlBoard_nws_yarp device.
- *
- * WIP - it is very basic now, not all interfaces are implemented yet.
  */
 class FakeMotionControlMicro :
         public yarp::os::PeriodicThread,

--- a/src/devices/frameGrabberCropper/frameGrabberCropper.cpp
+++ b/src/devices/frameGrabberCropper/frameGrabberCropper.cpp
@@ -59,38 +59,12 @@ bool FrameGrabberCropper::open(yarp::os::Searchable& config)
         forwardRgbVisualParams = true;
     }
 
-    if (config.check("subdevice")) {
-        yarp::os::Property p;
-        subdevice = new yarp::dev::PolyDriver;
-        p.fromString(config.toString());
-        p.unput("device");
-        p.put("device", config.find("subdevice").asString()); // subdevice was already checked before
-
-        // if errors occurred during open, quit here.
-        if (!subdevice->open(p) || !(subdevice->isValid())) {
-            yCError(FRAMEGRABBERCROPPER, "Could not open subdevice");
-            return false;
-        }
-
-        if (!attach(subdevice)) {
-            yCError(FRAMEGRABBERCROPPER, "Could not attach subdevice");
-            subdevice->close();
-            return false;
-        }
-        subdeviceOwned = true;
-    }
-
     return true;
 }
 
 
 bool FrameGrabberCropper::close()
 {
-    if (subdeviceOwned) {
-        subdevice->close();
-        delete subdevice;
-        subdevice = nullptr;
-    }
     return true;
 }
 

--- a/src/devices/frameGrabberCropper/frameGrabberCropper.h
+++ b/src/devices/frameGrabberCropper/frameGrabberCropper.h
@@ -66,9 +66,6 @@ class FrameGrabberCropper :
         public yarp::dev::IRgbVisualParams,
         public yarp::dev::IPreciselyTimed
 {
-    yarp::dev::PolyDriver* subdevice{nullptr};
-    bool subdeviceOwned{false};
-
     yarp::dev::IFrameGrabberControls* iFrameGrabberControls{nullptr};
     yarp::dev::IFrameGrabberControlsDC1394* iFrameGrabberControlsDC1394{nullptr};
     yarp::dev::IRgbVisualParams* iRgbVisualParams{nullptr};

--- a/src/devices/networkWrappers/AnalogWrapper/AnalogWrapper.h
+++ b/src/devices/networkWrappers/AnalogWrapper/AnalogWrapper.h
@@ -53,7 +53,6 @@ class AnalogPortEntry;
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:--------------------------: |:-----------------------------------------------------------------:|:-----:|
  * | name           |      -         | string  | -              |   -           | Yes                         | full name of the port opened by the device, like /robotName/part/ | MUST start with a '/' character |
  * | period         |      -         | int     | ms             |   20          | No                          | refresh period of the broadcasted values in ms                    | optional, default 20ms |
- * | subdevice      |      -         | string  | -              |   -           | alternative to netwok group | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
  * | ports          |      -         | group   | -              |   -           | alternative to subdevice    | this is expected to be a group parameter in xml format, a list in .ini file format. SubParameter are mandatory if this is used| - |
  * | -              | portName_1     | 4 * int | channel number |   -           |   if ports is used          | describe how to match subdevice_1 channels with the wrapper channels. First 2 numbers indicate first/last wrapper channel, last 2 numbers are subdevice first/last channel | The channels are intended to be consequent |
  * | -              |      ...       | 4 * int | channel number |   -           |   if ports is used          | same as above                                                     | The channels are intended to be consequent |
@@ -161,15 +160,6 @@ private:
     yarp::sig::Vector lastDataRead;             // the last vector of data read from the attached IAnalogSensor
     int _rate{DEFAULT_THREAD_PERIOD};
     std::string sensorId;
-
-    bool ownDevices{false};
-    // Open the wrapper only, the attach method needs to be called before using it
-    bool openDeferredAttach(yarp::os::Searchable &prop);
-
-    // For the simulator, if a subdevice parameter is given to the wrapper, it will
-    // open it and attach to it immediately.
-    yarp::dev::PolyDriver *subDeviceOwned{nullptr};
-    bool openAndAttachSubDevice(yarp::os::Searchable &prop);
 
     bool initialize_YARP(yarp::os::Searchable &config);
     void setHandlers();

--- a/src/devices/networkWrappers/JoypadControlServer/JoypadControlServer.h
+++ b/src/devices/networkWrappers/JoypadControlServer/JoypadControlServer.h
@@ -55,8 +55,6 @@ class JoypadControlServer :
     JoypadCtrlParser                m_parser;
     yarp::dev::IJoypadController*   m_IJoypad;
     yarp::os::Port                  m_rpcPort;
-    yarp::dev::PolyDriver*          m_subDeviceOwned;
-    bool                            m_isSubdeviceOwned;
     bool                            m_separatePorts;
     bool                            m_profile;
     std::string           m_rpcPortName;
@@ -87,7 +85,6 @@ public:
     bool fromConfig(yarp::os::Searchable& params);
     bool close() override;
     bool attach(yarp::dev::PolyDriver* poly) override;
-    bool attach(yarp::dev::IJoypadController* s);
     bool detach() override;
     bool threadInit() override;
     void threadRelease() override;

--- a/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.cpp
+++ b/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.cpp
@@ -295,6 +295,7 @@ bool RgbdSensor_nws_yarp::detach()
     }
 
     sensor_p = nullptr;
+    fgCtrl = nullptr;
     return true;
 }
 
@@ -451,7 +452,7 @@ bool RgbdSensor_nws_yarp::writeData()
     else { oldDepthStamp = depthStamp; }
 
     // TBD: We should check here somehow if the timestamp was correctly updated and, if not, update it ourselves.
-    if (rgb_data_ok)
+    if (rgb_data_ok && colorFrame_StreamingPort.getOutputCount() > 0)
     {
         FlexImage& yColorImage = colorFrame_StreamingPort.prepare();
         yColorImage.setPixelCode(colorImage.getPixelCode());
@@ -460,7 +461,7 @@ bool RgbdSensor_nws_yarp::writeData()
         colorFrame_StreamingPort.setEnvelope(colorStamp);
         colorFrame_StreamingPort.write();
     }
-    if (depth_data_ok)
+    if (depth_data_ok && depthFrame_StreamingPort.getOutputCount() > 0)
     {
         ImageOf<PixelFloat>& yDepthImage = depthFrame_StreamingPort.prepare();
         yDepthImage.setQuantum(depthImage.getQuantum());

--- a/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.cpp
+++ b/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.cpp
@@ -172,9 +172,7 @@ RgbdSensor_nws_yarp::RgbdSensor_nws_yarp() :
     sensor_p(nullptr),
     fgCtrl(nullptr),
     sensorStatus(IRGBDSensor::RGBD_SENSOR_NOT_READY),
-    verbose(4),
-    isSubdeviceOwned(false),
-    subDeviceOwned(nullptr)
+    verbose(4)
 {}
 
 RgbdSensor_nws_yarp::~RgbdSensor_nws_yarp()
@@ -210,23 +208,6 @@ bool RgbdSensor_nws_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
-    // check if we need to create subdevice or if they are
-    // passed later on through attachAll()
-    if(isSubdeviceOwned)
-    {
-        if(! openAndAttachSubDevice(config))
-        {
-            yCError(RGBDSENSORNWSYARP, "Error while opening subdevice");
-            return false;
-        }
-    }
-    else
-    {
-        if (!openDeferredAttach(config)) {
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -255,45 +236,6 @@ bool RgbdSensor_nws_yarp::fromConfig(yarp::os::Searchable &config)
     colorFrame_StreamingPort_Name = rootName + "/rgbImage:o";
     depthFrame_StreamingPort_Name = rootName + "/depthImage:o";
 
-    if(config.check("subdevice")) {
-        isSubdeviceOwned=true;
-    } else {
-        isSubdeviceOwned=false;
-    }
-
-    return true;
-}
-
-bool RgbdSensor_nws_yarp::openDeferredAttach(Searchable& prop)
-{
-    // I dunno what to do here now...
-    isSubdeviceOwned = false;
-    return true;
-}
-
-bool RgbdSensor_nws_yarp::openAndAttachSubDevice(Searchable& prop)
-{
-    Property p;
-    subDeviceOwned = new PolyDriver;
-    p.fromString(prop.toString());
-
-    p.unput("device");
-    p.put("device",prop.find("subdevice").asString());  // subdevice was already checked before
-
-    // if errors occurred during open, quit here.
-    yCDebug(RGBDSENSORNWSYARP, "Opening IRGBDSensor subdevice");
-    subDeviceOwned->open(p);
-
-    if (!subDeviceOwned->isValid())
-    {
-        yCError(RGBDSENSORNWSYARP, "Opening IRGBDSensor subdevice... FAILED");
-        return false;
-    }
-    isSubdeviceOwned = true;
-    if(!attach(subDeviceOwned)) {
-        return false;
-    }
-
     return true;
 }
 
@@ -302,21 +244,7 @@ bool RgbdSensor_nws_yarp::close()
     yCTrace(RGBDSENSORNWSYARP, "Close");
     detach();
 
-    // close subdevice if it was created inside the open (--subdevice option)
-    if(isSubdeviceOwned)
-    {
-        if(subDeviceOwned)
-        {
-            delete subDeviceOwned;
-            subDeviceOwned=nullptr;
-        }
-        sensor_p = nullptr;
-        fgCtrl = nullptr;
-        isSubdeviceOwned = false;
-    }
-
     // Closing port
-
     rpcPort.interrupt();
     colorFrame_StreamingPort.interrupt();
     depthFrame_StreamingPort.interrupt();
@@ -364,11 +292,6 @@ bool RgbdSensor_nws_yarp::detach()
 {
     if (yarp::os::PeriodicThread::isRunning()) {
         yarp::os::PeriodicThread::stop();
-    }
-
-    //check if we already instantiated a subdevice previously
-    if (isSubdeviceOwned) {
-        return false;
     }
 
     sensor_p = nullptr;
@@ -528,7 +451,7 @@ bool RgbdSensor_nws_yarp::writeData()
     else { oldDepthStamp = depthStamp; }
 
     // TBD: We should check here somehow if the timestamp was correctly updated and, if not, update it ourselves.
-    if (rgb_data_ok && colorFrame_StreamingPort.getOutputCount() > 0)
+    if (rgb_data_ok)
     {
         FlexImage& yColorImage = colorFrame_StreamingPort.prepare();
         yColorImage.setPixelCode(colorImage.getPixelCode());
@@ -537,7 +460,7 @@ bool RgbdSensor_nws_yarp::writeData()
         colorFrame_StreamingPort.setEnvelope(colorStamp);
         colorFrame_StreamingPort.write();
     }
-    if (depth_data_ok && depthFrame_StreamingPort.getOutputCount() > 0)
+    if (depth_data_ok)
     {
         ImageOf<PixelFloat>& yDepthImage = depthFrame_StreamingPort.prepare();
         yDepthImage.setQuantum(depthImage.getQuantum());

--- a/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.h
+++ b/src/devices/networkWrappers/RGBDSensor_nws_yarp/RgbdSensor_nws_yarp.h
@@ -79,7 +79,6 @@ public:
  * |:--------------:|:-----------------------:|:-------:|:--------------:|:-------------:|:-----------------------------: |:---------------------------------------------------------------------------------------------------:|:-----:|
  * | period         |      -                  | double  | s              |   0.02        | No                             | refresh period of the broadcasted values in s                                                       | default 0.02s |
  * | name           |      -                  | string  | -              |   -           | Yes                            | Prefix name of the ports opened by the RGBD wrapper, e.g. /robotName/RGBD                           | Required suffix like '/rpc' will be added by the device      |
- * | subdevice      |      -                  | string  | -              |   -           | alternative to 'attach' action | name of the subdevice to use as a data source                                                       | when used, parameters for the subdevice must be provided as well |
  *
  * Some example of configuration files:
  *
@@ -147,16 +146,6 @@ private:
     yarp::dev::IRGBDSensor::RGBDSensor_status sensorStatus;
     int                            verbose;
     bool                           initialize_YARP(yarp::os::Searchable& config);
-
-    // Open the wrapper only, the attach method needs to be called before using it
-    // Typical usage: yarprobotinterface
-    bool                           openDeferredAttach(yarp::os::Searchable& prop);
-
-    // If a subdevice parameter is given, the wrapper will open it and attach to immediately.
-    // Typical usage: simulator or command line
-    bool                           isSubdeviceOwned;
-    yarp::dev::PolyDriver*         subDeviceOwned;
-    bool                           openAndAttachSubDevice(yarp::os::Searchable& prop);
 
     // Synch
     yarp::os::Stamp                colorStamp;

--- a/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2D_nws_yarp.cpp
+++ b/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2D_nws_yarp.cpp
@@ -33,8 +33,7 @@ YARP_LOG_COMPONENT(RANGEFINDER2D_NWS_YARP, "yarp.devices.Rangefinder2D_nws_yarp"
     maxAngle(0),
     minDistance(0),
     maxDistance(0),
-    resolution(0),
-    isDeviceOwned(false)
+    resolution(0)
 {}
 
 Rangefinder2D_nws_yarp::~Rangefinder2D_nws_yarp()
@@ -325,25 +324,6 @@ bool Rangefinder2D_nws_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
-    if(config.check("subdevice"))
-    {
-        Property       p;
-        p.fromString(config.toString(), false);
-        p.put("device", config.find("subdevice").asString());
-
-        if(!m_driver.open(p) || !m_driver.isValid())
-        {
-            yCError(RANGEFINDER2D_NWS_YARP) << "failed to open subdevice.. check params";
-            return false;
-        }
-
-        if(!attach(&m_driver))
-        {
-            yCError(RANGEFINDER2D_NWS_YARP) << "failed to open subdevice.. check params";
-            return false;
-        }
-        isDeviceOwned = true;
-    }
     return true;
 }
 

--- a/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2D_nws_yarp.h
+++ b/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2D_nws_yarp.h
@@ -48,7 +48,6 @@
    * |:--------------:|:-----------------------:|:-------:|:--------------:|:-------------:|:-----------------------------: |:---------------------------------------------------------------------------------------------------:|:-----:|
    * | period         |      -                  | double  | s              |   0.02        | No                             | refresh period of the broadcasted values in s                                                      | default 0.02s |
    * | name           |      -                  | string  | -              |   -           | Yes                            | Prefix name of the ports opened by the wrapper, e.g. /robotName/Rangefinder2DSensor                 | Required suffix like '/rpc' will be added by the device      |
-   * | subdevice      |      -                  | string  | -              |   -           | alternative to 'attach' action | name of the subdevice to use as a data source                                                       | when used, parameters for the subdevice must be provided as well |
    * | frame_id       |      -                  | string  | -              |   -           | No                             | name of the attached frame                                                                          | Currently not used, reserved for future use                  |
    *
    * Example of configuration file using .ini format.
@@ -91,7 +90,6 @@ private:
     yarp::os::BufferedPort<yarp::dev::LaserScan2D> streamingPort;
 
     //interfaces
-    yarp::dev::PolyDriver m_driver;
     yarp::dev::IRangefinder2D *sens_p;
 
     //device data
@@ -100,7 +98,6 @@ private:
     double minAngle, maxAngle;
     double minDistance, maxDistance;
     double resolution;
-    bool   isDeviceOwned;
 
     //private methods
     bool initialize_YARP(yarp::os::Searchable &config);

--- a/src/devices/networkWrappers/audioPlayerWrapper/AudioPlayerWrapper.cpp
+++ b/src/devices/networkWrappers/audioPlayerWrapper/AudioPlayerWrapper.cpp
@@ -194,30 +194,6 @@ bool AudioPlayerWrapper::open(yarp::os::Searchable &config)
     yCInfo(AUDIOPLAYERWRAPPER) << "Using a 'playback_network_buffer_size' of" << m_buffer_delay << "s";
     yCInfo(AUDIOPLAYERWRAPPER) << "Increase this value to robustify the real-time audio stream (it will increase latency too)";
 
-    if(config.check("subdevice"))
-    {
-        Property       p;
-        p.fromString(config.toString(), false);
-        p.put("device", config.find("subdevice").asString());
-
-        if(!m_driver.open(p) || !m_driver.isValid())
-        {
-            yCError(AUDIOPLAYERWRAPPER) << "Failed to open subdevice.. check params";
-            return false;
-        }
-        if(!attach(&m_driver))
-        {
-            yCError(AUDIOPLAYERWRAPPER) << "Failed to open subdevice.. check params";
-            return false;
-        }
-        m_isDeviceOwned = true;
-        if (m_irender == nullptr)
-        {
-            yCError(AUDIOPLAYERWRAPPER, "m_irender is null\n");
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -325,9 +301,5 @@ bool AudioPlayerWrapper::close()
         PeriodicThread::stop();
     }
 
-    if(m_config.check("subdevice"))
-    {
-        detach();
-    }
     return true;
 }

--- a/src/devices/networkWrappers/audioPlayerWrapper/AudioPlayerWrapper.h
+++ b/src/devices/networkWrappers/audioPlayerWrapper/AudioPlayerWrapper.h
@@ -86,8 +86,6 @@ public:
     void run() override;
 
 private:
-    yarp::dev::PolyDriver m_driver;
-
     std::string m_rpcPortName;
     yarp::os::Port  m_rpcPort;
     std::string  m_audioInPortName;
@@ -103,7 +101,6 @@ private:
     std::queue<scheduled_sound_type> m_sound_buffer;
     double m_period;
     double m_buffer_delay;
-    bool   m_isDeviceOwned = false;
     bool   m_debug_enabled = false;
     bool   m_isPlaying = false;
 

--- a/src/devices/networkWrappers/audioRecorderWrapper/AudioRecorderWrapper.cpp
+++ b/src/devices/networkWrappers/audioRecorderWrapper/AudioRecorderWrapper.cpp
@@ -90,27 +90,6 @@ bool AudioRecorderWrapper::open(yarp::os::Searchable& config)
     }
     m_rpcPort.setReader(*this);
 
-    // Subdevice check and initialization
-    if (config.check("subdevice"))
-    {
-        yarp::os::Property       p;
-        p.fromString(config.toString(), false);
-        p.put("device", config.find("subdevice").asString());
-
-        if (!m_driver.open(p) || !m_driver.isValid())
-        {
-            yCError(AUDIORECORDERWRAPPER) << "Failed to open subdevice.. check params";
-            return false;
-        }
-
-        if (!attach(&m_driver))
-        {
-            yCError(AUDIORECORDERWRAPPER) << "Failed to open subdevice.. check params";
-            return false;
-        }
-        m_isDeviceOwned = true;
-    }
-
     return true;
 }
 

--- a/src/devices/networkWrappers/audioRecorderWrapper/AudioRecorderWrapper.h
+++ b/src/devices/networkWrappers/audioRecorderWrapper/AudioRecorderWrapper.h
@@ -49,7 +49,6 @@ class AudioRecorderWrapper :
         public yarp::os::PortReader
 {
 private:
-    yarp::dev::PolyDriver          m_driver;
     yarp::dev::IAudioGrabberSound* m_mic = nullptr; //The microphone device
     yarp::os::Property             m_config;
     double                         m_period;
@@ -60,7 +59,6 @@ private:
     size_t                         m_min_number_of_samples_over_network;
     size_t                         m_max_number_of_samples_over_network;
     double                         m_getSound_timeout;
-    bool                           m_isDeviceOwned =false;
     bool                           m_isRecording=false;
     AudioRecorderStatusThread*     m_statusThread = nullptr;
     AudioRecorderDataThread*       m_dataThread =nullptr;

--- a/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.h
+++ b/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.h
@@ -56,7 +56,6 @@
  * |:--------------:|:--------------:|:-------:|:--------------:|:-------------:|:--------------------------: |:-----------------------------------------------------------------:|:-----:|
  * | name           |      -         | string  | -              |   -           | Yes                         | full name of the port opened by the device, like /robotName/part/ | MUST start with a '/' character |
  * | period         |      -         | double  | s              |   0.02        | No                          | refresh period of the broadcasted values in s                     | optional, default 0.02s period|
- * | subdevice      |      -         | string  | -              |   -           | No                          | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
  */
 
 class ControlBoard_nws_yarp :
@@ -87,8 +86,6 @@ private:
     yarp::sig::Vector times; // time for each joint
     yarp::os::Stamp time; // envelope to attach to the state port
 
-    yarp::dev::DeviceDriver* subdevice_ptr{nullptr};
-    bool subdevice_owned = false;
     size_t subdevice_joints {0};
     bool subdevice_ready = false;
 

--- a/src/devices/networkWrappers/frameGrabber_nws_yarp/FrameGrabber_nws_yarp.cpp
+++ b/src/devices/networkWrappers/frameGrabber_nws_yarp/FrameGrabber_nws_yarp.cpp
@@ -51,14 +51,6 @@ bool FrameGrabber_nws_yarp::close()
     delete img_Raw;
     img_Raw = nullptr;
 
-    if (subdevice) {
-        subdevice->close();
-        delete subdevice;
-        subdevice = nullptr;
-    }
-
-    isSubdeviceOwned = false;
-
     return true;
 }
 
@@ -118,37 +110,7 @@ bool FrameGrabber_nws_yarp::open(yarp::os::Searchable& config)
     }
     pImg.setReader(*this);
 
-
-    // Check "subdevice" option and eventually open the device
-    isSubdeviceOwned = config.check("subdevice");
-    if (isSubdeviceOwned) {
-        yarp::os::Property p;
-        subdevice = new yarp::dev::PolyDriver;
-        p.fromString(config.toString());
-        if (cap == COLOR) {
-            p.put("pixelType", VOCAB_PIXEL_RGB);
-        } else {
-            p.put("pixelType", VOCAB_PIXEL_MONO);
-        }
-
-        p.unput("device");
-        p.put("device", config.find("subdevice").asString()); // subdevice was already checked before
-
-        // if errors occurred during open, quit here.
-        subdevice->open(p);
-
-        if (!(subdevice->isValid())) {
-            yCError(FRAMEGRABBER_NWS_YARP, "Unable to open subdevice");
-            return false;
-        }
-        if (!attach(subdevice)) {
-            yCError(FRAMEGRABBER_NWS_YARP, "Unable to attach subdevice");
-            return false;
-        }
-    } else {
-        yCInfo(FRAMEGRABBER_NWS_YARP) << "Running, waiting for attach...";
-    }
-
+    yCInfo(FRAMEGRABBER_NWS_YARP) << "Running, waiting for attach...";
     active = true;
 
     return true;

--- a/src/devices/networkWrappers/frameGrabber_nws_yarp/FrameGrabber_nws_yarp.h
+++ b/src/devices/networkWrappers/frameGrabber_nws_yarp/FrameGrabber_nws_yarp.h
@@ -45,7 +45,6 @@
  * | period         |      -                  | double  | s              |   0.03        | No       | refresh period (in s) of the broadcasted values through yarp ports               | default 0.03s |
  * | name           |      -                  | string  | -              |   /grabber    | No       | Prefix name of the ports opened by the FrameGrabber_nws_yarp                     | Required suffix like '/rpc' will be added by the device |
  * | capabilities   |      -                  | string  | -              |   COLOR       | No       | two capabilities supported, COLOR and RAW respectively for rgb and raw streaming | - |
- * | subdevice      |      -                  | string  | -              |   -           | No       | name of the subdevice to use as a data source                                    | when used, parameters for the subdevice must be provided as well; when not used, the device should be 'attached' |
 // FIXME DRDANZ no_drop?
  *
  * Some example of configuration files:
@@ -91,10 +90,6 @@ private:
     // Ports
     yarp::os::RpcServer rpcPort;
     yarp::os::BufferedPort<yarp::sig::FlexImage> pImg;
-
-    // Subdevice
-    yarp::dev::PolyDriver* subdevice {nullptr};
-    bool isSubdeviceOwned {false};
 
     // Interfaces handled
     yarp::dev::IRgbVisualParams* iRgbVisualParams {nullptr};

--- a/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.cpp
+++ b/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.cpp
@@ -82,30 +82,7 @@ bool MobileBaseVelocityControl_nws_yarp::open(yarp::os::Searchable &config)
         m_StreamingInput.useCallback();
     }
 
-    //attach subdevice if required
-    if (config.check("subdevice"))
-    {
-        Property       p;
-        p.fromString(config.toString(), false);
-        p.put("device", config.find("subdevice").asString());
-
-        if (!m_subdev.open(p) || !m_subdev.isValid())
-        {
-            yCError(MOBVEL_NWS_YARP) << "Failed to open subdevice.. check params";
-            return false;
-        }
-
-        if (!attach(&m_subdev))
-        {
-            yCError(MOBVEL_NWS_YARP) << "Failed to attach subdevice.. check params";
-            return false;
-        }
-    }
-    else
-    {
-        yCInfo(MOBVEL_NWS_YARP) << "Waiting for device to attach";
-    }
-
+    yCInfo(MOBVEL_NWS_YARP) << "Waiting for device to attach";
     return true;
 }
 
@@ -113,7 +90,6 @@ bool MobileBaseVelocityControl_nws_yarp::close()
 {
     m_rpc_port_navigation_server.close();
     m_StreamingInput.close();
-    if (m_subdev.isValid()) { m_subdev.close(); }
     return true;
 }
 
@@ -137,6 +113,7 @@ bool MobileBaseVelocityControl_nws_yarp::attach(PolyDriver* driver)
     }
     m_StreamingInput.m_iVel = m_iNavVel;
 
+    yCInfo(MOBVEL_NWS_YARP) << "Attach complete";
     return true;
 }
 

--- a/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.h
@@ -33,7 +33,6 @@
  * | Parameter name | SubParameter   | Type    | Units | Default Value | Required | Description                                                       | Notes |
  * |:--------------:|:--------------:|:-------:|:-----:|:-------------:|:-------: |:-----------------------------------------------------------------:|:-----:|
  * | local          |      -         | string  | -     |   -           | Yes      | Full name of the port opened by the device. For both ports (i.e. /rpc:i, /data:i) the corresponding suffix is automatically added |       |
- * | subdevice      |      -         | string  | -     |   -           | No       | name of the subdevice to instantiate                              | when used, parameters for the subdevice must be provided as well |
  *
  * Example usage:
  * yarpdev --device mobileBaseVelocityControl_nws_yarp --subdevice velocityInputHandler --local /input1
@@ -61,7 +60,6 @@ protected:
     VelocityInputPortProcessor    m_StreamingInput;
     std::string                   m_local_name;
 
-    yarp::dev::PolyDriver                           m_subdev;
     yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
 
 public:

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -152,36 +152,8 @@ bool MultipleAnalogSensorsServer::open(yarp::os::Searchable& config)
     m_RPCPortName = name + "/rpc:o";
     m_streamingPortName = name + "/measures:o";
 
-    if (config.check("subdevice"))
-    {
-        std::string subdeviceName = config.find("subdevice").asString();
 
-        yarp::os::Property driverConfig;
-        driverConfig.fromString(config.toString());
-        driverConfig.put("device", subdeviceName);
 
-        if (!m_subdevice.open(driverConfig))
-        {
-            yCError(MULTIPLEANALOGSENSORSSERVER, "Opening subdevice failed.");
-            return false;
-        }
-
-        yarp::dev::PolyDriverList driverList;
-        driverList.push(&m_subdevice, subdeviceName.c_str());
-
-        if (!attachAll(driverList))
-        {
-            yCError(MULTIPLEANALOGSENSORSSERVER, "Attaching subdevice failed.");
-            return false;
-        }
-
-        yCInfo(MULTIPLEANALOGSENSORSSERVER,
-               "Subdevice \"%s\" successfully configured and attached.",
-               subdeviceName.c_str());
-        m_isDeviceOwned = true;
-    }
-
-    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Open complete");
     return true;
 }
 
@@ -189,13 +161,6 @@ bool MultipleAnalogSensorsServer::close()
 {
     bool ok = this->detachAll();
 
-    if (m_isDeviceOwned)
-    {
-        ok &= m_subdevice.close();
-        m_isDeviceOwned = false;
-    }
-
-    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Close complete");
     return ok;
 }
 
@@ -449,7 +414,6 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
 
     if(!ok)
     {
-        yCError(MULTIPLEANALOGSENSORSSERVER, "Failure in populateAllSensorsMetadata()");
         close();
         return false;
     }
@@ -489,7 +453,6 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
         return false;
     }
 
-    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Attach complete");
     return true;
 }
 
@@ -504,7 +467,6 @@ bool MultipleAnalogSensorsServer::detachAll()
     m_rpcPort.close();
     m_streamingPort.close();
 
-    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Detach complete");
     return true;
 }
 

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -414,6 +414,7 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
 
     if(!ok)
     {
+        yCError(MULTIPLEANALOGSENSORSSERVER, "Failure in populateAllSensorsMetadata()");
         close();
         return false;
     }
@@ -453,6 +454,7 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
         return false;
     }
 
+    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Attach complete");
     return true;
 }
 
@@ -467,6 +469,7 @@ bool MultipleAnalogSensorsServer::detachAll()
     m_rpcPort.close();
     m_streamingPort.close();
 
+    yCDebug(MULTIPLEANALOGSENSORSSERVER, "Detach complete");
     return true;
 }
 

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -52,10 +52,6 @@ class MultipleAnalogSensorsServer :
     // Generic vector buffer
     yarp::sig::Vector m_buffer;
 
-    // Wrapped subdevices, if any
-    yarp::dev::PolyDriver m_subdevice;
-    bool m_isDeviceOwned{false};
-
     // Interface of the wrapped device
     yarp::dev::IThreeAxisGyroscopes* m_iThreeAxisGyroscopes{nullptr};
     yarp::dev::IThreeAxisLinearAccelerometers* m_iThreeAxisLinearAccelerometers{nullptr};


### PR DESCRIPTION
The individual implementations of the parameter `subdevice` have been removed from all yarp wrapper devices.
Depends on #3079
Discussed in details in https://github.com/robotology/yarp/discussions/3078
