### PR TITLE
yarpviz: Support compilation with graphviz >= 9

### DIFF
--- a/doc/release/yarp_3_9/yarpviz_graphviz9.md
+++ b/doc/release/yarp_3_9/yarpviz_graphviz9.md
@@ -1,0 +1,3 @@
+#### `yarpviz`
+
+* Support compilation with Graphviz >= 9.

--- a/extern/qgv/CMakeLists.txt
+++ b/extern/qgv/CMakeLists.txt
@@ -53,6 +53,12 @@ if(Graphviz_DEFINITIONS)
   target_compile_definitions(YARP_priv_qgvcore PRIVATE ${Graphviz_DEFINITIONS})
 endif()
 
+if(Graphviz_VERSION)
+  if(Graphviz_VERSION VERSION_GREATER_EQUAL 9.0)
+    target_compile_definitions(YARP_priv_qgvcore PRIVATE GRAPHVIZ_VERSION_GE_9)
+  endif()
+endif()
+
 set_property(TARGET YARP_priv_qgvcore PROPERTY FOLDER "Libraries/External")
 
 

--- a/extern/qgv/qgv/QGVCore/private/QGVCore.h
+++ b/extern/qgv/qgv/QGVCore/private/QGVCore.h
@@ -93,7 +93,9 @@ public:
         rdr.len = strlen(cp);
         rdr.cur = 0;
 
+#ifndef GRAPHVIZ_VERSION_GE_9
         disc.mem = &AgMemDisc;
+#endif
         disc.id = &AgIdDisc;
         disc.io = &memIoDisc;
         g = agread (&rdr, &disc);


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1537 .