### PR TITLE
yarprobotinterface `show-device-parameters` option

### DIFF
--- a/doc/release/v4_0_0.MD
+++ b/doc/release/v4_0_0.MD
@@ -36,6 +36,10 @@ Added new PortMonitor `throttleDown` to limit the bandwidth usage over a port co
 
 * improved generator to support services with multiple containers (lists, maps, sets)
 
+### Yarprobotinterface
+
+* added option `show-device-parameters` (default false).
+By default, device parameters are no more displayed by yarprobotinterface in the opening phase.
 
 Deprecations and removals
 ---------------------------

--- a/src/commands/yarprobotinterface/Module.cpp
+++ b/src/commands/yarprobotinterface/Module.cpp
@@ -149,6 +149,7 @@ bool yarprobotinterface::Module::configure(yarp::os::ResourceFinder& rf)
     mPriv->robot.setVerbose(verbosity);
     mPriv->robot.setAllowDeprecatedDevices(rf.check("allow-deprecated-devices"));
     mPriv->robot.setDryRun(dryrun);
+    mPriv->robot.setShowDeviceParameters(rf.check("show-device-parameters"));
 
     std::string portprefix = mPriv->robot.portprefix();
     if (portprefix[0] != '/') {

--- a/src/commands/yarprobotinterface/cmd_yarprobotinterface.dox
+++ b/src/commands/yarprobotinterface/cmd_yarprobotinterface.dox
@@ -36,6 +36,9 @@ The details of the xml format of the files loaded by yarprobotinterface are docu
 - If this option is specified, then xml file is only loaded without actually opening devices.
   This option is useful to validate if xml files are well formed.
 
+`--show-device-parameters`
+- If this option is specified, then yarprobotinterface shows the complete list of parameters used to open every single device.
+
 `--enable_tags (xxx yyy ... zzz)`
 - This options can be used to enable optional devices which have been marked with the in `enabled_by` attribute in the xml file. See \ref yarp_robotinterface_xml_config_files
 

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.cpp
@@ -115,6 +115,7 @@ public:
     yarp::dev::PolyDriverList externalDevices;
     yarp::robotinterface::ActionPhase currentPhase {ActionPhaseUnknown};
     unsigned int currentLevel {0};
+    bool showDeviceParameters {false};
     bool dryrun {false};
     bool reverseShutdownActionOrder {false};
     yarp::dev::PolyDriver m_ddstorage;
@@ -220,8 +221,16 @@ bool yarp::robotinterface::Robot::Private::openDevices()
     m_ddstorage.view(m_istorage);
 
     bool ret = true;
-    for (auto& device : devices) {
-        yCInfo(YRI_ROBOT) << "Opening device" << device.name() << "with parameters" << device.params();
+    for (auto& device : devices)
+    {
+        if (showDeviceParameters)
+        {
+            yCInfo(YRI_ROBOT) << "Opening device" << device.name() << "with parameters" << device.params();
+        }
+        else
+        {
+            yCInfo(YRI_ROBOT) << "Opening device" << device.name() << ". Use option `show-device-parameters` for additional info.";
+        }
 
         if (dryrun) {
             continue;
@@ -582,6 +591,7 @@ yarp::robotinterface::Robot::Robot(const yarp::robotinterface::Robot& other) :
     mPriv->currentPhase = other.mPriv->currentPhase;
     mPriv->currentLevel = other.mPriv->currentLevel;
     mPriv->dryrun = other.mPriv->dryrun;
+    mPriv->showDeviceParameters = other.mPriv->showDeviceParameters;
     mPriv->reverseShutdownActionOrder = other.mPriv->reverseShutdownActionOrder;
     mPriv->devices = other.mPriv->devices;
     mPriv->params = other.mPriv->params;
@@ -596,6 +606,7 @@ yarp::robotinterface::Robot& yarp::robotinterface::Robot::operator=(const yarp::
         mPriv->currentPhase = other.mPriv->currentPhase;
         mPriv->currentLevel = other.mPriv->currentLevel;
         mPriv->dryrun = other.mPriv->dryrun;
+        mPriv->showDeviceParameters = other.mPriv->showDeviceParameters;
         mPriv->reverseShutdownActionOrder = other.mPriv->reverseShutdownActionOrder;
 
         mPriv->devices.clear();
@@ -648,6 +659,11 @@ void yarp::robotinterface::Robot::setAllowDeprecatedDevices(bool allowDeprecated
             device.params().push_back(Param("allow-deprecated-devices", "1"));
         }
     }
+}
+
+void yarp::robotinterface::Robot::setShowDeviceParameters(bool show)
+{
+    mPriv->showDeviceParameters = show;
 }
 
 void yarp::robotinterface::Robot::setDryRun(bool dryrun)

--- a/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
+++ b/src/libYARP_robotinterface/src/yarp/robotinterface/Robot.h
@@ -29,6 +29,7 @@ public:
     void setVerbose(bool verbose);
     void setAllowDeprecatedDevices(bool allowDeprecatedDevices);
     void setDryRun(bool dryrun);
+    void setShowDeviceParameters(bool show);
     void setReverseShutdownActionOrder(bool reverseShutdownActionOrder);
 
     ParamList& params();


### PR DESCRIPTION
added option `show-device-parameters` (default false).
By default, device parameters are no more displayed by yarprobotinterface in the opening phase.
@valegagge 