### PR TITLE
IJacobianCoupling: fix linker error under windows

### DIFF
--- a/src/libYARP_dev/src/CMakeLists.txt
+++ b/src/libYARP_dev/src/CMakeLists.txt
@@ -173,6 +173,7 @@ set(YARP_dev_SRCS
   yarp/dev/IFrameWriterAudioVisual.cpp
   yarp/dev/IFrameWriterImage.cpp
   yarp/dev/IGenericSensor.cpp
+  yarp/dev/IJacobianCoupling.cpp
   yarp/dev/IJoypadController.cpp
   yarp/dev/ILLM.cpp
   yarp/dev/IMultipleWrapper.cpp

--- a/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2023 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/dev/IJacobianCoupling.h>
+
+yarp::dev::IJacobianCoupling::~IJacobianCoupling() = default;

--- a/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h
+++ b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h
@@ -63,7 +63,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~IJacobianCoupling() {}
+    virtual ~IJacobianCoupling();
 
     /**
      * @brief Get the Jacobian mapping the Actuated Axes to Physical Joints velocity


### PR DESCRIPTION
It needs the destructor definition in the .cpp. It fixes #3278