### PR TITLE
Yarpllmgui

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -576,6 +576,10 @@ yarp_dependent_option(
   YARP_COMPILE_RobotTestingFramework_ADDONS "Compile Robot Testing Framework addons." ON
   "YARP_HAS_RobotTestingFramework" OFF
 )
+yarp_dependent_option(
+  YARP_COMPILE_yarpllmgui "Do you want to compile yarpllmgui" ON
+  "YARP_COMPILE_EXECUTABLES;YARP_COMPILE_GUIS;YARP_HAS_Qt5" OFF
+)
 
 ################################################################################
 # Disable some parts if they are not required

--- a/doc/release/yarp_3_9_master/master.md
+++ b/doc/release/yarp_3_9_master/master.md
@@ -32,6 +32,10 @@ Added new device `LLM_nwc_yarp`.
 
 `yarp::sig::sound` refactored to avoid the internal use (private implementation) of yarp::sig::Image data type.
 
+# llmgui
+
+Added a gui for `llmdevice`.
+
 # deprecation
 
 Removed deprecated devices: transformClient, transformServer, controlBoardWrapper

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ if(YARP_COMPILE_EXECUTABLES)
     add_subdirectory(yarplaserscannergui)
     add_subdirectory(yarpviz)
     add_subdirectory(yarpaudiocontrolgui)
+    add_subdirectory(yarpllmgui)
 endif()
 
 # Robot Testing Framework addons

--- a/src/devices/LLM_nws_yarp/CMakeLists.txt
+++ b/src/devices/LLM_nws_yarp/CMakeLists.txt
@@ -22,7 +22,10 @@ if(NOT SKIP_LLM_nws_yarp)
   )
 
   target_sources(yarp_LLM_nws_yarp PRIVATE $<TARGET_OBJECTS:ILLMMsgs>)
-  target_include_directories(yarp_LLM_nws_yarp PRIVATE $<TARGET_PROPERTY:ILLMMsgs,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_include_directories(yarp_LLM_nws_yarp
+    PRIVATE
+    $<TARGET_PROPERTY:ILLMMsgs,INTERFACE_INCLUDE_DIRECTORIES>
+    ${CMAKE_CURRENT_SOURCE_DIR})
 
   target_link_libraries(yarp_LLM_nws_yarp
     YARP::YARP_os

--- a/src/devices/LLM_nws_yarp/ILLMServerImpl.cpp
+++ b/src/devices/LLM_nws_yarp/ILLMServerImpl.cpp
@@ -1,26 +1,31 @@
 /*
  * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
- * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "ILLMServerImpl.h"
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
 
-namespace
-{
-    YARP_LOG_COMPONENT(LLMSERVER, "yarp.device.LLMServer")
+#include <ILLMServerImpl.h>
+
+namespace {
+YARP_LOG_COMPONENT(LLMSERVER, "yarp.device.LLMServer")
 }
 
-bool ILLMRPCd::setPrompt(const std::string &prompt)
+bool ILLMRPCd::setPrompt(const std::string& prompt)
 {
-    if (m_iLlm == nullptr)
-    {
+    if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
         return false;
     }
-    // TODO: maybe we can catch errors here, that would be better
-    m_iLlm->setPrompt(prompt);
+
+    if (!m_iLlm->setPrompt(prompt)) {
+        yCError(LLMSERVER, "setPrompt failed");
+        return false;
+    }
+
+    m_stream_conversation();
+
     return true;
 }
 
@@ -29,8 +34,7 @@ yarp::dev::llm::return_readPrompt ILLMRPCd::readPrompt()
 
     yarp::dev::llm::return_readPrompt ret;
 
-    if (m_iLlm == nullptr)
-    {
+    if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
         ret.ret = false;
     }
@@ -40,36 +44,57 @@ yarp::dev::llm::return_readPrompt ILLMRPCd::readPrompt()
     return ret;
 }
 
-yarp::dev::llm::return_ask ILLMRPCd::ask(const std::string &question)
+yarp::dev::llm::return_ask ILLMRPCd::ask(const std::string& question)
 {
     yarp::dev::llm::return_ask ret;
 
-    if (m_iLlm == nullptr)
-    {
+    if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
         ret.ret = false;
     }
 
-    ret.ret = m_iLlm->ask(question,ret.answer);
+    ret.ret = m_iLlm->ask(question, ret.answer);
+
+    if (ret.ret) {
+        m_stream_conversation();
+    }
 
     return ret;
 }
+
+void ILLMRPCd::m_stream_conversation()
+{
+    std::vector<std::pair<Author, Content>> conversation;
+    if (!m_iLlm->getConversation(conversation)) {
+        yCError(LLMSERVER, "Unable to retrieve the conversation");
+        return;
+    }
+
+    auto& bot = m_streaming_port.prepare();
+    auto& list = bot.addList();
+    for (const auto& [author, message] : conversation) {
+        auto& message_bot = list.addList();
+        message_bot.addString(author);
+        message_bot.addString(message);
+    }
+
+    m_streaming_port.write();
+}
+
 
 yarp::dev::llm::return_getConversation ILLMRPCd::getConversation()
 {
     yarp::dev::llm::return_getConversation ret;
 
-    if (m_iLlm == nullptr)
-    {
+    if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
         ret.ret = false;
     }
 
-    std::vector<std::pair<Author,Content>> conversation;
+    std::vector<std::pair<Author, Content>> conversation;
     ret.ret = m_iLlm->getConversation(conversation);
 
-    for (const auto &[author, message] : conversation)
-    {
+    for (const auto& [author, message] : conversation) {
         ret.conversation.push_back(yarp::dev::llm::Message(author, message));
     }
 
@@ -78,10 +103,16 @@ yarp::dev::llm::return_getConversation ILLMRPCd::getConversation()
 
 bool ILLMRPCd::deleteConversation()
 {
-    if (m_iLlm == nullptr)
-    {
+    bool ret = false;
+    if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
     }
 
-    return m_iLlm->deleteConversation();
+    ret = m_iLlm->deleteConversation();
+
+    if (ret) {
+        m_stream_conversation();
+    }
+
+    return ret;
 }

--- a/src/devices/LLM_nws_yarp/ILLMServerImpl.h
+++ b/src/devices/LLM_nws_yarp/ILLMServerImpl.h
@@ -3,20 +3,36 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <yarp/dev/llm/ILLMMsgs.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Bottle.h>
 #include <yarp/dev/ILLM.h>
+#include <yarp/dev/llm/ILLMMsgs.h>
 
 class ILLMRPCd : public yarp::dev::llm::ILLMMsgs
 {
 private:
-    yarp::dev::ILLM *m_iLlm = nullptr;
+    yarp::dev::ILLM* m_iLlm = nullptr;
+
+    // The conversation is streamed on a yarp port
+    yarp::os::BufferedPort<yarp::os::Bottle> m_streaming_port;
+    void m_stream_conversation();
 
 public:
-    void setInterface(yarp::dev::ILLM *_iLlm) { m_iLlm = _iLlm; }
+
+    void setInterface(yarp::dev::ILLM* _iLlm, const std::string& streaming_port_name)
+    {
+        m_iLlm = _iLlm;
+        m_streaming_port.open(streaming_port_name);
+    }
+    void unsetInterface()
+    {
+        m_iLlm = nullptr;
+        m_streaming_port.close();
+    }
     // From IGPTMsgs
-    bool setPrompt(const std::string &prompt) override;
+    bool setPrompt(const std::string& prompt) override;
     yarp::dev::llm::return_readPrompt readPrompt() override;
-    yarp::dev::llm::return_ask ask(const std::string &question) override;
+    yarp::dev::llm::return_ask ask(const std::string& question) override;
     yarp::dev::llm::return_getConversation getConversation() override;
     bool deleteConversation() override;
 };

--- a/src/devices/LLM_nws_yarp/LLM_nws_yarp.h
+++ b/src/devices/LLM_nws_yarp/LLM_nws_yarp.h
@@ -29,6 +29,9 @@ class LLM_nws_yarp : public yarp::dev::DeviceDriver,
                      public yarp::os::PortReader
 {
 
+private:
+    std::string m_streaming_port_name = "/llm/conv:o";
+
 protected:
     ILLMRPCd    m_RPC;
     yarp::os::RpcServer m_RpcPort;

--- a/src/devices/fakeLLMDevice/fakeLLMDevice.cpp
+++ b/src/devices/fakeLLMDevice/fakeLLMDevice.cpp
@@ -4,9 +4,17 @@
  */
 
 #include "fakeLLMDevice.h"
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
 
 bool fakeLLMDevice::setPrompt(const std::string &prompt)
 {
+    if(!m_conversation.empty())
+    {
+        yError() << "The conversation is already ongoing. You must first delete the whole conversation and start from scratch.";
+        return false;
+    }
+
     m_conversation.push_back(std::make_pair("system", prompt));
     return true;
 }

--- a/src/yarpllmgui/CMakeLists.txt
+++ b/src/yarpllmgui/CMakeLists.txt
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+if(YARP_COMPILE_yarpllmgui)
+  include(YarpUseQt5)
+  include(YarpMacOSUtilities)
+
+  add_executable(yarpllmgui WIN32)
+
+  set(yarpllmgui_SRCS
+    main.cpp
+    ConversationModel.cpp
+  )
+
+  set(yarpllmgui_HDRS
+    ConversationModel.h
+  )
+
+  set(yarpllmgui_QRC_FILES
+    res.qrc
+  )
+
+  set(yarpllmgui_QML_FILES
+    main.qml
+  )
+
+  qt5_add_resources(yarpllmgui_QRC_GEN_SRCS ${yarpllmgui_QRC_FILES})
+  qtyarp_use_qml_plugin()
+
+  source_group(
+    TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PREFIX "Source Files"
+    FILES ${yarpllmgui_SRCS}
+  )
+  source_group(
+    TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PREFIX "Header Files"
+    FILES ${yarpllmgui_HDRS}
+  )
+  source_group(
+    "Resources Files"
+    FILES ${yarpllmgui_QRC_FILES}
+  )
+  source_group(
+    "Generated Files"
+    FILES
+      ${yarpllmgui_QRC_GEN_SRCS}
+   )
+
+  target_sources(yarpllmgui
+   PRIVATE
+     ${yarpllmgui_SRCS}
+     ${yarpllmgui_HDRS}
+     ${yarpllmgui_QRC_FILES}
+     ${yarpllmgui_QRC_GEN_SRCS}
+     ${yarpllmgui_QML_FILES}
+  )
+
+  target_include_directories(yarpllmgui PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  target_link_libraries(yarpllmgui
+  PRIVATE
+    YARP::YARP_os
+    YARP::YARP_init
+    YARP::YARP_dev
+    Qt5::Widgets
+    Qt5::Gui
+    Qt5::Qml
+    Qt5::Quick
+  )
+
+  install(TARGETS yarpllmgui DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+endif()

--- a/src/yarpllmgui/CMakeLists.txt
+++ b/src/yarpllmgui/CMakeLists.txt
@@ -10,10 +10,12 @@ if(YARP_COMPILE_yarpllmgui)
   set(yarpllmgui_SRCS
     main.cpp
     ConversationModel.cpp
+    ConversationCallback.cpp
   )
 
   set(yarpllmgui_HDRS
     ConversationModel.h
+    ConversationCallback.h
   )
 
   set(yarpllmgui_QRC_FILES
@@ -22,6 +24,7 @@ if(YARP_COMPILE_yarpllmgui)
 
   set(yarpllmgui_QML_FILES
     main.qml
+    ConfigurePopup.qml
   )
 
   qt5_add_resources(yarpllmgui_QRC_GEN_SRCS ${yarpllmgui_QRC_FILES})

--- a/src/yarpllmgui/ConfigurePopup.qml
+++ b/src/yarpllmgui/ConfigurePopup.qml
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import QtQuick.Controls 2.15
+import QtQuick.Dialogs 1.3
+import QtQuick.Layouts 1.12
+import QtQuick 2.15
+
+Popup {
+    id: configurePopup
+    width: 500
+    height: 300
+
+    x: (mainWindow.width - width) / 2  // Center horizontally
+    y: (mainWindow.height - height) / 2  // Center vertically
+
+    ColumnLayout {
+
+        width: configurePopup.width
+        Layout.alignment: Qt.AlignHCenter
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            Text {
+                text: "Remote rpc"
+            }
+            TextField {
+                id: remote_rpc
+                placeholderText: "/yarpllm/rpc"
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            Text {
+                text: "Remote streaming port"
+            }
+            TextField {
+                id: streaming_port
+                placeholderText: "/yarpllm/conv:o"
+            }
+        }
+
+
+
+    }
+
+    Button {
+        anchors.bottom : parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "Confirm"
+        onClicked: {
+            // Handle the confirmation here
+            listView.model.configure(remote_rpc.text, streaming_port.text)
+            configurePopup.close();
+        }
+    }
+}

--- a/src/yarpllmgui/ConversationCallback.cpp
+++ b/src/yarpllmgui/ConversationCallback.cpp
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "ConversationCallback.h"
+
+void ConversationCallback::onRead(yarp::os::Bottle& input)
+{
+    emit conversationChanged();
+}

--- a/src/yarpllmgui/ConversationCallback.h
+++ b/src/yarpllmgui/ConversationCallback.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#ifndef __CONVERSATION_CALLBACK_H_
+#define __CONVERSATION_CALLBACK_H_
+
+#include <yarp/os/Bottle.h>
+#include <yarp/os/TypedReaderCallback.h>
+#include <QObject>
+
+class ConversationCallback : public QObject, public yarp::os::TypedReaderCallback<yarp::os::Bottle>
+{
+private:
+    Q_OBJECT;
+
+public:
+    ConversationCallback(QObject* parent = nullptr) :
+            QObject(parent)
+    {
+    }
+    void onRead(yarp::os::Bottle&) override;
+
+signals:
+    void conversationChanged();
+};
+
+#endif

--- a/src/yarpllmgui/ConversationModel.cpp
+++ b/src/yarpllmgui/ConversationModel.cpp
@@ -1,0 +1,118 @@
+#include "ConversationModel.h"
+
+#include <iostream>
+
+void ConversationModel::setLocalRpc(const std::string& localRpc)
+{
+    m_prop.put("local",localRpc);
+}
+
+void ConversationModel::setRemoteRpc(const std::string& remoteRpc)
+{
+    m_prop.put("remote",remoteRpc);
+}
+
+void ConversationModel::configure()
+{
+    if (!m_poly.open(m_prop)) {
+        yWarning() << "Cannot open LLM_nwc_yarp, is it running?";
+    }
+    m_poly.view(m_iLlm);
+}
+
+QVariant ConversationModel::data(const QModelIndex& index, int role) const
+{
+    if (index.row() < 0 || index.row() >= m_conversation.count())
+        return QVariant();
+
+    const Message& message = m_conversation[index.row()];
+    if (role == TypeRole)
+        return message.type();
+    else if (role == ContentRole)
+        return message.content();
+
+    return QVariant();
+}
+
+int ConversationModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent);
+    return m_conversation.count();
+}
+
+QHash<int, QByteArray> ConversationModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[TypeRole] = "type";
+    roles[ContentRole] = "content";
+    return roles;
+}
+
+void ConversationModel::eraseConversation()
+{
+    beginRemoveRows(QModelIndex(), 0, rowCount());
+    m_conversation.clear();
+    endRemoveRows();
+}
+
+void ConversationModel::deleteConversation()
+{
+    if (!m_iLlm) {
+        yError() << m_no_device_message;
+        return;
+    }
+
+    m_iLlm->deleteConversation();
+    refreshConversation();
+}
+
+void ConversationModel::refreshConversation()
+{
+
+    this->eraseConversation();
+
+    if (!m_iLlm) {
+        yError() << m_no_device_message;
+        return;
+    }
+
+    std::vector<std::pair<Author, Content>> conversation;
+    auto ok = m_iLlm->getConversation(conversation);
+
+    for (const auto& [author, message] : conversation) {
+        addMessage(Message(QString::fromStdString(author), QString::fromStdString(message)));
+    }
+}
+
+void ConversationModel::addMessage(const Message& message)
+{
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+    m_conversation << message;
+    endInsertRows();
+}
+
+void ConversationModel::sendMessage(const QString& message)
+{
+
+    std::string answer;
+
+    if (!m_iLlm) {
+        yError() << m_no_device_message;
+        return;
+    }
+
+    if (rowCount() == 0) {
+        m_iLlm->setPrompt(message.toStdString());
+    } else {
+        m_iLlm->ask(message.toStdString(), answer);
+    }
+
+    this->refreshConversation();
+}
+
+void ConversationModel::eraseMessage(const int& index)
+{
+    beginRemoveRows(QModelIndex(), index, index);
+    m_conversation.removeAt(index);
+    endRemoveRows();
+}

--- a/src/yarpllmgui/ConversationModel.h
+++ b/src/yarpllmgui/ConversationModel.h
@@ -1,0 +1,85 @@
+#ifndef CONVERSATIONMODEL_H
+#define CONVERSATIONMODEL_H
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Property.h>
+
+#include <yarp/dev/ILLM.h>
+#include <yarp/dev/PolyDriver.h>
+
+#include <QAbstractListModel>
+
+class Message
+{
+public:
+    Message(const QString& type, const QString& content) :
+            m_type {type}, m_content {content}
+    {
+    }
+
+    QString type() const
+    {
+        return m_type;
+    }
+    QString content() const
+    {
+        return m_content;
+    }
+
+private:
+    QString m_type;
+    QString m_content;
+};
+
+class ConversationModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum ConversationRoles
+    {
+        TypeRole = Qt::UserRole + 1,
+        ContentRole
+    };
+
+    explicit ConversationModel(QObject* parent = nullptr) :
+            QAbstractListModel(parent)
+    {
+        m_prop.put("device", "LLM_nwc_yarp");
+    }
+
+    ~ConversationModel() {  m_poly.close(); }
+
+    // Configure rpc port names and configure the polydriver 
+    void setLocalRpc(const std::string& localRpc);
+    void setRemoteRpc(const std::string& remoteRpc);
+    void configure();
+
+    QVariant data(const QModelIndex& index, int role) const override;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    void addMessage(const Message& message);
+    void refreshConversation(); // Added so that we don't rely on keeping local data in sync.
+    void eraseConversation();
+
+    // bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    // Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+    Q_INVOKABLE void deleteConversation(); // TODO: We have to come up with better names for this one
+    Q_INVOKABLE void eraseMessage(const int& index);
+    Q_INVOKABLE void sendMessage(const QString& message);
+
+protected:
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    yarp::dev::PolyDriver m_poly;
+    yarp::os::Property m_prop;
+
+    yarp::dev::ILLM* m_iLlm;
+    QList<Message> m_conversation;
+    const std::string m_no_device_message = "yarpLLMGui: no LLM_nwc was found. Operation is not allowed.";
+    
+};
+
+#endif // CONVERSATIONMODEL_H

--- a/src/yarpllmgui/ConversationModel.h
+++ b/src/yarpllmgui/ConversationModel.h
@@ -1,6 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #ifndef CONVERSATIONMODEL_H
 #define CONVERSATIONMODEL_H
 
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>
@@ -8,8 +15,12 @@
 #include <yarp/dev/ILLM.h>
 #include <yarp/dev/PolyDriver.h>
 
+#include <ConversationCallback.h>
 #include <QAbstractListModel>
 
+/**
+ * Inner class for message representation in ConversationModel.
+ */
 class Message
 {
 public:
@@ -32,6 +43,18 @@ private:
     QString m_content;
 };
 
+/**
+ * The model of the conversation data in the ui.
+
+ * It calls the llm_nwc functions in a way that allows the user to modify
+ * the conversation.
+
+ * It allows the user to modify the configuration from the UI.
+
+ * It has an inner callback mechanism that refreshes the UI if the conversation
+ * is changed outside of it.
+ *
+*/
 class ConversationModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -47,39 +70,75 @@ public:
             QAbstractListModel(parent)
     {
         m_prop.put("device", "LLM_nwc_yarp");
+        m_prop.put("local", m_local_rpc_port);
     }
 
-    ~ConversationModel() {  m_poly.close(); }
+    ~ConversationModel()
+    {
+        m_conversation_port.close();
+        m_poly.close();
+    }
 
-    // Configure rpc port names and configure the polydriver 
-    void setLocalRpc(const std::string& localRpc);
-    void setRemoteRpc(const std::string& remoteRpc);
-    void configure();
+    /**
+     * Configures the remote rpc and streaming port.
+     * @param remoteRpc name of the rpc port opened by the llm_nws
+     * @param remote_streaming_port_name name of the streaming port opened by the llm nws.
+     * It is used by the model callback.
+     * @return True if connection to the port and/or device opening is successful, false otherwise.
+     */
+    bool configure(const std::string& remote_rpc, const std::string& streaming_port_name);
 
+    // QAbstractListModel overrides
     QVariant data(const QModelIndex& index, int role) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-    void addMessage(const Message& message);
-    void refreshConversation(); // Added so that we don't rely on keeping local data in sync.
-    void eraseConversation();
 
-    // bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-    // Qt::ItemFlags flags(const QModelIndex &index) const override;
-
-    Q_INVOKABLE void deleteConversation(); // TODO: We have to come up with better names for this one
+    /**
+     * Deletes the conversation. Invokable from the ui.
+     */
+    Q_INVOKABLE void deleteConversation();
     Q_INVOKABLE void eraseMessage(const int& index);
+
+    /**
+     * Sends a message. Invokable from the ui.
+     * @param message. The message to send
+     */
     Q_INVOKABLE void sendMessage(const QString& message);
 
+    /**
+     * Configures the rpc and streaming port. Invokable from the ui.
+     * @param remoteRpc name of the rpc port opened by the llm_nws
+     * @param remote_streaming_port_name name of the streaming port opened by the llm nws.
+     */
+    Q_INVOKABLE void configure(const QString& remote_rpc, const QString& streaming_port_name);
+
+public slots:
+
+    /**
+     * Deletes and reuploads the conversation. This way the data that we keep locally is
+     * always fully synchronized with the nws.
+     */
+    void refreshConversation();
+
 protected:
-    QHash<int, QByteArray> roleNames() const;
+    QHash<int, QByteArray> roleNames() const override;
 
 private:
     yarp::dev::PolyDriver m_poly;
     yarp::os::Property m_prop;
 
-    yarp::dev::ILLM* m_iLlm;
+    yarp::dev::ILLM* m_iLlm = nullptr;
+    ConversationCallback m_callback;
     QList<Message> m_conversation;
+    yarp::os::BufferedPort<yarp::os::Bottle> m_conversation_port;
+    const std::string m_conversation_port_name = "/llmgui/conv:i";
+    const std::string m_local_rpc_port = "/yarpllmgui/rpc";
     const std::string m_no_device_message = "yarpLLMGui: no LLM_nwc was found. Operation is not allowed.";
-    
+
+    void setRemoteRpc(const std::string& remoteRpc);
+    bool setRemoteStreamingPort(const std::string& remote_streaming_port_name);
+    bool setInterface();
+    void addMessage(const Message& message);
+    void eraseConversation();
 };
 
 #endif // CONVERSATIONMODEL_H

--- a/src/yarpllmgui/main.cpp
+++ b/src/yarpllmgui/main.cpp
@@ -1,17 +1,23 @@
-#include "ConversationModel.h"
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/os/ResourceFinder.h>
+
+#include <ConversationModel.h>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
-#include <QQuickView>
 #include <QQmlContext>
-#include <yarp/os/ResourceFinder.h>
+#include <QQuickView>
 
 /**
  * Main file for yarpllmgui. The GUI should be invoked with the following parameters
  * @remote_rpc name of the rpc port to attach to.
- * @local_rpc name of the rpc port that the gui exposes. 
+ * @local_rpc name of the rpc port that the gui exposes.
  * Define it only if the name "/yarpllmgui/rpc" conflicts with an existing name
  * To define the parameters use the following utilities provided by the ResourceFinder.
-*/
+ */
 
 int main(int argc, char* argv[])
 {
@@ -26,13 +32,12 @@ int main(int argc, char* argv[])
     yarp::os::ResourceFinder rf;
     rf.setDefaultConfigFile("config.ini");
     rf.setDefaultContext("yarpllmgui");
-    rf.configure(argc,argv);
-    std::string local_rpc = rf.check("local_rpc",yarp::os::Value("/yarpllmgui/rpc")).asString();
-    std::string remote_rpc = rf.check("remote_rpc",yarp::os::Value("/yarpgpt/rpc")).asString();
+    rf.configure(argc, argv);
+    std::string remote_rpc = rf.check("remote_rpc", yarp::os::Value("/yarpgpt/rpc")).asString();
+    std::string streaming_port = rf.check("streaming_port", yarp::os::Value("/yarpllm/conv:o")).asString();
 
-    aConversationModel.setLocalRpc(local_rpc);
-    aConversationModel.setRemoteRpc(remote_rpc);
-    aConversationModel.configure();
+    // Configuration based on user's input from resource finder. Can be changed from ui.
+    aConversationModel.configure(remote_rpc, streaming_port);
     aConversationModel.refreshConversation();
 
     QQmlApplicationEngine engine;
@@ -44,8 +49,7 @@ int main(int argc, char* argv[])
     int ret;
     try {
         ret = app.exec();
-    }
-    catch(const std::bad_alloc &){
+    } catch (const std::bad_alloc&) {
         yError() << "Failure during application";
         return EXIT_FAILURE;
     }

--- a/src/yarpllmgui/main.cpp
+++ b/src/yarpllmgui/main.cpp
@@ -12,11 +12,14 @@
 #include <QQuickView>
 
 /**
- * Main file for yarpllmgui. The GUI should be invoked with the following parameters
- * @remote_rpc name of the rpc port to attach to.
- * @local_rpc name of the rpc port that the gui exposes.
- * Define it only if the name "/yarpllmgui/rpc" conflicts with an existing name
- * To define the parameters use the following utilities provided by the ResourceFinder.
+ * Main file for yarpllmgui. The GUI can be invoked with the following parameters
+ * @remote_rpc. Mandatory. Name of the rpc port to attach to.
+ * @streaming_port Optional. Name of the streaming port opened by the nws (by default /llm/conv:o).
+ * Allows to autorefresh the conversation in case it gets updated from outside the gui.
+ *
+ * These can also be specified within the gui after the opening. The gui will not work
+ * until a valid remote_rpc has been configured.
+ *
  */
 
 int main(int argc, char* argv[])

--- a/src/yarpllmgui/main.cpp
+++ b/src/yarpllmgui/main.cpp
@@ -1,0 +1,54 @@
+#include "ConversationModel.h"
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQuickView>
+#include <QQmlContext>
+#include <yarp/os/ResourceFinder.h>
+
+/**
+ * Main file for yarpllmgui. The GUI should be invoked with the following parameters
+ * @remote_rpc name of the rpc port to attach to.
+ * @local_rpc name of the rpc port that the gui exposes. 
+ * Define it only if the name "/yarpllmgui/rpc" conflicts with an existing name
+ * To define the parameters use the following utilities provided by the ResourceFinder.
+*/
+
+int main(int argc, char* argv[])
+{
+
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication app(argc, argv);
+
+    qmlRegisterType<ConversationModel>("conversationmodel", 1, 0, "ConversationModel");
+    ConversationModel aConversationModel;
+
+    // Load configuration
+    yarp::os::ResourceFinder rf;
+    rf.setDefaultConfigFile("config.ini");
+    rf.setDefaultContext("yarpllmgui");
+    rf.configure(argc,argv);
+    std::string local_rpc = rf.check("local_rpc",yarp::os::Value("/yarpllmgui/rpc")).asString();
+    std::string remote_rpc = rf.check("remote_rpc",yarp::os::Value("/yarpgpt/rpc")).asString();
+
+    aConversationModel.setLocalRpc(local_rpc);
+    aConversationModel.setRemoteRpc(remote_rpc);
+    aConversationModel.configure();
+    aConversationModel.refreshConversation();
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty("aConversationModel", &aConversationModel);
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty())
+        return -1;
+
+    int ret;
+    try {
+        ret = app.exec();
+    }
+    catch(const std::bad_alloc &){
+        yError() << "Failure during application";
+        return EXIT_FAILURE;
+    }
+
+    return ret;
+}

--- a/src/yarpllmgui/main.qml
+++ b/src/yarpllmgui/main.qml
@@ -1,0 +1,179 @@
+
+import QtQuick 2.15
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.15
+import conversationmodel 1.0
+import QtQuick.Controls.Styles 1.2
+
+ApplicationWindow {
+    width: 540
+    height: 960
+    visible: true
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        ListView {
+            id: listView
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: pane.leftPadding + messageField.leftPadding
+            displayMarginBeginning: 40
+            displayMarginEnd: 40
+            verticalLayoutDirection: ListView.TopToBottom
+            spacing: 12
+            model: aConversationModel
+            delegate: Row {
+                readonly property bool sentByUser: model.type == "user"
+                readonly property bool isPrompt: model.type == "system"
+
+                id: messageRow
+                anchors.right: (sentByUser || isPrompt) ? listView.contentItem.right : undefined
+                //anchors.centerIn: parent
+                spacing: 6
+
+                Rectangle {
+                    id: messageBox
+                    width: Math.min(messageText.implicitWidth + 24,
+                            listView.width - (!sentByUser ? messageRow.spacing + listView.width/8 : 0))
+                    height: messageText.implicitHeight + 24
+                    color: isPrompt ? "green" : (sentByUser ? "lightgrey" : "steelblue")
+                    opacity : 0.8
+                    Label {
+                        id: messageText
+                        anchors.centerIn: parent
+                        text: model.content
+                        color: sentByUser ? "black" : "white"    
+                        anchors.fill: parent
+                        anchors.margins: 12
+                        wrapMode: Label.Wrap
+                    }
+                }
+
+                // Button {
+                //     background: Rectangle {
+                //         implicitWidth: 45
+                //         implicitHeight: 45
+                //         opacity: 0.3
+                //         radius: 2
+                //     }
+                //     id: erase
+                //     icon.source: "https://cdn3.iconfinder.com/data/icons/objects/512/Bin-512.png"
+                //     opacity: hovered ? 0.6 : 0.3
+
+                //     MouseArea {
+                //         id: hoverArea
+                //         anchors.fill: parent
+                //         hoverEnabled: true
+                //         // Triggered when mouse enters the button
+                //         onEntered: {
+                //             // popupText.text = "Erase element";
+                //             // popup.x = erase.x - popup.width;
+                //             // popup.y = erase.y - popup.height;
+                //             messageBox.opacity = 0.4;
+                //             // popup.open();
+                //         }
+                //         // Triggered when mouse leaves the button
+                //         onExited: {
+                //             messageBox.opacity = 1;
+                //             // popup.close();
+                //         }
+                //         onClicked: {
+                //             console.log("Clicked");
+                //             listView.model.eraseMessage(index);
+                //         }
+                //     }
+                // }
+            }
+
+            ScrollBar.vertical: ScrollBar {}
+        }
+
+        Button {
+            background: Rectangle {
+                implicitWidth: 60
+                implicitHeight: 60
+                opacity: 0.3
+                radius: 2
+            }
+            id: eraseConversation
+            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+            icon.source: "https://cdn3.iconfinder.com/data/icons/objects/512/Bin-512.png"
+            opacity: hovered ? 0.6 : 0.3
+                        // MouseArea to detect hover
+            MouseArea {
+                id: hoverArea
+                anchors.fill: parent
+                hoverEnabled: true
+                // Triggered when mouse enters the button
+                onEntered: {
+                    popupText.text = "Erase conversation";
+                    popup.x = eraseConversation.x - popup.width;
+                    popup.y = eraseConversation.y - popup.height;
+                    listView.opacity = 0.4;
+                    popup.open();
+                }
+
+                // Triggered when mouse leaves the button
+                onExited: {
+                    popup.close();
+                    listView.opacity = 1;
+                }
+
+                onClicked: {
+                    listView.model.deleteConversation();
+                }
+            }
+        }
+
+        Pane {
+            id: pane
+            Layout.fillWidth: true
+
+            RowLayout {
+                width: parent.width
+
+                TextArea {
+                    id: messageField
+                    Layout.fillWidth: true
+                    placeholderText: qsTr("Compose message")
+                    wrapMode: TextArea.Wrap
+                    Keys.onReturnPressed: {
+                        listView.model.sendMessage(messageField.text);
+                        messageField.text = "";
+                    }
+
+                }
+
+                Button {
+                    id: sendButton
+                    text: qsTr("Send")
+                    enabled: messageField.length > 0
+                    onClicked: {
+                        listView.model.sendMessage(messageField.text);
+                        messageField.text = "";
+                    }
+                }
+            }
+        }
+
+        Popup {
+            id: popup
+            modal: false
+            width: 200
+            height: 50
+            focus: true
+
+            Rectangle {
+                anchors.fill: parent
+                color: "lightgray"
+
+                Text {
+                    id: popupText
+                    anchors.centerIn: parent
+                }
+            }
+        }
+    }
+
+}

--- a/src/yarpllmgui/main.qml
+++ b/src/yarpllmgui/main.qml
@@ -1,11 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 import QtQuick 2.15
 import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.15
 import conversationmodel 1.0
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Dialogs 1.3
 
 ApplicationWindow {
+    id: mainWindow
     width: 540
     height: 960
     visible: true
@@ -13,167 +19,152 @@ ApplicationWindow {
     ColumnLayout {
         anchors.fill: parent
 
-        ListView {
-            id: listView
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.margins: pane.leftPadding + messageField.leftPadding
-            displayMarginBeginning: 40
-            displayMarginEnd: 40
-            verticalLayoutDirection: ListView.TopToBottom
-            spacing: 12
-            model: aConversationModel
-            delegate: Row {
-                readonly property bool sentByUser: model.type == "user"
-                readonly property bool isPrompt: model.type == "system"
+        MenuBar {
+            width: mainWindow.width // Make the menu bar span the width
 
-                id: messageRow
-                anchors.right: (sentByUser || isPrompt) ? listView.contentItem.right : undefined
-                //anchors.centerIn: parent
-                spacing: 6
-
-                Rectangle {
-                    id: messageBox
-                    width: Math.min(messageText.implicitWidth + 24,
-                            listView.width - (!sentByUser ? messageRow.spacing + listView.width/8 : 0))
-                    height: messageText.implicitHeight + 24
-                    color: isPrompt ? "green" : (sentByUser ? "lightgrey" : "steelblue")
-                    opacity : 0.8
-                    Label {
-                        id: messageText
-                        anchors.centerIn: parent
-                        text: model.content
-                        color: sentByUser ? "black" : "white"    
-                        anchors.fill: parent
-                        anchors.margins: 12
-                        wrapMode: Label.Wrap
+            Menu {
+                title: "Options"
+                MenuItem {
+                    text: "Configure"
+                    onTriggered: {
+                        var popupComponent = Qt.createComponent("ConfigurePopup.qml");
+                        if (popupComponent.status === Component.Ready)
+                        {
+                            var popup = popupComponent.createObject(mainWindow);
+                            popup.open();
+                        } else {
+                        console.log("Error loading component:", popupComponent.errorString());
                     }
-                }
-
-                // Button {
-                //     background: Rectangle {
-                //         implicitWidth: 45
-                //         implicitHeight: 45
-                //         opacity: 0.3
-                //         radius: 2
-                //     }
-                //     id: erase
-                //     icon.source: "https://cdn3.iconfinder.com/data/icons/objects/512/Bin-512.png"
-                //     opacity: hovered ? 0.6 : 0.3
-
-                //     MouseArea {
-                //         id: hoverArea
-                //         anchors.fill: parent
-                //         hoverEnabled: true
-                //         // Triggered when mouse enters the button
-                //         onEntered: {
-                //             // popupText.text = "Erase element";
-                //             // popup.x = erase.x - popup.width;
-                //             // popup.y = erase.y - popup.height;
-                //             messageBox.opacity = 0.4;
-                //             // popup.open();
-                //         }
-                //         // Triggered when mouse leaves the button
-                //         onExited: {
-                //             messageBox.opacity = 1;
-                //             // popup.close();
-                //         }
-                //         onClicked: {
-                //             console.log("Clicked");
-                //             listView.model.eraseMessage(index);
-                //         }
-                //     }
-                // }
-            }
-
-            ScrollBar.vertical: ScrollBar {}
-        }
-
-        Button {
-            background: Rectangle {
-                implicitWidth: 60
-                implicitHeight: 60
-                opacity: 0.3
-                radius: 2
-            }
-            id: eraseConversation
-            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
-            icon.source: "https://cdn3.iconfinder.com/data/icons/objects/512/Bin-512.png"
-            opacity: hovered ? 0.6 : 0.3
-                        // MouseArea to detect hover
-            MouseArea {
-                id: hoverArea
-                anchors.fill: parent
-                hoverEnabled: true
-                // Triggered when mouse enters the button
-                onEntered: {
-                    popupText.text = "Erase conversation";
-                    popup.x = eraseConversation.x - popup.width;
-                    popup.y = eraseConversation.y - popup.height;
-                    listView.opacity = 0.4;
-                    popup.open();
-                }
-
-                // Triggered when mouse leaves the button
-                onExited: {
-                    popup.close();
-                    listView.opacity = 1;
-                }
-
-                onClicked: {
-                    listView.model.deleteConversation();
-                }
-            }
-        }
-
-        Pane {
-            id: pane
-            Layout.fillWidth: true
-
-            RowLayout {
-                width: parent.width
-
-                TextArea {
-                    id: messageField
-                    Layout.fillWidth: true
-                    placeholderText: qsTr("Compose message")
-                    wrapMode: TextArea.Wrap
-                    Keys.onReturnPressed: {
-                        listView.model.sendMessage(messageField.text);
-                        messageField.text = "";
-                    }
-
-                }
-
-                Button {
-                    id: sendButton
-                    text: qsTr("Send")
-                    enabled: messageField.length > 0
-                    onClicked: {
-                        listView.model.sendMessage(messageField.text);
-                        messageField.text = "";
-                    }
-                }
-            }
-        }
-
-        Popup {
-            id: popup
-            modal: false
-            width: 200
-            height: 50
-            focus: true
-
-            Rectangle {
-                anchors.fill: parent
-                color: "lightgray"
-
-                Text {
-                    id: popupText
-                    anchors.centerIn: parent
                 }
             }
         }
     }
 
-}
+    ListView {
+        id: listView
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.margins: pane.leftPadding + messageField.leftPadding
+        displayMarginBeginning: 40
+        displayMarginEnd: 40
+        verticalLayoutDirection: ListView.TopToBottom
+        spacing: 12
+        model: aConversationModel
+        delegate: Row {
+            readonly property bool sentByUser: model.type == "user"
+                readonly property bool isPrompt: model.type == "system"
+
+                    id: messageRow
+                    anchors.right: (sentByUser || isPrompt) ? listView.contentItem.right : undefined
+                    spacing: 6
+
+                    Rectangle {
+                        id: messageBox
+                        width: Math.min(messageText.implicitWidth + 24,
+                        listView.width - (!sentByUser ? messageRow.spacing + listView.width/8 : 0))
+                        height: messageText.implicitHeight + 24
+                        color: isPrompt ? "green" : (sentByUser ? "lightgrey" : "steelblue")
+                        opacity : 0.8
+                        Label {
+                            id: messageText
+                            anchors.centerIn: parent
+                            text: model.content
+                            color: sentByUser ? "black" : "white"
+                            anchors.fill: parent
+                            anchors.margins: 12
+                            wrapMode: Label.Wrap
+                        }
+                    }
+                }
+
+                ScrollBar.vertical: ScrollBar {}
+            }
+
+            Button {
+                background: Rectangle {
+                    implicitWidth: 60
+                    implicitHeight: 60
+                    opacity: 0.3
+                    radius: 2
+                }
+                id: eraseConversation
+                Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+                icon.source: "https://cdn3.iconfinder.com/data/icons/objects/512/Bin-512.png"
+                opacity: hovered ? 0.6 : 0.3
+                // MouseArea to detect hover
+                MouseArea {
+                    id: hoverArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    // Triggered when mouse enters the button
+                    onEntered: {
+                        popupText.text = "Erase conversation";
+                        popup.x = eraseConversation.x - popup.width;
+                        popup.y = eraseConversation.y - popup.height;
+                        listView.opacity = 0.4;
+                        popup.open();
+                    }
+
+                    // Triggered when mouse leaves the button
+                    onExited: {
+                        popup.close();
+                        listView.opacity = 1;
+                    }
+
+                    onClicked: {
+                        listView.model.deleteConversation();
+                    }
+                }
+            }
+
+            Pane {
+                id: pane
+                Layout.fillWidth: true
+
+                RowLayout {
+                    width: parent.width
+
+                    TextArea {
+                        id: messageField
+                        Layout.fillWidth: true
+                        placeholderText: qsTr("Compose message")
+                        wrapMode: TextArea.Wrap
+                        Keys.onReturnPressed: {
+                            listView.model.sendMessage(messageField.text);
+                            messageField.text = "";
+                        }
+
+                    }
+
+                    Button {
+                        id: sendButton
+                        text: qsTr("Send")
+                        enabled: messageField.length > 0
+                        onClicked: {
+                            listView.model.sendMessage(messageField.text);
+                            messageField.text = "";
+                        }
+                    }
+                }
+            }
+
+            Popup {
+                id: popup
+                modal: false
+                width: 200
+                height: 50
+                focus: true
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: "lightgray"
+
+                    Text {
+                        id: popupText
+                        anchors.centerIn: parent
+                    }
+                }
+            }
+        }
+
+    }

--- a/src/yarpllmgui/res.qrc
+++ b/src/yarpllmgui/res.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="/">
+    <file>main.qml</file>
+</qresource>
+</RCC>

--- a/src/yarpllmgui/res.qrc
+++ b/src/yarpllmgui/res.qrc
@@ -1,5 +1,6 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource prefix="/">
     <file>main.qml</file>
+    <file>ConfigurePopup.qml</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This PR adds a minimal gui for the LLMDevices.

- The gui can be used both passively - following a conversation happening via nws - or actively.
- fakeDevice now can't modify the prompt after a conversation has started. This means that once the first question has been asked, if the user wants to change the prompt he/she also has to start a new conversation.
- Added a streaming port in the nws that serves to notify the gui of changes happening in the conversation. This makes it possible to use the gui to passively follow a conversation happening in the nws. 