### PR TITLE
Fix set_property of non-existant CustomInit.cpp file

### DIFF
--- a/src/libYARP_init/src/CMakeLists.txt
+++ b/src/libYARP_init/src/CMakeLists.txt
@@ -7,8 +7,9 @@ add_library(YARP::YARP_init ALIAS YARP_init)
 
 set(YARP_init_HDRS)
 set(YARP_init_IMPL_HDRS)
+set(YARP_custom_init_SRC "yarp/os/Network.CustomInit.cpp"
 set(YARP_init_SRCS
-  yarp/os/Network.CustomInit.cpp
+  ${YARP_custom_init_SRC}
 )
 
 source_group(
@@ -39,7 +40,7 @@ target_compile_features(YARP_init PUBLIC cxx_std_17)
 if(YARP_LINK_PLUGINS)
   if(YARP_COMPILE_CARRIER_PLUGINS)
     set_property(
-      SOURCE CustomInit.cpp
+      SOURCE ${YARP_custom_init_SRC}
       APPEND PROPERTY COMPILE_DEFINITIONS yarpcar_INIT_FUNCTION=add_yarpcar_plugins
     )
     target_link_libraries(YARP_init PRIVATE YARP::yarpcar)
@@ -48,7 +49,7 @@ if(YARP_LINK_PLUGINS)
 
   if(YARP_COMPILE_PORTMONITOR_PLUGINS)
     set_property(
-      SOURCE CustomInit.cpp
+      SOURCE ${YARP_custom_init_SRC}
       APPEND PROPERTY COMPILE_DEFINITIONS yarppm_INIT_FUNCTION=add_yarppm_plugins
     )
     target_link_libraries(YARP_init PRIVATE YARP::yarppm)
@@ -57,7 +58,7 @@ if(YARP_LINK_PLUGINS)
 
   if(YARP_COMPILE_DEVICE_PLUGINS)
     set_property(
-      SOURCE CustomInit.cpp
+      SOURCE ${YARP_custom_init_SRC}
       APPEND PROPERTY COMPILE_DEFINITIONS yarpmod_INIT_FUNCTION=add_yarpmod_plugins
     )
     target_link_libraries(YARP_init PRIVATE YARP::yarpmod)
@@ -66,7 +67,7 @@ if(YARP_LINK_PLUGINS)
 
   if(YARP_COMPILE_RFMODULE_PLUGINS)
     set_property(
-      SOURCE CustomInit.cpp
+      SOURCE ${YARP_custom_init_SRC}
       APPEND PROPERTY COMPILE_DEFINITIONS yarprfmod_INIT_FUNCTION=add_yarprfmod_plugins
     )
     target_link_libraries(YARP_init PRIVATE YARP::yarprfmod)

--- a/src/libYARP_init/src/CMakeLists.txt
+++ b/src/libYARP_init/src/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(YARP::YARP_init ALIAS YARP_init)
 
 set(YARP_init_HDRS)
 set(YARP_init_IMPL_HDRS)
-set(YARP_custom_init_SRC "yarp/os/Network.CustomInit.cpp"
+set(YARP_custom_init_SRC "yarp/os/Network.CustomInit.cpp")
 set(YARP_init_SRCS
   ${YARP_custom_init_SRC}
 )


### PR DESCRIPTION
The `CustomInit.cpp` file was renamed in https://github.com/robotology/yarp/commit/3eb97000f57d388bc746e7304eb46de1c2c0e1b0#diff-e26e6136eee05544fca0d9360616145d09f0910dff53c12cbd8c046c0790fb5a (part of https://github.com/robotology/yarp/pull/2123, a ~1000 files modified PR that apparently I approved :D ) but the CMake code that referred to it was not modified. In this PR, we fix this and avoid to define the name of the file in multiple places.