### PR TITLE
NWCs with protocol check

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -1,0 +1,20 @@
+YARP <yarp-4.0> (UNRELEASED)                                         {#yarp_4_0}
+============================
+
+[TOC]
+
+YARP <yarp-4.0.> Release Notes
+=============================
+
+
+A (partial) list of bug fixed and issues resolved in this release can be found
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.12%22).
+
+New Features
+----------------
+
+### Devices
+
+All nwc devices now use the method checkProtocolVersion() to guarantee netowrk protocol 
+compatibility with the corresponding nws device.
+

--- a/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.cpp
@@ -39,7 +39,10 @@ bool LLM_nwc_yarp::open(yarp::os::Searchable &config)
         yCError(LLM_NWC_YARP, "Cannot attach the m_rpc_port_to_LLM_server port as client");
     }
 
-    yCDebug(LLM_NWC_YARP) << "Opening of nwc successful";
+    //Check the protocol version
+    if (!m_LLM_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(LLM_NWC_YARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
@@ -102,6 +102,10 @@ bool AudioRecorder_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_audiograb_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(AUDIORECORDER_NWC) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.cpp
@@ -217,6 +217,12 @@ bool Battery_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_battery_RPC.checkProtocolVersion()) {
+        return false;
+    }
+
+    yCInfo(BATTERYCLIENT) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.cpp
@@ -42,7 +42,10 @@ bool ChatBot_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
-    yCDebug(CHATBOT_NWC_YARP) << "Opening of nwc successful";
+    //Check the protocol version
+    if (!m_thriftClient.checkProtocolVersion()) { return false; }
+
+    yCInfo(CHATBOT_NWC_YARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/frameGrabber_nwc_yarp/FrameGrabber_nwc_yarp.cpp
@@ -246,6 +246,11 @@ bool FrameGrabber_nwc_yarp::open(yarp::os::Searchable& config)
         yCInfo(FRAMEGRABBER_NWC_YARP) << "No remote specified. Waiting for connection";
     }
 
+    // Check the protocol version
+    //if (!rpcPort.checkProtocolVersion()) {
+    //    return false;
+    //}
+
     return true;
 }
 

--- a/src/devices/networkWrappers/frameTransformGet_nwc_yarp/FrameTransformGet_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/frameTransformGet_nwc_yarp/FrameTransformGet_nwc_yarp.cpp
@@ -122,6 +122,10 @@ bool FrameTransformGet_nwc_yarp::open(yarp::os::Searchable& config)
         yCInfo(FRAMETRANSFORMGETNWCYARP) << "Receiving transforms from Yarp port NOT enabled";
     }
 
+    //Check the protocol version
+    if (!m_frameTransformStorageGetRPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(FRAMETRANSFORMGETNWCYARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/frameTransformSet_nwc_yarp/FrameTransformSet_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/frameTransformSet_nwc_yarp/FrameTransformSet_nwc_yarp.cpp
@@ -79,6 +79,10 @@ bool FrameTransformSet_nwc_yarp::open(yarp::os::Searchable& config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_setRPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(FRAMETRANSFORMSETNWCYARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/localization2D_nwc_yarp/Localization2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/localization2D_nwc_yarp/Localization2D_nwc_yarp.cpp
@@ -68,6 +68,10 @@ bool Localization2D_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(LOCALIZATION2D_NWC_YARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/map2D_nwc_yarp/Map2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/map2D_nwc_yarp/Map2D_nwc_yarp.cpp
@@ -54,6 +54,10 @@ bool Map2D_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_map_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(MAP2D_NWC_YARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/mobileBaseVelocityControl_nwc_yarp/MobileBaseVelocityControl_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/mobileBaseVelocityControl_nwc_yarp/MobileBaseVelocityControl_nwc_yarp.cpp
@@ -52,6 +52,10 @@ bool MobileBaseVelocityControl_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(MOBVEL_NWC_YARP) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/navigation2D_nwc_yarp/Navigation2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/navigation2D_nwc_yarp/Navigation2D_nwc_yarp.cpp
@@ -120,6 +120,12 @@ bool Navigation2D_nwc_yarp::open(yarp::os::Searchable &config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_loc_RPC.checkProtocolVersion()) { return false; }
+    if (!m_nav_RPC.checkProtocolVersion()) { return false; }
+    if (!m_map_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(NAVIGATION2D_NWC_YARP) << "Opening of NWC successful";
     m_rpc_port_user_commands.setReader(*this);
     return true;
 }

--- a/src/devices/networkWrappers/odometry2D_nwc_yarp/Odometry2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/odometry2D_nwc_yarp/Odometry2D_nwc_yarp.cpp
@@ -176,8 +176,10 @@ bool Odometry2D_nwc_yarp::open(yarp::os::Searchable &config)
        return false;
     }
 
-    //protocol check
-    //to be added here
+    // Check the protocol version
+    if (!m_RPC.checkProtocolVersion()) {
+        return false;
+    }
 
     return true;
 }

--- a/src/devices/networkWrappers/rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
@@ -199,6 +199,10 @@ bool Rangefinder2D_nwc_yarp::open(yarp::os::Searchable &config)
        return false;
     }
 
+    //Check the protocol version
+    if (!m_RPC.checkProtocolVersion()) { return false; }
+
+    yCInfo(RANGEFINDER2DCLIENT) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/robotDescription_nwc_yarp/RobotDescription_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/robotDescription_nwc_yarp/RobotDescription_nwc_yarp.cpp
@@ -46,8 +46,10 @@ bool RobotDescription_nwc_yarp::open(yarp::os::Searchable &config)
        return false;
     }
 
-    //protocol check
-    //to be added here
+    // Check the protocol version
+    if (!m_RPC.checkProtocolVersion()) {
+        return false;
+    }
 
     return true;
 }

--- a/src/devices/networkWrappers/serialPort_nwc_yarp/SerialPort_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/serialPort_nwc_yarp/SerialPort_nwc_yarp.cpp
@@ -6,6 +6,7 @@
 #include "SerialPort_nwc_yarp.h"
 
 #include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/os/Os.h>
 
 namespace {
@@ -110,5 +111,9 @@ bool SerialPort_nwc_yarp::open(Searchable& config)
         }
     }
 
+    //Check the protocol version
+    if (!m_rpc.checkProtocolVersion()) { return false; }
+
+    yCInfo(SERIAL_NWC) << "Opening of NWC successful";
     return true;
 }

--- a/src/devices/networkWrappers/speechSynthesizer_nwc_yarp/SpeechSynthesizer_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/speechSynthesizer_nwc_yarp/SpeechSynthesizer_nwc_yarp.cpp
@@ -53,6 +53,10 @@ bool SpeechSynthesizer_nwc_yarp::open(yarp::os::Searchable& config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_thriftClient.checkProtocolVersion()) { return false; }
+
+    yCInfo(SPEECHSYNTH_NWC) << "Opening of NWC successful";
     return true;
 }
 

--- a/src/devices/networkWrappers/speechTranscription_nwc_yarp/SpeechTranscription_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/speechTranscription_nwc_yarp/SpeechTranscription_nwc_yarp.cpp
@@ -51,6 +51,10 @@ bool SpeechTranscription_nwc_yarp::open(yarp::os::Searchable& config)
         return false;
     }
 
+    //Check the protocol version
+    if (!m_thriftClient.checkProtocolVersion()) { return false; }
+
+    yCInfo(SPEECHTR_NWC) << "Opening of NWC successful";
     return true;
 }
 


### PR DESCRIPTION
- [x]  audioRecorder_nwc_yarp
- [x]  battery_nwc_yarp
- [x]  chatBot_nwc_yarp
- [ ]  frameGrabber_nwc_yarp -> part2 after https://github.com/robotology/yarp/pull/3184
- [ ] frameWriter_nwc_yarp -> part2 after https://github.com/robotology/yarp/pull/3184
- [ ] RGBDSensor_nws_yarp -> part2 after https://github.com/robotology/yarp/pull/3184
- [x]  frameTransformGet_nwc_yarp
- [x]  frameTransformSet_nwc_yarp
- [x]  LLM_nwc_yarp
- [x]  localization2D_nwc_yarp
- [x]  map2D_nwc_yarp
- [x]  mobileBaseVelocityControl_nwc_yarp
- [x]  navigation2D_nwc_yarp
- [x]  odometry2D_nwc_yarp
- [x]  rangefinder2D_nwc_yarp
- [x]  robotDescription_nwc_yarp
- [x]  serialPort_nwc_yarp
- [x]  speechSynthesizer_nwc_yarp
- [x]  speechTranscription_nwc_yarp

This PR will break compatibility with NWS belonging to YARP versions < 4
Requires https://github.com/robotology/yarp/pull/3219