### PR TITLE
Permit to build yarp-rerun as an indipendent CMake project

### DIFF
--- a/src/commands/yarpRerun/CMakeLists.txt
+++ b/src/commands/yarpRerun/CMakeLists.txt
@@ -1,6 +1,16 @@
 # SPDX-FileCopyrightText: 2025-2025 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
+if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
+  cmake_minimum_required(VERSION 3.19)
+
+  project(yarp-rerun)
+
+  find_package(YARP REQUIRED)
+
+  include(GNUInstallDirs)
+endif()
+
 find_package(rerun_sdk QUIET)
 if(NOT rerun_sdk_FOUND)
     message(STATUS  "rerun_sdk not found. Skipping yarpRerun.")


### PR DESCRIPTION
Similar to what we do for bindings in https://github.com/robotology/yarp/blob/v3.12.1/bindings/CMakeLists.txt#L5, for packaging purposes it is convenient to be able to build yarp-rerun as a standalone package, to avoid the need to add the rerun dependency in the main YARP package.