### PR TITLE
FrameTransformStorage - Timed tf refresh timeout parameter

### DIFF
--- a/doc/release/yarp_3_9_master/fix_frameTransform_tf_refresh_timeout.md
+++ b/doc/release/yarp_3_9_master/fix_frameTransform_tf_refresh_timeout.md
@@ -1,0 +1,11 @@
+fix_frameTransform_tf_refresh_timeout {#master}
+-------------------
+
+### Devices
+
+#### `frameTransformStorage` + `frameTransformClient` + `frameTransformServer`
+
+* Added a timeout related parameter (`FrameTransform_container_timeout`) to change the refresh interval for old timed frame transforms.
+* The parameter has also been added to the `frameTransformClient` and `frameTransformServer` configuration files. The `extern-name` for this parameter is:
+  * `ftc_storage_timeout` for `frameTransformClient` files
+  * `fts_storage_timeout` for `frameTransformServer` files

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_full_ros.xml
@@ -50,6 +50,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetmpx"> ftc_mpxGet </elem>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_local_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_local_only.xml
@@ -13,6 +13,7 @@
     <devices>
         <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         </device>
     </devices>
 </robot>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_ros.xml
@@ -38,6 +38,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetros"> ftGet_nwc_ros </elem>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_ros.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_ros.xml
@@ -25,6 +25,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetros"> ftGet_nwc_ros </elem>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_sub_yarp_only.xml
@@ -21,6 +21,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetyarp"> ftGet_nwc_yarp </elem>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only.xml
@@ -26,6 +26,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetyarp"> ftGet_nwc_yarp </elem>

--- a/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
+++ b/src/devices/frameTransformClient/robotinterface_xml/ftc_yarp_only_single_client.xml
@@ -13,6 +13,7 @@
         <param extern-name="FrameTransform_verbose_debug" name="FrameTransform_verbose_debug">0</param>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="ftc_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         </device>
         <!-- **************** YARP NWS **************** -->
         <device name="ftSet_nws_yarp" type="frameTransformSet_nws_yarp">

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
@@ -56,6 +56,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="fts_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
                     <elem name="subdevicegetros"> ftGet_nwc_ros </elem>

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_full_ros.xml
@@ -15,7 +15,7 @@
             <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevicestorage"> ftc_storage </elem>
+                    <elem name="subdevicestorage"> fts_storage </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -25,7 +25,7 @@
             <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevicestorage"> ftc_storage </elem>
+                    <elem name="subdevicestorage"> fts_storage </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -55,7 +55,7 @@
             </group>
         </device>
         <!-- **************** STORAGE **************** -->
-        <device name="ftc_storage" type="frameTransformStorage">
+        <device name="fts_storage" type="frameTransformStorage">
             <param extern-name="fts_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
@@ -67,7 +67,7 @@
         <device name="ftc_mpxSet" type="frameTransformSetMultiplexer">
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevicestorage"> ftc_storage </elem>
+                    <elem name="subdevicestorage"> fts_storage </elem>
                     <elem name="subdevicesetros"> ftSet_nwc_ros </elem>
                 </paramlist>
             </action>

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
@@ -15,7 +15,7 @@
             <param extern-name="ft_server_prefix" name="nws_thrift_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevicestorage"> ftc_storage </elem>
+                    <elem name="subdevicestorage"> fts_storage </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
@@ -25,13 +25,13 @@
             <param extern-name="ft_server_prefix" name="output_streaming_port_prefix">""</param>
             <action phase="startup" level="5" type="attach">
                 <paramlist name="networks">
-                    <elem name="subdevicestorage"> ftc_storage </elem>
+                    <elem name="subdevicestorage"> fts_storage </elem>
                 </paramlist>
             </action>
             <action phase="shutdown" level="5" type="detach" />
         </device>
         <!-- **************** STORAGE **************** -->
-        <device name="ftc_storage" type="frameTransformStorage">
+        <device name="fts_storage" type="frameTransformStorage">
             <param extern-name="fts_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         </device>
     </devices>

--- a/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
+++ b/src/devices/frameTransformServer/robotinterface_xml/fts_yarp_only.xml
@@ -32,6 +32,7 @@
         </device>
         <!-- **************** STORAGE **************** -->
         <device name="ftc_storage" type="frameTransformStorage">
+            <param extern-name="fts_storage_timeout" name="FrameTransform_container_timeout"> 0.2 </param>
         </device>
     </devices>
 </robot>

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -35,6 +35,11 @@ bool FrameTransformStorage::open(yarp::os::Searchable& config)
         m_tf_container.m_name = this->id() + ".container";
     }
 
+    if (config.check("FrameTransform_container_timeout"))
+    {
+        m_tf_container.m_timeout = config.find("FrameTransform_container_timeout").asFloat64();
+    }
+
     yCTrace(FRAMETRANSFORSTORAGE);
     bool b = this->start();
     return b;


### PR DESCRIPTION
### Devices

#### `frameTransformStorage` + `frameTransformClient` + `frameTransformServer`

* Added a timeout related parameter (`FrameTransform_container_timeout`) to change the refresh interval for old timed frame transforms.
* The parameter has also been added to the `frameTransformClient` and `frameTransformServer` configuration files. The `extern-name` for this parameter is:
  * `ftc_storage_timeout` for `frameTransformClient` files
  * `fts_storage_timeout` for `frameTransformServer` files