### PR TITLE
Improvements to IImpendaceControl interface

### DIFF
--- a/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t2_test.cpp
+++ b/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t2_test.cpp
@@ -17,6 +17,7 @@
 #include <yarp/dev/ICurrentControl.h>
 #include <yarp/dev/IRemoteCalibrator.h>
 #include <yarp/dev/IControlLimits.h>
+#include <yarp/dev/IImpedanceControl.h>
 #include <yarp/os/Network.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/WrapperMultiple.h>
@@ -35,6 +36,7 @@
 #include <yarp/dev/tests/IRemoteCalibratorTest.h>
 #include <yarp/dev/tests/IJointFaultTest.h>
 #include <yarp/dev/tests/IControlLimitsTest.h>
+#include <yarp/dev/tests/IImpedanceControlTest.h>
 
 #include <catch2/catch_amalgamated.hpp>
 #include <harness.h>
@@ -68,6 +70,7 @@ TEST_CASE("dev::ControlBoardRemapperTest2", "[yarp::dev]")
         ICurrentControl* icurr = nullptr;
         IJointFault* ifault = nullptr;
         IControlLimits* ilims = nullptr;
+        IImpedanceControl* iimp = nullptr;
         //IRemoteCalibrator* iremotecalib = nullptr;
 
         ////////"Checking opening map2DServer and map2DClient polydrivers"
@@ -107,6 +110,7 @@ TEST_CASE("dev::ControlBoardRemapperTest2", "[yarp::dev]")
         ddremapper.view(icurr);   REQUIRE(icurr);
         ddremapper.view(ifault);  REQUIRE(ifault);
         ddremapper.view(ilims);   REQUIRE(ilims);
+        ddremapper.view(iimp);   REQUIRE(iimp);
         //ddremapper.view(iremotecalib);  REQUIRE(iremotecalib);
 
         yarp::dev::tests::exec_iPositionControl_test_1(ipos, icmd);
@@ -125,6 +129,7 @@ TEST_CASE("dev::ControlBoardRemapperTest2", "[yarp::dev]")
         //yarp::dev::tests::exec_iRemoteCalibrator_test_1(iremotecalib);
         yarp::dev::tests::exec_iJointFault_test_1(ifault);
         yarp::dev::tests::exec_iControlLimits_test1(ilims, iinfo);
+        yarp::dev::tests::exec_iImpedanceControl_test1(iimp);
 
         //"Close all polydrivers and check"
         {

--- a/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t2_test.cpp
+++ b/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t2_test.cpp
@@ -129,7 +129,7 @@ TEST_CASE("dev::ControlBoardRemapperTest2", "[yarp::dev]")
         //yarp::dev::tests::exec_iRemoteCalibrator_test_1(iremotecalib);
         yarp::dev::tests::exec_iJointFault_test_1(ifault);
         yarp::dev::tests::exec_iControlLimits_test1(ilims, iinfo);
-        yarp::dev::tests::exec_iImpedanceControl_test1(iimp);
+        yarp::dev::tests::exec_iImpedanceControl_test_1(iimp);
 
         //"Close all polydrivers and check"
         {

--- a/src/devices/fake/fakeMotionControl/FakeMotionControl.cpp
+++ b/src/devices/fake/fakeMotionControl/FakeMotionControl.cpp
@@ -227,7 +227,9 @@ bool FakeMotionControl::alloc(int nj)
     _rotorlimits_min = allocAndCheck<double>(nj);
     _hwfault_code = allocAndCheck<int>(nj);
     _hwfault_message = allocAndCheck<std::string>(nj);
-
+    _stiffness = allocAndCheck<double>(nj);
+    _damping = allocAndCheck<double>(nj);
+    _force_offset =allocAndCheck<double>(nj);
 
     _ppids=allocAndCheck<Pid>(nj);
     _tpids=allocAndCheck<Pid>(nj);
@@ -372,7 +374,9 @@ bool FakeMotionControl::dealloc()
     checkAndDestroy(_torques);
     checkAndDestroy(_hwfault_code);
     checkAndDestroy(_hwfault_message);
-
+    checkAndDestroy(_stiffness);
+    checkAndDestroy(_damping);
+    checkAndDestroy(_force_offset);
     return true;
 }
 
@@ -2129,27 +2133,45 @@ bool FakeMotionControl::getRefTorqueRaw(int j, double *t)
 
 bool FakeMotionControl::getImpedanceRaw(int j, double *stiffness, double *damping)
 {
-    return NOT_YET_IMPLEMENTED("getImpedanceRaw");
+    _mutex.lock();
+    *stiffness = _stiffness[j];
+    *damping = _damping[j];
+    _mutex.unlock();
+    return true;
 }
 
 bool FakeMotionControl::setImpedanceRaw(int j, double stiffness, double damping)
 {
-    return NOT_YET_IMPLEMENTED("setImpedanceRaw");
+    _mutex.lock();
+    _stiffness[j] = stiffness;
+    _damping[j] = damping;
+    _mutex.unlock();
+    return true;
 }
 
 bool FakeMotionControl::setImpedanceOffsetRaw(int j, double offset)
 {
-    return NOT_YET_IMPLEMENTED("setImpedanceOffsetRaw");
+    _mutex.lock();
+    _force_offset[j] = offset;
+    _mutex.unlock();
+    return true;
 }
 
 bool FakeMotionControl::getImpedanceOffsetRaw(int j, double *offset)
 {
-    return NOT_YET_IMPLEMENTED("getImpedanceOffsetRaw");
+    _mutex.lock();
+    *offset = _force_offset[j];
+    _mutex.unlock();
+    return true;
 }
 
 bool FakeMotionControl::getCurrentImpedanceLimitRaw(int j, double *min_stiff, double *max_stiff, double *min_damp, double *max_damp)
 {
-    return NOT_YET_IMPLEMENTED("getCurrentImpedanceLimitRaw");
+    *min_stiff=1.0;
+    *max_stiff=10.0;
+    *min_damp=2.0;
+    *max_damp=20.0;
+    return true;
 }
 
 bool FakeMotionControl::getMotorTorqueParamsRaw(int j, MotorTorqueParameters *params)

--- a/src/devices/fake/fakeMotionControl/FakeMotionControl.h
+++ b/src/devices/fake/fakeMotionControl/FakeMotionControl.h
@@ -239,6 +239,11 @@ private:
     double  *_ref_accs = nullptr;             // for velocity control, in position min jerk eq is used.
     double  *_ref_torques = nullptr;          // for torque control.
     double  *_ref_currents = nullptr;
+
+    double  *_stiffness = nullptr;
+    double  *_damping = nullptr;
+    double  *_force_offset = nullptr;
+
     yarp::sig::Vector       current, nominalCurrent, maxCurrent, peakCurrent;
     yarp::sig::Vector       pwm, pwmLimit, refpwm, supplyVoltage,last_velocity_command, last_pwm_command;
     yarp::sig::Vector pos, dpos, vel, speed, acc, loc, amp;

--- a/src/devices/fake/fakeMotionControl/tests/fakeMotionControl_test.cpp
+++ b/src/devices/fake/fakeMotionControl/tests/fakeMotionControl_test.cpp
@@ -10,6 +10,7 @@
 #include <yarp/dev/IAxisInfo.h>
 #include <yarp/dev/IInteractionMode.h>
 #include <yarp/dev/IMotorEncoders.h>
+#include <yarp/dev/IImpedanceControl.h>
 #include <yarp/dev/IMotor.h>
 #include <yarp/dev/IPidControl.h>
 #include <yarp/dev/IPWMControl.h>
@@ -36,6 +37,7 @@
 #include <yarp/dev/tests/IRemoteCalibratorTest.h>
 #include <yarp/dev/tests/IJointFaultTest.h>
 #include <yarp/dev/tests/IControlLimitsTest.h>
+#include <yarp/dev/tests/IImpedanceControlTest.h>
 
 #include <catch2/catch_amalgamated.hpp>
 #include <harness.h>
@@ -67,6 +69,7 @@ TEST_CASE("dev::fakeMotionControl", "[yarp::dev]")
         ICurrentControl* icurr = nullptr;
         IJointFault* ifault = nullptr;
         IControlLimits* ilims = nullptr;
+        IImpedanceControl* iimp = nullptr;
         //IRemoteCalibrator* icalib = nullptr;
 
         ////////"Checking opening polydrivers"
@@ -92,6 +95,7 @@ TEST_CASE("dev::fakeMotionControl", "[yarp::dev]")
         ddmc.view(icurr);   REQUIRE(icurr);
         ddmc.view(ifault);  REQUIRE(ifault);
         ddmc.view(ilims);   REQUIRE(ilims);
+        ddmc.view(iimp);    REQUIRE(iimp);
         //ddmc.view(iremotecalib);  REQUIRE(iremotecalib);
 
         yarp::dev::tests::exec_iPositionControl_test_1(ipos, icmd);
@@ -110,6 +114,7 @@ TEST_CASE("dev::fakeMotionControl", "[yarp::dev]")
         //yarp::dev::tests::exec_iRemoteCalibrator_test_1(iremotecalib);
         yarp::dev::tests::exec_iJointFault_test_1(ifault);
         yarp::dev::tests::exec_iControlLimits_test1(ilims, iinfo);
+        yarp::dev::tests::exec_iImpedanceControl_test_1(iimp);
 
         //"Close all polydrivers and check"
         {

--- a/src/devices/networkWrappers/RemoteControlBoard/tests/RemoteControlBoard_test.cpp
+++ b/src/devices/networkWrappers/RemoteControlBoard/tests/RemoteControlBoard_test.cpp
@@ -15,6 +15,7 @@
 #include <yarp/dev/IPidControl.h>
 #include <yarp/dev/IPWMControl.h>
 #include <yarp/dev/ICurrentControl.h>
+#include <yarp/dev/IImpedanceControl.h>
 #include <yarp/dev/IRemoteCalibrator.h>
 #include <yarp/dev/IControlLimits.h>
 #include <yarp/os/Network.h>
@@ -28,6 +29,7 @@
 #include <yarp/dev/tests/IControlModeTest.h>
 #include <yarp/dev/tests/IInteractionModeTest.h>
 #include <yarp/dev/tests/ICurrentControlTest.h>
+#include <yarp/dev/tests/IImpedanceControlTest.h>
 #include <yarp/dev/tests/IPWMControlTest.h>
 #include <yarp/dev/tests/IPidControlTest.h>
 #include <yarp/dev/tests/IMotorTest.h>
@@ -70,6 +72,7 @@ TEST_CASE("dev::RemoteControlBoardTest", "[yarp::dev]")
         ICurrentControl* icurr = nullptr;
         IJointFault* ifault = nullptr;
         IControlLimits* ilims = nullptr;
+        IImpedanceControl* iimp = nullptr;
         //IRemoteCalibrator* iremotecalib = nullptr;
 
         ////////"Checking opening fakeMotionControl and controlBoard_nws_yarp polydrivers"
@@ -124,6 +127,8 @@ TEST_CASE("dev::RemoteControlBoardTest", "[yarp::dev]")
         ddnwc.view(icurr);   REQUIRE(icurr);
         ddnwc.view(ifault);  REQUIRE(ifault);
         ddnwc.view(ilims);   REQUIRE(ilims);
+        ddnwc.view(iimp);    REQUIRE(iimp);
+        REQUIRE(iimp);
         //ddnwc.view(icalib);  REQUIRE(iremotecalib);
 
         yarp::dev::tests::exec_iPositionControl_test_1(ipos,icmd);
@@ -142,6 +147,7 @@ TEST_CASE("dev::RemoteControlBoardTest", "[yarp::dev]")
         //yarp::dev::tests::exec_iRemoteCalibrator_test_1(icalib);
         yarp::dev::tests::exec_iJointFault_test_1(ifault);
         yarp::dev::tests::exec_iControlLimits_test1(ilims, iinfo);
+        yarp::dev::tests::exec_iImpedanceControl_test_1(iimp);
 
         //"Close all polydrivers and check"
         {

--- a/src/guis/yarpmotorgui/partitem.cpp
+++ b/src/guis/yarpmotorgui/partitem.cpp
@@ -646,34 +646,45 @@ void PartItem::onSendPWM(int jointIndex, double pwmVal)
     }
 }
 
-void PartItem::onSendStiffness(int jointIdex,double stiff,double damp,double force)
+void PartItem::onSendForceOffset(int jointIdex,double force)
 {
-    Q_UNUSED(force);
-    double stiff_val=0;
-    double damp_val=0;
     double offset_val=0;
 
+    m_iImp->setImpedanceOffset(jointIdex, force);
+    yarp::os::SystemClock::delaySystem(0.005);
+    m_iImp->getImpedanceOffset(jointIdex, &offset_val);
+
+    double off_max=0.0;
+    double off_min=0.0;
+    m_iTrq->getTorqueRange(jointIdex, &off_min, &off_max);
+
+    if (m_currentPidDlg)
+    {
+        m_currentPidDlg->initTorqueOffset(offset_val, off_min, off_max);
+    }
+}
+
+void PartItem::onSendStiffness(int jointIdex,double stiff,double damp)
+{
+    double stiff_val=0;
+    double damp_val=0;
+
     m_iImp->setImpedance(jointIdex, stiff, damp);
-    //imp->setImpedanceOffset(jointIdex, force);
     yarp::os::SystemClock::delaySystem(0.005);
     m_iImp->getImpedance(jointIdex, &stiff_val, &damp_val);
-    m_iImp->getImpedanceOffset(jointIdex, &offset_val);
 
     //update the impedance limits
     double stiff_max=0.0;
     double stiff_min=0.0;
     double damp_max=0.0;
     double damp_min=0.0;
-    double off_max=0.0;
-    double off_min=0.0;
+
     m_iImp->getCurrentImpedanceLimit(jointIdex, &stiff_min, &stiff_max, &damp_min, &damp_max);
-    m_iTrq->getTorqueRange(jointIdex, &off_min, &off_max);
 
     if (m_currentPidDlg)
     {
         m_currentPidDlg->initStiffness(stiff_val, stiff_min, stiff_max,
-                                     damp_val,damp_min,damp_max,
-                                     offset_val,off_min,off_max);
+                                       damp_val, damp_min, damp_max);
     }
 
 
@@ -776,7 +787,8 @@ void PartItem::onRefreshPids(int jointIndex)
         m_currentPidDlg->initTorque(myTrqPid, motorTorqueParams);
         m_currentPidDlg->initVelocity(myVelPid);
         m_currentPidDlg->initCurrent(myCurPid);
-        m_currentPidDlg->initStiffness(stiff_val, stiff_min, stiff_max, damp_val, damp_min, damp_max, impedance_offset_val, off_min, off_max);
+        m_currentPidDlg->initStiffness(stiff_val, stiff_min, stiff_max, damp_val, damp_min, damp_max);
+        m_currentPidDlg->initTorqueOffset(impedance_offset_val, off_min, off_max);
         m_currentPidDlg->initPWM(pwm_reference, current_pwm);
         m_currentPidDlg->initRemoteVariables(m_iVar);
     }
@@ -848,7 +860,8 @@ void PartItem::onPidClicked(JointItem *joint)
     connect(m_currentPidDlg, SIGNAL(sendSingleRemoteVariable(std::string, yarp::os::Bottle)), this, SLOT(onSendSingleRemoteVariable(std::string, yarp::os::Bottle)));
     connect(m_currentPidDlg, SIGNAL(updateAllRemoteVariables()), this, SLOT(onUpdateAllRemoteVariables()));
     connect(m_currentPidDlg, SIGNAL(sendTorquePid(int, Pid, MotorTorqueParameters)), this, SLOT(onSendTorquePid(int, Pid, MotorTorqueParameters)));
-    connect(m_currentPidDlg, SIGNAL(sendStiffness(int, double, double, double)), this, SLOT(onSendStiffness(int, double, double, double)));
+    connect(m_currentPidDlg, SIGNAL(sendStiffness(int, double, double)), this, SLOT(onSendStiffness(int, double, double)));
+    connect(m_currentPidDlg, SIGNAL(sendForceOffset(int, double)), this, SLOT(onSendForceOffset(int, double)));
     connect(m_currentPidDlg, SIGNAL(sendPWM(int, double)), this, SLOT(onSendPWM(int, double)));
     connect(m_currentPidDlg, SIGNAL(refreshPids(int)), this, SLOT(onRefreshPids(int)));
     connect(m_currentPidDlg, SIGNAL(dumpRemoteVariables()), this, SLOT(onDumpAllRemoteVariables()));

--- a/src/guis/yarpmotorgui/partitem.h
+++ b/src/guis/yarpmotorgui/partitem.h
@@ -226,7 +226,8 @@ private slots:
     void onSendSingleRemoteVariable(std::string key, yarp::os::Bottle val);
     void onUpdateAllRemoteVariables();
     void onSendTorquePid(int jointIndex, Pid newPid, MotorTorqueParameters newTorqueParam);
-    void onSendStiffness(int jointIdex, double stiff, double damp, double force);
+    void onSendStiffness(int jointIdex, double stiff, double damp);
+    void onSendForceOffset(int jointIdex, double force);
     void onSendPWM(int jointIndex, double dutyVal);
     void onRefreshPids(int jointIndex);
     void onDumpAllRemoteVariables();

--- a/src/guis/yarpmotorgui/piddlg.cpp
+++ b/src/guis/yarpmotorgui/piddlg.cpp
@@ -82,7 +82,7 @@ PidDlg::PidDlg(QString partname, int jointIndex, QString jointName, QWidget *par
     connect(ui->btnSend,SIGNAL(clicked()),this,SLOT(onSend()));
     connect(ui->btnCancel,SIGNAL(clicked()),this,SLOT(onCancel()));
     connect(ui->btnDump, SIGNAL(clicked()), this, SLOT(onDumpRemoteVariables()));
- 
+
     connect(ui->tableStiffness, &QTableWidget::itemChanged, this, [this](QTableWidgetItem* item)
     {
         if (item == ui->tableStiffness->item(2, 3))
@@ -347,6 +347,7 @@ void PidDlg::initTorqueOffset(double curForceVal, double minForce, double maxFor
     ui->tableStiffness->item(2,1)->setText(QString("%L1").arg(minForce,0,'f',3));
     ui->tableStiffness->item(2,2)->setText(QString("%L1").arg(maxForce,0,'f',3));
     ui->tableStiffness->item(2,3)->setText(QString("%L1").arg(curForceVal,0,'f',3));
+    forceOffsetChanged=false;
 }
 
 

--- a/src/guis/yarpmotorgui/piddlg.h
+++ b/src/guis/yarpmotorgui/piddlg.h
@@ -39,14 +39,15 @@ public:
     void initTorque(Pid myPid, MotorTorqueParameters TorqueParam);
     void initCurrent(Pid myPid);
     void initStiffness(double curStiffVal, double minStiff, double maxStiff,
-                       double curDampVal, double minDamp, double maxDamp,
-                       double curForceVal, double minForce, double maxForce);
+                       double curDampVal, double minDamp, double maxDamp);
+    void initTorqueOffset(double curForceVal, double minForce, double maxForce);
     void initPWM(double pwmVal, double pwm);
     void initRemoteVariables(IRemoteVariables* iVar);
 
 
 signals:
-    void sendStiffness(int,double,double,double);
+    void sendStiffness(int,double,double);
+    void sendForceOffset(int,double);
     void sendPositionPid(int jointIndex, Pid pid);
     void sendVelocityPid(int jointIndex, Pid pid);
     void sendTorquePid(int jointIndex,Pid,MotorTorqueParameters newTorqueParam);
@@ -62,6 +63,7 @@ private:
     Ui::PidDlg *ui;
     int jointIndex;
     std::vector <QPushButton*> buttons;
+    bool forceOffsetChanged = false;
 
 private slots:
     void onRefresh();
@@ -69,6 +71,7 @@ private slots:
     void onCancel();
     void onSendRemoteVariable();
     void onDumpRemoteVariables();
+    void onForceOffsetChanged(QString forceOffset);
 };
 
 class TableIntDelegate : public QItemDelegate

--- a/src/libYARP_dev/src/yarp/dev/tests/CMakeLists.txt
+++ b/src/libYARP_dev/src/yarp/dev/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(YARP_dev_test_HDRS
     IChatBotTest.h
     IVelocityControlTest.h
     IControlModeTest.h
+    IImpedanceControlTest.h
     IInteractionModeTest.h
     ICurrentControlTest.h
     IPWMControlTest.h
@@ -41,6 +42,7 @@ set(YARP_dev_test_SRCS
     IChatBotTest.cpp
     IVelocityControlTest.cpp
     IControlModeTest.cpp
+    IImpedanceControlTest.cpp
     IInteractionModeTest.cpp
     ICurrentControlTest.cpp
     IPWMControlTest.cpp

--- a/src/libYARP_dev/src/yarp/dev/tests/IImpedanceControlTest.cpp
+++ b/src/libYARP_dev/src/yarp/dev/tests/IImpedanceControlTest.cpp
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "IImpedanceControlTest.h"

--- a/src/libYARP_dev/src/yarp/dev/tests/IImpedanceControlTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/IImpedanceControlTest.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IIMPEDANCECONTROLTEST_H
+#define IIMPEDANCECONTROLTEST_H
+
+#include <yarp/dev/IImpedanceControl.h>
+#include <catch2/catch_amalgamated.hpp>
+
+#include <memory>
+#include <numeric>
+#include <vector>
+
+using namespace yarp::dev;
+using namespace yarp::os;
+
+namespace yarp::dev::tests
+{
+    inline void exec_iImpedanceControl_test_1(IImpedanceControl* iimp)
+    {
+        REQUIRE(iimp != nullptr);
+
+        int axis=0;
+        double val = 0;
+        bool b = true;
+
+        b = iimp->getAxes(&axis);
+        CHECK (b);
+        CHECK (axis>0);
+
+        double vstiff=1;
+        double vdamp=2;
+        double voff=3;
+
+        {
+            double stiff=0;
+            double damp=0;
+            b = iimp->getImpedance(0, &stiff, &damp);
+            CHECK(b);
+            CHECK(stiff==0);
+            CHECK(damp==0);
+
+            double off=0;
+            b = iimp->getImpedanceOffset(0, &off);
+            CHECK(b);
+            CHECK(off==0);
+        }
+
+        {
+            b = iimp->setImpedance(0, vstiff, vdamp);
+            CHECK(b);
+            b = iimp->setImpedanceOffset(0, voff);
+            CHECK(b);
+
+            double stiff=0;
+            double damp=0;
+            b = iimp->getImpedance(0, &stiff, &damp);
+            CHECK(b);
+            CHECK(stiff==1);
+            CHECK(damp==2);
+
+            double off=0;
+            b = iimp->getImpedanceOffset(0, &off);
+            CHECK(b);
+            CHECK(off==3);
+        }
+
+        {
+            double mins=0;
+            double maxs=0;
+            double mind=0;
+            double maxd=0;
+            b = iimp->getCurrentImpedanceLimit(0, &mins,&maxs, &mind, &maxd);
+            CHECK(b);
+            CHECK(mins==1.0);
+            CHECK(maxs==10.0);
+            CHECK(mind==2.0);
+            CHECK(maxd==20.0);
+        }
+
+    }
+}
+
+#endif


### PR DESCRIPTION
Added new tests to check IImpedanceControl interface.
Improved yarpmotorgui to handle forceOffset of IImpedanceControl interface: the value is sent only if the value in the table is changed.
Fixes: https://github.com/robotology/yarp/issues/3119