### PR TITLE
 Restore compatibility with C++17 in public headers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Main project
 project(
   YARP
-  VERSION 3.11.0
+  VERSION 3.11.1
   LANGUAGES C CXX
 )
 set(PROJECT_DESCRIPTION "YARP: A thin middleware for humanoid robots and more")

--- a/doc/release/yarp_3_11/000_yarp_3_11.md
+++ b/doc/release/yarp_3_11/000_yarp_3_11.md
@@ -10,3 +10,12 @@ YARP <yarp-3.11> Release Notes
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.11%22).
 
+
+Changes
+----------------
+
+### Compiler features
+
+The `PUBLIC` and `INTERFACE` values set by `target_compile_features` have been changed back from `cxx_std_20` to `cxx_std_17`, to permit
+to continue to compile downstream projects with C++17. This is not a long term decision, and in future the minimum C++ version required
+to compile headers could be increased again.

--- a/src/libYARP_companion/src/CMakeLists.txt
+++ b/src/libYARP_companion/src/CMakeLists.txt
@@ -92,7 +92,7 @@ target_include_directories(YARP_companion
 target_link_libraries(YARP_companion PUBLIC YARP::YARP_os)
 list(APPEND YARP_companion_PUBLIC_DEPS YARP_os )
 
-target_compile_features(YARP_companion PUBLIC cxx_std_20)
+target_compile_features(YARP_companion PUBLIC cxx_std_17)
 
 if(YARP_HAS_ACE)
   target_compile_definitions(YARP_companion PRIVATE YARP_HAS_ACE)

--- a/src/libYARP_conf/src/CMakeLists.txt
+++ b/src/libYARP_conf/src/CMakeLists.txt
@@ -121,7 +121,7 @@ target_include_directories(YARP_conf
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_conf INTERFACE cxx_std_20)
+target_compile_features(YARP_conf INTERFACE cxx_std_17)
 
 
 #########################################################################

--- a/src/libYARP_cv/src/CMakeLists.txt
+++ b/src/libYARP_cv/src/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(YARP_cv
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_conf INTERFACE cxx_std_20)
+target_compile_features(YARP_conf INTERFACE cxx_std_17)
 
 target_link_libraries(YARP_cv INTERFACE YARP::YARP_sig)
 list(APPEND YARP_cv_PUBLIC_DEPS YARP_sig)

--- a/src/libYARP_dataplayer/src/CMakeLists.txt
+++ b/src/libYARP_dataplayer/src/CMakeLists.txt
@@ -41,7 +41,7 @@ if(MSVC)
   target_include_directories(YARP_dataplayer SYSTEM PRIVATE ${dirent_INCLUDE_DIRS})
 endif()
 
-target_compile_features(YARP_dataplayer PUBLIC cxx_std_20)
+target_compile_features(YARP_dataplayer PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_dataplayer
   PUBLIC

--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -334,7 +334,7 @@ target_include_directories(YARP_dev
     $<BUILD_INTERFACE:${YARP_dev_idl_BUILD_INTERFACE_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_dev PUBLIC cxx_std_20)
+target_compile_features(YARP_dev PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_dev
   PUBLIC

--- a/src/libYARP_dev/src/yarp/dev/ReturnValue.h
+++ b/src/libYARP_dev/src/yarp/dev/ReturnValue.h
@@ -9,7 +9,11 @@
 #include <yarp/dev/api.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Portable.h>
+
+#if __cplusplus >= 202002L
 #include <source_location>
+#endif
+
 #include <string>
 
 // If this macro is enabled (default value=enabled), a bool value cannot be automatically converted to ReturnValue.

--- a/src/libYARP_eigen/src/CMakeLists.txt
+++ b/src/libYARP_eigen/src/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(YARP_eigen
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_eigen INTERFACE cxx_std_20)
+target_compile_features(YARP_eigen INTERFACE cxx_std_17)
 
 target_link_libraries(YARP_eigen INTERFACE YARP_sig)
 list(APPEND YARP_eigen_PUBLIC_DEPS YARP_sig)

--- a/src/libYARP_gsl/src/CMakeLists.txt
+++ b/src/libYARP_gsl/src/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(YARP_gsl
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_gsl PUBLIC cxx_std_20)
+target_compile_features(YARP_gsl PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_gsl PUBLIC YARP::YARP_sig)
 list(APPEND YARP_gsl_PUBLIC_DEPS YARP_sig)

--- a/src/libYARP_init/src/CMakeLists.txt
+++ b/src/libYARP_init/src/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(YARP_init
     YARP::YARP_conf
     YARP::YARP_os
 )
-target_compile_features(YARP_init PUBLIC cxx_std_20)
+target_compile_features(YARP_init PUBLIC cxx_std_17)
 
 if(YARP_LINK_PLUGINS)
   if(YARP_COMPILE_CARRIER_PLUGINS)

--- a/src/libYARP_logger/src/CMakeLists.txt
+++ b/src/libYARP_logger/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(YARP_logger
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_logger PUBLIC cxx_std_20)
+target_compile_features(YARP_logger PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_logger
   PUBLIC

--- a/src/libYARP_manager/src/CMakeLists.txt
+++ b/src/libYARP_manager/src/CMakeLists.txt
@@ -99,7 +99,7 @@ target_include_directories(YARP_manager
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_manager PUBLIC cxx_std_20)
+target_compile_features(YARP_manager PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_manager
   PUBLIC

--- a/src/libYARP_math/src/CMakeLists.txt
+++ b/src/libYARP_math/src/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(YARP_math
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_math PUBLIC cxx_std_20)
+target_compile_features(YARP_math PUBLIC cxx_std_17)
 
 # import math symbols from standard cmath
 target_compile_definitions(YARP_math PRIVATE _USE_MATH_DEFINES)

--- a/src/libYARP_name/src/CMakeLists.txt
+++ b/src/libYARP_name/src/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(YARP_name
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_name PUBLIC cxx_std_20)
+target_compile_features(YARP_name PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_name
   PUBLIC

--- a/src/libYARP_os/src/CMakeLists.txt
+++ b/src/libYARP_os/src/CMakeLists.txt
@@ -442,7 +442,7 @@ target_include_directories(YARP_os
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_os PUBLIC cxx_std_20)
+target_compile_features(YARP_os PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_os PUBLIC YARP::YARP_conf)
 list(APPEND YARP_os_PUBLIC_DEPS YARP_conf)

--- a/src/libYARP_pcl/src/CMakeLists.txt
+++ b/src/libYARP_pcl/src/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(YARP_pcl
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_pcl INTERFACE cxx_std_20)
+target_compile_features(YARP_pcl INTERFACE cxx_std_17)
 
 target_link_libraries(YARP_pcl INTERFACE YARP::YARP_sig)
 list(APPEND YARP_pcl_PUBLIC_DEPS YARP_sig)

--- a/src/libYARP_profiler/src/CMakeLists.txt
+++ b/src/libYARP_profiler/src/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(YARP_profiler
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_profiler PUBLIC cxx_std_20)
+target_compile_features(YARP_profiler PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_profiler
   PUBLIC

--- a/src/libYARP_robotinterface/src/CMakeLists.txt
+++ b/src/libYARP_robotinterface/src/CMakeLists.txt
@@ -87,7 +87,7 @@ target_include_directories(YARP_robotinterface
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_robotinterface PUBLIC cxx_std_20)
+target_compile_features(YARP_robotinterface PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_robotinterface
   PUBLIC

--- a/src/libYARP_robottestingframework/src/CMakeLists.txt
+++ b/src/libYARP_robottestingframework/src/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(YARP_robottestingframework
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_robottestingframework PUBLIC cxx_std_20)
+target_compile_features(YARP_robottestingframework PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_robottestingframework
   PUBLIC

--- a/src/libYARP_run/src/CMakeLists.txt
+++ b/src/libYARP_run/src/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(YARP_run
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_run PUBLIC cxx_std_20)
+target_compile_features(YARP_run PUBLIC cxx_std_17)
 
 option(YARP_ENABLE_YARPRUN_LOG "Enable yarprun log file in temp dir" OFF)
 mark_as_advanced(YARP_ENABLE_YARPRUN_LOG)

--- a/src/libYARP_serversql/src/CMakeLists.txt
+++ b/src/libYARP_serversql/src/CMakeLists.txt
@@ -77,7 +77,7 @@ target_include_directories(YARP_serversql
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_compile_features(YARP_serversql PUBLIC cxx_std_20)
+target_compile_features(YARP_serversql PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_serversql
   PUBLIC

--- a/src/libYARP_sig/src/CMakeLists.txt
+++ b/src/libYARP_sig/src/CMakeLists.txt
@@ -127,7 +127,7 @@ target_include_directories(YARP_sig
     $<BUILD_INTERFACE:${YARP_sig_idl_BUILD_INTERFACE_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_features(YARP_sig PUBLIC cxx_std_20)
+target_compile_features(YARP_sig PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_sig
   PUBLIC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,3 +113,4 @@ add_subdirectory(yarpidl_thrift)
 
 add_subdirectory(integration)
 add_subdirectory(harness_tests)
+add_subdirectory(header_smoke_test)

--- a/tests/header_smoke_test/CMakeLists.txt
+++ b/tests/header_smoke_test/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This test compile an example executable that include several YARP headers, and verify
+# that they compile given the specified PUBLIC target_compile_features
+add_executable(header_smoke_test header_smoke_test.cpp)
+target_link_libraries(header_smoke_test PRIVATE YARP::YARP_os YARP::YARP_sig YARP::YARP_dev)
+
+# We need to ensure that headers are compatible with C++17, if in the future we want to
+# change the minimum compatible version of the headers, this value should be updated
+# with the minimum version for which we want to keep compatibility.
+set_target_properties(header_smoke_test PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS OFF)

--- a/tests/header_smoke_test/header_smoke_test.cpp
+++ b/tests/header_smoke_test/header_smoke_test.cpp
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define HEADER_SMOKE_TEST
+#include <yarp/os/all.h>
+#include <yarp/dev/all.h>
+#include <yarp/sig/all.h>
+
+// We verify that the version tested is indeed the requested in the CMakeList.txt,
+// and not some following version due to some transitive target_compile_features requirement
+static_assert(__cplusplus <= 201703L, "This test should be compiled with C++17, or anyhow with the version required in its CMakeLists.txt");
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
As discussed in a meeting with @randaz81, @elandini84  and @Nicogene, in the short term to avoid downstream problems it is convenient to keep at least the header of YARP compatible with C++ 17 . 

This is not a long term decision, and in future the minimum C++ version required to compile headers could be increased again.