### PR TITLE
Improve closing behavior when attempting to close a device implementing the service interface

### DIFF
--- a/src/libYARP_dev/src/yarp/dev/Drivers.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Drivers.cpp
@@ -325,7 +325,6 @@ DriverCreator* Drivers::Private::load(const char *name) {
 }
 
 static std::string terminatorKey;
-static bool terminated = false;
 static void handler (int)
 {
     Time::useSystemClock();
@@ -343,7 +342,6 @@ static void handler (int)
     }
     if (!terminatorKey.empty()) {
         yCInfo(DRIVERS, "[try %d of 3] Trying to shut down %s", ct, terminatorKey.c_str());
-        terminated = true;
         Terminator::terminateByName(terminatorKey.c_str());
     } else {
         yCInfo(DRIVERS, "Aborting...");
@@ -529,6 +527,7 @@ int Drivers::yarpdev(int argc, char *argv[]) {
             service = nullptr;
         }
     }
+    bool terminated = false;
     while (dd.isValid() && !(terminated||(terminee&&terminee->mustQuit()))) {
         if (service!=nullptr) {
             double now = Time::now();


### PR DESCRIPTION
I am implementing a device which can close prematurely depending on the internal state. I want ``yarpdev`` to be notified when this happens and close consequently.

In order to have this behavior, I implemented the ``IService`` interface. But then, if I press CTRL+C in the ``yarpdev`` terminal, it seems to always get stuck, and then I have to kill the ``yarpdev`` process. The last message was
```
[INFO] |yarp.dev.Drivers| [try 1 of 3] Trying to shut down /yarpdev/quit
```

After some debugging, I noticed that when the signal handler was setting the static flag "terminated" to true, it was also attempting to close immediately the terminator port. But the terminator port is receiving the termination message and some race condition seemed to occur on Windows.

If we avoid to set the ``terminated`` flag from the signal handler and instead we wait for the termination port to do its job, then ``yarpdev`` closes smoothly without issues.

cc @randaz81 @Nicogene @traversaro 