### PR TITLE
Add support for external blob values in robotinterface

### DIFF
--- a/doc/release/yarp_3_9/yarprobotinterface_extern_blob.md
+++ b/doc/release/yarp_3_9/yarprobotinterface_extern_blob.md
@@ -1,0 +1,3 @@
+#### `libYARP_robotinterface`
+
+* Add support for blob values in the extra configuration passed to `XMLReader::getRobotFrom{File|String}` and linked in the XML via `extern-name`.

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/impl/XMLReaderFileV3.cpp
@@ -573,7 +573,11 @@ yarp::robotinterface::Param yarp::robotinterface::impl::XMLReaderFileV3::Private
         // FIXME Check DTD >= 3.1
         if (config.find(extern_name).isList())
         {
-            param.value() = "(" + config.find(extern_name).asList()->toString() + ")";
+            param.value() = "(" + config.find(extern_name).toString() + ")";
+        }
+        else if (config.find(extern_name).isBlob())
+        {
+            param.value() = "{" + config.find(extern_name).toString() + "}";
         }
         else
         {


### PR DESCRIPTION
It is possible to externally (i.e. outside the XML robot configuration) override any parameters marked as `extern-name` with compound (lists) or simple (strings, integers...) values. This patch adds support for blobs, with unit testing (also covering external lists for completeness).

Use case: https://github.com/roboticslab-uc3m/yarp-devices/issues/271#issuecomment-1879676086.