### PR TITLE
Improvements on the `ffmpeg` port monitor to allow using different couples of coders/decodes

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -28,6 +28,7 @@ Fixes
 -----
 
 * Configuration files installed by the `yarp_configure_plugins_installation` CMake macro are now relocatable (https://github.com/robotology/yarp/issues/2445, ).
+* Improved `ffmpeg` port monitor to allow using different couples of coders/decodes
 
 New Features
 ------------

--- a/src/portmonitors/image_compression_ffmpeg/README.md
+++ b/src/portmonitors/image_compression_ffmpeg/README.md
@@ -54,13 +54,20 @@ All the parameters will be passed to the compression/decompression context of th
 ## Parameters
 
 The parameters that can be set on the command line can have different types.<br>
-The encoding formats implemented are:
--   H264
--   H265
--   MPEG2VIDEO
+The default codecs are:
+-   ``h264``
+-   ``h265``
+-   ``mpeg2video``
 
-If no codec is chosen via the connection string, MPEG2VIDEO codec is used as default. <br>
-Parameters can be used to manipulate image quality. For example, the right values for "qmin" and "qmax" parameters can lead you to the best quality (at the expense of the bandwidth).
+These codecs can be set via the ``codec`` parameter. If no codec is chosen via the connection string, ``mpeg2video`` codec is used as default. <br>
+In some cases, it might be useful to specify the encoder and the decoder separately. This is possible via the ``custom_enc`` and ``custom_dec`` parameters.
+When specifying a ``custom_enc``, it is also necessary to specify a ``custom_dec``, and viceversa. The availability of a given encoder/decoder depends on ``ffmpeg``.
+It is possible to check which encoder/decoder is available with the commands ``ffmpeg -encoders``/``ffmpeg -decoders``.<br>
+According to the chosen encoder/decoder, the default pixel format (AV_PIX_FMT_YUV420P) might not be available. In this case, an error is printed either on the receiver
+or the sender side, with an indication about the supported pixel formats, and a suggested one. It is possible to specify the desired pixel format with the
+parameter ``pixel_format``. <br>
+Parameters can be used to manipulate image quality. It is possible to check the available parameters of a given encoder/decoder with the command ``ffmpeg -h encoder=<name>``.
+For example, the right values for "qmin" and "qmax" parameters can lead you to the best quality (at the expense of the bandwidth).
 The best values for these two parameters for each codec are defined in [this page](https://slhck.info/video/2017/02/24/vbr-settings.html) and reported in the following table. <br>
 | Codec       | qmin        | qmax        |
 | ----------- | ----------- | ----------- |

--- a/src/portmonitors/image_compression_ffmpeg/constants.h
+++ b/src/portmonitors/image_compression_ffmpeg/constants.h
@@ -82,6 +82,12 @@ static const std::string FFMPEGPORTMONITOR_CL_PIXEL_FORMAT_KEY = "pixel_format";
 static const std::string FFMPEGPORTMONITOR_CL_FRAME_RATE_KEY = "frame_rate";
 
 /**
+ * @brief This string is the "key" value to enable the print statistics
+ *
+ */
+static const std::string FFMPEGPORTMONITOR_CL_PRINT_STATISTICS_KEY = "print_statistics";
+
+/**
  * @brief This vector contains the codec ids corresponding to the codecs of the FFMPEGPORTMONITOR_CL_CODECS vector.
  *
  */

--- a/src/portmonitors/image_compression_ffmpeg/constants.h
+++ b/src/portmonitors/image_compression_ffmpeg/constants.h
@@ -76,6 +76,12 @@ static const std::string FFMPEGPORTMONITOR_CL_CUSTOM_DEC_KEY = "custom_dec";
 static const std::string FFMPEGPORTMONITOR_CL_PIXEL_FORMAT_KEY = "pixel_format";
 
 /**
+ * @brief This string is the "key" value for the frame rate parameter
+ *
+ */
+static const std::string FFMPEGPORTMONITOR_CL_FRAME_RATE_KEY = "frame_rate";
+
+/**
  * @brief This vector contains the codec ids corresponding to the codecs of the FFMPEGPORTMONITOR_CL_CODECS vector.
  *
  */

--- a/src/portmonitors/image_compression_ffmpeg/constants.h
+++ b/src/portmonitors/image_compression_ffmpeg/constants.h
@@ -58,6 +58,24 @@ static const std::vector<std::string> FFMPEGPORTMONITOR_CL_CODECS {
 };
 
 /**
+ * @brief This string is the "key" value for the custom encoder parameter
+ *
+ */
+static const std::string FFMPEGPORTMONITOR_CL_CUSTOM_ENC_KEY = "custom_enc";
+
+/**
+ * @brief This string is the "key" value for the custom decoder parameter
+ *
+ */
+static const std::string FFMPEGPORTMONITOR_CL_CUSTOM_DEC_KEY = "custom_dec";
+
+/**
+ * @brief This string is the "key" value for the pixel format parameter
+ *
+ */
+static const std::string FFMPEGPORTMONITOR_CL_PIXEL_FORMAT_KEY = "pixel_format";
+
+/**
  * @brief This vector contains the codec ids corresponding to the codecs of the FFMPEGPORTMONITOR_CL_CODECS vector.
  *
  */
@@ -80,13 +98,9 @@ static std::map<int, int> FFMPEGPORTMONITOR_PIXELMAP = {
 };
 
 /**
- * @brief This structure maps Ffmpeg video codecs with their needed Ffmpeg pixel format code.
+ * @brief Default pixel format to be used within ffmpeg.
  *
  */
-static std::map<int, int> FFMPEGPORTMONITOR_CODECPIXELMAP = {
-    { AV_CODEC_ID_H264, AV_PIX_FMT_YUV420P },
-    { AV_CODEC_ID_H265, AV_PIX_FMT_YUV420P },
-    { AV_CODEC_ID_MPEG2VIDEO, AV_PIX_FMT_YUV420P }
-};
+static AVPixelFormat FFMPEGPORTMONITOR_DEFAULT_PIXEL_FORMAT = AV_PIX_FMT_YUV420P;
 
 #endif  // YARP_FFMPEG_CARRIER_FFMPEGPORTMONITOR_CL_PARAMS_H

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
@@ -347,9 +347,17 @@ yarp::os::Things& FfmpegMonitorObject::update(yarp::os::Things& thing)
         int pixelCode = compressedBottle->get(3).asInt32();
         int pixelSize = compressedBottle->get(4).asInt32();
         // Set information into final image
-        imageOut.setPixelCode(pixelCode);
-        imageOut.setPixelSize(pixelSize);
-        imageOut.resize(width, height);
+
+        if (pixelCode != VOCAB_PIXEL_INVALID)
+        {
+            imageOut.setPixelCode(pixelCode);
+            imageOut.setPixelSize(pixelSize);
+            imageOut.resize(width, height);
+        }
+        else
+        {
+			yCError(FFMPEGMONITOR, "Invalid input pixel code");
+		}
 
         // Check if compression was successful
         if (compressedBottle->get(0).asInt32() == 1) {

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
@@ -271,14 +271,14 @@ yarp::os::Things& FfmpegMonitorObject::update(yarp::os::Things& thing)
         Image* img = thing.cast_as< Image >();
 
         if (img == nullptr) {
-			Bottle* bot = thing.cast_as<Bottle>();
+            Bottle* bot = thing.cast_as<Bottle>();
             if (!yarp::os::Portable::copyPortable(*bot, imageBottleBuffer))
             {
                 yCError(FFMPEGMONITOR, "The input type is a Bottle, but it cannot be copied to an Image");
-			    success = false;
+                success = false;
             }
             img = &imageBottleBuffer;
-		}
+        }
 
         // Allocate memory for packet
         AVPacket *packet = av_packet_alloc();
@@ -356,8 +356,8 @@ yarp::os::Things& FfmpegMonitorObject::update(yarp::os::Things& thing)
         }
         else
         {
-			yCError(FFMPEGMONITOR, "Invalid input pixel code");
-		}
+            yCError(FFMPEGMONITOR, "Invalid input pixel code");
+        }
 
         // Check if compression was successful
         if (compressedBottle->get(0).asInt32() == 1) {

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
@@ -609,7 +609,7 @@ int FfmpegMonitorObject::decompress(AVPacket* pkt, int w, int h, int pixelCode) 
 
 }
 
-bool FfmpegMonitorObject::getParamsFromCommandLine(std::string carrierString, AVCodec*& codecOut, AVPixelFormat& pixelFormatOut) {
+bool FfmpegMonitorObject::getParamsFromCommandLine(std::string carrierString, const AVCodec*& codecOut, AVPixelFormat& pixelFormatOut) {
 
     std::vector<std::string> parameters;
     // Split command line string using '+' delimiter

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
@@ -105,6 +105,11 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          */
         int setCommandLineParams();
 
+        /**
+         * @brief Print some network statistics
+         */
+        void updateStatistics(yarp::os::Bottle &inputBottle, double currentLag);
+
     public:
         /**
          * @brief The object returned by the "update" function; it can be a yarp::os::Bottle (sender side) or a yarp::sig::Image (receiver side).
@@ -153,6 +158,37 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          *
          */
         bool firstTime;
+
+        /**
+         * @brief Boolean variable used to check whether the bandwidth statistics should be printed
+         *
+         */
+        bool printStatistics;
+
+        /**
+         * @brief Seconds since epoch of the previous frame;
+         */
+        double previousFrameTime;
+
+        /**
+         * @brief Variable storing the current bandwidth average for statistics
+         */
+        double bandwidthRunningAverage;
+
+        /**
+         * @brief Variable storing the current lag for statistics
+         */
+        double lagRunningAverage;
+
+        /**
+         * @brief Utility counter for printing statistics
+         */
+        int statisticsCounter;
+
+        /**
+         * @brief Utility variable to store the time in which the last time the statistics have been printed.
+         */
+        double previousStatisticPrintTime;
 
         /**
          * @brief Structure that maps every parameter inserted from command line into its value (both as strings).

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
@@ -96,7 +96,7 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          * @param codecId       The codec for video compression / decompression.
          * @return int          0 on success, -1 otherwise.
          */
-        bool getParamsFromCommandLine(std::string carrierString, const AVCodec *&codecOut, AVPixelFormat &pixelFormatOut);
+        bool getParamsFromCommandLine(std::string carrierString, const AVCodec *&codecOut, AVPixelFormat &pixelFormatOut, int &frameRate);
 
         /**
          * @brief This function iterates over the attribute paramsMap and sets all the specified parameters into the attribute codecContext.

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
@@ -130,6 +130,12 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
         yarp::sig::FlexImage imageOut;
 
         /**
+         * @brief The final decompressed image that will be sent to the original destination.
+         *
+         */
+        yarp::sig::Image imageBottleBuffer;
+
+        /**
          * @brief Boolean variable that tells if the current execution is in sender side or not.
          *
          */

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
@@ -96,7 +96,7 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          * @param codecId       The codec for video compression / decompression.
          * @return int          0 on success, -1 otherwise.
          */
-        int getParamsFromCommandLine(std::string carrierString, AVCodecID &codecId);
+        bool getParamsFromCommandLine(std::string carrierString, AVCodec *&codecOut, AVPixelFormat &pixelFormatOut);
 
         /**
          * @brief This function iterates over the attribute paramsMap and sets all the specified parameters into the attribute codecContext.
@@ -131,22 +131,22 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
         bool senderSide;
 
         /**
-         * @brief The string containing codec name.
-         *
-         */
-        std::string codecName;
-
-        /**
          * @brief Ffmpeg structure containing all codec information needed for compression / decompression.
          *
          */
-        const AVCodec *codec;
+        AVCodec *codec;
 
         /**
          * @brief Ffmpeg structure containing all codec context information needed for compression / decompression.
          *
          */
         AVCodecContext *codecContext = NULL;
+
+        /**
+         * @brief Ffmpeg pixel format.
+         *
+         */
+        AVPixelFormat pixelFormat{AV_PIX_FMT_YUV420P};
 
         /**
          * @brief Boolean variable used to check if the current call to the "compression" (or "decompression") function is the first one or not.

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.h
@@ -96,7 +96,7 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          * @param codecId       The codec for video compression / decompression.
          * @return int          0 on success, -1 otherwise.
          */
-        bool getParamsFromCommandLine(std::string carrierString, AVCodec *&codecOut, AVPixelFormat &pixelFormatOut);
+        bool getParamsFromCommandLine(std::string carrierString, const AVCodec *&codecOut, AVPixelFormat &pixelFormatOut);
 
         /**
          * @brief This function iterates over the attribute paramsMap and sets all the specified parameters into the attribute codecContext.
@@ -134,7 +134,7 @@ class FfmpegMonitorObject : public yarp::os::MonitorObject
          * @brief Ffmpeg structure containing all codec information needed for compression / decompression.
          *
          */
-        AVCodec *codec;
+        const AVCodec *codec;
 
         /**
          * @brief Ffmpeg structure containing all codec context information needed for compression / decompression.


### PR DESCRIPTION
With this PR it is possible to select all the encoders and decoders available with ``ffmpeg``. In order to do so, I had to allow specifying custom pixel formats, listing also all those available for each encoder/decoder. 
Moreover, I managed to fix a crash occurring when launching two port monitor instances.

I also added a utility to print the estimated bandwidth requested (it is a lower bound) and I made it work also in conjunction with ``yarp repeat``.

We are currently using it with the NVIDIA ``hevc`` codecs in both Windows and Linux.

cc @mebbaid @GiulioRomualdi @traversaro 