### PR TITLE
Fix for static builds: avoiding multiple symbols definitions

### DIFF
--- a/doc/release/yarp_3_11/000_yarp_3_11.md
+++ b/doc/release/yarp_3_11/000_yarp_3_11.md
@@ -10,3 +10,9 @@ YARP <yarp-3.11> Release Notes
 A (partial) list of bug fixed and issues resolved in this release can be found
 [here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-3.11%22).
 
+Fixes
+-----
+
+* Rename vendored TinyXML cmake project and package from `YARP_priv_tinyxml` to `YARP_priv_TinyXML`
+* Added test for `yarp::dev::Drivers::factory()` compiled with `BUILD_SHARED_LIBS=OFF`
+* Fixed static build of devices, port-monitors, carriers and, more in general, yarp_dev plugins

--- a/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor.cpp
+++ b/src/devices/fake/fakeLaserWithMotor/FakeLaserWithMotor.cpp
@@ -23,7 +23,7 @@
 #define DEG2RAD M_PI/180.0
 #endif
 
-YARP_LOG_COMPONENT(FAKE_LASER, "yarp.devices.fakeLaserWithMotor")
+YARP_LOG_COMPONENT(FAKE_LASER_WITH_MOTOR, "yarp.devices.fakeLaserWithMotor")
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -42,18 +42,18 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
 
     if (config.check("help"))
     {
-        yCInfo(FAKE_LASER,"Some examples:");
-        yCInfo(FAKE_LASER,"yarpdev --device fakeLaserWithMotor --help");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test no_obstacles");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_pattern");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_constant --const_distance 0.5");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_constant --const_distance 0.5 --SENSOR::resolution 0.5 --SKIP::min 0 50 --SKIP::max 10 60");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_port /fakeLaser/location:i");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_server /localizationServer");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_client /fakeLaser/localizationClient --localization_server /localizationServer");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_context context --map_file mymap.map");
-        yCInfo(FAKE_LASER,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_client /fakeLaser/localizationClient --localization_server /localization2D_nws_yarp --localization_device localization2D_nwc_yarp");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"Some examples:");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device fakeLaserWithMotor --help");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test no_obstacles");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_pattern");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_constant --const_distance 0.5");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_constant --const_distance 0.5 --SENSOR::resolution 0.5 --SKIP::min 0 50 --SKIP::max 10 60");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_port /fakeLaser/location:i");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_server /localizationServer");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_client /fakeLaser/localizationClient --localization_server /localizationServer");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_context context --map_file mymap.map");
+        yCInfo(FAKE_LASER_WITH_MOTOR,"yarpdev --device rangefinder2D_nws_yarp --subdevice fakeLaserWithMotor --period 0.01 --name /fakeLaser:o --test use_mapfile --map_file mymap.map --localization_client /fakeLaser/localizationClient --localization_server /localization2D_nws_yarp --localization_device localization2D_nwc_yarp");
         return false;
     }
 
@@ -63,12 +63,12 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
     else if (string_test_mode == "use_mapfile") { m_test_mode = USE_MAPFILE; }
     else if (string_test_mode == "use_constant") { m_test_mode = USE_CONSTANT_VALUE; }
     else if (string_test_mode == "use_square_trap") { m_test_mode = USE_SQUARE_TRAP; }
-    else    { yCError(FAKE_LASER) << "invalid/unknown value for param 'test'"; return false; }
+    else    { yCError(FAKE_LASER_WITH_MOTOR) << "invalid/unknown value for param 'test'"; return false; }
 
     //parse all the parameters related to the linear/angular range of the sensor
     if (this->parseConfiguration(config) == false)
     {
-        yCError(FAKE_LASER) << ": error parsing parameters";
+        yCError(FAKE_LASER_WITH_MOTOR) << ": error parsing parameters";
         return false;
     }
 
@@ -110,12 +110,12 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
                 map_file = rf.findFile(tmp_filename);
                 if (map_file == "")
                 {
-                    yCWarning(FAKE_LASER, "Unable to find file: %s from context: %s\n", tmp_filename.c_str(), tmp_contextname.c_str());
+                    yCWarning(FAKE_LASER_WITH_MOTOR, "Unable to find file: %s from context: %s\n", tmp_filename.c_str(), tmp_contextname.c_str());
                 }
             }
             else
             {
-                yCWarning(FAKE_LASER, "Unable to find file: %s from context: %s\n", tmp_filename.c_str(), tmp_contextname.c_str());
+                yCWarning(FAKE_LASER_WITH_MOTOR, "Unable to find file: %s from context: %s\n", tmp_filename.c_str(), tmp_contextname.c_str());
             }
         }
         else if (!m_MAP_MODE_map_file.empty())
@@ -124,19 +124,19 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
         }
         else
         {
-            yCError(FAKE_LASER) << "Missing `map_file` or `map_context`+`map_file` parameters";
+            yCError(FAKE_LASER_WITH_MOTOR) << "Missing `map_file` or `map_context`+`map_file` parameters";
             return false;
         }
 
         if (map_file=="")
         {
-            yCError(FAKE_LASER) << "File not found";
+            yCError(FAKE_LASER_WITH_MOTOR) << "File not found";
             return false;
         }
         bool ret = m_originally_loaded_map.loadFromFile(map_file);
         if (ret == false)
         {
-            yCError(FAKE_LASER) << "A problem occurred while opening:" << map_file;
+            yCError(FAKE_LASER_WITH_MOTOR) << "A problem occurred while opening:" << map_file;
             return false;
         }
         m_map = m_originally_loaded_map;
@@ -145,8 +145,8 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
         m_robot_loc_t=0;
     }
 
-    yCInfo(FAKE_LASER) << "Starting debug mode";
-    yCInfo(FAKE_LASER) << "test mode:"<< m_test_mode << " i.e. " << string_test_mode;
+    yCInfo(FAKE_LASER_WITH_MOTOR) << "Starting debug mode";
+    yCInfo(FAKE_LASER_WITH_MOTOR) << "test mode:"<< m_test_mode << " i.e. " << string_test_mode;
 
     //  INIT ALL INTERFACES
     std::vector<double> tmpZeros; tmpZeros.resize(m_njoints, 0.0);
@@ -163,7 +163,7 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
     ImplementAxisInfo::initialize(m_njoints, axisMap.data());
     if (!alloc(m_njoints))
     {
-        yCError(FAKE_LASER) << "Malloc failed";
+        yCError(FAKE_LASER_WITH_MOTOR) << "Malloc failed";
         return false;
     }
     _jointType[0] = VOCAB_JOINTTYPE_PRISMATIC;
@@ -178,7 +178,7 @@ bool FakeLaserWithMotor::open(yarp::os::Searchable& config)
 
     if (!m_rpcPort.open("/fakeLaser/rpc:i"))
     {
-        yCError(FAKE_LASER, "Failed to open port %s", "/fakeLaser/rpc:i");
+        yCError(FAKE_LASER_WITH_MOTOR, "Failed to open port %s", "/fakeLaser/rpc:i");
         return false;
     }
     m_rpcPort.setReader(*this);
@@ -301,7 +301,7 @@ bool FakeLaserWithMotor::read(yarp::os::ConnectionReader& connection)
     }
     else
     {
-        yCError(FAKE_LASER) << "Invalid command";
+        yCError(FAKE_LASER_WITH_MOTOR) << "Invalid command";
         reply.addVocab32(VOCAB_ERR);
     }
 

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.cpp
@@ -42,12 +42,12 @@ double constrainAngle(double x)
     return x;
 }
 
-InputPortProcessor::InputPortProcessor()
+LaserFromExternalPort_InputPortProcessor::LaserFromExternalPort_InputPortProcessor()
 {
     m_contains_data=false;
 }
 
-void InputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
+void LaserFromExternalPort_InputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
 {
     m_port_mutex.lock();
         m_lastScan = b;
@@ -56,7 +56,7 @@ void InputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
     m_port_mutex.unlock();
 }
 
-inline void InputPortProcessor::getLast(yarp::sig::LaserScan2D& data, Stamp& stmp)
+inline void LaserFromExternalPort_InputPortProcessor::getLast(yarp::sig::LaserScan2D& data, Stamp& stmp)
 {
     //this blocks untils the first data is received;
     size_t counter =0;
@@ -107,7 +107,7 @@ bool LaserFromExternalPort::open(yarp::os::Searchable& config)
 
         for (size_t i = 0; i < m_port_names.size(); i++)
         {
-            InputPortProcessor proc;
+            LaserFromExternalPort_InputPortProcessor proc;
             m_input_ports.push_back(proc);
         }
         m_last_stamp.resize(m_port_names.size());

--- a/src/devices/laserFromExternalPort/laserFromExternalPort.h
+++ b/src/devices/laserFromExternalPort/laserFromExternalPort.h
@@ -26,14 +26,7 @@
 typedef unsigned char byte;
 
 //---------------------------------------------------------------------------------------------------------------
-enum base_enum
-{
-    BASE_IS_NAN = 0,
-    BASE_IS_INF = 1,
-    BASE_IS_ZERO = 2
-};
-
-class InputPortProcessor :
+class LaserFromExternalPort_InputPortProcessor :
         public yarp::os::BufferedPort<yarp::sig::LaserScan2D>
 {
     std::mutex             m_port_mutex;
@@ -42,7 +35,7 @@ class InputPortProcessor :
     bool                   m_contains_data;
 
 public:
-    InputPortProcessor(const InputPortProcessor& alt) :
+    LaserFromExternalPort_InputPortProcessor(const LaserFromExternalPort_InputPortProcessor& alt) :
             yarp::os::BufferedPort<yarp::sig::LaserScan2D>(),
             m_lastScan(alt.m_lastScan),
             m_lastStamp(alt.m_lastStamp),
@@ -50,7 +43,7 @@ public:
     {
     }
 
-    InputPortProcessor();
+    LaserFromExternalPort_InputPortProcessor();
     using yarp::os::BufferedPort<yarp::sig::LaserScan2D>::onRead;
     void onRead(yarp::sig::LaserScan2D& v) override;
     void getLast(yarp::sig::LaserScan2D& data, yarp::os::Stamp& stmp);
@@ -88,10 +81,17 @@ class LaserFromExternalPort : public yarp::dev::Lidar2DDeviceBase,
                               public yarp::os::PeriodicThread,
                               public yarp::dev::DeviceDriver
 {
+    enum base_enum
+    {
+        BASE_IS_NAN = 0,
+        BASE_IS_INF = 1,
+        BASE_IS_ZERO = 2
+    };
+
 protected:
     bool                            m_option_override_limits;
     std::vector <std::string>       m_port_names;
-    std::vector<InputPortProcessor> m_input_ports;
+    std::vector<LaserFromExternalPort_InputPortProcessor> m_input_ports;
     std::vector <yarp::os::Stamp>        m_last_stamp;
     std::vector<yarp::sig::LaserScan2D> m_last_scan_data;
     yarp::dev::PolyDriver                m_tc_driver;

--- a/src/devices/networkWrappers/AnalogSensorClient/AnalogSensorClient.cpp
+++ b/src/devices/networkWrappers/AnalogSensorClient/AnalogSensorClient.cpp
@@ -28,7 +28,7 @@ inline int checkResponse(bool ok, const yarp::os::Bottle& response)
 
 } // namespace
 
-inline void InputPortProcessor::resetStat()
+inline void AnalogSensorClient_InputPortProcessor::resetStat()
 {
     mutex.lock();
     count=0;
@@ -40,13 +40,13 @@ inline void InputPortProcessor::resetStat()
     mutex.unlock();
 }
 
-InputPortProcessor::InputPortProcessor()
+AnalogSensorClient_InputPortProcessor::AnalogSensorClient_InputPortProcessor()
 {
     state=IAnalogSensor::AS_ERROR;
     resetStat();
 }
 
-void InputPortProcessor::onRead(yarp::sig::Vector &v)
+void AnalogSensorClient_InputPortProcessor::onRead(yarp::sig::Vector &v)
 {
     now=Time::now();
     mutex.lock();
@@ -100,7 +100,7 @@ void InputPortProcessor::onRead(yarp::sig::Vector &v)
     mutex.unlock();
 }
 
-inline int InputPortProcessor::getLast(yarp::sig::Vector &data, Stamp &stmp)
+inline int AnalogSensorClient_InputPortProcessor::getLast(yarp::sig::Vector &data, Stamp &stmp)
 {
     mutex.lock();
     int ret=state;
@@ -114,7 +114,7 @@ inline int InputPortProcessor::getLast(yarp::sig::Vector &data, Stamp &stmp)
     return ret;
 }
 
-inline int InputPortProcessor::getIterations()
+inline int AnalogSensorClient_InputPortProcessor::getIterations()
 {
     mutex.lock();
     int ret=count;
@@ -123,7 +123,7 @@ inline int InputPortProcessor::getIterations()
 }
 
 // time is in ms
-void InputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
+void AnalogSensorClient_InputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
 {
     mutex.lock();
     ite=count;
@@ -141,12 +141,12 @@ void InputPortProcessor::getEstFrequency(int &ite, double &av, double &min, doub
     mutex.unlock();
 }
 
-int InputPortProcessor::getState()
+int AnalogSensorClient_InputPortProcessor::getState()
 {
     return state;
 }
 
-int InputPortProcessor::getChannels()
+int AnalogSensorClient_InputPortProcessor::getChannels()
 {
     if (state==IAnalogSensor::AS_ERROR)
     {

--- a/src/devices/networkWrappers/AnalogSensorClient/AnalogSensorClient.h
+++ b/src/devices/networkWrappers/AnalogSensorClient/AnalogSensorClient.h
@@ -19,12 +19,10 @@
 
 #include <mutex>
 
-
-const int ANALOG_TIMEOUT=100; //ms
-
-
-class InputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Vector>
+class AnalogSensorClient_InputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Vector>
 {
+    const int ANALOG_TIMEOUT = 100; // ms
+
     yarp::sig::Vector lastVector;
     std::mutex mutex;
     yarp::os::Stamp lastStamp;
@@ -38,20 +36,19 @@ class InputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Vector>
     int count;
 
 public:
-
     inline void resetStat();
 
-    InputPortProcessor();
+    AnalogSensorClient_InputPortProcessor();
 
     using yarp::os::BufferedPort<yarp::sig::Vector>::onRead;
-    void onRead(yarp::sig::Vector &v) override;
+    void onRead(yarp::sig::Vector& v) override;
 
-    inline int getLast(yarp::sig::Vector &data, yarp::os::Stamp &stmp);
+    inline int getLast(yarp::sig::Vector& data, yarp::os::Stamp& stmp);
 
     inline int getIterations();
 
     // time is in ms
-    void getEstFrequency(int &ite, double &av, double &min, double &max);
+    void getEstFrequency(int& ite, double& av, double& min, double& max);
 
     int getState();
 
@@ -89,7 +86,7 @@ class AnalogSensorClient :
         public yarp::dev::IAnalogSensor
 {
 protected:
-    InputPortProcessor inputPort;
+    AnalogSensorClient_InputPortProcessor inputPort;
     yarp::os::Port rpcPort;
     std::string local;
     std::string remote;

--- a/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.cpp
@@ -31,7 +31,7 @@ namespace {
 YARP_LOG_COMPONENT(RANGEFINDER2DCLIENT, "yarp.device.Rangefinder2D_nwc_yarp")
 }
 
-inline void  Rangefinder2DInputPortProcessor::resetStat()
+inline void  Rangefinder2D_InputPortProcessor::resetStat()
 {
     mutex.lock();
     count=0;
@@ -43,13 +43,13 @@ inline void  Rangefinder2DInputPortProcessor::resetStat()
     mutex.unlock();
 }
 
-Rangefinder2DInputPortProcessor::Rangefinder2DInputPortProcessor()
+Rangefinder2D_InputPortProcessor::Rangefinder2D_InputPortProcessor()
 {
     state = IRangefinder2D::DEVICE_GENERAL_ERROR;
     resetStat();
 }
 
-void Rangefinder2DInputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
+void Rangefinder2D_InputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
 {
     now=SystemClock::nowSystem();
     mutex.lock();
@@ -103,7 +103,7 @@ void Rangefinder2DInputPortProcessor::onRead(yarp::sig::LaserScan2D& b)
     mutex.unlock();
 }
 
-inline int Rangefinder2DInputPortProcessor::getLast(yarp::sig::LaserScan2D& data, Stamp& stmp)
+inline int Rangefinder2D_InputPortProcessor::getLast(yarp::sig::LaserScan2D& data, Stamp& stmp)
 {
     mutex.lock();
     int ret=state;
@@ -117,7 +117,7 @@ inline int Rangefinder2DInputPortProcessor::getLast(yarp::sig::LaserScan2D& data
     return ret;
 }
 
-yarp::dev::IRangefinder2D::Device_status Rangefinder2DInputPortProcessor::getStatus()
+yarp::dev::IRangefinder2D::Device_status Rangefinder2D_InputPortProcessor::getStatus()
 {
     mutex.lock();
     auto status = (yarp::dev::IRangefinder2D::Device_status) lastScan.status;
@@ -125,7 +125,7 @@ yarp::dev::IRangefinder2D::Device_status Rangefinder2DInputPortProcessor::getSta
     return status;
 }
 
-inline int Rangefinder2DInputPortProcessor::getIterations()
+inline int Rangefinder2D_InputPortProcessor::getIterations()
 {
     mutex.lock();
     int ret=count;
@@ -134,7 +134,7 @@ inline int Rangefinder2DInputPortProcessor::getIterations()
 }
 
 // time is in ms
-void Rangefinder2DInputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
+void Rangefinder2D_InputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
 {
     mutex.lock();
     ite=count;

--- a/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.h
+++ b/src/devices/networkWrappers/Rangefinder2D_nwc_yarp/Rangefinder2D_nwc_yarp.h
@@ -23,7 +23,7 @@
 #include "IRangefinder2DMsgs.h"
 #include "Rangefinder2D_nwc_yarp_ParamsParser.h"
 
-class Rangefinder2DInputPortProcessor :
+class Rangefinder2D_InputPortProcessor :
         public yarp::os::BufferedPort<yarp::sig::LaserScan2D>
 {
     yarp::sig::LaserScan2D lastScan;
@@ -42,7 +42,7 @@ public:
 
     inline void resetStat();
 
-    Rangefinder2DInputPortProcessor();
+    Rangefinder2D_InputPortProcessor();
 
     using yarp::os::BufferedPort<yarp::sig::LaserScan2D>::onRead;
     void onRead(yarp::sig::LaserScan2D& v) override;
@@ -72,7 +72,7 @@ class Rangefinder2D_nwc_yarp:
         public Rangefinder2D_nwc_yarp_ParamsParser
 {
 protected:
-    Rangefinder2DInputPortProcessor m_inputPort;
+    Rangefinder2D_InputPortProcessor m_inputPort;
     IRangefinder2DMsgs m_RPC;
     std::mutex         m_mutex;
 

--- a/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.cpp
@@ -17,11 +17,11 @@ namespace {
 YARP_LOG_COMPONENT(AUDIORECORDER_NWC, "yarp.device.audioRecorder_nwc_yarp")
 } // namespace
 
-InputPortProcessor::InputPortProcessor()
+AudioRecorder_InputPortProcessor::AudioRecorder_InputPortProcessor()
 {
 }
 
-void InputPortProcessor::onRead(yarp::sig::Sound& b)
+void AudioRecorder_InputPortProcessor::onRead(yarp::sig::Sound& b)
 {
     mutex.lock();
 
@@ -40,7 +40,7 @@ void InputPortProcessor::onRead(yarp::sig::Sound& b)
     mutex.unlock();
 }
 
-inline bool InputPortProcessor::getLast(yarp::sig::Sound& data, Stamp &stmp)
+inline bool AudioRecorder_InputPortProcessor::getLast(yarp::sig::Sound& data, Stamp &stmp)
 {
     mutex.lock();
       data = lastSound;

--- a/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.h
+++ b/src/devices/networkWrappers/audioRecorder_nwc_yarp/AudioRecorder_nwc_yarp.h
@@ -19,19 +19,19 @@
 #include <mutex>
 #include "AudioRecorder_nwc_yarp_ParamsParser.h"
 
-class InputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Sound>
+class AudioRecorder_InputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Sound>
 {
     yarp::sig::Sound lastSound;
-    yarp::os::Stamp  lastStamp;
+    yarp::os::Stamp lastStamp;
     std::mutex mutex;
 
 public:
-    InputPortProcessor();
+    AudioRecorder_InputPortProcessor();
 
     using yarp::os::BufferedPort<yarp::sig::Sound>::onRead;
-    void onRead(yarp::sig::Sound&v) override;
+    void onRead(yarp::sig::Sound& v) override;
 
-    inline bool getLast(yarp::sig::Sound& data, yarp::os::Stamp &stmp);
+    inline bool getLast(yarp::sig::Sound& data, yarp::os::Stamp& stmp);
 };
 
 /**
@@ -51,7 +51,7 @@ class AudioRecorder_nwc_yarp :
         public AudioRecorder_nwc_yarp_ParamsParser
 {
 protected:
-    InputPortProcessor  m_inputPort;
+    AudioRecorder_InputPortProcessor  m_inputPort;
     yarp::os::Port      m_rpcPort;
     IAudioGrabberMsgs   m_audiograb_RPC;
     std::mutex          m_mutex;

--- a/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorder_nws_yarp.cpp
+++ b/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorder_nws_yarp.cpp
@@ -68,16 +68,6 @@ bool AudioRecorder_nws_yarp::close()
     m_statusPort.interrupt();
     m_statusPort.close();
 
-    if (m_dataThread)
-    {
-        delete m_dataThread;
-        m_dataThread = nullptr;
-    }
-    if (m_statusThread)
-    {
-        delete m_statusThread;
-        m_statusThread = nullptr;
-    }
     return true;
 }
 
@@ -107,8 +97,8 @@ bool AudioRecorder_nws_yarp::attach(PolyDriver* driver)
 
     m_RPC.setInterface(m_mic);
 
-    m_dataThread = new AudioRecorderDataThread(this);
-    m_statusThread = new AudioRecorderStatusThread(this);
+    m_dataThread = std::make_unique<AudioRecorderDataThread>(this);
+    m_statusThread = std::make_unique<AudioRecorderStatusThread>(this);
     m_dataThread->setPeriod(m_period);
     m_dataThread->start();
     m_statusThread->start();
@@ -142,7 +132,7 @@ bool AudioRecorder_nws_yarp::detach()
     return true;
 }
 
-void AudioRecorderStatusThread::run()
+void AudioRecorder_nws_yarp::AudioRecorderStatusThread::run()
 {
     yarp::sig::AudioBufferSize device_buffer_current_size;
     yarp::sig::AudioBufferSize device_buffer_max_size;
@@ -171,7 +161,7 @@ void AudioRecorderStatusThread::run()
     m_ARW->m_statusPort.write(status);
 }
 
-void AudioRecorderDataThread::run()
+void AudioRecorder_nws_yarp::AudioRecorderDataThread::run()
 {
     if (0)
     {
@@ -267,7 +257,7 @@ void AudioRecorderDataThread::run()
     }
 }
 
-bool AudioRecorderDataThread::sendSound(yarp::sig::Sound& s)
+bool AudioRecorder_nws_yarp::AudioRecorderDataThread::sendSound(yarp::sig::Sound& s)
 {
     //check before sending data
     if (s.getSamples() == 0)

--- a/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorder_nws_yarp.h
+++ b/src/devices/networkWrappers/audioRecorder_nws_yarp/AudioRecorder_nws_yarp.h
@@ -26,9 +26,6 @@
 #include "AudioRecorderServerImpl.h"
 #include "AudioRecorder_nws_yarp_ParamsParser.h"
 
-class AudioRecorderStatusThread;
-class AudioRecorderDataThread;
-
 /**
  * @ingroup dev_impl_nws_yarp
  *
@@ -46,6 +43,9 @@ class AudioRecorder_nws_yarp :
         public AudioRecorder_nws_yarp_ParamsParser
 {
 private:
+    class AudioRecorderStatusThread;
+    class AudioRecorderDataThread;
+
     yarp::dev::PolyDriver          m_driver;
     yarp::dev::IAudioGrabberSound* m_mic = nullptr; //The microphone device
     yarp::os::Property             m_config;
@@ -53,8 +53,8 @@ private:
     yarp::os::Port                 m_streamingPort;
     yarp::os::Port                 m_statusPort;
     yarp::os::Stamp                m_stamp;
-    AudioRecorderStatusThread*     m_statusThread = nullptr;
-    AudioRecorderDataThread*       m_dataThread =nullptr;
+    std::unique_ptr<AudioRecorderStatusThread> m_statusThread;
+    std::unique_ptr<AudioRecorderDataThread> m_dataThread;
     const bool                     m_debug_enabled = false;
     std::list <yarp::sig::Sound>   m_listofsnds;
 
@@ -89,7 +89,7 @@ public:
 };
 
 //----------------------------------------------------------------
-class AudioRecorderStatusThread : public yarp::os::PeriodicThread
+class AudioRecorder_nws_yarp::AudioRecorderStatusThread : public yarp::os::PeriodicThread
 {
 public:
     AudioRecorder_nws_yarp* m_ARW = nullptr;
@@ -103,7 +103,7 @@ public:
 };
 
 //----------------------------------------------------------------
-class AudioRecorderDataThread : public yarp::os::PeriodicThread
+class AudioRecorder_nws_yarp::AudioRecorderDataThread : public yarp::os::PeriodicThread
 {
 public:
     AudioRecorder_nws_yarp* m_ARW = nullptr;

--- a/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.cpp
@@ -19,7 +19,7 @@ namespace {
 YARP_LOG_COMPONENT(BATTERYCLIENT, "yarp.device.Battery_nwc_yarp")
 } // namespace
 
-inline void BatteryInputPortProcessor::resetStat()
+inline void Battery_InputPortProcessor::resetStat()
 {
     mutex.lock();
     count=0;
@@ -31,13 +31,13 @@ inline void BatteryInputPortProcessor::resetStat()
     mutex.unlock();
 }
 
-BatteryInputPortProcessor::BatteryInputPortProcessor()
+Battery_InputPortProcessor::Battery_InputPortProcessor()
 {
     state=IBattery::BATTERY_GENERAL_ERROR;
     resetStat();
 }
 
-void BatteryInputPortProcessor::onRead(yarp::os::Bottle &b)
+void Battery_InputPortProcessor::onRead(yarp::os::Bottle &b)
 {
     now=Time::now();
     mutex.lock();
@@ -91,7 +91,7 @@ void BatteryInputPortProcessor::onRead(yarp::os::Bottle &b)
     mutex.unlock();
 }
 
-inline int BatteryInputPortProcessor::getLast(yarp::os::Bottle &data, Stamp &stmp)
+inline int Battery_InputPortProcessor::getLast(yarp::os::Bottle &data, Stamp &stmp)
 {
     mutex.lock();
     int ret=state;
@@ -105,7 +105,7 @@ inline int BatteryInputPortProcessor::getLast(yarp::os::Bottle &data, Stamp &stm
     return ret;
 }
 
-double BatteryInputPortProcessor::getVoltage()
+double Battery_InputPortProcessor::getVoltage()
 {
     mutex.lock();
     double voltage = lastBottle.get(0).asFloat64();
@@ -113,7 +113,7 @@ double BatteryInputPortProcessor::getVoltage()
     return voltage;
 }
 
-double BatteryInputPortProcessor::getCurrent()
+double Battery_InputPortProcessor::getCurrent()
 {
     mutex.lock();
     double current = lastBottle.get(1).asFloat64();
@@ -121,7 +121,7 @@ double BatteryInputPortProcessor::getCurrent()
     return current;
 }
 
-double BatteryInputPortProcessor::getCharge()
+double Battery_InputPortProcessor::getCharge()
 {
     mutex.lock();
     double charge = lastBottle.get(2).asFloat64();
@@ -129,7 +129,7 @@ double BatteryInputPortProcessor::getCharge()
     return charge;
 }
 
-int    BatteryInputPortProcessor::getStatus()
+int    Battery_InputPortProcessor::getStatus()
 {
     mutex.lock();
     int status = lastBottle.get(4).asInt32();
@@ -137,7 +137,7 @@ int    BatteryInputPortProcessor::getStatus()
     return status;
 }
 
-double BatteryInputPortProcessor::getTemperature()
+double Battery_InputPortProcessor::getTemperature()
 {
     mutex.lock();
     double temperature = lastBottle.get(3).asFloat64();
@@ -145,7 +145,7 @@ double BatteryInputPortProcessor::getTemperature()
     return temperature;
 }
 
-inline int BatteryInputPortProcessor::getIterations()
+inline int Battery_InputPortProcessor::getIterations()
 {
     mutex.lock();
     int ret=count;
@@ -154,7 +154,7 @@ inline int BatteryInputPortProcessor::getIterations()
 }
 
 // time is in ms
-void BatteryInputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
+void Battery_InputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
 {
     mutex.lock();
     ite=count;

--- a/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.h
+++ b/src/devices/networkWrappers/battery_nwc_yarp/Battery_nwc_yarp.h
@@ -21,11 +21,11 @@
 #include "Battery_nwc_yarp_ParamsParser.h"
 
 #define DEFAULT_THREAD_PERIOD 20 //ms
-const int BATTERY_TIMEOUT=100; //ms
 
-
-class BatteryInputPortProcessor : public yarp::os::BufferedPort<yarp::os::Bottle>
+class Battery_InputPortProcessor : public yarp::os::BufferedPort<yarp::os::Bottle>
 {
+    const int BATTERY_TIMEOUT=100; //ms
+
     yarp::os::Bottle lastBottle;
     std::mutex mutex;
     yarp::os::Stamp lastStamp;
@@ -42,7 +42,7 @@ public:
 
     inline void resetStat();
 
-    BatteryInputPortProcessor();
+    Battery_InputPortProcessor();
 
     using yarp::os::BufferedPort<yarp::os::Bottle>::onRead;
     void onRead(yarp::os::Bottle &v) override;
@@ -77,7 +77,7 @@ class Battery_nwc_yarp :
         public Battery_nwc_yarp_ParamsParser
 {
 protected:
-    BatteryInputPortProcessor inputPort;
+    Battery_InputPortProcessor inputPort;
     yarp::os::Port rpcPort;
     yarp::os::Stamp lastTs; //used by IPreciselyTimed
     std::string deviceId;

--- a/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.cpp
+++ b/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.cpp
@@ -64,12 +64,10 @@ bool  ChatBot_nws_yarp::attach(yarp::dev::PolyDriver* deviceToAttach)
 
     yCInfo(CHATBOT_NWS_YARP, "Attach done");
 
-    m_cbkHelper = new ChatBotRPC_CallbackHelper();
+    m_cbkHelper = std::make_unique<ChatBotRPC_CallbackHelper>();
     if(!m_cbkHelper->setCommunications(m_iChatBot,&m_outputPort))
     {
         yCError(CHATBOT_NWS_YARP) << "Error setting ChatBot_CallbackHelper object interfaces";
-        delete m_cbkHelper;
-        m_cbkHelper=nullptr;
         return false;
     }
     m_inputBuffer.useCallback(*m_cbkHelper);
@@ -95,7 +93,6 @@ bool ChatBot_nws_yarp::closeMain()
     m_inputPort.close();
     m_outputPort.close();
     m_thriftServerPort.close();
-    if (m_cbkHelper) {delete m_cbkHelper; m_cbkHelper=nullptr;}
     return true;
 }
 

--- a/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.h
+++ b/src/devices/networkWrappers/chatBot_nws_yarp/ChatBot_nws_yarp.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <memory>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
@@ -26,8 +27,7 @@ using namespace yarp::os;
 using namespace yarp::dev;
 
 // Callback implementation after buffered input.
-class ChatBotRPC_CallbackHelper :
-        public yarp::os::TypedReaderCallback<yarp::os::Bottle>
+class ChatBotRPC_CallbackHelper : public yarp::os::TypedReaderCallback<yarp::os::Bottle>
 {
 protected:
     yarp::dev::IChatBot* m_iChatBot{nullptr};
@@ -90,7 +90,7 @@ private:
     IChatBotMsgsImpl     m_msgsImpl;
 
     yarp::os::PortReaderBuffer <yarp::os::Bottle> m_inputBuffer;
-    ChatBotRPC_CallbackHelper*                    m_cbkHelper{ nullptr };
+    std::unique_ptr<ChatBotRPC_CallbackHelper>    m_cbkHelper;
 
     // yarp::dev::IWrapper
     bool  attach(yarp::dev::PolyDriver* deviceToAttach) override;

--- a/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.cpp
+++ b/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.cpp
@@ -24,7 +24,7 @@ YARP_LOG_COMPONENT(MOBVEL_NWS_YARP, "yarp.device.MobileBaseVelocityControl_nws_y
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-void VelocityInputPortProcessor::onRead(yarp::dev::MobileBaseVelocity& v)
+void Velocity_InputPortProcessor::onRead(yarp::dev::MobileBaseVelocity& v)
 {
     if (m_iVel)
     {

--- a/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.h
+++ b/src/devices/networkWrappers/mobileBaseVelocityControl_nws_yarp/MobileBaseVelocityControl_nws_yarp.h
@@ -22,7 +22,7 @@
 
 #include "MobileBaseVelocityControl_nws_yarp_ParamsParser.h"
 
-class VelocityInputPortProcessor : public yarp::os::BufferedPort<yarp::dev::MobileBaseVelocity>
+class Velocity_InputPortProcessor : public yarp::os::BufferedPort<yarp::dev::MobileBaseVelocity>
 {
 public:
     double m_timeout = 0.1;
@@ -56,7 +56,7 @@ class MobileBaseVelocityControl_nws_yarp:
 protected:
     std::mutex                    m_mutex;
     yarp::os::Port                m_rpc_port_navigation_server;
-    VelocityInputPortProcessor    m_StreamingInput;
+    Velocity_InputPortProcessor   m_StreamingInput;
 
     yarp::dev::Nav2D::INavigation2DVelocityActions* m_iNavVel = nullptr;
 

--- a/src/devices/networkWrappers/serialPort_nws_yarp/SerialPort_nws_yarp.cpp
+++ b/src/devices/networkWrappers/serialPort_nws_yarp/SerialPort_nws_yarp.cpp
@@ -80,7 +80,7 @@ bool  SerialPort_nws_yarp::attach(yarp::dev::PolyDriver* deviceToAttach)
 
     yCInfo(SERIAL_NWS, "Attach done");
 
-    callback_impl = new ImplementCallbackHelper2(m_iserial);
+    callback_impl = std::make_unique<SerialPort_CallbackHelper>(m_iserial);
     command_buffer.useCallback(*callback_impl);
     m_rpc.setInterfaces(m_iserial);
 
@@ -129,7 +129,6 @@ bool SerialPort_nws_yarp::closeMain()
     toDevice.close();
     fromDevice.close();
     m_rpcPort.close();
-    if (callback_impl) {delete callback_impl; callback_impl=nullptr;}
     return true;
 }
 
@@ -173,7 +172,7 @@ int ISerialMsgsd::flush()
 
 //--------------------------------------------------
 // ImplementCallbackHelper class.
-ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISerialDevice*x)
+SerialPort_CallbackHelper::SerialPort_CallbackHelper(yarp::dev::ISerialDevice*x)
 {
     if (x ==nullptr)
     {
@@ -183,7 +182,7 @@ ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISerialDevice*x)
     m_iser= x;
 }
 
-void ImplementCallbackHelper2::onRead(Bottle &b)
+void SerialPort_CallbackHelper::onRead(Bottle &b)
 {
     if (m_iser)
     {

--- a/src/devices/networkWrappers/serialPort_nws_yarp/SerialPort_nws_yarp.h
+++ b/src/devices/networkWrappers/serialPort_nws_yarp/SerialPort_nws_yarp.h
@@ -19,6 +19,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/dev/WrapperSingle.h>
+#include <memory>
 #include "ISerialMsgs.h"
 
 #include "SerialPort_nws_yarp_ParamsParser.h"
@@ -29,19 +30,17 @@ using namespace yarp::dev;
 
 class SerialPort_nws_yarp;
 
-/**
- * Callback implementation after buffered input.
- */
-class ImplementCallbackHelper2 :
+// Callback implementation after buffered input.
+class SerialPort_CallbackHelper :
         public yarp::os::TypedReaderCallback<yarp::os::Bottle>
 {
 protected:
     yarp::dev::ISerialDevice* m_iser{nullptr};
 
 public:
-    ImplementCallbackHelper2();
-    ImplementCallbackHelper2(yarp::dev::ISerialDevice* x);
-    virtual ~ImplementCallbackHelper2() override {};
+    SerialPort_CallbackHelper();
+    SerialPort_CallbackHelper(yarp::dev::ISerialDevice* x);
+    virtual ~SerialPort_CallbackHelper() override {};
 
     using yarp::os::TypedReaderCallback<Bottle>::onRead;
     void onRead(Bottle& b) override;
@@ -91,7 +90,7 @@ private:
 
     yarp::os::PortWriterBuffer <yarp::os::Bottle> reply_buffer;
     yarp::os::PortReaderBuffer <yarp::os::Bottle> command_buffer;
-    ImplementCallbackHelper2* callback_impl{ nullptr };
+    std::unique_ptr<SerialPort_CallbackHelper> callback_impl;
 
     // yarp::dev::IWrapper
     bool  attach(yarp::dev::PolyDriver* deviceToAttach) override;

--- a/src/devices/networkWrappers/speechSynthesizer_nws_yarp/SpeechSynthesizer_nws_yarp.cpp
+++ b/src/devices/networkWrappers/speechSynthesizer_nws_yarp/SpeechSynthesizer_nws_yarp.cpp
@@ -7,6 +7,7 @@
 
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/Os.h>
+#include <memory>
 
 namespace {
 YARP_LOG_COMPONENT(SPEECHSYNTH_NWS, "yarp.devices.speechSynthesizer_nws_yarp")
@@ -68,7 +69,7 @@ bool  SpeechSynthesizer_nws_yarp::attach(yarp::dev::PolyDriver* deviceToAttach)
 
     yCInfo(SPEECHSYNTH_NWS, "Attach done");
 
-    callback_impl = new ImplementCallbackHelper2(m_isptr,&m_outputPort);
+    callback_impl = std::make_unique<SpeechSynthesizer_CallbackHelper>(m_isptr,&m_outputPort);
     input_buffer.useCallback(*callback_impl);
     m_rpc.setInterfaces(m_isptr);
     m_rpc.setOutputPort(&m_outputPort);
@@ -93,7 +94,6 @@ bool SpeechSynthesizer_nws_yarp::closeMain()
     m_inputPort.close();
     m_outputPort.close();
     m_rpcPort.close();
-    if (callback_impl) {delete callback_impl; callback_impl=nullptr;}
     return true;
 }
 
@@ -259,7 +259,7 @@ return_synthesize ISpeechSynthesizerMsgsd::synthesize(const std::string& text)
 
 //--------------------------------------------------
 // ImplementCallbackHelper class.
-ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISpeechSynthesizer*x, yarp::os::Port* p)
+SpeechSynthesizer_CallbackHelper::SpeechSynthesizer_CallbackHelper(yarp::dev::ISpeechSynthesizer*x, yarp::os::Port* p)
 {
     if (x ==nullptr || p==nullptr)
     {
@@ -270,7 +270,7 @@ ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISpeechSynthesizer
     m_output_port = p;
 }
 
-void ImplementCallbackHelper2::onRead(yarp::os::Bottle &b)
+void SpeechSynthesizer_CallbackHelper::onRead(yarp::os::Bottle &b)
 {
     if (m_isptr)
     {

--- a/src/devices/networkWrappers/speechSynthesizer_nws_yarp/SpeechSynthesizer_nws_yarp.h
+++ b/src/devices/networkWrappers/speechSynthesizer_nws_yarp/SpeechSynthesizer_nws_yarp.h
@@ -8,6 +8,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
@@ -27,20 +28,18 @@ using namespace yarp::os;
 using namespace yarp::sig;
 using namespace yarp::dev;
 
-class SerialPort_nws_yarp;
-
 // Callback implementation after buffered input.
-class ImplementCallbackHelper2 :
+class SpeechSynthesizer_CallbackHelper :
         public yarp::os::TypedReaderCallback<yarp::os::Bottle>
 {
 protected:
-    yarp::dev::ISpeechSynthesizer* m_isptr{nullptr};
-    yarp::os::Port* m_output_port{ nullptr };
+    yarp::dev::ISpeechSynthesizer* m_isptr {nullptr};
+    yarp::os::Port* m_output_port {nullptr};
 
 public:
-    ImplementCallbackHelper2() = delete;
-    ImplementCallbackHelper2(yarp::dev::ISpeechSynthesizer* x, yarp::os::Port* output_port);
-    virtual ~ImplementCallbackHelper2() override {};
+    SpeechSynthesizer_CallbackHelper() = delete;
+    SpeechSynthesizer_CallbackHelper(yarp::dev::ISpeechSynthesizer* x, yarp::os::Port* output_port);
+    virtual ~SpeechSynthesizer_CallbackHelper() override {};
 
     using yarp::os::TypedReaderCallback<yarp::os::Bottle>::onRead;
     void onRead(yarp::os::Bottle& b) override;
@@ -100,7 +99,7 @@ private:
     ISpeechSynthesizerMsgsd   m_rpc;
 
     yarp::os::PortReaderBuffer <yarp::os::Bottle> input_buffer;
-    ImplementCallbackHelper2* callback_impl{ nullptr };
+    std::unique_ptr<SpeechSynthesizer_CallbackHelper> callback_impl;
 
     // yarp::dev::IWrapper
     bool  attach(yarp::dev::PolyDriver* deviceToAttach) override;

--- a/src/devices/networkWrappers/speechTranscription_nws_yarp/SpeechTranscription_nws_yarp.cpp
+++ b/src/devices/networkWrappers/speechTranscription_nws_yarp/SpeechTranscription_nws_yarp.cpp
@@ -68,7 +68,7 @@ bool  SpeechTranscription_nws_yarp::attach(yarp::dev::PolyDriver* deviceToAttach
 
     yCInfo(SPEECHTR_NWS, "Attach done");
 
-    callback_impl = new ImplementCallbackHelper2(m_isptr,&m_outputPort);
+    callback_impl = std::make_unique<SpeechTranscription_CallbackHelper>(m_isptr,&m_outputPort);
     input_buffer.useCallback(*callback_impl);
     m_rpc.setInterfaces(m_isptr);
     m_rpc.setOutputPort(&m_outputPort);
@@ -93,7 +93,6 @@ bool SpeechTranscription_nws_yarp::closeMain()
     m_inputPort.close();
     m_outputPort.close();
     m_rpcPort.close();
-    if (callback_impl) {delete callback_impl; callback_impl=nullptr;}
     return true;
 }
 
@@ -175,7 +174,7 @@ return_transcribe ISpeechTranscriptionMsgsd::transcribe(const yarp::sig::Sound& 
 
 //--------------------------------------------------
 // ImplementCallbackHelper class.
-ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISpeechTranscription*x, yarp::os::Port* p)
+SpeechTranscription_CallbackHelper::SpeechTranscription_CallbackHelper(yarp::dev::ISpeechTranscription*x, yarp::os::Port* p)
 {
     if (x ==nullptr || p==nullptr)
     {
@@ -186,7 +185,7 @@ ImplementCallbackHelper2::ImplementCallbackHelper2(yarp::dev::ISpeechTranscripti
     m_output_port = p;
 }
 
-void ImplementCallbackHelper2::onRead(yarp::sig::Sound &b)
+void SpeechTranscription_CallbackHelper::onRead(yarp::sig::Sound &b)
 {
     if (m_isptr)
     {

--- a/src/devices/networkWrappers/speechTranscription_nws_yarp/SpeechTranscription_nws_yarp.h
+++ b/src/devices/networkWrappers/speechTranscription_nws_yarp/SpeechTranscription_nws_yarp.h
@@ -30,17 +30,17 @@ using namespace yarp::dev;
 class SerialPort_nws_yarp;
 
 // Callback implementation after buffered input.
-class ImplementCallbackHelper2 :
+class SpeechTranscription_CallbackHelper :
         public yarp::os::TypedReaderCallback<yarp::sig::Sound>
 {
 protected:
-    yarp::dev::ISpeechTranscription* m_isptr{nullptr};
-    yarp::os::Port* m_output_port{ nullptr };
+    yarp::dev::ISpeechTranscription* m_isptr {nullptr};
+    yarp::os::Port* m_output_port {nullptr};
 
 public:
-    ImplementCallbackHelper2() = delete;
-    ImplementCallbackHelper2(yarp::dev::ISpeechTranscription* x, yarp::os::Port* output_port);
-    virtual ~ImplementCallbackHelper2() override {};
+    SpeechTranscription_CallbackHelper() = delete;
+    SpeechTranscription_CallbackHelper(yarp::dev::ISpeechTranscription* x, yarp::os::Port* output_port);
+    virtual ~SpeechTranscription_CallbackHelper() override {};
 
     using yarp::os::TypedReaderCallback<yarp::sig::Sound>::onRead;
     void onRead(yarp::sig::Sound& b) override;
@@ -94,7 +94,7 @@ private:
     ISpeechTranscriptionMsgsd m_rpc;
 
     yarp::os::PortReaderBuffer <yarp::sig::Sound> input_buffer;
-    ImplementCallbackHelper2* callback_impl{ nullptr };
+    std::unique_ptr<SpeechTranscription_CallbackHelper> callback_impl;
 
     // yarp::dev::IWrapper
     bool  attach(yarp::dev::PolyDriver* deviceToAttach) override;

--- a/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.cpp
+++ b/src/portmonitors/bottle_compression_zlib/BottleZlibPortmonitor.cpp
@@ -26,17 +26,17 @@ YARP_LOG_COMPONENT(BOTTLE_ZLIB_MONITOR,
                    yarp::os::Log::LogTypeReserved,
                    yarp::os::Log::printCallback(),
                    nullptr)
-}
-
 
 void split(const std::string& s, char delim, std::vector<std::string>& elements)
 {
     std::istringstream iss(s);
     std::string item;
-    while (std::getline(iss, item, delim)) {
+    while (std::getline(iss, item, delim))
+    {
         elements.push_back(item);
     }
 }
+} //anonymous namespace
 
 void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
 {

--- a/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
+++ b/src/portmonitors/image_compression_ffmpeg/ffmpegPortmonitor.cpp
@@ -41,31 +41,23 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 namespace {
-
-// YARP logging component
 YARP_LOG_COMPONENT(FFMPEGMONITOR,
                    "yarp.carrier.portmonitor.image_compression_ffmpeg",
                    yarp::os::Log::minimumPrintLevel(),
                    yarp::os::Log::LogTypeReserved,
                    yarp::os::Log::printCallback(),
                    nullptr)
-}
 
-/**
- * @brief This function simply splits a string into a vector of strings basing on a delimiter character.
- * It it used for command line parameters parsing.
- *
- * @param s         The initial string.
- * @param delim     The delimiter character.
- * @param elements  The final vector of strings.
- */
-void split(const std::string &s, char delim, std::vector<std::string> &elements) {
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
     std::istringstream iss(s);
     std::string item;
-    while (std::getline(iss, item, delim)) {
+    while (std::getline(iss, item, delim))
+    {
         elements.push_back(item);
     }
 }
+} // anonymous namespace
 
 // As per version 5.1.2 of ffmpeg, there seem to be race conditions between sws_scale and
 // sws_freeContext even when called from different instances on different threads.

--- a/src/portmonitors/image_rotation/imageRotation.cpp
+++ b/src/portmonitors/image_rotation/imageRotation.cpp
@@ -26,7 +26,17 @@ YARP_LOG_COMPONENT(IMAGEROTATION,
                    yarp::os::Log::LogTypeReserved,
                    yarp::os::Log::printCallback(),
                    nullptr)
+
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
+    std::istringstream iss(s);
+    std::string item;
+    while (std::getline(iss, item, delim))
+    {
+        elements.push_back(item);
+    }
 }
+} //anonymous namespace
 
 bool ImageRotation::create(const yarp::os::Property& options)
 {
@@ -75,15 +85,6 @@ bool ImageRotation::create(const yarp::os::Property& options)
 
 void ImageRotation::destroy()
 {
-}
-
-void split(const std::string& s, char delim, std::vector<std::string>& elements)
-{
-    std::istringstream iss(s);
-    std::string item;
-    while (std::getline(iss, item, delim)) {
-        elements.push_back(item);
-    }
 }
 
 void ImageRotation::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)

--- a/src/portmonitors/sound_marker/Sound_marker.cpp
+++ b/src/portmonitors/sound_marker/Sound_marker.cpp
@@ -9,6 +9,7 @@
 
 using namespace yarp::os;
 
+namespace {
 YARP_LOG_COMPONENT(SOUND_MARKER, "sound_marker")
 
 void split(const std::string& s, char delim, std::vector<std::string>& elements)
@@ -19,6 +20,8 @@ void split(const std::string& s, char delim, std::vector<std::string>& elements)
         elements.push_back(item);
     }
 }
+} //anonymous namespace
+
 
 void Sound_marker::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
 {

--- a/src/portmonitors/soundfilter_resample/SoundFilter_resample.cpp
+++ b/src/portmonitors/soundfilter_resample/SoundFilter_resample.cpp
@@ -9,6 +9,7 @@
 
 using namespace yarp::os;
 
+namespace {
 YARP_LOG_COMPONENT(SOUNDFILTER_RESAMPLE, "soundfilter_resample")
 
 void split(const std::string& s, char delim, std::vector<std::string>& elements)
@@ -19,6 +20,7 @@ void split(const std::string& s, char delim, std::vector<std::string>& elements)
         elements.push_back(item);
     }
 }
+} //anonymous namespace
 
 void SoundFilter_resample::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
 {


### PR DESCRIPTION
Fixed the generation of the plugins static library.
Renamed symbols with the same name used by different devices/portmonitors