### PR TITLE
Do not refer anymore to deb binary packages from icub.eu anymore

### DIFF
--- a/doc/001_installation/3_install.dox
+++ b/doc/001_installation/3_install.dox
@@ -11,6 +11,8 @@ systems.
 - \subpage install_yarp_linux
 - \subpage install_yarp_windows
 - \subpage install_yarp_mac
+- \subpage install_yarp_conda
+
 
 After your are done installing YARP you can proceed with the following link:
 \subpage check_your_installation.

--- a/doc/001_installation/3_install_conda.md
+++ b/doc/001_installation/3_install_conda.md
@@ -1,0 +1,99 @@
+Installing YARP on Linux, macOS or Windows with conda        {#install_yarp_conda}
+=====================================================
+
+[TOC]
+
+Installation on Linux, macOS or Windows with conda           {#install_on_conda}
+=========================
+
+These instructions for installing yarp on any Linux distributions, macOS or Windows,
+if you are using the conda package manager.
+
+
+Install from binaries                             {#install_conda_from_binaries}
+---------------------
+
+To create a new environment called `yarpenv` with the `yarp` C++ library, tools and Python bindings, run:
+
+~~~{.sh}
+conda create -n yarpenv -c conda-forge yarp
+~~~
+
+If you are experiencing problems with [conda-forge](https://conda-forge.org/) binaries of yarp, please open an issue at 
+[conda-forge/yarp-feedstock](https://github.com/conda-forge/yarp-feedstock) GitHub repo.
+
+You are now ready to check you installation, see \ref check_your_installation.
+
+
+Install from sources                               {#install_conda_from_sources}
+--------------------
+
+### Required Dependencies                             {#install_required_conda}
+
+
+To create an environment called `yarpsrcdev` in which to compile yarp from source, run the following command
+
+~~~{.sh}
+conda create -n yarpsrcdev -c conda-forge cmake compilers pkg-config make ninja ycm-cmake-modules ace tinyxml eigen sdl sqlite libjpeg-turbo robot-testing-framework libpng libzlib soxr libopencv portaudio qt-main ffmpeg
+~~~
+
+### Compiling YARP                                             {#compiling_yarp}
+
+To get the source you can download the latest release at
+https://github.com/robotology/yarp/releases/
+or clone YARP git repository from one of the following addresses:
+
+\li(git read-only) git://github.com/robotology/yarp.git
+\li(ssh read+write) git@github.com:robotology/yarp.git
+\li(https read+write) https://github.com/robotology/yarp.git
+
+For example:
+
+~~~{.sh}
+  git clone https://github.com/robotology/yarp.git
+~~~
+
+By default the `master` (development) branch is cloned, if you need a stable
+branches they are named `yarp-<version>`. For example
+
+~~~{.sh}
+  git clone -b yarp-3.3 https://github.com/robotology/yarp.git
+~~~
+
+
+Generate Ninja build files using CMake in the environment you created before, and specify that you want to install
+yarp in the same environment, by executing the following commands on Linux or macOS:
+
+~~~{.sh}
+  conda activate yarpsrcdev
+  cd yarp
+  mkdir build
+  cd build
+  cmake -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+~~~
+
+or on Windows:
+
+~~~{.sh}
+  conda activate yarpsrcdev
+  cd yarp
+  mkdir build
+  cd build
+  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% ..
+~~~
+
+Usually you want to check in the CMake output that "Compile GUIs" and
+"Compile YARP_math library" are enabled, if they are not, you are probably
+missing some dependency.
+
+
+Compile:
+
+~~~{.sh}
+ninja
+ninja install
+~~~
+
+You are now ready to check you installation, see \ref check_your_installation.
+
+\remark Do not select other options unless you know what you are doing.

--- a/doc/001_installation/3_install_linux.md
+++ b/doc/001_installation/3_install_linux.md
@@ -31,13 +31,7 @@ Ubuntu 18.04, see
 [robotology/QA#364](https://github.com/robotology/QA/issues/364))
 
 
-Install [YCM](https://github.com/robotology/ycm/) from sources or install it
-from binaries by configuring the icub.eu repository (Follow the instructions at
-\ref install_linux_from_binaries), and install it with
-
-~~~{.sh}
-sudo apt-get install ycm-cmake-modules
-~~~
+Install [YCM](https://github.com/robotology/ycm/) from sources.
 
 Depending on what parts of YARP you want to enable, you will also have to
 install some other packages
@@ -49,7 +43,6 @@ what is installed and why, proceed to the following sections.
 
 ~~~{.sh}
 sudo apt-get install build-essential git cmake cmake-curses-gui \
-  ycm-cmake-modules \
   libeigen3-dev \
   libace-dev \
   libedit-dev \

--- a/doc/001_installation/3_install_linux.md
+++ b/doc/001_installation/3_install_linux.md
@@ -12,45 +12,6 @@ the same, but you will need to figure out how to install the dependencies on
 your system.
 
 
-Install from binaries                             {#install_linux_from_binaries}
----------------------
-
-Add www.icub.eu to your APT sources as below (replace `ubuntu` with `debian` according to your system):
-
-~~~{.sh}
-sudo sh -c 'echo "deb http://www.icub.eu/ubuntu `lsb_release -cs` contrib/science" > /etc/apt/sources.list.d/icub.list'
-~~~
-
-Import the repository public key:
-
-~~~{.sh}
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57A5ACB6110576A6
-~~~
-
-Update the list of packages:
-
-~~~{.sh}
-sudo apt update
-~~~
-
-If you stumble upon an error related to an unsupported `i386` architecture, just add the option `[arch=amd64]` in the file `/etc/apt/sources.list.d/icub.list`
-at the corresponding line, as below (e.g., for a `ubuntu/jammy` distribution):
-
-~~~
-deb [arch=amd64] http://www.icub.eu/ubuntu jammy contrib/science
-~~~
-
-Install YARP:
-
-~~~{.sh}
-sudo apt install yarp
-~~~
-
-You are now ready to check you installation, see \ref check_your_installation.
-
-
-
-
 
 Install from sources                               {#install_linux_from_sources}
 --------------------


### PR DESCRIPTION
This repository will be soon be offline, see https://github.com/orgs/robotology/discussions/653 .

See also:
* https://github.com/orgs/robotology/discussions/612
* https://github.com/icub-tech-iit/documentation/issues/261