### PR TITLE
Strip trailing newline from `CMAKE_INSTALL_PYTHON3DIR`

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -46,12 +46,14 @@ target_include_directories(${SWIG_MODULE_yarp_python_REAL_NAME} BEFORE PRIVATE $
 
 # installation path is determined reliably on most platforms using sysconfig
 if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
-    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import os;import sysconfig;relative_site_packages = sysconfig.get_path('purelib').replace(sysconfig.get_path('data'), '').lstrip(os.path.sep);print(relative_site_packages)"
-      OUTPUT_VARIABLE Python3_INSTDIR)
-  else()
-    execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
-      OUTPUT_VARIABLE Python3_INSTDIR)
-  endif()
+  execute_process(COMMAND ${Python3_EXECUTABLE} -c "import os;import sysconfig;relative_site_packages = sysconfig.get_path('purelib').replace(sysconfig.get_path('data'), '').lstrip(os.path.sep);print(relative_site_packages)"
+    OUTPUT_VARIABLE Python3_INSTDIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+    OUTPUT_VARIABLE Python3_INSTDIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 set(_CMAKE_INSTALL_PYTHON3DIR "${Python3_INSTDIR}")
 set(CMAKE_INSTALL_PYTHON3DIR ${_CMAKE_INSTALL_PYTHON3DIR} CACHE PATH "python3 bindings (${_CMAKE_INSTALL_PYTHON3DIR})")


### PR DESCRIPTION
Follow-up to https://github.com/robotology/yarp/pull/3247 (cc @PasMarra). I noticed this warning during the CMake configuration step:

```
CMake Warning:
  Value of CMAKE_INSTALL_PYTHON3DIR contained a newline; truncating
```

This means that the output of:

https://github.com/robotology/yarp/blob/d046789b8ffceb85292957ef0a2881a2b72de692/bindings/python/CMakeLists.txt#L49-L50

contains a trailing newline. I replicated this code on a different project, hit the same warning, and observed the following glitch on `cmake --install` ([CI run](https://github.com/roboticslab-uc3m/vision/actions/runs/16393021350)):

```
-- Installing: /usr/local/lib/python3.12/dist-packages
/roboticslab_vision.py
-- Installing: /usr/local/lib/python3.12/dist-packages
/_roboticslab_vision.so
```

Due to the presence of said newline in the CMake variable, it is also present in *install_manifest.txt*, and hence it breaks uninstallation. This happened despite CMake also notifying about the truncation, which for some reason worked for the YARP installation, but not for the other project. However, I presume this might cause hard-to-debug issues in the future, therefore this patch proposes that the newline is removed altogether (and the warning is never generated).

PS: Also improve indentation.