### PR TITLE
libYARP_robotinterface: Does not complain if device does not derive from IDeviceDriverParams

### DIFF
--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -236,10 +236,6 @@ bool yarp::robotinterface::Robot::Private::openDevices()
                         stp = dparams->getListOfParams();
                         scfg = dparams->getConfiguration();
                     }
-                    else
-                    {
-                        yCError(YRI_ROBOT) << "Device" << device.name() << "does not derive from IDeviceDriverParams.";
-                    }
                 }
                 if (!pddrv || scfg.empty())
                 {


### PR DESCRIPTION
Fix https://github.com/robotology/yarp/issues/3243 . The message can be re-introduced once the soft requirement for a device to derive from `IDeviceDriverParams` to be loaded in the `libYARP_robotinterface` is documented.