### PR TITLE
Fix for portaudioRecorder, portaudioPlayer device ID selection

### DIFF
--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
@@ -216,11 +216,19 @@ bool PortAudioPlayerDeviceDriver::configureDeviceAndStart()
         return false;
     }
 
-    m_outputParameters.device = (m_id == -1) ? Pa_GetDefaultOutputDevice() : m_id;
+    m_outputParameters.device = (m_audio_device_id == -1) ? Pa_GetDefaultOutputDevice() : m_audio_device_id;
     m_outputParameters.channelCount = static_cast<int>(m_audioplayer_cfg.numChannels);
     m_outputParameters.sampleFormat = PA_SAMPLE_TYPE;
-    m_outputParameters.suggestedLatency = Pa_GetDeviceInfo(m_outputParameters.device)->defaultLowOutputLatency;
     m_outputParameters.hostApiSpecificStreamInfo = nullptr;
+
+    const PaDeviceInfo* devinfo = Pa_GetDeviceInfo(m_outputParameters.device);
+    std::string devname = "unknown";
+    if (devinfo != nullptr)
+    {
+        m_outputParameters.suggestedLatency = devinfo->defaultLowOutputLatency;
+        devname = devinfo->name;
+    }
+    yCInfo(PORTAUDIOPLAYER, "Selected device: number: %d, name: %s", m_outputParameters.device, devname.c_str());
 
     m_err = Pa_OpenStream(
         &m_stream,

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_ParamsParser.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_ParamsParser.cpp
@@ -8,7 +8,7 @@
 // This is an automatically generated file. Please do not edit it.
 // It will be re-generated if the cmake flag ALLOW_DEVICE_PARAM_PARSER_GERNERATION is ON.
 
-// Generated on: Sun Mar 10 12:19:37 2024
+// Generated on: Tue Oct 15 17:35:46 2024
 
 
 #include "PortAudioPlayerDeviceDriver_ParamsParser.h"
@@ -28,7 +28,7 @@ PortAudioPlayerDeviceDriver_ParamsParser::PortAudioPlayerDeviceDriver_ParamsPars
 std::vector<std::string> PortAudioPlayerDeviceDriver_ParamsParser::getListOfParams() const
 {
     std::vector<std::string> params;
-    params.push_back("id");
+    params.push_back("audio_device_id");
     params.push_back("driver_frame_size");
     return params;
 }
@@ -44,18 +44,18 @@ bool      PortAudioPlayerDeviceDriver_ParamsParser::parseParams(const yarp::os::
 
     std::string config_string = config.toString();
     yarp::os::Property prop_check(config_string.c_str());
-    //Parser of parameter id
+    //Parser of parameter audio_device_id
     {
-        if (config.check("id"))
+        if (config.check("audio_device_id"))
         {
-            m_id = config.find("id").asInt64();
-            yCInfo(PortAudioPlayerDeviceDriverParamsCOMPONENT) << "Parameter 'id' using value:" << m_id;
+            m_audio_device_id = config.find("audio_device_id").asInt64();
+            yCInfo(PortAudioPlayerDeviceDriverParamsCOMPONENT) << "Parameter 'audio_device_id' using value:" << m_audio_device_id;
         }
         else
         {
-            yCInfo(PortAudioPlayerDeviceDriverParamsCOMPONENT) << "Parameter 'id' using DEFAULT value:" << m_id;
+            yCInfo(PortAudioPlayerDeviceDriverParamsCOMPONENT) << "Parameter 'audio_device_id' using DEFAULT value:" << m_audio_device_id;
         }
-        prop_check.unput("id");
+        prop_check.unput("audio_device_id");
     }
 
     //Parser of parameter driver_frame_size
@@ -108,11 +108,11 @@ std::string      PortAudioPlayerDeviceDriver_ParamsParser::getDocumentationOfDev
     doc = doc + std::string("This is the help for device: PortAudioPlayerDeviceDriver\n");
     doc = doc + std::string("\n");
     doc = doc + std::string("This is the list of the parameters accepted by the device:\n");
-    doc = doc + std::string("'id': The device id, if multiple sound cards are present\n");
+    doc = doc + std::string("'audio_device_id': The device id, if multiple sound cards are present\n");
     doc = doc + std::string("'driver_frame_size': the number of samples to process on each iteration of the main thread\n");
     doc = doc + std::string("\n");
     doc = doc + std::string("Here are some examples of invocation command with yarpdev, with all params:\n");
-    doc = doc + " yarpdev --device portaudioPlayer --id -1 --driver_frame_size 512\n";
+    doc = doc + " yarpdev --device portaudioPlayer --audio_device_id -1 --driver_frame_size 512\n";
     doc = doc + std::string("Using only mandatory params:\n");
     doc = doc + " yarpdev --device portaudioPlayer\n";
     doc = doc + std::string("=============================================\n\n");    return doc;

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_ParamsParser.h
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_ParamsParser.h
@@ -8,7 +8,7 @@
 // This is an automatically generated file. Please do not edit it.
 // It will be re-generated if the cmake flag ALLOW_DEVICE_PARAM_PARSER_GERNERATION is ON.
 
-// Generated on: Sun Mar 10 12:19:37 2024
+// Generated on: Tue Oct 15 17:35:46 2024
 
 
 #ifndef PORTAUDIOPLAYERDEVICEDRIVER_PARAMSPARSER_H
@@ -25,12 +25,12 @@
 * These are the used parameters:
 * | Group name | Parameter name    | Type   | Units   | Default Value | Required | Description                                                           | Notes                                                    |
 * |:----------:|:-----------------:|:------:|:-------:|:-------------:|:--------:|:---------------------------------------------------------------------:|:--------------------------------------------------------:|
-* | -          | id                | int    | -       | -1            | 0        | The device id, if multiple sound cards are present                    | if not specified, the default system device will be used |
+* | -          | audio_device_id   | int    | -       | -1            | 0        | The device id, if multiple sound cards are present                    | if not specified, the default system device will be used |
 * | -          | driver_frame_size | size_t | samples | 512           | 0        | the number of samples to process on each iteration of the main thread | -                                                        |
 *
 * The device can be launched by yarpdev using one of the following examples (with and without all optional parameters):
 * \code{.unparsed}
-* yarpdev --device portaudioPlayer --id -1 --driver_frame_size 512
+* yarpdev --device portaudioPlayer --audio_device_id -1 --driver_frame_size 512
 * \endcode
 *
 * \code{.unparsed}
@@ -56,10 +56,10 @@ public:
     };
     const parser_version_type m_parser_version = {};
 
-    const std::string m_id_defaultValue = {"-1"};
+    const std::string m_audio_device_id_defaultValue = {"-1"};
     const std::string m_driver_frame_size_defaultValue = {"512"};
 
-    int m_id = {-1};
+    int m_audio_device_id = {-1};
     size_t m_driver_frame_size = {512};
 
     bool          parseParams(const yarp::os::Searchable & config) override;
@@ -67,6 +67,8 @@ public:
     std::string   getDeviceName() const override { return m_device_name; }
     std::string   getDocumentationOfDeviceParams() const override;
     std::vector<std::string> getListOfParams() const override;
+
+    std::string   getDocumentationOfPortAudioPlayerDeviceDriver() const;
 };
 
 #endif

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_params.md
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver_params.md
@@ -1,2 +1,2 @@
-* |  | id                | int        | -              |  -1                      | No                          | The device id, if multiple sound cards are present                | if not specified, the default system device will be used |
+* |  | audio_device_id   | int        | -              |  -1                      | No                          | The device id, if multiple sound cards are present                | if not specified, the default system device will be used |
 * |  | driver_frame_size | size_t     | samples        |  512                     | No                          | the number of samples to process on each iteration of the main thread  | - |

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
@@ -146,14 +146,19 @@ bool PortAudioRecorderDeviceDriver::open(yarp::os::Searchable& config)
         return false;
     }
 
-    m_inputParameters.device = (m_id ==-1)?Pa_GetDefaultInputDevice(): m_id;
-    yCInfo(PORTAUDIORECORDER, "Device number %d", m_inputParameters.device);
+    m_inputParameters.device = (m_audio_device_id == -1) ? Pa_GetDefaultInputDevice() : m_audio_device_id;
     m_inputParameters.channelCount = static_cast<int>(m_audiorecorder_cfg.numChannels);
     m_inputParameters.sampleFormat = PA_SAMPLE_TYPE;
-    if ((Pa_GetDeviceInfo(m_inputParameters.device ))!=nullptr) {
-        m_inputParameters.suggestedLatency = Pa_GetDeviceInfo(m_inputParameters.device )->defaultLowInputLatency;
-    }
     m_inputParameters.hostApiSpecificStreamInfo = nullptr;
+
+    const PaDeviceInfo* devinfo = Pa_GetDeviceInfo(m_inputParameters.device);
+    std::string devname = "unknown";
+    if (devinfo != nullptr)
+    {
+        m_inputParameters.suggestedLatency = devinfo->defaultLowInputLatency;
+        devname = devinfo->name;
+    }
+    yCInfo(PORTAUDIORECORDER, "Selected device: number: %d, name: %s", m_inputParameters.device, devname.c_str());
 
     m_err = Pa_OpenStream(
               &m_stream,

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_ParamsParser.cpp
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_ParamsParser.cpp
@@ -8,7 +8,7 @@
 // This is an automatically generated file. Please do not edit it.
 // It will be re-generated if the cmake flag ALLOW_DEVICE_PARAM_PARSER_GERNERATION is ON.
 
-// Generated on: Sun Mar 10 12:19:37 2024
+// Generated on: Tue Oct 15 17:35:46 2024
 
 
 #include "PortAudioRecorderDeviceDriver_ParamsParser.h"
@@ -28,7 +28,7 @@ PortAudioRecorderDeviceDriver_ParamsParser::PortAudioRecorderDeviceDriver_Params
 std::vector<std::string> PortAudioRecorderDeviceDriver_ParamsParser::getListOfParams() const
 {
     std::vector<std::string> params;
-    params.push_back("id");
+    params.push_back("audio_device_id");
     params.push_back("driver_frame_size");
     return params;
 }
@@ -44,18 +44,18 @@ bool      PortAudioRecorderDeviceDriver_ParamsParser::parseParams(const yarp::os
 
     std::string config_string = config.toString();
     yarp::os::Property prop_check(config_string.c_str());
-    //Parser of parameter id
+    //Parser of parameter audio_device_id
     {
-        if (config.check("id"))
+        if (config.check("audio_device_id"))
         {
-            m_id = config.find("id").asInt64();
-            yCInfo(PortAudioRecorderDeviceDriverParamsCOMPONENT) << "Parameter 'id' using value:" << m_id;
+            m_audio_device_id = config.find("audio_device_id").asInt64();
+            yCInfo(PortAudioRecorderDeviceDriverParamsCOMPONENT) << "Parameter 'audio_device_id' using value:" << m_audio_device_id;
         }
         else
         {
-            yCInfo(PortAudioRecorderDeviceDriverParamsCOMPONENT) << "Parameter 'id' using DEFAULT value:" << m_id;
+            yCInfo(PortAudioRecorderDeviceDriverParamsCOMPONENT) << "Parameter 'audio_device_id' using DEFAULT value:" << m_audio_device_id;
         }
-        prop_check.unput("id");
+        prop_check.unput("audio_device_id");
     }
 
     //Parser of parameter driver_frame_size
@@ -108,11 +108,11 @@ std::string      PortAudioRecorderDeviceDriver_ParamsParser::getDocumentationOfD
     doc = doc + std::string("This is the help for device: PortAudioRecorderDeviceDriver\n");
     doc = doc + std::string("\n");
     doc = doc + std::string("This is the list of the parameters accepted by the device:\n");
-    doc = doc + std::string("'id': The device id, if multiple sound cards are present\n");
+    doc = doc + std::string("'audio_device_id': The device id, if multiple sound cards are present\n");
     doc = doc + std::string("'driver_frame_size': the number of samples to process on each iteration of the main thread\n");
     doc = doc + std::string("\n");
     doc = doc + std::string("Here are some examples of invocation command with yarpdev, with all params:\n");
-    doc = doc + " yarpdev --device portaudioRecorder --id -1 --driver_frame_size 512\n";
+    doc = doc + " yarpdev --device portaudioRecorder --audio_device_id -1 --driver_frame_size 512\n";
     doc = doc + std::string("Using only mandatory params:\n");
     doc = doc + " yarpdev --device portaudioRecorder\n";
     doc = doc + std::string("=============================================\n\n");    return doc;

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_ParamsParser.h
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_ParamsParser.h
@@ -8,7 +8,7 @@
 // This is an automatically generated file. Please do not edit it.
 // It will be re-generated if the cmake flag ALLOW_DEVICE_PARAM_PARSER_GERNERATION is ON.
 
-// Generated on: Sun Mar 10 12:19:37 2024
+// Generated on: Tue Oct 15 17:35:46 2024
 
 
 #ifndef PORTAUDIORECORDERDEVICEDRIVER_PARAMSPARSER_H
@@ -25,12 +25,12 @@
 * These are the used parameters:
 * | Group name | Parameter name    | Type   | Units   | Default Value | Required | Description                                                           | Notes                                                    |
 * |:----------:|:-----------------:|:------:|:-------:|:-------------:|:--------:|:---------------------------------------------------------------------:|:--------------------------------------------------------:|
-* | -          | id                | int    | -       | -1            | 0        | The device id, if multiple sound cards are present                    | if not specified, the default system device will be used |
+* | -          | audio_device_id   | int    | -       | -1            | 0        | The device id, if multiple sound cards are present                    | if not specified, the default system device will be used |
 * | -          | driver_frame_size | size_t | samples | 512           | 0        | the number of samples to process on each iteration of the main thread | -                                                        |
 *
 * The device can be launched by yarpdev using one of the following examples (with and without all optional parameters):
 * \code{.unparsed}
-* yarpdev --device portaudioRecorder --id -1 --driver_frame_size 512
+* yarpdev --device portaudioRecorder --audio_device_id -1 --driver_frame_size 512
 * \endcode
 *
 * \code{.unparsed}
@@ -56,10 +56,10 @@ public:
     };
     const parser_version_type m_parser_version = {};
 
-    const std::string m_id_defaultValue = {"-1"};
+    const std::string m_audio_device_id_defaultValue = {"-1"};
     const std::string m_driver_frame_size_defaultValue = {"512"};
 
-    int m_id = {-1};
+    int m_audio_device_id = {-1};
     size_t m_driver_frame_size = {512};
 
     bool          parseParams(const yarp::os::Searchable & config) override;
@@ -67,6 +67,8 @@ public:
     std::string   getDeviceName() const override { return m_device_name; }
     std::string   getDocumentationOfDeviceParams() const override;
     std::vector<std::string> getListOfParams() const override;
+
+    std::string   getDocumentationOfPortAudioRecorderDeviceDriver() const;
 };
 
 #endif

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_params.md
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver_params.md
@@ -1,2 +1,2 @@
-* |  | id                | int        | -              |  -1                      | No                          | The device id, if multiple sound cards are present                | if not specified, the default system device will be used |
+* |  | audio_device_id   | int        | -              |  -1                      | No                          | The device id, if multiple sound cards are present                | if not specified, the default system device will be used |
 * |  | driver_frame_size | size_t     | samples        |  512                     | No                          | the number of samples to process on each iteration of the main thread  | - |


### PR DESCRIPTION
Replaced parameter "id" in portaudioPlayer, portaudioRecorder with "a…udio_device_id" because "id" and "device_id" are keywords reserved by yarprobotinterface.
Additionally a new print now shows the name of the selected interface.