### PR TITLE
Change references from RGBDSensorWrapper to rgbdSensor_nws_yarp

### DIFF
--- a/example/dev/RGBD/README.md
+++ b/example/dev/RGBD/README.md
@@ -18,7 +18,7 @@ In this example we will use a fake device, for testing purposes: the `fakeDepthC
 
 ```
 Terminal 1: yarpserver
-Terminal 2: yarpdev --device RGBDSensorWrapper --name /server --subdevice fakeDepthCamera --mode ball
+Terminal 2: yarpdev --device rgbdSensor_nws_yarp --name /server --subdevice fakeDepthCamera --mode ball
 ```
 The parameters here means:
 - device: The server we want to open
@@ -84,14 +84,14 @@ The general procedure for instantiating devices does not change when using serve
 
 #### Server side:
 The server side application will still open the device driver, but now it will also open the corresponding YARP server used to broadcast data over the network and reply to Remote Procedure Calls (RPC).
-This way of using a device driver is shown in file [`RGBD_test_1b_server.cpp`](RGBD_test_1b_server.cpp), the server class is called `RGBDSensorWrapper`:
+This way of using a device driver is shown in file [`RGBD_test_1b_server.cpp`](RGBD_test_1b_server.cpp), the server class is called `rgbdSensor_nws_yarp`:
 
 ``` c++
 PolyDriver wrapperDriver;
 Property   wrapperConfig;
 
 // Wrapper config
-wrapperConfig.put("device", "RGBDSensorWrapper");       // Network server broadcasting data through network
+wrapperConfig.put("device", "rgbdSensor_nws_yarp");       // Network server broadcasting data through network
 wrapperConfig.put("name",   "/server");                 // Prefix for port names opened by the YARP server
 
 // Instantiating RGBD server

--- a/example/dev/RGBD/RGBD_test_1b_server.cpp
+++ b/example/dev/RGBD/RGBD_test_1b_server.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
     // Keyword 'device' is used by YARP framework
 
     // Wrapper config
-    wrapperConfig.put("device", "RGBDSensorWrapper"); // Network server broadcasting data through YARP network
+    wrapperConfig.put("device", "rgbdSensor_nws_yarp"); // Network server broadcasting data through YARP network
     wrapperConfig.put("name", "/server");             // Prefix for port names opened by the YARP server
 
     // Device driver config

--- a/src/devices/openNI2DepthCamera/depthCameraDriver.h
+++ b/src/devices/openNI2DepthCamera/depthCameraDriver.h
@@ -40,7 +40,7 @@ class  streamFrameListener;
  *
  * See the documentation for more details about each interface.
  *
- * This device is paired with its server called RGBDSensorWrapper to stream the images and perform remote operations.
+ * This device is paired with its server called rgbdSensor_nws_yarp to stream the images and perform remote operations.
  *
  * The config file is subdivided into 5 major sections called "SETTINGS", "HW_DESCRIPTION", "RGB_INTRINSIC_PARAMETERS",
  * "DEPTH_INTRINSIC_PARAMETERS", "EXTRINSIC_PARAMETERS".
@@ -125,7 +125,7 @@ class  streamFrameListener;
  *
  * \code{.unparsed}
 
-device       RGBDSensorWrapper
+device       rgbdSensor_nws_yarp
 subdevice    depthCamera
 name         /depthCamera
 


### PR DESCRIPTION
The `RGBDSensorWrapper` device was deprecated in YARP 3.5 and removed in YARP 3.8 (see https://github.com/robotology/yarp/commit/4da405c7fb077b4604029fd87e4e51a633e2d7eb) and it has been substituted by `rgbdSensor_nws_yarp`. Note that the corresponding network wrapper client (`nwc`) device that reads the rgbd data from a YARP port is called `RGBDSensorClient`.

However, there was still docs that was referring to `RGBDSensorWrapper`, this PR fixes those occurrences.

fyi @nicktrem @davidegorbani 