### PR TITLE
Fix capitalization of AudioRecorderWrapper and AudioPlayerWrapper in audio_doc documentation

### DIFF
--- a/doc/module_yarp_sig/audio_doc.dox
+++ b/doc/module_yarp_sig/audio_doc.dox
@@ -27,9 +27,9 @@ Audio-related devices include <b>physical device drivers</b> and <b>wrapper devi
 \section driver_devices Physical device drivers 
 - fakeMicrophone a device which generates a predefined audio tone for testing purposes.
 - fakeSpeaker a device which receives audio data and consume it (without playing) for testing purposes.
-- audioFromFileDevice a device which reads a audio file from disk and sends it over the network via audioRecorderWrapper.
+- audioFromFileDevice a device which reads a audio file from disk and sends it over the network via AudioRecorderWrapper.
 - audioToFileDevice a device which receives audio data and writes it on disk.
-- portaudioRecorder (PortAudioRecorderDeviceDriver) a device which records audio from the local hardware using <a href="http://portaudio.com/">portaudio</a>  library and sends it over the network via audioRecorderWrapper
+- portaudioRecorder (PortAudioRecorderDeviceDriver) a device which records audio from the local hardware using <a href="http://portaudio.com/">portaudio</a>  library and sends it over the network via AudioRecorderWrapper
 - portaudioPlayer (PortAudioPlayerDeviceDriver) a device which receives audio data and plays it on the local hardware, using <a href="http://portaudio.com/">portaudio</a>  library.
 
 All these devices derive from the same base classes yarp::dev::AudioRecorderDeviceBase and yarp::dev::AudioPlayerDeviceBase which are also responsible for parsing 
@@ -39,7 +39,7 @@ Important: the `AUDIO_BASE::samples` parameter requires additional explanation. 
 for temporary storing the audio data during the recording/playback.
 The length of the buffer expressed in seconds is equal to the number of samples multiplied by the parameter `AUDIO_BASE::rate`.
 The size of this buffer should be large enough to store the data received by the attached wrapper. 
-For example a playback buffer of 2000 samples is required if the attached audioPlayerWrapper is expected to receive sounds which have a length of 1000 samples maximum
+For example a playback buffer of 2000 samples is required if the attached AudioPlayerWrapper is expected to receive sounds which have a length of 1000 samples maximum
 (in general we recommend to use a buffer which has twice the size of the received audio sound).
 
 Another important parameter for the devices deriving from yarp::dev::AudioPlayerDeviceBase is the playback mode which can be either `immediate` or `append`. In the 
@@ -98,16 +98,16 @@ The following example reads an audio from a file, sends data through the network
 The chosen configuration uses an internal buffer of 32000 samples (corresponding to 2 seconds of audio if audio samples with a freq of 16KHz are received).
 The playback has a latency of 0.1s.
 \code
-yarpdev --device audioRecorderWrapper --subdevice audioFromFileDevice --start --file_name audio_in.wav
-yarpdev --device audioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 32000
+yarpdev --device AudioRecorderWrapper --subdevice audioFromFileDevice --start --file_name audio_in.wav
+yarpdev --device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 32000
 yarp connect /audioRecorderWrapper/audio:o /audioPlayerWrapper/audio:i
 \endcode
 
 The following example grabs data from a microphone, sends data through the network, and saves it to a file.
 The chosen configuration forces the recorderWrapper to send data packets composed by 3200 samples, corresponding to 0.2s.
 \code
-yarpdev --device audioRecorderWrapper --subdevice portaudioRecorder --start --min_samples_over_network 3200 --max_samples_over_network 3200 --AUDIO_BASE::rate 16000 --AUDIO_BASE::samples 6400 --AUDIO_BASE::channels 1
-yarpdev --device audioPlayerWrapper --subdevice audioToFileDevice --start  --file_name audio_out.wav --save_mode overwrite_file
+yarpdev --device AudioRecorderWrapper --subdevice portaudioRecorder --start --min_samples_over_network 3200 --max_samples_over_network 3200 --AUDIO_BASE::rate 16000 --AUDIO_BASE::samples 6400 --AUDIO_BASE::channels 1
+yarpdev --device AudioPlayerWrapper --subdevice audioToFileDevice --start  --file_name audio_out.wav --save_mode overwrite_file
 yarp connect /audioRecorderWrapper/audio:o /audioPlayerWrapper/audio:i
 \endcode
 
@@ -116,8 +116,8 @@ yarp connect /audioRecorderWrapper/audio:o /audioPlayerWrapper/audio:i
 The audio system currently do not support real-time audio transmission for audio conference purposes. Of course the systems allows to do it, as shown in 
 following example:
 \code
-yarpdev --device audioRecorderWrapper --subdevice portaudioRecorder --start --min_samples_over_network 3200 --max_samples_over_network 3200 --AUDIO_BASE::rate 16000 --AUDIO_BASE::samples 6400 --AUDIO_BASE::channels 1
-yarpdev --device audioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 32000
+yarpdev --device AudioRecorderWrapper --subdevice portaudioRecorder --start --min_samples_over_network 3200 --max_samples_over_network 3200 --AUDIO_BASE::rate 16000 --AUDIO_BASE::samples 6400 --AUDIO_BASE::channels 1
+yarpdev --device AudioPlayerWrapper --subdevice portaudioPlayer --start --playback_network_buffer_size 0.1 --AUDIO_BASE::samples 32000
 yarp connect /audioRecorderWrapper/audio:o /audioPlayerWrapper/audio:i
 \endcode
 This example has several problems. First of some inevitable pop-clicks distortions will be happens,


### PR DESCRIPTION
Originally reported by @giotherobot .