### PR TITLE
CMake: Use OpenCV_LIBS instead of OpenCV_LIBRARIES as documented in official OpenCV docs

### DIFF
--- a/example/cmake/with_opencv/CMakeLists.txt
+++ b/example/cmake/with_opencv/CMakeLists.txt
@@ -25,4 +25,4 @@ find_package(OpenCV REQUIRED)
 # add OpenCV include directories
 target_include_directories(foo PRIVATE ${OPENCV_INCLUDE_DIR})
 # link OpenCV libraries
-target_link_libraries(foo PRIVATE ${OPENCV_LIBRARIES}
+target_link_libraries(foo PRIVATE ${OpenCV_LIBS}

--- a/example/opencv/CMakeLists.txt
+++ b/example/opencv/CMakeLists.txt
@@ -10,4 +10,4 @@ find_package(OpenCV REQUIRED)
 
 add_executable(opencv_test)
 target_sources(opencv_test PRIVATE main.cpp)
-target_link_libraries(opencv_test PRIVATE ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(opencv_test PRIVATE ${YARP_LIBRARIES} ${OpenCV_LIBS})

--- a/src/devices/opencv/CMakeLists.txt
+++ b/src/devices/opencv/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT SKIP_opencv_grabber)
   )
 
   target_include_directories(yarp_opencv SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS})
-  target_link_libraries(yarp_opencv PRIVATE ${OpenCV_LIBRARIES})
+  target_link_libraries(yarp_opencv PRIVATE ${OpenCV_LIBS})
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS OpenCV) (not using targets)
 
   yarp_install(

--- a/src/devices/usbCamera/CMakeLists.txt
+++ b/src/devices/usbCamera/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ENABLE_usbCamera OR ENABLE_usbCameraRaw)
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS Libv4lconvert) (not using targets)
 
   target_include_directories(yarp_usbCamera SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS})
-  target_link_libraries(yarp_usbCamera PRIVATE ${OpenCV_LIBRARIES})
+  target_link_libraries(yarp_usbCamera PRIVATE ${OpenCV_LIBS})
 #   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS OpenCV) (not using targets)
 
   yarp_install(

--- a/src/libYARP_cv/CMakeLists.txt
+++ b/src/libYARP_cv/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 project(YARP_cv)
 
-# OpenCV is required, otherwise the OpenCV_INCLUDE_DIR and OpenCV_LIBRARIES
+# OpenCV is required, otherwise the OpenCV_INCLUDE_DIR and OpenCV_LIBS
 # (used in the CMakeLists.txt file in the src direcrory) are not expanded).
 # FIXME Remove this check when OpenCV targets will be used.
 if (NOT YARP_HAS_OpenCV)

--- a/src/libYARP_cv/src/CMakeLists.txt
+++ b/src/libYARP_cv/src/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(YARP_cv INTERFACE YARP::YARP_sig)
 list(APPEND YARP_cv_PUBLIC_DEPS YARP_sig)
 
 target_include_directories(YARP_cv SYSTEM INTERFACE ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(YARP_cv INTERFACE ${OpenCV_LIBRARIES})
+target_link_libraries(YARP_cv INTERFACE ${OpenCV_LIBS})
 list(APPEND YARP_cv_PUBLIC_DEPS OpenCV)
 
 # set_property(TARGET YARP_cv PROPERTY PUBLIC_HEADER ${YARP_cv_HDRS})

--- a/src/portmonitors/image_rotation/CMakeLists.txt
+++ b/src/portmonitors/image_rotation/CMakeLists.txt
@@ -31,7 +31,7 @@ list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
 )
 
  target_include_directories(yarp_pm_image_rotation SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS})
- target_link_libraries(yarp_pm_image_rotation PRIVATE ${OpenCV_LIBRARIES})
+ target_link_libraries(yarp_pm_image_rotation PRIVATE ${OpenCV_LIBS})
 
 yarp_install(
   TARGETS yarp_pm_image_rotation

--- a/src/yarpdatadumper/CMakeLists.txt
+++ b/src/yarpdatadumper/CMakeLists.txt
@@ -22,7 +22,7 @@ if(YARP_COMPILE_yarpdatadumper)
 
   if(YARP_HAS_OpenCV)
     target_compile_definitions(yarpdatadumper PRIVATE ADD_VIDEO)
-    target_link_libraries(yarpdatadumper PRIVATE ${OpenCV_LIBRARIES})
+    target_link_libraries(yarpdatadumper PRIVATE ${OpenCV_LIBS})
     target_link_libraries(yarpdatadumper PRIVATE YARP::YARP_cv)
   endif()
 

--- a/src/yarpdataplayer/CMakeLists.txt
+++ b/src/yarpdataplayer/CMakeLists.txt
@@ -117,7 +117,7 @@ if(YARP_COMPILE_yarpdataplayer)
     target_include_directories(yarpdataplayer PRIVATE ${OpenCV_INCLUDE_DIRS})
     target_link_libraries(yarpdataplayer
       PRIVATE
-        ${OpenCV_LIBRARIES}
+        ${OpenCV_LIBS}
         YARP::YARP_cv
     )
   endif()

--- a/src/yarplaserscannergui/CMakeLists.txt
+++ b/src/yarplaserscannergui/CMakeLists.txt
@@ -63,7 +63,7 @@ if(YARP_COMPILE_yarplaserscannergui)
   )
 
   target_include_directories(yarplaserscannergui PRIVATE ${OpenCV_INCLUDE_DIRS})
-  target_link_libraries(yarplaserscannergui PRIVATE ${OpenCV_LIBRARIES})
+  target_link_libraries(yarplaserscannergui PRIVATE ${OpenCV_LIBS})
 
   install(TARGETS yarplaserscannergui COMPONENT utilities DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
`OpenCV_LIBS` is the variable documented in official OpenCV docs (https://docs.opencv.org/4.x/db/df5/tutorial_linux_gcc_cmake.html). `OpenCV_LIBRARIES` was a YCM extension, that is going to be deprecated (see https://github.com/robotology/ycm/pull/434).