### PR TITLE
Rename vendored TinyXML cmake project and package from YARP_priv_tinyxml to YARP_priv_TinyXML

### DIFF
--- a/extern/tinyxml/CMakeLists.txt
+++ b/extern/tinyxml/CMakeLists.txt
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # TinyXML
-project(YARP_priv_tinyxml)
+project(YARP_priv_TinyXML)
 
-add_library(YARP_priv_tinyxml STATIC)
+add_library(YARP_priv_TinyXML STATIC)
 
 set(tinyxml_SRCS
   tinyxml/tinyxml.cpp
@@ -17,22 +17,22 @@ set(tinyxml_HDRS
   tinyxml/tinyxml.h
 )
 
-target_sources(YARP_priv_tinyxml PRIVATE ${tinyxml_SRCS})
+target_sources(YARP_priv_TinyXML PRIVATE ${tinyxml_SRCS})
 
-target_include_directories(YARP_priv_tinyxml PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tinyxml>)
+target_include_directories(YARP_priv_TinyXML PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tinyxml>)
 
-target_compile_definitions(YARP_priv_tinyxml PUBLIC "TIXML_USE_STL")
+target_compile_definitions(YARP_priv_TinyXML PUBLIC "TIXML_USE_STL")
 
-set_property(TARGET YARP_priv_tinyxml PROPERTY FOLDER "Libraries/External")
+set_property(TARGET YARP_priv_TinyXML PROPERTY FOLDER "Libraries/External")
 
 set(TinyXML_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/tinyxml PARENT_SCOPE)
-set(TinyXML_LIBRARIES "YARP_priv_tinyxml" PARENT_SCOPE)
+set(TinyXML_LIBRARIES "YARP_priv_TinyXML" PARENT_SCOPE)
 set(TinyXML_DEFINITIONS "-DTIXML_USE_STL" PARENT_SCOPE)
 
 install(
-  TARGETS YARP_priv_tinyxml
-  EXPORT YARP_priv_tinyxml
-  COMPONENT YARP_priv_tinyxml
+  TARGETS YARP_priv_TinyXML
+  EXPORT YARP_priv_TinyXML
+  COMPONENT YARP_priv_TinyXML
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -40,5 +40,5 @@ install(
 
 if(NOT CREATE_SHARED_LIBS)
   include(YarpInstallBasicPackageFiles)
-  yarp_install_basic_package_files(YARP_priv_tinyxml)
+  yarp_install_basic_package_files(YARP_priv_TinyXML)
 endif()


### PR DESCRIPTION
For TinyXML (1), the CMake project/package name that we use is `TinyXML`, for example also in ycm-cmake-modules there is a `FindTinyXML.cmake` file. This is different from tinyxml2 (that ideally at some point we should migrate to), where the CMake project/package name is `tinyxml2`. So it make sense that also the vendored CMake package is called `YARP_priv_TinyXML`, not `YARP_priv_tinyxml`.


Fix https://github.com/robotology/yarp/issues/3197 .
Fix https://github.com/robotology/yarp/issues/2512 .

@vmartinlac can you check if this change works for you? Thanks! This PR is targeting `yarp-3.11`, but this file was not changed in years, so I think the patch should apply in a clean way to older releases.