### PR TITLE
fix for c# with swig version 4.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1434,6 +1434,7 @@ jobs:
           set(_cmake_extra_options ${{ matrix.config.cmake_extra_options }})
         endif()
 
+        #SWIGFIX temporary fix for swig 4.2.1. The following lines should be removed.
         set(_swig_extra_options)
         if(NOT "${{ matrix.config.swig_extra_options }}" STREQUAL "")
           set(_swig_extra_options ${{ matrix.config.swig_extra_options }})
@@ -1592,6 +1593,12 @@ jobs:
                                        -D CMAKE_CXX_COMPILER_LAUNCHER=${_ccache_cmd})
         endif()
 
+        #SWIGFIX temporary fix for swig 4.2.1. The following lines should be removed.
+        set(_swig_extra_options)
+        if(NOT "${{ matrix.config.swig_extra_options }}" STREQUAL "")
+          set(_swig_extra_options ${{ matrix.config.swig_extra_options }})
+        endif()
+
         execute_process_x(
           COMMAND ${CMAKE_COMMAND}
             -S bindings
@@ -1667,6 +1674,12 @@ jobs:
           find_program(_ccache_cmd ccache PATHS ENV GITHUB_WORKSPACE)
           set(_cmake_compiler_lauchers -D CMAKE_C_COMPILER_LAUNCHER=${_ccache_cmd}
                                        -D CMAKE_CXX_COMPILER_LAUNCHER=${_ccache_cmd})
+        endif()
+
+        #SWIGFIX temporary fix for swig 4.2.1. The following lines should be removed.
+        set(_swig_extra_options)
+        if(NOT "${{ matrix.config.swig_extra_options }}" STREQUAL "")
+          set(_swig_extra_options ${{ matrix.config.swig_extra_options }})
         endif()
 
         execute_process_x(

--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -451,8 +451,10 @@ MAKE_COMMS(Bottle)
   %include "matlab/vectors_fromTo_matlab.i"
 #endif
 
+#if SWIG_VERSION < 0x040201
 #if defined(SWIGCSHARP)
   SWIG_STD_VECTOR_SPECIALIZE_MINIMUM(Pid,yarp::dev::Pid)
+#endif
 #endif
 %template(PidVector) std::vector<yarp::dev::Pid>;
 


### PR DESCRIPTION
SWIG_STD_VECTOR_SPECIALIZE_MINIMUM is not more used with swig 4.2.1