### PR TITLE
fixed dangling pointer using std::string

### DIFF
--- a/src/libYARP_manager/src/yarp/manager/broker.h
+++ b/src/libYARP_manager/src/yarp/manager/broker.h
@@ -41,16 +41,13 @@ public:
     virtual bool start() = 0;
     virtual bool stop() = 0;
     virtual bool kill() = 0;
-    virtual bool connect(const char* from, const char* to,
-                        const char* carrier, bool persist=false) = 0;
-    virtual bool disconnect(const char* from, const char* to,
-                            const char* carrier) = 0;
+    virtual bool connect(const std::string& from, const std::string& to, const std::string& carrier, bool persist = false) = 0;
+    virtual bool disconnect(const std::string& from, const std::string& to, const std::string& carrier) = 0;
     virtual int  running() = 0; // 0 if is not running and 1 if is running; otherwise -1.
-    virtual bool exists(const char* port) = 0;
-    virtual std::string requestRpc(const char* szport, const char* request, double timeout=0.0) = 0;
-    virtual bool connected(const char* from, const char* to,
-                           const char* carrier) = 0;
-    virtual const char* error() = 0;
+    virtual bool exists(const std::string& port) = 0;
+    virtual std::string requestRpc(const std::string& szport, const std::string& request, double timeout = 0.0) = 0;
+    virtual bool connected(const std::string& from, const std::string& to, const std::string& carrier) = 0;
+    virtual std::string error() = 0;
     virtual bool initialized() = 0;
     virtual bool attachStdout() = 0;
     virtual void detachStdout() = 0;
@@ -62,7 +59,7 @@ public:
     bool hasWatchDog() { return bWithWatchDog; }
     void setDisplay(const char* szDisplay) { if(szDisplay) { strDisplay = szDisplay; } }
 
-    const char* getDisplay() const {return strDisplay.c_str(); }
+    std::string getDisplay() const {return strDisplay; }
 protected:
     unsigned int UNIQUEID;
     BrokerEventSink* eventSink;

--- a/src/libYARP_manager/src/yarp/manager/broker.h
+++ b/src/libYARP_manager/src/yarp/manager/broker.h
@@ -47,7 +47,7 @@ public:
                             const char* carrier) = 0;
     virtual int  running() = 0; // 0 if is not running and 1 if is running; otherwise -1.
     virtual bool exists(const char* port) = 0;
-    virtual const char* requestRpc(const char* szport, const char* request, double timeout=0.0) = 0;
+    virtual std::string requestRpc(const char* szport, const char* request, double timeout=0.0) = 0;
     virtual bool connected(const char* from, const char* to,
                            const char* carrier) = 0;
     virtual const char* error() = 0;

--- a/src/libYARP_manager/src/yarp/manager/execstate.cpp
+++ b/src/libYARP_manager/src/yarp/manager/execstate.cpp
@@ -229,7 +229,7 @@ void Ready::startModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot run "<<executable->getCommand()<<" on "<<executable->getHost();
-        if (executable->getBroker()->error()) {
+        if (!executable->getBroker()->error().empty()) {
             msg << " : " << executable->getBroker()->error();
         }
         logger->addError(msg);
@@ -305,7 +305,7 @@ void Connecting::connectAllPorts()
             {
                 OSTRINGSTREAM msg;
                 msg<<"cannot connect "<<(*itr).from() <<" to "<<(*itr).to();
-                if (executable->getBroker()->error()) {
+                if (!executable->getBroker()->error().empty()) {
                     msg << " : " << executable->getBroker()->error();
                 }
                 logger->addError(msg);
@@ -418,7 +418,7 @@ void Dying::stopModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot stop "<<executable->getCommand()<<" on "<<executable->getHost();
-        if (executable->getBroker()->error()) {
+        if (!executable->getBroker()->error().empty()) {
             msg << " : " << executable->getBroker()->error();
         }
         logger->addError(msg);
@@ -439,7 +439,7 @@ void Dying::killModule()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot kill "<<executable->getCommand()<<" on "<<executable->getHost();
-        if (executable->getBroker()->error()) {
+        if (!executable->getBroker()->error().empty()) {
             msg << " : " << executable->getBroker()->error();
         }
         logger->addError(msg);
@@ -467,7 +467,7 @@ void Dying::disconnectAllPorts()
             {
                 OSTRINGSTREAM msg;
                 msg<<"cannot disconnect "<<(*itr).from() <<" to "<<(*itr).to();
-                if (executable->getBroker()->error()) {
+                if (!executable->getBroker()->error().empty()) {
                     msg << " : " << executable->getBroker()->error();
                 }
                 logger->addError(msg);

--- a/src/libYARP_manager/src/yarp/manager/execstate.cpp
+++ b/src/libYARP_manager/src/yarp/manager/execstate.cpp
@@ -127,10 +127,10 @@ bool Ready::checkResources(bool silent)
         }
         // check the rpc request/reply if required
         if(strlen((*itr).getRequest()) != 0) {
-            const char* reply = executable->getBroker()->requestRpc((*itr).getPort(),
+            std::string reply = executable->getBroker()->requestRpc((*itr).getPort(),
                                                                     (*itr).getRequest(),
                                                                     (*itr).getTimeout());
-            if(reply == nullptr) {
+            if(reply.empty()) {
                 allOK = false;
                 OSTRINGSTREAM msg;
                 msg<<"cannot request resource "<<(*itr).getPort()<<" for "<<(*itr).getRequest();
@@ -142,7 +142,7 @@ bool Ready::checkResources(bool silent)
                 }
             }
 
-            if(!compareString(reply, (*itr).getReply())) {
+            if (!compareString(reply.c_str(), (*itr).getReply())) {
                 allOK = false;
                 OSTRINGSTREAM msg;
                 msg<<"waiting for the expected reply from resource "<<(*itr).getPort();

--- a/src/libYARP_manager/src/yarp/manager/executable.cpp
+++ b/src/libYARP_manager/src/yarp/manager/executable.cpp
@@ -65,7 +65,7 @@ bool Executable::initialize()
     {
         OSTRINGSTREAM msg;
         msg<<"cannot initialize broker. : ";
-        if (broker->error()) {
+        if (!broker->error().empty()) {
             msg << broker->error();
         }
         logger->addError(msg);

--- a/src/libYARP_manager/src/yarp/manager/localbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/localbroker.cpp
@@ -445,21 +445,21 @@ bool LocalBroker::exists(const char* port)
 }
 
 
-const char* LocalBroker::requestRpc(const char* szport, const char* request, double timeout)
+std::string LocalBroker::requestRpc(const char* szport, const char* request, double timeout)
 {
     if ((szport == nullptr) || (request == nullptr)) {
-        return nullptr;
+        return {};
     }
 
     if (!exists(szport)) {
-        return nullptr;
+        return {};
     }
 
     // opening the port
     yarp::os::Port port;
     port.setTimeout((float)((timeout>0.0) ? timeout : CONNECTION_TIMEOUT));
     if (!port.open("...")) {
-        return nullptr;
+        return {};
     }
 
     ContactStyle style;
@@ -476,7 +476,7 @@ const char* LocalBroker::requestRpc(const char* szport, const char* request, dou
 
     if(!ret) {
         port.close();
-        return nullptr;
+        return {};
     }
 
     Bottle msg, response;
@@ -485,7 +485,7 @@ const char* LocalBroker::requestRpc(const char* szport, const char* request, dou
     NetworkBase::disconnect(port.getName(), szport);
     if(!response.size() || !ret) {
         port.close();
-        return nullptr;
+        return {};
     }
 
     port.close();

--- a/src/libYARP_manager/src/yarp/manager/localbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/localbroker.cpp
@@ -355,17 +355,16 @@ int LocalBroker::running()
 /**
  *  connection broker
  */
-bool LocalBroker::connect(const char* from, const char* to,
-            const char* carrier, bool persist)
+bool LocalBroker::connect(const std::string& from, const std::string& to, const std::string& carrier, bool persist)
 {
 
-    if(!from)
+    if(from.empty())
     {
         strError = "no source port is introduced.";
         return false;
     }
 
-    if(!to)
+    if (to.empty())
     {
         strError = "no destination port is introduced.";
         return false;
@@ -395,16 +394,16 @@ bool LocalBroker::connect(const char* from, const char* to,
     return true;
 }
 
-bool LocalBroker::disconnect(const char* from, const char* to, const char *carrier)
+bool LocalBroker::disconnect(const std::string& from, const std::string& to, const std::string& carrier)
 {
 
-    if(!from)
+    if (from.empty())
     {
         strError = "no source port is introduced.";
         return false;
     }
 
-    if(!to)
+    if (to.empty())
     {
         strError = "no destination port is introduced.";
         return false;
@@ -439,15 +438,15 @@ bool LocalBroker::disconnect(const char* from, const char* to, const char *carri
 
 }
 
-bool LocalBroker::exists(const char* port)
+bool LocalBroker::exists(const std::string& port)
 {
     return NetworkBase::exists(port);
 }
 
 
-std::string LocalBroker::requestRpc(const char* szport, const char* request, double timeout)
+std::string LocalBroker::requestRpc(const std::string& szport, const std::string& request, double timeout)
 {
-    if ((szport == nullptr) || (request == nullptr)) {
+    if (szport.empty() || request.empty()) {
         return {};
     }
 
@@ -492,7 +491,7 @@ std::string LocalBroker::requestRpc(const char* szport, const char* request, dou
     return response.toString().c_str();
 }
 
-bool LocalBroker::connected(const char* from, const char* to, const char* carrier)
+bool LocalBroker::connected(const std::string& from, const std::string& to, const std::string& carrier)
 {
     if (!exists(from) || !exists(to)) {
         return false;
@@ -501,9 +500,9 @@ bool LocalBroker::connected(const char* from, const char* to, const char* carrie
 }
 
 
-const char* LocalBroker::error()
+std::string LocalBroker::error()
 {
-    return strError.c_str();
+    return strError;
 }
 
 bool LocalBroker::attachStdout()

--- a/src/libYARP_manager/src/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/localbroker.h
@@ -56,7 +56,7 @@ public:
                     const char *carrier) override;
     int running() override;
     bool exists(const char* port) override;
-    const char* requestRpc(const char* szport, const char* request, double timeout) override;
+    std::string requestRpc(const char* szport, const char* request, double timeout) override;
     bool connected(const char* from, const char* to,
                    const char* carrier) override;
     const char* error() override;

--- a/src/libYARP_manager/src/yarp/manager/localbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/localbroker.h
@@ -50,16 +50,13 @@ public:
     bool start() override;
     bool stop() override;
     bool kill() override;
-    bool connect(const char* from, const char* to,
-                 const char* carrier, bool persist=false) override;
-    bool disconnect(const char* from, const char* to,
-                    const char *carrier) override;
+    bool connect(const std::string& from, const std::string& to, const std::string& carrier, bool persist = false) override;
+    bool disconnect(const std::string& from, const std::string& to, const std::string& carrier) override;
     int running() override;
-    bool exists(const char* port) override;
-    std::string requestRpc(const char* szport, const char* request, double timeout) override;
-    bool connected(const char* from, const char* to,
-                   const char* carrier) override;
-    const char* error() override;
+    bool exists(const std::string& port) override;
+    std::string requestRpc(const std::string& szport, const std::string& request, double timeout) override;
+    bool connected(const std::string& from, const std::string& to, const std::string& carrier) override;
+    std::string error() override;
     bool initialized() override { return bInitialized;}
     bool attachStdout() override;
     void detachStdout() override;

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.cpp
@@ -97,9 +97,9 @@ bool ScriptLocalBroker::init(const char* szcmd, const char* szparam,
      }
 
 
-bool ScriptYarprunBroker::whichFile(const char* server, const char* filename, std::string& filenameWithPath)
+bool ScriptYarprunBroker::whichFile(const std::string& server, const std::string& filename, std::string& filenameWithPath)
 {
-    if (!strlen(server)) {
+    if (server.empty()) {
         return false;
     }
 

--- a/src/libYARP_manager/src/yarp/manager/scriptbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/scriptbroker.h
@@ -47,8 +47,8 @@ public:
             const char* szhost, const char* szstdio,
             const char* szworkdir, const char* szenv) override;
 private:
-    bool whichFile(const char* server, const char* filename, std::string& filenameWithPath);
-    std::string script;
+     bool whichFile(const std::string& server, const std::string& filename, std::string& filenameWithPath);
+     std::string script;
 };
 
 } // namespace yarp::manager

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
@@ -529,21 +529,21 @@ bool YarpBroker::exists(const char* szport)
     return NetworkBase::exists(szport, style);
 }
 
-const char* YarpBroker::requestRpc(const char* szport, const char* request, double timeout)
+std::string YarpBroker::requestRpc(const char* szport, const char* request, double timeout)
 {
     if ((szport == nullptr) || (request == nullptr)) {
-        return nullptr;
+        return {};
     }
 
     if (!exists(szport)) {
-        return nullptr;
+        return {};
     }
 
     // opening the port
     yarp::os::Port port;
     port.setTimeout((float)((timeout>0.0) ? timeout : CONNECTION_TIMEOUT));
     if (!port.open("...")) {
-        return nullptr;
+        return {};
     }
 
     ContactStyle style;
@@ -560,7 +560,7 @@ const char* YarpBroker::requestRpc(const char* szport, const char* request, doub
 
     if(!ret) {
         port.close();
-        return nullptr;
+        return {};
     }
 
     Bottle msg, response;
@@ -569,7 +569,7 @@ const char* YarpBroker::requestRpc(const char* szport, const char* request, doub
     NetworkBase::disconnect(port.getName(), szport);
     if(!response.size() || !ret) {
         port.close();
-        return nullptr;
+        return {};
     }
 
     port.close();

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
@@ -408,16 +408,15 @@ Property& YarpBroker::runProperty()
 /**
  *  connection broker
  */
-bool YarpBroker::connect(const char* from, const char* to,
-            const char* carrier, bool persist)
+bool YarpBroker::connect(const std::string& from, const std::string& to, const std::string& carrier, bool persist)
 {
-    if(!from)
+    if(from.empty())
     {
         strError = "no source port is introduced.";
         return false;
     }
 
-    if(!to)
+    if(to.empty())
     {
         strError = "no destination port is introduced.";
         return false;
@@ -471,16 +470,16 @@ bool YarpBroker::connect(const char* from, const char* to,
     return true;
 }
 
-bool YarpBroker::disconnect(const char* from, const char* to, const char* carrier)
+bool YarpBroker::disconnect(const std::string& from, const std::string& to, const std::string& carrier)
 {
 
-    if(!from)
+    if(from.empty())
     {
         strError = "no source port is introduced.";
         return false;
     }
 
-    if(!to)
+    if(to.empty())
     {
         strError = "no destination port is introduced.";
         return false;
@@ -521,7 +520,7 @@ bool YarpBroker::disconnect(const char* from, const char* to, const char* carrie
 
 }
 
-bool YarpBroker::exists(const char* szport)
+bool YarpBroker::exists(const std::string& szport)
 {
     ContactStyle style;
     style.quiet = true;
@@ -529,9 +528,9 @@ bool YarpBroker::exists(const char* szport)
     return NetworkBase::exists(szport, style);
 }
 
-std::string YarpBroker::requestRpc(const char* szport, const char* request, double timeout)
+std::string YarpBroker::requestRpc(const std::string& szport, const std::string& request, double timeout)
 {
-    if ((szport == nullptr) || (request == nullptr)) {
+    if (szport.empty() || request.empty()) {
         return {};
     }
 
@@ -576,7 +575,7 @@ std::string YarpBroker::requestRpc(const char* szport, const char* request, doub
     return response.toString().c_str();
 }
 
-bool YarpBroker::connected(const char* from, const char* to, const char* carrier)
+bool YarpBroker::connected(const std::string& from, const std::string& to, const std::string& carrier)
 {
     if (!exists(from) || !exists(to)) {
         return false;
@@ -588,9 +587,9 @@ bool YarpBroker::connected(const char* from, const char* to, const char* carrier
     return NetworkBase::isConnected(from, to, style);
 }
 
-bool YarpBroker::getSystemInfo(const char* server, SystemInfoSerializer& info)
+bool YarpBroker::getSystemInfo(const std::string& server, SystemInfoSerializer& info)
 {
-    if (!strlen(server)) {
+    if (server.empty()) {
         return false;
     }
     if (!semParam.check()) {
@@ -681,10 +680,10 @@ bool YarpBroker::getAllPorts(std::vector<std::string> &ports)
     return true;
 }
 
-bool YarpBroker::getAllProcesses(const char* server,
+bool YarpBroker::getAllProcesses(const std::string& server,
                                  ProcessContainer& processes)
 {
-    if (!strlen(server)) {
+    if (server.empty()) {
         return false;
     }
 
@@ -729,9 +728,9 @@ bool YarpBroker::getAllProcesses(const char* server,
 }
 
 
-bool YarpBroker::rmconnect(const char* from, const char* to)
+bool YarpBroker::rmconnect(const std::string& from, const std::string& to)
 {
-    std::string topic = std::string(from) + std::string(to);
+    std::string topic = from + to;
     Bottle cmd, reply;
     cmd.addString("untopic");
     cmd.addString(topic.c_str());
@@ -743,23 +742,23 @@ bool YarpBroker::rmconnect(const char* from, const char* to)
                                  CONNECTION_TIMEOUT);
 }
 
-bool YarpBroker::setQos(const char* from, const char *to,
-                        const char *qosFrom, const char *qosTo) {
+bool YarpBroker::setQos(const std::string& from, const std::string& to, const std::string& qosFrom, const std::string& qosTo)
+{
     strError.clear();
 
-    if (qosFrom && qosTo && !strlen(qosFrom) && !strlen(qosTo)) {
+    if (qosFrom.empty() && qosTo.empty()) {
         return true;
     }
 
     QosStyle styleFrom;
     QosStyle styleTo;
-    if(qosFrom != nullptr && strlen(qosFrom)) {
+    if (qosFrom.empty() == false) {
         if(!getQosFromString(qosFrom, styleFrom)) {
             strError = "Error in parsing Qos properties of " + std::string(from);
             return false;
         }
     }
-    if (qosTo != nullptr && strlen(qosTo)) {
+    if (qosTo.empty() == false) {
         if(!getQosFromString(qosTo, styleTo)) {
             strError = "Error in parsing Qos properties of " + std::string(to);
             return false;
@@ -768,7 +767,8 @@ bool YarpBroker::setQos(const char* from, const char *to,
     return NetworkBase::setConnectionQos(from, to, styleFrom, styleTo, true);
 }
 
-bool YarpBroker::getQosFromString(const char* qos, yarp::os::QosStyle& style) {
+bool YarpBroker::getQosFromString(const std::string& qos, yarp::os::QosStyle& style)
+{
     std::string strQos(qos);
     transform(strQos.begin(), strQos.end(), strQos.begin(),
               (int(*)(int))toupper);
@@ -804,9 +804,9 @@ bool YarpBroker::getQosFromString(const char* qos, yarp::os::QosStyle& style) {
     return true;
 }
 
-const char* YarpBroker::error()
+std::string YarpBroker::error()
 {
-    return strError.c_str();
+    return strError;
 }
 
 

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.h
@@ -49,7 +49,7 @@ public:
      bool rmconnect(const char* from, const char* to);
      int running() override;
      bool exists(const char* port) override;
-     const char* requestRpc(const char* szport, const char* request, double timeout) override;
+     std::string requestRpc(const char* szport, const char* request, double timeout) override;
      bool connected(const char* from, const char* to, const char* carrier) override;
      const char* error() override;
      bool initialized() override { return bInitialized;}

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.h
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.h
@@ -43,27 +43,25 @@ public:
      bool start() override;
      bool stop() override;
      bool kill() override;
-     bool connect(const char* from, const char* to,
-                        const char* carrier, bool persist=false) override;
-     bool disconnect(const char* from, const char* to, const char* carrier) override;
-     bool rmconnect(const char* from, const char* to);
+     bool connect(const std::string& from, const std::string& to, const std::string& carrier, bool persist = false) override;
+     bool disconnect(const std::string& from, const std::string& to, const std::string& carrier) override;
+     bool rmconnect(const std::string& from, const std::string& to);
      int running() override;
-     bool exists(const char* port) override;
-     std::string requestRpc(const char* szport, const char* request, double timeout) override;
-     bool connected(const char* from, const char* to, const char* carrier) override;
-     const char* error() override;
+     bool exists(const std::string& port) override;
+     std::string requestRpc(const std::string& szport, const std::string& request, double timeout) override;
+     bool connected(const std::string& from, const std::string& to, const std::string& carrier) override;
+     std::string error() override;
      bool initialized() override { return bInitialized;}
      bool attachStdout() override;
      void detachStdout() override;
 
-     bool getSystemInfo(const char* server,
+     bool getSystemInfo(const std::string& server,
                         yarp::os::SystemInfoSerializer& info);
-     bool getAllProcesses(const char* server,
+     bool getAllProcesses(const std::string& server,
                         ProcessContainer &processes);
      bool getAllPorts(std::vector<std::string> &stingList);
 
-     bool setQos(const char* from, const char* to,
-                 const char* qosFrom, const char* qosTo);
+     bool setQos(const std::string& from, const std::string& to, const std::string& qosFrom, const std::string& qosTo);
 
 public: // for rate thread
     void run() override;
@@ -97,7 +95,7 @@ private:
     int requestServer(yarp::os::Property& config);
     int SendMsg(yarp::os::Bottle& msg, std::string target,
                 yarp::os::Bottle& resp, float fTimeout=5.0);
-    bool getQosFromString(const char* qos, yarp::os::QosStyle& style);
+    bool getQosFromString(const std::string& qos, yarp::os::QosStyle& style);
 
 };
 

--- a/src/yarpmanager/src-manager/applicationviewwidget.cpp
+++ b/src/yarpmanager/src-manager/applicationviewwidget.cpp
@@ -1774,10 +1774,10 @@ void ApplicationViewWidget::onYARPView()
             yarp::manager::LocalBroker launcher;
             if (launcher.init("yarpview", nullptr, nullptr, nullptr, nullptr, env.toLatin1().data()))
             {
-                if (!launcher.start() && strlen(launcher.error()))
+                if (!launcher.start() && !launcher.error().empty())
                 {
                     QString msg;
-                    msg = QString("Error while launching yarpview. %1").arg(launcher.error());
+                    msg = QString("Error while launching yarpview. %1").arg(launcher.error().c_str());
                     logger->addError(msg.toLatin1().data());
                     reportErrors();
                 }
@@ -1792,7 +1792,7 @@ void ApplicationViewWidget::onYARPView()
                     }
                     if (!launcher.connect(from.toLatin1().data(), to.toLatin1().data(), "udp")) {
                         QString msg;
-                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error());
+                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error().c_str());
                         logger->addError(msg.toLatin1().data());
                         launcher.stop();
                         reportErrors();
@@ -1835,10 +1835,10 @@ void ApplicationViewWidget::onYARPHear()
             launcher.setWindowMode(yarp::manager::LocalBroker::WINDOW_VISIBLE);
             if (launcher.init(cmd.toLatin1().data(), param.toLatin1().data(), nullptr, nullptr, nullptr, nullptr))
             {
-                if (!launcher.start() && strlen(launcher.error()))
+                if (!launcher.start() && !launcher.error().empty())
                 {
                     QString  msg;
-                    msg = QString("Error while launching yarpread. %1").arg(launcher.error());
+                    msg = QString("Error while launching yarpread. %1").arg(launcher.error().c_str());
                     logger->addError(msg.toLatin1().data());
                     reportErrors();
                 }
@@ -1853,13 +1853,13 @@ void ApplicationViewWidget::onYARPHear()
                     }
                     if (!launcher.exists(to.toLatin1().data())) {
                         QString msg;
-                        msg = QString("Cannot inspect '%1' : %2. Did you build yarp with 'portaudio' module?").arg(from).arg(launcher.error());
+                        msg = QString("Cannot inspect '%1' : %2. Did you build yarp with 'portaudio' module?").arg(from).arg(launcher.error().c_str());
                         logger->addError(msg.toLatin1().data());
                         launcher.stop();
                         reportErrors();
                     }else if (!launcher.connect(from.toLatin1().data(), to.toLatin1().data(), "udp")) {
                         QString msg;
-                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error());
+                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error().c_str());
                         logger->addError(msg.toLatin1().data());
                         launcher.stop();
                         reportErrors();
@@ -1904,10 +1904,10 @@ void ApplicationViewWidget::onYARPRead()
             launcher.setWindowMode(yarp::manager::LocalBroker::WINDOW_VISIBLE);
             if (launcher.init(cmd.toLatin1().data(), param.toLatin1().data(), nullptr, nullptr, nullptr, nullptr))
             {
-                if (!launcher.start() && strlen(launcher.error()))
+                if (!launcher.start() && !launcher.error().empty())
                 {
                     QString msg;
-                    msg = QString("Error while launching yarpread. %1").arg(launcher.error());
+                    msg = QString("Error while launching yarpread. %1").arg(launcher.error().c_str());
                     logger->addError(msg.toLatin1().data());
                     reportErrors();
                 }
@@ -1922,7 +1922,7 @@ void ApplicationViewWidget::onYARPRead()
                     }
                     if (!launcher.connect(from.toLatin1().data(), to.toLatin1().data(), "udp")) {
                         QString msg;
-                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error());
+                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error().c_str());
                         logger->addError(msg.toLatin1().data());
                         launcher.stop();
                         reportErrors();
@@ -1969,9 +1969,9 @@ void ApplicationViewWidget::onYARPScope()
 
             yarp::manager::LocalBroker launcher;
             if (launcher.init("yarpscope", param.toLatin1().data(), nullptr, nullptr, nullptr, env.toLatin1().data())) {
-                if (!launcher.start() && strlen(launcher.error())) {
+                if (!launcher.start() && !launcher.error().empty()) {
                     QString msg;
-                    msg = QString("Error while launching yarpscope. %1").arg(launcher.error());
+                    msg = QString("Error while launching yarpscope. %1").arg(launcher.error().c_str());
                     logger->addError(msg.toLatin1().data());
                     reportErrors();
                 }
@@ -1985,7 +1985,7 @@ void ApplicationViewWidget::onYARPScope()
                     }
                     if (!launcher.connect(from.toLatin1().data(), to.toLatin1().data(), "udp")) {
                         QString msg;
-                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error());
+                        msg = QString("Cannot inspect '%1' : %2").arg(from).arg(launcher.error().c_str());
                         logger->addError(msg.toLatin1().data());
                         launcher.stop();
                         reportErrors();

--- a/src/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/yarpmanager/src-manager/mainwindow.cpp
@@ -1042,8 +1042,8 @@ void MainWindow::onNewResource()
 
     yarp::manager::LocalBroker launcher;
     if(launcher.init(ext_editor.c_str(), fileName.toLatin1().data(), nullptr, nullptr, nullptr, nullptr)){
-        if(!launcher.start() && strlen(launcher.error())){
-            QString msg = QString("Error while launching %1. %2").arg(ext_editor.c_str()).arg(launcher.error());
+        if(!launcher.start() && !launcher.error().empty()){
+            QString msg = QString("Error while launching %1. %2").arg(ext_editor.c_str()).arg(launcher.error().c_str());
             logger->addError(msg.toLatin1().data());
             reportErrors();
         }
@@ -1069,8 +1069,8 @@ void MainWindow::onNewModule()
 
     yarp::manager::LocalBroker launcher;
     if(launcher.init(ext_editor.c_str(), fileName.toLatin1().data(), nullptr, nullptr, nullptr, nullptr)){
-        if(!launcher.start() && strlen(launcher.error())){
-            QString msg = QString("Error while launching %1. %2").arg(ext_editor.c_str()).arg(launcher.error());
+        if(!launcher.start() && !launcher.error().empty()){
+            QString msg = QString("Error while launching %1. %2").arg(ext_editor.c_str()).arg(launcher.error().c_str());
             logger->addError(msg.toLatin1().data());
             reportErrors();
         }


### PR DESCRIPTION
Fix for: https://github.com/robotology/yarp/issues/3105
I'm aware that std::string is not a plain char*. 
..but do we need to stick to this oooooold '99 style in libyarpmanager? I think not.  
BTW, strings are used elsewhere in the same lib.