### PR TITLE
New class for return values of interface methods PART3

### DIFF
--- a/src/devices/frameTransformClient/FrameTransformClient.h
+++ b/src/devices/frameTransformClient/FrameTransformClient.h
@@ -106,20 +106,20 @@ public:
     bool read(yarp::os::ConnectionReader& connection) override;
 
     //IFrameTransform
-    bool     allFramesAsString(std::string &all_frames) override;
-    bool     canTransform(const std::string &target_frame, const std::string &source_frame) override;
-    bool     clear() override;
-    bool     frameExists(const std::string &frame_id) override;
-    bool     getAllFrameIds(std::vector< std::string > &ids) override;
-    bool     getParent(const std::string &frame_id, std::string &parent_frame_id) override;
-    bool     getTransform(const std::string &target_frame_id, const std::string &source_frame_id, yarp::sig::Matrix &transform) override;
-    bool     setTransform(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) override;
-    bool     setTransformStatic(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) override;
-    bool     deleteTransform(const std::string &target_frame_id, const std::string &source_frame_id) override;
-    bool     transformPoint(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, yarp::sig::Vector &transformed_point) override;
-    bool     transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, yarp::sig::Vector &transformed_pose) override;
-    bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) override;
-    bool     waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) override;
+    yarp::dev::ReturnValue  allFramesAsString(std::string &all_frames) override;
+    yarp::dev::ReturnValue  canTransform(const std::string &target_frame, const std::string &source_frame, bool& exists) override;
+    yarp::dev::ReturnValue  clear() override;
+    yarp::dev::ReturnValue  frameExists(const std::string &frame_id, bool& exists) override;
+    yarp::dev::ReturnValue  getAllFrameIds(std::vector< std::string > &ids) override;
+    yarp::dev::ReturnValue  getParent(const std::string &frame_id, std::string &parent_frame_id) override;
+    yarp::dev::ReturnValue  getTransform(const std::string &target_frame_id, const std::string &source_frame_id, yarp::sig::Matrix &transform) override;
+    yarp::dev::ReturnValue  setTransform(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) override;
+    yarp::dev::ReturnValue  setTransformStatic(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) override;
+    yarp::dev::ReturnValue  deleteTransform(const std::string &target_frame_id, const std::string &source_frame_id) override;
+    yarp::dev::ReturnValue  transformPoint(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, yarp::sig::Vector &transformed_point) override;
+    yarp::dev::ReturnValue  transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, yarp::sig::Vector &transformed_pose) override;
+    yarp::dev::ReturnValue  transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) override;
+    yarp::dev::ReturnValue  waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) override;
 
     //PeriodicThread
     bool     threadInit() override;

--- a/src/devices/frameTransformGet/FrameTransformGetMultiplexer.cpp
+++ b/src/devices/frameTransformGet/FrameTransformGetMultiplexer.cpp
@@ -75,7 +75,7 @@ bool FrameTransformGetMultiplexer::attachAll(const yarp::dev::PolyDriverList& de
 }
 
 
-bool FrameTransformGetMultiplexer::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
+yarp::dev::ReturnValue FrameTransformGetMultiplexer::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
 {
     for (size_t i = 0; i < m_iFrameTransformStorageGetList.size(); i++)
     {
@@ -86,10 +86,11 @@ bool FrameTransformGetMultiplexer::getTransforms(std::vector<yarp::math::FrameTr
                               localTransform.begin(),
                               localTransform.end());
         }
-        else {
+        else
+        {
             yCError(FRAMETRANSFORMGETMULTIPLEXER) << "pointer to interface IFrameTransformStorageGet not valid";
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
     }
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/frameTransformGet/FrameTransformGetMultiplexer.h
+++ b/src/devices/frameTransformGet/FrameTransformGetMultiplexer.h
@@ -41,7 +41,7 @@ public:
     bool detachAll() override;
 
     // yarp::dev::IFrameTransformStorageGet
-    bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
+    yarp::dev::ReturnValue getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
 private:
     int    m_verbose{4};

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.cpp
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.cpp
@@ -8,6 +8,8 @@
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>
 
+using namespace yarp::dev;
+
 YARP_LOG_COMPONENT(FRAMETRANSFORMGETNWCYARP, "yarp.devices.FrameTransformGet_nwc_yarp")
 
 
@@ -136,7 +138,7 @@ bool FrameTransformGet_nwc_yarp::close()
 }
 
 
-bool FrameTransformGet_nwc_yarp::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
+ReturnValue FrameTransformGet_nwc_yarp::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
 {
     if (!m_streaming_port_enabled)
     {
@@ -144,10 +146,10 @@ bool FrameTransformGet_nwc_yarp::getTransforms(std::vector<yarp::math::FrameTran
         if(!retrievedFromRPC.retvalue)
         {
             yCError(FRAMETRANSFORMGETNWCYARP, "Unable to get transformations");
-            return false;
+            return retrievedFromRPC.retvalue;
         }
         transforms = retrievedFromRPC.transforms_list;
-        return true;
+        return retrievedFromRPC.retvalue;
     }
     else
     {
@@ -156,10 +158,10 @@ bool FrameTransformGet_nwc_yarp::getTransforms(std::vector<yarp::math::FrameTran
             return_getAllTransforms retrievedFromSteaming;
             m_dataReader->getData(retrievedFromSteaming);
             transforms = retrievedFromSteaming.transforms_list;
-            return true;
+            return retrievedFromSteaming.retvalue;
         }
         yCError(FRAMETRANSFORMGETNWCYARP, "Unable to get transformations");
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
 }
 

--- a/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
+++ b/src/devices/frameTransformGet/FrameTransformGet_nwc_yarp.h
@@ -126,7 +126,7 @@ public:
     bool  close() override;
 
     // yarp::dev::IFrameTransformStorageGet
-    bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
+    yarp::dev::ReturnValue getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
 private:
     int            m_verbose{4};

--- a/src/devices/frameTransformSet/FrameTransformSetMultiplexer.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSetMultiplexer.cpp
@@ -78,38 +78,40 @@ bool FrameTransformSetMultiplexer::attachAll(const yarp::dev::PolyDriverList& de
 }
 
 
-bool FrameTransformSetMultiplexer::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
+yarp::dev::ReturnValue FrameTransformSetMultiplexer::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
     {
         if (m_iFrameTransformStorageSetList[i] != nullptr) {
             m_iFrameTransformStorageSetList[i]->setTransforms(transforms);
         }
-        else {
+        else
+        {
             yCError(FRAMETRANSFORMSETMULTIPLEXER) << "pointer to interface IFrameTransformStorageSet not valid";
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 
-bool FrameTransformSetMultiplexer::setTransform(const yarp::math::FrameTransform& transform)
+yarp::dev::ReturnValue FrameTransformSetMultiplexer::setTransform(const yarp::math::FrameTransform& transform)
 {
     for (size_t i = 0; i < m_iFrameTransformStorageSetList.size(); i++)
     {
         if (m_iFrameTransformStorageSetList[i] != nullptr) {
             m_iFrameTransformStorageSetList[i]->setTransform(transform);
         }
-        else {
+        else
+        {
             yCError(FRAMETRANSFORMSETMULTIPLEXER) << "pointer to interface IFrameTransformStorageSet not valid";
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FrameTransformSetMultiplexer::deleteTransform(std::string t1, std::string t2)
+yarp::dev::ReturnValue FrameTransformSetMultiplexer::deleteTransform(std::string t1, std::string t2)
 {
     //stopThreads();
 
@@ -121,18 +123,21 @@ bool FrameTransformSetMultiplexer::deleteTransform(std::string t1, std::string t
         {
             frame_deleted &= m_iFrameTransformStorageSetList[i]->deleteTransform(t1,t2);
         }
-        else {
+        else
+        {
             yCError(FRAMETRANSFORMSETMULTIPLEXER) << "pointer to interface IFrameTransformStorageSet not valid";
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
     }
 
     //startThreads();
 
-    return frame_deleted;
+    if (frame_deleted) { return ReturnValue_ok; }
+
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
-bool FrameTransformSetMultiplexer::clearAll()
+yarp::dev::ReturnValue FrameTransformSetMultiplexer::clearAll()
 {
     //stopThreads();
 
@@ -141,15 +146,16 @@ bool FrameTransformSetMultiplexer::clearAll()
         if (m_iFrameTransformStorageSetList[i] != nullptr) {
             m_iFrameTransformStorageSetList[i]->clearAll();
         }
-        else {
+        else
+        {
             yCError(FRAMETRANSFORMSETMULTIPLEXER) << "pointer to interface IFrameTransformStorageSet not valid";
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
     }
 
     //startThreads();
 
-    return true;
+    return ReturnValue_ok;
 }
 
 void FrameTransformSetMultiplexer::stopThreads()

--- a/src/devices/frameTransformSet/FrameTransformSetMultiplexer.h
+++ b/src/devices/frameTransformSet/FrameTransformSetMultiplexer.h
@@ -41,10 +41,10 @@ public:
     bool detachAll() override;
 
     // yarp::dev::IFrameTransformStorageSet
-    bool setTransform(const yarp::math::FrameTransform& transform) override;
-    bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    virtual bool deleteTransform(std::string t1, std::string t2) override;
-    virtual bool clearAll() override;
+    yarp::dev::ReturnValue setTransform(const yarp::math::FrameTransform& transform) override;
+    yarp::dev::ReturnValue setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    yarp::dev::ReturnValue deleteTransform(std::string t1, std::string t2) override;
+    yarp::dev::ReturnValue clearAll() override;
 
     void startThreads();
     void stopThreads();

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.cpp
@@ -91,46 +91,54 @@ bool FrameTransformSet_nwc_yarp::close()
     return true;
 }
 
-bool FrameTransformSet_nwc_yarp::setTransform(const yarp::math::FrameTransform& transform)
+ReturnValue FrameTransformSet_nwc_yarp::setTransform(const yarp::math::FrameTransform& transform)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if(!m_setRPC.setTransformRPC(transform))
+
+    auto ret = m_setRPC.setTransformRPC(transform);
+    if(!ret)
     {
         yCError(FRAMETRANSFORMSETNWCYARP, "Unable to set transformation");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nwc_yarp::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
+ReturnValue FrameTransformSet_nwc_yarp::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if(!m_setRPC.setTransformsRPC(transforms))
+
+    auto ret = m_setRPC.setTransformsRPC(transforms);
+    if(!ret)
     {
         yCError(FRAMETRANSFORMSETNWCYARP, "Unable to set transformations");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nwc_yarp::deleteTransform(std::string t1, std::string t2)
+ReturnValue FrameTransformSet_nwc_yarp::deleteTransform(std::string t1, std::string t2)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if (!m_setRPC.deleteTransformRPC(t1,t2))
+
+    auto ret = m_setRPC.deleteTransformRPC(t1, t2);
+    if (!ret)
     {
         yCError(FRAMETRANSFORMSETNWCYARP, "Unable to delete transformation");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nwc_yarp::clearAll()
+ReturnValue FrameTransformSet_nwc_yarp::clearAll()
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if (!m_setRPC.clearAllRPC())
+
+    auto ret = m_setRPC.clearAllRPC();
+    if (!ret)
     {
         yCError(FRAMETRANSFORMSETNWCYARP, "Unable to clear all transformations");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }

--- a/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nwc_yarp.h
@@ -80,10 +80,10 @@ public:
     bool close() override;
 
     //FrameTransformStorageSetRPC functions
-    bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    bool setTransform(const yarp::math::FrameTransform& transform) override;
-    bool deleteTransform(std::string t1, std::string t2) override;
-    bool clearAll() override;
+    yarp::dev::ReturnValue setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    yarp::dev::ReturnValue setTransform(const yarp::math::FrameTransform& transform) override;
+    yarp::dev::ReturnValue deleteTransform(std::string t1, std::string t2) override;
+    yarp::dev::ReturnValue clearAll() override;
 
 private:
     mutable std::mutex          m_trf_mutex;

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.cpp
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.cpp
@@ -80,53 +80,60 @@ bool FrameTransformSet_nws_yarp::detach()
     return true;
 }
 
-bool FrameTransformSet_nws_yarp::setTransformRPC(const yarp::math::FrameTransform& transform)
+ReturnValue FrameTransformSet_nws_yarp::setTransformRPC(const yarp::math::FrameTransform& transform)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
 
-    if(!m_iSetIf->setTransform(transform))
+    auto ret = m_iSetIf->setTransform(transform);
+    if(!ret)
     {
         yCError(FRAMETRANSFORMSETNWSYARP, "Unable to set transform");
-        return false;
+        return ret;
     }
 
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nws_yarp::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)
+ReturnValue FrameTransformSet_nws_yarp::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if(!m_iSetIf->setTransforms(transforms))
+
+    auto ret = m_iSetIf->setTransforms(transforms);
+    if(!ret)
     {
         yCError(FRAMETRANSFORMSETNWSYARP, "Unable to set transformations");
-        return false;
+        return ret;
     }
 
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nws_yarp::deleteTransformRPC(const std::string& src, const std::string& dst)
+ReturnValue FrameTransformSet_nws_yarp::deleteTransformRPC(const std::string& src, const std::string& dst)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if (!m_iSetIf->deleteTransform(src,dst))
+
+    auto ret = m_iSetIf->deleteTransform(src, dst);
+    if (!ret)
     {
         yCError(FRAMETRANSFORMSETNWSYARP, "Unable to delete transforms");
-        return false;
+        return ret;
     }
 
-    return true;
+    return ret;
 }
 
-bool FrameTransformSet_nws_yarp::clearAllRPC()
+ReturnValue FrameTransformSet_nws_yarp::clearAllRPC()
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
-    if (!m_iSetIf->clearAll())
+
+    auto ret = m_iSetIf->clearAll();
+    if (!ret)
     {
         yCError(FRAMETRANSFORMSETNWSYARP, "Unable to clear all transforms");
-        return false;
+        return ret;
     }
 
-    return true;
+    return ret;
 }
 
 

--- a/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
+++ b/src/devices/frameTransformSet/FrameTransformSet_nws_yarp.h
@@ -73,10 +73,10 @@ public:
     bool detach() override;
 
     //FrameTransformStorageSetRPC functions
-    bool setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    bool setTransformRPC(const yarp::math::FrameTransform& transform) override;
-    bool deleteTransformRPC(const std::string& src, const std::string& dst) override;
-    bool clearAllRPC()override;
+    yarp::dev::ReturnValue setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    yarp::dev::ReturnValue setTransformRPC(const yarp::math::FrameTransform& transform) override;
+    yarp::dev::ReturnValue deleteTransformRPC(const std::string& src, const std::string& dst) override;
+    yarp::dev::ReturnValue clearAllRPC()override;
 
 private:
     mutable std::mutex                      m_pd_mutex;

--- a/src/devices/frameTransformStorage/FrameTransformStorage.cpp
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.cpp
@@ -18,10 +18,10 @@ YARP_LOG_COMPONENT(FRAMETRANSFORSTORAGE, "yarp.device.frameTransformStorage")
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-bool FrameTransformStorage::getInternalContainer(FrameTransformContainer*& container)
+yarp::dev::ReturnValue FrameTransformStorage::getInternalContainer(FrameTransformContainer*& container)
 {
     container = &m_tf_container;
-    return true;
+    return ReturnValue_ok;
 }
 
 bool FrameTransformStorage::open(yarp::os::Searchable& config)
@@ -52,25 +52,25 @@ bool FrameTransformStorage::close()
     return true;
 }
 
-bool FrameTransformStorage::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
+yarp::dev::ReturnValue FrameTransformStorage::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
     return m_tf_container.getTransforms(transforms);
 }
 
-bool FrameTransformStorage::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
+yarp::dev::ReturnValue FrameTransformStorage::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
     return m_tf_container.setTransforms(transforms);
 }
 
-bool FrameTransformStorage::setTransform(const yarp::math::FrameTransform& t)
+yarp::dev::ReturnValue FrameTransformStorage::setTransform(const yarp::math::FrameTransform& t)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
     return m_tf_container.setTransform (t);
 }
 
-bool FrameTransformStorage::deleteTransform(std::string t1, std::string t2)
+yarp::dev::ReturnValue FrameTransformStorage::deleteTransform(std::string t1, std::string t2)
 {
     std::lock_guard <std::mutex> lg(m_pd_mutex);
     return m_tf_container.deleteTransform(t1,t2);
@@ -123,22 +123,30 @@ bool FrameTransformStorage::attach(yarp::dev::PolyDriver* driver)
     return false;
 }
 
-bool FrameTransformStorage::clearAll()
+yarp::dev::ReturnValue FrameTransformStorage::clearAll()
 {
     return m_tf_container.clearAll();
 }
 
-bool FrameTransformStorage::size(size_t& size) const
+yarp::dev::ReturnValue FrameTransformStorage::size(size_t& size) const
 {
-    return m_tf_container.size(size);
+    if (m_tf_container.size(size))
+    {
+        return ReturnValue_ok;
+    }
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
-bool FrameTransformStorage::startStorageThread()
+yarp::dev::ReturnValue FrameTransformStorage::startStorageThread()
 {
-    return this->start();
+    if (this->start())
+    {
+        return ReturnValue_ok;
+    }
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
-bool FrameTransformStorage::stopStorageThread()
+yarp::dev::ReturnValue FrameTransformStorage::stopStorageThread()
 {
     this->askToStop();
     do
@@ -146,5 +154,5 @@ bool FrameTransformStorage::stopStorageThread()
         yarp::os::Time::delay(0.001);
     }
     while (this->isRunning());
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/frameTransformStorage/FrameTransformStorage.h
+++ b/src/devices/frameTransformStorage/FrameTransformStorage.h
@@ -16,6 +16,7 @@
 #include <yarp/dev/FrameTransformContainer.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/WrapperSingle.h>
+#include <yarp/dev/ReturnValue.h>
 #include <mutex>
 #include <map>
 #include <mutex>
@@ -55,19 +56,19 @@ public:
     bool close() override;
 
     //IFrameTransformStorageSet interface
-    bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    bool setTransform(const yarp::math::FrameTransform& transform) override;
+    yarp::dev::ReturnValue setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    yarp::dev::ReturnValue setTransform(const yarp::math::FrameTransform& transform) override;
 
     //IFrameTransformStorageGet interface
-    bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
+    yarp::dev::ReturnValue getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
     //IFrameTransformStorageUtils interface
-    bool deleteTransform(std::string t1, std::string t2) override;
-    bool size(size_t& size) const override;
-    bool clearAll() override;
-    bool getInternalContainer(yarp::dev::FrameTransformContainer*&  container) override;
-    bool startStorageThread() override;
-    bool stopStorageThread() override;
+    yarp::dev::ReturnValue deleteTransform(std::string t1, std::string t2) override;
+    yarp::dev::ReturnValue size(size_t& size) const override;
+    yarp::dev::ReturnValue clearAll() override;
+    yarp::dev::ReturnValue getInternalContainer(yarp::dev::FrameTransformContainer*&  container) override;
+    yarp::dev::ReturnValue startStorageThread() override;
+    yarp::dev::ReturnValue stopStorageThread() override;
 
     //wrapper and interfaces
     bool attach(yarp::dev::PolyDriver* driver) override;

--- a/src/devices/messages/frameTransformStorageMsgs/CMakeLists.txt
+++ b/src/devices/messages/frameTransformStorageMsgs/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(frameTransformStorageMsgs PRIVATE ${FTM_THRIFT_GEN_FILES})
 target_link_libraries(frameTransformStorageMsgs
   PRIVATE
     YARP::YARP_os
+    YARP::YARP_dev
     YARP::YARP_sig
     YARP::YARP_math
 )

--- a/src/devices/messages/frameTransformStorageMsgs/frameTransformStorageMsgs.thrift
+++ b/src/devices/messages/frameTransformStorageMsgs/frameTransformStorageMsgs.thrift
@@ -9,18 +9,24 @@ struct YarpFrameTransform {
   yarp.includefile="yarp/math/FrameTransform.h"
 )
 
+struct yReturnValue {
+} (
+  yarp.name = "yarp::dev::ReturnValue"
+  yarp.includefile = "yarp/dev/ReturnValue.h"
+)
+
 struct return_getAllTransforms
 {
-  1: bool retvalue;
+  1: yReturnValue retvalue;
   2: list<YarpFrameTransform> transforms_list;
 }
 
 service FrameTransformStorageSetRPC
 {
-  bool setTransformsRPC(1:list<YarpFrameTransform> transforms) ;
-  bool setTransformRPC(1:YarpFrameTransform transform);
-  bool deleteTransformRPC(1:string src, 2:string dst);
-  bool clearAllRPC()
+  yReturnValue setTransformsRPC(1:list<YarpFrameTransform> transforms) ;
+  yReturnValue setTransformRPC(1:YarpFrameTransform transform);
+  yReturnValue deleteTransformRPC(1:string src, 2:string dst);
+  yReturnValue clearAllRPC()
 }
 
 service FrameTransformStorageGetRPC

--- a/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.cpp
+++ b/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.cpp
@@ -60,10 +60,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const std::vector<yarp::math::FrameTransform>&);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const std::vector<yarp::math::FrameTransform>&);
     void call(FrameTransformStorageSetRPC* ptr);
 
     Command cmd;
@@ -73,7 +73,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool FrameTransformStorageSetRPC::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue FrameTransformStorageSetRPC::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)"};
     static constexpr const char* s_help{""};
 };
 
@@ -123,10 +123,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const yarp::math::FrameTransform&);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const yarp::math::FrameTransform&);
     void call(FrameTransformStorageSetRPC* ptr);
 
     Command cmd;
@@ -136,7 +136,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool FrameTransformStorageSetRPC::setTransformRPC(const yarp::math::FrameTransform& transform)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue FrameTransformStorageSetRPC::setTransformRPC(const yarp::math::FrameTransform& transform)"};
     static constexpr const char* s_help{""};
 };
 
@@ -187,10 +187,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const std::string&, const std::string&);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const std::string&, const std::string&);
     void call(FrameTransformStorageSetRPC* ptr);
 
     Command cmd;
@@ -200,7 +200,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{3};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool FrameTransformStorageSetRPC::deleteTransformRPC(const std::string& src, const std::string& dst)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue FrameTransformStorageSetRPC::deleteTransformRPC(const std::string& src, const std::string& dst)"};
     static constexpr const char* s_help{""};
 };
 
@@ -245,10 +245,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(FrameTransformStorageSetRPC* ptr);
 
     Command cmd;
@@ -258,7 +258,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{1};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool FrameTransformStorageSetRPC::clearAllRPC()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue FrameTransformStorageSetRPC::clearAllRPC()"};
     static constexpr const char* s_help{""};
 };
 
@@ -411,10 +411,7 @@ bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Reply::read(yarp::os::
 bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -423,14 +420,11 @@ bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Reply::write(const yar
 
 bool FrameTransformStorageSetRPC_setTransformsRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -565,10 +559,7 @@ bool FrameTransformStorageSetRPC_setTransformRPC_helper::Reply::read(yarp::os::C
 bool FrameTransformStorageSetRPC_setTransformRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -577,14 +568,11 @@ bool FrameTransformStorageSetRPC_setTransformRPC_helper::Reply::write(const yarp
 
 bool FrameTransformStorageSetRPC_setTransformRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -731,10 +719,7 @@ bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Reply::read(yarp::os
 bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -743,14 +728,11 @@ bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Reply::write(const y
 
 bool FrameTransformStorageSetRPC_deleteTransformRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -864,10 +846,7 @@ bool FrameTransformStorageSetRPC_clearAllRPC_helper::Reply::read(yarp::os::Conne
 bool FrameTransformStorageSetRPC_clearAllRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -876,14 +855,11 @@ bool FrameTransformStorageSetRPC_clearAllRPC_helper::Reply::write(const yarp::os
 
 bool FrameTransformStorageSetRPC_clearAllRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -901,44 +877,44 @@ FrameTransformStorageSetRPC::FrameTransformStorageSetRPC()
     yarp().setOwner(*this);
 }
 
-bool FrameTransformStorageSetRPC::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)
+yarp::dev::ReturnValue FrameTransformStorageSetRPC::setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", FrameTransformStorageSetRPC_setTransformsRPC_helper::s_prototype);
     }
     FrameTransformStorageSetRPC_setTransformsRPC_helper helper{transforms};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool FrameTransformStorageSetRPC::setTransformRPC(const yarp::math::FrameTransform& transform)
+yarp::dev::ReturnValue FrameTransformStorageSetRPC::setTransformRPC(const yarp::math::FrameTransform& transform)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", FrameTransformStorageSetRPC_setTransformRPC_helper::s_prototype);
     }
     FrameTransformStorageSetRPC_setTransformRPC_helper helper{transform};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool FrameTransformStorageSetRPC::deleteTransformRPC(const std::string& src, const std::string& dst)
+yarp::dev::ReturnValue FrameTransformStorageSetRPC::deleteTransformRPC(const std::string& src, const std::string& dst)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", FrameTransformStorageSetRPC_deleteTransformRPC_helper::s_prototype);
     }
     FrameTransformStorageSetRPC_deleteTransformRPC_helper helper{src, dst};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool FrameTransformStorageSetRPC::clearAllRPC()
+yarp::dev::ReturnValue FrameTransformStorageSetRPC::clearAllRPC()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", FrameTransformStorageSetRPC_clearAllRPC_helper::s_prototype);
     }
     FrameTransformStorageSetRPC_clearAllRPC_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 // help method

--- a/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.h
+++ b/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/FrameTransformStorageSetRPC.h
@@ -13,6 +13,7 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/math/FrameTransform.h>
 
 class FrameTransformStorageSetRPC :
@@ -22,13 +23,13 @@ public:
     // Constructor
     FrameTransformStorageSetRPC();
 
-    virtual bool setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms);
+    virtual yarp::dev::ReturnValue setTransformsRPC(const std::vector<yarp::math::FrameTransform>& transforms);
 
-    virtual bool setTransformRPC(const yarp::math::FrameTransform& transform);
+    virtual yarp::dev::ReturnValue setTransformRPC(const yarp::math::FrameTransform& transform);
 
-    virtual bool deleteTransformRPC(const std::string& src, const std::string& dst);
+    virtual yarp::dev::ReturnValue deleteTransformRPC(const std::string& src, const std::string& dst);
 
-    virtual bool clearAllRPC();
+    virtual yarp::dev::ReturnValue clearAllRPC();
 
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");

--- a/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/return_getAllTransforms.cpp
+++ b/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/return_getAllTransforms.cpp
@@ -11,7 +11,7 @@
 #include <return_getAllTransforms.h>
 
 // Constructor with field values
-return_getAllTransforms::return_getAllTransforms(const bool retvalue,
+return_getAllTransforms::return_getAllTransforms(const yarp::dev::ReturnValue& retvalue,
                                                  const std::vector<yarp::math::FrameTransform>& transforms_list) :
         WirePortable(),
         retvalue(retvalue),
@@ -22,7 +22,7 @@ return_getAllTransforms::return_getAllTransforms(const bool retvalue,
 // Read structure on a Wire
 bool return_getAllTransforms::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retvalue(reader)) {
+    if (!nested_read_retvalue(reader)) {
         return false;
     }
     if (!read_transforms_list(reader)) {
@@ -50,7 +50,7 @@ bool return_getAllTransforms::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getAllTransforms::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retvalue(writer)) {
+    if (!nested_write_retvalue(writer)) {
         return false;
     }
     if (!write_transforms_list(writer)) {
@@ -92,7 +92,7 @@ bool return_getAllTransforms::read_retvalue(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(retvalue)) {
+    if (!reader.read(retvalue)) {
         reader.fail();
         return false;
     }
@@ -102,7 +102,7 @@ bool return_getAllTransforms::read_retvalue(yarp::os::idl::WireReader& reader)
 // write retvalue field
 bool return_getAllTransforms::write_retvalue(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retvalue)) {
+    if (!writer.write(retvalue)) {
         return false;
     }
     return true;
@@ -115,7 +115,7 @@ bool return_getAllTransforms::nested_read_retvalue(yarp::os::idl::WireReader& re
         reader.fail();
         return false;
     }
-    if (!reader.readBool(retvalue)) {
+    if (!reader.readNested(retvalue)) {
         reader.fail();
         return false;
     }
@@ -125,7 +125,7 @@ bool return_getAllTransforms::nested_read_retvalue(yarp::os::idl::WireReader& re
 // write (nested) retvalue field
 bool return_getAllTransforms::nested_write_retvalue(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retvalue)) {
+    if (!writer.writeNested(retvalue)) {
         return false;
     }
     return true;

--- a/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/return_getAllTransforms.h
+++ b/src/devices/messages/frameTransformStorageMsgs/idl_generated_code/return_getAllTransforms.h
@@ -13,6 +13,7 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/math/FrameTransform.h>
 
 class return_getAllTransforms :
@@ -20,14 +21,14 @@ class return_getAllTransforms :
 {
 public:
     // Fields
-    bool retvalue{false};
+    yarp::dev::ReturnValue retvalue{};
     std::vector<yarp::math::FrameTransform> transforms_list{};
 
     // Default constructor
     return_getAllTransforms() = default;
 
     // Constructor with field values
-    return_getAllTransforms(const bool retvalue,
+    return_getAllTransforms(const yarp::dev::ReturnValue& retvalue,
                             const std::vector<yarp::math::FrameTransform>& transforms_list);
 
     // Read structure on a Wire

--- a/src/libYARP_dev/src/yarp/dev/FrameTransformContainer.cpp
+++ b/src/libYARP_dev/src/yarp/dev/FrameTransformContainer.cpp
@@ -35,25 +35,25 @@ void FrameTransformContainer::invalidateTransform(yarp::math::FrameTransform& tr
     }
 }
 
-bool FrameTransformContainer::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
+ReturnValue FrameTransformContainer::getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const
 {
     std::lock_guard<std::recursive_mutex> lock(m_trf_mutex);
     std::copy_if (m_transforms.begin(), m_transforms.end(), std::back_inserter(transforms), [](const yarp::math::FrameTransform& trf){return trf.isValid();});
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FrameTransformContainer::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
+ReturnValue FrameTransformContainer::setTransforms(const std::vector<yarp::math::FrameTransform>& transforms)
 {
     for (auto& it : transforms)
     {
         setTransform(it);
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FrameTransformContainer::setTransform(const yarp::math::FrameTransform& new_tr)
+ReturnValue FrameTransformContainer::setTransform(const yarp::math::FrameTransform& new_tr)
 {
-    if (new_tr.isValid()==false) return true;
+    if (new_tr.isValid()==false) return ReturnValue_ok;
 
     std::lock_guard<std::recursive_mutex> lock(m_trf_mutex);
     for (auto& it : m_transforms)
@@ -69,27 +69,27 @@ bool FrameTransformContainer::setTransform(const yarp::math::FrameTransform& new
                 if (new_tr.timestamp > it.timestamp)
                 {
                     it = new_tr;
-                    return true;
+                    return ReturnValue_ok;
                 }
                 else
                 {
                     //yCDebug(FRAMETRANSFORMCONTAINER) << "Received old transform" << it.dst_frame_id << it.src_frame_id << std::to_string(it.timestamp) << it.isStatic;
-                    return true;
+                    return ReturnValue_ok;
                 }
             }
             else
             {
-                return true;
+                return ReturnValue_ok;
             }
         }
     }
 
     //add a new transform
     m_transforms.push_back(new_tr);
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
+ReturnValue FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
 {
     std::lock_guard<std::recursive_mutex> lock(m_trf_mutex);
     if (t1 == "*" && t2 == "*")
@@ -98,7 +98,7 @@ bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
         {
             invalidateTransform(m_transforms[i]);
         }
-        return true;
+        return ReturnValue_ok;
     }
     else
     {
@@ -112,7 +112,7 @@ bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
                     invalidateTransform(m_transforms[i]);
                 }
             }
-            return true;
+            return ReturnValue_ok;
         }
         else
         {
@@ -126,7 +126,7 @@ bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
                         invalidateTransform(m_transforms[i]);
                     }
                 }
-                return true;
+                return ReturnValue_ok;
             }
             else
             {
@@ -136,7 +136,7 @@ bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
                         (m_transforms[i].dst_frame_id == t2 && m_transforms[i].src_frame_id == t1))
                     {
                         invalidateTransform(m_transforms[i]);
-                        return true;
+                        return ReturnValue_ok;
                     }
                 }
             }
@@ -144,17 +144,17 @@ bool FrameTransformContainer::deleteTransform(std::string t1, std::string t2)
     }
 
     yCError(FRAMETRANSFORMCONTAINER) << "Transformation deletion not successful";
-    return false;
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
-bool FrameTransformContainer::clearAll()
+ReturnValue FrameTransformContainer::clearAll()
 {
     std::lock_guard<std::recursive_mutex> lock(m_trf_mutex);
     for (size_t i = 0; i < m_transforms.size(); i++)
     {
         invalidateTransform(m_transforms[i]);
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 bool FrameTransformContainer::checkAndRemoveExpired()
@@ -180,7 +180,7 @@ bool FrameTransformContainer::checkAndRemoveExpired()
             goto check_vector;
         }
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 bool FrameTransformContainer::checkAndRemoveExpired() const

--- a/src/libYARP_dev/src/yarp/dev/FrameTransformContainer.h
+++ b/src/libYARP_dev/src/yarp/dev/FrameTransformContainer.h
@@ -14,6 +14,7 @@
 #include <yarp/dev/api.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/ReturnValue.h>
 #include <mutex>
 #include <map>
 
@@ -105,15 +106,15 @@ public:
     ~FrameTransformContainer() {}
 
     //IFrameTransformStorageSet interface
-    bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
-    bool setTransform(const yarp::math::FrameTransform& transform) override;
+    yarp::dev::ReturnValue setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) override;
+    yarp::dev::ReturnValue setTransform(const yarp::math::FrameTransform& transform) override;
 
     //IFrameTransformStorageGet interface
-    bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
+    yarp::dev::ReturnValue getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const override;
 
     //IFrameTransformStorageUtils interface
-    bool deleteTransform(std::string t1, std::string t2) override;
-    bool clearAll() override;
+    yarp::dev::ReturnValue deleteTransform(std::string t1, std::string t2) override;
+    yarp::dev::ReturnValue clearAll() override;
 
     bool size(size_t& size) const;
 

--- a/src/libYARP_dev/src/yarp/dev/IFrameTransform.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameTransform.h
@@ -14,6 +14,7 @@
 #include <yarp/sig/Matrix.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/math/Quaternion.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev {
 class IFrameTransform;
@@ -43,37 +44,39 @@ public:
     * @param all_frames the returned string containing the frames
     * @return true/false
     */
-    virtual bool allFramesAsString(std::string &all_frames) = 0;
+    virtual yarp::dev::ReturnValue allFramesAsString(std::string &all_frames) = 0;
 
     /**
     Test if a transform exists.
     * @param target_frame_id the name of target reference frame
     * @param source_frame_id the name of source reference frame
+    * @return canTransform true if the transformation exists, false otherwise
     * @return true/false
     */
-    virtual bool     canTransform (const std::string &target_frame, const std::string &source_frame)  = 0;
+    virtual yarp::dev::ReturnValue     canTransform (const std::string &target_frame, const std::string &source_frame, bool& canTransform)  = 0;
 
     /**
      Removes all the registered transforms.
     * @return true/false
     */
-    virtual bool     clear () = 0;
+    virtual yarp::dev::ReturnValue     clear () = 0;
 
     /**
     Check if a frame exists.
     * @param frame_id the frame to be searched
     * @param target_frame_id the name of target reference frame
     * @param source_frame_id the name of source reference frame
+    * @return exists true if the transformation exists, false otherwise
     * @return true/false
     */
-    virtual bool     frameExists (const std::string &frame_id) = 0;
+    virtual yarp::dev::ReturnValue     frameExists (const std::string &frame_id, bool& exists) = 0;
 
     /**
     Gets a vector containing all the registered frames.
     * @param ids the returned vector containing all frame ids
     * @return true/false
     */
-    virtual bool    getAllFrameIds (std::vector< std::string > &ids) = 0;
+    virtual yarp::dev::ReturnValue    getAllFrameIds (std::vector< std::string > &ids) = 0;
 
     /**
      Get the parent of a frame.
@@ -81,7 +84,7 @@ public:
     * @param parent_frame_id the name of parent reference frame
     * @return true/false
     */
-    virtual bool     getParent (const std::string &frame_id, std::string &parent_frame_id) = 0;
+    virtual yarp::dev::ReturnValue     getParent (const std::string &frame_id, std::string &parent_frame_id) = 0;
 
     /**
      Get the transform between two frames.
@@ -90,7 +93,7 @@ public:
     * @param transform the transformation matrix from source_frame_id to target_frame_id
     * @return true/false
     */
-    virtual bool     getTransform (const std::string &target_frame_id, const std::string &source_frame_id, yarp::sig::Matrix &transform) = 0;
+    virtual yarp::dev::ReturnValue     getTransform (const std::string &target_frame_id, const std::string &source_frame_id, yarp::sig::Matrix &transform) = 0;
 
     /**
      Register a transform between two frames.
@@ -99,7 +102,7 @@ public:
     * @param transform the transformation matrix from source_frame_id to target_frame_id
     * @return true/false
     */
-    virtual bool     setTransform (const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) = 0;
+    virtual yarp::dev::ReturnValue     setTransform (const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) = 0;
 
     /**
     Register a static transform between two frames.
@@ -108,7 +111,7 @@ public:
     * @param transform the transformation matrix from source_frame_id to target_frame_id
     * @return true/false
     */
-    virtual bool     setTransformStatic(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) = 0;
+    virtual yarp::dev::ReturnValue     setTransformStatic(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Matrix &transform) = 0;
 
     /**
      Deletes a transform between two frames.
@@ -116,7 +119,7 @@ public:
     * @param source_frame_id the name of source reference frame
     * @return true/false
     */
-    virtual bool     deleteTransform (const std::string &target_frame_id, const std::string &source_frame_id) = 0;
+    virtual yarp::dev::ReturnValue     deleteTransform (const std::string &target_frame_id, const std::string &source_frame_id) = 0;
 
     /**
     Transform a point into the target frame.
@@ -126,7 +129,7 @@ public:
     * @param transformed_point the returned point (x y z)
     * @return true/false
     */
-    virtual bool     transformPoint (const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, yarp::sig::Vector &transformed_point) = 0;
+    virtual yarp::dev::ReturnValue     transformPoint (const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_point, yarp::sig::Vector &transformed_point) = 0;
 
     /**
      Transform a Stamped Pose into the target frame.
@@ -136,7 +139,7 @@ public:
     * @param transformed_pose the returned (x y z r p y)
     * @return true/false
     */
-    virtual bool     transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, yarp::sig::Vector &transformed_pose) = 0;
+    virtual yarp::dev::ReturnValue     transformPose(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::sig::Vector &input_pose, yarp::sig::Vector &transformed_pose) = 0;
 
     /**
      Transform a quaternion into the target frame.
@@ -146,7 +149,7 @@ public:
     * @param transformed_quaternion the returned quaternion (x y z w)
     * @return true/false
     */
-    virtual bool     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) = 0;
+    virtual yarp::dev::ReturnValue     transformQuaternion(const std::string &target_frame_id, const std::string &source_frame_id, const yarp::math::Quaternion &input_quaternion, yarp::math::Quaternion &transformed_quaternion) = 0;
 
     /**
      Block until a transform from source_frame_id to target_frame_id is possible or it times out.
@@ -156,7 +159,7 @@ public:
     * @param error_msg string filled with error message (if error occurred)
     * @return true/false
     */
-    virtual bool     waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) = 0;
+    virtual yarp::dev::ReturnValue     waitForTransform(const std::string &target_frame_id, const std::string &source_frame_id, const double &timeout) = 0;
 };
 
 constexpr yarp::conf::vocab32_t VOCAB_ITRANSFORM              = yarp::os::createVocab32('i','t','r','f');

--- a/src/libYARP_dev/src/yarp/dev/IFrameTransformStorage.h
+++ b/src/libYARP_dev/src/yarp/dev/IFrameTransformStorage.h
@@ -12,6 +12,7 @@
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/math/FrameTransform.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev {
 class IFrameTransformStorageSet;
@@ -35,20 +36,20 @@ public:
     * @param transforms the list of transforms to be stored
     * @return true/false
     */
-    virtual bool setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) = 0;
+    virtual yarp::dev::ReturnValue setTransforms(const std::vector<yarp::math::FrameTransform>& transforms) = 0;
 
     /**
     * Save a frame transform in a storage.
     * @param transforms the transform to be stored
     * @return true/false
     */
-    virtual bool setTransform(const yarp::math::FrameTransform& transform) = 0;
+    virtual yarp::dev::ReturnValue setTransform(const yarp::math::FrameTransform& transform) = 0;
 
     /**
     * Delete all transforms in a storage.
     * @return true/false
     */
-    virtual bool clearAll() = 0;
+    virtual yarp::dev::ReturnValue clearAll() = 0;
 
     /**
     * Delete a single transform in the storage.
@@ -56,7 +57,7 @@ public:
     * @param dst the destination of frame transform to delete
     * @return true/false
     */
-    virtual bool deleteTransform(std::string src, std::string dst) = 0;
+    virtual yarp::dev::ReturnValue deleteTransform(std::string src, std::string dst) = 0;
 };
 
 /**
@@ -74,7 +75,7 @@ public:
     * @param transforms the returned list of frame transforms
     * @return true/false
     */
-    virtual bool getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const = 0;
+    virtual yarp::dev::ReturnValue getTransforms(std::vector<yarp::math::FrameTransform>& transforms) const = 0;
 };
 
 /**
@@ -87,13 +88,13 @@ class YARP_dev_API yarp::dev::IFrameTransformStorageUtils
 public:
     virtual ~IFrameTransformStorageUtils();
 
-    virtual bool size (size_t& size) const =0;
+    virtual yarp::dev::ReturnValue size (size_t& size) const =0;
 
-    virtual bool getInternalContainer(yarp::dev::FrameTransformContainer*& container)  =0;
+    virtual yarp::dev::ReturnValue getInternalContainer(yarp::dev::FrameTransformContainer*& container)  =0;
 
-    virtual bool startStorageThread() = 0;
+    virtual yarp::dev::ReturnValue startStorageThread() = 0;
 
-    virtual bool stopStorageThread() = 0;
+    virtual yarp::dev::ReturnValue stopStorageThread() = 0;
 };
 
 #endif // YARP_DEV_IFRAMETRANSFORM_STORAGE_H

--- a/src/libYARP_dev/src/yarp/dev/ReturnValue.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ReturnValue.cpp
@@ -89,8 +89,6 @@ std::string ReturnValue::toString()
     {
         case return_code::return_value_ok:
             return std::string("ok");
-        case return_code::return_value_uninitialized:
-            return std::string("return_value_uninitialized");
         case return_code::return_value_error_deprecated:
             return std::string("return_value_error_deprecated");
         case return_code::return_value_error_generic:
@@ -101,8 +99,11 @@ std::string ReturnValue::toString()
             return std::string("return_value_error_not_implemented_by_device");
         case return_code::return_value_error_nws_nwc_communication_error:
             return std::string("return_value_error_nws_nwc_communication_error");
+        case return_code::return_value_error_not_ready:
+            return std::string("return_value_error_not_ready");
         default:
-            return std::string("unknown");
+        case return_code::return_value_uninitialized:
+            return std::string("unknown/uninitialized");
     }
 }
 

--- a/src/libYARP_dev/src/yarp/dev/ReturnValue.h
+++ b/src/libYARP_dev/src/yarp/dev/ReturnValue.h
@@ -37,6 +37,7 @@ class YARP_dev_API ReturnValue : public yarp::os::Portable
         return_value_error_nws_nwc_communication_error = 3, /// Command answer lost during network transmission. Status unknown.
         return_value_error_deprecated = 4, /// Method is deprecated
         return_value_error_method_failed = 5, /// Method failed due to invalid internal status/invalid request
+        return_value_error_not_ready = 6, /// Method failed because some initialization is missing
         return_value_uninitialized = 100 /// Default value, should never be explicitly assigned
     };
 

--- a/src/libYARP_dev/src/yarp/dev/tests/IFrameTransformTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/IFrameTransformTest.h
@@ -167,17 +167,23 @@ namespace yarp::dev::tests
 
         //test3
         {
+            bool exists = false;
             yInfo() << "Running Sub-test3";
-            CHECK(itf->frameExists("frame3"));
-            CHECK_FALSE(itf->frameExists("frame3_err")); // frameExists ok
+            CHECK(itf->frameExists("frame3", exists));
+            CHECK(exists);
+            CHECK(itf->frameExists("frame3_err",exists)); // frameExists ok
+            CHECK(!exists);
             yInfo() << "Sub-test complete";
         }
 
         //test4
         {
+            bool canTransform = false;
             yInfo() << "Running Sub-test4";
-            CHECK(itf->canTransform("frame2", "frame1"));
-            CHECK_FALSE(itf->canTransform("frame11", "frame1")); // canTransform ok
+            CHECK(itf->canTransform("frame2", "frame1", canTransform));
+            CHECK(canTransform);
+            CHECK(itf->canTransform("frame11", "frame1", canTransform)); // canTransform ok
+            CHECK(!canTransform);
             yInfo() << "Sub-test complete";
         }
 
@@ -185,18 +191,22 @@ namespace yarp::dev::tests
         {
             yInfo() << "Running Sub-test4b";
             bool b_canb1;
-            b_canb1 = itf->canTransform("frame3b", "frame1");
+            bool canTransform = false;
+            b_canb1 = itf->canTransform("frame3b", "frame1", canTransform);
             CHECK(b_canb1); // canTransform Bis ok
+            CHECK(canTransform);
             yInfo() << "Sub-test complete";
         }
 
-        //test4 tris (transform between sibilings)
+        //test4tris (transform between siblings)
         {
             yInfo() << "Running Sub-test4c";
             yarp::sig::Matrix sib;
-            CHECK(itf->canTransform("sibiling_test_frame", "frame3")); // canTransform between sibilings ok
-            CHECK(itf->getTransform("sibiling_test_frame", "frame3", sib)); // getTransform between sibilings ok
-            CHECK(isEqual(sib, SE3inv(m2) * SE3inv(m1) * sibiling, precision)); // transform between sibilings ok
+            bool canTransform = false;
+            CHECK(itf->canTransform("sibiling_test_frame", "frame3",canTransform)); // canTransform between siblings ok
+            CHECK(canTransform);
+            CHECK(itf->getTransform("sibiling_test_frame", "frame3", sib)); // getTransform between siblings ok
+            CHECK(isEqual(sib, SE3inv(m2) * SE3inv(m1) * sibiling, precision)); // transform between siblings ok
             yInfo() << "Sub-test complete";
         }
 
@@ -290,18 +300,22 @@ namespace yarp::dev::tests
             yInfo() << "Running Sub-test8";
             itf->setTransformStatic("frame_test", "frame1", m1);
             yarp::os::Time::delay(1);
-            bool del_bool = itf->frameExists("frame_test");
+            bool exists = false;
+            bool del_bool = itf->frameExists("frame_test", exists);
             CHECK(del_bool); // frame exists
+            CHECK(exists);
             del_bool &= itf->deleteTransform("frame_test", "frame1");
             CHECK(del_bool); // deleteTransform ok
-            del_bool &= (!itf->frameExists("frame_test"));
+            del_bool &= (itf->frameExists("frame_test", exists));
             CHECK(del_bool); // check if frame has been successfully removed
+            CHECK(!exists);
 
             //let's wait some time and check gain to be sure that
             //frame does not reappears....
             yarp::os::Time::delay(0.5);
-            del_bool &= (!itf->frameExists("frame_test"));
+            del_bool = itf->frameExists("frame_test", exists);
             CHECK(del_bool);
+            CHECK(!exists);
 
             //just print
             std::string strs;
@@ -337,11 +351,14 @@ namespace yarp::dev::tests
             itf->setTransform("frame2", "frame10", m1);
             yarp::os::Time::delay(0.050);
             bool b_can;
-            b_can = itf->canTransform("frame2", "frame10");
+            bool canTransform = false;
+            b_can = itf->canTransform("frame2", "frame10",canTransform);
             CHECK(b_can); // itf->setTransform ok
+            CHECK(canTransform);
             yarp::os::Time::delay(0.6);
-            b_can = itf->canTransform("frame2", "frame10");
-            CHECK_FALSE(b_can); // itf->setTransform successfully expired after 0.6s
+            b_can = itf->canTransform("frame2", "frame10",canTransform);
+            CHECK(b_can);
+            CHECK(!canTransform); // itf->setTransform successfully expired after 0.6s
             yInfo() << "Sub-test complete";
         }
 
@@ -455,14 +472,18 @@ namespace yarp::dev::tests
             yInfo() << "Running Sub-test13";
             itf->clear();
             bool bcan = false;
-            bcan = itf->canTransform("not_existing_frame", "not_existing_frame");
+            bool canTransform = false;
+            bcan = itf->canTransform("not_existing_frame", "not_existing_frame", canTransform);
             CHECK(bcan);
+            CHECK(canTransform);
 
             CHECK(itf->setTransformStatic("frame2", "frame1", m1));
-            bcan = itf->canTransform("frame2", "frame2");
+            bcan = itf->canTransform("frame2", "frame2", canTransform);
             CHECK(bcan);
-            bcan = itf->canTransform("frame1", "frame1");
+            CHECK(canTransform);
+            bcan = itf->canTransform("frame1", "frame1", canTransform);
             CHECK(bcan);
+            CHECK(canTransform);
 
             yarp::sig::Matrix mt1;
             yarp::sig::Matrix eyemat(4, 4); eyemat.eye();
@@ -523,12 +544,18 @@ namespace yarp::dev::tests
         }
 
         // test canTransform
-        CHECK(itf->canTransform("/finger", "/arm"));
-        CHECK(!itf->canTransform("/finger", "/head"));
+        bool canTransform = false;
+        CHECK(itf->canTransform("/finger", "/arm", canTransform));
+        CHECK(canTransform);
+        CHECK(itf->canTransform("/finger", "/head", canTransform));
+        CHECK(!canTransform);
 
         // test frameExists
-        CHECK(itf->frameExists("/finger"));
-        CHECK(!itf->frameExists("/head"));
+        bool exists = false;
+        CHECK(itf->frameExists("/finger", exists));
+        CHECK(exists);
+        CHECK(itf->frameExists("/head", exists));
+        CHECK(!exists);
 
         // test getAllFrameIds
         CHECK(itf->clear());


### PR DESCRIPTION
sequel of https://github.com/robotology/yarp/pull/3167.
All frameTransform interfaces/devices have been updated to use yarp::dev::ReturnValue