### PR TITLE
yarpmotorgui bugfix

### DIFF
--- a/src/yarpmotorgui/piddlg.ui
+++ b/src/yarpmotorgui/piddlg.ui
@@ -1551,6 +1551,37 @@
            <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
           </property>
          </item>
+         <item row="18" column="0">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="background">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>207</red>
+             <green>207</green>
+             <blue>207</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="foreground">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>35</red>
+             <green>38</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="flags">
+           <set>ItemIsEnabled</set>
+          </property>
+         </item>
+         <item row="18" column="1">
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
**What's new:**
- when the `PID` button is clicked now it works as expected without crash.


**Note:**
- Tested on `five-small-joint` setup

cc @pattacini @pattacini @AntonioConsilvio @isorrentino 