### PR TITLE
Fix compilation of downstream bindings that include yarp.i

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -156,6 +156,16 @@ if(YARP_COMPILE_BINDINGS)
   unset(SWIG_COMMON_FLAGS)
 
   #############################################################################
+  ## Pass a macro to permit to code in yarp.i to distinguish between when is
+  ## swig is processing yarp.i because it is generated yarp bindings, or if
+  ## it is processing yarp.i as it was included in some downstream bindings
+  ## (such as icub-main bindings)
+  ## If you mantain a project downstream of YARP that is including yarp.i,
+  ## make sure that you DO NOT define this macro
+  list(APPEND SWIG_COMMON_FLAGS "-DSWIG_GENERATING_YARP_BINDINGS")
+
+
+  #############################################################################
   ## Do not build deprecated functions when disabled
 
   if(YARP_NO_DEPRECATED)

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -2005,10 +2005,11 @@ public:
 }
 
 //////////////////////////////////////////////////////////////////////////
-// Just in Python add some code to automatically call
+// Just in Python (and in yarp bindings itself, not in downstream bindings
+// that include yarp.i) add some code to automatically call
 // add_dll_directory as necessary
 // See https://github.com/robotology/robotology-superbuild/issues/1268
 // for more details
-#ifdef SWIGPYTHON
+#if defined(SWIGPYTHON) && defined(SWIG_GENERATING_YARP_BINDINGS)
 %include <swig_python_windows_preable.i>
 #endif


### PR DESCRIPTION
In https://github.com/robotology/yarp/pull/3146 there was a regression, as a new file `swig_python_windows_preable.i` was included in the `yarp.i` and it was generated by CMake in its binary directory. However, that file is not supposed to be included (and it is not even availble in the include path) when a downstream project (like `icub-main`) includes the file in its own `.i` swig binding file.

This PR fixes the issue by only including the file when `yarp.i` is used to generate the yarp bindings, and not when the `yarp.i` is included in a downstream project, by checking if the `SWIG_GENERATING_YARP_BINDINGS` preprocessor macro (that is only defined in the CMake build of YARP bindings) is defined.

Fix https://github.com/robotology/icub-main/issues/992 .