### PR TITLE
Add documentation about local_rpc in frameTransformClient device

### DIFF
--- a/src/devices/frameTransformClient/FrameTransformClient.h
+++ b/src/devices/frameTransformClient/FrameTransformClient.h
@@ -51,6 +51,7 @@ const int MAX_PORTS = 5;
  * | period           | -                    | float   | -              | 10ms                  | no           | The period for publishing individual tfs on port                                                           |
  * | ft_client_prefix | -                    | string  | -              | ""                    | no           | A prefix to add to the names of all the ports opened by the NWCs instantiated by the frameTransformClient  |
  * | ft_server_prefix | -                    | string  | -              | ""                    | no           | The prefix added to all the names of the ports opened by the NWSs instantiated by the frameTransformServer |
+ * | local_rpc        | -                    | string  | -              | "/ftClient/rpc"       | no           | Name of the utility RPC port opened by the client                                                          |
  *
  * Example of command line:
  * \code{.unparsed}


### PR DESCRIPTION
The ``frameTransformClient`` opens a utility RPC port named ``/ftClient/rpc`` independently from the ``ft_client_prefix``. This can raise a name conflict problem in case there is more than one client in the network.

The problem can be avoided by specifying the ``local_rpc`` option, but this was not documented. The commit adds the parameter in the documentation.

cc @elandini84 @randaz81 