### PR TITLE
Bump YARP version to 3.8.100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Main project
 project(
   YARP
-  VERSION 3.8.1
+  VERSION 3.8.100
   LANGUAGES C CXX
 )
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")


### PR DESCRIPTION
The current `master` of YARP (used in the CI of the robotology-superbuild to catch errors as early as possible) contains a breaking change introduced in https://github.com/robotology/yarp/commit/a29c6b28801e9d84f340f44a6295aeb74ef79de5 . We can easily handle this in downstream libraries, but to avoid a tight coupling between the YARP version and the version of downstream libraries, we would need some way to know which version of YARP contains this change. While we wait for YARP 3.9.0, an easy fix for this is to bump the version of YARP to 3.8.100, that is a simple way to mark development builds.