### PR TITLE
Generate dependent IDL headers before parsing yarp.i

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -37,6 +37,7 @@ set_target_properties(${SWIG_MODULE_yarp_python_REAL_NAME}
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/python3"
     # treat Python3_INCLUDE_DIRS as non-system so that it can be overriden
     NO_SYSTEM_FROM_IMPORTED TRUE
+    SWIG_DEPENDS "${SWIG_YARP_LIBRARIES}"
 )
 
 # INCLUDE_DIRECTORIES might have gotten polluted by 3rd-party deps, make sure


### PR DESCRIPTION
PR https://github.com/robotology/yarp/pull/3269 requires that the *yarp/dev/LLM_Message.h* header is present at the time *yarp.i* is parsed. If YARP bindings are built along with the core libraries, it can cause a "Error: Unable to find 'yarp/dev/LLM_Message.h'" SWIG compiler error due to this header being generated by the IDL parser afterwards.

To reproduce this, create a build tree from scratch and configure YARP bindings, e.g.:

```
cmake .. -DYARP_COMPILE_BINDINGS=ON -DCREATE_PYTHON=ON
```

The following target fails with the aforementioned error:

```
make yarp_python_swig_compilation
```

Using `${SWIG_YARP_LIBRARIES}` instead of an explicit `YARP::YARP_dev` for maintainability, although this is the only YARP component needed.