### PR TITLE
Added markers to yarp::sig::sound

### DIFF
--- a/src/commands/yarpAudioPlayer/idl_generated_code/yarpAudioPlayer_IDL.cpp
+++ b/src/commands/yarpAudioPlayer/idl_generated_code/yarpAudioPlayer_IDL.cpp
@@ -177,7 +177,7 @@ class yarpAudioPlayer_IDL_test_helper :
 {
 public:
     yarpAudioPlayer_IDL_test_helper() = default;
-    explicit yarpAudioPlayer_IDL_test_helper(const double duration);
+    yarpAudioPlayer_IDL_test_helper(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels);
     bool write(yarp::os::ConnectionWriter& connection) const override;
     bool read(yarp::os::ConnectionReader& connection) override;
 
@@ -186,7 +186,7 @@ public:
     {
     public:
         Command() = default;
-        explicit Command(const double duration);
+        Command(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels);
 
         ~Command() override = default;
 
@@ -201,7 +201,12 @@ public:
         bool readTag(yarp::os::idl::WireReader& reader);
         bool readArgs(yarp::os::idl::WireReader& reader);
 
-        double duration{0.0};
+        std::string type{"sine"};
+        double duration{0.000000};
+        double frequency{0.000000};
+        std::int16_t amplitude{30000};
+        std::int16_t sampling_rate{16000};
+        std::int16_t channels{1};
     };
 
     class Reply :
@@ -220,7 +225,7 @@ public:
         bool return_helper{false};
     };
 
-    using funcptr_t = bool (*)(const double);
+    using funcptr_t = bool (*)(const std::string&, const double, const double, const std::int16_t, const std::int16_t, const std::int16_t);
     void call(yarpAudioPlayer_IDL* ptr);
 
     Command cmd;
@@ -228,11 +233,17 @@ public:
 
     static constexpr const char* s_tag{"test"};
     static constexpr size_t s_tag_len{1};
-    static constexpr size_t s_cmd_len{2};
+    static constexpr size_t s_cmd_len{7};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool yarpAudioPlayer_IDL::test(const double duration)"};
+    static constexpr const char* s_prototype{"bool yarpAudioPlayer_IDL::test(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels)"};
     static constexpr const char* s_help{
-        "Generate and and send a sine test tone\n"
+        "Generate and send a test sound\n"
+        "@param type can be \"sine\" , \"sawtooth\"  , \"squarewave\"\n"
+        "@param duration the duration of the sound in seconds\n"
+        "@param frequency the signal in hertz\n"
+        "@param amplitude the amplitude of the signal (16 bit)\n"
+        "@param channels number of channels\n"
+        "@param sampling_rate signal sampling rate (samples/s)\n"
         "@return true/false on success/failure"
     };
 };
@@ -392,8 +403,8 @@ void yarpAudioPlayer_IDL_play_helper::call(yarpAudioPlayer_IDL* ptr)
 }
 
 // test helper class implementation
-yarpAudioPlayer_IDL_test_helper::yarpAudioPlayer_IDL_test_helper(const double duration) :
-        cmd{duration}
+yarpAudioPlayer_IDL_test_helper::yarpAudioPlayer_IDL_test_helper(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels) :
+        cmd{type, duration, frequency, amplitude, sampling_rate, channels}
 {
 }
 
@@ -407,8 +418,13 @@ bool yarpAudioPlayer_IDL_test_helper::read(yarp::os::ConnectionReader& connectio
     return reply.read(connection);
 }
 
-yarpAudioPlayer_IDL_test_helper::Command::Command(const double duration) :
-        duration{duration}
+yarpAudioPlayer_IDL_test_helper::Command::Command(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels) :
+        type{type},
+        duration{duration},
+        frequency{frequency},
+        amplitude{amplitude},
+        sampling_rate{sampling_rate},
+        channels{channels}
 {
 }
 
@@ -452,7 +468,22 @@ bool yarpAudioPlayer_IDL_test_helper::Command::writeTag(const yarp::os::idl::Wir
 
 bool yarpAudioPlayer_IDL_test_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
 {
+    if (!writer.writeString(type)) {
+        return false;
+    }
     if (!writer.writeFloat64(duration)) {
+        return false;
+    }
+    if (!writer.writeFloat64(frequency)) {
+        return false;
+    }
+    if (!writer.writeI16(amplitude)) {
+        return false;
+    }
+    if (!writer.writeI16(sampling_rate)) {
+        return false;
+    }
+    if (!writer.writeI16(channels)) {
         return false;
     }
     return true;
@@ -484,13 +515,23 @@ bool yarpAudioPlayer_IDL_test_helper::Command::readTag(yarp::os::idl::WireReader
 
 bool yarpAudioPlayer_IDL_test_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
 {
-    if (reader.noMore()) {
-        reader.fail();
-        return false;
+    if (!reader.readString(type)) {
+        type = "sine";
     }
     if (!reader.readFloat64(duration)) {
-        reader.fail();
-        return false;
+        duration = 1;
+    }
+    if (!reader.readFloat64(frequency)) {
+        frequency = 440;
+    }
+    if (!reader.readI16(amplitude)) {
+        amplitude = 30000;
+    }
+    if (!reader.readI16(sampling_rate)) {
+        sampling_rate = 16000;
+    }
+    if (!reader.readI16(channels)) {
+        channels = 1;
     }
     if (!reader.noMore()) {
         reader.fail();
@@ -542,7 +583,7 @@ bool yarpAudioPlayer_IDL_test_helper::Reply::read(yarp::os::idl::WireReader& rea
 
 void yarpAudioPlayer_IDL_test_helper::call(yarpAudioPlayer_IDL* ptr)
 {
-    reply.return_helper = ptr->test(cmd.duration);
+    reply.return_helper = ptr->test(cmd.type, cmd.duration, cmd.frequency, cmd.amplitude, cmd.sampling_rate, cmd.channels);
 }
 
 // Constructor
@@ -561,12 +602,12 @@ bool yarpAudioPlayer_IDL::play(const std::string& filename)
     return ok ? helper.reply.return_helper : bool{};
 }
 
-bool yarpAudioPlayer_IDL::test(const double duration)
+bool yarpAudioPlayer_IDL::test(const std::string& type, const double duration, const double frequency, const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", yarpAudioPlayer_IDL_test_helper::s_prototype);
     }
-    yarpAudioPlayer_IDL_test_helper helper{duration};
+    yarpAudioPlayer_IDL_test_helper helper{type, duration, frequency, amplitude, sampling_rate, channels};
     bool ok = yarp().write(helper, helper);
     return ok ? helper.reply.return_helper : bool{};
 }

--- a/src/commands/yarpAudioPlayer/idl_generated_code/yarpAudioPlayer_IDL.h
+++ b/src/commands/yarpAudioPlayer/idl_generated_code/yarpAudioPlayer_IDL.h
@@ -39,10 +39,16 @@ public:
     virtual bool play(const std::string& filename);
 
     /**
-     * Generate and and send a sine test tone
+     * Generate and send a test sound
+     * @param type can be "sine" , "sawtooth"  , "squarewave"
+     * @param duration the duration of the sound in seconds
+     * @param frequency the signal in hertz
+     * @param amplitude the amplitude of the signal (16 bit)
+     * @param channels number of channels
+     * @param sampling_rate signal sampling rate (samples/s)
      * @return true/false on success/failure
      */
-    virtual bool test(const double duration);
+    virtual bool test(const std::string& type = "sine", const double duration = 1, const double frequency = 440, const std::int16_t amplitude = 30000, const std::int16_t sampling_rate = 16000, const std::int16_t channels = 1);
 
     // help method
     virtual std::vector<std::string> help(const std::string& functionName = "--all");

--- a/src/commands/yarpAudioPlayer/yarpAudioPlayer.cpp
+++ b/src/commands/yarpAudioPlayer/yarpAudioPlayer.cpp
@@ -26,7 +26,7 @@ class PlayerModule: public yarp::os::RFModule, public yarpAudioPlayer_IDL
 
     public: //yarpAudioPlayer_IDL methods
     bool play(const std::string& filename) override;
-    bool test(double duration) override;
+    bool test(const std::string& type, const double duration, const double frequency,const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels) override;
 
     protected: //internal methods
     bool openFile(const std::string& file_name);
@@ -44,6 +44,16 @@ class PlayerModule: public yarp::os::RFModule, public yarpAudioPlayer_IDL
 
         if (rf.check("split_size"))
         { m_split_size = rf.find("split_size").asInt32(); }
+
+        if (rf.check("help"))
+        {
+            yInfo() << "yarpAudioPlayer --name <portname> --split_size <value>";
+            yInfo() << "portname: prefix for the opened ports default: /yarpAudioPlayer";
+            yInfo() << "value: int32 (default value 16000) The output sound will be split into packets of <value> samples each";
+            yInfo() << "the tool accepts commands on its rpc port";
+            yInfo() << "";
+            return false;
+        }
 
         // rpc port
         ret = m_rpcPort.open((m_name + "/rpc").c_str());
@@ -112,12 +122,21 @@ bool PlayerModule::play(const std::string& filename)
     return true;
 }
 
-bool PlayerModule::test(double duration)
+bool PlayerModule::test(const std::string& type, const double duration, const double frequency,const std::int16_t amplitude, const std::int16_t sampling_rate, const std::int16_t channels)
 {
     bool ret;
-    size_t channels = 1;
-    size_t sampleRate = 16000;
-    ret = yarp::sig::utils::makeTone(m_audioFile,duration,channels,sampleRate);
+    if (type == "sine")
+    { ret = yarp::sig::utils::makeTone(m_audioFile,duration,channels, sampling_rate, frequency, amplitude); }
+    else if (type == "sawtooth" )
+    { ret = yarp::sig::utils::makeSawTooth(m_audioFile,duration,channels,sampling_rate, frequency, amplitude); }
+    else if (type == "squarewave" )
+    { ret = yarp::sig::utils::makeSquareWave(m_audioFile,duration,channels,sampling_rate, frequency, amplitude); }
+    else
+    {
+        yInfo() << "Invalid type, should be `sine`, `sawtooth`, or `squarewave`";
+        return false;
+    }
+
     yInfo() << "Generated tone of " << duration << "s, with the following properties: samples:" << m_audioFile.getSamples() << " channels:"<< m_audioFile.getChannels() << " frequency:" << m_audioFile.getFrequency() << " bytes per samples:" << m_audioFile.getBytesPerSample();
     if (!ret) { return false; }
 

--- a/src/commands/yarpAudioPlayer/yarpAudioPlayer.thrift
+++ b/src/commands/yarpAudioPlayer/yarpAudioPlayer.thrift
@@ -18,8 +18,14 @@ service yarpAudioPlayer_IDL
   bool play(1: string filename);
 
   /**
-  * Generate and and send a sine test tone
+  * Generate and send a test sound
+  * @param type can be "sine" , "sawtooth"  , "squarewave"
+  * @param duration the duration of the sound in seconds
+  * @param frequency the signal in hertz
+  * @param amplitude the amplitude of the signal (16 bit)
+  * @param channels number of channels
+  * @param sampling_rate signal sampling rate (samples/s)
   * @return true/false on success/failure
   */
-  bool test(1: double duration);
+  bool test(1: string type="sine", 2: double duration=1, 3: double frequency=440, 4: i16 amplitude=30000, 5: i16 sampling_rate=16000, 6: i16 channels=1);
 }

--- a/src/libYARP_sig/src/yarp/sig/Sound.cpp
+++ b/src/libYARP_sig/src/yarp/sig/Sound.cpp
@@ -49,8 +49,6 @@ public:
     yarp::os::NetInt32 bytesPerSample{ 0 };
     yarp::os::NetInt32 frequencyTag{ 0 };
     yarp::os::NetInt32 frequency{ 0 };
-    yarp::os::NetInt32 listTag{ 0 };
-    yarp::os::NetInt32 listLen{ 0 };
 
     SoundHeader() = default;
 };
@@ -60,7 +58,6 @@ Sound::Sound(size_t bytesPerSample)
 {
     init(bytesPerSample);
     m_frequency = 0;
-
 }
 
 Sound::Sound(const Sound& alt) : yarp::os::Portable()
@@ -113,6 +110,10 @@ void Sound::overwrite(const Sound& alt, size_t offset, size_t len)
         unsigned char* src = &alt.getRawData()[psrc];
         memcpy((void*) dst, (void*) src, len * this->m_bytesPerSample);
     }
+
+    //invalidate all the markers
+    m_markers.clear();
+
 }
 
 Sound& Sound::operator += (const Sound& alt)
@@ -151,6 +152,9 @@ Sound& Sound::operator += (const Sound& alt)
         memcpy((void *) &pout[out2], (void *) (alt_start  + alt_pointer),  alt_singlechannel_size);
     }
 
+    //invalidate all the markers
+    m_markers.clear();
+
     return *this;
 }
 
@@ -160,6 +164,7 @@ const Sound& Sound::operator = (const Sound& alt)
     m_frequency = alt.m_frequency;
     m_channels = alt.m_channels;
     m_samples = alt.m_samples;
+    m_markers = alt.m_markers;
 
     if (m_bytesPerSample == 1)
     {
@@ -319,6 +324,10 @@ bool Sound::clearChannel(size_t chan)
     {
         set(0, i, chan);
     }
+
+    //invalidate all the markers
+    m_markers.clear();
+
     return true;
 }
 
@@ -367,19 +376,50 @@ bool Sound::read(ConnectionReader& connection)
     m_frequency = header.frequency;
     m_channels = header.channelsSize;
     m_samples = header.samplesSize;
-    size_t data_size = header.listLen;
 
+    connection.expectInt32(); //dummy list
+    size_t data_size = connection.expectInt32(); //data size
     if (data_size != m_channels * m_samples)
     {
         return false;
     }
 
+    //sound data
     auto* pp = ((std::vector<NetUint16>*)(implementation));
     pp->resize(data_size);
     for (size_t l = 0; l < data_size; l++)
     {
         pp->at(l) = connection.expectInt16();
     }
+
+    connection.expectInt32(); //dummy list
+    size_t markersListLen = connection.expectInt32(); //markers size
+
+    //markers data
+    m_markers.clear();
+    for (int i = 0; i < markersListLen; i++)
+    {
+        int innerTag = connection.expectInt32();
+        if (innerTag != BOTTLE_TAG_LIST) {
+            return false;
+        }
+
+        int innerSize = connection.expectInt32();
+        if (innerSize != 4) {
+            return false;
+        }
+
+        std::string key = connection.expectString();
+
+        yarp::sig::SoundMarker marker;
+        marker.label = connection.expectString();
+        marker.channel = connection.expectInt32();
+        marker.sample_id = static_cast<size_t>(connection.expectInt64());
+
+        m_markers[key] = marker;
+    }
+
+
     return true;
 }
 
@@ -388,24 +428,43 @@ bool Sound::write(yarp::os::ConnectionWriter& connection) const
 {
     SoundHeader header;
     header.outerListTag = BOTTLE_TAG_LIST;
-    header.outerListLen = 5;
-    header.samplesSizeTag = BOTTLE_TAG_INT32;
+    header.outerListLen = 6;
+    header.samplesSizeTag = BOTTLE_TAG_INT32; //1
     header.samplesSize = m_samples;
-    header.bytesPerSampleTag = BOTTLE_TAG_INT32;
+    header.bytesPerSampleTag = BOTTLE_TAG_INT32; //2
     header.bytesPerSample = m_bytesPerSample;
-    header.channelsSizeTag = BOTTLE_TAG_INT32;
+    header.channelsSizeTag = BOTTLE_TAG_INT32; //3
     header.channelsSize = m_channels;
-    header.frequencyTag = BOTTLE_TAG_INT32;
+    header.frequencyTag = BOTTLE_TAG_INT32; //4
     header.frequency = m_frequency;
+
+    connection.appendBlock((char*)&header, sizeof(header));
 
     auto* pp = ((std::vector<NetUint16>*)(implementation));
     size_t siz = pp->size();
-    header.listTag = BOTTLE_TAG_LIST + BOTTLE_TAG_INT16;
-    header.listLen = siz; //this must be equal to m_samples*m_channels
-    //BOTTLE_TAG_LIST is special and must be followed by its size.
-    connection.appendBlock((char*)&header, sizeof(header));
+    connection.appendInt32(BOTTLE_TAG_LIST+BOTTLE_TAG_INT16);
+    connection.appendInt32(siz);
+
+    //add the sound data
     for (size_t l = 0; l < pp->size(); l++) {
         connection.appendInt16(pp->at(l));
+    }
+
+    connection.appendInt32(BOTTLE_TAG_LIST);
+    connection.appendInt32(static_cast<int32_t>(m_markers.size()));
+
+    //add the markers data
+    for (const auto& it : m_markers) {
+        const std::string& key = it.first;
+        const yarp::sig::SoundMarker& marker = it.second;
+
+        connection.appendInt32(BOTTLE_TAG_LIST);
+        connection.appendInt32(4); // key + 3 fields of the struct
+
+        connection.appendString(key);
+        connection.appendString(marker.label);
+        connection.appendInt32(marker.channel);
+        connection.appendInt64(static_cast<int64_t>(marker.sample_id));
     }
 
     connection.convertTextMode();
@@ -429,6 +488,7 @@ unsigned char *Sound::getRawData() const
 
     yCError(SOUND, "sound only implemented for 8-16 bit samples");
     yCAssert(SOUND, false); // that's all that's implemented right now
+    return nullptr;         // unreachable, but avoids compiler warning
 }
 
 size_t Sound::getRawDataSize() const
@@ -482,6 +542,9 @@ bool Sound::operator==(const Sound& alt) const
     if (this->m_samples != alt.getSamples()) {
         return false;
     }
+    if (this->m_markers != alt.m_markers) {
+        return false;
+    }
 
     for (size_t ch = 0; ch < this->m_channels; ch++)
     {
@@ -509,6 +572,10 @@ bool Sound::replaceChannel(size_t id, Sound schannel)
     {
         this->setSafe(schannel.getSafe(s, 0), s, id);
     }
+
+    //invalidate all the markers
+    m_markers.clear();
+
     return true;
 }
 
@@ -673,4 +740,104 @@ void Sound::findPeak(size_t& channelId, size_t& sampleId, audio_sample& sampleVa
             channelId = c;
         }
     }
+}
+
+/// --------------------------------------------------
+/// MARKERS
+/// --------------------------------------------------
+
+void  Sound::add_marker(std::string marker_label, size_t sample_id, int channel)
+{
+    SoundMarker sm;
+    sm.sample_id = sample_id;
+    sm.channel=channel;
+    sm.label=marker_label;
+
+    m_markers[marker_label] = sm;
+}
+
+bool  Sound::get_marker(std::string marker_label, size_t&  sample_id, int& channel) const
+{
+    auto it = m_markers.find(marker_label);
+    if (it == m_markers.end())
+    {
+        yCWarning(SOUND) << "Sound marker not found:" << marker_label;
+        sample_id=0;
+        channel=-1;
+        return false;
+    }
+
+    const SoundMarker& sm = it->second;
+    sample_id = sm.sample_id;
+    channel = sm.channel;
+    return true;
+}
+
+void  Sound::remove_marker(std::string marker_label)
+{
+    m_markers.erase(marker_label);
+}
+
+void  Sound::remove_all_markers()
+{
+    m_markers.clear();
+}
+
+size_t yarp::sig::Sound::getMarkersCount() const
+{
+    return m_markers.size();
+}
+
+yarp::sig::SoundMarker yarp::sig::Sound::getMarker(size_t index) const
+{
+    if (index >= m_markers.size()) {
+        return yarp::sig::SoundMarker();
+    }
+    auto it = m_markers.begin();
+    std::advance(it, index);
+    return it->second;
+}
+
+std::vector<yarp::sig::SoundMarker> yarp::sig::Sound::getMarkers() const
+{
+    std::vector<yarp::sig::SoundMarker> v;
+    v.reserve(m_markers.size());
+    for (auto const& [key, val] : m_markers) {
+        v.push_back(val);
+    }
+    return v;
+}
+
+Sound Sound::subSound(std::string marker_start, std::string marker_end)
+{
+    Sound s;
+
+    SoundMarker mstart;
+    mstart.sample_id =0;
+
+    SoundMarker mend;
+    mend.sample_id = this->m_samples - 1;
+
+    auto its = m_markers.find(marker_start);
+    if (its == m_markers.end())
+    {
+        yCWarning(SOUND) << "Sound marker not found:" << marker_start;
+    }
+    else
+    {
+        mstart = its->second;
+    }
+
+    auto ite = m_markers.find(marker_end);
+    if (ite == m_markers.end())
+    {
+        yCWarning(SOUND) << "Sound marker not found:" << marker_end;
+    }
+    else
+    {
+        mend = ite->second;
+    }
+
+    s = subSound(mstart.sample_id, mend.sample_id-mstart.sample_id+1);
+    return s;
 }

--- a/src/libYARP_sig/src/yarp/sig/Sound.h
+++ b/src/libYARP_sig/src/yarp/sig/Sound.h
@@ -13,7 +13,24 @@
 #include <vector>
 #include <string>
 
+#include <map>
+
 namespace yarp::sig {
+
+struct YARP_sig_API SoundMarker
+{
+public:
+    std::string label;
+    int channel=-1;
+    size_t sample_id=0;
+
+    bool operator==(const SoundMarker& other) const
+    {
+        return label == other.label &&
+               channel == other.channel &&
+               sample_id == other.sample_id;
+    }
+};
 
 /**
  * \ingroup sig_class
@@ -238,9 +255,68 @@ public:
     /**
      * Print matrix to a string. Useful for debugging.
      * The output string is represented in non-interleaved format
-     *
      */
     std::string toString() const;
+
+public:
+    /**
+     * Adds a marker to the sound, identified by a label, a sample id and an optional channel number (if not specified, the marker is valid for all channels).
+     * If a marker with the same label already exists, it will be overwritten.
+     * @param marker_label the label of the marker
+     * @param sample_id the sample id of the marker
+     * @param channel the channel number of the marker (optional, default value = -1, meaning that the marker is valid for all channels)
+     */
+    void  add_marker(std::string marker_label, size_t sample_id, int channel=-1);
+
+    /**
+     * Gets the sample id and channel number of a marker given its label. If the marker is not found, the method returns false and the output parameters are not modified.
+     * @param marker_label the label of the marker
+     * @param sample_id the sample id of the marker (output parameter)
+     * @param channel the channel number of the marker (output parameter)
+     * @return true if the marker is found, false otherwise
+     */
+    bool  get_marker(std::string marker_label, size_t&  sample_id, int& channel) const;
+
+    /**
+     * Gets the number of markers contained in the sound.
+     * @return the number of markers
+     */
+    size_t getMarkersCount() const;
+
+    /**
+     * Get the marker at the specified index. The order of the markers is not guaranteed and may change in the future.
+     * If the index is out of range, the method throws an std::out_of_range exception.
+     * Used by yarp bindings.
+     * @param index the index of the marker to retrieve
+     * @return the marker at the specified index
+     */
+    yarp::sig::SoundMarker getMarker(size_t index) const;
+
+    /**
+     * Get all the markers contained in the sound. The order of the markers is not guaranteed and may change in the future. Used by yarp bindings.
+     * @return a vector containing all the markers of the sound
+     */
+    std::vector<yarp::sig::SoundMarker> getMarkers() const;
+
+    /**
+     * Removes a marker given its label. If the marker is not found, the method does nothing.
+     * @param marker_label the label of the marker to remove
+     */
+    void  remove_marker(std::string marker_label);
+
+    /**
+     * Removes all the markers contained in the sound.
+     */
+    void  remove_all_markers();
+
+    /**
+     * Returns a subSound of the current sound, starting from the sample identified by marker_start and ending at the sample identified by marker_end (including the two markers).
+     * If one of the two markers is not found, or if marker_start is after marker_end, the method throws an std::invalid_argument exception.
+     * @param marker_start the label of the marker identifying the starting sample of the subSound
+     * @param marker_end the label of the marker identifying the ending sample of the subSound
+     * @return the subSound identified by the two markers
+     */
+    Sound subSound(std::string marker_start, std::string marker_end);
 
 private:
     /**
@@ -271,6 +347,8 @@ private:
     size_t m_channels;
     size_t m_bytesPerSample;
     int    m_frequency;
+
+    std::map<std::string,yarp::sig::SoundMarker> m_markers;
 };
 
 } // namespace yarp::sig

--- a/src/libYARP_sig/src/yarp/sig/SoundFileWav.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundFileWav.cpp
@@ -56,6 +56,7 @@ public:
     NetInt32 dataLength;
 
     void setup_to_write(const Sound& sound, FILE *fp);
+    void setup_to_write_with_markers(const Sound& sound, FILE *fp);
     bool parse_from_file(FILE *fp);
 };
 YARP_END_PACK
@@ -246,6 +247,140 @@ void PcmWavHeader::setup_to_write(const Sound& src, FILE *fp)
 
 }
 
+void PcmWavHeader::setup_to_write_with_markers(const Sound& src, FILE *fp)
+{
+    int bitsPerSample = 16;
+    size_t channels = src.getChannels();
+    size_t bytes = channels*src.getSamples()*2;
+    int align = channels*((bitsPerSample+7)/8);
+
+    // Calculate sizes for marker chunks
+    size_t num_markers = src.getMarkersCount();
+
+    // Size of cue chunk: 4 bytes (chunk ID) + 4 bytes (chunk size) + 4 bytes (num cue points) + 24 bytes per cue point
+    size_t cue_chunk_size = 0;
+    if (num_markers > 0) {
+        cue_chunk_size = 4 + 4 + (4 + num_markers * 24);
+    }
+
+    // Size of LIST/adtl chunk for labels: 4 bytes (LIST) + 4 bytes (size) + 4 bytes (adtl) + labels
+    size_t list_chunk_size = 0;
+    if (num_markers > 0)
+    {
+        list_chunk_size = 4 + 4 + 4; // LIST + size + adtl
+        for (size_t i = 0; i < num_markers; i++)
+        {
+            SoundMarker marker = src.getMarker(i);
+            // Each label chunk: 'labl' (4) + size (4) + cue point ID (4) + null-terminated string
+            size_t label_len = marker.label.length() + 1; // +1 for null terminator
+            if (label_len % 2) label_len++; // Pad to even number
+            list_chunk_size += 4 + 4 + 4 + label_len;
+        }
+    }
+
+    wavHeader = yarp::os::createVocab32('R','I','F','F');
+    wavLength = bytes + sizeof(PcmWavHeader) - 2*sizeof(NetInt32) + cue_chunk_size + list_chunk_size;
+    formatHeader1 = yarp::os::createVocab32('W','A','V','E');
+    formatHeader2 = yarp::os::createVocab32('f','m','t',' ');
+    formatLength = sizeof(pcm);
+
+    pcm.pcmFormatTag = 1; /* PCM! */
+    pcm.pcmChannels = channels;
+    pcm.pcmSamplesPerSecond = (int)src.getFrequency();
+    pcm.pcmBytesPerSecond = align*pcm.pcmSamplesPerSecond;
+    pcm.pcmBlockAlign = align;
+    pcm.pcmBitsPerSample = bitsPerSample;
+
+    dataHeader = yarp::os::createVocab32('d','a','t','a');
+    dataLength = bytes;
+
+    // Write RIFF header
+    fwrite(&wavHeader,sizeof(wavHeader),1,fp);
+    fwrite(&wavLength,sizeof(wavLength),1,fp);
+    fwrite(&formatHeader1,sizeof(formatHeader1),1,fp);
+
+    // Write fmt chunk
+    fwrite(&formatHeader2,sizeof(formatHeader2),1,fp);
+    fwrite(&formatLength,sizeof(formatLength),1,fp);
+
+    fwrite(&pcm.pcmFormatTag,sizeof(pcm.pcmFormatTag),1,fp);
+    fwrite(&pcm.pcmChannels,sizeof(pcm.pcmChannels),1,fp);
+    fwrite(&pcm.pcmSamplesPerSecond,sizeof(pcm.pcmSamplesPerSecond),1,fp);
+    fwrite(&pcm.pcmBytesPerSecond,sizeof(pcm.pcmBytesPerSecond),1,fp);
+    fwrite(&pcm.pcmBlockAlign,sizeof(pcm.pcmBlockAlign),1,fp);
+    fwrite(&pcm.pcmBitsPerSample,sizeof(pcm.pcmBitsPerSample),1,fp);
+
+    // Write cue chunk if markers exist
+    if (num_markers > 0) {
+        NetInt32 cueHeader = yarp::os::createVocab32('c','u','e',' ');
+        NetInt32 cueChunkSize = 4 + num_markers * 24; // 4 bytes for num cue points + 24 bytes per cue point
+        NetInt32 numCuePoints = num_markers;
+
+        fwrite(&cueHeader, sizeof(cueHeader), 1, fp);
+        fwrite(&cueChunkSize, sizeof(cueChunkSize), 1, fp);
+        fwrite(&numCuePoints, sizeof(numCuePoints), 1, fp);
+
+        // Write each cue point
+        for (size_t i = 0; i < num_markers; i++) {
+            SoundMarker marker = src.getMarker(i);
+
+            NetInt32 cuePointId = i + 1; // Cue point IDs start from 1
+            NetInt32 position = marker.sample_id;
+            NetInt32 dataChunkId = yarp::os::createVocab32('d','a','t','a');
+            NetInt32 chunkStart = 0;
+            NetInt32 blockStart = 0;
+            NetInt32 sampleOffset = position;
+
+            fwrite(&cuePointId, sizeof(cuePointId), 1, fp);
+            fwrite(&position, sizeof(position), 1, fp);
+            fwrite(&dataChunkId, sizeof(dataChunkId), 1, fp);
+            fwrite(&chunkStart, sizeof(chunkStart), 1, fp);
+            fwrite(&blockStart, sizeof(blockStart), 1, fp);
+            fwrite(&sampleOffset, sizeof(sampleOffset), 1, fp);
+        }
+    }
+
+    // Write LIST/adtl chunk with labels if markers exist
+    if (num_markers > 0) {
+        NetInt32 listHeader = yarp::os::createVocab32('L','I','S','T');
+        NetInt32 listChunkSize = list_chunk_size - 8; // Total size minus 'LIST' and size fields
+        NetInt32 adtlHeader = yarp::os::createVocab32('a','d','t','l');
+
+        fwrite(&listHeader, sizeof(listHeader), 1, fp);
+        fwrite(&listChunkSize, sizeof(listChunkSize), 1, fp);
+        fwrite(&adtlHeader, sizeof(adtlHeader), 1, fp);
+
+        // Write each label
+        for (size_t i = 0; i < num_markers; i++) {
+            SoundMarker marker = src.getMarker(i);
+
+            NetInt32 lablHeader = yarp::os::createVocab32('l','a','b','l');
+            NetInt32 cuePointId = i + 1;
+
+            std::string label = marker.label;
+            size_t label_len = label.length() + 1; // +1 for null terminator
+            bool need_pad = (label_len % 2) == 1;
+            if (need_pad) label_len++;
+
+            NetInt32 lablChunkSize = 4 + label_len; // 4 bytes for cue point ID + label string
+
+            fwrite(&lablHeader, sizeof(lablHeader), 1, fp);
+            fwrite(&lablChunkSize, sizeof(lablChunkSize), 1, fp);
+            fwrite(&cuePointId, sizeof(cuePointId), 1, fp);
+            fwrite(label.c_str(), label.length() + 1, 1, fp); // Write null-terminated string
+
+            if (need_pad) {
+                char pad = 0;
+                fwrite(&pad, 1, 1, fp);
+            }
+        }
+    }
+
+    // Write data chunk header
+    fwrite(&dataHeader,sizeof(dataHeader),1,fp);
+    fwrite(&dataLength,sizeof(dataLength),1,fp);
+}
+
 //#######################################################################################################
 
 bool yarp::sig::file::read_wav_file(Sound& sound_data, const char * filename)
@@ -306,7 +441,13 @@ bool yarp::sig::file::write_wav_file(const Sound& sound_data, const char * filen
     }
 
     PcmWavHeader header;
-    header.setup_to_write(sound_data, fp);
+
+    // Use the new method if markers are present, otherwise use the old method
+    if (sound_data.getMarkersCount() > 0) {
+        header.setup_to_write_with_markers(sound_data, fp);
+    } else {
+        header.setup_to_write(sound_data, fp);
+    }
 
     ManagedBytes bytes(header.dataLength);
     auto* data = reinterpret_cast<NetInt16*>(bytes.get());
@@ -323,5 +464,38 @@ bool yarp::sig::file::write_wav_file(const Sound& sound_data, const char * filen
     fwrite(bytes.get(),bytes.length(),1,fp);
 
     fclose(fp);
+
+    // Write Audacity label file if markers are present
+    if (sound_data.getMarkersCount() > 0)
+    {
+        std::string label_filename(filename);
+        size_t dot_pos = label_filename.find_last_of('.');
+        if (dot_pos != std::string::npos)
+        {
+            label_filename = label_filename.substr(0, dot_pos);
+        }
+        label_filename += ".txt";
+
+        FILE *label_fp = fopen(label_filename.c_str(), "w");
+        if (!label_fp)
+        {
+            yCWarning(SOUNDFILE_WAV, "cannot open file %s for writing Audacity labels\n", label_filename.c_str());
+        }
+        else
+        {
+            double frequency = sound_data.getFrequency();
+            for (size_t i = 0; i < sound_data.getMarkersCount(); i++)
+            {
+                SoundMarker marker = sound_data.getMarker(i);
+                double time_seconds = static_cast<double>(marker.sample_id) / frequency;
+                // Audacity label format: start_time\tend_time\tlabel
+                // For point labels, start and end time are the same
+                fprintf(label_fp, "%.6f\t%.6f\t%s\n", time_seconds, time_seconds, marker.label.c_str());
+            }
+            fclose(label_fp);
+            yCInfo(SOUNDFILE_WAV, "Audacity label file written: %s\n", label_filename.c_str());
+        }
+    }
+
     return true;
 }

--- a/src/libYARP_sig/src/yarp/sig/SoundUtils.cpp
+++ b/src/libYARP_sig/src/yarp/sig/SoundUtils.cpp
@@ -6,6 +6,7 @@
 #include <yarp/sig/SoundUtils.h>
 #include <cstring>
 #include <cmath>
+#include <algorithm>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 
@@ -15,9 +16,9 @@ using namespace yarp::sig;
 #define M_PI 3.14159265358979323846
 #endif
 
-bool utils::makeTone(Sound& outSound,double duration_s, size_t channels, size_t sampleRate)
+bool prepareSound(Sound& outSound,double duration_s, size_t channels, size_t sampleRate, double frequency, size_t amplitude)
 {
-    if (duration_s <= 0 || channels == 0 || sampleRate == 0)
+    if (duration_s <= 0 || channels == 0 || sampleRate == 0 || frequency == 0 || amplitude == 0)
     {
         yError() << "yarp::sig::utils::makeTone: invalid parameters";
         return false;
@@ -26,22 +27,111 @@ bool utils::makeTone(Sound& outSound,double duration_s, size_t channels, size_t 
     // Sound parameters
     size_t totalSamples = sampleRate * duration_s;
 
-    // Generate sine wave parameters
-    double frequency = 440.0;  // A4 standard tone
-    double amplitude = 30000;  // max ~32767 for 16-bit
-    double twoPiF = 2.0 * M_PI * frequency;
-
     // Create the sound object
     outSound = yarp::sig::Sound();
     outSound.resize(totalSamples, channels);
     outSound.setFrequency(sampleRate);
 
-    // Fill the sound buffer with a sine wave
+    return true;
+}
+
+bool utils::makeSawTooth(Sound& outSound,double duration_s, size_t channels, size_t sampleRate, double frequency, size_t amplitude)
+{
+    if (!prepareSound(outSound, duration_s, channels, sampleRate, frequency, amplitude)) { return false; }
+
+    size_t totalSamples = outSound.getSamples();
+
     for (size_t i = 0; i < totalSamples; i++)
     {
         double t = static_cast<double>(i) / sampleRate;
-        short sample = static_cast<short>(amplitude * sin(twoPiF * t));
-        outSound.set(sample, i, 0);
+        double value = 2.0 * (t * frequency - floor(t * frequency + 0.5));
+        short sample = static_cast<short>(amplitude * value);
+        for (size_t ch = 0; ch < channels; ch++)
+        {
+            outSound.set(sample, i, ch);
+        }
     }
+
     return true;
+}
+
+bool utils::makeSquareWave(Sound& outSound,double duration_s, size_t channels, size_t sampleRate, double frequency, size_t amplitude)
+{
+    if (!prepareSound(outSound, duration_s, channels, sampleRate, frequency, amplitude)) { return false; }
+
+    double twoPiF = 2.0 * M_PI * frequency;
+
+    for (size_t i = 0; i < outSound.getSamples(); i++)
+    {
+        double t = static_cast<double>(i) / sampleRate;
+
+        double s = sin(twoPiF * t);
+        short sample = (s >= 0) ? amplitude : -amplitude;
+
+        for (size_t ch = 0; ch < channels; ch++)
+        {
+            outSound.set(sample, i, ch);
+        }
+    }
+
+    return true;
+}
+
+bool utils::makeTone(Sound& outSound,double duration_s, size_t channels, size_t sampleRate, double frequency, size_t amplitude)
+{
+    if (!prepareSound(outSound, duration_s, channels, sampleRate, frequency, amplitude)) { return false; }
+
+    // Fill the sound buffer with a sine wave
+    double twoPiF = 2.0 * M_PI * frequency;
+    for (size_t i = 0; i < outSound.getSamples(); i++)
+    {
+        double t = static_cast<double>(i) / sampleRate;
+        short sample = static_cast<short>((double)(amplitude) * sin(twoPiF * t));
+        for (size_t ch = 0; ch < channels; ch++)
+        {
+            outSound.set(sample, i, ch);
+        }
+    }
+
+    return true;
+}
+
+Sound utils::mix(const Sound& A, const Sound& B, double percentage)
+{
+    Sound result;
+
+    // Ensure percentage is clamped between 0 and 1
+    if (percentage < 0.0) percentage = 0.0;
+    if (percentage > 1.0) percentage = 1.0;
+
+    // Check for matching sample rates and number of channels
+    if (A.getFrequency() != B.getFrequency() || A.getChannels() != B.getChannels())
+    {
+        yError() << "Cannot mix sounds with different sample rates or channel counts.";
+        return result;
+    }
+
+    // Determine the length of the resulting sound
+    size_t maxSamples = std::max(A.getSamples(), B.getSamples());
+    size_t channels = A.getChannels();
+    double alpha = percentage;
+    double beta = 1.0 - percentage;
+
+    // Create the resulting sound
+    result.resize(maxSamples, channels);
+    result.setFrequency(A.getFrequency());
+
+    // Mix samples
+    for (size_t ch = 0; ch < channels; ++ch)
+    {
+        for (size_t i = 0; i < maxSamples; ++i)
+        {
+            double sampleA = (i < A.getSamples()) ? A.getSafe(i, ch) : 0.0;
+            double sampleB = (i < B.getSamples()) ? B.getSafe(i, ch) : 0.0;
+            yarp::sig::Sound::audio_sample sampleO = static_cast<yarp::sig::Sound::audio_sample>(alpha * sampleA + beta * sampleB);
+            result.setSafe(sampleO, i, ch);
+        }
+    }
+
+    return result;
 }

--- a/src/libYARP_sig/src/yarp/sig/SoundUtils.h
+++ b/src/libYARP_sig/src/yarp/sig/SoundUtils.h
@@ -11,14 +11,64 @@
 namespace yarp::sig::utils {
 
 /**
+ * @brief Generate a sound containing a sawtooth signal.
+ * @param[out] outSound The generated sound.
+ * @param[in] duration_s Duration of the tone in seconds.
+ * @param[in] channels Number of channels for the sound.
+ * @param[in] sampleRate The sample rate of the sound in Hz.
+ * @param[in] frequency The frequency of the generated sawtooth signal in Hz
+ * @param[in] amplitude The amplitude of the generated sawtooth signal (max ~32767 for 16-bit)
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API makeSawTooth(Sound& outSound, double duration_s=1.0, size_t channels=1, size_t sampleRate=16000, double frequency=1, size_t amplitude=30000);
+
+/**
  * @brief Generate a sound containing a sine wave tone.
  * @param[out] outSound The generated sound.
  * @param[in] duration_s Duration of the tone in seconds.
  * @param[in] channels Number of channels for the sound.
  * @param[in] sampleRate The sample rate of the sound in Hz.
+ * @param[in] frequency The frequency of the generated tone in Hz (default = 440Hz A4)
+ * @param[in] amplitude The amplitude of the generated tone (max ~32767 for 16-bit)
  * @return true on success, false otherwise.
  */
-bool YARP_sig_API makeTone(Sound& outSound, double duration_s=1.0, size_t channels=1, size_t sampleRate=16000);
+bool YARP_sig_API makeTone(Sound& outSound, double duration_s=1.0, size_t channels=1, size_t sampleRate=16000, double frequency=440, size_t amplitude=30000);
+
+/**
+ * @brief Generate a sound containing a square wave signal.
+ * @param[out] outSound The generated sound.
+ * @param[in] duration_s Duration of the tone in seconds.
+ * @param[in] channels Number of channels for the sound.
+ * @param[in] sampleRate The sample rate of the sound in Hz.
+ * @param[in] frequency The frequency of the generated square wave signal in Hz (default = 1Hz)
+ * @param[in] amplitude The amplitude of the generated square wave signal (max ~32767 for 16-bit)
+ * @return true on success, false otherwise.
+ */
+bool YARP_sig_API makeSquareWave(Sound& outSound, double duration_s=1.0, size_t channels=1, size_t sampleRate=16000, double frequency=1, size_t amplitude=30000);
+
+/**
+ * @brief Mixes two sounds together into a single sound.
+ *
+ * This function combines the audio of two sounds with the same number of channels and sample rate.
+ * If the sounds have different durations, silence will be added to the shorter one to match the length
+ * of the longer sound before mixing.
+ *
+ * The @c percentage parameter controls the relative loudness of the two sounds in the mix.
+ * For example, if @c percentage is 0.7, the resulting sound will consist of 70% of the first sound (@c A)
+ * and 30% of the second sound (@c B).
+ *
+ * The resulting mixed sound is returned as a new Sound object. The original sounds (@c A and @c B)
+ * are not modified.
+ *
+ * @param A The first sound to mix.
+ * @param B The second sound to mix.
+ * @param percentage The weight of the first sound in the mix (between 0.0 and 1.0).
+ *                   The second sound will have a weight of (1 - percentage).
+ * @return A new Sound object containing the mixed audio.
+ *
+ * @throws std::runtime_error If the sounds have different sample rates or channel counts.
+ */
+Sound YARP_sig_API mix(const Sound& A, const Sound& B, double percentage);
 
 } // namespace yarp::sig::utils
 

--- a/src/libYARP_sig/tests/SoundTest.cpp
+++ b/src/libYARP_sig/tests/SoundTest.cpp
@@ -6,6 +6,7 @@
 
 #include <yarp/sig/Sound.h>
 #include <yarp/sig/SoundFile.h>
+#include <yarp/sig/SoundUtils.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Log.h>
@@ -21,13 +22,13 @@ using namespace yarp::os::impl;
 using namespace yarp::sig;
 using namespace yarp::os;
 
-void generate_test_sound(Sound& snd, size_t samples, size_t size_channels, int base=0)
+void generate_test_sound(Sound& snd, size_t samples, size_t size_channels, int base=0, int factor=1)
 {
     for (size_t ch = 0; ch<snd.getChannels(); ch++)
     {
         for (size_t s = 0; s<snd.getSamples(); s++)
         {
-            snd.set((Sound::audio_sample)(ch * 100 + s + base), s, ch);
+            snd.set((Sound::audio_sample)(ch * 100 + s * factor + base), s, ch);
         }
     }
 }
@@ -87,6 +88,47 @@ TEST_CASE("sig::SoundTest", "[yarp::sig]")
 
         bool b3 = (snd1 == snd2);
         CHECK(b3);
+    }
+
+    SECTION("Test Sound markers")
+    {
+        bool b;
+
+        Sound snd1;
+        snd1.resize(10, 3);
+        generate_test_sound(snd1, 10, 3);
+
+        snd1.add_marker("M1", 1, -1);
+        size_t id1;
+        int ch1;
+        b = snd1.get_marker("M1", id1, ch1);
+        CHECK(b);
+        CHECK(id1==1);
+        CHECK(ch1==-1);
+
+        snd1.add_marker("M2", 5, -1);
+        size_t id2;
+        int ch2;
+        b = snd1.get_marker("M2", id2, ch2);
+        CHECK(b);
+        CHECK(id2==5);
+        CHECK(ch2==-1);
+
+        Sound snd;
+        snd = snd1.subSound("M1", "M2");
+        CHECK (snd.getSamples()==5);
+
+        snd1.remove_marker("M1");
+        b = snd1.get_marker("M1",id1, ch1);
+        CHECK(!b);
+        CHECK(id1==0);
+        CHECK(ch1==-1);
+
+        snd1.remove_all_markers();
+        b = snd1.get_marker("M2",id2, ch2);
+        CHECK(!b);
+        CHECK(id2==0);
+        CHECK(ch2==-1);
     }
 
     SECTION("Test a very long sound")
@@ -441,6 +483,59 @@ TEST_CASE("sig::SoundTest", "[yarp::sig]")
 
         output.close();
         input.close();
+    }
+
+    SECTION("check write file with markers.")
+    {
+        Sound snd1;
+        snd1.resize(30000, 2);
+        snd1.setFrequency(44100);
+        generate_test_sound(snd1, 30000, 2);
+        snd1.add_marker("M1", 1000,  0);
+        snd1.add_marker("M2", 2000,  1);
+        snd1.add_marker("M3", 3000, -1);
+        bool b = yarp::sig::file::write(snd1, "testwav_markers.wav");
+        if (!b)
+        {
+            WARN("Failed to write file, test skipped");
+        }
+    }
+
+    SECTION("Test the mix function")
+    {
+        std::string ss;
+
+        Sound snd1;
+        snd1.resize(10, 2);
+        snd1.setFrequency(44100);
+        generate_test_sound(snd1, 10, 2, 0, 2);
+        ss = snd1.toString();
+
+        Sound snd2;
+        snd2.resize(5, 2);
+        snd2.setFrequency(44100);
+        generate_test_sound(snd2, 5, 2, 0, 4);
+        ss = snd2.toString();
+
+        Sound sndMix = yarp::sig::utils::mix(snd1, snd2, 0.5);
+        CHECK(sndMix.getSamples() == 10);
+        ss = sndMix.toString();
+        CHECK(sndMix.getSafe(0,0) == 0);
+        CHECK(sndMix.getSafe(1,0) == 3);
+        CHECK(sndMix.getSafe(2,0) == 6);
+        CHECK(sndMix.getSafe(3,0) == 9);
+        CHECK(sndMix.getSafe(4,0) == 12);
+        CHECK(sndMix.getSafe(5,0) == 5);
+        CHECK(sndMix.getSafe(6,0) == 6);
+        CHECK(sndMix.getSafe(7,0) == 7);
+        CHECK(sndMix.getSafe(8,0) == 8);
+        CHECK(sndMix.getSafe(9,0) == 9);
+
+
+        Sound stest;
+        yarp::sig::utils::makeSawTooth(stest, 1.0, 2, 44100, 1000);
+        yarp::sig::utils::makeSquareWave(stest, 1.0, 2, 44100, 1000);
+        yarp::sig::utils::makeTone(stest, 1.0, 2, 44100, 1000);
     }
 
     SECTION("check write file.")

--- a/src/portmonitors/sound_marker/README.md
+++ b/src/portmonitors/sound_marker/README.md
@@ -1,7 +1,7 @@
 
 sound_marker_portmonitor plugin
 ======================================================================
-This portmonitor adds a marker (i.e. extra audio samples with a specific pattern) at the end of each processed yarp::sig::Sound
+This portmonitor adds a marker at the beginning and at the end of each processed yarp::sig::Sound
 
 Usage:
 -----

--- a/src/portmonitors/sound_marker/Sound_marker.cpp
+++ b/src/portmonitors/sound_marker/Sound_marker.cpp
@@ -103,26 +103,18 @@ yarp::os::Things & Sound_marker::update(yarp::os::Things &thing)
         return thing;
     }
 
-    size_t ss_size = s->getSamples();
-    size_t ch_size = s->getChannels();
+    // add markers at the edges of the sound
     m_s2 = *s;
-    m_s2.resize(ss_size+5, ch_size);
+    m_s2.remove_all_markers();
+    m_s2.add_marker("SND_MARKER_START" + std::to_string(marker_counter), 0);
+    m_s2.add_marker("SND_MARKER_END"   + std::to_string(marker_counter), s->getSamples()-1);
 
-    for (size_t c = 0; c < ch_size; c++)
-    {
-        for (size_t i = 0; i < ss_size; i++)
-        {
-            m_s2.set(s->get(i,c), i, c);
-        }
-        for (size_t i = ss_size; i < ss_size+5; i++)
-        {
-            m_s2.set(32000,i,c);
-        }
-        m_s2.set(-32000, 0, c);
-    }
+    yDebug() << m_s2.getMarkersCount();
 
     //send data
     m_th.setPortWriter(&m_s2);
+
+    marker_counter++;
     return m_th;
 }
 

--- a/src/portmonitors/sound_marker/Sound_marker.h
+++ b/src/portmonitors/sound_marker/Sound_marker.h
@@ -22,6 +22,7 @@ class Sound_marker : public yarp::os::MonitorObject
 {
     yarp::os::Things m_th;
     yarp::sig::Sound m_s2;
+    size_t marker_counter = 0;
 
 public:
     void getParamsFromCommandLine(std::string carrierString, yarp::os::Property& prop);


### PR DESCRIPTION
-Improvements to yarp::sig::Sound, with markers management directly inside the data type. Added tests.
-Added the possibility to save markers inside .wav files (+.txt additional file)
-Added sawtooth and squarewave generators to yarpAudioPlayer