### PR TITLE
New class for return values of interface methods PART4

### DIFF
--- a/src/devices/audioFromFileDevice/AudioFromFileDevice.cpp
+++ b/src/devices/audioFromFileDevice/AudioFromFileDevice.cpp
@@ -36,10 +36,10 @@ AudioFromFileDevice::~AudioFromFileDevice()
 {
 }
 
-bool AudioFromFileDevice::setHWGain(double gain)
+ReturnValue AudioFromFileDevice::setHWGain(double gain)
 {
     yCInfo(AUDIOFROMFILE) << "Not yet implemented";
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 bool AudioFromFileDevice::open(yarp::os::Searchable &config)
@@ -100,9 +100,9 @@ bool AudioFromFileDevice::close()
     return true;
 }
 
-bool AudioFromFileDevice::stopRecording()
+ReturnValue AudioFromFileDevice::stopRecording()
 {
-    bool b = AudioRecorderDeviceBase::stopRecording();
+    ReturnValue b = AudioRecorderDeviceBase::stopRecording();
     if (b && m_reset_on_stop)
     {
         m_bpnt=0;

--- a/src/devices/audioFromFileDevice/AudioFromFileDevice.h
+++ b/src/devices/audioFromFileDevice/AudioFromFileDevice.h
@@ -52,8 +52,8 @@ private:
     void run() override;
 
 public:
-    bool setHWGain(double gain) override;
-    bool stopRecording () override;
+    yarp::dev::ReturnValue setHWGain(double gain) override;
+    yarp::dev::ReturnValue stopRecording () override;
 
 private:
     yarp::sig::Sound m_audioFile;

--- a/src/devices/audioToFileDevice/AudioToFileDevice.cpp
+++ b/src/devices/audioToFileDevice/AudioToFileDevice.cpp
@@ -127,7 +127,7 @@ bool AudioToFileDevice::close()
     return true;
 }
 
-bool AudioToFileDevice::startPlayback()
+ReturnValue AudioToFileDevice::startPlayback()
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     yCDebug(AUDIOTOFILE) << "start";
@@ -136,10 +136,10 @@ bool AudioToFileDevice::startPlayback()
     {
         m_sounds.clear();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioToFileDevice::stopPlayback()
+ReturnValue AudioToFileDevice::stopPlayback()
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     yCDebug(AUDIOTOFILE) << "stop";
@@ -148,34 +148,34 @@ bool AudioToFileDevice::stopPlayback()
     {
         save_to_file();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioToFileDevice::renderSound(const yarp::sig::Sound& sound)
+ReturnValue AudioToFileDevice::renderSound(const yarp::sig::Sound& sound)
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (m_save_mode_enum == save_break_file)
     {
        m_sounds.push_back(sound);
        save_to_file();
-       return true;
+       return ReturnValue_ok;
     }
     if (m_playback_enabled)
     {
         m_sounds.push_back(sound);
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioToFileDevice::setHWGain(double gain)
+ReturnValue AudioToFileDevice::setHWGain(double gain)
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_hw_gain = gain;
-        return true;
+        return ReturnValue_ok;
     }
-    return false;
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
 bool AudioToFileDevice::configureDeviceAndStart()

--- a/src/devices/audioToFileDevice/AudioToFileDevice.h
+++ b/src/devices/audioToFileDevice/AudioToFileDevice.h
@@ -60,10 +60,10 @@ public:
     bool close() override;
 
 public:
-    virtual bool renderSound(const yarp::sig::Sound& sound) override;
-    virtual bool startPlayback() override;
-    virtual bool stopPlayback()override;
-    virtual bool setHWGain(double gain) override;
+    virtual yarp::dev::ReturnValue renderSound(const yarp::sig::Sound& sound) override;
+    virtual yarp::dev::ReturnValue startPlayback() override;
+    virtual yarp::dev::ReturnValue stopPlayback()override;
+    virtual yarp::dev::ReturnValue setHWGain(double gain) override;
     virtual bool configureDeviceAndStart() override;
     virtual bool interruptDeviceAndClose() override;
     virtual void waitUntilPlaybackStreamIsComplete() override;

--- a/src/devices/fake/fakeMicrophone/FakeMicrophone.cpp
+++ b/src/devices/fake/fakeMicrophone/FakeMicrophone.cpp
@@ -85,15 +85,15 @@ bool FakeMicrophone::close()
     return true;
 }
 
-bool FakeMicrophone::setHWGain(double gain)
+ReturnValue FakeMicrophone::setHWGain(double gain)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_hw_gain = gain;
-        return true;
+        return ReturnValue_ok;
     }
-    return false;
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
 bool FakeMicrophone::threadInit()

--- a/src/devices/fake/fakeMicrophone/FakeMicrophone.h
+++ b/src/devices/fake/fakeMicrophone/FakeMicrophone.h
@@ -42,7 +42,7 @@ public:
     virtual ~FakeMicrophone() override;
 
 public:
-    bool setHWGain(double gain) override;
+    yarp::dev::ReturnValue setHWGain(double gain) override;
 
 public: // DeviceDriver
     bool open(yarp::os::Searchable &config) override;

--- a/src/devices/fake/fakeSpeaker/FakeSpeaker.cpp
+++ b/src/devices/fake/fakeSpeaker/FakeSpeaker.cpp
@@ -99,15 +99,15 @@ void FakeSpeaker::run()
     }
 }
 
-bool FakeSpeaker::setHWGain(double gain)
+ReturnValue FakeSpeaker::setHWGain(double gain)
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_hw_gain = gain;
-        return true;
+        return ReturnValue_ok;
     }
-    return false;
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
 bool FakeSpeaker::configureDeviceAndStart()

--- a/src/devices/fake/fakeSpeaker/FakeSpeaker.h
+++ b/src/devices/fake/fakeSpeaker/FakeSpeaker.h
@@ -46,7 +46,7 @@ public:
     bool close() override;
 
     //interface
-    virtual bool setHWGain(double gain) override;
+    virtual yarp::dev::ReturnValue setHWGain(double gain) override;
     virtual bool configureDeviceAndStart() override;
     virtual bool interruptDeviceAndClose() override;
 

--- a/src/devices/messages/IAudioGrabberMsgs/IAudioGrabberMsgs.thrift
+++ b/src/devices/messages/IAudioGrabberMsgs/IAudioGrabberMsgs.thrift
@@ -5,11 +5,6 @@
 
 //-------------------------------------------------
 
-struct return_isRecording {
-  1: bool ret = false;
-  2: bool isRecording = false;
-}
-
 struct yarp_sig_AudioBufferSize {
 } (
   yarp.name = "yarp::sig::AudioBufferSize"
@@ -22,18 +17,29 @@ struct yarp_sig_Sound {
   yarp.includefile = "yarp/sig/Sound.h"
 )
 
+struct yReturnValue {
+} (
+  yarp.name = "yarp::dev::ReturnValue"
+  yarp.includefile = "yarp/dev/ReturnValue.h"
+)
+
+struct return_isRecording {
+  1: yReturnValue ret;
+  2: bool isRecording = false;
+}
+
 struct return_getSound {
-  1: bool ret = false;
+  1: yReturnValue ret;
   2: yarp_sig_Sound sound;
 }
 
 struct return_getRecordingAudioBufferCurrentSize {
-  1: bool ret = false;
+  1: yReturnValue ret;
   2: yarp_sig_AudioBufferSize bufsize;
 }
 
 struct return_getRecordingAudioBufferMaxSize {
-  1: bool ret = false;
+  1: yReturnValue ret;
   2: yarp_sig_AudioBufferSize bufsize;
 }
 
@@ -41,13 +47,13 @@ typedef i32 ( yarp.type = "size_t" ) size_t
 
 service IAudioGrabberMsgs
 {
-    bool setHWGain_RPC (1:double gain);
-    bool setSWGain_RPC (1:double gain);
-    bool resetRecordingAudioBuffer_RPC ();
-    bool startRecording_RPC ();
-    bool stopRecording_RPC ();
-    return_isRecording isRecording_RPC ();
-    return_getSound getSound_RPC (1: size_t min_number_of_samples, 2: size_t max_number_of_samples, 3: double max_samples_timeout_s);
-    return_getRecordingAudioBufferMaxSize getRecordingAudioBufferMaxSize_RPC ();
+    yReturnValue                              setHWGain_RPC (1:double gain);
+    yReturnValue                              setSWGain_RPC (1:double gain);
+    yReturnValue                              resetRecordingAudioBuffer_RPC ();
+    yReturnValue                              startRecording_RPC ();
+    yReturnValue                              stopRecording_RPC ();
+    return_isRecording                        isRecording_RPC ();
+    return_getSound                           getSound_RPC (1: size_t min_number_of_samples, 2: size_t max_number_of_samples, 3: double max_samples_timeout_s);
+    return_getRecordingAudioBufferMaxSize     getRecordingAudioBufferMaxSize_RPC ();
     return_getRecordingAudioBufferCurrentSize getRecordingAudioBufferCurrentSize_RPC ();
 }

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/IAudioGrabberMsgs.cpp
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/IAudioGrabberMsgs.cpp
@@ -60,10 +60,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double);
     void call(IAudioGrabberMsgs* ptr);
 
     Command cmd;
@@ -73,7 +73,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{3};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IAudioGrabberMsgs::setHWGain_RPC(const double gain)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IAudioGrabberMsgs::setHWGain_RPC(const double gain)"};
     static constexpr const char* s_help{""};
 };
 
@@ -123,10 +123,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double);
     void call(IAudioGrabberMsgs* ptr);
 
     Command cmd;
@@ -136,7 +136,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{3};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IAudioGrabberMsgs::setSWGain_RPC(const double gain)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IAudioGrabberMsgs::setSWGain_RPC(const double gain)"};
     static constexpr const char* s_help{""};
 };
 
@@ -181,10 +181,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(IAudioGrabberMsgs* ptr);
 
     Command cmd;
@@ -194,7 +194,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IAudioGrabberMsgs::resetRecordingAudioBuffer_RPC()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IAudioGrabberMsgs::resetRecordingAudioBuffer_RPC()"};
     static constexpr const char* s_help{""};
 };
 
@@ -239,10 +239,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(IAudioGrabberMsgs* ptr);
 
     Command cmd;
@@ -252,7 +252,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IAudioGrabberMsgs::startRecording_RPC()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IAudioGrabberMsgs::startRecording_RPC()"};
     static constexpr const char* s_help{""};
 };
 
@@ -297,10 +297,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(IAudioGrabberMsgs* ptr);
 
     Command cmd;
@@ -310,7 +310,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IAudioGrabberMsgs::stopRecording_RPC()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IAudioGrabberMsgs::stopRecording_RPC()"};
     static constexpr const char* s_help{""};
 };
 
@@ -676,10 +676,7 @@ bool IAudioGrabberMsgs_setHWGain_RPC_helper::Reply::read(yarp::os::ConnectionRea
 bool IAudioGrabberMsgs_setHWGain_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -688,14 +685,11 @@ bool IAudioGrabberMsgs_setHWGain_RPC_helper::Reply::write(const yarp::os::idl::W
 
 bool IAudioGrabberMsgs_setHWGain_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -830,10 +824,7 @@ bool IAudioGrabberMsgs_setSWGain_RPC_helper::Reply::read(yarp::os::ConnectionRea
 bool IAudioGrabberMsgs_setSWGain_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -842,14 +833,11 @@ bool IAudioGrabberMsgs_setSWGain_RPC_helper::Reply::write(const yarp::os::idl::W
 
 bool IAudioGrabberMsgs_setSWGain_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -963,10 +951,7 @@ bool IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper::Reply::read(yarp::o
 bool IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -975,14 +960,11 @@ bool IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper::Reply::write(const 
 
 bool IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1096,10 +1078,7 @@ bool IAudioGrabberMsgs_startRecording_RPC_helper::Reply::read(yarp::os::Connecti
 bool IAudioGrabberMsgs_startRecording_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1108,14 +1087,11 @@ bool IAudioGrabberMsgs_startRecording_RPC_helper::Reply::write(const yarp::os::i
 
 bool IAudioGrabberMsgs_startRecording_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1229,10 +1205,7 @@ bool IAudioGrabberMsgs_stopRecording_RPC_helper::Reply::read(yarp::os::Connectio
 bool IAudioGrabberMsgs_stopRecording_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1241,14 +1214,11 @@ bool IAudioGrabberMsgs_stopRecording_RPC_helper::Reply::write(const yarp::os::id
 
 bool IAudioGrabberMsgs_stopRecording_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1843,54 +1813,54 @@ IAudioGrabberMsgs::IAudioGrabberMsgs()
     yarp().setOwner(*this);
 }
 
-bool IAudioGrabberMsgs::setHWGain_RPC(const double gain)
+yarp::dev::ReturnValue IAudioGrabberMsgs::setHWGain_RPC(const double gain)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IAudioGrabberMsgs_setHWGain_RPC_helper::s_prototype);
     }
     IAudioGrabberMsgs_setHWGain_RPC_helper helper{gain};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IAudioGrabberMsgs::setSWGain_RPC(const double gain)
+yarp::dev::ReturnValue IAudioGrabberMsgs::setSWGain_RPC(const double gain)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IAudioGrabberMsgs_setSWGain_RPC_helper::s_prototype);
     }
     IAudioGrabberMsgs_setSWGain_RPC_helper helper{gain};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IAudioGrabberMsgs::resetRecordingAudioBuffer_RPC()
+yarp::dev::ReturnValue IAudioGrabberMsgs::resetRecordingAudioBuffer_RPC()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper::s_prototype);
     }
     IAudioGrabberMsgs_resetRecordingAudioBuffer_RPC_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IAudioGrabberMsgs::startRecording_RPC()
+yarp::dev::ReturnValue IAudioGrabberMsgs::startRecording_RPC()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IAudioGrabberMsgs_startRecording_RPC_helper::s_prototype);
     }
     IAudioGrabberMsgs_startRecording_RPC_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IAudioGrabberMsgs::stopRecording_RPC()
+yarp::dev::ReturnValue IAudioGrabberMsgs::stopRecording_RPC()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IAudioGrabberMsgs_stopRecording_RPC_helper::s_prototype);
     }
     IAudioGrabberMsgs_stopRecording_RPC_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 return_isRecording IAudioGrabberMsgs::isRecording_RPC()

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/IAudioGrabberMsgs.h
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/IAudioGrabberMsgs.h
@@ -18,6 +18,7 @@
 #include <return_getRecordingAudioBufferMaxSize.h>
 #include <return_getSound.h>
 #include <return_isRecording.h>
+#include <yarp/dev/ReturnValue.h>
 
 class IAudioGrabberMsgs :
         public yarp::os::Wire
@@ -26,15 +27,15 @@ public:
     // Constructor
     IAudioGrabberMsgs();
 
-    virtual bool setHWGain_RPC(const double gain);
+    virtual yarp::dev::ReturnValue setHWGain_RPC(const double gain);
 
-    virtual bool setSWGain_RPC(const double gain);
+    virtual yarp::dev::ReturnValue setSWGain_RPC(const double gain);
 
-    virtual bool resetRecordingAudioBuffer_RPC();
+    virtual yarp::dev::ReturnValue resetRecordingAudioBuffer_RPC();
 
-    virtual bool startRecording_RPC();
+    virtual yarp::dev::ReturnValue startRecording_RPC();
 
-    virtual bool stopRecording_RPC();
+    virtual yarp::dev::ReturnValue stopRecording_RPC();
 
     virtual return_isRecording isRecording_RPC();
 

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferCurrentSize.cpp
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferCurrentSize.cpp
@@ -11,7 +11,7 @@
 #include <return_getRecordingAudioBufferCurrentSize.h>
 
 // Constructor with field values
-return_getRecordingAudioBufferCurrentSize::return_getRecordingAudioBufferCurrentSize(const bool ret,
+return_getRecordingAudioBufferCurrentSize::return_getRecordingAudioBufferCurrentSize(const yarp::dev::ReturnValue& ret,
                                                                                      const yarp::sig::AudioBufferSize& bufsize) :
         WirePortable(),
         ret(ret),
@@ -22,7 +22,7 @@ return_getRecordingAudioBufferCurrentSize::return_getRecordingAudioBufferCurrent
 // Read structure on a Wire
 bool return_getRecordingAudioBufferCurrentSize::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!nested_read_bufsize(reader)) {
@@ -50,7 +50,7 @@ bool return_getRecordingAudioBufferCurrentSize::read(yarp::os::ConnectionReader&
 // Write structure on a Wire
 bool return_getRecordingAudioBufferCurrentSize::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!nested_write_bufsize(writer)) {
@@ -88,8 +88,13 @@ std::string return_getRecordingAudioBufferCurrentSize::toString() const
 // read ret field
 bool return_getRecordingAudioBufferCurrentSize::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getRecordingAudioBufferCurrentSize::read_ret(yarp::os::idl::WireRead
 // write ret field
 bool return_getRecordingAudioBufferCurrentSize::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getRecordingAudioBufferCurrentSize::write_ret(const yarp::os::idl::W
 // read (nested) ret field
 bool return_getRecordingAudioBufferCurrentSize::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getRecordingAudioBufferCurrentSize::nested_read_ret(yarp::os::idl::W
 // write (nested) ret field
 bool return_getRecordingAudioBufferCurrentSize::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferCurrentSize.h
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferCurrentSize.h
@@ -15,6 +15,7 @@
 #include <yarp/os/idl/WireTypes.h>
 
 #include <IAudioGrabberMsgs_common.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/sig/AudioBufferSize.h>
 
 class return_getRecordingAudioBufferCurrentSize :
@@ -22,14 +23,14 @@ class return_getRecordingAudioBufferCurrentSize :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     yarp::sig::AudioBufferSize bufsize{};
 
     // Default constructor
     return_getRecordingAudioBufferCurrentSize() = default;
 
     // Constructor with field values
-    return_getRecordingAudioBufferCurrentSize(const bool ret,
+    return_getRecordingAudioBufferCurrentSize(const yarp::dev::ReturnValue& ret,
                                               const yarp::sig::AudioBufferSize& bufsize);
 
     // Read structure on a Wire

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferMaxSize.cpp
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferMaxSize.cpp
@@ -11,7 +11,7 @@
 #include <return_getRecordingAudioBufferMaxSize.h>
 
 // Constructor with field values
-return_getRecordingAudioBufferMaxSize::return_getRecordingAudioBufferMaxSize(const bool ret,
+return_getRecordingAudioBufferMaxSize::return_getRecordingAudioBufferMaxSize(const yarp::dev::ReturnValue& ret,
                                                                              const yarp::sig::AudioBufferSize& bufsize) :
         WirePortable(),
         ret(ret),
@@ -22,7 +22,7 @@ return_getRecordingAudioBufferMaxSize::return_getRecordingAudioBufferMaxSize(con
 // Read structure on a Wire
 bool return_getRecordingAudioBufferMaxSize::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!nested_read_bufsize(reader)) {
@@ -50,7 +50,7 @@ bool return_getRecordingAudioBufferMaxSize::read(yarp::os::ConnectionReader& con
 // Write structure on a Wire
 bool return_getRecordingAudioBufferMaxSize::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!nested_write_bufsize(writer)) {
@@ -88,8 +88,13 @@ std::string return_getRecordingAudioBufferMaxSize::toString() const
 // read ret field
 bool return_getRecordingAudioBufferMaxSize::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getRecordingAudioBufferMaxSize::read_ret(yarp::os::idl::WireReader& 
 // write ret field
 bool return_getRecordingAudioBufferMaxSize::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getRecordingAudioBufferMaxSize::write_ret(const yarp::os::idl::WireW
 // read (nested) ret field
 bool return_getRecordingAudioBufferMaxSize::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getRecordingAudioBufferMaxSize::nested_read_ret(yarp::os::idl::WireR
 // write (nested) ret field
 bool return_getRecordingAudioBufferMaxSize::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferMaxSize.h
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getRecordingAudioBufferMaxSize.h
@@ -15,6 +15,7 @@
 #include <yarp/os/idl/WireTypes.h>
 
 #include <IAudioGrabberMsgs_common.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/sig/AudioBufferSize.h>
 
 class return_getRecordingAudioBufferMaxSize :
@@ -22,14 +23,14 @@ class return_getRecordingAudioBufferMaxSize :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     yarp::sig::AudioBufferSize bufsize{};
 
     // Default constructor
     return_getRecordingAudioBufferMaxSize() = default;
 
     // Constructor with field values
-    return_getRecordingAudioBufferMaxSize(const bool ret,
+    return_getRecordingAudioBufferMaxSize(const yarp::dev::ReturnValue& ret,
                                           const yarp::sig::AudioBufferSize& bufsize);
 
     // Read structure on a Wire

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getSound.cpp
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getSound.cpp
@@ -11,7 +11,7 @@
 #include <return_getSound.h>
 
 // Constructor with field values
-return_getSound::return_getSound(const bool ret,
+return_getSound::return_getSound(const yarp::dev::ReturnValue& ret,
                                  const yarp::sig::Sound& sound) :
         WirePortable(),
         ret(ret),
@@ -22,7 +22,7 @@ return_getSound::return_getSound(const bool ret,
 // Read structure on a Wire
 bool return_getSound::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!nested_read_sound(reader)) {
@@ -50,7 +50,7 @@ bool return_getSound::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getSound::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!nested_write_sound(writer)) {
@@ -88,8 +88,13 @@ std::string return_getSound::toString() const
 // read ret field
 bool return_getSound::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getSound::read_ret(yarp::os::idl::WireReader& reader)
 // write ret field
 bool return_getSound::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getSound::write_ret(const yarp::os::idl::WireWriter& writer) const
 // read (nested) ret field
 bool return_getSound::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getSound::nested_read_ret(yarp::os::idl::WireReader& reader)
 // write (nested) ret field
 bool return_getSound::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getSound.h
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_getSound.h
@@ -15,6 +15,7 @@
 #include <yarp/os/idl/WireTypes.h>
 
 #include <IAudioGrabberMsgs_common.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/sig/Sound.h>
 
 class return_getSound :
@@ -22,14 +23,14 @@ class return_getSound :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     yarp::sig::Sound sound{};
 
     // Default constructor
     return_getSound() = default;
 
     // Constructor with field values
-    return_getSound(const bool ret,
+    return_getSound(const yarp::dev::ReturnValue& ret,
                     const yarp::sig::Sound& sound);
 
     // Read structure on a Wire

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_isRecording.cpp
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_isRecording.cpp
@@ -11,7 +11,7 @@
 #include <return_isRecording.h>
 
 // Constructor with field values
-return_isRecording::return_isRecording(const bool ret,
+return_isRecording::return_isRecording(const yarp::dev::ReturnValue& ret,
                                        const bool isRecording) :
         WirePortable(),
         ret(ret),
@@ -22,7 +22,7 @@ return_isRecording::return_isRecording(const bool ret,
 // Read structure on a Wire
 bool return_isRecording::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!read_isRecording(reader)) {
@@ -50,7 +50,7 @@ bool return_isRecording::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_isRecording::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!write_isRecording(writer)) {
@@ -88,8 +88,13 @@ std::string return_isRecording::toString() const
 // read ret field
 bool return_isRecording::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_isRecording::read_ret(yarp::os::idl::WireReader& reader)
 // write ret field
 bool return_isRecording::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_isRecording::write_ret(const yarp::os::idl::WireWriter& writer) cons
 // read (nested) ret field
 bool return_isRecording::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_isRecording::nested_read_ret(yarp::os::idl::WireReader& reader)
 // write (nested) ret field
 bool return_isRecording::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_isRecording.h
+++ b/src/devices/messages/IAudioGrabberMsgs/idl_generated_code/return_isRecording.h
@@ -15,20 +15,21 @@
 #include <yarp/os/idl/WireTypes.h>
 
 #include <IAudioGrabberMsgs_common.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_isRecording :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     bool isRecording{false};
 
     // Default constructor
     return_isRecording() = default;
 
     // Constructor with field values
-    return_isRecording(const bool ret,
+    return_isRecording(const yarp::dev::ReturnValue& ret,
                        const bool isRecording);
 
     // Read structure on a Wire

--- a/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
@@ -115,89 +115,89 @@ bool AudioRecorder_nwc_yarp::close()
     return true;
 }
 
-bool AudioRecorder_nwc_yarp::setSWGain(double gain)
+ReturnValue AudioRecorder_nwc_yarp::setSWGain(double gain)
 {
-    bool b = m_audiograb_RPC.setSWGain_RPC(gain);
+    ReturnValue b = m_audiograb_RPC.setSWGain_RPC(gain);
     return b;
 }
 
-bool AudioRecorder_nwc_yarp::setHWGain(double gain)
+ReturnValue AudioRecorder_nwc_yarp::setHWGain(double gain)
 {
-    bool b = m_audiograb_RPC.setHWGain_RPC(gain);
+    ReturnValue b = m_audiograb_RPC.setHWGain_RPC(gain);
     return b;
 }
 
-bool AudioRecorder_nwc_yarp::startRecording()
+ReturnValue AudioRecorder_nwc_yarp::startRecording()
 {
-    bool b = m_audiograb_RPC.startRecording_RPC();
+    ReturnValue b = m_audiograb_RPC.startRecording_RPC();
     return b;
 }
 
-bool AudioRecorder_nwc_yarp::stopRecording()
+ReturnValue AudioRecorder_nwc_yarp::stopRecording()
 {
-    bool b = m_audiograb_RPC.stopRecording_RPC();
+    ReturnValue b = m_audiograb_RPC.stopRecording_RPC();
     return b;
 }
 
-bool AudioRecorder_nwc_yarp::resetRecordingAudioBuffer()
+ReturnValue AudioRecorder_nwc_yarp::resetRecordingAudioBuffer()
 {
-    bool b = m_audiograb_RPC.resetRecordingAudioBuffer_RPC();
+    ReturnValue b = m_audiograb_RPC.resetRecordingAudioBuffer_RPC();
     return b;
 }
 
-bool   AudioRecorder_nwc_yarp::isRecording(bool& recording_enabled)
+ReturnValue AudioRecorder_nwc_yarp::isRecording(bool& recording_enabled)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
     auto ret = m_audiograb_RPC.isRecording_RPC();
     if (!ret.ret)
     {
         yCError(AUDIORECORDER_NWC, "Unable to: isRecording()");
-        return false;
+        return ret.ret;
     }
     recording_enabled = ret.isRecording;
-    return true;
+    return ret.ret;
 }
 
-bool   AudioRecorder_nwc_yarp::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
+ReturnValue AudioRecorder_nwc_yarp::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
     auto ret = m_audiograb_RPC.getRecordingAudioBufferMaxSize_RPC();
     if (!ret.ret)
     {
         yCError(AUDIORECORDER_NWC, "Unable to: getRecordingAudioBufferMaxSize()");
-        return false;
+        return ret.ret;
     }
     size = ret.bufsize;
-    return true;
+    return ret.ret;
 }
 
-bool   AudioRecorder_nwc_yarp::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
+ReturnValue AudioRecorder_nwc_yarp::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
     auto ret = m_audiograb_RPC.getRecordingAudioBufferCurrentSize_RPC();
     if (!ret.ret)
     {
         yCError(AUDIORECORDER_NWC, "Unable to: getRecordingAudioBufferCurrentSize()");
-        return false;
+        return ret.ret;
     }
     size = ret.bufsize;
-    return true;
+    return ret.ret;
 }
 
-bool AudioRecorder_nwc_yarp::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s)
+ReturnValue AudioRecorder_nwc_yarp::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s)
 {
     if (m_useStream)
     {
         yCError(AUDIORECORDER_NWC, "Unable to: getSound() streaming version not yet implemented");
-        return false;
+        return ReturnValue::return_code::return_value_error_not_implemented_by_device;
     }
     std::lock_guard <std::mutex> lg(m_mutex);
     auto ret = m_audiograb_RPC.getSound_RPC(min_number_of_samples,max_number_of_samples, max_samples_timeout_s);
     if (!ret.ret)
     {
         yCError(AUDIORECORDER_NWC, "Unable to: getSound()");
-        return false;
+        return ret.ret;
     }
     sound = ret.sound;
-    return true;
+    return ret.ret;
 }

--- a/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.h
+++ b/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.h
@@ -63,15 +63,15 @@ public:
     bool close() override;
 
     /* IAudioGrabberSound */
-    virtual bool getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) override;
-    virtual bool startRecording() override;
-    virtual bool stopRecording() override;
-    virtual bool isRecording(bool& recording_enabled) override;
-    virtual bool getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool resetRecordingAudioBuffer() override;
-    virtual bool setSWGain(double gain) override;
-    virtual bool setHWGain(double gain) override;
+    virtual yarp::dev::ReturnValue getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) override;
+    virtual yarp::dev::ReturnValue startRecording() override;
+    virtual yarp::dev::ReturnValue stopRecording() override;
+    virtual yarp::dev::ReturnValue isRecording(bool& recording_enabled) override;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue resetRecordingAudioBuffer() override;
+    virtual yarp::dev::ReturnValue setSWGain(double gain) override;
+    virtual yarp::dev::ReturnValue setHWGain(double gain) override;
 
 };
 

--- a/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorderServerImpl.cpp
+++ b/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorderServerImpl.cpp
@@ -18,76 +18,81 @@ namespace {
 YARP_LOG_COMPONENT(AUDIOGRAB_RPC, "yarp.device.map2D_nws_yarp.IAudioGrabberRPCd")
 }
 
-#define CHECK_POINTER(xxx) {if (xxx==nullptr) {yCError(AUDIOGRAB_RPC, "Invalid interface"); return false;}}
+#define CHECK_POINTER(xxx) {if (xxx==nullptr) {yCError(AUDIOGRAB_RPC, "Invalid interface"); return ReturnValue::return_code::return_value_error_not_ready;}}
 
-bool IAudioGrabberRPCd::setHWGain_RPC(const double gain)
+ReturnValue IAudioGrabberRPCd::setHWGain_RPC(const double gain)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_igrab == nullptr) { yCError(AUDIOGRAB_RPC, "Invalid interface"); return false; }}
+    CHECK_POINTER(m_igrab)
 
-    if (!m_igrab->setHWGain(gain))
+    auto ret = m_igrab->setHWGain(gain);
+    if (!ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to setHWGain");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool IAudioGrabberRPCd::setSWGain_RPC(const double gain)
+ReturnValue IAudioGrabberRPCd::setSWGain_RPC(const double gain)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_igrab == nullptr) { yCError(AUDIOGRAB_RPC, "Invalid interface"); return false; }}
+    CHECK_POINTER(m_igrab)
 
-    if (!m_igrab->setSWGain(gain))
+    auto ret = m_igrab->setSWGain(gain);
+    if (!ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to setSWGain");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool IAudioGrabberRPCd::resetRecordingAudioBuffer_RPC()
+ReturnValue IAudioGrabberRPCd::resetRecordingAudioBuffer_RPC()
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_igrab == nullptr) { yCError(AUDIOGRAB_RPC, "Invalid interface"); return false; }}
+    CHECK_POINTER(m_igrab)
 
-    if (!m_igrab->resetRecordingAudioBuffer())
+    auto ret = m_igrab->resetRecordingAudioBuffer();
+    if (!ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to resetRecordingAudioBuffer");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool IAudioGrabberRPCd::startRecording_RPC()
+ReturnValue IAudioGrabberRPCd::startRecording_RPC()
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_igrab == nullptr) { yCError(AUDIOGRAB_RPC, "Invalid interface"); return false; }}
+    CHECK_POINTER(m_igrab)
 
-    if (!m_igrab->startRecording())
+    auto ret = m_igrab->startRecording();
+    if (!ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to startRecording");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool IAudioGrabberRPCd::stopRecording_RPC()
+ReturnValue IAudioGrabberRPCd::stopRecording_RPC()
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_igrab == nullptr) { yCError(AUDIOGRAB_RPC, "Invalid interface"); return false; }}
+    CHECK_POINTER(m_igrab)
 
-    if (!m_igrab->stopRecording())
+    auto ret = m_igrab->stopRecording();
+    if (!ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to stopRecording");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
 return_isRecording IAudioGrabberRPCd::isRecording_RPC()
@@ -98,19 +103,20 @@ return_isRecording IAudioGrabberRPCd::isRecording_RPC()
     if (m_igrab == nullptr)
     {
         yCError(AUDIOGRAB_RPC, "Invalid interface");
-        ret.ret=false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
-    bool recording_enabled;
-    if (!m_igrab->isRecording(recording_enabled))
+    bool recording_enabled=false;
+    auto rec_ret = m_igrab->isRecording(recording_enabled);
+    if (!rec_ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to evaluate isRecording");
-        ret.ret = false;
+        ret.ret = rec_ret;
         return ret;
     }
 
-    ret.ret = true;
+    ret.ret = ReturnValue_ok;
     ret.isRecording= recording_enabled;
     return ret;
 }
@@ -123,18 +129,18 @@ return_getSound IAudioGrabberRPCd::getSound_RPC(const size_t min_number_of_sampl
     if (m_igrab == nullptr)
     {
         yCError(AUDIOGRAB_RPC, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
-    if (!m_igrab->getSound(ret.sound, min_number_of_samples, max_number_of_samples, max_samples_timeout_s))
+    ret.ret = m_igrab->getSound(ret.sound, min_number_of_samples, max_number_of_samples, max_samples_timeout_s);
+    if (!ret.ret)
     {
         yCError(AUDIOGRAB_RPC, "Unable to evaluate isRecording");
-        ret.ret = false;
         return ret;
     }
 
-    ret.ret = true;
+    ret.ret = ReturnValue_ok;
     return ret;
 }
 
@@ -146,18 +152,19 @@ return_getRecordingAudioBufferMaxSize IAudioGrabberRPCd::getRecordingAudioBuffer
     if (m_igrab == nullptr)
     {
         yCError(AUDIOGRAB_RPC, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
-    if (!m_igrab->getRecordingAudioBufferMaxSize(ret.bufsize))
+    ReturnValue r2 = m_igrab->getRecordingAudioBufferMaxSize(ret.bufsize);
+    if (!r2)
     {
         yCError(AUDIOGRAB_RPC, "Unable to evaluate isRecording");
-        ret.ret = false;
+        ret.ret = r2;
         return ret;
     }
 
-    ret.ret = true;
+    ret.ret = ReturnValue_ok;
     return ret;
 }
 
@@ -169,17 +176,18 @@ return_getRecordingAudioBufferCurrentSize IAudioGrabberRPCd::getRecordingAudioBu
     if (m_igrab == nullptr)
     {
         yCError(AUDIOGRAB_RPC, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
-    if (!m_igrab->getRecordingAudioBufferCurrentSize(ret.bufsize))
+    ReturnValue r2 = m_igrab->getRecordingAudioBufferCurrentSize(ret.bufsize);
+    if (!r2)
     {
         yCError(AUDIOGRAB_RPC, "Unable to evaluate isRecording");
-        ret.ret = false;
+        ret.ret = r2;
         return ret;
     }
 
-    ret.ret = true;
+    ret.ret = ReturnValue_ok;
     return ret;
 }

--- a/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorderServerImpl.h
+++ b/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorderServerImpl.h
@@ -8,6 +8,7 @@
 
 #include "IAudioGrabberMsgs.h"
 #include <yarp/dev/IAudioGrabberSound.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/os/Stamp.h>
 
 class IAudioGrabberRPCd : public IAudioGrabberMsgs
@@ -19,11 +20,11 @@ class IAudioGrabberRPCd : public IAudioGrabberMsgs
     public:
     void setInterface(yarp::dev::IAudioGrabberSound* _iaudiograb) { m_igrab = _iaudiograb; }
 
-    virtual bool setHWGain_RPC(const double gain) override;
-    virtual bool setSWGain_RPC(const double gain) override;
-    virtual bool resetRecordingAudioBuffer_RPC() override;
-    virtual bool startRecording_RPC() override;
-    virtual bool stopRecording_RPC() override;
+    virtual yarp::dev::ReturnValue setHWGain_RPC(const double gain) override;
+    virtual yarp::dev::ReturnValue setSWGain_RPC(const double gain) override;
+    virtual yarp::dev::ReturnValue resetRecordingAudioBuffer_RPC() override;
+    virtual yarp::dev::ReturnValue startRecording_RPC() override;
+    virtual yarp::dev::ReturnValue stopRecording_RPC() override;
     virtual return_isRecording isRecording_RPC() override;
     virtual return_getSound getSound_RPC(const size_t min_number_of_samples, const size_t max_number_of_samples, const double max_samples_timeout_s) override;
     virtual return_getRecordingAudioBufferMaxSize getRecordingAudioBufferMaxSize_RPC() override;

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.cpp
@@ -299,10 +299,10 @@ bool PortAudioPlayerDeviceDriver::abortSound()
     return (m_err==paNoError);
 }
 
-bool PortAudioPlayerDeviceDriver::setHWGain(double gain)
+ReturnValue PortAudioPlayerDeviceDriver::setHWGain(double gain)
 {
     yCError(PORTAUDIOPLAYER, "Not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 void PortAudioPlayerDeviceDriver::waitUntilPlaybackStreamIsComplete()
@@ -317,20 +317,20 @@ void PortAudioPlayerDeviceDriver::waitUntilPlaybackStreamIsComplete()
     }
 }
 
-bool PortAudioPlayerDeviceDriver::startPlayback()
+ReturnValue PortAudioPlayerDeviceDriver::startPlayback()
 {
     AudioPlayerDeviceBase::startPlayback();
     m_err = Pa_StartStream(m_stream);
-    if (m_err < 0) { handleError(); return false; }
+    if (m_err < 0) { handleError(); return ReturnValue::return_code::return_value_error_method_failed; }
     yCInfo(PORTAUDIOPLAYER) << "started playback";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool PortAudioPlayerDeviceDriver::stopPlayback()
+ReturnValue PortAudioPlayerDeviceDriver::stopPlayback()
 {
     AudioPlayerDeviceBase::stopPlayback();
     m_err = Pa_StopStream(m_stream);
-    if (m_err < 0) { handleError(); return false; }
+    if (m_err < 0) { handleError(); return ReturnValue::return_code::return_value_error_method_failed; }
     yCInfo(PORTAUDIOPLAYER) << "stopped playback";
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.h
+++ b/src/devices/portaudioPlayer/PortAudioPlayerDeviceDriver.h
@@ -59,10 +59,11 @@ public: //DeviceDriver
 
 public: //AudioRecorderDeviceBase(IAudioGrabberSound)
     void waitUntilPlaybackStreamIsComplete() override;
-    bool setHWGain(double gain) override;
+    yarp::dev::ReturnValue setHWGain(double gain) override;
+    yarp::dev::ReturnValue startPlayback() override;
+    yarp::dev::ReturnValue stopPlayback() override;
+
     bool interruptDeviceAndClose() override;
-    bool startPlayback() override;
-    bool stopPlayback() override;
 
 public: //Thread
     void threadRelease() override;

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.cpp
@@ -220,28 +220,28 @@ bool PortAudioRecorderDeviceDriver::close()
     return (m_err==paNoError);
 }
 
-bool PortAudioRecorderDeviceDriver::startRecording()
+ReturnValue PortAudioRecorderDeviceDriver::startRecording()
 {
     AudioRecorderDeviceBase::startRecording();
     m_err = Pa_StartStream(m_stream );
-    if(m_err < 0 ) {handleError(); return false;}
+    if(m_err < 0 ) {handleError(); return ReturnValue::return_code::return_value_error_method_failed;}
     yCInfo(PORTAUDIORECORDER) << "started recording";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool PortAudioRecorderDeviceDriver::setHWGain(double gain)
+ReturnValue PortAudioRecorderDeviceDriver::setHWGain(double gain)
 {
     yCInfo(PORTAUDIORECORDER) << "not yet implemented recording";
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
-bool PortAudioRecorderDeviceDriver::stopRecording()
+ReturnValue PortAudioRecorderDeviceDriver::stopRecording()
 {
     AudioRecorderDeviceBase::stopRecording();
     m_err = Pa_StopStream(m_stream );
-    if(m_err < 0 ) {handleError(); return false;}
+    if(m_err < 0 ) {handleError(); return ReturnValue::return_code::return_value_error_method_failed;}
     yCInfo(PORTAUDIORECORDER) << "stopped recording";
-    return true;
+    return ReturnValue_ok;
 }
 
 void PortAudioRecorderDeviceDriver::threadRelease()

--- a/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.h
+++ b/src/devices/portaudioRecorder/PortAudioRecorderDeviceDriver.h
@@ -53,9 +53,9 @@ public: //DeviceDriver
     bool close() override;
 
 public: //AudioRecorderDeviceBase(IAudioGrabberSound)
-    bool startRecording() override;
-    bool stopRecording() override;
-    bool setHWGain(double gain) override;
+    yarp::dev::ReturnValue startRecording() override;
+    yarp::dev::ReturnValue stopRecording() override;
+    yarp::dev::ReturnValue setHWGain(double gain) override;
 
 public: //Thread
     void threadRelease() override;

--- a/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/AudioPlayerDeviceBase.h
@@ -60,14 +60,14 @@ protected:
     enum { RENDER_APPEND = 0, RENDER_IMMEDIATE = 1 } m_renderMode= RENDER_APPEND;
 
 public:
-    virtual bool renderSound(const yarp::sig::Sound& sound) override;
-    virtual bool startPlayback() override;
-    virtual bool stopPlayback() override;
-    virtual bool isPlaying(bool& playback_enabled) override;
-    virtual bool getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool resetPlaybackAudioBuffer() override;
-    virtual bool setSWGain(double gain) override;
+    virtual yarp::dev::ReturnValue renderSound(const yarp::sig::Sound& sound) override;
+    virtual yarp::dev::ReturnValue startPlayback() override;
+    virtual yarp::dev::ReturnValue stopPlayback() override;
+    virtual yarp::dev::ReturnValue isPlaying(bool& playback_enabled) override;
+    virtual yarp::dev::ReturnValue getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue resetPlaybackAudioBuffer() override;
+    virtual yarp::dev::ReturnValue setSWGain(double gain) override;
 
     virtual ~AudioPlayerDeviceBase();
 

--- a/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.cpp
@@ -26,7 +26,7 @@ YARP_LOG_COMPONENT(AUDIORECORDER_BASE, "yarp.devices.AudioRecorderDeviceBase")
 #define DEFAULT_NUM_CHANNELS    (2)
 #define DEFAULT_SAMPLE_SIZE     (2)
 
-bool AudioRecorderDeviceBase::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s)
+ReturnValue AudioRecorderDeviceBase::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s)
 {
     //check for something_to_record
     {
@@ -56,7 +56,7 @@ bool AudioRecorderDeviceBase::getSound(yarp::sig::Sound& sound, size_t min_numbe
     if (max_number_of_samples < min_number_of_samples)
     {
         yCError(AUDIORECORDER_BASE) << "max_number_of_samples must be greater than min_number_of_samples!";
-        return false;
+        return ReturnValue::return_code::return_value_error_method_failed;
     }
     if (max_number_of_samples > this->m_audiorecorder_cfg.numSamples)
     {
@@ -120,59 +120,60 @@ bool AudioRecorderDeviceBase::getSound(yarp::sig::Sound& sound, size_t min_numbe
     double ct2 = yarp::os::Time::now();
     yCDebug(AUDIORECORDER_BASE) << ct2 - ct1;
     #endif
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioRecorderDeviceBase::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
+ReturnValue AudioRecorderDeviceBase::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
 {
     if (m_inputBuffer == nullptr)
     {
         yCError(AUDIORECORDER_BASE) << "getRecordingAudioBufferMaxSize() called, but no audio buffer is allocated yet";
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
     //no lock guard is needed here
     size = this->m_inputBuffer->getMaxSize();
-    return true;
+    return ReturnValue_ok;
 }
 
 
-bool AudioRecorderDeviceBase::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
+ReturnValue AudioRecorderDeviceBase::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
 {
     if (m_inputBuffer == nullptr)
     {
         yCError(AUDIORECORDER_BASE) << "getRecordingAudioBufferCurrentSize() called, but no audio buffer is allocated yet";
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
     //no lock guard is needed here
     size = this->m_inputBuffer->size();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioRecorderDeviceBase::setSWGain(double gain)
+ReturnValue AudioRecorderDeviceBase::setSWGain(double gain)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (gain > 0)
     {
         m_sw_gain = gain;
-        return true;
+        return ReturnValue_ok;
     }
-    return false;
+    //negative gain
+    return ReturnValue::return_code::return_value_error_method_failed;
 }
 
-bool AudioRecorderDeviceBase::resetRecordingAudioBuffer()
+ReturnValue AudioRecorderDeviceBase::resetRecordingAudioBuffer()
 {
     if (m_inputBuffer == nullptr)
     {
         yCError(AUDIORECORDER_BASE) << "resetRecordingAudioBuffer() called, but no audio buffer is allocated yet";
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
     std::lock_guard<std::mutex> lock(m_mutex);
     m_inputBuffer->clear();
     yCDebug(AUDIORECORDER_BASE) << "resetRecordingAudioBuffer";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioRecorderDeviceBase::startRecording()
+ReturnValue AudioRecorderDeviceBase::startRecording()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_recording_enabled = true;
@@ -181,10 +182,10 @@ bool AudioRecorderDeviceBase::startRecording()
         this->m_inputBuffer->clear();
     }
     yCInfo(AUDIORECORDER_BASE) << "Recording started";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioRecorderDeviceBase::stopRecording()
+ReturnValue AudioRecorderDeviceBase::stopRecording()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_recording_enabled = false;
@@ -195,13 +196,13 @@ bool AudioRecorderDeviceBase::stopRecording()
         //this->m_inputBuffer->clear();
     }
     yCInfo(AUDIORECORDER_BASE) << "Recording stopped";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool AudioRecorderDeviceBase::isRecording(bool& recording_enabled)
+ReturnValue AudioRecorderDeviceBase::isRecording(bool& recording_enabled)
 {
     recording_enabled = m_recording_enabled;
-    return true;
+    return ReturnValue_ok;
 }
 
 AudioRecorderDeviceBase::~AudioRecorderDeviceBase()

--- a/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/AudioRecorderDeviceBase.h
@@ -57,14 +57,14 @@ protected:
     int16_t         m_cliptol = 3;
 
 public:
-    virtual bool getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) override;
-    virtual bool startRecording() override;
-    virtual bool stopRecording() override;
-    virtual bool isRecording(bool& recording_enabled) override;
-    virtual bool getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
-    virtual bool resetRecordingAudioBuffer() override;
-    virtual bool setSWGain(double gain) override;
+    virtual yarp::dev::ReturnValue getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) override;
+    virtual yarp::dev::ReturnValue startRecording() override;
+    virtual yarp::dev::ReturnValue stopRecording() override;
+    virtual yarp::dev::ReturnValue isRecording(bool& recording_enabled) override;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
+    virtual yarp::dev::ReturnValue resetRecordingAudioBuffer() override;
+    virtual yarp::dev::ReturnValue setSWGain(double gain) override;
 
     virtual ~AudioRecorderDeviceBase();
 

--- a/src/libYARP_dev/src/yarp/dev/IAudioGrabberSound.h
+++ b/src/libYARP_dev/src/yarp/dev/IAudioGrabberSound.h
@@ -8,6 +8,7 @@
 #define YARP_DEV_IAUDIOGRABBERSOUND_H
 
 #include <yarp/dev/api.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/sig/AudioBufferSize.h>
 #include <yarp/sig/Sound.h>
 
@@ -38,48 +39,48 @@ public:
      * @param max_samples_timeout_s. The timeout (in seconds) to retrieve max_number_of_samples.
      * @return true upon success, false for an invalid set of parameters, such as max_number_of_samples<min_number_of_samples, etc.
      */
-    virtual bool getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) = 0;
+    virtual yarp::dev::ReturnValue getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, size_t max_number_of_samples, double max_samples_timeout_s) = 0;
 
     /**
      * Start the recording.
      *
      * @return true/false upon success/failure
      */
-    virtual bool startRecording() = 0;
+    virtual yarp::dev::ReturnValue startRecording() = 0;
 
     /**
      * Stop the recording.
      *
      * @return true/false upon success/failure
      */
-    virtual bool stopRecording() = 0;
+    virtual yarp::dev::ReturnValue stopRecording() = 0;
 
     /**
      * Check if the recording has been enabled (e.g. via startRecording()/stopRecording())
      * @param recording_enabled the status of the device
      * @return true/false upon success/failure
      */
-    virtual bool isRecording(bool& recording_enabled) = 0;
+    virtual yarp::dev::ReturnValue isRecording(bool& recording_enabled) = 0;
 
-    virtual bool getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) = 0;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) = 0;
 
-    virtual bool getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) = 0;
+    virtual yarp::dev::ReturnValue getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) = 0;
 
-    virtual bool resetRecordingAudioBuffer() = 0;
+    virtual yarp::dev::ReturnValue resetRecordingAudioBuffer() = 0;
 
     /**
      * Sets a software gain for the grabbed audio
      * @param gain the audio gain (1.0 is the default value)
      * @return true/false upon success/failure
      */
-    virtual bool setSWGain(double gain) = 0;
+    virtual yarp::dev::ReturnValue setSWGain(double gain) = 0;
 
     /**
      * Sets the hardware gain of the grabbing device (if supported by the hardware)
      * @param gain the audio gain (1.0 is the default value)
      * @return true/false upon success/failure
      */
-    virtual bool setHWGain(double gain) = 0;
+    virtual yarp::dev::ReturnValue setHWGain(double gain) = 0;
 };
 
 } // namespace yarp::dev

--- a/src/libYARP_dev/src/yarp/dev/IAudioRender.h
+++ b/src/libYARP_dev/src/yarp/dev/IAudioRender.h
@@ -10,6 +10,7 @@
 #include <yarp/sig/Sound.h>
 #include <yarp/dev/api.h>
 #include <yarp/sig/AudioBufferSize.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev {
 
@@ -33,48 +34,48 @@ public:
      * @param sound the sound to be rendered
      * @return true/false upon success/failure
      */
-    virtual bool renderSound(const yarp::sig::Sound& sound) = 0;
+    virtual yarp::dev::ReturnValue renderSound(const yarp::sig::Sound& sound) = 0;
 
     /**
      * Start the playback.
      *
      * @return true/false upon success/failure
      */
-    virtual bool startPlayback() = 0;
+    virtual yarp::dev::ReturnValue startPlayback() = 0;
 
     /**
      * Stop the playback.
      *
      * @return true/false upon success/failure
      */
-    virtual bool stopPlayback() = 0;
+    virtual yarp::dev::ReturnValue stopPlayback() = 0;
 
     /**
      * Check if the playback has been enabled (e.g. via startPlayback()/stopPlayback())
      * @param playback_enabled the status of the device
      * @return true/false upon success/failure
      */
-    virtual bool isPlaying(bool& playback_enabled) = 0;
+    virtual yarp::dev::ReturnValue isPlaying(bool& playback_enabled) = 0;
 
-    virtual bool getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) = 0;
+    virtual yarp::dev::ReturnValue getPlaybackAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) = 0;
 
-    virtual bool getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) = 0;
+    virtual yarp::dev::ReturnValue getPlaybackAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) = 0;
 
-    virtual bool resetPlaybackAudioBuffer() = 0;
+    virtual yarp::dev::ReturnValue resetPlaybackAudioBuffer() = 0;
 
     /**
      * Sets a software gain for the played audio
      * @param gain the audio gain (1.0 is the default value)
      * @return true/false upon success/failure
      */
-    virtual bool setSWGain(double gain) = 0;
+    virtual yarp::dev::ReturnValue setSWGain(double gain) = 0;
 
     /**
      * Sets the hardware gain of the playback device (if supported by the hardware)
      * @param gain the audio gain (1.0 is the default value)
      * @return true/false upon success/failure
      */
-    virtual bool setHWGain(double gain) = 0;
+    virtual yarp::dev::ReturnValue setHWGain(double gain) = 0;
 };
 
 } // namespace yarp::dev


### PR DESCRIPTION
sequel of https://github.com/robot
All audio related interfaces/devices have been updated to use `yarp::dev::ReturnValue`