### PR TITLE
Add Motor Temperature to stateExt and Convert PWM to Float

### DIFF
--- a/src/devices/networkWrappers/RemoteControlBoard/RemoteControlBoard.cpp
+++ b/src/devices/networkWrappers/RemoteControlBoard/RemoteControlBoard.cpp
@@ -1542,12 +1542,23 @@ bool RemoteControlBoard::getNumberOfMotors(int *num)
 
 bool RemoteControlBoard::getTemperature      (int m, double* val)
 {
-    return get1V1I1D(VOCAB_TEMPERATURE, m, val);
+    double localArrivalTime = 0.0;
+
+    extendedPortMutex.lock();
+    bool ret = extendedIntputStatePort.getLastSingle(m, VOCAB_TEMPERATURE, val, lastStamp, localArrivalTime);
+    extendedPortMutex.unlock();
+    return ret;
 }
 
 bool RemoteControlBoard::getTemperatures     (double *vals)
 {
-    return get1VDA(VOCAB_TEMPERATURES, vals);
+    double localArrivalTime = 0.0;
+
+    extendedPortMutex.lock();
+    bool ret = extendedIntputStatePort.getLastVector(VOCAB_TEMPERATURE, vals, lastStamp, localArrivalTime);
+    extendedPortMutex.unlock();
+
+    return ret;
 }
 
 bool RemoteControlBoard::getTemperatureLimit (int m, double* val)

--- a/src/devices/networkWrappers/RemoteControlBoard/stateExtendedReader.cpp
+++ b/src/devices/networkWrappers/RemoteControlBoard/stateExtendedReader.cpp
@@ -62,6 +62,7 @@ void StateExtendedInputPort::init(int numberOfJoints)
     last.motorAcceleration.resize(numberOfJoints);
     last.torque.resize(numberOfJoints);
     last.pwmDutycycle.resize(numberOfJoints);
+    last.temperature.resize(numberOfJoints);
     last.current.resize(numberOfJoints);
     last.controlMode.resize(numberOfJoints);
     last.interactionMode.resize(numberOfJoints);
@@ -146,13 +147,19 @@ bool StateExtendedInputPort::getLastSingle(int j, int field, double *data, Stamp
 
             case VOCAB_PWMCONTROL_PWM_OUTPUT:
                 ret = last.pwmDutycycle_isValid;
-                *data = last.pwmDutycycle[j];
+                *data = double(last.pwmDutycycle[j]);
             break;
 
             case VOCAB_AMP_CURRENT:
                 ret = last.current_isValid;
                 *data = last.current[j];
                 break;
+
+            case VOCAB_TEMPERATURE:
+                ret = last.temperature_isValid;
+                *data = double(last.temperature[j]);
+                break;
+
 
             default:
                 yCError(REMOTECONTROLBOARD) << "RemoteControlBoard internal error while reading data. Cannot get 'single' data of type " << yarp::os::Vocab32::decode(field);
@@ -247,12 +254,25 @@ bool StateExtendedInputPort::getLastVector(int field, double* data, Stamp& stamp
 
             case VOCAB_PWMCONTROL_PWM_OUTPUTS:
                 ret = last.pwmDutycycle_isValid;
-                memcpy(data, last.pwmDutycycle.data(), last.pwmDutycycle.size() * last.pwmDutycycle.getElementSize());
+
+                // In the interface the pwmDutycycle is a double, but in the jointData it is a float so we need to copy it manually
+                for (size_t i = 0; i < last.pwmDutycycle.size(); i++) {
+                    data[i] = last.pwmDutycycle[i];
+                }
             break;
 
             case VOCAB_AMP_CURRENTS:
                 ret = last.current_isValid;
                 memcpy(data, last.current.data(), last.current.size() * last.current.getElementSize());
+                break;
+
+            case VOCAB_TEMPERATURES:
+                ret = last.temperature_isValid;
+
+                // In the interface the temperature is a double, but in the jointData it is a float so we need to copy it manually
+                for (size_t i = 0; i < last.temperature.size(); i++) {
+                    data[i] = last.temperature[i];
+                }
                 break;
 
             default:

--- a/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.cpp
+++ b/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.cpp
@@ -397,9 +397,9 @@ void ControlBoard_nws_yarp::run()
     if (iMotor) {
         // the temperature is a double in the interface, but a float in the jointData struct.
         data.temperature_isValid = iMotor->getTemperatures(tmpVariableForFloatSignals.data());
-        
+
         // The temperature values are stored as double in the interface but need to be converted to float in the jointData struct.
-        // We manually copy them, and while this conversion may lead to a minor loss of precision, it is negligible for temperature values, 
+        // We manually copy them, and while this conversion may lead to a minor loss of precision, it is negligible for temperature values,
         // which typically do not require double precision. std::copy ensures a safe and efficient conversion.
         std::copy(tmpVariableForFloatSignals.begin(), tmpVariableForFloatSignals.end(), data.temperature.begin());
     } else {

--- a/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.h
+++ b/src/devices/networkWrappers/controlBoard_nws_yarp/ControlBoard_nws_yarp.h
@@ -83,6 +83,7 @@ private:
     yarp::os::Stamp time; // envelope to attach to the state port
 
     size_t subdevice_joints {0};
+    yarp::sig::VectorOf<double> tmpVariableForFloatSignals; // temporary variable to store float signals before copying them into the jointData struct
     bool subdevice_ready = false;
 
     yarp::dev::IPidControl* iPidControl{nullptr};

--- a/src/libYARP_dev/src/idl/stateExt.thrift
+++ b/src/libYARP_dev/src/idl/stateExt.thrift
@@ -12,6 +12,13 @@ struct VectorOfDouble {
   yarp.includefile="yarp/sig/Vector.h"
 )
 
+struct VectorOfFloat {
+  1: list<float> content;
+} (
+  yarp.name = "yarp::sig::VectorOf<float>"
+  yarp.includefile="yarp/sig/Vector.h"
+)
+
 struct VectorOfInt {
   1: list<i32> content;
 } (
@@ -35,7 +42,7 @@ struct jointData
   12: bool motorAcceleration_isValid;
   13: VectorOfDouble torque;
   14: bool torque_isValid;
-  15: VectorOfDouble pwmDutycycle;
+  15: VectorOfFloat pwmDutycycle;
   16: bool pwmDutycycle_isValid;
   17: VectorOfDouble current;
   18: bool current_isValid;
@@ -43,6 +50,8 @@ struct jointData
   20: bool controlMode_isValid;
   21: VectorOfInt interactionMode;
   22: bool interactionMode_isValid;
+  23: VectorOfFloat temperature;
+  24: bool temperature_isValid;
 } (
     yarp.api.include = "yarp/dev/api.h"
     yarp.api.keyword = "YARP_dev_API"

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/impl/jointData.cpp
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/impl/jointData.cpp
@@ -27,14 +27,16 @@ jointData::jointData(const yarp::sig::VectorOf<double>& jointPosition,
                      const bool motorAcceleration_isValid,
                      const yarp::sig::VectorOf<double>& torque,
                      const bool torque_isValid,
-                     const yarp::sig::VectorOf<double>& pwmDutycycle,
+                     const yarp::sig::VectorOf<float>& pwmDutycycle,
                      const bool pwmDutycycle_isValid,
                      const yarp::sig::VectorOf<double>& current,
                      const bool current_isValid,
                      const yarp::sig::VectorOf<int>& controlMode,
                      const bool controlMode_isValid,
                      const yarp::sig::VectorOf<int>& interactionMode,
-                     const bool interactionMode_isValid) :
+                     const bool interactionMode_isValid,
+                     const yarp::sig::VectorOf<float>& temperature,
+                     const bool temperature_isValid) :
         WirePortable(),
         jointPosition(jointPosition),
         jointPosition_isValid(jointPosition_isValid),
@@ -57,7 +59,9 @@ jointData::jointData(const yarp::sig::VectorOf<double>& jointPosition,
         controlMode(controlMode),
         controlMode_isValid(controlMode_isValid),
         interactionMode(interactionMode),
-        interactionMode_isValid(interactionMode_isValid)
+        interactionMode_isValid(interactionMode_isValid),
+        temperature(temperature),
+        temperature_isValid(temperature_isValid)
 {
 }
 
@@ -130,6 +134,12 @@ bool jointData::read(yarp::os::idl::WireReader& reader)
     if (!read_interactionMode_isValid(reader)) {
         return false;
     }
+    if (!nested_read_temperature(reader)) {
+        return false;
+    }
+    if (!read_temperature_isValid(reader)) {
+        return false;
+    }
     if (reader.isError()) {
         return false;
     }
@@ -140,7 +150,7 @@ bool jointData::read(yarp::os::idl::WireReader& reader)
 bool jointData::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(22)) {
+    if (!reader.readListHeader(24)) {
         return false;
     }
     if (!read(reader)) {
@@ -218,6 +228,12 @@ bool jointData::write(const yarp::os::idl::WireWriter& writer) const
     if (!write_interactionMode_isValid(writer)) {
         return false;
     }
+    if (!nested_write_temperature(writer)) {
+        return false;
+    }
+    if (!write_temperature_isValid(writer)) {
+        return false;
+    }
     if (writer.isError()) {
         return false;
     }
@@ -228,7 +244,7 @@ bool jointData::write(const yarp::os::idl::WireWriter& writer) const
 bool jointData::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(22)) {
+    if (!writer.writeListHeader(24)) {
         return false;
     }
     if (!write(writer)) {
@@ -1254,6 +1270,98 @@ bool jointData::nested_read_interactionMode_isValid(yarp::os::idl::WireReader& r
 bool jointData::nested_write_interactionMode_isValid(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeBool(interactionMode_isValid)) {
+        return false;
+    }
+    return true;
+}
+
+// read temperature field
+bool jointData::read_temperature(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(temperature)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write temperature field
+bool jointData::write_temperature(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.write(temperature)) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) temperature field
+bool jointData::nested_read_temperature(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(temperature)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write (nested) temperature field
+bool jointData::nested_write_temperature(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeNested(temperature)) {
+        return false;
+    }
+    return true;
+}
+
+// read temperature_isValid field
+bool jointData::read_temperature_isValid(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readBool(temperature_isValid)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write temperature_isValid field
+bool jointData::write_temperature_isValid(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeBool(temperature_isValid)) {
+        return false;
+    }
+    return true;
+}
+
+// read (nested) temperature_isValid field
+bool jointData::nested_read_temperature_isValid(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readBool(temperature_isValid)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+// write (nested) temperature_isValid field
+bool jointData::nested_write_temperature_isValid(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeBool(temperature_isValid)) {
         return false;
     }
     return true;

--- a/src/libYARP_dev/src/idl_generated_code/yarp/dev/impl/jointData.h
+++ b/src/libYARP_dev/src/idl_generated_code/yarp/dev/impl/jointData.h
@@ -38,7 +38,7 @@ public:
     bool motorAcceleration_isValid{false};
     yarp::sig::VectorOf<double> torque{};
     bool torque_isValid{false};
-    yarp::sig::VectorOf<double> pwmDutycycle{};
+    yarp::sig::VectorOf<float> pwmDutycycle{};
     bool pwmDutycycle_isValid{false};
     yarp::sig::VectorOf<double> current{};
     bool current_isValid{false};
@@ -46,6 +46,8 @@ public:
     bool controlMode_isValid{false};
     yarp::sig::VectorOf<int> interactionMode{};
     bool interactionMode_isValid{false};
+    yarp::sig::VectorOf<float> temperature{};
+    bool temperature_isValid{false};
 
     // Default constructor
     jointData() = default;
@@ -65,14 +67,16 @@ public:
               const bool motorAcceleration_isValid,
               const yarp::sig::VectorOf<double>& torque,
               const bool torque_isValid,
-              const yarp::sig::VectorOf<double>& pwmDutycycle,
+              const yarp::sig::VectorOf<float>& pwmDutycycle,
               const bool pwmDutycycle_isValid,
               const yarp::sig::VectorOf<double>& current,
               const bool current_isValid,
               const yarp::sig::VectorOf<int>& controlMode,
               const bool controlMode_isValid,
               const yarp::sig::VectorOf<int>& interactionMode,
-              const bool interactionMode_isValid);
+              const bool interactionMode_isValid,
+              const yarp::sig::VectorOf<float>& temperature,
+              const bool temperature_isValid);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;
@@ -224,6 +228,18 @@ private:
     bool write_interactionMode_isValid(const yarp::os::idl::WireWriter& writer) const;
     bool nested_read_interactionMode_isValid(yarp::os::idl::WireReader& reader);
     bool nested_write_interactionMode_isValid(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write temperature field
+    bool read_temperature(yarp::os::idl::WireReader& reader);
+    bool write_temperature(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_temperature(yarp::os::idl::WireReader& reader);
+    bool nested_write_temperature(const yarp::os::idl::WireWriter& writer) const;
+
+    // read/write temperature_isValid field
+    bool read_temperature_isValid(yarp::os::idl::WireReader& reader);
+    bool write_temperature_isValid(const yarp::os::idl::WireWriter& writer) const;
+    bool nested_read_temperature_isValid(yarp::os::idl::WireReader& reader);
+    bool nested_write_temperature_isValid(const yarp::os::idl::WireWriter& writer) const;
 };
 
 } // namespace yarp::dev::impl

--- a/src/libYARP_sig/src/yarp/sig/Vector.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Vector.cpp
@@ -46,6 +46,7 @@ const std::map<int, std::string> tag2FormatStr = {
     {BOTTLE_TAG_VOCAB32, "c"},
     {BOTTLE_TAG_STRING, "s"},
     {BOTTLE_TAG_FLOAT64, "lf"},
+    {BOTTLE_TAG_FLOAT32, "f"}
 };
 
 bool VectorBase::read(yarp::os::ConnectionReader& connection) {

--- a/src/libYARP_sig/src/yarp/sig/Vector.h
+++ b/src/libYARP_sig/src/yarp/sig/Vector.h
@@ -92,6 +92,11 @@ inline int BottleTagMap <double> () {
   }
 
 template<>
+inline int BottleTagMap <float> () {
+    return BOTTLE_TAG_FLOAT32;
+  }
+
+template<>
 inline int BottleTagMap <int> () {
     return BOTTLE_TAG_INT32;
   }


### PR DESCRIPTION
After a discussion with @randaz81 and @traversaro, we decided to add motor temperature data to `stateExt`, streamed as a vector of floats. To avoid increasing the message size, we also decided to convert the PWM data from a vector of doubles to a vector of floats.  

This pull request introduces several changes to the `RemoteControlBoard` and related components to support temperature data. The modifications affect data structures, methods, and interfaces to handle temperature readings properly.  

The PR consists of two commits:  
- https://github.com/robotology/yarp/commit/e889527bc308ef3636dc727a414619af80399c2b: Modifies the message to add temperature data and converts the PWM vector to float.  
- https://github.com/robotology/yarp/commit/a435ecd640f4324df705e75c08a6a2ef568e596d: Adds support for `float32` conversion in `Bottle`. Without this, reading from the `stateExt` port results in the following error:  
  ```
  [ERROR]  |yarp.os.impl.BottleImpl| Reader failed, unrecognized object code 0
  ```

> [!NOTE]
> I also regenerated the `jointData.cpp` and `jointData.h` to be compliant with the new thrift