### PR TITLE
MultipleAnalogSensorServer fix

### DIFF
--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -365,33 +365,11 @@ bool MultipleAnalogSensorsServer::resizeAllMeasureVectors(SensorStreamingData& s
     return ok;
 }
 
-bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
+bool MultipleAnalogSensorsServer::attach(yarp::dev::PolyDriver* poly)
 {
-    // Attach the device
-    if (p.size() > 1)
-    {
-        yCError(MULTIPLEANALOGSENSORSSERVER,
-                "This device only supports exposing a "
-                "single MultipleAnalogSensors device on YARP ports, but %d devices have been passed in attachAll.",
-                p.size());
-        yCError(MULTIPLEANALOGSENSORSSERVER,
-                "Please use the multipleanalogsensorsremapper device to combine several device in a new device.");
-        close();
-        return false;
-    }
-
-    if (p.size() == 0)
-    {
-        yCError(MULTIPLEANALOGSENSORSSERVER, "No device passed to attachAll, please pass a device to expose on YARP ports.");
-        close();
-        return false;
-    }
-
-    yarp::dev::PolyDriver* poly = p[0]->poly;
-
     if (!poly)
     {
-        yCError(MULTIPLEANALOGSENSORSSERVER, "Null pointer passed to attachAll.");
+        yCError(MULTIPLEANALOGSENSORSSERVER, "Null pointer passed to attach.");
         close();
         return false;
     }
@@ -460,7 +438,7 @@ bool MultipleAnalogSensorsServer::attachAll(const yarp::dev::PolyDriverList& p)
     return true;
 }
 
-bool MultipleAnalogSensorsServer::detachAll()
+bool MultipleAnalogSensorsServer::detach()
 {
     // Stop the thread on detach
     if (this->isRunning())

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -11,7 +11,7 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/WrapperSingle.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
 // Thrift-generated classes
@@ -33,7 +33,7 @@
 class MultipleAnalogSensorsServer :
         public yarp::os::PeriodicThread,
         public yarp::dev::DeviceDriver,
-        public yarp::dev::IMultipleWrapper,
+        public yarp::dev::WrapperSingle,
         public MultipleAnalogSensorsMetadata,
         public MultipleAnalogSensorsServer_ParamsParser
 {
@@ -108,9 +108,9 @@ public:
     bool open(yarp::os::Searchable &params) override;
     bool close() override;
 
-    /* IMultipleWrapper methods */
-    bool attachAll(const yarp::dev::PolyDriverList &p) override;
-    bool detachAll() override;
+    /* IWrapper methods */
+    bool attach(yarp::dev::PolyDriver* p) override;
+    bool detach() override;
 
     /* RateThread methods */
     void threadRelease() override;


### PR DESCRIPTION
MultipleAnalogSensorServer now derives yarp::dev::WrapperSingle instead of yarp::dev::IMultipleWrapper
https://github.com/robotology/yarp/issues/3152