### PR TITLE
LogForwarder: set enableBackgroundWrite() to false

### DIFF
--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
@@ -46,7 +46,7 @@ yarp::os::impl::LogForwarder::LogForwarder()
     if (!outputPort.open(logPortName)) {
         printf("LogForwarder error while opening port %s\n", logPortName.c_str());
     }
-    outputPort.enableBackgroundWrite(true);
+    outputPort.enableBackgroundWrite(false);
     outputPort.addOutput("/yarplogger", "fast_tcp");
 
     started = true;


### PR DESCRIPTION
In the past days, I performed a bunch of tests involving `yarplogger`: in particular, I was analyzing the content of the log retrieved from the yarplogger GUI compared to the log produced by yarprobotinterface. I noticed that the logging port opened when the yarprobotinterface when launched with `YARP_FORWARD_LOG_ENABLE=1` (typically `/log/<hostname>/yarprobotinterface/<pid>`) was streaming fewer messages wrt the copy-paste log of the yarprobotinterface itself. For example:

- Copy-paste log: [log.txt](https://github.com/user-attachments/files/20943012/log.txt)
- Log from yarplogger: [log_yarplogger.txt](https://github.com/user-attachments/files/20943026/log_ydd.txt)

Looking into the code, I found that the `LogForwarder` is configured with enableBackgroundWrite(true). From my understanding, it makes write() non-blocking, causing the write to return immediately, which can result in dropped messages if the queue is full. I tried setting it to false, making the write synchronous, and that seems to solve the problem: the number of messages received through the logging port now matches those in the original YRI log.

I’d like to propose this change as a way to address the issue, but I’m open to alternative solutions or suggestions.

cc @randaz81 @Nicogene @pattacini