### PR TITLE
ILLM, IChatBot interfaces modified to use yarp::dev::ReturnValue

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -43,6 +43,8 @@ Breaking Changes
 
 * The following interfaces have been modified to use `yarp::dev::ReturnValue`:
   - `IRangeFinder2D`
+  - `ILLM`
+  - `IChatBot`
 
 ### Devices
 
@@ -52,6 +54,9 @@ Breaking Changes
   - `FakeLaserWithMotor`
   - `Rangefinder2D_nws_yarp`
   - `Rangefinder2D_nwc_yarp`
-
-
-
+  - `fakeChatBotDevice`
+  - `chatBot_nws_yarp`
+  - `chatBot_nwc_yarp`
+  - `fakeLLMDevice`
+  - `LLM_nwc_yarp`
+  - `LLM_nws_yarp`

--- a/src/devices/fake/fakeChatBotDevice/FakeChatBotDevice.cpp
+++ b/src/devices/fake/fakeChatBotDevice/FakeChatBotDevice.cpp
@@ -9,6 +9,8 @@
 
 YARP_LOG_COMPONENT(FAKECHATBOTDEVICE, "yarp.devices.FakeChatBotDevice")
 
+using namespace yarp::dev;
+
 FakeChatBotDevice::FakeChatBotDevice() :
     m_fallback{"Sorry, I did not get that. Can you repeat?"},
     m_noInput{"I heard nothing. Can you please speak up?"},
@@ -25,17 +27,17 @@ FakeChatBotDevice::FakeChatBotDevice() :
         }
 {}
 
-bool FakeChatBotDevice::interact(const std::string& messageIn, std::string& messageOut)
+ReturnValue FakeChatBotDevice::interact(const std::string& messageIn, std::string& messageOut)
 {
     if(messageIn.empty())
     {
         messageOut = m_noInput;
-        return true;
+        return ReturnValue_ok;
     }
     if(m_qAndA[m_status].count(messageIn) < 1)
     {
         messageOut = m_fallback;
-        return true;
+        return ReturnValue_ok;
     }
 
     messageOut = m_qAndA[m_status][messageIn];
@@ -45,38 +47,37 @@ bool FakeChatBotDevice::interact(const std::string& messageIn, std::string& mess
         m_status = "chatting";
     }
 
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeChatBotDevice::setLanguage(const std::string& language)
+ReturnValue FakeChatBotDevice::setLanguage(const std::string& language)
 {
     if (language != "eng")
     {
-        yCError(FAKECHATBOTDEVICE) << "Unsopported language. Only English is supported for the moment being";
-        return false;
+        yCError(FAKECHATBOTDEVICE) << "Unsupported language. Only English is supported for the moment being";
+        return ReturnValue::return_code::return_value_error_method_failed;
     }
     m_language = language;
 
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeChatBotDevice::getLanguage(std::string& language)
+ReturnValue FakeChatBotDevice::getLanguage(std::string& language)
 {
     language = m_language;
-
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeChatBotDevice::getStatus(std::string& status)
+ReturnValue FakeChatBotDevice::getStatus(std::string& status)
 {
     status = m_status;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeChatBotDevice::resetBot()
+ReturnValue FakeChatBotDevice::resetBot()
 {
     m_status = "greetings";
-    return true;
+    return ReturnValue_ok;
 }
 
 bool FakeChatBotDevice::open(yarp::os::Searchable& config)

--- a/src/devices/fake/fakeChatBotDevice/FakeChatBotDevice.h
+++ b/src/devices/fake/fakeChatBotDevice/FakeChatBotDevice.h
@@ -27,11 +27,11 @@ class FakeChatBotDevice : public yarp::dev::IChatBot,
 
 public:
     FakeChatBotDevice();
-    bool interact(const std::string& messageIn, std::string& messageOut) override;
-    bool setLanguage(const std::string& language) override;
-    bool getLanguage(std::string& language) override;
-    bool getStatus(std::string& status) override;
-    bool resetBot() override;
+    yarp::dev::ReturnValue interact(const std::string& messageIn, std::string& messageOut) override;
+    yarp::dev::ReturnValue setLanguage(const std::string& language) override;
+    yarp::dev::ReturnValue getLanguage(std::string& language) override;
+    yarp::dev::ReturnValue getStatus(std::string& status) override;
+    yarp::dev::ReturnValue resetBot() override;
 
     bool open(yarp::os::Searchable& config) override;
     bool close() override;

--- a/src/devices/fake/fakeLLMDevice/FakeLLMDevice.h
+++ b/src/devices/fake/fakeLLMDevice/FakeLLMDevice.h
@@ -26,12 +26,12 @@ class FakeLLMDevice : public yarp::dev::ILLM,
 
 public:
     FakeLLMDevice() : m_conversation{} {}
-    bool setPrompt(const std::string &prompt) override;
-    bool readPrompt(std::string &oPromp) override;
-    bool ask(const std::string &question, yarp::dev::LLM_Message &oAnswer) override;
-    bool getConversation(std::vector<yarp::dev::LLM_Message> &oConversation) override;
-    bool deleteConversation() noexcept override;
-    bool refreshConversation() noexcept override;
+    yarp::dev::ReturnValue setPrompt(const std::string &prompt) override;
+    yarp::dev::ReturnValue readPrompt(std::string &oPromp) override;
+    yarp::dev::ReturnValue ask(const std::string &question, yarp::dev::LLM_Message &oAnswer) override;
+    yarp::dev::ReturnValue getConversation(std::vector<yarp::dev::LLM_Message> &oConversation) override;
+    yarp::dev::ReturnValue deleteConversation() noexcept override;
+    yarp::dev::ReturnValue refreshConversation() noexcept override;
 
     bool open(yarp::os::Searchable& config) override;
     bool close() override;

--- a/src/devices/messages/IChatBotMsgs/IChatBotMsgs.thrift
+++ b/src/devices/messages/IChatBotMsgs/IChatBotMsgs.thrift
@@ -3,25 +3,31 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+struct yReturnValue {
+} (
+  yarp.name = "yarp::dev::ReturnValue"
+  yarp.includefile = "yarp/dev/ReturnValue.h"
+)
+
 struct return_interact{
-    1: bool result;
+    1: yReturnValue result;
     2: string messageOut;
 }
 
 struct return_getLanguage{
-    1: bool result;
+    1: yReturnValue result;
     2: string language;
 }
 
 struct return_getStatus{
-    1: bool result;
+    1: yReturnValue result;
     2: string status;
 }
 
 service IChatBotMsgs {
     return_interact interactRPC(1: string messageIn);
-    bool setLanguageRPC(1: string language);
+    yReturnValue setLanguageRPC(1: string language);
     return_getLanguage getLanguageRPC();
     return_getStatus getStatusRPC();
-    bool resetBotRPC();
+    yReturnValue resetBotRPC();
 }

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/IChatBotMsgs.cpp
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/IChatBotMsgs.cpp
@@ -8,11 +8,102 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
+#include <yarp/conf/version.h>
 #include <IChatBotMsgs.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
 
 #include <yarp/os/idl/WireTypes.h>
 
 #include <algorithm>
+
+namespace
+{
+    YARP_LOG_COMPONENT(SERVICE_LOG_COMPONENT, "IChatBotMsgs")
+}
+
+//IChatBotMsgs_getRemoteProtocolVersion_helper declaration
+class IChatBotMsgs_getRemoteProtocolVersion_helper :
+public yarp::os::Portable
+{
+public:
+    IChatBotMsgs_getRemoteProtocolVersion_helper() = default;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    yarp::os::ApplicationNetworkProtocolVersion helper_proto;
+};
+
+bool IChatBotMsgs_getRemoteProtocolVersion_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeString("getRemoteProtocolVersion")) {
+        return false;
+    }
+    return true;
+}
+
+bool IChatBotMsgs_getRemoteProtocolVersion_helper ::read(yarp::os::ConnectionReader & connection)
+ {
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+
+    if (!helper_proto.read(connection)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+//ProtocolVersion, client side
+yarp::os::ApplicationNetworkProtocolVersion IChatBotMsgs::getRemoteProtocolVersion()
+ {
+    if(!yarp().canWrite()) {
+        yError(" Missing server method IChatBotMsgs::getRemoteProtocolVersion");
+    }
+    IChatBotMsgs_getRemoteProtocolVersion_helper helper{};
+    bool ok = yarp().write(helper, helper);
+    if (ok) {
+        return helper.helper_proto;}
+    else {
+        yarp::os::ApplicationNetworkProtocolVersion failureproto;
+        return failureproto;}
+}
+
+//ProtocolVersion, client side
+bool IChatBotMsgs::checkProtocolVersion()
+ {
+        auto locproto = this->getLocalProtocolVersion();
+        auto remproto = this->getRemoteProtocolVersion();
+        if (remproto.protocol_version != locproto.protocol_version)
+        {
+            yCError(SERVICE_LOG_COMPONENT) << "Invalid communication protocol.";
+            yCError(SERVICE_LOG_COMPONENT) << "Local Protocol Version: " << locproto.toString();
+            yCError(SERVICE_LOG_COMPONENT) << "Remote Protocol Version: " << remproto.toString();
+            return false;
+        }
+        return true;
+}
+
+//ProtocolVersion, server side
+yarp::os::ApplicationNetworkProtocolVersion IChatBotMsgs::getLocalProtocolVersion()
+{
+    yarp::os::ApplicationNetworkProtocolVersion myproto;
+    //myproto.protocol_version using default value = 0
+    //to change this value add the following line to the .thrift file:
+    //const i16 protocol_version = <your_number_here>
+    myproto.protocol_version = 0;
+    myproto.yarp_major = YARP_VERSION_MAJOR;
+    myproto.yarp_minor = YARP_VERSION_MINOR;
+    myproto.yarp_patch = YARP_VERSION_PATCH;
+    return myproto;
+}
 
 // interactRPC helper class declaration
 class IChatBotMsgs_interactRPC_helper :
@@ -123,10 +214,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const std::string&);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const std::string&);
     void call(IChatBotMsgs* ptr);
 
     Command cmd;
@@ -136,7 +227,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IChatBotMsgs::setLanguageRPC(const std::string& language)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IChatBotMsgs::setLanguageRPC(const std::string& language)"};
     static constexpr const char* s_help{""};
 };
 
@@ -297,10 +388,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(IChatBotMsgs* ptr);
 
     Command cmd;
@@ -310,7 +401,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{1};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool IChatBotMsgs::resetBotRPC()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue IChatBotMsgs::resetBotRPC()"};
     static constexpr const char* s_help{""};
 };
 
@@ -591,10 +682,7 @@ bool IChatBotMsgs_setLanguageRPC_helper::Reply::read(yarp::os::ConnectionReader&
 bool IChatBotMsgs_setLanguageRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -603,14 +691,11 @@ bool IChatBotMsgs_setLanguageRPC_helper::Reply::write(const yarp::os::idl::WireW
 
 bool IChatBotMsgs_setLanguageRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -990,10 +1075,7 @@ bool IChatBotMsgs_resetBotRPC_helper::Reply::read(yarp::os::ConnectionReader& co
 bool IChatBotMsgs_resetBotRPC_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1002,14 +1084,11 @@ bool IChatBotMsgs_resetBotRPC_helper::Reply::write(const yarp::os::idl::WireWrit
 
 bool IChatBotMsgs_resetBotRPC_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1037,14 +1116,14 @@ return_interact IChatBotMsgs::interactRPC(const std::string& messageIn)
     return ok ? helper.reply.return_helper : return_interact{};
 }
 
-bool IChatBotMsgs::setLanguageRPC(const std::string& language)
+yarp::dev::ReturnValue IChatBotMsgs::setLanguageRPC(const std::string& language)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IChatBotMsgs_setLanguageRPC_helper::s_prototype);
     }
     IChatBotMsgs_setLanguageRPC_helper helper{language};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 return_getLanguage IChatBotMsgs::getLanguageRPC()
@@ -1067,14 +1146,14 @@ return_getStatus IChatBotMsgs::getStatusRPC()
     return ok ? helper.reply.return_helper : return_getStatus{};
 }
 
-bool IChatBotMsgs::resetBotRPC()
+yarp::dev::ReturnValue IChatBotMsgs::resetBotRPC()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", IChatBotMsgs_resetBotRPC_helper::s_prototype);
     }
     IChatBotMsgs_resetBotRPC_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 // help method
@@ -1138,6 +1217,26 @@ bool IChatBotMsgs::read(yarp::os::ConnectionReader& connection)
         tag = reader.readTag(1);
     }
     while (tag_len <= max_tag_len && !reader.isError()) {
+        if(tag == "getRemoteProtocolVersion") {
+            if (!reader.noMore()) {
+                yError("Reader invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+                reader.fail();
+                return false;
+            }
+
+            auto proto = getLocalProtocolVersion();
+
+            yarp::os::idl::WireWriter writer(reader);
+           if (!writer.writeListHeader(1)) {
+                yWarning("Writer invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+               return false;}
+            if (!writer.write(proto)) {
+                yWarning("Writer invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
         if (tag == IChatBotMsgs_interactRPC_helper::s_tag) {
             IChatBotMsgs_interactRPC_helper helper;
             if (!helper.cmd.readArgs(reader)) {

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/IChatBotMsgs.h
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/IChatBotMsgs.h
@@ -13,26 +13,34 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/os/ApplicationNetworkProtocolVersion.h>
 #include <return_getLanguage.h>
 #include <return_getStatus.h>
 #include <return_interact.h>
+#include <yarp/dev/ReturnValue.h>
 
 class IChatBotMsgs :
         public yarp::os::Wire
 {
 public:
+    //ProtocolVersion
+    virtual yarp::os::ApplicationNetworkProtocolVersion getLocalProtocolVersion();
+    virtual yarp::os::ApplicationNetworkProtocolVersion getRemoteProtocolVersion();
+    virtual bool checkProtocolVersion();
+
     // Constructor
     IChatBotMsgs();
 
+    //Service methods
     virtual return_interact interactRPC(const std::string& messageIn);
 
-    virtual bool setLanguageRPC(const std::string& language);
+    virtual yarp::dev::ReturnValue setLanguageRPC(const std::string& language);
 
     virtual return_getLanguage getLanguageRPC();
 
     virtual return_getStatus getStatusRPC();
 
-    virtual bool resetBotRPC();
+    virtual yarp::dev::ReturnValue resetBotRPC();
 
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getLanguage.cpp
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getLanguage.cpp
@@ -11,7 +11,7 @@
 #include <return_getLanguage.h>
 
 // Constructor with field values
-return_getLanguage::return_getLanguage(const bool result,
+return_getLanguage::return_getLanguage(const yarp::dev::ReturnValue& result,
                                        const std::string& language) :
         WirePortable(),
         result(result),
@@ -22,7 +22,7 @@ return_getLanguage::return_getLanguage(const bool result,
 // Read structure on a Wire
 bool return_getLanguage::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_result(reader)) {
+    if (!nested_read_result(reader)) {
         return false;
     }
     if (!read_language(reader)) {
@@ -50,7 +50,7 @@ bool return_getLanguage::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getLanguage::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_result(writer)) {
+    if (!nested_write_result(writer)) {
         return false;
     }
     if (!write_language(writer)) {
@@ -92,7 +92,7 @@ bool return_getLanguage::read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.read(result)) {
         reader.fail();
         return false;
     }
@@ -102,7 +102,7 @@ bool return_getLanguage::read_result(yarp::os::idl::WireReader& reader)
 // write result field
 bool return_getLanguage::write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.write(result)) {
         return false;
     }
     return true;
@@ -115,7 +115,7 @@ bool return_getLanguage::nested_read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.readNested(result)) {
         reader.fail();
         return false;
     }
@@ -125,7 +125,7 @@ bool return_getLanguage::nested_read_result(yarp::os::idl::WireReader& reader)
 // write (nested) result field
 bool return_getLanguage::nested_write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.writeNested(result)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getLanguage.h
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getLanguage.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getLanguage :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool result{false};
+    yarp::dev::ReturnValue result{};
     std::string language{};
 
     // Default constructor
     return_getLanguage() = default;
 
     // Constructor with field values
-    return_getLanguage(const bool result,
+    return_getLanguage(const yarp::dev::ReturnValue& result,
                        const std::string& language);
 
     // Read structure on a Wire

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getStatus.cpp
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getStatus.cpp
@@ -11,7 +11,7 @@
 #include <return_getStatus.h>
 
 // Constructor with field values
-return_getStatus::return_getStatus(const bool result,
+return_getStatus::return_getStatus(const yarp::dev::ReturnValue& result,
                                    const std::string& status) :
         WirePortable(),
         result(result),
@@ -22,7 +22,7 @@ return_getStatus::return_getStatus(const bool result,
 // Read structure on a Wire
 bool return_getStatus::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_result(reader)) {
+    if (!nested_read_result(reader)) {
         return false;
     }
     if (!read_status(reader)) {
@@ -50,7 +50,7 @@ bool return_getStatus::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getStatus::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_result(writer)) {
+    if (!nested_write_result(writer)) {
         return false;
     }
     if (!write_status(writer)) {
@@ -92,7 +92,7 @@ bool return_getStatus::read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.read(result)) {
         reader.fail();
         return false;
     }
@@ -102,7 +102,7 @@ bool return_getStatus::read_result(yarp::os::idl::WireReader& reader)
 // write result field
 bool return_getStatus::write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.write(result)) {
         return false;
     }
     return true;
@@ -115,7 +115,7 @@ bool return_getStatus::nested_read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.readNested(result)) {
         reader.fail();
         return false;
     }
@@ -125,7 +125,7 @@ bool return_getStatus::nested_read_result(yarp::os::idl::WireReader& reader)
 // write (nested) result field
 bool return_getStatus::nested_write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.writeNested(result)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getStatus.h
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_getStatus.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_getStatus :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool result{false};
+    yarp::dev::ReturnValue result{};
     std::string status{};
 
     // Default constructor
     return_getStatus() = default;
 
     // Constructor with field values
-    return_getStatus(const bool result,
+    return_getStatus(const yarp::dev::ReturnValue& result,
                      const std::string& status);
 
     // Read structure on a Wire

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_interact.cpp
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_interact.cpp
@@ -11,7 +11,7 @@
 #include <return_interact.h>
 
 // Constructor with field values
-return_interact::return_interact(const bool result,
+return_interact::return_interact(const yarp::dev::ReturnValue& result,
                                  const std::string& messageOut) :
         WirePortable(),
         result(result),
@@ -22,7 +22,7 @@ return_interact::return_interact(const bool result,
 // Read structure on a Wire
 bool return_interact::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_result(reader)) {
+    if (!nested_read_result(reader)) {
         return false;
     }
     if (!read_messageOut(reader)) {
@@ -50,7 +50,7 @@ bool return_interact::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_interact::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_result(writer)) {
+    if (!nested_write_result(writer)) {
         return false;
     }
     if (!write_messageOut(writer)) {
@@ -92,7 +92,7 @@ bool return_interact::read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.read(result)) {
         reader.fail();
         return false;
     }
@@ -102,7 +102,7 @@ bool return_interact::read_result(yarp::os::idl::WireReader& reader)
 // write result field
 bool return_interact::write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.write(result)) {
         return false;
     }
     return true;
@@ -115,7 +115,7 @@ bool return_interact::nested_read_result(yarp::os::idl::WireReader& reader)
         reader.fail();
         return false;
     }
-    if (!reader.readBool(result)) {
+    if (!reader.readNested(result)) {
         reader.fail();
         return false;
     }
@@ -125,7 +125,7 @@ bool return_interact::nested_read_result(yarp::os::idl::WireReader& reader)
 // write (nested) result field
 bool return_interact::nested_write_result(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(result)) {
+    if (!writer.writeNested(result)) {
         return false;
     }
     return true;

--- a/src/devices/messages/IChatBotMsgs/idl_generated_code/return_interact.h
+++ b/src/devices/messages/IChatBotMsgs/idl_generated_code/return_interact.h
@@ -13,20 +13,21 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 class return_interact :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
-    bool result{false};
+    yarp::dev::ReturnValue result{};
     std::string messageOut{};
 
     // Default constructor
     return_interact() = default;
 
     // Constructor with field values
-    return_interact(const bool result,
+    return_interact(const yarp::dev::ReturnValue& result,
                     const std::string& messageOut);
 
     // Read structure on a Wire

--- a/src/devices/messages/ILLMMsgs/ILLMMsgs.thrift
+++ b/src/devices/messages/ILLMMsgs/ILLMMsgs.thrift
@@ -11,26 +11,32 @@ struct LLM_Message {
   yarp.includefile="yarp/dev/ILLM.h"
 )
 
+struct yReturnValue {
+} (
+  yarp.name = "yarp::dev::ReturnValue"
+  yarp.includefile = "yarp/dev/ReturnValue.h"
+)
+
 struct return_readPrompt{
-    1: bool ret = false;
+    1: yReturnValue ret;
     2: string prompt;
 }
 
 struct return_ask{
-    1: bool ret = false;
+    1: yReturnValue ret;
     2: LLM_Message answer;
 }
 
 struct return_getConversation{
-    1: bool ret = false;
+    1: yReturnValue ret;
     2: list<LLM_Message> conversation;
 }
 
 service ILLMMsgs {
-    bool setPrompt(1: string prompt);
+    yReturnValue setPrompt(1: string prompt);
     return_readPrompt readPrompt();
     return_ask ask(1: string question);
     return_getConversation getConversation();
-    bool deleteConversation();
-    bool refreshConversation();
+    yReturnValue deleteConversation();
+    yReturnValue refreshConversation();
 }

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/ILLMMsgs.cpp
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/ILLMMsgs.cpp
@@ -8,13 +8,104 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
+#include <yarp/conf/version.h>
 #include <yarp/dev/llm/ILLMMsgs.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
 
 #include <yarp/os/idl/WireTypes.h>
 
 #include <algorithm>
 
+namespace
+{
+    YARP_LOG_COMPONENT(SERVICE_LOG_COMPONENT, "ILLMMsgs")
+}
+
 namespace yarp::dev::llm {
+
+//ILLMMsgs_getRemoteProtocolVersion_helper declaration
+class ILLMMsgs_getRemoteProtocolVersion_helper :
+public yarp::os::Portable
+{
+public:
+    ILLMMsgs_getRemoteProtocolVersion_helper() = default;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    yarp::os::ApplicationNetworkProtocolVersion helper_proto;
+};
+
+bool ILLMMsgs_getRemoteProtocolVersion_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeString("getRemoteProtocolVersion")) {
+        return false;
+    }
+    return true;
+}
+
+bool ILLMMsgs_getRemoteProtocolVersion_helper ::read(yarp::os::ConnectionReader & connection)
+ {
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+
+    if (!helper_proto.read(connection)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+//ProtocolVersion, client side
+yarp::os::ApplicationNetworkProtocolVersion ILLMMsgs::getRemoteProtocolVersion()
+ {
+    if(!yarp().canWrite()) {
+        yError(" Missing server method ILLMMsgs::getRemoteProtocolVersion");
+    }
+    ILLMMsgs_getRemoteProtocolVersion_helper helper{};
+    bool ok = yarp().write(helper, helper);
+    if (ok) {
+        return helper.helper_proto;}
+    else {
+        yarp::os::ApplicationNetworkProtocolVersion failureproto;
+        return failureproto;}
+}
+
+//ProtocolVersion, client side
+bool ILLMMsgs::checkProtocolVersion()
+ {
+        auto locproto = this->getLocalProtocolVersion();
+        auto remproto = this->getRemoteProtocolVersion();
+        if (remproto.protocol_version != locproto.protocol_version)
+        {
+            yCError(SERVICE_LOG_COMPONENT) << "Invalid communication protocol.";
+            yCError(SERVICE_LOG_COMPONENT) << "Local Protocol Version: " << locproto.toString();
+            yCError(SERVICE_LOG_COMPONENT) << "Remote Protocol Version: " << remproto.toString();
+            return false;
+        }
+        return true;
+}
+
+//ProtocolVersion, server side
+yarp::os::ApplicationNetworkProtocolVersion ILLMMsgs::getLocalProtocolVersion()
+{
+    yarp::os::ApplicationNetworkProtocolVersion myproto;
+    //myproto.protocol_version using default value = 0
+    //to change this value add the following line to the .thrift file:
+    //const i16 protocol_version = <your_number_here>
+    myproto.protocol_version = 0;
+    myproto.yarp_major = YARP_VERSION_MAJOR;
+    myproto.yarp_minor = YARP_VERSION_MINOR;
+    myproto.yarp_patch = YARP_VERSION_PATCH;
+    return myproto;
+}
 
 // setPrompt helper class declaration
 class ILLMMsgs_setPrompt_helper :
@@ -62,10 +153,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)(const std::string&);
+    using funcptr_t = yarp::dev::ReturnValue (*)(const std::string&);
     void call(ILLMMsgs* ptr);
 
     Command cmd;
@@ -75,7 +166,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{2};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool ILLMMsgs::setPrompt(const std::string& prompt)"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue ILLMMsgs::setPrompt(const std::string& prompt)"};
     static constexpr const char* s_help{""};
 };
 
@@ -299,10 +390,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(ILLMMsgs* ptr);
 
     Command cmd;
@@ -312,7 +403,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{1};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool ILLMMsgs::deleteConversation()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue ILLMMsgs::deleteConversation()"};
     static constexpr const char* s_help{""};
 };
 
@@ -357,10 +448,10 @@ public:
         bool write(const yarp::os::idl::WireWriter& writer) const override;
         bool read(yarp::os::idl::WireReader& reader) override;
 
-        bool return_helper{false};
+        yarp::dev::ReturnValue return_helper{};
     };
 
-    using funcptr_t = bool (*)();
+    using funcptr_t = yarp::dev::ReturnValue (*)();
     void call(ILLMMsgs* ptr);
 
     Command cmd;
@@ -370,7 +461,7 @@ public:
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{1};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool ILLMMsgs::refreshConversation()"};
+    static constexpr const char* s_prototype{"yarp::dev::ReturnValue ILLMMsgs::refreshConversation()"};
     static constexpr const char* s_help{""};
 };
 
@@ -497,10 +588,7 @@ bool ILLMMsgs_setPrompt_helper::Reply::read(yarp::os::ConnectionReader& connecti
 bool ILLMMsgs_setPrompt_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -509,14 +597,11 @@ bool ILLMMsgs_setPrompt_helper::Reply::write(const yarp::os::idl::WireWriter& wr
 
 bool ILLMMsgs_setPrompt_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1050,10 +1135,7 @@ bool ILLMMsgs_deleteConversation_helper::Reply::read(yarp::os::ConnectionReader&
 bool ILLMMsgs_deleteConversation_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1062,14 +1144,11 @@ bool ILLMMsgs_deleteConversation_helper::Reply::write(const yarp::os::idl::WireW
 
 bool ILLMMsgs_deleteConversation_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1183,10 +1262,7 @@ bool ILLMMsgs_refreshConversation_helper::Reply::read(yarp::os::ConnectionReader
 bool ILLMMsgs_refreshConversation_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.writeBool(return_helper)) {
+        if (!writer.write(return_helper)) {
             return false;
         }
     }
@@ -1195,14 +1271,11 @@ bool ILLMMsgs_refreshConversation_helper::Reply::write(const yarp::os::idl::Wire
 
 bool ILLMMsgs_refreshConversation_helper::Reply::read(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readListReturn()) {
-        return false;
-    }
     if (reader.noMore()) {
         reader.fail();
         return false;
     }
-    if (!reader.readBool(return_helper)) {
+    if (!reader.read(return_helper)) {
         reader.fail();
         return false;
     }
@@ -1220,14 +1293,14 @@ ILLMMsgs::ILLMMsgs()
     yarp().setOwner(*this);
 }
 
-bool ILLMMsgs::setPrompt(const std::string& prompt)
+yarp::dev::ReturnValue ILLMMsgs::setPrompt(const std::string& prompt)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", ILLMMsgs_setPrompt_helper::s_prototype);
     }
     ILLMMsgs_setPrompt_helper helper{prompt};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 return_readPrompt ILLMMsgs::readPrompt()
@@ -1260,24 +1333,24 @@ return_getConversation ILLMMsgs::getConversation()
     return ok ? helper.reply.return_helper : return_getConversation{};
 }
 
-bool ILLMMsgs::deleteConversation()
+yarp::dev::ReturnValue ILLMMsgs::deleteConversation()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", ILLMMsgs_deleteConversation_helper::s_prototype);
     }
     ILLMMsgs_deleteConversation_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
-bool ILLMMsgs::refreshConversation()
+yarp::dev::ReturnValue ILLMMsgs::refreshConversation()
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", ILLMMsgs_refreshConversation_helper::s_prototype);
     }
     ILLMMsgs_refreshConversation_helper helper{};
     bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : bool{};
+    return ok ? helper.reply.return_helper : yarp::dev::ReturnValue{};
 }
 
 // help method
@@ -1345,6 +1418,26 @@ bool ILLMMsgs::read(yarp::os::ConnectionReader& connection)
         tag = reader.readTag(1);
     }
     while (tag_len <= max_tag_len && !reader.isError()) {
+        if(tag == "getRemoteProtocolVersion") {
+            if (!reader.noMore()) {
+                yError("Reader invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+                reader.fail();
+                return false;
+            }
+
+            auto proto = getLocalProtocolVersion();
+
+            yarp::os::idl::WireWriter writer(reader);
+           if (!writer.writeListHeader(1)) {
+                yWarning("Writer invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+               return false;}
+            if (!writer.write(proto)) {
+                yWarning("Writer invalid protocol?! %s:%d - %s", __FILE__, __LINE__, __YFUNCTION__);
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
         if (tag == ILLMMsgs_setPrompt_helper::s_tag) {
             ILLMMsgs_setPrompt_helper helper;
             if (!helper.cmd.readArgs(reader)) {

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/ILLMMsgs.h
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/ILLMMsgs.h
@@ -13,6 +13,8 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/os/ApplicationNetworkProtocolVersion.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/dev/llm/return_ask.h>
 #include <yarp/dev/llm/return_getConversation.h>
 #include <yarp/dev/llm/return_readPrompt.h>
@@ -23,10 +25,16 @@ class ILLMMsgs :
         public yarp::os::Wire
 {
 public:
+    //ProtocolVersion
+    virtual yarp::os::ApplicationNetworkProtocolVersion getLocalProtocolVersion();
+    virtual yarp::os::ApplicationNetworkProtocolVersion getRemoteProtocolVersion();
+    virtual bool checkProtocolVersion();
+
     // Constructor
     ILLMMsgs();
 
-    virtual bool setPrompt(const std::string& prompt);
+    //Service methods
+    virtual yarp::dev::ReturnValue setPrompt(const std::string& prompt);
 
     virtual return_readPrompt readPrompt();
 
@@ -34,9 +42,9 @@ public:
 
     virtual return_getConversation getConversation();
 
-    virtual bool deleteConversation();
+    virtual yarp::dev::ReturnValue deleteConversation();
 
-    virtual bool refreshConversation();
+    virtual yarp::dev::ReturnValue refreshConversation();
 
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_ask.cpp
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_ask.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev::llm {
 
 // Constructor with field values
-return_ask::return_ask(const bool ret,
+return_ask::return_ask(const yarp::dev::ReturnValue& ret,
                        const yarp::dev::LLM_Message& answer) :
         WirePortable(),
         ret(ret),
@@ -24,7 +24,7 @@ return_ask::return_ask(const bool ret,
 // Read structure on a Wire
 bool return_ask::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!nested_read_answer(reader)) {
@@ -52,7 +52,7 @@ bool return_ask::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_ask::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!nested_write_answer(writer)) {
@@ -90,8 +90,13 @@ std::string return_ask::toString() const
 // read ret field
 bool return_ask::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -99,7 +104,7 @@ bool return_ask::read_ret(yarp::os::idl::WireReader& reader)
 // write ret field
 bool return_ask::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -108,8 +113,13 @@ bool return_ask::write_ret(const yarp::os::idl::WireWriter& writer) const
 // read (nested) ret field
 bool return_ask::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -117,7 +127,7 @@ bool return_ask::nested_read_ret(yarp::os::idl::WireReader& reader)
 // write (nested) ret field
 bool return_ask::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_ask.h
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_ask.h
@@ -14,6 +14,7 @@
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
 #include <yarp/dev/ILLM.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev::llm {
 
@@ -22,14 +23,14 @@ class return_ask :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     yarp::dev::LLM_Message answer{};
 
     // Default constructor
     return_ask() = default;
 
     // Constructor with field values
-    return_ask(const bool ret,
+    return_ask(const yarp::dev::ReturnValue& ret,
                const yarp::dev::LLM_Message& answer);
 
     // Read structure on a Wire

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_getConversation.cpp
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_getConversation.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev::llm {
 
 // Constructor with field values
-return_getConversation::return_getConversation(const bool ret,
+return_getConversation::return_getConversation(const yarp::dev::ReturnValue& ret,
                                                const std::vector<yarp::dev::LLM_Message>& conversation) :
         WirePortable(),
         ret(ret),
@@ -24,7 +24,7 @@ return_getConversation::return_getConversation(const bool ret,
 // Read structure on a Wire
 bool return_getConversation::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!read_conversation(reader)) {
@@ -52,7 +52,7 @@ bool return_getConversation::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_getConversation::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!write_conversation(writer)) {
@@ -90,8 +90,13 @@ std::string return_getConversation::toString() const
 // read ret field
 bool return_getConversation::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -99,7 +104,7 @@ bool return_getConversation::read_ret(yarp::os::idl::WireReader& reader)
 // write ret field
 bool return_getConversation::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -108,8 +113,13 @@ bool return_getConversation::write_ret(const yarp::os::idl::WireWriter& writer) 
 // read (nested) ret field
 bool return_getConversation::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -117,7 +127,7 @@ bool return_getConversation::nested_read_ret(yarp::os::idl::WireReader& reader)
 // write (nested) ret field
 bool return_getConversation::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_getConversation.h
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_getConversation.h
@@ -14,6 +14,7 @@
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
 #include <yarp/dev/ILLM.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev::llm {
 
@@ -22,14 +23,14 @@ class return_getConversation :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     std::vector<yarp::dev::LLM_Message> conversation{};
 
     // Default constructor
     return_getConversation() = default;
 
     // Constructor with field values
-    return_getConversation(const bool ret,
+    return_getConversation(const yarp::dev::ReturnValue& ret,
                            const std::vector<yarp::dev::LLM_Message>& conversation);
 
     // Read structure on a Wire

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_readPrompt.cpp
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_readPrompt.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev::llm {
 
 // Constructor with field values
-return_readPrompt::return_readPrompt(const bool ret,
+return_readPrompt::return_readPrompt(const yarp::dev::ReturnValue& ret,
                                      const std::string& prompt) :
         WirePortable(),
         ret(ret),
@@ -24,7 +24,7 @@ return_readPrompt::return_readPrompt(const bool ret,
 // Read structure on a Wire
 bool return_readPrompt::read(yarp::os::idl::WireReader& reader)
 {
-    if (!read_ret(reader)) {
+    if (!nested_read_ret(reader)) {
         return false;
     }
     if (!read_prompt(reader)) {
@@ -52,7 +52,7 @@ bool return_readPrompt::read(yarp::os::ConnectionReader& connection)
 // Write structure on a Wire
 bool return_readPrompt::write(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!write_ret(writer)) {
+    if (!nested_write_ret(writer)) {
         return false;
     }
     if (!write_prompt(writer)) {
@@ -90,8 +90,13 @@ std::string return_readPrompt::toString() const
 // read ret field
 bool return_readPrompt::read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -99,7 +104,7 @@ bool return_readPrompt::read_ret(yarp::os::idl::WireReader& reader)
 // write ret field
 bool return_readPrompt::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.write(ret)) {
         return false;
     }
     return true;
@@ -108,8 +113,13 @@ bool return_readPrompt::write_ret(const yarp::os::idl::WireWriter& writer) const
 // read (nested) ret field
 bool return_readPrompt::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
-    if (!reader.readBool(ret)) {
-        ret = false;
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readNested(ret)) {
+        reader.fail();
+        return false;
     }
     return true;
 }
@@ -117,7 +127,7 @@ bool return_readPrompt::nested_read_ret(yarp::os::idl::WireReader& reader)
 // write (nested) ret field
 bool return_readPrompt::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeBool(ret)) {
+    if (!writer.writeNested(ret)) {
         return false;
     }
     return true;

--- a/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_readPrompt.h
+++ b/src/devices/messages/ILLMMsgs/idl_generated_code/yarp/dev/llm/return_readPrompt.h
@@ -13,6 +13,7 @@
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
+#include <yarp/dev/ReturnValue.h>
 
 namespace yarp::dev::llm {
 
@@ -21,14 +22,14 @@ class return_readPrompt :
 {
 public:
     // Fields
-    bool ret{false};
+    yarp::dev::ReturnValue ret{};
     std::string prompt{};
 
     // Default constructor
     return_readPrompt() = default;
 
     // Constructor with field values
-    return_readPrompt(const bool ret,
+    return_readPrompt(const yarp::dev::ReturnValue& ret,
                       const std::string& prompt);
 
     // Read structure on a Wire

--- a/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.cpp
@@ -13,6 +13,8 @@ namespace
     YARP_LOG_COMPONENT(LLM_NWC_YARP, "yarp.device.LLM_nwc_yarp")
 }
 
+using namespace yarp::dev;
+
 bool LLM_nwc_yarp::open(yarp::os::Searchable &config)
 {
     if (!parseParams(config)) { return false; }
@@ -47,12 +49,12 @@ bool LLM_nwc_yarp::close()
     return true;
 }
 
-bool LLM_nwc_yarp::setPrompt(const std::string &prompt)
+ReturnValue LLM_nwc_yarp::setPrompt(const std::string &prompt)
 {
     return m_LLM_RPC.setPrompt(prompt);
 }
 
-bool LLM_nwc_yarp::readPrompt(std::string &oPrompt)
+ReturnValue LLM_nwc_yarp::readPrompt(std::string &oPrompt)
 {
     auto ret = m_LLM_RPC.readPrompt();
 
@@ -60,7 +62,7 @@ bool LLM_nwc_yarp::readPrompt(std::string &oPrompt)
     return ret.ret;
 }
 
-bool LLM_nwc_yarp::ask(const std::string &question, yarp::dev::LLM_Message &oAnswer)
+ReturnValue LLM_nwc_yarp::ask(const std::string &question, yarp::dev::LLM_Message &oAnswer)
 {
     auto ret = m_LLM_RPC.ask(question);
 
@@ -68,7 +70,7 @@ bool LLM_nwc_yarp::ask(const std::string &question, yarp::dev::LLM_Message &oAns
     return ret.ret;
 }
 
-bool LLM_nwc_yarp::getConversation(std::vector<yarp::dev::LLM_Message> &oConversation)
+ReturnValue LLM_nwc_yarp::getConversation(std::vector<yarp::dev::LLM_Message> &oConversation)
 {
     auto ret = m_LLM_RPC.getConversation();
     for (const auto &message : ret.conversation)
@@ -76,15 +78,15 @@ bool LLM_nwc_yarp::getConversation(std::vector<yarp::dev::LLM_Message> &oConvers
         oConversation.push_back(message);
     }
 
-    return true;
+    return ReturnValue_ok;
 }
 
-bool LLM_nwc_yarp::deleteConversation()
+ReturnValue LLM_nwc_yarp::deleteConversation()
 {
     return m_LLM_RPC.deleteConversation();
 }
 
-bool LLM_nwc_yarp::refreshConversation()
+ReturnValue LLM_nwc_yarp::refreshConversation()
 {
     return m_LLM_RPC.refreshConversation();
 }

--- a/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.h
+++ b/src/devices/networkWrappers/LLM_nwc_yarp/LLM_nwc_yarp.h
@@ -35,10 +35,10 @@ public:
     bool close() override;
 
     //From ILLM
-    bool setPrompt(const std::string& prompt) override;
-    bool readPrompt(std::string& oPrompt) override;
-    bool ask(const std::string& question, yarp::dev::LLM_Message& oAnswer) override;
-    bool getConversation(std::vector<yarp::dev::LLM_Message>& oConversation) override;
-    bool deleteConversation() override;
-    bool refreshConversation() override;
+    yarp::dev::ReturnValue setPrompt(const std::string& prompt) override;
+    yarp::dev::ReturnValue readPrompt(std::string& oPrompt) override;
+    yarp::dev::ReturnValue ask(const std::string& question, yarp::dev::LLM_Message& oAnswer) override;
+    yarp::dev::ReturnValue getConversation(std::vector<yarp::dev::LLM_Message>& oConversation) override;
+    yarp::dev::ReturnValue deleteConversation() override;
+    yarp::dev::ReturnValue refreshConversation() override;
 };

--- a/src/devices/networkWrappers/LLM_nws_yarp/ILLMServerImpl.cpp
+++ b/src/devices/networkWrappers/LLM_nws_yarp/ILLMServerImpl.cpp
@@ -8,25 +8,28 @@
 
 #include <ILLMServerImpl.h>
 
+using namespace yarp::dev;
+
 namespace {
 YARP_LOG_COMPONENT(LLMSERVER, "yarp.device.LLMServer")
 }
 
-bool ILLMRPCd::setPrompt(const std::string& prompt)
+ReturnValue ILLMRPCd::setPrompt(const std::string& prompt)
 {
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
 
-    if (!m_iLlm->setPrompt(prompt)) {
+    auto ret = m_iLlm->setPrompt(prompt);
+    if (!ret) {
         yCError(LLMSERVER, "setPrompt failed");
-        return false;
+        return ret;
     }
 
     m_stream_conversation();
 
-    return true;
+    return ret;
 }
 
 yarp::dev::llm::return_readPrompt ILLMRPCd::readPrompt()
@@ -36,7 +39,7 @@ yarp::dev::llm::return_readPrompt ILLMRPCd::readPrompt()
 
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
@@ -51,7 +54,7 @@ yarp::dev::llm::return_ask ILLMRPCd::ask(const std::string& question)
 
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
@@ -102,7 +105,7 @@ yarp::dev::llm::return_getConversation ILLMRPCd::getConversation()
 
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        ret.ret = false;
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
         return ret;
     }
 
@@ -113,15 +116,14 @@ yarp::dev::llm::return_getConversation ILLMRPCd::getConversation()
     return ret;
 }
 
-bool ILLMRPCd::deleteConversation()
+ReturnValue ILLMRPCd::deleteConversation()
 {
-    bool ret = false;
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
 
-    ret = m_iLlm->deleteConversation();
+    auto ret = m_iLlm->deleteConversation();
 
     if (ret) {
         m_stream_conversation();
@@ -130,15 +132,14 @@ bool ILLMRPCd::deleteConversation()
     return ret;
 }
 
-bool ILLMRPCd::refreshConversation()
+ReturnValue ILLMRPCd::refreshConversation()
 {
-    bool ret = false;
     if (m_iLlm == nullptr) {
         yCError(LLMSERVER, "Invalid interface");
-        return false;
+        return ReturnValue::return_code::return_value_error_not_ready;
     }
 
-    ret = m_iLlm->refreshConversation();
+    auto ret = m_iLlm->refreshConversation();
 
     if (ret) {
         m_stream_conversation();

--- a/src/devices/networkWrappers/LLM_nws_yarp/ILLMServerImpl.h
+++ b/src/devices/networkWrappers/LLM_nws_yarp/ILLMServerImpl.h
@@ -30,10 +30,10 @@ public:
         m_streaming_port.close();
     }
     // From IGPTMsgs
-    bool setPrompt(const std::string& prompt) override;
+    yarp::dev::ReturnValue setPrompt(const std::string& prompt) override;
     yarp::dev::llm::return_readPrompt readPrompt() override;
     yarp::dev::llm::return_ask ask(const std::string& question) override;
     yarp::dev::llm::return_getConversation getConversation() override;
-    bool deleteConversation() override;
-    bool refreshConversation() override;
+    yarp::dev::ReturnValue deleteConversation() override;
+    yarp::dev::ReturnValue refreshConversation() override;
 };

--- a/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.cpp
@@ -13,6 +13,8 @@ namespace
     YARP_LOG_COMPONENT(CHATBOT_NWC_YARP, "yarp.device.chatBot_nwc_yarp")
 }
 
+using namespace yarp::dev;
+
 bool ChatBot_nwc_yarp::open(yarp::os::Searchable &config)
 {
     if (!parseParams(config)) { return false; }
@@ -50,59 +52,61 @@ bool ChatBot_nwc_yarp::close()
     return true;
 }
 
-bool ChatBot_nwc_yarp::interact(const std::string& messageIn, std::string& messageOut)
+ReturnValue ChatBot_nwc_yarp::interact(const std::string& messageIn, std::string& messageOut)
 {
     return_interact output = m_thriftClient.interactRPC(messageIn);
     if(!output.result)
     {
         yCError(CHATBOT_NWC_YARP) << "Could not interact with the chatbot";
-        return false;
+        return output.result;
     }
 
     messageOut = output.messageOut;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool ChatBot_nwc_yarp::setLanguage(const std::string& language)
+ReturnValue ChatBot_nwc_yarp::setLanguage(const std::string& language)
 {
-    if(!m_thriftClient.setLanguageRPC(language))
+    auto ret = m_thriftClient.setLanguageRPC(language);
+    if(!ret)
     {
         yCError(CHATBOT_NWC_YARP) << "Could not set the chatbot language to" << language;
-        return false;
+        return ret;
     }
-    return true;
+    return ReturnValue_ok;
 }
 
-bool ChatBot_nwc_yarp::getLanguage(std::string& language)
+ReturnValue ChatBot_nwc_yarp::getLanguage(std::string& language)
 {
-    return_getLanguage output = m_thriftClient.getLanguageRPC();
+    auto output = m_thriftClient.getLanguageRPC();
     if(!output.result)
     {
         yCError(CHATBOT_NWC_YARP) << "Could not retrieve the currently set language";
-        return false;
+        return output.result;
     }
     language = output.language;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool ChatBot_nwc_yarp::getStatus(std::string& status)
+ReturnValue ChatBot_nwc_yarp::getStatus(std::string& status)
 {
-    return_getStatus output = m_thriftClient.getStatusRPC();
+    auto output = m_thriftClient.getStatusRPC();
     if(!output.result)
     {
         yCError(CHATBOT_NWC_YARP) << "Could not retrieve the current bot status";
-        return false;
+        return output.result;
     }
     status = output.status;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool ChatBot_nwc_yarp::resetBot()
+ReturnValue ChatBot_nwc_yarp::resetBot()
 {
-    if(!m_thriftClient.resetBotRPC())
+    auto output = m_thriftClient.resetBotRPC();
+    if(!output)
     {
         yCError(CHATBOT_NWC_YARP) << "Could not reset the chatbot";
-        return false;
+        return output;
     }
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.h
+++ b/src/devices/networkWrappers/chatBot_nwc_yarp/ChatBot_nwc_yarp.h
@@ -38,11 +38,11 @@ public:
     bool close() override;
 
     //From IChatBot
-    bool interact(const std::string& messageIn, std::string& messageOut) override;
-    bool setLanguage(const std::string& language) override;
-    bool getLanguage(std::string& language) override;
-    bool getStatus(std::string& status) override;
-    bool resetBot() override;
+    yarp::dev::ReturnValue interact(const std::string& messageIn, std::string& messageOut) override;
+    yarp::dev::ReturnValue setLanguage(const std::string& language) override;
+    yarp::dev::ReturnValue getLanguage(std::string& language) override;
+    yarp::dev::ReturnValue getStatus(std::string& status) override;
+    yarp::dev::ReturnValue resetBot() override;
 };
 
 #endif // YARP_DEV_CHATBOT_NWC_YARP_H

--- a/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.h
+++ b/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.h
@@ -51,10 +51,10 @@ private:
 
 public:
     return_interact    interactRPC(const std::string& messageIn) override;
-    bool               setLanguageRPC(const std::string& language) override;
+    ReturnValue        setLanguageRPC(const std::string& language) override;
     return_getLanguage getLanguageRPC() override;
     return_getStatus   getStatusRPC() override;
-    bool               resetBotRPC() override;
+    ReturnValue        resetBotRPC() override;
 
 public:
     bool setInterfaces(yarp::dev::IChatBot* iChatBot);

--- a/src/devices/networkWrappers/chatBot_nws_yarp/IChatBotMsgsImpl.cpp
+++ b/src/devices/networkWrappers/chatBot_nws_yarp/IChatBotMsgsImpl.cpp
@@ -13,6 +13,8 @@ namespace {
 YARP_LOG_COMPONENT(ICHATBOTMSGSIMPL, "yarp.devices.chatBot_nws_yarp.ChatBotRPC_CallbackHelper")
 }
 
+using namespace yarp::dev;
+
 bool IChatBotMsgsImpl::setInterfaces(yarp::dev::IChatBot* iChatBot)
 {
     if(!iChatBot)
@@ -32,28 +34,31 @@ return_interact IChatBotMsgsImpl::interactRPC(const std::string& messageIn)
     return_interact response;
     std::string messageOut;
 
-    if(!m_iChatBot->interact(messageIn,messageOut))
+    auto ret = m_iChatBot->interact(messageIn, messageOut);
+    if(!ret)
     {
         yCError(ICHATBOTMSGSIMPL) << "An error occurred while interacting with the chatBot";
-        response.result = false;
+        response.result = ret;
         return response;
     }
 
+    response.result = ret;
     response.messageOut = messageOut;
-    response.result = true;
     return response;
 }
 
-bool IChatBotMsgsImpl::setLanguageRPC(const std::string& language)
+ReturnValue IChatBotMsgsImpl::setLanguageRPC(const std::string& language)
 {
     std::lock_guard <std::mutex> lg(m_mutex);
-    if(!m_iChatBot->setLanguage(language))
+
+    auto ret = m_iChatBot->setLanguage(language);
+    if(!ret)
     {
         yCError(ICHATBOTMSGSIMPL) << "Could not set bot language to" << language;
-        return false;
+        return ret;
     }
 
-    return true;
+    return ReturnValue_ok;
 }
 
 return_getLanguage IChatBotMsgsImpl::getLanguageRPC()
@@ -61,14 +66,16 @@ return_getLanguage IChatBotMsgsImpl::getLanguageRPC()
     std::lock_guard <std::mutex> lg(m_mutex);
     return_getLanguage response;
     std::string language;
-    if(!m_iChatBot->getLanguage(language))
+
+    auto ret = m_iChatBot->getLanguage(language);
+    if(!ret)
     {
         yCError(ICHATBOTMSGSIMPL) << "Could not retrieve the chatbot language";
-        response.result = false;
+        response.result = ret;
         return response;
     }
 
-    response.result = true;
+    response.result = ret;
     response.language = language;
 
     return response;
@@ -79,28 +86,31 @@ return_getStatus IChatBotMsgsImpl::getStatusRPC()
     std::lock_guard <std::mutex> lg(m_mutex);
     return_getStatus response;
     std::string status;
-    if(!m_iChatBot->getStatus(status))
+
+    auto ret = m_iChatBot->getStatus(status);
+    if(!ret)
     {
         yCError(ICHATBOTMSGSIMPL) << "Could not retrieve the chatbot status";
-        response.result = false;
+        response.result = ret;
         return response;
     }
 
-    response.result = true;
+    response.result = ret;
     response.status = status;
 
     return response;
 }
 
-bool IChatBotMsgsImpl::resetBotRPC()
+ReturnValue IChatBotMsgsImpl::resetBotRPC()
 {
     std::lock_guard <std::mutex> lg(m_mutex);
-    if(!m_iChatBot->resetBot())
+
+    auto ret = m_iChatBot->resetBot();
+    if(!ret)
     {
         yCError(ICHATBOTMSGSIMPL) << "Could not reset the bot";
-
-        return false;
+        return ret;
     }
 
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/libYARP_dev/src/yarp/dev/IChatBot.h
+++ b/src/libYARP_dev/src/yarp/dev/IChatBot.h
@@ -7,6 +7,7 @@
 #define YARP_DEV_ICHATBOT_H
 
 #include <yarp/dev/api.h>
+#include <yarp/dev/ReturnValue.h>
 
 #include <string>
 #include <vector>
@@ -35,34 +36,34 @@ public:
     * @param messageOut the output message
     * @return true/false
     */
-    virtual bool interact(const std::string& messageIn, std::string& messageOut) = 0;
+    virtual yarp::dev::ReturnValue interact(const std::string& messageIn, std::string& messageOut) = 0;
 
     /**
      * Sets the chat bot language.
      * \param language a string (code) representing the speech language (e.g. ita, eng...). Default value is "auto".
      * \return true on success
      */
-    virtual bool setLanguage(const std::string& language="auto") = 0;
+    virtual yarp::dev::ReturnValue setLanguage(const std::string& language="auto") = 0;
 
     /**
      * Gets the current chatbot language.
      * \param language the returned string (code) representing the speech language (e.g. ita, eng...). Default value is "auto".
      * \return true on success
      */
-    virtual bool getLanguage(std::string& language) = 0;
+    virtual yarp::dev::ReturnValue getLanguage(std::string& language) = 0;
 
     /**
      * Gets the current status of the bot
      * \param status the current bot status
      * \return true on success
     */
-    virtual bool getStatus(std::string& status) = 0;
+    virtual yarp::dev::ReturnValue getStatus(std::string& status) = 0;
 
     /**
      * Resets the chatbot
      * \return true on success
     */
-    virtual bool resetBot() = 0;
+    virtual yarp::dev::ReturnValue resetBot() = 0;
 };
 
 

--- a/src/libYARP_dev/src/yarp/dev/ILLM.h
+++ b/src/libYARP_dev/src/yarp/dev/ILLM.h
@@ -7,6 +7,7 @@
 #define YARP_DEV_ILLM_H
 
 #include <yarp/dev/api.h>
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/dev/LLM_Message.h>
 
 #include <string>
@@ -34,14 +35,14 @@ public:
     * @param prompt provides a prompt to the LLM
     * @return true/false
     */
-    virtual bool setPrompt(const std::string& prompt) = 0;
+    virtual yarp::dev::ReturnValue setPrompt(const std::string& prompt) = 0;
 
     /**
     * Retrieves the provided prompt
     * @param prompt the stored prompt
     * @return true/false
     */
-    virtual bool readPrompt(std::string& oPrompt) = 0;
+    virtual yarp::dev::ReturnValue readPrompt(std::string& oPrompt) = 0;
 
     /**
     * Performs a question
@@ -49,26 +50,26 @@ public:
     * @param answer the returned answer
     * @return true/false
     */
-    virtual bool ask(const std::string& question, yarp::dev::LLM_Message& answer) = 0;
+    virtual yarp::dev::ReturnValue ask(const std::string& question, yarp::dev::LLM_Message& answer) = 0;
 
     /**
     * Retrieves the whole conversation
     * @param conversation the conversation
     * @return true/false
     */
-    virtual bool getConversation(std::vector<yarp::dev::LLM_Message>& conversation) = 0;
+    virtual yarp::dev::ReturnValue getConversation(std::vector<yarp::dev::LLM_Message>& conversation) = 0;
 
     /**
     * Delete the conversation and clear the system context from any internally stored context.
     * @return true/false
     */
-    virtual bool deleteConversation() = 0;
+    virtual yarp::dev::ReturnValue deleteConversation() = 0;
 
     /**
     *  Refresh the conversation
     * @return true/false
     */
-    virtual bool refreshConversation() = 0;
+    virtual yarp::dev::ReturnValue refreshConversation() = 0;
 };
 
 #endif


### PR DESCRIPTION
* The following interfaces have been modified to use `yarp::dev::ReturnValue`:
  - `ILLM`
  - `IChatBot`

* The following devices have been modified to use `yarp::dev::ReturnValue`:
  - `fakeChatBotDevice`
  - `chatBot_nws_yarp`
  - `chatBot_nwc_yarp`
  - `fakeLLMDevice`
  - `LLM_nwc_yarp`
  - `LLM_nws_yarp`