### PR TITLE
Bump YARP version to 3.10.100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Main project
 project(
   YARP
-  VERSION 3.10.1
+  VERSION 3.10.100
   LANGUAGES C CXX
 )
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")


### PR DESCRIPTION
To easily deal with the breaking changes introduced in https://github.com/robotology/yarp/pull/3169#issuecomment-2627626286 even before waiting for the YARP 3.11.0 release, it is convenient to bump the patch number of the YARP version. The high number (100) is done to ensure that this can't be confused for a possible patch release done in https://github.com/robotology/yarp/tree/yarp-3.10 . Note this version bump is just to simplify downstream usage of YARP master branch, it does not require (and actually it would be instead confusing) to have an actual `3.10.100` tag.