### PR TITLE
Fix use of shmem and unix_stream carriers in remote_controlboard and multipleanalogsensorclient network wrapper clients

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -51,6 +51,7 @@ New Features
 * Removed h264 Carrier
 * Added gstreamer carrier with extended functionalities.
 * Added new gstreamers plugins: yarpvideosource, yarpvidepassthrough, yarpvideosink
+* Fixed segfault on disconnection with shmem carrier.
 
 ### Devices
 
@@ -98,7 +99,11 @@ New Features
 
 #### FakePythonSpeechTranscription
 
-* Added new device `FakePythonSpeechTranscription`. The device is also an example which demonstrates the encapsulation of python code inside a c++ device implementing a Yarp interface. 
+* Added new device `FakePythonSpeechTranscription`. The device is also an example which demonstrates the encapsulation of python code inside a c++ device implementing a Yarp interface.
+
+#### multipleanalogsensorsclient
+
+* Always establish the `rpc` connection with the `tcp` carrier, instead of using the `carrier` option as done in YARP <= 3.9 .
 
 ### GUIs
 

--- a/src/carriers/shmem_carrier/ShmemInputStream.cpp
+++ b/src/carriers/shmem_carrier/ShmemInputStream.cpp
@@ -43,6 +43,8 @@ bool ShmemInputStreamImpl::isOk() const
 
 bool ShmemInputStreamImpl::open(int port, ACE_SOCK_Stream* pSock, int size)
 {
+    std::lock_guard<std::recursive_mutex> l_guard(m_generalMutex);
+
     m_pSock = pSock;
 
     m_pAccessMutex = m_pWaitDataMutex = nullptr;
@@ -102,6 +104,8 @@ bool ShmemInputStreamImpl::open(int port, ACE_SOCK_Stream* pSock, int size)
 
 bool ShmemInputStreamImpl::Resize()
 {
+    std::lock_guard<std::recursive_mutex> l_guard(m_generalMutex);
+
     ++m_ResizeNum;
 
     ACE_Shared_Memory* pNewMap;
@@ -155,6 +159,8 @@ bool ShmemInputStreamImpl::Resize()
 
 int ShmemInputStreamImpl::read(char* data, int len)
 {
+    std::lock_guard<std::recursive_mutex> l_guard(m_generalMutex);
+
     m_pAccessMutex->acquire();
 
     if (m_pHeader->close) {
@@ -193,6 +199,8 @@ int ShmemInputStreamImpl::read(char* data, int len)
 
 yarp::conf::ssize_t ShmemInputStreamImpl::read(yarp::os::Bytes& b)
 {
+    std::lock_guard<std::recursive_mutex> l_guard(m_generalMutex);
+
     m_ReadSerializerMutex.lock();
 
     if (!m_bOpen) {
@@ -230,6 +238,8 @@ yarp::conf::ssize_t ShmemInputStreamImpl::read(yarp::os::Bytes& b)
 
 void ShmemInputStreamImpl::close()
 {
+    std::lock_guard<std::recursive_mutex> l_guard(m_generalMutex);
+
     if (!m_bOpen) {
         return;
     }

--- a/src/carriers/shmem_carrier/ShmemInputStream.h
+++ b/src/carriers/shmem_carrier/ShmemInputStream.h
@@ -63,6 +63,9 @@ protected:
 
     std::mutex m_ReadSerializerMutex;
 
+    // Mutex for the whole class, to avoid concurrent close and read
+    std::recursive_mutex m_generalMutex;
+
     ACE_Shared_Memory* m_pMap;
     char* m_pData;
     ShmemHeader_t* m_pHeader;

--- a/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -75,7 +75,8 @@ bool MultipleAnalogSensorsClient::open(yarp::os::Searchable& config)
 
     // Connect ports
     if (!m_externalConnection) {
-        ok = yarp::os::Network::connect(localRPCPortName, remoteRPCPortName, m_carrier);
+        // RPC port needs to be tcp, therefore no carrier option is added here
+        ok = yarp::os::Network::connect(localRPCPortName, remoteRPCPortName);
         if (!ok) {
             yCError(MULTIPLEANALOGSENSORSCLIENT,
                     "Failure connecting port %s to %s.",


### PR DESCRIPTION
In the context of walking, inside the `ergocub-torso` we are interested in establishing connection that continue to run even if the network interface over which they are established temporary goes down. The rationale for this is that at the moment in most demos we run the `yarpserver` in the operator laptop and the walking and the robot robotinterface inside the `ergocub-torso` board embedded in the robot, and while walking the robot could loose the connection with the operator laptop where the yarpserver is running.

To do so, we experimented with using `shmem` and `unix_stream` carriers, experiencing the following problems:
* For `shmem`, sometimes there was a segfault on one of the two sides of the connection when the shmem connection was disconnected.
* For `unix_stream`, it was not possible to open a connection via the `multipleanalogsensorsclient`.

This PR fixes all these problems, in particular:
* Fix the segfault when `shmem` is disconnected by adding a generic mutex for the overall class, to ensure that it is not possible that a thread is calling on `ShmemInputStreamImpl::write` and that calls gets preempted by another thread that is calling `ShmemInputStreamImpl::close` and that is destryong the attributes that  `ShmemInputStreamImpl::write` was using, that was the reason for our segfaults.
* For `multipleanalogsensorsclient`, we were using the `carrier` parameter also for the `rpc` connection, but that is not aligned with other `nwc`, so we switched to always use `tcp` for `rpc` connection as it happens for `remote_controlboard`. I am not sure if the `rpc` not working over `unix_stream` is expected or not, but anyhow modifying `multipleanalogsensorsclient` to be more similar to other `nwc` made sense to me anyhow. See also the related comment https://github.com/robotology/yarp/pull/2716#issuecomment-919873814 .

~Furthermore, in this PR we also use the `GENERATE` functionality of `catch` to ensure that the `multipleanalogsensorsclient` and `remotecontrolboardremapper` tests are running on all the following carriers:`tcp`,`fast_tcp`,`shmem`,`unix_stream`~

The testing part was dropped as it was also exposed some existing issues that are hard to debug and for which the fix had to touch the internal behaviour of YARP's Port, with an high chance of regressions. For reference, those attempts are documented in the comment in this PRs (that are not hidden as outdated) and the related code is https://github.com/traversaro/yarp/tree/archiveattemptofixvalgrind .
