### PR TITLE
ControlBoardRemapper: fix wrong buffer resize in resizeSubControlBoadBuffers

### DIFF
--- a/src/devices/controlBoardRemapper/ControlBoardRemapperHelpers.cpp
+++ b/src/devices/controlBoardRemapper/ControlBoardRemapperHelpers.cpp
@@ -560,6 +560,6 @@ void ControlBoardArbitraryAxesDecomposition::resizeSubControlBoardBuffers(const 
     for(size_t ctrlBrd=0; ctrlBrd < remappedControlBoards.getNrOfSubControlBoards(); ctrlBrd++)
     {
         yCAssert(CONTROLBOARDREMAPPER, (unsigned)m_nJointsInSubControlBoard[ctrlBrd] == m_jointsInSubControlBoard[ctrlBrd].size());
-        m_bufferForSubControlBoard.resize(m_nJointsInSubControlBoard[ctrlBrd]);
+        m_bufferForSubControlBoard[ctrlBrd].resize(m_nJointsInSubControlBoard[ctrlBrd]);
     }
 }


### PR DESCRIPTION
It fixes:
- https://github.com/robotology/gz-sim-yarp-plugins/issues/260

cc @PasMarra