### PR TITLE
Logforwarder test + simulated_network_delay portmonitor

### DIFF
--- a/src/libYARP_logger/CMakeLists.txt
+++ b/src/libYARP_logger/CMakeLists.txt
@@ -4,6 +4,7 @@
 project(YARP_logger)
 
 add_subdirectory(src)
+add_subdirectory(tests)
 
 include(YarpInstallBasicPackageFiles)
 yarp_install_basic_package_files(YARP_logger

--- a/src/libYARP_logger/CMakeLists.txt
+++ b/src/libYARP_logger/CMakeLists.txt
@@ -4,7 +4,10 @@
 project(YARP_logger)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(YARP_COMPILE_TESTS)
+  add_subdirectory(tests)
+endif()
 
 include(YarpInstallBasicPackageFiles)
 yarp_install_basic_package_files(YARP_logger

--- a/src/libYARP_logger/src/yarp/logger/YarpLogger.cpp
+++ b/src/libYARP_logger/src/yarp/logger/YarpLogger.cpp
@@ -256,7 +256,7 @@ void LoggerEngine::logger_thread::run()
 
             if (b->size()!=2)
             {
-                fprintf (stderr, "ERROR: unknown log format!\n");
+                fprintf (stderr, "ERROR: unknown log format [err1]!\n");
                 unknown_format_received++;
                 continue;
             }
@@ -270,7 +270,7 @@ void LoggerEngine::logger_thread::run()
             }
             else
             {
-                fprintf(stderr, "ERROR: unknown log format!\n");
+                fprintf(stderr, "ERROR: unknown log format! [err2]\n");
                 unknown_format_received++;
                 continue;
             }
@@ -291,7 +291,7 @@ void LoggerEngine::logger_thread::run()
             }
             else
             {
-                fprintf(stderr, "ERROR: unknown log format!\n");
+                fprintf(stderr, "ERROR: unknown log format! [err3]\n");
                 unknown_format_received++;
                 continue;
             }

--- a/src/libYARP_logger/tests/CMakeLists.txt
+++ b/src/libYARP_logger/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+include(YarpCatchUtils)
+
+add_executable(harness_logger)
+
+target_sources(harness_logger PRIVATE
+  LogForwarderTest.cpp
+)
+
+target_include_directories(harness_logger PRIVATE ${hmac_INCLUDE_DIRS})
+
+target_link_libraries(harness_logger
+  PRIVATE
+    YARP_harness
+    YARP::YARP_os
+    YARP::YARP_logger
+)
+
+if(YARP_HAS_ACE)
+  target_compile_definitions(harness_logger PRIVATE YARP_HAS_ACE)
+  target_link_libraries(harness_logger PRIVATE ACE::ACE_INLINE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(harness_logger PRIVATE pthread)
+endif()
+
+set_property(TARGET harness_logger PROPERTY FOLDER "Test")
+
+yarp_catch_discover_tests(harness_logger)

--- a/src/libYARP_logger/tests/LogForwarderTest.cpp
+++ b/src/libYARP_logger/tests/LogForwarderTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/os/SystemClock.h>
+#include <yarp/os/NetType.h>
+#include <yarp/os/LogStream.h>
+
+#include <yarp/os/impl/LogForwarder.h>
+#include <yarp/logger/YarpLogger.h>
+
+#include <array>
+#include <thread>
+
+#include <catch2/catch_amalgamated.hpp>
+#include <harness.h>
+
+void testLogForwarder( yarp::os::impl::LogForwarder& fwd, yarp::yarpLogger::LoggerEngine* the_logger,std::string logportName, std::string carrier)
+{
+    INFO("Testing LogForwarder with carrier: " + carrier);
+
+    //connect the logger to the forwarder
+    bool logger_connected = yarp::os::Network::connect(logportName, "/logger", carrier, false);
+    CHECK(logger_connected);
+
+    const int max_num_messages = 10000;
+    uint64_t counter = 0;
+    double t = 0.00001;
+
+    const double start = yarp::os::SystemClock::nowSystem();
+
+    // send some messages
+    double ptime = yarp::os::SystemClock::nowSystem();
+    for (size_t i = 0; i < max_num_messages; i++)
+    {
+        double ctime = yarp::os::SystemClock::nowSystem();
+        double difftime = ctime-ptime;
+        std::string message = "message " + std::to_string(counter) + " " + std::to_string(ctime) + " " + std::to_string(difftime);
+        fwd.forward(message);
+        counter++;
+        yarp::os::Time::delay(t);
+        ptime = ctime;
+    }
+    const double end = yarp::os::SystemClock::nowSystem();
+    double elapsed = end-start;
+    std::string info_msg = "Test duration: " + std::to_string(elapsed);
+    yDebug() << info_msg;
+
+    yarp::os::Time::delay(1.0);
+
+    //check what the logger received from the forwarder
+    std::list<yarp::yarpLogger::MessageEntry> messages;
+    the_logger->get_messages(messages);
+    size_t messagesnum = messages.size();
+    CHECK(messagesnum == max_num_messages);
+
+    messages.clear();
+    the_logger->clear();
+    the_logger->get_messages(messages);
+    messagesnum = messages.size();
+    CHECK(messagesnum == 0);
+}
+
+TEST_CASE("logger::LogForwarderTest", "[yarp::logger]")
+{
+    yarp::os::Network yarp(yarp::os::YARP_CLOCK_SYSTEM);
+
+    yarp::os::NetworkBase::setLocalMode(true);
+
+    yarp::os::Time::delay(1.0);
+
+    //create the forwarder
+    static yarp::os::impl::LogForwarder& fwd =  yarp::os::impl::LogForwarder::getInstance();
+    std::string logportName = fwd.getLogPortName();
+
+    //create the logger
+    yarp::yarpLogger::LoggerEngine* the_logger = nullptr;
+    the_logger = new yarp::yarpLogger::LoggerEngine ("/logger");
+    the_logger->start_logging();
+
+    yarp::os::Time::delay(1.0);
+
+    testLogForwarder(fwd, the_logger, logportName, "fast_tcp");
+    testLogForwarder(fwd, the_logger, logportName, "fast_tcp+send.portmonitor+file.simulated_network_delay+delay_ms.100+type.dll");
+    testLogForwarder(fwd, the_logger, logportName, "fast_tcp+recv.portmonitor+file.simulated_network_delay+delay_ms.100+type.dll");
+
+    yarp::os::Time::delay(1.0);
+
+    //stop the logger
+    the_logger->stop_logging();
+    delete the_logger;
+    the_logger = nullptr;
+
+    //stop the forwarder
+    fwd.shutdown();
+}

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.cpp
@@ -52,6 +52,11 @@ yarp::os::impl::LogForwarder::LogForwarder()
     started = true;
 }
 
+std::string yarp::os::impl::LogForwarder::getLogPortName()
+{
+    return outputPort.getName();
+}
+
 void yarp::os::impl::LogForwarder::forward(const std::string& message)
 {
     mutex.lock();

--- a/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
+++ b/src/libYARP_os/src/yarp/os/impl/LogForwarder.h
@@ -22,6 +22,7 @@ public:
     static LogForwarder& getInstance();
 
     void forward(const std::string& message);
+    std::string getLogPortName();
     static void shutdown();
 
 private:

--- a/src/portmonitors/CMakeLists.txt
+++ b/src/portmonitors/CMakeLists.txt
@@ -23,6 +23,7 @@ yarp_begin_plugin_library(yarppm
   add_subdirectory(soundfilter_resample)
   add_subdirectory(sound_marker)
   add_subdirectory(sensorMeasurements_to_vector)
+  add_subdirectory(simulated_network_delay)
 yarp_end_plugin_library(yarppm QUIET)
 add_library(YARP::yarppm ALIAS yarppm)
 

--- a/src/portmonitors/depthimage_to_mono/CMakeLists.txt
+++ b/src/portmonitors/depthimage_to_mono/CMakeLists.txt
@@ -6,6 +6,7 @@ yarp_prepare_plugin(depthimage_to_mono
   INCLUDE DepthImage.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
 )
 
 yarp_renamed_option(ENABLE_yarpcar_depthimage ENABLE_yarppm_depthimage_to_mono) # YARP_DEPRECATED since 3.5

--- a/src/portmonitors/depthimage_to_rgb/CMakeLists.txt
+++ b/src/portmonitors/depthimage_to_rgb/CMakeLists.txt
@@ -6,6 +6,7 @@ yarp_prepare_plugin(depthimage_to_rgb
   INCLUDE DepthImage2.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
 )
 
 yarp_renamed_option(ENABLE_yarpcar_depthimage2 ENABLE_yarppm_depthimage_to_rgb) # YARP_DEPRECATED since 3.5

--- a/src/portmonitors/depthimage_to_vector/CMakeLists.txt
+++ b/src/portmonitors/depthimage_to_vector/CMakeLists.txt
@@ -6,6 +6,7 @@ yarp_prepare_plugin(depthimage_to_vector
   INCLUDE DepthImageVec.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
 )
 
 if(SKIP_depthimage_to_vector)

--- a/src/portmonitors/segmentationimage_to_rgb/CMakeLists.txt
+++ b/src/portmonitors/segmentationimage_to_rgb/CMakeLists.txt
@@ -6,6 +6,7 @@ yarp_prepare_plugin(segmentationimage_to_rgb
   INCLUDE SegmentationImage.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
 )
 
 yarp_renamed_option(ENABLE_yarpcar_segmentationimage ENABLE_yarppm_segmentationimage_to_rgb) # YARP_DEPRECATED since 3.5

--- a/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
+++ b/src/portmonitors/sensorMeasurements_to_vector/CMakeLists.txt
@@ -6,6 +6,7 @@ yarp_prepare_plugin(sensorMeasurements_to_vector
   INCLUDE SM_to_vec.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
+  DEFAULT ON
 )
 
 if(SKIP_sensorMeasurements_to_vector)

--- a/src/portmonitors/simulated_network_delay/CMakeLists.txt
+++ b/src/portmonitors/simulated_network_delay/CMakeLists.txt
@@ -1,28 +1,28 @@
-# SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-yarp_prepare_plugin(soundfilter_resample
-  TYPE SoundFilter_resample
-  INCLUDE SoundFilter_resample.h
+yarp_prepare_plugin(simulated_network_delay
+  TYPE Simulated_network_delay
+  INCLUDE Simulated_network_delay.h
   CATEGORY portmonitor
   DEPENDS "ENABLE_yarpcar_portmonitor"
   DEFAULT ON
 )
 
-if(SKIP_soundfilter_resample)
+if(SKIP_simulated_network_delay)
   return()
 endif()
 
-yarp_add_plugin(yarp_pm_soundfilter_resample)
+yarp_add_plugin(yarp_pm_simulated_network_delay)
 
-target_sources(yarp_pm_soundfilter_resample
+target_sources(yarp_pm_simulated_network_delay
   PRIVATE
-    SoundFilter_resample.cpp
-    SoundFilter_resample.h
+    Simulated_network_delay.cpp
+    Simulated_network_delay.h
 )
 
-target_link_libraries(yarp_pm_soundfilter_resample
+target_link_libraries(yarp_pm_simulated_network_delay
   PRIVATE
     YARP::YARP_os
     YARP::YARP_sig
@@ -30,7 +30,7 @@ target_link_libraries(yarp_pm_soundfilter_resample
 )
 
 yarp_install(
-  TARGETS yarp_pm_soundfilter_resample
+  TARGETS yarp_pm_simulated_network_delay
   EXPORT YARP_${YARP_PLUGIN_MASTER}
   COMPONENT ${YARP_PLUGIN_MASTER}
   LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
@@ -39,4 +39,4 @@ yarp_install(
 )
 set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
 
-set_property(TARGET yarp_pm_soundfilter_resample PROPERTY FOLDER "Plugins/Port Monitor")
+set_property(TARGET yarp_pm_simulated_network_delay PROPERTY FOLDER "Plugins/Port Monitor")

--- a/src/portmonitors/simulated_network_delay/README.md
+++ b/src/portmonitors/simulated_network_delay/README.md
@@ -1,0 +1,8 @@
+
+simulated_network_delay_portmonitor plugin
+======================================================================
+This portmonitor adds a user defined delay (in milliseconds) to the connection
+
+Usage:
+-----
+yarp connect /sender/data:o /receiver/data:i tcp+recv.portmonitor+file.simulated_network_delay+delay_ms.10+type.dll

--- a/src/portmonitors/simulated_network_delay/Simulated_network_delay.cpp
+++ b/src/portmonitors/simulated_network_delay/Simulated_network_delay.cpp
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "Simulated_network_delay.h"
+#include <yarp/os/Value.h>
+#include <yarp/os/Time.h>
+#include <vector>
+
+#include <iostream>
+
+using namespace yarp::os;
+
+namespace {
+
+void split(const std::string& s, char delim, std::vector<std::string>& elements)
+{
+    std::istringstream iss(s);
+    std::string item;
+    while (std::getline(iss, item, delim)) {
+        elements.push_back(item);
+    }
+}
+} //anonymous namespace
+
+
+void Simulated_network_delay::getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop)
+{
+    // Split command line string using '+' delimiter
+    std::vector<std::string> parameters;
+    split(carrierString, '+', parameters);
+
+    // Iterate over result strings
+    for (std::string param : parameters)
+    {
+        // If there is no '.', then the param is bad formatted, skip it.
+        auto pointPosition = param.find('.');
+        if (pointPosition == std::string::npos)
+        {
+            continue;
+        }
+
+        // Otherwise, separate key and value
+        std::string paramKey = param.substr(0, pointPosition);
+        yarp::os::Value paramValue;
+        std::string s = param.substr(pointPosition + 1, param.length());
+        paramValue.fromString(s.c_str());
+
+        //and append to the returned property
+        prop.put(paramKey, paramValue);
+    }
+    return;
+}
+
+bool Simulated_network_delay::create(const yarp::os::Property &options)
+{
+    //parse the user parameters
+    yarp::os::Property m_user_params;
+    std::string str = options.find("carrier").asString();
+    getParamsFromCommandLine(str, m_user_params);
+
+    if (m_user_params.check("delay_ms"))
+    {
+        m_delay = m_user_params.find("delay_ms").asFloat32();
+        m_delay /= 1000.0;
+    }
+
+    return true;
+}
+
+void Simulated_network_delay::destroy()
+{
+}
+
+bool Simulated_network_delay::setparam(const yarp::os::Property &params)
+{
+    return false;
+}
+
+bool Simulated_network_delay::getparam(yarp::os::Property &params)
+{
+    return false;
+}
+
+bool Simulated_network_delay::accept(yarp::os::Things &thing)
+{
+    return true;
+}
+
+yarp::os::Things & Simulated_network_delay::update(yarp::os::Things &thing)
+{
+    yarp::os::Time::delay(m_delay);
+    return thing;
+}
+
+void Simulated_network_delay::trig()
+{
+}

--- a/src/portmonitors/simulated_network_delay/Simulated_network_delay.h
+++ b/src/portmonitors/simulated_network_delay/Simulated_network_delay.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SIMULATED_NETWORK_DELAY_H
+#define SIMULATED_NETWORK_DELAY_H
+
+#include <yarp/os/Things.h>
+#include <yarp/os/MonitorObject.h>
+
+ /**
+  * @ingroup portmonitors_lists
+  * \brief `simulated_network_delay`:  Documentation to be added
+  */
+class Simulated_network_delay : public yarp::os::MonitorObject
+{
+    double m_delay = 0.0;
+
+public:
+    void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop);
+
+    bool create(const yarp::os::Property &options) override;
+    void destroy() override;
+
+    bool setparam(const yarp::os::Property &params) override;
+    bool getparam(yarp::os::Property &params) override;
+
+    void trig() override;
+
+    bool accept(yarp::os::Things &thing) override;
+    yarp::os::Things &update(yarp::os::Things &thing) override;
+};
+
+#endif


### PR DESCRIPTION
Added new test LogForwarderTest to check that all forwarded messages are caught by the logger engine.
Added new portmonitor 'simulated_network_delay' to test the logger under various network delay conditions
NB: CI is supposed to fail after this commit (it will be fixed by PR https://github.com/robotology/yarp/pull/2789)