### PR TITLE
New portmonitor throttleDown

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -22,6 +22,9 @@ compatibility with the corresponding nws device.
 
 Added VectorOf<float> (32 bit)
 
+### PortMonitors
+
+Added new PortMonitor `throttleDown` to limit the bandwidth usage over a port connection.
 
 Deprecations and removals
 ---------------------------

--- a/src/portmonitors/CMakeLists.txt
+++ b/src/portmonitors/CMakeLists.txt
@@ -23,6 +23,8 @@ yarp_begin_plugin_library(yarppm
   add_subdirectory(soundfilter_resample)
   add_subdirectory(sound_marker)
   add_subdirectory(sensorMeasurements_to_vector)
+  add_subdirectory(throttleDown)
+
 yarp_end_plugin_library(yarppm QUIET)
 add_library(YARP::yarppm ALIAS yarppm)
 

--- a/src/portmonitors/throttleDown/CMakeLists.txt
+++ b/src/portmonitors/throttleDown/CMakeLists.txt
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+yarp_prepare_plugin(throttleDown
+  TYPE ThrottleDown
+  INCLUDE ThrottleDown.h
+  CATEGORY portmonitor
+  DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
+)
+
+if(SKIP_ThrottleDown)
+  return()
+endif()
+
+yarp_add_plugin(yarp_pm_throttleDown)
+
+target_sources(yarp_pm_throttleDown
+  PRIVATE
+    ThrottleDown.cpp
+    ThrottleDown.h
+)
+
+target_link_libraries(yarp_pm_throttleDown
+  PRIVATE
+    YARP::YARP_os
+    YARP::YARP_sig
+)
+list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS
+  YARP_os
+  YARP_sig
+)
+
+yarp_install(
+  TARGETS yarp_pm_throttleDown
+  EXPORT YARP_${YARP_PLUGIN_MASTER}
+  COMPONENT ${YARP_PLUGIN_MASTER}
+  LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+  ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+  YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+)
+
+set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+set_property(TARGET yarp_pm_throttleDown PROPERTY FOLDER "Plugins/Port Monitor")

--- a/src/portmonitors/throttleDown/README.md
+++ b/src/portmonitors/throttleDown/README.md
@@ -1,0 +1,14 @@
+
+ThrottleDown plugin
+======================================================================
+Portmonitor plugin for reducing the throughput of a port connection, decimating the transmitted messages.
+For example, this portmonitor can be used to reduce a port streamed data from 10 to 1 message per second,
+reducing the overall bandwidth usage. Please note that this portmonitor can be attached to both the sender and the receiver port,
+however bandwidth consumption will be reduced only if the portmonitor is attached to the sender port.
+
+Usage:
+-----
+
+yarp write /test --period 0.01
+yarp read ... /in
+yarp connect  /test /in tcp+send.portmonitor+type.dll+file.throttleDown+period_ms.500

--- a/src/portmonitors/throttleDown/ThrottleDown.cpp
+++ b/src/portmonitors/throttleDown/ThrottleDown.cpp
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "ThrottleDown.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Time.h>
+
+using namespace yarp::os;
+
+namespace {
+YARP_LOG_COMPONENT(PM_THRD,
+                   "yarp.carrier.portmonitor.ThrottleDown",
+                   yarp::os::Log::minimumPrintLevel(),
+                   yarp::os::Log::LogTypeReserved,
+                   yarp::os::Log::printCallback(),
+                   nullptr)
+
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
+    std::istringstream iss(s);
+    std::string item;
+    while (std::getline(iss, item, delim))
+    {
+        elements.push_back(item);
+    }
+}
+
+}//anonymous namespace
+
+
+bool ThrottleDown::create(const yarp::os::Property& options)
+{
+    // parse the user parameters
+    yarp::os::Property m_user_params;
+    std::string str = options.find("carrier").asString();
+    yCDebug(PM_THRD) << "parsed string:" << str << " "<< options.toString();
+    getParamsFromCommandLine(str, m_user_params);
+    yCDebug(PM_THRD) << "parsed params:" << m_user_params.toString();
+
+    // get the value of the parameters
+    /* if (m_user_params.check("period")) {
+        //Float64 have issues related to the '.' character.
+        //Even replacing the separator character in getParamsFromCommandLine() from ` ` to `=`
+        //0.02 becomes 0.2, probabibly located in protocol .cpp
+        m_period = m_user_params.find("period").asFloat64();
+        yCDebug(PM_THRD) << "period set:" << m_period;
+    }*/
+    if (m_user_params.check("period_ms")) {
+        m_period = m_user_params.find("period_ms").asInt32();
+        m_period /= 1000.0;
+        yCDebug(PM_THRD) << "period set:" << m_period;
+    }
+
+    m_last_time= yarp::os::Time::now();
+
+    return true;
+}
+
+void ThrottleDown::destroy()
+{
+}
+
+void ThrottleDown::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
+{
+    // Split command line string using '+' delimiter
+    std::vector<std::string> parameters;
+    split(carrierString, '+', parameters);
+
+    // Iterate over result strings
+    for (std::string param : parameters) {
+        // If there is no '.', then the param is bad formatted, skip it.
+        auto pointPosition = param.find('.');
+        if (pointPosition == std::string::npos) {
+            continue;
+        }
+
+        // Otherwise, separate key and value
+        std::string paramKey = param.substr(0, pointPosition);
+        yarp::os::Value paramValue;
+        std::string s = param.substr(pointPosition + 1, param.length());
+        paramValue.fromString(s.c_str());
+
+        // and append to the returned property
+        prop.put(paramKey, paramValue);
+    }
+    return;
+}
+
+
+bool ThrottleDown::setparam(const yarp::os::Property& params)
+{
+    return false;
+}
+
+bool ThrottleDown::getparam(yarp::os::Property& params)
+{
+    return false;
+}
+
+bool ThrottleDown::accept(yarp::os::Things& thing)
+{
+    double cur_time = yarp::os::Time::now();
+    if (cur_time - m_last_time > m_period)
+    {
+        m_last_time = cur_time;
+        return true;
+    }
+    return false;
+}
+
+yarp::os::Things& ThrottleDown::update(yarp::os::Things& thing)
+{
+    return thing;
+}

--- a/src/portmonitors/throttleDown/ThrottleDown.h
+++ b/src/portmonitors/throttleDown/ThrottleDown.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef YARP_PM_THROTTLEDOWN
+#define YARP_PM_THROTTLEDOWN
+
+#include <yarp/os/Property.h>
+#include <yarp/os/Things.h>
+#include <yarp/os/MonitorObject.h>
+
+#include <string>
+#include <vector>
+
+ /**
+  * @ingroup portmonitors_lists
+  * \brief `ThrottleDown`:
+  * Portmonitor plugin for reducing the throughput of a port connection, decimating the transmitted messages.
+  * For example, this portmonitor can be used to reduce a port streamed data from 10 to 1 message per second,
+  * reducing the overall bandwidth usage. Please note that this portmonitor can be attached to both the
+  * sender and the receiver port, however bandwidth consumption will be reduced only if the portmonitor is
+  * attached to the sender port.
+  *
+  * Example usage:
+  * yarp write /test --period 0.01
+  * yarp read ... /in
+  * yarp connect  /test /in tcp+send.portmonitor+type.dll+file.throttleDown+period_ms.500
+  */
+class ThrottleDown : public yarp::os::MonitorObject
+{
+    double m_last_time = 0;
+    double m_period = 1.0;
+
+public:
+    bool create(const yarp::os::Property& options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property& params) override;
+    bool getparam(yarp::os::Property& params) override;
+
+    bool accept(yarp::os::Things& thing) override;
+    yarp::os::Things& update(yarp::os::Things& thing) override;
+
+    void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop);
+};
+
+#endif  // YARP_PM_THROTTLEDOWN


### PR DESCRIPTION
Added new PortMonitor `throttleDown` to limit the bandwidth usage over a port connection.