### PR TITLE
Removed topics from yarp::os

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -46,5 +46,7 @@ Breaking Changes
 
 ### libYARP_os
 
+* Removed the following methods from `yarp::os::NameSpace` : `connectPortToTopic`, `connectTopicToPort`,
+  `disconnectPortFromTopic`, `disconnectTopicFromPort`
 * Removed classes `yarp::os::Node`,`yarp::os::Nodes`,`yarp::os::Publisher`,`yarp::os::Subscriber`
 * Removed ROS1-related management logic in YARP nameserver

--- a/src/libYARP_os/src/yarp/os/MultiNameSpace.cpp
+++ b/src/libYARP_os/src/yarp/os/MultiNameSpace.cpp
@@ -280,50 +280,6 @@ Contact MultiNameSpace::queryName(const std::string& name)
     return HELPER(this).queryName(name);
 }
 
-bool MultiNameSpace::connectPortToTopic(const Contact& src,
-                                        const Contact& dest,
-                                        const ContactStyle& style)
-{
-    NameSpace* ns = HELPER(this).getOne();
-    if (ns == nullptr) {
-        return false;
-    }
-    return ns->connectPortToTopic(src, dest, style);
-}
-
-bool MultiNameSpace::connectTopicToPort(const Contact& src,
-                                        const Contact& dest,
-                                        const ContactStyle& style)
-{
-    NameSpace* ns = HELPER(this).getOne();
-    if (ns == nullptr) {
-        return false;
-    }
-    return ns->connectTopicToPort(src, dest, style);
-}
-
-bool MultiNameSpace::disconnectPortFromTopic(const Contact& src,
-                                             const Contact& dest,
-                                             const ContactStyle& style)
-{
-    NameSpace* ns = HELPER(this).getOne();
-    if (ns == nullptr) {
-        return false;
-    }
-    return ns->disconnectPortFromTopic(src, dest, style);
-}
-
-bool MultiNameSpace::disconnectTopicFromPort(const Contact& src,
-                                             const Contact& dest,
-                                             const ContactStyle& style)
-{
-    NameSpace* ns = HELPER(this).getOne();
-    if (ns == nullptr) {
-        return false;
-    }
-    return ns->disconnectTopicFromPort(src, dest, style);
-}
-
 bool MultiNameSpace::connectPortToPortPersistently(const Contact& src,
                                                    const Contact& dest,
                                                    const ContactStyle& style)

--- a/src/libYARP_os/src/yarp/os/MultiNameSpace.h
+++ b/src/libYARP_os/src/yarp/os/MultiNameSpace.h
@@ -40,22 +40,6 @@ public:
 
     Value* getProperty(const std::string& name, const std::string& key) override;
 
-    virtual bool connectPortToTopic(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) override;
-
-    virtual bool connectTopicToPort(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) override;
-
-    virtual bool disconnectPortFromTopic(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) override;
-
-    virtual bool disconnectTopicFromPort(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) override;
-
     virtual bool connectPortToPortPersistently(const Contact& src,
                                                const Contact& dest,
                                                const ContactStyle& style) override;

--- a/src/libYARP_os/src/yarp/os/NameSpace.h
+++ b/src/libYARP_os/src/yarp/os/NameSpace.h
@@ -123,34 +123,6 @@ public:
                                const std::string& key) = 0;
 
     /**
-     * Publish a port to a topic.
-     */
-    virtual bool connectPortToTopic(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) = 0;
-
-    /**
-     * Subscribe a port to a topic.
-     */
-    virtual bool connectTopicToPort(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) = 0;
-
-    /**
-     * Stop publishing a port to a topic.
-     */
-    virtual bool disconnectPortFromTopic(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) = 0;
-
-    /**
-     * Stop subscribing a port to a topic.
-     */
-    virtual bool disconnectTopicFromPort(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) = 0;
-
-    /**
      * Connect two ports with persistence.
      */
     virtual bool connectPortToPortPersistently(const Contact& src,

--- a/src/libYARP_os/src/yarp/os/Network.cpp
+++ b/src/libYARP_os/src/yarp/os/Network.cpp
@@ -490,42 +490,6 @@ static int metaConnect(const std::string& src,
         destIsTopic = true;
     }
 
-    if (srcIsTopic || destIsTopic) {
-        Bottle cmd;
-        Bottle reply;
-        NameSpace& ns = getNameSpace();
-
-        bool ok = false;
-        if (srcIsTopic) {
-            if (mode == YARP_ENACT_CONNECT) {
-                ok = ns.connectTopicToPort(staticSrc, staticDest, style);
-            } else if (mode == YARP_ENACT_DISCONNECT) {
-                ok = ns.disconnectTopicFromPort(staticSrc, staticDest, style);
-            } else {
-                yCError(NETWORK, "Failure: cannot check subscriptions yet");
-                return 1;
-            }
-        } else {
-            if (mode == YARP_ENACT_CONNECT) {
-                ok = ns.connectPortToTopic(staticSrc, staticDest, style);
-            } else if (mode == YARP_ENACT_DISCONNECT) {
-                ok = ns.disconnectPortFromTopic(staticSrc, staticDest, style);
-            } else {
-                yCError(NETWORK, "Failure: cannot check subscriptions yet");
-                return 1;
-            }
-        }
-        if (!ok) {
-            return 1;
-        }
-        if (!style.quiet) {
-            if (style.verboseOnSuccess) {
-                yCInfo(NETWORK, "Success: connection to topic %s.", mode == YARP_ENACT_CONNECT ? "added" : "removed");
-            }
-        }
-        return 0;
-    }
-
     yCTrace(NETWORK,
             "dynamicSrc.getCarrier() = %s",
             dynamicSrc.getCarrier().c_str());

--- a/src/libYARP_os/src/yarp/os/YarpNameSpace.cpp
+++ b/src/libYARP_os/src/yarp/os/YarpNameSpace.cpp
@@ -57,49 +57,11 @@ Contact YarpNameSpace::registerContact(const Contact& contact)
     Contact address = nic.registerName(contact.getName(), contact);
     yCDebug(YARPNAMESPACE, "Registered address: %s", address.toURI().c_str());
 
-    if (address.isValid()) {
-        NestedContact nc;
-        nc.fromString(address.getRegName());
-        std::string cat = nc.getCategory();
-        if (!nc.getNestedName().empty()) {
-            //bool service = (cat.find("1") != std::string::npos);
-            bool publish = (cat.find('+') != std::string::npos);
-            bool subscribe = (cat.find('-') != std::string::npos);
-            ContactStyle style;
-            Contact c1(nc.getFullName());
-            Contact c2(std::string("topic:/") + nc.getNestedName());
-            if (subscribe) {
-                style.persistenceType = ContactStyle::END_WITH_TO_PORT;
-                connectPortToTopic(c2, c1, style);
-            }
-            if (publish) {
-                style.persistenceType = ContactStyle::END_WITH_FROM_PORT;
-                connectPortToTopic(c1, c2, style);
-            }
-        }
-    }
     return address;
 }
 
 Contact YarpNameSpace::unregisterName(const std::string& name)
 {
-    NestedContact nc;
-    nc.fromString(name);
-    std::string cat = nc.getCategory();
-    if (!nc.getNestedName().empty()) {
-        //bool service = (cat.find("1") != std::string::npos);
-        bool publish = (cat.find('+') != std::string::npos);
-        bool subscribe = (cat.find('-') != std::string::npos);
-        ContactStyle style;
-        Contact c1(nc.getFullName());
-        Contact c2(std::string("topic:/") + nc.getNestedName());
-        if (subscribe) {
-            disconnectPortFromTopic(c2, c1, style);
-        }
-        if (publish) {
-            disconnectPortFromTopic(c1, c2, style);
-        }
-    }
     NameClient& nic = HELPER(this);
     return nic.unregisterName(name);
 }

--- a/src/libYARP_os/src/yarp/os/YarpNameSpace.h
+++ b/src/libYARP_os/src/yarp/os/YarpNameSpace.h
@@ -41,34 +41,6 @@ public:
     virtual Value* getProperty(const std::string& name,
                                const std::string& key) override;
 
-    virtual bool connectPortToTopic(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) override
-    {
-        return connectTopic("subscribe", false, true, src, dest, style);
-    }
-
-    virtual bool connectTopicToPort(const Contact& src,
-                                    const Contact& dest,
-                                    const ContactStyle& style) override
-    {
-        return connectTopic("subscribe", true, false, src, dest, style);
-    }
-
-    virtual bool disconnectPortFromTopic(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) override
-    {
-        return connectTopic("unsubscribe", false, true, src, dest, style);
-    }
-
-    virtual bool disconnectTopicFromPort(const Contact& src,
-                                         const Contact& dest,
-                                         const ContactStyle& style) override
-    {
-        return connectTopic("unsubscribe", true, false, src, dest, style);
-    }
-
     virtual bool connectPortToPortPersistently(const Contact& src,
                                                const Contact& dest,
                                                const ContactStyle& style) override


### PR DESCRIPTION
Removed the following methods from `yarp::os::NameSpace` :
* `connectPortToTopic`
*  `connectTopicToPort`
* `disconnectPortFromTopic`
*  `disconnectTopicFromPort`