### PR TITLE
Feature: `yarpmanager` log messages time stamp

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -29,7 +29,7 @@ Fixes
 New Features
 ------------
 
-### devices 
+### devices
 
 #### multiplenalogsensorremapper
 
@@ -41,6 +41,10 @@ New Features
 #### `yarpopencvdisplay`
 
 * `yarpopencvdisplay` is now able to display a `yarp::sig::LayeredImage`
+
+#### `yarpmanager`
+  * Added time info to `libYARP_manager` logger and to `yarpmanager` GUI.
+  * The time info can be displayed as the current time (obtained from `std::chrono::system_clock::now()`) or as time elapsed since yarpmanager GUI launch
 
 ### Libraries
 
@@ -62,7 +66,7 @@ New Features
   IMap2D
   INavigation2D
   IOdometry2D
-  
+
 #### `devices`
 
 * Updated all devices which use the interfaces employing the new class `ReturnValue`:

--- a/src/guis/yarpmanager/src-manager/clusterWidget.h
+++ b/src/guis/yarpmanager/src-manager/clusterWidget.h
@@ -47,6 +47,7 @@ private:
     bool checkNameserver();
     bool checkNode(const std::string& name);
     void updateServerEntries();
+    void reportErrors();
 
 
     Ui::ClusterWidget *ui;

--- a/src/guis/yarpmanager/src-manager/main.cpp
+++ b/src/guis/yarpmanager/src-manager/main.cpp
@@ -33,6 +33,7 @@ Options:\n\
   --auto_connect        \n\
   --auto_dependency     \n\
   --add_current_dir     add the current dir to the search path\n\
+  --elapsed_time        if present the time stamp for log messages will be relative to the GUI start time\n\
 "
 
 #define DEF_CONFIG_FILE     "ymanager.ini"
@@ -204,6 +205,12 @@ int main(int argc, char *argv[])
 
     if(!config.check("auto_dependency")){
         config.put("auto_dependency", "no");
+    }
+
+    if(!config.check("elapsed_time"))
+    {
+        yarp::manager::ClockStart& clock = yarp::manager::ClockStart::getInstance();
+        clock.setStartTime("00:00:00");
     }
 
 #if defined(_WIN32)

--- a/src/guis/yarpmanager/src-manager/mainwindow.cpp
+++ b/src/guis/yarpmanager/src-manager/mainwindow.cpp
@@ -890,6 +890,8 @@ void MainWindow::onLogWarning(QString msg)
  */
 void MainWindow::onLogMessage(QString msg)
 {
+    ClockStart& clock = ClockStart::getInstance();
+    msg = QString("[time: %1] ").arg(getElapsedTimeString(clock.getStartTime()).c_str()) + msg;
     QString text = QString ("[MSG] %1").arg(msg);
     ui->logWidget->addItem(text);
     ui->logWidget->setCurrentRow(ui->logWidget->count() - 1);

--- a/src/libYARP_manager/src/yarp/manager/utility.h
+++ b/src/libYARP_manager/src/yarp/manager/utility.h
@@ -13,6 +13,8 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+#include <chrono>
+#include <iomanip>
 
 #include <yarp/manager/ymm-types.h>
 
@@ -78,8 +80,65 @@ private:
     std::vector<std::string> warnings;
 };
 
+/**
+ * Singleton class For storing execution start time
+ */
+class ClockStart {
+public:
+    static ClockStart& getInstance() {
+        static ClockStart instance;
+        return instance;
+    }
+
+    ClockStart(const ClockStart&) = delete;
+    ClockStart& operator=(const ClockStart&) = delete;
+
+    /**
+     * @brief Get the starting time as a string in HH:MM:SS format
+     * @return the starting time as a string
+     */
+    std::string getStartTime() const {
+        std::ostringstream oss;
+        oss << std::put_time(&startTimeStruct, "%H:%M:%S");
+        return oss.str();
+    }
+
+    /**
+     * @brief Set the starting time from a string in HH:MM:SS format
+     * @param startTimeStr the starting time as a string
+     */
+    void setStartTime(std::string startTimeStr) {
+        std::istringstream iss(startTimeStr);
+        std::tm tm = {};
+        if (iss >> std::get_time(&tm, "%H:%M:%S")) {
+            startTimeStruct = tm;
+        }
+    }
+
+private:
+    std::chrono::system_clock::time_point startTime;
+    std::tm startTimeStruct;
+
+    /**
+     * @brief Private constructor to initialize the start time
+     * @details The start time is initialized to the current time
+     */
+    ClockStart() {
+        startTime = std::chrono::system_clock::now();
+        std::time_t startTimeT = std::chrono::system_clock::to_time_t(startTime);
+
+#ifdef _WIN32
+        localtime_s(&startTimeStruct, &startTimeT);
+#else
+        localtime_r(&startTimeT, &startTimeStruct);
+#endif
+    }
+};
+
 
 bool compareString(const char* szFirst, const char* szSecond);
+std::string getCurrentTimeString();
+std::string getElapsedTimeString(const std::string& startTimeStr);
 void trimString(std::string& str);
 OS strToOS(const char* szOS);
 

--- a/src/yarpmanager-console/ymanager.cpp
+++ b/src/yarpmanager-console/ymanager.cpp
@@ -97,6 +97,7 @@ Options:\n\
   --silent                Do not print the status messages (should be used with --application)\n\
   --exit                  Immediately exit after executing the commands (should be used with --application)\n\
   --from <conf>           Configuration file name\n\
+  --elapsed_time          if present the time stamp for log messages will be relative to the GUI start time\n\
   --version               Show current version\n\
   --help                  Show help\n"
 
@@ -150,6 +151,13 @@ YConsoleManager::YConsoleManager(int argc, char* argv[]) : Manager()
     {
         std::cout<<VERSION_MESSAGE<<'\n';
         return;
+    }
+
+    // I the option elapsed_time is not set, set the start time to 00:00:00 (For error and warning logging)
+    if(!config.check("elapsed_time"))
+    {
+        yarp::manager::ClockStart& clock = yarp::manager::ClockStart::getInstance();
+        clock.setStartTime("00:00:00");
     }
 
     /**


### PR DESCRIPTION
  * Added time info to `libYARP_manager` logger and to `yarpmanager` GUI.
  * The time info can be displayed as the current time (obtained from `std::chrono::system_clock::now()`) or as time elapsed since yarpmanager GUI launch

This PR aims to address this particular issue: #3120
