### PR TITLE
Fix fakeDepthCamera wrapper

### DIFF
--- a/src/devices/fakeDepthCamera/CMakeLists.txt
+++ b/src/devices/fakeDepthCamera/CMakeLists.txt
@@ -10,7 +10,7 @@ yarp_prepare_plugin(fakeDepthCamera
   TYPE fakeDepthCameraDriver
   INCLUDE fakeDepthCameraDriver.h
   EXTRA_CONFIG
-    WRAPPER=RGBDSensorWrapper
+    WRAPPER=rgbdSensor_nws_yarp
 )
 
 if(ENABLE_fakeDepthCamera)


### PR DESCRIPTION
The fakeDepthCamera had the old `RGBDCameraWrapper` instead of the `rgbdSensor_nws_yarp`, as such running `yarpdev --device fakeDepthCamera` resulted in an error.

