### PR TITLE
Register bindings for `yarp::dev::ReturnValue`

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -416,6 +416,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %include <yarp/dev/DeviceDriver.h>
 %include <yarp/dev/PolyDriver.h>
 %include <yarp/dev/Drivers.h>
+%include <yarp/dev/ReturnValue.h>
 %include <yarp/dev/IFrameGrabberImage.h>
 %include <yarp/dev/IFrameGrabberControls.h>
 %include <yarp/dev/IFrameGrabberControlsDC1394.h>

--- a/src/libYARP_dev/src/yarp/dev/ReturnValue.h
+++ b/src/libYARP_dev/src/yarp/dev/ReturnValue.h
@@ -74,6 +74,7 @@ public:
     bool write(yarp::os::ConnectionWriter& connection) const override;
 };
 
+#ifndef SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
 #define ReturnValue_ok ReturnValue(yarp::dev::ReturnValue::return_code::return_value_ok)
 
 #if __cplusplus >= 202002L
@@ -101,7 +102,7 @@ inline ReturnValue yarp_method_deprecated(const char* location)
 }
 #define YARP_METHOD_DEPRECATED() yarp_method_deprecated(__func__)
 #endif
-
+#endif // SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
 
 }
 


### PR DESCRIPTION
This avoids "swig/python detected a memory leak of type 'yarp::dev::ReturnValue *', no destructor found." when using interfaces that have been migrated to [`yarp::dev::ReturnValue`](https://github.com/robotology/yarp/blob/ce8ff4c8c1c5245a9242196bc3a17eebde05d69d/src/libYARP_dev/src/yarp/dev/ReturnValue.h) (https://github.com/robotology/yarp/discussions/3168). Parts that did not compile successfully have been enclosed in `SWIG_PREPROCESSOR_SHOULD_SKIP_THIS` guards.