### PR TITLE
ReturnValue fix

### DIFF
--- a/doc/release/yarp_3_11/000_yarp_3_11.md
+++ b/doc/release/yarp_3_11/000_yarp_3_11.md
@@ -17,3 +17,4 @@ Fixes
 * Added test for `yarp::dev::Drivers::factory()` compiled with `BUILD_SHARED_LIBS=OFF`
 * Fixed static build of devices, port-monitors, carriers and, more in general, yarp_dev plugins
 * Fixed `yarp::sig::Sound::getDuration()`, previously it was always returning 0
+* Fixed `yarp::dev::ReturnValue` serialization when used from command line (e.g. yarp rpc /xxx)


### PR DESCRIPTION
Fixed `yarp::dev::ReturnValue` serialization when used from command line (e.g. yarp rpc /xxx)