### PR TITLE
Add fix for conflict between windows.h inclusion and std::min use

### DIFF
--- a/src/libYARP_os/src/yarp/os/Log.cpp
+++ b/src/libYARP_os/src/yarp/os/Log.cpp
@@ -43,6 +43,10 @@
 #endif
 
 #ifdef YARP_HAS_WIN_VT_SUPPORT
+// Workaround for https://github.com/robotology/yarp/issues/3031
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Fix https://github.com/robotology/yarp/issues/3031 .