### PR TITLE
Fix setPriority error messages

### DIFF
--- a/src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp
@@ -257,7 +257,7 @@ int ThreadImpl::setPriority(int priority, int policy)
         if (std::is_same<std::thread::native_handle_type, ACE_hthread_t>::value) {
             return ACE_Thread::setprio(thread.native_handle(), priority, policy);
         }
-        yCError(THREADIMPL, "Cannot set priority without ACE");
+        yCError(THREADIMPL, "Cannot set priority as std::thread::native_handle_type is not ACE_hthread_t");
 #elif defined(__unix__) || defined(__APPLE__)
         if (std::is_same<std::thread::native_handle_type, pthread_t>::value) {
             struct sched_param thread_param;
@@ -265,7 +265,7 @@ int ThreadImpl::setPriority(int priority, int policy)
             int ret = pthread_setschedparam(thread.native_handle(), policy, &thread_param);
             return (ret != 0) ? -1 : 0;
         } else {
-            yCError(THREADIMPL, "Cannot set priority without ACE");
+            yCError(THREADIMPL, "Cannot set priority as std::thread::native_handle_type is not pthread_t");
         }
 #else
         yCError(THREADIMPL, "Cannot set priority without ACE");


### PR DESCRIPTION
The printed error was always `Cannot set priority without ACE`, even if the reason was the error was actually something else.