### PR TITLE
Fix `Sound::getDuration()` always returning zero

### DIFF
--- a/doc/release/yarp_3_11/000_yarp_3_11.md
+++ b/doc/release/yarp_3_11/000_yarp_3_11.md
@@ -16,3 +16,4 @@ Fixes
 * Rename vendored TinyXML cmake project and package from `YARP_priv_tinyxml` to `YARP_priv_TinyXML`
 * Added test for `yarp::dev::Drivers::factory()` compiled with `BUILD_SHARED_LIBS=OFF`
 * Fixed static build of devices, port-monitors, carriers and, more in general, yarp_dev plugins
+* Fixed `yarp::sig::Sound::getDuration()`, previously it was always returning 0

--- a/src/libYARP_sig/src/yarp/sig/Sound.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Sound.cpp
@@ -607,7 +607,7 @@ size_t Sound::getChannels() const
 
 double Sound::getDuration() const
 {
-    return (double)(this->m_samples)*(double)(1 / this->m_frequency);
+    return (double)(this->m_samples)*(double)(1.0 / this->m_frequency);
 }
 
 void Sound::normalizeChannel(size_t channel)


### PR DESCRIPTION
Since `m_frequency` is an integer, dividing the unit by this number was always yielding zero. Either the unit or this variable must be converted to a floating point type to get the correct result.