### PR TITLE
yarp read and envelope display

### DIFF
--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdRead.cpp
@@ -29,7 +29,7 @@ using yarp::os::NetworkBase;
  * @param trim number of characters of the string that should be printed
  * @return 0 on success, non-zero on failure
  */
-int Companion::read(const char *name, const char *src, bool showEnvelope, bool justOnce, int trim)
+int Companion::read(const char *name, const char *src, Companion::showEnvelopeEnum showEnvelope, bool justOnce, int trim)
 {
     Companion::installHandler();
     BottleReader reader;
@@ -58,12 +58,15 @@ int Companion::cmdRead(int argc, char *argv[])
 
     const char *name = argv[0];
     const char *src = nullptr;
-    bool showEnvelope = false;
+    showEnvelopeEnum showEnvelope = showEnvelopeEnum::do_not_show;
     size_t trim = -1;
     bool justOnce = false;
+    bool envelopeInline = true;
     while (argc>1) {
-        if (strcmp(argv[1], "envelope")==0) {
-            showEnvelope = true;
+        if (strcmp(argv[1], "envelope") == 0) {
+            showEnvelope = showEnvelopeEnum::show_inline;
+        } else if (strcmp(argv[1], "envelope2") == 0) {
+            showEnvelope = showEnvelopeEnum::show_two_lines;
         } else if (strcmp(argv[1], "trim") == 0) {
             argc--;
             argv++;

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdReadWrite.cpp
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.cmdReadWrite.cpp
@@ -25,7 +25,7 @@ int Companion::cmdReadWrite(int argc, char *argv[])
 
     Companion::installHandler();
     BottleReader reader;
-    reader.open(read_port_name, false, false);
+    reader.open(read_port_name, Companion::showEnvelopeEnum::do_not_show, false);
 
     int ret = write(write_port_name, 1, (char**)&verbatim);
 

--- a/src/libYARP_companion/src/yarp/companion/impl/Companion.h
+++ b/src/libYARP_companion/src/yarp/companion/impl/Companion.h
@@ -34,6 +34,12 @@ public:
 
     int dispatch(const char *name, int argc, char *argv[]);
 
+    enum showEnvelopeEnum
+    {
+        do_not_show = 0,
+        show_inline = 1,
+        show_two_lines = 2
+    };
 
     // Defined in Companion.cmdCheck.cpp
     int cmdCheck(int argc, char *argv[]);
@@ -102,7 +108,7 @@ public:
     int cmdPrioritySched(int argc, char *argv[]);
 
     // Defined in Companion.cmdRead.cpp
-    int read(const char *name, const char *src = nullptr, bool showEnvelope = false, bool justOnce = false, int trim = -1);
+    int read(const char *name, const char *src = nullptr, showEnvelopeEnum showEnvelope = showEnvelopeEnum::do_not_show, bool justOnce = false, int trim = -1);
     int cmdRead(int argc, char *argv[]);
 
     // Defined in Companion.cmdReadWrite.cpp


### PR DESCRIPTION
the command `yarp read ... /port envelope` now displays the envelope inline with the data, while the command `yarp read ... /port envelope2` displays the envelope and the data on two different lines