### PR TITLE
[sonarcloud/coverage] Updated sonar scanner version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,7 +1675,7 @@ jobs:
         SONAR_TESTS: 'tests'
         SONAR_CFAMILY_GCOV_REPORTSPATH: 'build/coverage.info'
         SONAR_CFAMILY_CACHE_ENABLED: true
-        SONAR_SCANNER_VERSION: '4.6.0.2311'
+        SONAR_SCANNER_VERSION: '5.0.1.3006'
         SONAR_THREADS: 2
       run: |
         # Internal variables
@@ -1848,6 +1848,7 @@ jobs:
         which ccache
         ccache --version
         ccache -p
+
 
         ls -la --color=always /usr/lib/ccache
 


### PR DESCRIPTION
Updating sonar-scanner version to use java-11 before deprecation, as recommended in https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597.