### PR TITLE
removed deprecated device Portaudio

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -92,6 +92,10 @@ New Features
 
 * Deprecated device
 
+#### portaudio
+
+* Portaudio device, previously marked as deprecated, has been definitely removed from devices' CMakeLists.txt
+
 #### FakePythonSpeechTranscription
 
 * Added new device `FakePythonSpeechTranscription`. The device is also an example which demonstrates the encapsulation of python code inside a c++ device implementing a Yarp interface. 

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -46,8 +46,6 @@ yarp_begin_plugin_library(yarpmod
   add_subdirectory(JoypadControlNetUtils)
   add_subdirectory(frameGrabberCropper)
 
-  add_subdirectory(portaudio) # DEPRECATED Since YARP 3.2
-
   # Test devices
   add_subdirectory(test_segfault)
   add_subdirectory(test_nop)

--- a/src/devices/portaudio/DEPRECATION_NOTICE.TXT
+++ b/src/devices/portaudio/DEPRECATION_NOTICE.TXT
@@ -1,0 +1,2 @@
+The code contained in this folder has been deprecated and it is no more maintained.
+It will be removed in the near future.

--- a/src/devices/portaudio/PortAudioBuffer.h
+++ b/src/devices/portaudio/PortAudioBuffer.h
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <portaudio.h>
-#include <yarp/dev/AudioBufferSize.h>
+#include <yarp/sig/AudioBufferSize.h>
 #include <yarp/dev/CircularAudioBuffer.h>
 #include <cstdio>
 

--- a/src/devices/portaudio/PortAudioDeviceDriver.cpp
+++ b/src/devices/portaudio/PortAudioDeviceDriver.cpp
@@ -18,6 +18,7 @@
 
 using namespace yarp::os;
 using namespace yarp::dev;
+using namespace yarp::sig;
 
 #define SLEEP_TIME 0.005f
 
@@ -618,13 +619,13 @@ bool PortAudioDeviceDriver::appendSound(const yarp::sig::Sound& sound)
     return true;
 }
 
-bool PortAudioDeviceDriver::getPlaybackAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size)
+bool PortAudioDeviceDriver::getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
 {
     size = this->dataBuffers.playData->size();
     return true;
 }
 
-bool PortAudioDeviceDriver::getPlaybackAudioBufferMaxSize(yarp::dev::AudioBufferSize& size)
+bool PortAudioDeviceDriver::getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
 {
     size = this->dataBuffers.playData->getMaxSize();
     return true;
@@ -636,13 +637,13 @@ bool PortAudioDeviceDriver::resetPlaybackAudioBuffer()
     return true;
 }
 
-bool PortAudioDeviceDriver::getRecordingAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size)
+bool PortAudioDeviceDriver::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
 {
     size = this->dataBuffers.recData->size();
     return true;
 }
 
-bool PortAudioDeviceDriver::getRecordingAudioBufferMaxSize(yarp::dev::AudioBufferSize& size)
+bool PortAudioDeviceDriver::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
 {
     size = this->dataBuffers.recData->getMaxSize();
     return true;

--- a/src/devices/portaudio/PortAudioDeviceDriver.h
+++ b/src/devices/portaudio/PortAudioDeviceDriver.h
@@ -114,12 +114,12 @@ public:
     bool immediateSound(const yarp::sig::Sound& sound);
     bool appendSound(const yarp::sig::Sound& sound);
 
-    bool getPlaybackAudioBufferMaxSize(yarp::dev::AudioBufferSize& size) override;
-    bool getPlaybackAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size) override;
+    bool getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+    bool getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
     bool resetPlaybackAudioBuffer() override;
 
-    bool getRecordingAudioBufferMaxSize(yarp::dev::AudioBufferSize& size) override;
-    bool getRecordingAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size) override;
+    bool getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+    bool getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
     bool resetRecordingAudioBuffer() override;
 
     bool setHWGain(double gain) override;


### PR DESCRIPTION
Portaudio device, previously marked as deprecated, has been definitely removed from devices' CMakeLists.txt