### PR TITLE
IRangeFinder2D interface modified to use yarp::dev::ReturnValue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Main project
 project(
   YARP
-  VERSION 3.11.1
+  VERSION 3.11.100
   LANGUAGES C CXX
 )
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")

--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -10,3 +10,21 @@ YARP <yarp-3.11> Release Notes
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.11%22).
 
+Breaking Changes
+----------------
+
+### Library
+
+#### `libYARP_dev`
+
+* The following interfaces have been modified to use `yarp::dev::ReturnValue`:
+  - `IRangeFinder2D`
+
+### Devices
+
+* The following devices haven been modified to use `yarp::dev::ReturnValue`:
+  - `Rangefinder2DTranformer`
+  - `FakeLaser`
+  - `FakeLaserWithMotor`
+  - `Rangefinder2D_nws_yarp`
+  - `Rangefinder2D_nwc_yarp`

--- a/src/devices/Rangefinder2DTransformer/Rangefinder2DTransformer.cpp
+++ b/src/devices/Rangefinder2DTransformer/Rangefinder2DTransformer.cpp
@@ -86,32 +86,32 @@ bool Rangefinder2DTransformer::close()
     return true;
 }
 
-bool Rangefinder2DTransformer::getRawData(yarp::sig::Vector& data, double* timestamp)
+ReturnValue Rangefinder2DTransformer::getRawData(yarp::sig::Vector& data, double* timestamp)
 {
     std::vector<LaserMeasurementData> scans;
     double lastTs;
 
-    bool ret = sens_p->getLaserMeasurement(scans, &lastTs);
+    auto ret = sens_p->getLaserMeasurement(scans, &lastTs);
     if (!ret) {
-        return false;
+        return ret;
     }
 
     if (timestamp != nullptr)
     {
         *timestamp = lastTs;
     }
-    return true;
+    return ret;
 }
 
-bool Rangefinder2DTransformer::getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp)
+ReturnValue Rangefinder2DTransformer::getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp)
 {
     std::vector<LaserMeasurementData> scans;
     double lastTs;
 
-    bool ret = sens_p->getLaserMeasurement(scans,&lastTs);
+    auto ret = sens_p->getLaserMeasurement(scans,&lastTs);
     if (!ret)
     {
-        return false;
+        return ret;
     }
 
     size_t size = scans.size();
@@ -119,7 +119,7 @@ bool Rangefinder2DTransformer::getLaserMeasurement(std::vector<LaserMeasurementD
     if (m_scan_angle_max < m_scan_angle_min)
     {
         yCError(RANGEFINDER2DTRANSFORMER) << "getLaserMeasurement failed";
-        return false;
+        return ReturnValue::return_code::return_value_error_method_failed;
     }
     double laser_angle_of_view = m_scan_angle_max - m_scan_angle_min;
     for (size_t i = 0; i < size; i++)
@@ -138,55 +138,55 @@ bool Rangefinder2DTransformer::getLaserMeasurement(std::vector<LaserMeasurementD
     {
         *timestamp = lastTs;
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2DTransformer::getDistanceRange(double& min, double& max)
+ReturnValue Rangefinder2DTransformer::getDistanceRange(double& min, double& max)
 {
     return sens_p->getDistanceRange(min, max);
 }
 
-bool Rangefinder2DTransformer::setDistanceRange(double min, double max)
+ReturnValue Rangefinder2DTransformer::setDistanceRange(double min, double max)
 {
     return sens_p->setDistanceRange(min, max);
 }
 
-bool Rangefinder2DTransformer::getScanLimits(double& min, double& max)
+ReturnValue Rangefinder2DTransformer::getScanLimits(double& min, double& max)
 {
     return sens_p->getScanLimits(min, max);
 }
 
-bool Rangefinder2DTransformer::setScanLimits(double min, double max)
+ReturnValue Rangefinder2DTransformer::setScanLimits(double min, double max)
 {
     return sens_p->setScanLimits(min, max);
 }
 
-bool Rangefinder2DTransformer::getHorizontalResolution(double& step)
+ReturnValue Rangefinder2DTransformer::getHorizontalResolution(double& step)
 {
     return sens_p->getHorizontalResolution(step);
 }
 
-bool Rangefinder2DTransformer::setHorizontalResolution(double step)
+ReturnValue Rangefinder2DTransformer::setHorizontalResolution(double step)
 {
     return sens_p->setHorizontalResolution(step);
 }
 
-bool Rangefinder2DTransformer::getScanRate(double& rate)
+ReturnValue Rangefinder2DTransformer::getScanRate(double& rate)
 {
     return sens_p->getScanRate(rate);
 }
 
-bool Rangefinder2DTransformer::setScanRate(double rate)
+ReturnValue Rangefinder2DTransformer::setScanRate(double rate)
 {
     return sens_p->setScanRate(rate);
 }
 
-bool Rangefinder2DTransformer::getDeviceStatus(Device_status& status)
+ReturnValue Rangefinder2DTransformer::getDeviceStatus(Device_status& status)
 {
     return sens_p->getDeviceStatus(status);
 }
 
-bool Rangefinder2DTransformer::getDeviceInfo(std::string& device_info)
+ReturnValue Rangefinder2DTransformer::getDeviceInfo(std::string& device_info)
 {
     return sens_p->getDeviceInfo(device_info);
 }

--- a/src/devices/Rangefinder2DTransformer/Rangefinder2DTransformer.h
+++ b/src/devices/Rangefinder2DTransformer/Rangefinder2DTransformer.h
@@ -30,8 +30,8 @@ const int LASER_TIMEOUT=100; //ms
 * @ingroup dev_impl_wrapper dev_impl_network_lidar
 *
 * \brief `Rangefinder2DTransformer`: A device which acts a virtual laser, it attaches to another lidar,
-* which provides a stream a measurements, and reclocates them in the space. The new origin can be specified
-* both manually, as a 2D point in space, or though a tranform.
+* which provides a stream a measurements, and relocates them in the space. The new origin can be specified
+* both manually, as a 2D point in space, or though a transform.
 *
 * Parameters required by this device are shown in class: Rangefinder2DTransformer_ParamsParser
 *
@@ -57,18 +57,18 @@ public:
     bool close() override;
 
     /* IRangefinder2D methods */
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
-    bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
-    bool getDeviceStatus(Device_status &status) override;
-    bool getDistanceRange(double& min, double& max) override;
-    bool setDistanceRange(double min, double max) override;
-    bool getScanLimits(double& min, double& max) override;
-    bool setScanLimits(double min, double max) override;
-    bool getHorizontalResolution(double& step) override;
-    bool setHorizontalResolution(double step) override;
-    bool getScanRate(double& rate) override;
-    bool setScanRate(double rate) override;
-    bool getDeviceInfo(std::string &device_info) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getDeviceStatus(Device_status &status) override;
+    yarp::dev::ReturnValue getDistanceRange(double& min, double& max) override;
+    yarp::dev::ReturnValue setDistanceRange(double min, double max) override;
+    yarp::dev::ReturnValue getScanLimits(double& min, double& max) override;
+    yarp::dev::ReturnValue setScanLimits(double min, double max) override;
+    yarp::dev::ReturnValue getHorizontalResolution(double& step) override;
+    yarp::dev::ReturnValue setHorizontalResolution(double step) override;
+    yarp::dev::ReturnValue getScanRate(double& rate) override;
+    yarp::dev::ReturnValue setScanRate(double rate) override;
+    yarp::dev::ReturnValue getDeviceInfo(std::string &device_info) override;
 
     /* WrapperSingle  methods */
     bool attach(yarp::dev::PolyDriver* driver) override;

--- a/src/devices/fake/fakeLaser/FakeLaser.cpp
+++ b/src/devices/fake/fakeLaser/FakeLaser.cpp
@@ -211,38 +211,38 @@ bool FakeLaser::close()
     return true;
 }
 
-bool FakeLaser::setDistanceRange(double min, double max)
+ReturnValue FakeLaser::setDistanceRange(double min, double max)
 {
     m_mutex.lock();
     m_min_distance = min;
     m_max_distance = max;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaser::setScanLimits(double min, double max)
+ReturnValue FakeLaser::setScanLimits(double min, double max)
 {
     m_mutex.lock();
     m_min_angle = min;
     m_max_angle = max;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaser::setHorizontalResolution(double step)
+ReturnValue FakeLaser::setHorizontalResolution(double step)
 {
     m_mutex.lock();
     m_resolution = step;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaser::setScanRate(double rate)
+ReturnValue FakeLaser::setScanRate(double rate)
 {
     m_mutex.lock();
     m_GENERAL_period = (1.0 / rate);
     m_mutex.unlock();
-    return false;
+    return ReturnValue_ok;
 }
 
 bool FakeLaser::threadInit()

--- a/src/devices/fake/fakeLaser/FakeLaser.h
+++ b/src/devices/fake/fakeLaser/FakeLaser.h
@@ -136,10 +136,10 @@ private:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange    (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor.h
+++ b/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor.h
@@ -142,10 +142,10 @@ private:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange    (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 public:
     // internal stuff

--- a/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor_laser.cpp
+++ b/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor_laser.cpp
@@ -29,38 +29,38 @@ using namespace yarp::os;
 using namespace yarp::dev;
 using namespace yarp::dev::Nav2D;
 
-bool FakeLaserWithMotor::setDistanceRange(double min, double max)
+ReturnValue FakeLaserWithMotor::setDistanceRange(double min, double max)
 {
     m_mutex.lock();
     m_min_distance = min;
     m_max_distance = max;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaserWithMotor::setScanLimits(double min, double max)
+ReturnValue FakeLaserWithMotor::setScanLimits(double min, double max)
 {
     m_mutex.lock();
     m_min_angle = min;
     m_max_angle = max;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaserWithMotor::setHorizontalResolution(double step)
+ReturnValue FakeLaserWithMotor::setHorizontalResolution(double step)
 {
     m_mutex.lock();
     m_resolution = step;
     m_mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeLaserWithMotor::setScanRate(double rate)
+ReturnValue FakeLaserWithMotor::setScanRate(double rate)
 {
     m_mutex.lock();
     m_GENERAL_period = (1.0 / rate);
     m_mutex.unlock();
-    return false;
+    return ReturnValue_ok;
 }
 
 bool FakeLaserWithMotor::acquireDataFromHW()

--- a/src/devices/laserFromDepth/laserFromDepth.cpp
+++ b/src/devices/laserFromDepth/laserFromDepth.cpp
@@ -100,33 +100,33 @@ bool LaserFromDepth::close()
     return true;
 }
 
-bool LaserFromDepth::setDistanceRange(double min, double max)
+ReturnValue LaserFromDepth::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromDepth::setScanLimits(double min, double max)
+ReturnValue LaserFromDepth::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_DEPTH) << "setScanLimits not yet implemented";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromDepth::setHorizontalResolution(double step)
+ReturnValue LaserFromDepth::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_DEPTH) << "setHorizontalResolution not yet implemented";
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromDepth::setScanRate(double rate)
+ReturnValue LaserFromDepth::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_DEPTH) << "setScanRate not yet implemented";
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 bool LaserFromDepth::threadInit()

--- a/src/devices/laserFromDepth/laserFromDepth.h
+++ b/src/devices/laserFromDepth/laserFromDepth.h
@@ -58,10 +58,10 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange    (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
@@ -249,35 +249,35 @@ bool LaserFromExternalPort::close()
 
 
 
-bool LaserFromExternalPort::setDistanceRange(double min, double max)
+ReturnValue LaserFromExternalPort::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromExternalPort::setScanLimits(double min, double max)
+ReturnValue LaserFromExternalPort::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_EXTERNAL_PORT) << "setScanLimits not yet implemented";
-    return true;
+    return ReturnValue_ok;
 }
 
 
 
-bool LaserFromExternalPort::setHorizontalResolution(double step)
+ReturnValue LaserFromExternalPort::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_EXTERNAL_PORT, "setHorizontalResolution not yet implemented");
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromExternalPort::setScanRate(double rate)
+ReturnValue LaserFromExternalPort::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_EXTERNAL_PORT, "setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.h
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.h
@@ -123,10 +123,10 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange        (double min, double max) override;
-    bool setScanLimits           (double min, double max) override;
-    bool setHorizontalResolution (double step) override;
-    bool setScanRate             (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange        (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits           (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution (double step) override;
+    yarp::dev::ReturnValue setScanRate             (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/laserFromPointCloud/laserFromPointCloud.cpp
+++ b/src/devices/laserFromPointCloud/laserFromPointCloud.cpp
@@ -190,34 +190,34 @@ bool LaserFromPointCloud::close()
     return true;
 }
 
-bool LaserFromPointCloud::setDistanceRange(double min, double max)
+ReturnValue LaserFromPointCloud::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
 
-bool LaserFromPointCloud::setScanLimits(double min, double max)
+ReturnValue LaserFromPointCloud::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_POINTCLOUD,"setScanLimits not yet implemented");
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromPointCloud::setHorizontalResolution(double step)
+ReturnValue LaserFromPointCloud::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_POINTCLOUD,"setHorizontalResolution not yet implemented");
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LaserFromPointCloud::setScanRate(double rate)
+ReturnValue LaserFromPointCloud::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(LASER_FROM_POINTCLOUD,"setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 

--- a/src/devices/laserFromPointCloud/laserFromPointCloud.h
+++ b/src/devices/laserFromPointCloud/laserFromPointCloud.h
@@ -80,10 +80,10 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange    (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/laserHokuyo/laserHokuyo.cpp
+++ b/src/devices/laserHokuyo/laserHokuyo.cpp
@@ -280,59 +280,59 @@ bool laserHokuyo::close()
     return true;
 }
 
-bool laserHokuyo::getDistanceRange(double& min, double& max)
+ReturnValue laserHokuyo::getDistanceRange(double& min, double& max)
 {
     //should return range 0.1-30m (or 100, 30000mm depending on the measurement units)
     min = 0.1;
     max = 30;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool laserHokuyo::setDistanceRange(double min, double max)
+ReturnValue laserHokuyo::setDistanceRange(double min, double max)
 {
     yCError(LASERHOKUYO, "setDistanceRange NOT YET IMPLEMENTED");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
-bool laserHokuyo::getScanLimits(double& min, double& max)
+ReturnValue laserHokuyo::getScanLimits(double& min, double& max)
 {
     //degrees
     min = min_angle;
     max = max_angle;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool laserHokuyo::setScanLimits(double min, double max)
+ReturnValue laserHokuyo::setScanLimits(double min, double max)
 {
     yCError(LASERHOKUYO, "setScanLimits NOT YET IMPLEMENTED");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
-bool laserHokuyo::getHorizontalResolution(double& step)
+ReturnValue laserHokuyo::getHorizontalResolution(double& step)
 {
     step = 0.25; //deg //1080*0.25=270
-    return true;
+    return ReturnValue_ok;
 }
 
-bool laserHokuyo::setHorizontalResolution(double step)
+ReturnValue laserHokuyo::setHorizontalResolution(double step)
 {
     yCError(LASERHOKUYO, "setHorizontalResolution NOT YET IMPLEMENTED");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
-bool laserHokuyo::getScanRate(double& rate)
+ReturnValue laserHokuyo::getScanRate(double& rate)
 {
     rate = 20; //20 Hz = 50 ms
-    return true;
+    return ReturnValue_ok;
 }
 
-bool laserHokuyo::setScanRate(double rate)
+ReturnValue laserHokuyo::setScanRate(double rate)
 {
     yCError(LASERHOKUYO, "setScanRate NOT YET IMPLEMENTED");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
-bool laserHokuyo::getRawData(yarp::sig::Vector &out, double* timestamp)
+ReturnValue laserHokuyo::getRawData(yarp::sig::Vector &out, double* timestamp)
 {
     if (internal_status != HOKUYO_STATUS_NOT_READY)
     {
@@ -341,13 +341,13 @@ bool laserHokuyo::getRawData(yarp::sig::Vector &out, double* timestamp)
         out = laser_data;
         mutex.unlock();
         device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-        return true;
+        return ReturnValue_ok;
     }
     device_status = yarp::dev::IRangefinder2D::DEVICE_GENERAL_ERROR;
-    return false;
+    return ReturnValue::return_code::return_value_error_not_ready;
 }
 
-bool laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
+ReturnValue laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
 {
     if (internal_status != HOKUYO_STATUS_NOT_READY)
     {
@@ -359,7 +359,7 @@ bool laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data, d
         {
             yCError(LASERHOKUYO) << "getLaserMeasurement failed";
             mutex.unlock();
-            return false;
+            return ReturnValue::return_code::return_value_error_method_failed;
         }
 
         double laser_angle_of_view = max_angle - min_angle;
@@ -370,18 +370,18 @@ bool laserHokuyo::getLaserMeasurement(std::vector<LaserMeasurementData> &data, d
         }
         mutex.unlock();
         device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-        return true;
+        return ReturnValue_ok;
     }
 
     device_status = yarp::dev::IRangefinder2D::DEVICE_GENERAL_ERROR;
-    return false;
+    return ReturnValue::return_code::return_value_error_not_ready;
 }
-bool laserHokuyo::getDeviceStatus(Device_status &status)
+ReturnValue laserHokuyo::getDeviceStatus(Device_status &status)
 {
     mutex.lock();
     status = device_status;
     mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }
 
 bool laserHokuyo::threadInit()
@@ -580,10 +580,10 @@ void laserHokuyo::threadRelease()
     yCTrace(LASERHOKUYO, "... done.");
 }
 
-bool laserHokuyo::getDeviceInfo(std::string &device_info)
+ReturnValue laserHokuyo::getDeviceInfo(std::string &device_info)
 {
     this->mutex.lock();
     device_info = info;
     this->mutex.unlock();
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/laserHokuyo/laserHokuyo.h
+++ b/src/devices/laserHokuyo/laserHokuyo.h
@@ -104,18 +104,18 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector &data, double* timestamp) override;
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp) override;
-    bool getDeviceStatus     (Device_status &status) override;
-    bool getDeviceInfo       (std::string &device_info) override;
-    bool getDistanceRange    (double& min, double& max) override;
-    bool setDistanceRange    (double min, double max) override;
-    bool getScanLimits        (double& min, double& max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool getHorizontalResolution      (double& step) override;
-    bool setHorizontalResolution      (double step) override;
-    bool getScanRate         (double& rate) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp) override;
+    yarp::dev::ReturnValue getDeviceStatus     (Device_status &status) override;
+    yarp::dev::ReturnValue getDeviceInfo       (std::string &device_info) override;
+    yarp::dev::ReturnValue getDistanceRange    (double& min, double& max) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue getScanLimits        (double& min, double& max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue getHorizontalResolution      (double& step) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue getScanRate         (double& rate) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 private:
     //laser methods

--- a/src/devices/messages/IRangefinder2DMsgs/IRangefinder2DMsgs.thrift
+++ b/src/devices/messages/IRangefinder2DMsgs/IRangefinder2DMsgs.thrift
@@ -10,32 +10,38 @@ enum yarp_dev_IRangefinder2D_Device_status{
   yarp.enumbase = "yarp::conf::vocab32_t"
 )
 
+struct yReturnValue {
+} (
+  yarp.name = "yarp::dev::ReturnValue"
+  yarp.includefile = "yarp/dev/ReturnValue.h"
+)
+
 //-------------------------------------------------
 
 struct return_getDeviceStatus {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: yarp_dev_IRangefinder2D_Device_status status;
 }
 struct return_getDistanceRange {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: double min;
   3: double max;
 }
 struct return_getScanLimits {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: double min;
   3: double max;
 }
 struct return_getHorizontalResolution {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: double step;
 }
 struct return_getScanRate {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: double rate;
 }
 struct return_getDeviceInfo {
-  1: bool retval = false;
+  1: yReturnValue retval;
   2: string device_info
 }
 
@@ -49,8 +55,8 @@ service IRangefinder2DMsgs
     return_getHorizontalResolution getHorizontalResolution_RPC();
     return_getScanRate getScanRate_RPC();
     return_getDeviceInfo getDeviceInfo_RPC();
-    bool setDistanceRange_RPC(1:double min, 2:double max);
-    bool setScanLimits_RPC(1:double min, 2:double max);
-    bool setHorizontalResolution_RPC(1:double step);
-    bool setScanRate_RPC(1:double rate);
+    yReturnValue setDistanceRange_RPC(1:double min, 2:double max);
+    yReturnValue setScanLimits_RPC(1:double min, 2:double max);
+    yReturnValue setHorizontalResolution_RPC(1:double step);
+    yReturnValue setScanRate_RPC(1:double rate);
 }

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/IRangefinder2DMsgs.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/IRangefinder2DMsgs.cpp
@@ -409,10 +409,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double, const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double, const double);
     void call(IRangefinder2DMsgs* ptr);
 
     Command cmd;
@@ -422,7 +422,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{4};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IRangefinder2DMsgs::setDistanceRange_RPC(const double min, const double max)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IRangefinder2DMsgs::setDistanceRange_RPC(const double min, const double max)"};
     static constexpr const char* s_help{""};
 };
 
@@ -473,10 +473,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double, const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double, const double);
     void call(IRangefinder2DMsgs* ptr);
 
     Command cmd;
@@ -486,7 +486,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{4};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IRangefinder2DMsgs::setScanLimits_RPC(const double min, const double max)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IRangefinder2DMsgs::setScanLimits_RPC(const double min, const double max)"};
     static constexpr const char* s_help{""};
 };
 
@@ -536,10 +536,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double);
     void call(IRangefinder2DMsgs* ptr);
 
     Command cmd;
@@ -549,7 +549,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{3};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IRangefinder2DMsgs::setHorizontalResolution_RPC(const double step)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IRangefinder2DMsgs::setHorizontalResolution_RPC(const double step)"};
     static constexpr const char* s_help{""};
 };
 
@@ -599,10 +599,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const double);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const double);
     void call(IRangefinder2DMsgs* ptr);
 
     Command cmd;
@@ -612,7 +612,7 @@ public:
     static constexpr size_t s_tag_len{2};
     static constexpr size_t s_cmd_len{3};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IRangefinder2DMsgs::setScanRate_RPC(const double rate)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IRangefinder2DMsgs::setScanRate_RPC(const double rate)"};
     static constexpr const char* s_help{""};
 };
 
@@ -1549,10 +1549,7 @@ bool IRangefinder2DMsgs_setDistanceRange_RPC_helper::Reply::read(yarp::os::Conne
 bool IRangefinder2DMsgs_setDistanceRange_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1561,14 +1558,11 @@ bool IRangefinder2DMsgs_setDistanceRange_RPC_helper::Reply::write(const yarp::os
 
 bool IRangefinder2DMsgs_setDistanceRange_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1715,10 +1709,7 @@ bool IRangefinder2DMsgs_setScanLimits_RPC_helper::Reply::read(yarp::os::Connecti
 bool IRangefinder2DMsgs_setScanLimits_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1727,14 +1718,11 @@ bool IRangefinder2DMsgs_setScanLimits_RPC_helper::Reply::write(const yarp::os::i
 
 bool IRangefinder2DMsgs_setScanLimits_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1869,10 +1857,7 @@ bool IRangefinder2DMsgs_setHorizontalResolution_RPC_helper::Reply::read(yarp::os
 bool IRangefinder2DMsgs_setHorizontalResolution_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1881,14 +1866,11 @@ bool IRangefinder2DMsgs_setHorizontalResolution_RPC_helper::Reply::write(const y
 
 bool IRangefinder2DMsgs_setHorizontalResolution_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -2023,10 +2005,7 @@ bool IRangefinder2DMsgs_setScanRate_RPC_helper::Reply::read(yarp::os::Connection
 bool IRangefinder2DMsgs_setScanRate_RPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -2035,14 +2014,11 @@ bool IRangefinder2DMsgs_setScanRate_RPC_helper::Reply::write(const yarp::os::idl
 
 bool IRangefinder2DMsgs_setScanRate_RPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -2120,44 +2096,44 @@ return_getDeviceInfo IRangefinder2DMsgs::getDeviceInfo_RPC()
     return ok ? helper.reply.return_helper : return_getDeviceInfo{};
 }
 
-bool IRangefinder2DMsgs::setDistanceRange_RPC(const double min, const double max)
+yarp::dev::ReturnValue IRangefinder2DMsgs::setDistanceRange_RPC(const double min, const double max)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IRangefinder2DMsgs_setDistanceRange_RPC_helper::s_prototype);
     }
     IRangefinder2DMsgs_setDistanceRange_RPC_helper helper{min, max};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IRangefinder2DMsgs::setScanLimits_RPC(const double min, const double max)
+yarp::dev::ReturnValue IRangefinder2DMsgs::setScanLimits_RPC(const double min, const double max)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IRangefinder2DMsgs_setScanLimits_RPC_helper::s_prototype);
     }
     IRangefinder2DMsgs_setScanLimits_RPC_helper helper{min, max};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IRangefinder2DMsgs::setHorizontalResolution_RPC(const double step)
+yarp::dev::ReturnValue IRangefinder2DMsgs::setHorizontalResolution_RPC(const double step)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IRangefinder2DMsgs_setHorizontalResolution_RPC_helper::s_prototype);
     }
     IRangefinder2DMsgs_setHorizontalResolution_RPC_helper helper{step};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool IRangefinder2DMsgs::setScanRate_RPC(const double rate)
+yarp::dev::ReturnValue IRangefinder2DMsgs::setScanRate_RPC(const double rate)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IRangefinder2DMsgs_setScanRate_RPC_helper::s_prototype);
     }
     IRangefinder2DMsgs_setScanRate_RPC_helper helper{rate};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 // help method

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/IRangefinder2DMsgs.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/IRangefinder2DMsgs.h
@@ -19,6 +19,7 @@
 #include <return_getHorizontalResolution.h>
 #include <return_getScanLimits.h>
 #include <return_getScanRate.h>
+#include <yarp/dev/ReturnValue.h>
 
 class IRangefinder2DMsgs :
         public yarp::os::Wire
@@ -39,13 +40,13 @@ public:
 
     virtual return_getDeviceInfo getDeviceInfo_RPC();
 
-    virtual bool setDistanceRange_RPC(const double min, const double max);
+    virtual yarp::dev::ReturnValue setDistanceRange_RPC(const double min, const double max);
 
-    virtual bool setScanLimits_RPC(const double min, const double max);
+    virtual yarp::dev::ReturnValue setScanLimits_RPC(const double min, const double max);
 
-    virtual bool setHorizontalResolution_RPC(const double step);
+    virtual yarp::dev::ReturnValue setHorizontalResolution_RPC(const double step);
 
-    virtual bool setScanRate_RPC(const double rate);
+    virtual yarp::dev::ReturnValue setScanRate_RPC(const double rate);
 
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceInfo.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceInfo.cpp
@@ -11,7 +11,7 @@
 #include <return_getDeviceInfo.h>
 
 // Constructor with field values
-return_getDeviceInfo::return_getDeviceInfo(const bool retval,
+return_getDeviceInfo::return_getDeviceInfo(const yarp::dev::ReturnValue& retval,
                                            const std::string& device_info) :
         WirePortable(),
         retval(retval),
@@ -22,7 +22,7 @@ return_getDeviceInfo::return_getDeviceInfo(const bool retval,
 // Read structure on a Wire
 bool return_getDeviceInfo::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!read_device_info(reader)) {
@@ -50,7 +50,7 @@ bool return_getDeviceInfo::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getDeviceInfo::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!write_device_info(writer)) {
@@ -88,8 +88,13 @@ std::string return_getDeviceInfo::toString() const
 // read retval field
 bool return_getDeviceInfo::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getDeviceInfo::read_retval(yarp::os::idl::WireReader& reader)
 // write retval field
 bool return_getDeviceInfo::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getDeviceInfo::write_retval(const yarp::os::idl::WireWriter& writer)
 // read (nested) retval field
 bool return_getDeviceInfo::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getDeviceInfo::nested_read_retval(yarp::os::idl::WireReader& reader)
 // write (nested) retval field
 bool return_getDeviceInfo::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceInfo.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceInfo.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getDeviceInfo :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     std::string device_info{};
 
     // Default constructor
     return_getDeviceInfo() = default;
 
     // Constructor with field values
-    return_getDeviceInfo(const bool retval,
+    return_getDeviceInfo(const yarp::dev::ReturnValue& retval,
                          const std::string& device_info);
 
     // Read structure on a Wire

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceStatus.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceStatus.cpp
@@ -11,7 +11,7 @@
 #include <return_getDeviceStatus.h>
 
 // Constructor with field values
-return_getDeviceStatus::return_getDeviceStatus(const bool retval,
+return_getDeviceStatus::return_getDeviceStatus(const yarp::dev::ReturnValue& retval,
                                                const yarp::dev::IRangefinder2D::Device_status status) :
         WirePortable(),
         retval(retval),
@@ -22,7 +22,7 @@ return_getDeviceStatus::return_getDeviceStatus(const bool retval,
 // Read structure on a Wire
 bool return_getDeviceStatus::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!nested_read_status(reader)) {
@@ -50,7 +50,7 @@ bool return_getDeviceStatus::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getDeviceStatus::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!nested_write_status(writer)) {
@@ -88,8 +88,13 @@ std::string return_getDeviceStatus::toString() const
 // read retval field
 bool return_getDeviceStatus::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getDeviceStatus::read_retval(yarp::os::idl::WireReader& reader)
 // write retval field
 bool return_getDeviceStatus::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getDeviceStatus::write_retval(const yarp::os::idl::WireWriter& write
 // read (nested) retval field
 bool return_getDeviceStatus::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getDeviceStatus::nested_read_retval(yarp::os::idl::WireReader& reade
 // write (nested) retval field
 bool return_getDeviceStatus::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceStatus.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDeviceStatus.h
@@ -14,20 +14,21 @@
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
 #include <yarp/dev/IRangefinder2D.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getDeviceStatus :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     yarp::dev::IRangefinder2D::Device_status status{};
 
     // Default constructor
     return_getDeviceStatus() = default;
 
     // Constructor with field values
-    return_getDeviceStatus(const bool retval,
+    return_getDeviceStatus(const yarp::dev::ReturnValue& retval,
                            const yarp::dev::IRangefinder2D::Device_status status);
 
     // Read structure on a Wire

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDistanceRange.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDistanceRange.cpp
@@ -11,7 +11,7 @@
 #include <return_getDistanceRange.h>
 
 // Constructor with field values
-return_getDistanceRange::return_getDistanceRange(const bool retval,
+return_getDistanceRange::return_getDistanceRange(const yarp::dev::ReturnValue& retval,
                                                  const double min,
                                                  const double max) :
         WirePortable(),
@@ -24,7 +24,7 @@ return_getDistanceRange::return_getDistanceRange(const bool retval,
 // Read structure on a Wire
 bool return_getDistanceRange::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!read_min(reader)) {
@@ -55,7 +55,7 @@ bool return_getDistanceRange::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getDistanceRange::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!write_min(writer)) {
@@ -96,8 +96,13 @@ std::string return_getDistanceRange::toString() const
 // read retval field
 bool return_getDistanceRange::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -105,7 +110,7 @@ bool return_getDistanceRange::read_retval(yarp::os::idl::WireReader& reader)
 // write retval field
 bool return_getDistanceRange::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -114,8 +119,13 @@ bool return_getDistanceRange::write_retval(const yarp::os::idl::WireWriter& writ
 // read (nested) retval field
 bool return_getDistanceRange::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -123,7 +133,7 @@ bool return_getDistanceRange::nested_read_retval(yarp::os::idl::WireReader& read
 // write (nested) retval field
 bool return_getDistanceRange::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDistanceRange.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getDistanceRange.h
@@ -13,13 +13,14 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getDistanceRange :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     double min{0.0};
     double max{0.0};
 
@@ -27,7 +28,7 @@ public:
     return_getDistanceRange() = default;
 
     // Constructor with field values
-    return_getDistanceRange(const bool retval,
+    return_getDistanceRange(const yarp::dev::ReturnValue& retval,
                             const double min,
                             const double max);
 

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getHorizontalResolution.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getHorizontalResolution.cpp
@@ -11,7 +11,7 @@
 #include <return_getHorizontalResolution.h>
 
 // Constructor with field values
-return_getHorizontalResolution::return_getHorizontalResolution(const bool retval,
+return_getHorizontalResolution::return_getHorizontalResolution(const yarp::dev::ReturnValue& retval,
                                                                const double step) :
         WirePortable(),
         retval(retval),
@@ -22,7 +22,7 @@ return_getHorizontalResolution::return_getHorizontalResolution(const bool retval
 // Read structure on a Wire
 bool return_getHorizontalResolution::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!read_step(reader)) {
@@ -50,7 +50,7 @@ bool return_getHorizontalResolution::read(yarp::os::ConnectionReader& connection
 // Write structure on a Wire
 bool return_getHorizontalResolution::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!write_step(writer)) {
@@ -88,8 +88,13 @@ std::string return_getHorizontalResolution::toString() const
 // read retval field
 bool return_getHorizontalResolution::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getHorizontalResolution::read_retval(yarp::os::idl::WireReader& read
 // write retval field
 bool return_getHorizontalResolution::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getHorizontalResolution::write_retval(const yarp::os::idl::WireWrite
 // read (nested) retval field
 bool return_getHorizontalResolution::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getHorizontalResolution::nested_read_retval(yarp::os::idl::WireReade
 // write (nested) retval field
 bool return_getHorizontalResolution::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getHorizontalResolution.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getHorizontalResolution.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getHorizontalResolution :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     double step{0.0};
 
     // Default constructor
     return_getHorizontalResolution() = default;
 
     // Constructor with field values
-    return_getHorizontalResolution(const bool retval,
+    return_getHorizontalResolution(const yarp::dev::ReturnValue& retval,
                                    const double step);
 
     // Read structure on a Wire

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanLimits.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanLimits.cpp
@@ -11,7 +11,7 @@
 #include <return_getScanLimits.h>
 
 // Constructor with field values
-return_getScanLimits::return_getScanLimits(const bool retval,
+return_getScanLimits::return_getScanLimits(const yarp::dev::ReturnValue& retval,
                                            const double min,
                                            const double max) :
         WirePortable(),
@@ -24,7 +24,7 @@ return_getScanLimits::return_getScanLimits(const bool retval,
 // Read structure on a Wire
 bool return_getScanLimits::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!read_min(reader)) {
@@ -55,7 +55,7 @@ bool return_getScanLimits::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getScanLimits::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!write_min(writer)) {
@@ -96,8 +96,13 @@ std::string return_getScanLimits::toString() const
 // read retval field
 bool return_getScanLimits::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -105,7 +110,7 @@ bool return_getScanLimits::read_retval(yarp::os::idl::WireReader& reader)
 // write retval field
 bool return_getScanLimits::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -114,8 +119,13 @@ bool return_getScanLimits::write_retval(const yarp::os::idl::WireWriter& writer)
 // read (nested) retval field
 bool return_getScanLimits::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -123,7 +133,7 @@ bool return_getScanLimits::nested_read_retval(yarp::os::idl::WireReader& reader)
 // write (nested) retval field
 bool return_getScanLimits::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanLimits.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanLimits.h
@@ -13,13 +13,14 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getScanLimits :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     double min{0.0};
     double max{0.0};
 
@@ -27,7 +28,7 @@ public:
     return_getScanLimits() = default;
 
     // Constructor with field values
-    return_getScanLimits(const bool retval,
+    return_getScanLimits(const yarp::dev::ReturnValue& retval,
                          const double min,
                          const double max);
 

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanRate.cpp
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanRate.cpp
@@ -11,7 +11,7 @@
 #include <return_getScanRate.h>
 
 // Constructor with field values
-return_getScanRate::return_getScanRate(const bool retval,
+return_getScanRate::return_getScanRate(const yarp::dev::ReturnValue& retval,
                                        const double rate) :
         WirePortable(),
         retval(retval),
@@ -22,7 +22,7 @@ return_getScanRate::return_getScanRate(const bool retval,
 // Read structure on a Wire
 bool return_getScanRate::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_retval(reader)) {
+    if (!nested_read_retval(reader)) {
         return false;
     }
     if (!read_rate(reader)) {
@@ -50,7 +50,7 @@ bool return_getScanRate::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getScanRate::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_retval(writer)) {
+    if (!nested_write_retval(writer)) {
         return false;
     }
     if (!write_rate(writer)) {
@@ -88,8 +88,13 @@ std::string return_getScanRate::toString() const
 // read retval field
 bool return_getScanRate::read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -97,7 +102,7 @@ bool return_getScanRate::read_retval(yarp::os::idl::WireReader& reader)
 // write retval field
 bool return_getScanRate::write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.write(retval)) {
         return false;
     }
     return true;
@@ -106,8 +111,13 @@ bool return_getScanRate::write_retval(const yarp::os::idl::WireWriter& writer) c
 // read (nested) retval field
 bool return_getScanRate::nested_read_retval(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(retval)) {
-        retval = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(retval)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -115,7 +125,7 @@ bool return_getScanRate::nested_read_retval(yarp::os::idl::WireReader& reader)
 // write (nested) retval field
 bool return_getScanRate::nested_write_retval(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(retval)) {
+    if (!writer.writeNested(retval)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanRate.h
+++ b/src/devices/messages/IRangefinder2DMsgs/idl_generated_code/return_getScanRate.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getScanRate :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool retval{false};
+    yarp::dev::ReturnValue retval{};
     double rate{0.0};
 
     // Default constructor
     return_getScanRate() = default;
 
     // Constructor with field values
-    return_getScanRate(const bool retval,
+    return_getScanRate(const yarp::dev::ReturnValue& retval,
                        const double rate);
 
     // Read structure on a Wire

--- a/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
@@ -210,7 +210,7 @@ bool Rangefinder2D_nwc_yarp::close()
     return true;
 }
 
-bool Rangefinder2D_nwc_yarp::getRawData(yarp::sig::Vector &data, double* timestamp)
+ReturnValue Rangefinder2D_nwc_yarp::getRawData(yarp::sig::Vector &data, double* timestamp)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     yarp::sig::LaserScan2D scan;
@@ -222,10 +222,10 @@ bool Rangefinder2D_nwc_yarp::getRawData(yarp::sig::Vector &data, double* timesta
     {
         *timestamp = m_lastTs.getTime();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_yarp::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
+ReturnValue Rangefinder2D_nwc_yarp::getLaserMeasurement(std::vector<LaserMeasurementData> &data, double* timestamp)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     yarp::sig::LaserScan2D scan;
@@ -233,7 +233,11 @@ bool Rangefinder2D_nwc_yarp::getLaserMeasurement(std::vector<LaserMeasurementDat
 
     size_t size = scan.scans.size();
     data.resize(size);
-    if (m_scan_angle_max < m_scan_angle_min) { yCError(RANGEFINDER2DCLIENT) << "getLaserMeasurement failed"; return false; }
+    if (m_scan_angle_max < m_scan_angle_min)
+    {
+        yCError(RANGEFINDER2DCLIENT) << "getLaserMeasurement failed";
+        return ReturnValue::return_code::return_value_error_method_failed;
+    }
     double laser_angle_of_view = m_scan_angle_max - m_scan_angle_min;
     for (size_t i = 0; i < size; i++)
     {
@@ -245,118 +249,120 @@ bool Rangefinder2D_nwc_yarp::getLaserMeasurement(std::vector<LaserMeasurementDat
     {
         *timestamp = m_lastTs.getTime();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_yarp::getDistanceRange(double& min, double& max)
+ReturnValue Rangefinder2D_nwc_yarp::getDistanceRange(double& min, double& max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.getDistanceRange_RPC();
     if (!ret.retval) {
         yCError(RANGEFINDER2DCLIENT, "Unable to getDistanceRange");
-        return false;
+        return ret.retval;
     }
     min = ret.min;
     max = ret.max;
-    return true;
+    return ret.retval;
 }
 
-bool Rangefinder2D_nwc_yarp::setDistanceRange(double min, double max)
+ReturnValue Rangefinder2D_nwc_yarp::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.setDistanceRange_RPC(min, max);
-    if (!ret) {
+    if (!ret)
+    {
         yCError(RANGEFINDER2DCLIENT, "Unable to setDistanceRange");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool Rangefinder2D_nwc_yarp::getScanLimits(double& min, double& max)
+ReturnValue Rangefinder2D_nwc_yarp::getScanLimits(double& min, double& max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.getScanLimits_RPC();
     if (!ret.retval) {
         yCError(RANGEFINDER2DCLIENT, "Unable to getScanLimits");
-        return false;
+        return ret.retval;
     }
     min = ret.min;
     max = ret.max;
-    return true;
+    return ret.retval;
 }
 
-bool Rangefinder2D_nwc_yarp::setScanLimits(double min, double max)
+ReturnValue Rangefinder2D_nwc_yarp::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.setScanLimits_RPC(min,max);
     if (!ret) {
         yCError(RANGEFINDER2DCLIENT, "Unable to setScanLimits");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool Rangefinder2D_nwc_yarp::getHorizontalResolution(double& step)
+ReturnValue Rangefinder2D_nwc_yarp::getHorizontalResolution(double& step)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.getHorizontalResolution_RPC();
     if (!ret.retval) {
         yCError(RANGEFINDER2DCLIENT, "Unable to getHorizontalResolution");
-        return false;
+        return ret.retval;
     }
     step = ret.step;
-    return true;
+    return ret.retval;
 }
 
-bool Rangefinder2D_nwc_yarp::setHorizontalResolution(double step)
+ReturnValue Rangefinder2D_nwc_yarp::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.setScanRate_RPC(step);
     if (!ret) {
         yCError(RANGEFINDER2DCLIENT, "Unable to setHorizontalResolution");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool Rangefinder2D_nwc_yarp::getScanRate(double& rate)
+ReturnValue Rangefinder2D_nwc_yarp::getScanRate(double& rate)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.getScanRate_RPC();
     if (!ret.retval) {
         yCError(RANGEFINDER2DCLIENT, "Unable to getScanRate");
-        return false;
+        return ret.retval;
     }
     rate = ret.rate;
-    return true;
+    return ret.retval;
 }
 
-bool Rangefinder2D_nwc_yarp::setScanRate(double rate)
+ReturnValue Rangefinder2D_nwc_yarp::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.setScanRate_RPC(rate);
     if (!ret) {
         yCError(RANGEFINDER2DCLIENT, "Unable to setScanRate");
-        return false;
+        return ret;
     }
-    return true;
+    return ret;
 }
 
-bool Rangefinder2D_nwc_yarp::getDeviceStatus(Device_status &status)
+ReturnValue Rangefinder2D_nwc_yarp::getDeviceStatus(Device_status &status)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
     status = m_inputPort.getStatus();
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_yarp::getDeviceInfo(std::string &device_info)
+ReturnValue Rangefinder2D_nwc_yarp::getDeviceInfo(std::string &device_info)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
     auto ret = m_RPC.getDeviceInfo_RPC();
-    if (!ret.retval) {
+    if (!ret.retval)
+    {
         yCError(RANGEFINDER2DCLIENT, "Unable to getDeviceInfo");
-        return false;
+        return ret.retval;
     }
     device_info = ret.device_info;
-    return true;
+    return ret.retval;
 }

--- a/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.h
+++ b/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.h
@@ -91,18 +91,18 @@ public:
     bool close() override;
 
     /* IRangefinder2D methods */
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
-    bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
-    bool getDeviceStatus(Device_status &status) override;
-    bool getDistanceRange(double& min, double& max) override;
-    bool setDistanceRange(double min, double max) override;
-    bool getScanLimits(double& min, double& max) override;
-    bool setScanLimits(double min, double max) override;
-    bool getHorizontalResolution(double& step) override;
-    bool setHorizontalResolution(double step) override;
-    bool getScanRate(double& rate) override;
-    bool setScanRate(double rate) override;
-    bool getDeviceInfo(std::string &device_info) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getDeviceStatus(Device_status &status) override;
+    yarp::dev::ReturnValue getDistanceRange(double& min, double& max) override;
+    yarp::dev::ReturnValue setDistanceRange(double min, double max) override;
+    yarp::dev::ReturnValue getScanLimits(double& min, double& max) override;
+    yarp::dev::ReturnValue setScanLimits(double min, double max) override;
+    yarp::dev::ReturnValue getHorizontalResolution(double& step) override;
+    yarp::dev::ReturnValue setHorizontalResolution(double step) override;
+    yarp::dev::ReturnValue getScanRate(double& rate) override;
+    yarp::dev::ReturnValue setScanRate(double rate) override;
+    yarp::dev::ReturnValue getDeviceInfo(std::string &device_info) override;
 };
 
 #endif // YARP_DEV_RANGEFINDER2D_NWC_YARP_H

--- a/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2DServerImpl.cpp
+++ b/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2DServerImpl.cpp
@@ -20,72 +20,82 @@ YARP_LOG_COMPONENT(RANGEFINDER2D_RPC, "yarp.device.rangefinder2D_nws_yarp.IRange
 
 
 
-bool IRangefinder2DRPCd::setScanRate_RPC(const double rate)
+ReturnValue IRangefinder2DRPCd::setScanRate_RPC(const double rate)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
 
-    {if (m_irf == nullptr) { yCError(RANGEFINDER2D_RPC, "Invalid interface"); return false; }}
+    if (m_irf == nullptr)
+    {
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        return ReturnValue::return_code::return_value_error_not_ready;
+    }
 
-    if (!m_irf->setScanRate(rate))
+    auto rr = m_irf->setScanRate(rate);
+    if (!rr)
     {
         yCError(RANGEFINDER2D_RPC, "Unable to setScanRate");
-        return false;
+        return rr;
     }
-    return true;
+    return rr;
 }
 
-bool IRangefinder2DRPCd::setHorizontalResolution_RPC(const double resolution)
+ReturnValue IRangefinder2DRPCd::setHorizontalResolution_RPC(const double resolution)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
 
     {
         if (m_irf == nullptr) {
             yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return false;
+            return ReturnValue::return_code::return_value_error_not_ready;
         }
     }
 
-    if (!m_irf->setHorizontalResolution(resolution)) {
+    auto rr = m_irf->setHorizontalResolution(resolution);
+    if (!rr) {
         yCError(RANGEFINDER2D_RPC, "Unable to setHorizontalResolution");
-        return false;
+        return rr;
     }
-    return true;
+    return rr;
 }
 
-bool IRangefinder2DRPCd::setScanLimits_RPC(const double min, const double max)
+ReturnValue IRangefinder2DRPCd::setScanLimits_RPC(const double min, const double max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
 
     {
         if (m_irf == nullptr) {
             yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return false;
+            return ReturnValue::return_code::return_value_error_not_ready;
         }
     }
 
-    if (!m_irf->setScanLimits(min, max)) {
+    auto rr = m_irf->setScanLimits(min, max);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to setScanLimits");
-        return false;
+        return rr;
     }
-    return true;
+    return rr;
 }
 
-bool IRangefinder2DRPCd::setDistanceRange_RPC(const double min, const double max)
+ReturnValue IRangefinder2DRPCd::setDistanceRange_RPC(const double min, const double max)
 {
     std::lock_guard<std::mutex> lg(m_mutex);
 
     {
         if (m_irf == nullptr) {
             yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return false;
+            return ReturnValue::return_code::return_value_error_not_ready;
         }
     }
 
-    if (!m_irf->setDistanceRange(min, max)) {
+    auto rr = m_irf->setDistanceRange(min, max);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to setDistanceRange");
-        return false;
+        return rr;
     }
-    return true;
+    return rr;
 }
 
 return_getDeviceStatus IRangefinder2DRPCd::getDeviceStatus_RPC()
@@ -93,16 +103,23 @@ return_getDeviceStatus IRangefinder2DRPCd::getDeviceStatus_RPC()
     std::lock_guard <std::mutex> lg(m_mutex);
 
     return_getDeviceStatus ret;
-    {if (m_irf == nullptr) { yCError(RANGEFINDER2D_RPC, "Invalid interface"); return ret; }}
+    if (m_irf == nullptr)
+    {
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
+    }
+
     yarp::dev::IRangefinder2D::Device_status status;
-    if (!m_irf->getDeviceStatus(status))
+    auto rr = m_irf->getDeviceStatus(status);
+    if (!rr)
     {
         yCError(RANGEFINDER2D_RPC, "Unable to getDeviceStatus_RPC");
-        ret.retval = false;
+        ret.retval = rr;
     }
     else
     {
-        ret.retval = true;
+        ret.retval = rr;
         ret.status = status;
     }
     return ret;
@@ -113,18 +130,23 @@ return_getDistanceRange IRangefinder2DRPCd::getDistanceRange_RPC()
     std::lock_guard<std::mutex> lg(m_mutex);
 
     return_getDistanceRange ret;
+    if (m_irf == nullptr)
     {
-        if (m_irf == nullptr) {
-            yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return ret;
-        }
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
     }
+
     double min, max;
-    if (!m_irf->getDistanceRange(min, max)) {
+    auto rr = m_irf->getDistanceRange(min, max);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to getDistanceRange_RPC");
-        ret.retval = false;
-    } else {
-        ret.retval = true;
+        ret.retval = rr;
+    }
+    else
+    {
+        ret.retval = rr;
         ret.min = min;
         ret.max = max;
     }
@@ -136,18 +158,23 @@ return_getScanLimits IRangefinder2DRPCd::getScanLimits_RPC()
     std::lock_guard<std::mutex> lg(m_mutex);
 
     return_getScanLimits ret;
+    if (m_irf == nullptr)
     {
-        if (m_irf == nullptr) {
-            yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return ret;
-        }
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
     }
+
     double min, max;
-    if (!m_irf->getScanLimits(min, max)) {
+    auto rr = m_irf->getScanLimits(min, max);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to getScanLimits_RPC");
-        ret.retval = false;
-    } else {
-        ret.retval = true;
+        ret.retval = rr;
+    }
+    else
+    {
+        ret.retval = rr;
         ret.min = min;
         ret.max = max;
     }
@@ -159,18 +186,23 @@ return_getHorizontalResolution IRangefinder2DRPCd::getHorizontalResolution_RPC()
     std::lock_guard<std::mutex> lg(m_mutex);
 
     return_getHorizontalResolution ret;
+    if (m_irf == nullptr)
     {
-        if (m_irf == nullptr) {
-            yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return ret;
-        }
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
     }
+
     double step;
-    if (!m_irf->getHorizontalResolution(step)) {
+    auto rr = m_irf->getHorizontalResolution(step);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to getHorizontalResolution_RPC");
-        ret.retval = false;
-    } else {
-        ret.retval = true;
+        ret.retval = rr;
+    }
+    else
+    {
+        ret.retval = rr;
         ret.step = step;
     }
     return ret;
@@ -181,18 +213,23 @@ return_getScanRate IRangefinder2DRPCd::getScanRate_RPC()
     std::lock_guard<std::mutex> lg(m_mutex);
 
     return_getScanRate ret;
+    if (m_irf == nullptr)
     {
-        if (m_irf == nullptr) {
-            yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return ret;
-        }
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
     }
+
     double rate;
-    if (!m_irf->getScanRate(rate)) {
+    auto rr = m_irf->getScanRate(rate);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to getScanRate_RPC");
-        ret.retval = false;
-    } else {
-        ret.retval = true;
+        ret.retval = rr;
+    }
+    else
+    {
+        ret.retval = rr;
         ret.rate = rate;
     }
     return ret;
@@ -203,18 +240,23 @@ return_getDeviceInfo IRangefinder2DRPCd::getDeviceInfo_RPC()
     std::lock_guard<std::mutex> lg(m_mutex);
 
     return_getDeviceInfo ret;
+    if (m_irf == nullptr)
     {
-        if (m_irf == nullptr) {
-            yCError(RANGEFINDER2D_RPC, "Invalid interface");
-            return ret;
-        }
+        yCError(RANGEFINDER2D_RPC, "Invalid interface");
+        ret.retval = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
     }
+
     std::string info;
-    if (!m_irf->getDeviceInfo(info)) {
+    auto rr = m_irf->getDeviceInfo(info);
+    if (!rr)
+    {
         yCError(RANGEFINDER2D_RPC, "Unable to getDeviceInfo_RPC");
-        ret.retval = false;
-    } else {
-        ret.retval = true;
+        ret.retval = rr;
+    }
+    else
+    {
+        ret.retval = rr;
         ret.device_info = info;
     }
     return ret;

--- a/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2DServerImpl.h
+++ b/src/devices/networkWrappers/Rangefinder2D_nws_yarp/Rangefinder2DServerImpl.h
@@ -26,10 +26,10 @@ class IRangefinder2DRPCd : public IRangefinder2DMsgs
     return_getHorizontalResolution getHorizontalResolution_RPC() override;
     return_getScanRate getScanRate_RPC() override;
     return_getDeviceInfo getDeviceInfo_RPC() override;
-    bool setDistanceRange_RPC(const double min, const double max) override;
-    bool setScanLimits_RPC(const double min, const double max) override;
-    bool setHorizontalResolution_RPC(const double step) override;
-    bool setScanRate_RPC(const double rate) override;
+    yarp::dev::ReturnValue setDistanceRange_RPC(const double min, const double max) override;
+    yarp::dev::ReturnValue setScanLimits_RPC(const double min, const double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution_RPC(const double step) override;
+    yarp::dev::ReturnValue setScanRate_RPC(const double rate) override;
 
     std::mutex* getMutex() {return &m_mutex;}
 };

--- a/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
+++ b/src/libYARP_dev/src/yarp/dev/IRangefinder2D.h
@@ -8,6 +8,7 @@
 
 #include <yarp/os/Vocab.h>
 #include <yarp/dev/api.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/LaserMeasurementData.h>
 #include <vector>
@@ -48,7 +49,7 @@ public:
     * @param timestamp the timestamp of the retrieved data.
     * @return true/false
     */
-    virtual bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) = 0;
+    virtual ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) = 0;
 
     /**
     * Get the device measurements
@@ -56,14 +57,14 @@ public:
     * @param timestamp the timestamp of the retrieved data.
     * @return true/false.
     */
-    virtual bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) = 0;
+    virtual ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) = 0;
 
     /**
     * get the device status
     * @param status the device status
     * @return true/false.
     */
-    virtual bool getDeviceStatus(Device_status& status) = 0;
+    virtual ReturnValue getDeviceStatus(Device_status& status) = 0;
 
     /**
     * get the device detection range
@@ -71,7 +72,7 @@ public:
     * @param max the maximum detection distance
     * @return true/false.
     */
-    virtual bool getDistanceRange(double& min, double& max) = 0;
+    virtual ReturnValue getDistanceRange(double& min, double& max) = 0;
 
     /**
     * set the device detection range. Invalid setting will be discarded.
@@ -79,7 +80,7 @@ public:
     * @param max the maximum detection distance
     * @return true/false on success/failure.
     */
-    virtual bool setDistanceRange(double min, double max) = 0;
+    virtual ReturnValue setDistanceRange(double min, double max) = 0;
 
     /**
     * get the scan angular range.
@@ -87,7 +88,7 @@ public:
     * @param max end angle of the scan
     * @return true/false.
     */
-    virtual bool getScanLimits(double& min, double& max) = 0;
+    virtual ReturnValue getScanLimits(double& min, double& max) = 0;
 
     /**
     * set the scan angular range.
@@ -95,42 +96,42 @@ public:
     * @param max end angle of the scan
     * @return true/false on success/failure.
     */
-    virtual bool setScanLimits(double min, double max) = 0;
+    virtual ReturnValue setScanLimits(double min, double max) = 0;
 
     /**
     * get the angular step between two measurements.
     * @param step the angular step between two measurements
     * @return true/false.
     */
-    virtual bool getHorizontalResolution(double& step) = 0;
+    virtual ReturnValue getHorizontalResolution(double& step) = 0;
 
     /**
     * get the angular step between two measurements (if available)
     * @param step the angular step between two measurements
     * @return true/false on success/failure.
     */
-    virtual bool setHorizontalResolution(double step) = 0;
+    virtual ReturnValue setHorizontalResolution(double step) = 0;
 
     /**
     * get the scan rate (scans per seconds)
     * @param rate the scan rate
     * @return true/false.
     */
-    virtual bool getScanRate(double& rate) = 0;
+    virtual ReturnValue getScanRate(double& rate) = 0;
 
     /**
     * set the scan rate (scans per seconds)
     * @param rate the scan rate
     * @return true/false on success/failure.
     */
-    virtual bool setScanRate(double rate) = 0;
+    virtual ReturnValue setScanRate(double rate) = 0;
 
     /**
     * get the device hardware characteristics
     * @param device_info string containing the device infos
     * @return true/false.
     */
-    virtual bool getDeviceInfo(std::string &device_info) = 0;
+    virtual ReturnValue getDeviceInfo(std::string &device_info) = 0;
 };
 
 #endif // YARP_DEV_IRANGEFINDER2D_H

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.cpp
@@ -21,37 +21,37 @@ using namespace yarp::sig;
 
 YARP_LOG_COMPONENT(LASER_BASE, "yarp.devices.Lidar2DDeviceBase")
 
-bool Lidar2DDeviceBase::getScanLimits(double& min, double& max)
+ReturnValue Lidar2DDeviceBase::getScanLimits(double& min, double& max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     min = m_min_angle;
     max = m_max_angle;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getDistanceRange(double& min, double& max)
+ReturnValue Lidar2DDeviceBase::getDistanceRange(double& min, double& max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     min = m_min_distance;
     max = m_max_distance;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getHorizontalResolution(double& step)
+ReturnValue Lidar2DDeviceBase::getHorizontalResolution(double& step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     step = m_resolution;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getDeviceStatus(Device_status& status)
+ReturnValue Lidar2DDeviceBase::getDeviceStatus(Device_status& status)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     status = m_device_status;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out, double* timestamp)
+ReturnValue Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     out = m_laser_data;
@@ -59,24 +59,24 @@ bool Lidar2DDeviceBase::getRawData(yarp::sig::Vector& out, double* timestamp)
     {
         *timestamp = m_timestamp.getTime();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getScanRate(double& rate)
+ReturnValue Lidar2DDeviceBase::getScanRate(double& rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     rate = m_scan_rate;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getDeviceInfo(std::string& device_info)
+ReturnValue Lidar2DDeviceBase::getDeviceInfo(std::string& device_info)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     device_info = m_info;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp)
+ReturnValue Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& data, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 #ifdef LASER_DEBUG
@@ -84,7 +84,11 @@ bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& d
 #endif
     size_t size = m_laser_data.size();
     data.resize(size);
-    if (m_max_angle < m_min_angle) { yCError(LASER_BASE) << "getLaserMeasurement failed"; return false; }
+    if (m_max_angle < m_min_angle)
+    {
+        yCError(LASER_BASE) << "getLaserMeasurement failed";
+        return ReturnValue::return_code::return_value_error_method_failed;
+    }
     double laser_angle_of_view = m_max_angle - m_min_angle;
     for (size_t i = 0; i < size; i++)
     {
@@ -95,7 +99,7 @@ bool Lidar2DDeviceBase::getLaserMeasurement(std::vector<LaserMeasurementData>& d
     {
         *timestamp = m_timestamp.getTime();
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 Lidar2DDeviceBase::Lidar2DDeviceBase() :

--- a/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
+++ b/src/libYARP_dev/src/yarp/dev/Lidar2DDeviceBase.h
@@ -90,14 +90,14 @@ protected:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector& data, double* timestamp = nullptr) override;
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData>& data, double* timestamp = nullptr) override;
-    bool getDeviceStatus(Device_status& status) override;
-    bool getDeviceInfo(std::string& device_info) override;
-    bool getDistanceRange(double& min, double& max) override;
-    bool getScanLimits(double& min, double& max) override;
-    bool getHorizontalResolution(double& step) override;
-    bool getScanRate(double& rate) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector& data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData>& data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getDeviceStatus(Device_status& status) override;
+    yarp::dev::ReturnValue getDeviceInfo(std::string& device_info) override;
+    yarp::dev::ReturnValue getDistanceRange(double& min, double& max) override;
+    yarp::dev::ReturnValue getScanLimits(double& min, double& max) override;
+    yarp::dev::ReturnValue getHorizontalResolution(double& step) override;
+    yarp::dev::ReturnValue getScanRate(double& rate) override;
 
 private:
     //utility methods called internally by Lidar2DDeviceBase


### PR DESCRIPTION
Involved devices:
  - `Rangefinder2DTranformer`
  - `FakeLaser`
  - `FakeLaserWithMotor`
  - `Rangefinder2D_nws_yarp`
  - `Rangefinder2D_nwc_yarp`