### PR TITLE
Fix sending empty yarp::sig::Vector when building in Debug

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -32,6 +32,7 @@ Fixes
 * `yarpbatterygui` now compatible with battery_nwc_yarp.
 * Fixed compilation of portmonitor carrier when a custom non-system swig is used
 * Fixed compatibility with ffmpeg 7 (https://github.com/robotology/yarp/pull/3109).
+* Fix sending empty yarp::sig::Vector when building in Debug (https://github.com/robotology/yarp/pull/3123).
 
 New Features
 ------------

--- a/src/libYARP_sig/src/yarp/sig/Vector.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Vector.cpp
@@ -84,11 +84,15 @@ bool VectorBase::write(yarp::os::ConnectionWriter& connection) const {
     header.listLen = (int)getListSize();
 
     connection.appendBlock((char*)&header, sizeof(header));
-    const char *ptr = getMemoryBlock();
-    int elemSize=getElementSize();
-    yCAssert(VECTOR, ptr != nullptr);
 
-    connection.appendExternalBlock(ptr, elemSize*header.listLen);
+    if (header.listLen > 0)
+    {
+        const char *ptr = getMemoryBlock();
+        int elemSize=getElementSize();
+        yCAssert(VECTOR, ptr != nullptr);
+
+        connection.appendExternalBlock(ptr, elemSize*header.listLen);
+    }
 
     // if someone is foolish enough to connect in text mode,
     // let them see something readable.

--- a/src/libYARP_sig/tests/VectorOfTest.cpp
+++ b/src/libYARP_sig/tests/VectorOfTest.cpp
@@ -31,7 +31,6 @@ TEST_CASE("sig::VectorOfTest", "[yarp::sig]")
     SECTION("Check send and receive integers")
     {
         INFO("check VectorO<int> send receive");
-
         {
             Port portIn;
             Port portOut;
@@ -73,6 +72,42 @@ TEST_CASE("sig::VectorOfTest", "[yarp::sig]")
             }
 
             CHECK(success); // VectorOf<int> was sent and received correctly
+            portOut.interrupt();
+            portOut.close();
+            portIn.interrupt();
+            portIn.close();
+        }
+
+        INFO("check VectorOf<int> send empty vector");
+        {
+            Port portIn;
+            Port portOut;
+
+            portOut.open("/harness_sig/vtest/empty_vector/o");
+            portIn.open("/harness_sig/vtest/empty_vector/i");
+
+            Network::connect("/harness_sig/vtest/empty_vector/o", "/harness_sig/vtest/empty_vector/i");
+
+            portOut.enableBackgroundWrite(true);
+
+
+            VectorOf<int> vector;
+            vector.resize(0);
+
+            bool success = true;
+            portOut.write(vector);
+
+            VectorOf<int> tmp;
+            portIn.read(tmp);
+
+            //compare vector and tmp
+            if (tmp.size() != vector.size())
+            {
+                success = false;
+            }
+
+            CHECK(success); // empty VectorOf<int> was sent and received correctly
+
             portOut.interrupt();
             portOut.close();
             portIn.interrupt();


### PR DESCRIPTION
Before this PR, sending an empty yarp::sig::Vector on port in Debug mode resulted in a crash of the application attempting to do that:

~~~
(yarpdev) traversaro@IITBMP014LW012:~/pixiws/yarpdev/yarp/build$ ctest -R VectorOf -VV
UpdateCTestConfiguration  from :/home/traversaro/pixiws/yarpdev/yarp/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/traversaro/pixiws/yarpdev/yarp/build/DartConfiguration.tcl
Test project /home/traversaro/pixiws/yarpdev/yarp/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 73
    Start 73: sig::VectorOfTest

73: Test command: /home/traversaro/pixiws/yarpdev/yarp/build/bin/harness_sig "sig::VectorOfTest" "-s" "--colour-mode default"
73: Working Directory: /home/traversaro/pixiws/yarpdev/yarp/build/src/libYARP_sig/tests
73: Test timeout computed to be: 120
73: Filters: "sig::VectorOfTest"
73: Randomness seeded to: 3429436721
73: [INFO] |yarp.os.Port|/harness_sig/vtest/o| Port /harness_sig/vtest/o active at tcp://localhost:10002/
73: [INFO] |yarp.os.Port|/harness_sig/vtest/i| Port /harness_sig/vtest/i active at tcp://localhost:10003/
73: [INFO] |yarp.os.impl.PortCoreInputUnit|/harness_sig/vtest/i| Receiving input from /harness_sig/vtest/o to /harness_sig/vtest/i using tcp
73: [INFO] |yarp.os.impl.PortCoreOutputUnit|/harness_sig/vtest/o| Sending output from /harness_sig/vtest/o to /harness_sig/vtest/i using tcp
73:
73: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
73: harness_sig is a Catch2 v3.4.0 host application.
73: Run with -? for options
73:
73: -------------------------------------------------------------------------------
73: sig::VectorOfTest
73:   Check send and receive integers
73: -------------------------------------------------------------------------------
73: /home/traversaro/pixiws/yarpdev/yarp/src/libYARP_sig/tests/VectorOfTest.cpp:31
73: ...............................................................................
73:
73: /home/traversaro/pixiws/yarpdev/yarp/src/libYARP_sig/tests/VectorOfTest.cpp:74: PASSED:
73:   CHECK( success )
73: with expansion:
73:   true
73: with message:
73:   check VectorO<int> send receive
73:
73: [INFO] |yarp.os.impl.PortCoreInputUnit|/harness_sig/vtest/i| Removing input from /harness_sig/vtest/o to /harness_sig/vtest/i
73: [INFO] |yarp.os.impl.PortCoreOutputUnit|/harness_sig/vtest/o| Removing output from /harness_sig/vtest/o to /harness_sig/vtest/i
73: [INFO] |yarp.os.Port|/harness_sig/vtest/empty_vector/o| Port /harness_sig/vtest/empty_vector/o active at tcp://localhost:10004/
73: [INFO] |yarp.os.Port|/harness_sig/vtest/empty_vector/i| Port /harness_sig/vtest/empty_vector/i active at tcp://localhost:10005/
73: [INFO] |yarp.os.impl.PortCoreOutputUnit|/harness_sig/vtest/empty_vector/o| Sending output from /harness_sig/vtest/empty_vector/o to /harness_sig/vtest/empty_vector/i using tcp
73: [INFO] |yarp.os.impl.PortCoreInputUnit|/harness_sig/vtest/empty_vector/i| Receiving input from /harness_sig/vtest/empty_vector/o to /harness_sig/vtest/empty_vector/i using tcp
73: [FATAL] |yarp.sig.Vector| Assertion failure at /home/traversaro/pixiws/yarpdev/yarp/src/libYARP_sig/src/yarp/sig/Vector.cpp:89 (ptr != nullptr)
73: Trace requested at /home/traversaro/pixiws/yarpdev/yarp/src/libYARP_sig/src/yarp/sig/Vector.cpp:89 by code called from:
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_os.so.3(_Z16yarp_print_traceP8_IO_FILEPKcj+0x36) [0x7f210827cd66]
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_os.so.3(_ZNK4yarp2os3Log5fatalEPKcz+0xbe) [0x7f210827ce7e]
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_sig.so.3(_ZNK4yarp3sig10VectorBase5writeERNS_2os16ConnectionWriterE+0x10a) [0x7f210840888a]
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_os.so.3(+0x158fb3) [0x7f2108357fb3]
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_os.so.3(+0x1599c6) [0x7f21083589c6]
73: /home/traversaro/pixiws/yarpdev/yarp/build/lib/libYARP_os.so.3(+0x16c8a5) [0x7f210836b8a5]
73: /home/traversaro/pixiws/yarpdev/.pixi/envs/default/lib/libstdc++.so.6(+0xd3b55) [0x7f21080edb55]
73: /lib/x86_64-linux-gnu/libc.so.6(+0x9ca94) [0x7f2107d7da94]
73: /lib/x86_64-linux-gnu/libc.so.6(+0x129c3c) [0x7f2107e0ac3c]
1/1 Test #73: sig::VectorOfTest ................***Failed    0.02 sec
~~~

This PR fixes this problem, and add a test ensuring that empty yarp::sig::Vector can be successfully be transmitted on the YARP network.