### PR TITLE
Introduce IJointCoupling::evaluateCoupledJointsJacobian()

### DIFF
--- a/src/libYARP_dev/src/yarp/dev/IJointCoupling.h
+++ b/src/libYARP_dev/src/yarp/dev/IJointCoupling.h
@@ -9,6 +9,7 @@
 #include <yarp/dev/api.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/sig/Vector.h>
+#include <yarp/sig/Matrix.h>
 
 namespace yarp::dev {
 class IJointCoupling;
@@ -236,6 +237,17 @@ public:
      * @return true/false on success/failure
      */
     virtual bool getPhysicalJointLimits(size_t physicalJointIndex, double& min, double& max)=0;
+
+    /**
+     * @brief Get the Jacobian mapping the Actuated Axes to Physical Joints velocity
+     *
+     * @return true/false on success/failure
+     * @param[in] actAxesPos Actuated Axes position
+     * @param[out] actAxesVelToPhysJointsVelJacobian Jacobian mapping the Actuated
+     * Axes to Physical Joints velocity
+     */
+    virtual bool evaluateCoupledJointsJacobian(const yarp::sig::Vector& actAxesPos, yarp::sig::Matrix& actAxesVelToPhysJointsVelJacobian)=0;
+
 };
 
 #endif // YARP_DEV_IJOINTCOUPLING_H

--- a/src/libYARP_dev/src/yarp/dev/ImplementJointCoupling.cpp
+++ b/src/libYARP_dev/src/yarp/dev/ImplementJointCoupling.cpp
@@ -79,3 +79,8 @@ bool ImplementJointCoupling::getPhysicalJointLimits(size_t physicalJointIndex, d
     }
     return false;
 }
+
+bool ImplementJointCoupling::evaluateCoupledJointsJacobian(const yarp::sig::Vector& actAxesPos, yarp::sig::Matrix& actAxesVelToPhysJointsVelJacobian){
+    /* Override this function */
+    return false;
+}

--- a/src/libYARP_dev/src/yarp/dev/ImplementJointCoupling.h
+++ b/src/libYARP_dev/src/yarp/dev/ImplementJointCoupling.h
@@ -40,6 +40,7 @@ public:
     bool getPhysicalJointName(size_t physicalJointIndex, std::string& physicalJointName) override final;
     bool getActuatedAxisName(size_t actuatedAxisIndex, std::string& actuatedAxisName) override final;
     bool getPhysicalJointLimits(size_t physicalJointIndex, double& min, double& max) override final;
+    bool evaluateCoupledJointsJacobian(const yarp::sig::Vector& actAxesPos, yarp::sig::Matrix& actAxesVelToPhysJointsVelJacobian) override;
 protected:
     bool checkPhysicalJointIsCoupled(size_t physicalJointIndex);
 


### PR DESCRIPTION
This PR introduces `IJointCoupling::evaluateCoupledJointsJacobian()`, whose implementation should calculates the Jacobian mapping the Actuated Axes to Physical Joints velocity