### PR TITLE
ConnectThread: Include what you use

### DIFF
--- a/src/libYARP_serversql/src/yarp/serversql/impl/ConnectThread.h
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/ConnectThread.h
@@ -10,6 +10,7 @@
 #include <yarp/os/Thread.h>
 
 #include <mutex>
+#include <string>
 
 namespace yarp::serversql::impl {
 


### PR DESCRIPTION
`ConnectThread` is using `std::string` , but `<string>` was not used. See https://github.com/robotology/idyntree/pull/1103#issuecomment-1706468411 .