### PR TITLE
robotinterface: Do not print a message if a device does not derive from IWrapper

### DIFF
--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp
@@ -429,7 +429,8 @@ bool yarp::robotinterface::Device::attach(const yarp::dev::PolyDriverList& drive
     if (drivers.size() == 1) {
         yarp::dev::IWrapper* wrapper;
         if (!driver()->view(wrapper)) {
-            yCInfo(YRI_DEVICE) << name() << "is not an IWrapper. Trying IMultipleWrapper";
+            // If the device is not a IWrapper, let's continue as we will try to call attachAll via IMultipleWrapper
+            yCDebug(YRI_DEVICE) << name() << "is not an IWrapper. Trying IMultipleWrapper";
         } else if (wrapper->attach(drivers[0]->poly)) {
             return true;
         } else if (!multiplewrapper) {
@@ -441,7 +442,7 @@ bool yarp::robotinterface::Device::attach(const yarp::dev::PolyDriverList& drive
     }
 
     if (!multiplewrapper) {
-        yCError(YRI_DEVICE) << name() << "is not a multiplewrapper, therefore it cannot have" << ActionTypeToString(ActionTypeAttach) << "actions";
+        yCError(YRI_DEVICE) << name() << "is not derived from IWrapper or IMultipleWrapper, therefore it cannot have" << ActionTypeToString(ActionTypeAttach) << "actions";
         return false;
     }
 


### PR DESCRIPTION
robotinterface logs are always full of messages "is not an IWrapper. Trying IMultipleWrapper"

~~~
[INFO] Executing attach action, level 5 on device left_arm-mc_remapper with parameters [("networks" = "(left_arm_joints1)"), ("left_arm_joints1" = "left_arm_hardware_device")]
[INFO] left_arm-mc_remapper is not an IWrapper. Trying IMultipleWrapper
[INFO] Executing attach action, level 5 on device right_arm-mc_remapper with parameters [("networks" = "(right_arm_joints1)"), ("right_arm_joints1" = "right_arm_hardware_device")]
[INFO] right_arm-mc_remapper is not an IWrapper. Trying IMultipleWrapper
[INFO] Executing attach action, level 5 on device left_leg-mc_remapper with parameters [("networks" = "(left_leg_joints1)"), ("left_leg_joints1" = "left_leg_hardware_device")]
[INFO] left_leg-mc_remapper is not an IWrapper. Trying IMultipleWrapper
[INFO] Executing attach action, level 5 on device right_leg-mc_remapper with parameters [("networks" = "(right_leg_joints1)"), ("right_leg_joints1" = "right_leg_hardware_device")]
[INFO] right_leg-mc_remapper is not an IWrapper. Trying IMultipleWrapper
[INFO] Executing attach action, level 5 on device head-mc_remapper with parameters [("networks" = "(head_joints1)"), ("head_joints1" = "head_hardware_device")]
[INFO] head-mc_remapper is not an IWrapper. Trying IMultipleWrapper
~~~

However, this situation is quite normal as it is totally fine for a a device to only implement `IMultipleWrapper` and not `IWrapper`, so I think it could be a good idea to remove the " is not an IWrapper. Trying IMultipleWrapper" . I also modified the subsequent failure message if also IMultipleWrapper fails to be more descriptive.