### PR TITLE
Fix loading of Python bindings on Windows when installed in arbitrary directory

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -99,6 +99,32 @@ if(YARP_PYTHON_PIP_METADATA_INSTALL)
     DESTINATION ${CMAKE_INSTALL_PYTHON3DIR}/yarp-${YARP_VERSION_SHORT}.dist-info)
 endif()
 
+# We generate some preable for the yarp.py library so that the dll are correctly loaded on Windows
+set(swig_python_windows_preable_file ${CMAKE_CURRENT_BINARY_DIR}/swig_python_windows_preable.i)
+file(WRITE ${swig_python_windows_preable_file} "")
+# If we are on Windows and BUILD_SHARED_LIBS is ON, handle the fact that
+# the Python interpreter does not look into PATH to find dll (see https://docs.python.org/3.8/library/os.html#os.add_dll_directory)
+if(WIN32 AND BUILD_SHARED_LIBS)
+  if(IS_ABSOLUTE ${CMAKE_INSTALL_PYTHON3DIR})
+      set(PYTHON_FULL_INSTDIR "${CMAKE_INSTALL_PYTHON3DIR}")
+  else()
+      set(PYTHON_FULL_INSTDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_PYTHON3DIR}")
+  endif()
+  file(RELATIVE_PATH RELATIVE_PATH_BETWEEN_INIT_PY_AND_DLL_DIRECTORY ${PYTHON_FULL_INSTDIR} ${CMAKE_INSTALL_FULL_BINDIR})
+  file(APPEND ${swig_python_windows_preable_file} "%pythonbegin %{\n")
+  file(APPEND ${swig_python_windows_preable_file} "import os\n")
+  file(APPEND ${swig_python_windows_preable_file} "library_dll_path = os.path.join(os.path.dirname(__file__),'${RELATIVE_PATH_BETWEEN_INIT_PY_AND_DLL_DIRECTORY}')\n")
+  file(APPEND ${swig_python_windows_preable_file} "# Avoid to call add_dll_directory if not necessary,\n")
+  file(APPEND ${swig_python_windows_preable_file} "# for example if the library to find are already found in the proper location in a conda environment\n")
+  file(APPEND ${swig_python_windows_preable_file} "if(library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'Library','bin') and library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'bin')):\n")
+  file(APPEND ${swig_python_windows_preable_file} "    if(os.path.exists(library_dll_path)):\n")
+  file(APPEND ${swig_python_windows_preable_file} "        os.add_dll_directory(library_dll_path)\n")
+  file(APPEND ${swig_python_windows_preable_file} "%}\n")
+endif()
+# Make sure that the created file can be found by swig while parsing the main .i file
+set_property(TARGET ${SWIG_MODULE_yarp_python_REAL_NAME} APPEND PROPERTY SWIG_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
+
+
 if(YARP_COMPILE_TESTS)
   add_subdirectory(tests)
 endif()

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -2003,3 +2003,12 @@ public:
         return result;
     }
 }
+
+//////////////////////////////////////////////////////////////////////////
+// Just in Python add some code to automatically call
+// add_dll_directory as necessary
+// See https://github.com/robotology/robotology-superbuild/issues/1268
+// for more details
+#ifdef SWIGPYTHON
+%include <swig_python_windows_preable.i>
+#endif

--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -118,3 +118,9 @@ New Features
 * Improvements to serialization class `yarp::sig::Sound` (breaking change)
 * yarp_sig can now use IDL thrift to generate custom data types.
 * The following data types have been migrated from `yarp_dev` to `yarp_sig` library: `AudioPlayerStatus, AudioRecorderStatus, AudioBufferSize, AudioBufferSizeData, LaserMeasurementData, LaserScan2D`.
+
+### Bindings
+
+#### Python
+
+* Fix loading of Python bindings on Windows when installed in arbitrary directory.


### PR DESCRIPTION
Since Python 3.8, Python ignores the `PATH` env variable when trying to load the DLL of compiled Python extensions. 

We kind ignored the problem until now as if you install in `%CONDA_PREFIX%\Library\bin` in conda environment everything works out of the box, but the problem is present when bipedal-locomotion-framework is installed in an arbitrary install prefix and the Python bindings are found via `PYTHONPATH` env variable, see https://github.com/robotology/robotology-superbuild/issues/1268 .

This PR fixes the problem by adding some automatically generated code in the `__init__.py` file that automatically calls `os.add_dll_directory` as necessary.

As the Python code is generated by CMake it may be a bit cryptic, the actual rendered code is:

~~~py
import os
library_dll_path = os.path.join(os.path.dirname(__file__),'../../bin')
# Avoid to call add_dll_directory if not necessary,
# for example if the library to find are already found in the proper location in a conda environment
if(library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'Library','bin') and library_dll_path != os.path.join(os.environ.get('CONDA_PREFIX', ''),'bin')):
    if(os.path.exists(library_dll_path)):
        os.add_dll_directory(library_dll_path)
~~~

Similar to:
* https://github.com/robotology/idyntree/pull/1209
* https://github.com/robotology/human-dynamics-estimation/pull/398
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/905