### PR TITLE
Do not ignore ${SWIG_DIR} when invoking ${SWIG_EXECUTABLE}

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -29,6 +29,7 @@ Fixes
 
 * Configuration files installed by the `yarp_configure_plugins_installation` CMake macro are now relocatable (https://github.com/robotology/yarp/issues/2445, ).
 * Improved `ffmpeg` port monitor to allow using different couples of coders/decodes
+* Fixed compilation of portmonitor carrier when a custom non-system swig is used
 
 New Features
 ------------

--- a/src/carriers/portmonitor_carrier/CMakeLists.txt
+++ b/src/carriers/portmonitor_carrier/CMakeLists.txt
@@ -36,7 +36,7 @@ if (NOT SKIP_portmonitor)
       add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/lua/src_gen/swigluarun.h"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/lua/src_gen/"
-        COMMAND "${SWIG_EXECUTABLE}" -c++ -lua -external-runtime "${CMAKE_CURRENT_BINARY_DIR}/lua/src_gen/swigluarun.h"
+        COMMAND "${CMAKE_COMMAND}" -E env "SWIG_LIB=${SWIG_DIR}" "${SWIG_EXECUTABLE}" -c++ -lua -external-runtime "${CMAKE_CURRENT_BINARY_DIR}/lua/src_gen/swigluarun.h"
         COMMENT "Generating swig-lua runtime"
       )
       target_include_directories(yarp_portmonitor PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/lua/src_gen")


### PR DESCRIPTION
Without this fix, the compilation with a custom non-system swig is failing. See https://github.com/Kitware/CMake/blob/v3.29.2/Modules/UseSWIG.cmake#L725 for similar code inside CMake. 

This is important for compatibility with Ubuntu 24.04 when using apt dependencies, as the swig that ships with Ubuntu 24.04 is swig 4.2.0, that is not compatible with YARP. 