### PR TITLE
Add bindings for `yarp::dev::LLM_Message`

### DIFF
--- a/bindings/yarp.i
+++ b/bindings/yarp.i
@@ -451,6 +451,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %include <yarp/dev/IPositionDirect.h>
 %include <yarp/dev/ISpeechSynthesizer.h>
 %include <yarp/dev/ISpeechTranscription.h>
+%include <yarp/dev/LLM_Message.h>
 %include <yarp/dev/ILLM.h>
 %include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 %include <yarp/dev/IRGBDSensor.h>
@@ -463,6 +464,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
 %template(ShortVector) std::vector<short int>;
 %template() std::pair<std::string, std::string>;
 %template(SPairVector) std::vector<std::pair<std::string, std::string>>;
+%template(LLMVector) std::vector<yarp::dev::LLM_Message>;
 
 #ifdef SWIGMATLAB
   // Extend IVector for handling conversion of vectors from and to Matlab
@@ -1488,10 +1490,6 @@ MAKE_COMMS  (Sound, yarp::sig::Sound)
 %extend yarp::dev::ILLM {
     bool readPrompt(std::vector<string>& oPropmt) {
         return self->readPrompt(oPropmt[0]);
-    }
-
-    bool ask(const std::string& question, yarp::dev::LLM_Message& answer) {
-        return self->ask(question, answer);
     }
 }
 


### PR DESCRIPTION
This patch also enables invoking `yarp::dev::ILLM::getConversation` through the new `LLMVector` specialization of `std::vector<yarp::dev::LLM_Message>`.

Python usage:

```py
llm = device.viewILLM()

question = 'What is 2 + 2?';
answer = yarp.LLM_Message()
print(f'Asking: {question}')

if llm.ask(question, answer):
    print('Answer:')
    print(f'* type: {answer.type}')
    print(f'* content: {answer.content}')
    print(f'* parameters: {list(answer.parameters)}')
    print(f'* arguments: {list(answer.arguments)}')

conversation = yarp.LLMVector()

if llm.getConversation(conversation):
    for msg in conversation:
        print(msg.toString_c())
```

Besides, it was no longer necessary to extend `yarp::dev::ILLM::ask`, so I removed that.