### PR TITLE
NameServerContainer: do not print "database needs to be reset" message

### DIFF
--- a/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
+++ b/src/libYARP_serversql/src/yarp/serversql/impl/NameServerContainer.cpp
@@ -100,7 +100,7 @@ bool NameServerContainer::open(Searchable& options)
 
     bool reset = false;
     if (options.check("ip")||options.check("socket")) {
-        yCError(NAMESERVERCONTAINER, "Database needs to be reset, IP or port number set.");
+        yCInfo(NAMESERVERCONTAINER, "Database needs to be reset, IP or port number set.");
         reset = true;
     }
 


### PR DESCRIPTION
The message "Database needs to be reset, IP or port number set." is printed every time the `--ip` or `--socket` is passed, so it does not make sense to print as an error as it is printed even if everything is working as intended. This PR changes it from `yCError` to `yCInfo` .

This seems a regression from https://github.com/robotology/yarp/commit/d97ab7f6269b16b94b7187269918e41746eee5c8#diff-be8b39c3c66ca00e0f5ace04995b0d08fc83edaaff870d6d8d87dc349d7cc8a8R104 . Before that commit, the message was just printed on `stderr`, but not printed as an error. 