### PR TITLE
Add support for long paths on Windows for yarpidl_thrift

### DIFF
--- a/cmake/YarpInstallationHelpers.cmake
+++ b/cmake/YarpInstallationHelpers.cmake
@@ -468,3 +468,28 @@ macro(YARP_INSTALL _what)
   endif()
 
 endmacro()
+
+
+# yarp_enable_windows_longpath_support(<target>)
+#
+# This function enables longpath support on Windows on a given target by adding the appropriate
+# manifest as documented in https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation .
+#
+# On non-Windows platforms, this functions does not do anything
+function(YARP_ENABLE_WINDOWS_LONGPATH_SUPPORT _target)
+  if(MSVC)
+    set(yewls_manifest_filename "${_target}_longpath.manifest")
+    set(yewls_manifest_output "${CMAKE_CURRENT_BINARY_DIR}/${yewls_manifest_filename}")
+
+    set(yewls_manifest_contents [=[<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<application  xmlns="urn:schemas-microsoft-com:asm.v3">
+<windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+    <ws2:longPathAware>true</ws2:longPathAware>
+</windowsSettings>
+</application>
+</assembly>]=])
+    file(GENERATE OUTPUT "${yewls_manifest_output}" CONTENT "${yewls_manifest_contents}")
+    target_sources(${_target} PRIVATE "${yewls_manifest_output}")
+  endif()
+endfunction()

--- a/doc/release/yarp_3_9/yarpidl_thrift_windows_longpath.md
+++ b/doc/release/yarp_3_9/yarpidl_thrift_windows_longpath.md
@@ -1,0 +1,3 @@
+#### `yarpidl_thrift`
+
+* Add support for `yarpidl_thrift` to manipulate paths longer than 260 characters on Windows.

--- a/src/yarpidl_thrift/CMakeLists.txt
+++ b/src/yarpidl_thrift/CMakeLists.txt
@@ -121,6 +121,8 @@ target_sources(yarpidl_thrift
     ${yarpidl_thrift_YARP_SRCS}
 )
 
+yarp_enable_windows_longpath_support(yarpidl_thrift)
+
 install(
   TARGETS yarpidl_thrift
   EXPORT YARP_idl_tools


### PR DESCRIPTION
The `yarp_add_idl`  and `yarp_idl_to_dir` macros can be called in deeply nested folders in downstream projects, and the `yarpidl_thrift` invoked by them also create really long paths when creating the temporary folders it creates. For this reason, it can happen that the paths on which `yarpidl_thrift`  operates violates the 260 maximum character limit on Windows. To use the support for longer paths, as documented in https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation it is necessary to add  a specific manifest to the executable. 

This PR adds support to `yarpidl_thrift` to deal with path longer than 260 characters on Windows.