### PR TITLE
Quick status refresh for yarprun and yarpmanager console 

### DIFF
--- a/src/commands/yarpmanager-console/ymanager.cpp
+++ b/src/commands/yarpmanager-console/ymanager.cpp
@@ -1119,41 +1119,9 @@ void YConsoleManager::checkStates()
     ExecutablePIterator moditr;
     unsigned int id = 0;
     bShouldRun = false;
-    std::cout << INFO << "[checkStates] start: modules=" << modules.size() << ENDC << '\n';
-
-    // Collect all remote yarprun servers used by this application.
-    std::set<std::string> yarprunHosts;
-    for (auto* exe : modules) {
-        if (exe && exe->getBrokerType() == BrokerType::yarp) {
-            yarprunHosts.insert(exe->getHost());
-        }
-    }
-    std::cout << INFO << "[checkStates] yarprun hosts found: " << yarprunHosts.size() << ENDC << '\n';
-
-    // Query each yarprun server once via `ps`.
     std::map<std::string, ProcessContainer> hostProcesses;
     std::map<std::string, bool> hostQueryOk;
-    if (!yarprunHosts.empty()) {
-        YarpBroker connector;
-        if (connector.init()) {
-            for (const auto& host : yarprunHosts) {
-                ProcessContainer processes;
-                const bool ok = connector.getAllProcesses(host, processes);
-                hostQueryOk[host] = ok;
-                if (ok) {
-                    hostProcesses[host] = processes;
-                    std::cout << INFO << "[checkStates] ps(" << host << ") ok, processes=" << processes.size() << ENDC << '\n';
-                } else {
-                    std::cout << WARNING << "[checkStates] ps(" << host << ") failed, fallback to running(id) for modules on this host." << ENDC << '\n';
-                }
-            }
-        } else {
-            for (const auto& host : yarprunHosts) {
-                hostQueryOk[host] = false;
-            }
-            std::cout << WARNING << "[checkStates] cannot initialize YarpBroker connector, fallback to running(id) for all yarprun modules." << ENDC << '\n';
-        }
-    }
+    collectYarprunProcessesByHost(hostProcesses, hostQueryOk);
 
     for(moditr=modules.begin(); moditr<modules.end(); moditr++)
     {
@@ -1163,7 +1131,6 @@ void YConsoleManager::checkStates()
             const std::string host = exe->getHost();
             const auto hostOkIt = hostQueryOk.find(host);
             if (hostOkIt != hostQueryOk.end() && hostOkIt->second) {
-                std::cout << INFO << "[checkStates] module(" << id << ") using NEW ps-based check on host " << host << ENDC << '\n';
                 const auto procIt = hostProcesses.find(host);
                 if (procIt != hostProcesses.end()) {
                     const std::string exeCmd = exe->getCommand();
@@ -1180,12 +1147,10 @@ void YConsoleManager::checkStates()
                 }
             } else {
                 // Fallback to the old per-module check if the remote ps query failed.
-                std::cout << WARNING << "[checkStates] module(" << id << ") using FALLBACK running(id) because ps is unavailable on host " << host << ENDC << '\n';
                 isRunning = running(id);
             }
         } else {
             // Local and other brokers: keep previous behavior.
-            std::cout << INFO << "[checkStates] module(" << id << ") non-yarprun broker, using default running(id)." << ENDC << '\n';
             isRunning = running(id);
         }
 

--- a/src/commands/yarpmanager-console/ymanager.cpp
+++ b/src/commands/yarpmanager-console/ymanager.cpp
@@ -7,6 +7,7 @@
 
 #include <yarp/manager/xmlapploader.h>
 #include <yarp/manager/application.h>
+#include <yarp/manager/yarpbroker.h>
 #include <dirent.h>
 #include <yarp/conf/filesystem.h>
 #include <yarp/os/ResourceFinder.h>
@@ -19,6 +20,8 @@
 
 #include <cstring>
 #include <csignal>
+#include <map>
+#include <set>
 
 using namespace yarp::os;
 using namespace yarp::manager;
@@ -1116,9 +1119,77 @@ void YConsoleManager::checkStates()
     ExecutablePIterator moditr;
     unsigned int id = 0;
     bShouldRun = false;
+    std::cout << INFO << "[checkStates] start: modules=" << modules.size() << ENDC << '\n';
+
+    // Collect all remote yarprun servers used by this application.
+    std::set<std::string> yarprunHosts;
+    for (auto* exe : modules) {
+        if (exe && exe->getBrokerType() == BrokerType::yarp) {
+            yarprunHosts.insert(exe->getHost());
+        }
+    }
+    std::cout << INFO << "[checkStates] yarprun hosts found: " << yarprunHosts.size() << ENDC << '\n';
+
+    // Query each yarprun server once via `ps`.
+    std::map<std::string, ProcessContainer> hostProcesses;
+    std::map<std::string, bool> hostQueryOk;
+    if (!yarprunHosts.empty()) {
+        YarpBroker connector;
+        if (connector.init()) {
+            for (const auto& host : yarprunHosts) {
+                ProcessContainer processes;
+                const bool ok = connector.getAllProcesses(host, processes);
+                hostQueryOk[host] = ok;
+                if (ok) {
+                    hostProcesses[host] = processes;
+                    std::cout << INFO << "[checkStates] ps(" << host << ") ok, processes=" << processes.size() << ENDC << '\n';
+                } else {
+                    std::cout << WARNING << "[checkStates] ps(" << host << ") failed, fallback to running(id) for modules on this host." << ENDC << '\n';
+                }
+            }
+        } else {
+            for (const auto& host : yarprunHosts) {
+                hostQueryOk[host] = false;
+            }
+            std::cout << WARNING << "[checkStates] cannot initialize YarpBroker connector, fallback to running(id) for all yarprun modules." << ENDC << '\n';
+        }
+    }
+
     for(moditr=modules.begin(); moditr<modules.end(); moditr++)
     {
-        if(running(id))
+        bool isRunning = false;
+        Executable* exe = *moditr;
+        if (exe && exe->getBrokerType() == BrokerType::yarp) {
+            const std::string host = exe->getHost();
+            const auto hostOkIt = hostQueryOk.find(host);
+            if (hostOkIt != hostQueryOk.end() && hostOkIt->second) {
+                std::cout << INFO << "[checkStates] module(" << id << ") using NEW ps-based check on host " << host << ENDC << '\n';
+                const auto procIt = hostProcesses.find(host);
+                if (procIt != hostProcesses.end()) {
+                    const std::string exeCmd = exe->getCommand();
+                    const std::string exeParam = exe->getParam();
+                    for (const auto& proc : procIt->second) {
+                        const bool statusRunning = proc.status.empty() || proc.status == "running";
+                        const bool cmdMatches = proc.command.find(exeCmd) != std::string::npos;
+                        const bool paramMatches = exeParam.empty() || (proc.command.find(exeParam) != std::string::npos);
+                        if (statusRunning && cmdMatches && paramMatches) {
+                            isRunning = true;
+                            break;
+                        }
+                    }
+                }
+            } else {
+                // Fallback to the old per-module check if the remote ps query failed.
+                std::cout << WARNING << "[checkStates] module(" << id << ") using FALLBACK running(id) because ps is unavailable on host " << host << ENDC << '\n';
+                isRunning = running(id);
+            }
+        } else {
+            // Local and other brokers: keep previous behavior.
+            std::cout << INFO << "[checkStates] module(" << id << ") non-yarprun broker, using default running(id)." << ENDC << '\n';
+            isRunning = running(id);
+        }
+
+        if(isRunning)
         {
             bShouldRun = true;
             std::cout<<OKGREEN<<"<RUNNING> ";

--- a/src/libYARP_manager/src/yarp/manager/manager.cpp
+++ b/src/libYARP_manager/src/yarp/manager/manager.cpp
@@ -15,6 +15,7 @@
 #include <yarp/manager/xmlappsaver.h>
 #include <yarp/manager/singleapploader.h>
 #include <yarp/os/LogStream.h>
+#include <set>
 
 #include <yarp/os/impl/NameClient.h>
 
@@ -1277,6 +1278,41 @@ bool Manager::running(unsigned int id)
         return true;
     }
     return false;
+}
+
+void Manager::collectYarprunProcessesByHost(std::map<std::string, ProcessContainer>& hostProcesses,
+                                            std::map<std::string, bool>& hostQueryOk)
+{
+    hostProcesses.clear();
+    hostQueryOk.clear();
+
+    std::set<std::string> yarprunHosts;
+    for (auto* exe : runnables) {
+        if (exe && exe->getBrokerType() == BrokerType::yarp) {
+            yarprunHosts.insert(exe->getHost());
+        }
+    }
+
+    if (yarprunHosts.empty()) {
+        return;
+    }
+
+    YarpBroker queryBroker;
+    if (!queryBroker.init()) {
+        for (const auto& host : yarprunHosts) {
+            hostQueryOk[host] = false;
+        }
+        return;
+    }
+
+    for (const auto& host : yarprunHosts) {
+        ProcessContainer processes;
+        const bool ok = queryBroker.getAllProcesses(host, processes);
+        hostQueryOk[host] = ok;
+        if (ok) {
+            hostProcesses[host] = processes;
+        }
+    }
 }
 
 

--- a/src/libYARP_manager/src/yarp/manager/manager.h
+++ b/src/libYARP_manager/src/yarp/manager/manager.h
@@ -11,6 +11,7 @@
 #include <yarp/manager/utility.h>
 #include <yarp/manager/executable.h>
 #include <yarp/manager/yarpbroker.h>
+#include <map>
 
 namespace yarp::manager {
 
@@ -76,6 +77,8 @@ public:
     bool waitingModuleStop(unsigned int id);
     bool waitingModuleKill(unsigned int id);
     bool loadBalance();
+    void collectYarprunProcessesByHost(std::map<std::string, ProcessContainer>& hostProcesses,
+                                       std::map<std::string, bool>& hostQueryOk);
 
     void setDefaultBroker(const char* szBroker) { if(szBroker) { strDefBroker = szBroker; } }
     const char* defaultBroker() { return strDefBroker.c_str(); }

--- a/src/libYARP_manager/src/yarp/manager/primresource.h
+++ b/src/libYARP_manager/src/yarp/manager/primresource.h
@@ -161,7 +161,10 @@ private:
  * Class Computer
  */
 typedef struct _Process {
+    std::string tag;
+    std::string status;
     std::string command;
+    std::string env;
     int pid;
 } Process;
 

--- a/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
+++ b/src/libYARP_manager/src/yarp/manager/yarpbroker.cpp
@@ -695,23 +695,32 @@ bool YarpBroker::getAllProcesses(const std::string& server,
     grp.addString("ps");
     msg.addList()=grp;
 
-    int ret = SendMsg(msg, server, response, 3.0);
+    std::string targetServer = server;
+    if (targetServer[0] != '/') {
+        targetServer = std::string("/") + targetServer;
+    }
+
+    int ret = SendMsg(msg, targetServer, response, 3.0);
     if((ret == YARPRUN_OK) || (ret == YARPRUN_NORESPONSE))
     {
         for(size_t i=0; i<response.size(); i++)
         {
             Process proc;
-            std::string sprc;
             if (response.get(i).check("pid")) {
                 proc.pid = response.get(i).find("pid").asInt32();
             }
+            if (response.get(i).check("tag")) {
+                proc.tag = response.get(i).find("tag").asString();
+            }
+            if (response.get(i).check("status")) {
+                proc.status = response.get(i).find("status").asString();
+            }
             if (response.get(i).check("cmd")) {
-                sprc = response.get(i).find("cmd").asString();
+                proc.command = response.get(i).find("cmd").asString();
             }
-            if (response.get(i).check("env") && response.get(i).find("env").asString().length()) {
-                sprc.append("; ").append(response.get(i).find("env").asString());
+            if (response.get(i).check("env")) {
+                proc.env = response.get(i).find("env").asString();
             }
-            proc.command = sprc;
             processes.push_back(proc);
         }
         return true;

--- a/src/libYARP_run/src/CMakeLists.txt
+++ b/src/libYARP_run/src/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 
 set(YARP_run_SRCS
   yarp/run/Run.cpp
+  yarp/run/RunClient.cpp
+  yarp/run/RunServer.cpp
 )
 
 set(YARP_run_IMPL_SRCS

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -56,9 +56,6 @@ inline std::string lastError2String()
 }
 #else
 //#define SIGSTDIO SIGHUP
-#define READ_FROM_PIPE 0
-#define WRITE_TO_PIPE  1
-#define REDIRECT_TO(from, to) yarp::run::impl::dup2(to, from)
 YarpRunInfoVector* yarp::run::Run::mProcessVector = nullptr;
 YarpRunInfoVector* yarp::run::Run::mStdioVector = nullptr;
 ZombieHunterThread* yarp::run::Run::mBraveZombieHunter = nullptr;
@@ -74,8 +71,6 @@ int yarp::run::Run::mProcCNT=0;
 bool yarp::run::Run::mStresstest=false;
 bool yarp::run::Run::mLogged=false;
 std::string yarp::run::Run::mLoggerPort("/yarplogger");
-
-namespace fs = yarp::conf::filesystem;
 
 ////////////////////////////////////
 
@@ -94,44 +89,6 @@ void sigstdio_handler(int sig)
 }
 
 ////////////////////////////////////
-
-constexpr fs::value_type slash = fs::preferred_separator;
-constexpr auto sep = yarp::conf::environment::path_separator;
-////// adapted from libYARP_OS: ResourceFinder.cpp
-static yarp::os::Bottle parsePaths(const std::string& txt)
-{
-    yarp::os::Bottle result;
-    const char *at = txt.c_str();
-    int slash_tweak = 0;
-    int len = 0;
-    for (char ch : txt) {
-        if (ch==sep) {
-            result.addString(std::string(at, len-slash_tweak));
-            at += len+1;
-            len = 0;
-            slash_tweak = 0;
-            continue;
-        }
-        slash_tweak = (ch==slash && len>0)?1:0;
-        len++;
-    }
-    if (len>0) {
-        result.addString(std::string(at, len-slash_tweak));
-    }
-    return result;
-}
-
-static bool fileExists(const char *fname)
-{
-    FILE *fp = nullptr;
-    fp = fopen(fname, "r");
-    if (!fp) {
-        return false;
-    } else {
-        fclose(fp);
-        return true;
-    }
-}
 
 static std::string getProcLabel(const yarp::os::Bottle& msg)
 {
@@ -427,16 +384,33 @@ yarp::os::Bottle yarp::run::Run::sendMsg(yarp::os::Bottle& msg, std::string targ
     {
         yarp::os::RpcClient port;
 
+#if 0
         if (!port.open("..."))
+#else
+
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dist(0, 99999);
+        int number = dist(gen);
+        std::ostringstream oss;
+        oss << std::setw(5) << std::setfill('0') << number;
+        std::string tempy = "/yarprunclient/temp" + oss.str();
+        if (!port.open(tempy))
+#endif
         {
             yarp::os::SystemClock::delaySystem(DELAY);
+            fprintf(stderr, "retrying...");
             continue;
         }
 
-        if (!yarp::os::Network::connect(port.getName(), target))
+        std::string tempportname = port.getName();
+        bool bb = yarp::os::Network::isConnected(tempportname, target);
+
+        if (!yarp::os::Network::connect(tempportname, target, "fast_tcp", false))
         {
             port.close();
             yarp::os::SystemClock::delaySystem(DELAY);
+            fprintf(stderr, "retrying...");
             continue;
         }
 
@@ -445,11 +419,11 @@ yarp::os::Bottle yarp::run::Run::sendMsg(yarp::os::Bottle& msg, std::string targ
         {
             port.close();
             yarp::os::SystemClock::delaySystem(DELAY);
+            fprintf(stderr, "retrying...");
             continue;
         }
         RUNLOG(">>>port.write(msg, response)")
 
-        yarp::os::Network::disconnect(port.getName(), target);
         port.close();
 
         fprintf(stderr, "RESPONSE:\n=========\n");
@@ -471,370 +445,14 @@ yarp::os::Bottle yarp::run::Run::sendMsg(yarp::os::Bottle& msg, std::string targ
     return response;
 }
 
-void sigint_handler(int sig)
-{
-    YARP_UNUSED(sig);
-    yarp::run::Run::mStresstest=false;
-
-    if (yarp::run::Run::pServerPort)
-    {
-        yarp::os::RpcServer *pClose=yarp::run::Run::pServerPort;
-        yarp::run::Run::pServerPort = nullptr;
-        pClose->close();
-    }
-    //else
-    //{
-    //}
-}
 
 ///////////////////////////
 // WINDOWS SERVER
 #if defined(_WIN32)
-int yarp::run::Run::server()
-{
-    yarp::os::Semaphore serializer(1);
-
-    yarp::os::RpcServer port;
-
-    if (!port.open(mPortName.c_str()))
-    {
-        yError() << "Yarprun failed to open port: " << mPortName.c_str();
-        return YARPRUN_ERROR;
-    }
-
-    yarp::os::Bottle cmd, reply;
-    cmd.addString("set");
-    cmd.addString(port.getName());
-    cmd.addString("yarprun");
-    cmd.addString("true");
-    yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
-
-    yInfo() << "Yarprun successfully started on port: " << mPortName.c_str();
-
-    pServerPort=&port;
-
-    yarp::os::impl::signal(SIGINT, sigint_handler);
-    yarp::os::impl::signal(SIGTERM, sigint_handler);
-
-    // Enabling cpu load collector on windows
-    //yarp::os::impl::SystemInfo::enableCpuLoadCollector();
-
-    while (pServerPort)
-    {
-        yarp::os::Bottle msg;
-
-        RUNLOG("<<<port.read(msg, true)")
-        if (!port.read(msg, true)) break;
-        RUNLOG(">>>port.read(msg, true)")
-
-        if (!pServerPort) break;
-
-        //printf("<<< %s >>>\n", msg.toString().c_str());
-        //fflush(stdout);
-
-///////////////////////////////////////////////////
-
-        // command with stdio management
-        if (msg.check("stdio"))
-        {
-            std::string strOnPort=msg.find("on").asString();
-            std::string strStdioPort=msg.find("stdio").asString();
-
-            if (strOnPort==mPortName)
-            {
-                std::string strUUID=mPortName+"/"+int2String(getpid())+"/"+msg.find("as").asString()+"-"+int2String(mProcCNT++);
-                yarp::os::Bottle botUUID;
-                botUUID.addString("stdiouuid");
-                botUUID.addString(strUUID.c_str());
-                msg.addList()=botUUID;
-
-                if (mLogged || msg.check("log"))
-                {
-                    std::string strAlias=msg.find("as").asString();
-                    std::string portName="/log";
-                    portName+=mPortName+"/";
-                    std::string command = msg.findGroup("cmd").get(1).asString();
-                    command = command.substr(0, command.find(' '));
-                    command = command.substr(command.find_last_of("\\/") + 1);
-                    portName+=command;
-
-                    yarp::os::Bottle botFwd;
-                    botFwd.addString("forward");
-                    botFwd.addString(portName.c_str());
-                    if (msg.check("log"))
-                    {
-                        yarp::os::Bottle botLogger=msg.findGroup("log");
-
-                        if (botLogger.size()>1)
-                        {
-                            botFwd.addString(botLogger.get(1).asString());
-                        }
-                        else
-                        {
-                            botFwd.addString(mLoggerPort);
-                        }
-                    }
-                    else
-                    {
-                        botFwd.addString(mLoggerPort);
-                    }
-                    msg.addList()=botFwd;
-                }
-
-                yarp::os::Bottle cmdResult;
-                if (executeCmdAndStdio(msg, cmdResult)>0)
-                {
-                    if (strStdioPort==mPortName)
-                    {
-                        yarp::os::Bottle stdioResult;
-                        userStdio(msg, stdioResult);
-                        cmdResult.append(stdioResult);
-                    }
-                    else
-                    {
-                        cmdResult.append(sendMsg(msg, strStdioPort));
-                    }
-                }
-
-                port.reply(cmdResult);
-            }
-            else
-            {
-                yarp::os::Bottle stdioResult;
-                userStdio(msg, stdioResult);
-                port.reply(stdioResult);
-            }
-
-            continue;
-        }
-
-        // without stdio
-        if (msg.check("cmd"))
-        {
-            yarp::os::Bottle cmdResult;
-
-            if (msg.check("log"))
-            {
-                yarp::os::Bottle botLogger=msg.findGroup("log");
-
-                if (botLogger.size()>1)
-                {
-                    std::string loggerName=botLogger.get(1).asString();
-                    executeCmdStdout(msg, cmdResult, loggerName);
-                }
-                else
-                {
-                    executeCmdStdout(msg, cmdResult, mLoggerPort);
-                }
-            }
-            else if (mLogged)
-            {
-                executeCmdStdout(msg, cmdResult, mLoggerPort);
-            }
-            else
-            {
-                executeCmd(msg, cmdResult);
-            }
-            port.reply(cmdResult);
-            continue;
-        }
-
-        if (msg.check("kill"))
-        {
-            std::string alias(msg.findGroup("kill").get(1).asString());
-            int sig=msg.findGroup("kill").get(2).asInt32();
-            yarp::os::Bottle result;
-            result.addString(mProcessVector.Signal(alias, sig)?"kill OK":"kill FAILED");
-            port.reply(result);
-            continue;
-        }
-
-        if (msg.check("sigterm"))
-        {
-            std::string alias(msg.find("sigterm").asString());
-            yarp::os::Bottle result;
-            result.addString(mProcessVector.Signal(alias, SIGTERM)?"sigterm OK":"sigterm FAILED");
-            port.reply(result);
-            continue;
-        }
-
-        if (msg.check("sigtermall"))
-        {
-            mProcessVector.Killall(SIGTERM);
-            yarp::os::Bottle result;
-            result.addString("sigtermall OK");
-            port.reply(result);
-            continue;
-        }
-
-        if (msg.check("ps"))
-        {
-            yarp::os::Bottle result;
-            result.append(mProcessVector.PS());
-            port.reply(result);
-            continue;
-        }
-
-        if (msg.check("isrunning"))
-        {
-            std::string alias(msg.find("isrunning").asString());
-            yarp::os::Bottle result;
-            result.addString(mProcessVector.IsRunning(alias)?"running":"not running");
-            port.reply(result);
-            continue;
-        }
-
-        if (msg.check("killstdio"))
-        {
-            std::string alias(msg.find("killstdio").asString());
-            mStdioVector.Signal(alias, SIGTERM);
-            yarp::os::Bottle result;
-            result.addString("killstdio OK");
-            port.reply(result);
-            continue;
-        }
-
-////////////////////////////////////////////////////////////////////
-
-        if (msg.check("sysinfo"))
-        {
-            yarp::os::SystemInfoSerializer sysinfo;
-            port.reply(sysinfo);
-            continue;
-        }
-
-        if (msg.check("which"))
-        {
-            std::string fileName=msg.find("which").asString();
-            if (fileName!="")
-            {
-                yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::get_string("PATH"));
-                for (int i=0; i<possiblePaths.size(); ++i)
-                {
-                    std::string guessString=possiblePaths.get(i).asString() +
-                    std::string{slash} + fileName;
-                    const char* guess=guessString.c_str();
-                    if (fileExists (guess))
-                    {
-                        fileName= "\"" + std::string(guess) + "\"";
-                        break;
-                    }
-                }
-            }
-            yarp::os::Value fileNameWriter(fileName);
-            port.reply(fileNameWriter);
-            continue;
-        }
-
-        if (msg.check("exit"))
-        {
-            pServerPort=0;
-            yarp::os::Bottle result;
-            result.addString("exit OK");
-            port.reply(result);
-            port.close();
-        }
-    }
-
-
-    Run::mStdioVector.Killall(SIGTERM);
-
-    Run::mProcessVector.Killall(SIGTERM);
-
-    return 0;
-}
 
 ///////////////////////
 #else // LINUX SERVER
 ///////////////////////
-
-void yarp::run::Run::cleanBeforeExec()
-{
-    // zombie hunter stop
-
-    //yarp::os::impl::signal(SIGPIPE, SIG_IGN);
-    //yarp::os::impl::signal(SIGCHLD, SIG_DFL);
-    //yarp::os::impl::signal(SIGINT, SIG_DFL);
-    //yarp::os::impl::signal(SIGTERM, SIG_DFL);
-
-    if (mProcessVector)
-    {
-        YarpRunInfoVector *p=mProcessVector;
-        mProcessVector = nullptr;
-        delete p;
-    }
-    if (mStdioVector)
-    {
-        YarpRunInfoVector *p=mStdioVector;
-        mStdioVector = nullptr;
-        delete p;
-    }
-    if (mBraveZombieHunter)
-    {
-        ZombieHunterThread *p=mBraveZombieHunter;
-        mBraveZombieHunter = nullptr;
-        p->stop();
-        delete p;
-    }
-
-    //yarp::os::Network::fini();
-}
-
-void yarp::run::Run::writeToPipe(int fd, std::string str)
-{
-    int len = str.length() + 1;
-    int ret;
-    ret = write(fd, &len, sizeof(len));
-    if (ret != sizeof(len)) {
-        fprintf(stderr, "Warning: could not write string length to pipe.\n");
-    }
-    ret = write(fd, str.c_str(), len);
-    if (ret != len) {
-        fprintf(stderr, "Warning: could not write string to pipe.\n");
-    }
-}
-
-int yarp::run::Run::readFromPipe(int fd, char* &data, int& buffsize)
-{
-    int len=0;
-    char* buff=(char*)&len;
-
-    for (int c=4, r=0; c>0; c-=r)
-    {
-        r=read(fd, buff, c);
-
-        if (r < 1) {
-            return -1;
-        }
-
-        buff+=r;
-    }
-
-    if (len <= 0) {
-        return 0;
-    }
-
-    if (len>buffsize)
-    {
-        delete [] data;
-        data=new char[buffsize=1024+(len/1024)*1024];
-    }
-
-    buff=data;
-
-    for (int c=len, r=0; c>0; c-=r)
-    {
-        r=read(fd, buff, c);
-
-        if (r < 1) {
-            return -1;
-        }
-
-        buff+=r;
-    }
-
-    return len;
-}
 
 static void sigchld_handler(int sig)
 {
@@ -845,839 +463,8 @@ static void sigchld_handler(int sig)
     }
 }
 
-int yarp::run::Run::server()
-{
-    int pipe_server2manager[2];
-    int pipe_manager2server[2];
-
-    if (yarp::run::impl::pipe(pipe_server2manager))
-    {
-        fprintf(stderr, "Can't open pipe because %s\n", strerror(errno));
-        fflush(stderr);
-
-        return YARPRUN_ERROR;
-    }
-
-    if (yarp::run::impl::pipe(pipe_manager2server))
-    {
-        fprintf(stderr, "Can't open pipe because %s\n", strerror(errno));
-        fflush(stderr);
-
-        return YARPRUN_ERROR;
-    }
-
-    int pid_process_manager=yarp::run::impl::fork();
-
-    if (IS_INVALID(pid_process_manager))
-    {
-        int error=errno;
-
-        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
-        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
-        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
-        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
-
-        fprintf(stderr, "Can't fork process manager because %s\n", strerror(error));
-        fflush(stderr);
-
-        return YARPRUN_ERROR;
-    }
-
-    if (IS_PARENT_OF(pid_process_manager))
-    {
-        yarp::os::impl::signal(SIGPIPE, SIG_IGN);
-
-        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
-        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
-
-        yarp::os::RpcServer port;
-
-        if (!port.open(mPortName))
-        {
-            yError() << "Yarprun failed to open port: " << mPortName.c_str();
-
-            if (mPortName[0] != '/') {
-                yError("Invalid port name '%s', it should start with '/'\n", mPortName.c_str());
-            }
-            return YARPRUN_ERROR;
-        }
-        yarp::os::Bottle cmd, reply;
-        cmd.addString("set");
-        cmd.addString(port.getName());
-        cmd.addString("yarprun");
-        cmd.addString("true");
-
-        yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
-
-        yInfo() << "Yarprun successfully started on port: " << mPortName.c_str();
-
-        pServerPort=&port;
-
-        yarp::os::impl::signal(SIGINT, sigint_handler);
-        yarp::os::impl::signal(SIGTERM, sigint_handler);
-
-        int rsp_size=1024;
-        char *rsp_str=new char[rsp_size];
-
-        yarp::os::Bottle msg, response;
-
-        while (pServerPort)
-        {
-            RUNLOG("<<<port.read(msg, true)")
-            if (!port.read(msg, true)) {
-                break;
-            }
-            RUNLOG(">>>port.read(msg, true)")
-
-            if (!pServerPort) {
-                break;
-            }
-
-            if (msg.check("sysinfo"))
-            {
-                yarp::os::SystemInfoSerializer sysinfo;
-                port.reply(sysinfo);
-                continue;
-            }
-
-            if (msg.check("which"))
-            {
-                std::string fileName=msg.find("which").asString();
-                if (fileName!="")
-                {
-                    yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::get_string("PATH"));
-                    for (size_t i=0; i<possiblePaths.size(); ++i)
-                    {
-                        std::string guessString=possiblePaths.get(i).asString() + slash + fileName;
-                        const char* guess=guessString.c_str();
-                        if (fileExists (guess))
-                        {
-                            fileName = guess;
-                            break;
-                        }
-                    }
-                }
-                yarp::os::Value fileNameWriter(fileName);
-                port.reply(fileNameWriter);
-                continue;
-            }
-
-            if (msg.check("exit"))
-            {
-                pServerPort = nullptr;
-                yarp::os::Bottle result;
-                result.addString("exit OK");
-                port.reply(result);
-                port.close();
-                break;
-            }
-
-            RUNLOG("<<<writeToPipe")
-            writeToPipe(pipe_server2manager[WRITE_TO_PIPE], msg.toString());
-            RUNLOG(">>>writeToPipe")
-
-            RUNLOG("<<<readFromPipe")
-            int nread=readFromPipe(pipe_manager2server[READ_FROM_PIPE], rsp_str, rsp_size);
-            RUNLOG(">>>readFromPipe")
-
-            if (nread<0)
-            {
-                fprintf(stderr, "ERROR: broken pipe between server and manager\n");
-                fflush(stderr);
-                break;
-            }
-
-            if (nread)
-            {
-                response.fromString(rsp_str);
-                port.reply(response);
-            }
-        }
-
-        //yarp::os::Network::fini();
-
-        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
-        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
-
-        delete [] rsp_str;
-
-        return 0;
-    }
-
-    if (IS_NEW_PROCESS(pid_process_manager))
-    {
-        yarp::os::impl::signal(SIGPIPE, SIG_IGN);
-
-        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
-        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
-
-        //yarp::os::Network::init();
-
-        mProcessVector=new YarpRunInfoVector;
-        mStdioVector=new YarpRunInfoVector;
-
-        mBraveZombieHunter=new ZombieHunterThread;
-        mBraveZombieHunter->start();
-
-        yarp::os::impl::signal(SIGCHLD, sigchld_handler);
-        //yarp::os::impl::signal(SIGINT, SIG_IGN);
-        //yarp::os::impl::signal(SIGTERM, SIG_IGN);
-
-        int msg_size=1024;
-        char *msg_str=new char[msg_size];
-
-        yarp::os::Bottle msg;
-
-        //while(readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size)>0)
-        while (true)
-        {
-            RUNLOG("<<<readFromPipe")
-            if (readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size) <= 0) {
-                break;
-            }
-            RUNLOG(">>>readFromPipe")
-
-            //printf("<<< %s >>>\n", msg_str);
-            //fflush(stdout);
-
-            msg.fromString(msg_str);
-
-            // command with stdio management
-            if (msg.check("stdio"))
-            {
-                std::string strOnPort=msg.find("on").asString();
-                std::string strStdioPort=msg.find("stdio").asString();
-
-                if (strOnPort==mPortName)
-                {
-                    std::string strUUID=mPortName+"/"+int2String(getpid())+"/"+msg.find("as").asString()+"-"+int2String(mProcCNT++);
-                    yarp::os::Bottle botUUID;
-                    botUUID.addString("stdiouuid");
-                    botUUID.addString(strUUID.c_str());
-                    msg.addList()=botUUID;
-
-                    if (mLogged || msg.check("log"))
-                    {
-                        std::string strAlias=msg.find("as").asString();
-                        std::string portName="/log";
-                        portName+=mPortName+"/";
-                        std::string command = msg.findGroup("cmd").get(1).asString();
-                        command = command.substr(0, command.find(' '));
-                        command = command.substr(command.find_last_of("\\/") + 1);
-                        portName+=command;
-
-                        yarp::os::Bottle botFwd;
-                        botFwd.addString("forward");
-                        botFwd.addString(portName.c_str());
-                        if (msg.check("log"))
-                        {
-                            yarp::os::Bottle botLogger=msg.findGroup("log");
-
-                            if (botLogger.size()>1)
-                            {
-                                botFwd.addString(botLogger.get(1).asString());
-                            }
-                            else
-                            {
-                                botFwd.addString(mLoggerPort);
-                            }
-                        }
-                        else
-                        {
-                            botFwd.addString(mLoggerPort);
-                        }
-                        msg.addList()=botFwd;
-
-                        yarp::os::ContactStyle style;
-                        style.persistent=true;
-                        yarp::os::Network::connect(portName, mLoggerPort, style);
-                    }
-
-                    yarp::os::Bottle cmdResult;
-                    if (executeCmdAndStdio(msg, cmdResult)>0)
-                    {
-                        if (strStdioPort==mPortName)
-                        {
-                            yarp::os::Bottle stdioResult;
-                            userStdio(msg, stdioResult);
-                            cmdResult.append(stdioResult);
-                        }
-                        else
-                        {
-                            cmdResult.append(sendMsg(msg, strStdioPort));
-                        }
-                    }
-
-                    RUNLOG("<<<writeToPipe")
-                    writeToPipe(pipe_manager2server[WRITE_TO_PIPE], cmdResult.toString());
-                    RUNLOG(">>>writeToPipe")
-                }
-                else
-                {
-                    yarp::os::Bottle stdioResult;
-                    userStdio(msg, stdioResult);
-                    RUNLOG("<<<writeToPipe")
-                    writeToPipe(pipe_manager2server[WRITE_TO_PIPE], stdioResult.toString());
-                    RUNLOG(">>>writeToPipe")
-                }
-
-                continue;
-            }
-
-            // without stdio
-            if (msg.check("cmd"))
-            {
-                yarp::os::Bottle cmdResult;
-
-                if (msg.check("log"))
-                {
-                    yarp::os::Bottle botLogger=msg.findGroup("log");
-
-                    if (botLogger.size()>1)
-                    {
-                        std::string loggerName=botLogger.get(1).asString();
-                        executeCmdStdout(msg, cmdResult, loggerName);
-                    }
-                    else
-                    {
-                       executeCmdStdout(msg, cmdResult, mLoggerPort);
-                    }
-                }
-                else if (mLogged)
-                {
-                    executeCmdStdout(msg, cmdResult, mLoggerPort);
-                }
-                else
-                {
-                    executeCmd(msg, cmdResult);
-                }
-
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], cmdResult.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("kill"))
-            {
-                std::string alias(msg.findGroup("kill").get(1).asString());
-                int sig=msg.findGroup("kill").get(2).asInt32();
-                yarp::os::Bottle result;
-                result.addString(mProcessVector->Signal(alias, sig)?"kill OK":"kill FAILED");
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("sigterm"))
-            {
-                std::string alias(msg.find("sigterm").asString());
-                yarp::os::Bottle result;
-                result.addString(mProcessVector->Signal(alias, SIGTERM)?"sigterm OK":"sigterm FAILED");
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("sigtermall"))
-            {
-                mProcessVector->Killall(SIGTERM);
-                yarp::os::Bottle result;
-                result.addString("sigtermall OK");
-
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("ps"))
-            {
-                yarp::os::Bottle result;
-                result.append(mProcessVector->PS());
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("isrunning"))
-            {
-                std::string alias(msg.find("isrunning").asString());
-                yarp::os::Bottle result;
-                result.addString(mProcessVector->IsRunning(alias)?"running":"not running");
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-
-            if (msg.check("killstdio"))
-            {
-                std::string alias(msg.find("killstdio").asString());
-                mStdioVector->Signal(alias, SIGTERM);
-                yarp::os::Bottle result;
-                result.addString("killstdio OK");
-                RUNLOG("<<<writeToPipe")
-                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
-                RUNLOG(">>>writeToPipe")
-                continue;
-            }
-        }
-
-        mStdioVector->Killall(SIGTERM);
-
-        mProcessVector->Killall(SIGTERM);
-
-        if (mBraveZombieHunter)
-        {
-            mBraveZombieHunter->stop();
-            delete mBraveZombieHunter;
-            mBraveZombieHunter = nullptr;
-        }
-
-        delete mProcessVector;
-
-        delete mStdioVector;
-
-        //yarp::os::Network::fini();
-
-        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
-        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
-
-        delete [] msg_str;
-    }
-
-    return 0;
-} // LINUX SERVER
 #endif
 
-
-
-
-// CLIENT
-int yarp::run::Run::client(yarp::os::Property& config)
-{
-    // WITH STDIO
-    //
-    if (config.check("cmd") && config.check("stdio"))
-    {
-        ///////////////
-        // syntax check
-        if (config.find("stdio").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote stdio server\n");
-            return YARPRUN_ERROR;
-        }
-        if (config.find("cmd").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing command\n");
-            return YARPRUN_ERROR;
-        }
-        if (!config.check("as") || config.find("as").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing tag\n");
-            return YARPRUN_ERROR;
-        }
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-        //
-        ///////////////
-
-        printf("*********** %s ************\n", config.toString().c_str());
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("stdio");
-        msg.addList()=config.findGroup("cmd");
-        msg.addList()=config.findGroup("as");
-        msg.addList()=config.findGroup("on");
-
-        if (config.check("workdir")) {
-            msg.addList() = config.findGroup("workdir");
-        }
-        if (config.check("geometry")) {
-            msg.addList() = config.findGroup("geometry");
-        }
-        if (config.check("hold")) {
-            msg.addList() = config.findGroup("hold");
-        }
-        if (config.check("env")) {
-            msg.addList() = config.findGroup("env");
-        }
-        if (config.check("log")) {
-            msg.addList() = config.findGroup("log");
-        }
-        /*
-        {
-            yarp::os::Bottle log;
-            log.addString("log");
-            log.addString("log");
-            msg.addList()=log;
-        }
-        */
-
-        std::string on=config.find("on").asString();
-
-        yarp::os::Bottle response=sendMsg(msg, on);
-
-        if (!response.size()) {
-            return YARPRUN_ERROR;
-        }
-
-        if (response.get(0).asInt32() <= 0) {
-            return 2;
-        }
-
-        return 0;
-    }
-
-    // NO STDIO
-    //
-    if (config.check("cmd"))
-    {
-        ///////////////
-        // syntax check
-        if (config.find("cmd").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing command\n");
-            return YARPRUN_ERROR;
-        }
-        if (!config.check("as") || config.find("as").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing tag\n");
-            return YARPRUN_ERROR;
-        }
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-        //
-        ///////////////
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("cmd");
-        msg.addList()=config.findGroup("as");
-
-        if (config.check("workdir")) {
-            msg.addList() = config.findGroup("workdir");
-        }
-        if (config.check("log")) {
-            msg.addList() = config.findGroup("log");
-        }
-        /*
-        {
-            yarp::os::Bottle log;
-            log.addString("log");
-            log.addString("log");
-            msg.addList()=log;
-        }
-        */
-        if (config.check("env")) {
-            msg.addList() = config.findGroup("env");
-        }
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size()) {
-            return YARPRUN_ERROR;
-        }
-
-        if (response.get(0).asInt32() <= 0) {
-            return 2;
-        }
-
-        return 0;
-    }
-
-
-
-
-
-    // client -> cmd server
-    if (config.check("kill"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-        if (config.findGroup("kill").get(1).asString()=="")
-        {
-            Help("SYNTAX ERROR: missing tag\n");
-            return YARPRUN_ERROR;
-        }
-        if (config.findGroup("kill").get(2).asInt32()==0)
-        {
-            Help("SYNTAX ERROR: missing signum\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("kill");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return response.get(0).asString()=="kill OK"?0:2;
-    }
-
-    // client -> cmd server
-    if (config.check("sigterm"))
-    {
-        if (config.find("sigterm").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing tag");
-            return YARPRUN_ERROR;
-        }
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("sigterm");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return response.get(0).asString()=="sigterm OK"?0:2;
-    }
-
-    // client -> cmd server
-    if (config.check("sigtermall"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("sigtermall");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return 0;
-    }
-
-    if (config.check("ps"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("ps");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return 0;
-    }
-
-    if (config.check("isrunning"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-
-        if (config.find("isrunning").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing tag\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("isrunning");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return response.get(0).asString()=="running"?0:2;
-    }
-
-    if (config.check("sysinfo"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("sysinfo");
-
-        yarp::os::RpcClient port;
-        //port.setTimeout(5.0);
-        if (!port.open("..."))
-        {
-            fprintf(stderr, "RESPONSE:\n=========\n");
-            fprintf(stderr, "Cannot open port, aborting...\n");
-
-            return YARPRUN_ERROR;
-        }
-
-        bool connected = yarp::os::Network::connect(port.getName(), config.find("on").asString());
-
-        if (!connected)
-        {
-            fprintf(stderr, "RESPONSE:\n=========\n");
-            fprintf(stderr, "Cannot connect to remote server, aborting...\n");
-            port.close();
-            //yarp::os::Network::unregisterName(port.getName());
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::SystemInfoSerializer info;
-
-        RUNLOG("<<<port.write(msg, info)")
-        int ret = port.write(msg, info);
-        RUNLOG(">>>port.write(msg, info)")
-        yarp::os::Network::disconnect(port.getName(), config.find("on").asString());
-        port.close();
-        //yarp::os::Network::unregisterName(port.getName());
-        fprintf(stdout, "RESPONSE:\n=========\n\n");
-
-        if (!ret)
-        {
-            fprintf(stdout, "No response. (timeout)\n");
-
-            return YARPRUN_ERROR;
-        }
-
-        fprintf(stdout, "Platform name    : %s\n", info.platform.name.c_str());
-        fprintf(stdout, "Platform dist    : %s\n", info.platform.distribution.c_str());
-        fprintf(stdout, "Platform release : %s\n", info.platform.release.c_str());
-        fprintf(stdout, "Platform code    : %s\n", info.platform.codename.c_str());
-        fprintf(stdout, "Platform kernel  : %s\n\n", info.platform.kernel.c_str());
-
-        fprintf(stdout, "User Id        : %d\n", info.user.userID);
-        fprintf(stdout, "User name      : %s\n", info.user.userName.c_str());
-        fprintf(stdout, "User real name : %s\n", info.user.realName.c_str());
-        fprintf(stdout, "User home dir  : %s\n\n", info.user.homeDir.c_str());
-
-        fprintf(stdout, "Cpu load Ins.: %d\n", info.load.cpuLoadInstant);
-        fprintf(stdout, "Cpu load 1   : %.2lf\n", info.load.cpuLoad1);
-        fprintf(stdout, "Cpu load 5   : %.2lf\n", info.load.cpuLoad5);
-        fprintf(stdout, "Cpu load 15  : %.2lf\n\n", info.load.cpuLoad15);
-
-        fprintf(stdout, "Memory total : %dM\n", info.memory.totalSpace);
-        fprintf(stdout, "Memory free  : %dM\n\n", info.memory.freeSpace);
-
-        fprintf(stdout, "Storage total : %dM\n", info.storage.totalSpace);
-        fprintf(stdout, "Storage free  : %dM\n\n", info.storage.freeSpace);
-
-        fprintf(stdout, "Processor model     : %s\n", info.processor.model.c_str());
-        fprintf(stdout, "Processor model num : %d\n", info.processor.modelNumber);
-        fprintf(stdout, "Processor family    : %d\n", info.processor.family);
-        fprintf(stdout, "Processor vendor    : %s\n", info.processor.vendor.c_str());
-        fprintf(stdout, "Processor arch      : %s\n", info.processor.architecture.c_str());
-        fprintf(stdout, "Processor cores     : %d\n", info.processor.cores);
-        fprintf(stdout, "Processor siblings  : %d\n", info.processor.siblings);
-        fprintf(stdout, "Processor Mhz       : %.2lf\n\n", info.processor.frequency);
-
-        fprintf(stdout, "Environment variables  :\n%s\n", info.platform.environmentVars.toString().c_str());
-        //fprintf(stdout, "Network IP4 : %s\n", info.network.ip4.c_str());
-        //fprintf(stdout, "Network IP6 : %s\n", info.network.ip6.c_str());
-        //fprintf(stdout, "Network mac : %s\n\n", info.network.mac.c_str());
-
-        return 0;
-    }
-
-    if (config.check("which"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("which");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-        return 0;
-    }
-
-    if (config.check("exit"))
-    {
-        if (!config.check("on") || config.find("on").asString()=="")
-        {
-            Help("SYNTAX ERROR: missing remote server\n");
-
-            return YARPRUN_ERROR;
-        }
-
-        yarp::os::Bottle msg;
-        msg.addList()=config.findGroup("exit");
-
-        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
-
-        if (!response.size())
-        {
-            return YARPRUN_ERROR;
-        }
-
-        return 0;
-    }
-
-    return 0;
-}
-
-void yarp::run::Run::Help(const char *msg)
-{
-    fprintf(stderr, "%s", msg);
-    fprintf(stderr, "\nUSAGE:\n\n");
-    fprintf(stderr, "yarp run --server SERVERPORT\nrun a server on the local machine\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --as TAG --cmd COMMAND [ARGLIST] [--workdir WORKDIR] [--env ENVIRONMENT]\nrun a command on SERVERPORT server\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --as TAG --stdio STDIOSERVERPORT [--hold] [--geometry WxH+X+Y] --cmd COMMAND [ARGLIST] [--workdir WORKDIR] [--env ENVIRONMENT]\n");
-    fprintf(stderr, "run a command on SERVERPORT server sending I/O to STDIOSERVERPORT server\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --kill TAG SIGNUM\nsend SIGNUM signal to TAG command\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --sigterm TAG\nterminate TAG command\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --sigtermall\nterminate all commands\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --ps\nreport commands running on SERVERPORT\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --isrunning TAG\nTAG command is running?\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --sysinfo\nreport system information of SERVERPORT\n\n");
-    fprintf(stderr, "yarp run --on SERVERPORT --exit\nstop SERVERPORT server\n\n");
-}
 
 /////////////////////////
 // OS DEPENDENT FUNCTIONS
@@ -1688,7 +475,7 @@ void yarp::run::Run::Help(const char *msg)
 #if defined(_WIN32)
 
 // CMD SERVER
-int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::executeCmdAndStdio(const  yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     std::string strAlias=msg.find("as").asString();
     std::string strStdio=msg.find("stdio").asString();
@@ -1968,7 +755,7 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
     return cmd_process_info.dwProcessId;
 }
 
-int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
+int yarp::run::Run::executeCmdStdout(const  yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
 {
     std::string proc_label = getProcLabel(msg);
 
@@ -2195,7 +982,7 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
 }
 
 
-int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::executeCmd(const  yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     std::string strAlias=msg.find("as").asString().c_str();
 
@@ -2234,12 +1021,12 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
     }
 
     // Set the YARP_IS_YARPRUN environment variable to 1, so that the child
-    // process will now that is running inside yarprun.
+    // process will know that is running inside yarprun.
     lstrcpy(lpNew, (LPTCH) "YARP_IS_YARPRUN=1");
     lpNew += lstrlen(lpNew) + 1;
 
     // Set the YARPRUN_IS_FORWARDING_LOG environment variable to 0, so that
-    // the child process will now that yarprun is not logging the output.
+    // the child process will know that yarprun is not logging the output.
     lstrcpy(lpNew, (LPTCH) "YARPRUN_IS_FORWARDING_LOG=0");
     lpNew += lstrlen(lpNew) + 1;
 
@@ -2331,7 +1118,7 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
 }
 
 // STDIO SERVER
-int yarp::run::Run::userStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::userStdio(const  yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     PROCESS_INFORMATION stdio_process_info;
     ZeroMemory(&stdio_process_info, sizeof(PROCESS_INFORMATION));
@@ -2477,7 +1264,7 @@ void yarp::run::Run::CleanZombie(int pid)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::executeCmdAndStdio(const yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     std::string strAlias=msg.find("as").asString();
     std::string strCmd=msg.find("cmd").asString();
@@ -2923,7 +1710,7 @@ int yarp::run::Run::executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& 
     return YARPRUN_ERROR;
 }
 
-int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
+int yarp::run::Run::executeCmdStdout(const yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName)
 {
     std::string proc_label = getProcLabel(msg);
 
@@ -3285,7 +2072,7 @@ int yarp::run::Run::executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& re
     return YARPRUN_ERROR;
 }
 
-int yarp::run::Run::userStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::userStdio(const yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     std::string strAlias=msg.find("as").asString();
     std::string strUUID=msg.find("stdiouuid").asString();
@@ -3473,7 +2260,7 @@ int yarp::run::Run::userStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result)
     return YARPRUN_ERROR;
 }
 
-int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
+int yarp::run::Run::executeCmd(const yarp::os::Bottle& msg, yarp::os::Bottle& result)
 {
     std::string strAlias(msg.find("as").asString());
     std::string strCmd(msg.find("cmd").toString());
@@ -3714,155 +2501,3 @@ int yarp::run::Run::executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result)
 }
 
 #endif
-
-/////////////////////////////////////////////////////////////////
-// API
-/////////////////////////////////////////////////////////////////
-
-int yarp::run::Run::start(const std::string &node, yarp::os::Property &command, std::string &keyv)
-{
-    yarp::os::Bottle msg, grp, response;
-
-    grp.clear();
-    grp.addString("on");
-    grp.addString(node.c_str());
-    msg.addList()=grp;
-
-    std::string dest_srv=node;
-
-    if (command.check("stdio"))
-    {
-        dest_srv=std::string(command.find("stdio").asString());
-
-        grp.clear();
-        grp.addString("stdio");
-        grp.addString(dest_srv.c_str());
-        msg.addList()=grp;
-
-        if (command.check("geometry"))
-        {
-            grp.clear();
-            grp.addString("geometry");
-            grp.addString(command.find("geometry").asString().c_str());
-            msg.addList()=grp;
-        }
-
-        if (command.check("hold"))
-        {
-            grp.clear();
-            grp.addString("hold");
-            msg.addList()=grp;
-        }
-    }
-
-    grp.clear();
-    grp.addString("as");
-    grp.addString(keyv.c_str());
-    msg.addList()=grp;
-
-    grp.clear();
-    grp.addString("cmd");
-    grp.addString(command.find("name").asString().c_str());
-    grp.addString(command.find("parameters").asString().c_str());
-    msg.addList()=grp;
-
-    printf(":: %s\n", msg.toString().c_str());
-
-    response=sendMsg(msg, dest_srv);
-
-    char buff[16];
-    sprintf(buff, "%d", response.get(0).asInt32());
-    keyv=std::string(buff);
-
-    return response.get(0).asInt32()>0?0:YARPRUN_ERROR;
-}
-
-int yarp::run::Run::sigterm(const std::string &node, const std::string &keyv)
-{
-    yarp::os::Bottle msg, grp, response;
-
-    grp.clear();
-    grp.addString("on");
-    grp.addString(node.c_str());
-    msg.addList()=grp;
-
-    grp.clear();
-    grp.addString("sigterm");
-    grp.addString(keyv.c_str());
-    msg.addList()=grp;
-
-    printf(":: %s\n", msg.toString().c_str());
-
-    response=sendMsg(msg, node);
-
-    return response.get(0).asString()=="sigterm OK"?0:YARPRUN_ERROR;
-}
-
-int yarp::run::Run::sigterm(const std::string &node)
-{
-    yarp::os::Bottle msg, grp, response;
-
-    grp.clear();
-    grp.addString("on");
-    grp.addString(node.c_str());
-    msg.addList()=grp;
-
-    grp.clear();
-    grp.addString("sigtermall");
-    msg.addList()=grp;
-
-    printf(":: %s\n", msg.toString().c_str());
-
-    response=sendMsg(msg, node);
-
-    return response.get(0).asString()=="sigtermall OK"?0:YARPRUN_ERROR;
-}
-
-int yarp::run::Run::kill(const std::string &node, const std::string &keyv, int s)
-{
-    yarp::os::Bottle msg, grp, response;
-
-    grp.clear();
-    grp.addString("on");
-    grp.addString(node.c_str());
-    msg.addList()=grp;
-
-    grp.clear();
-    grp.addString("kill");
-    grp.addString(keyv.c_str());
-    grp.addInt32(s);
-    msg.addList()=grp;
-
-    printf(":: %s\n", msg.toString().c_str());
-
-    response=sendMsg(msg, node);
-
-    return response.get(0).asString()=="kill OK"?0:YARPRUN_ERROR;
-}
-
-bool yarp::run::Run::isRunning(const std::string &node, std::string &keyv)
-{
-    yarp::os::Bottle msg, grp, response;
-
-    grp.clear();
-    grp.addString("on");
-    grp.addString(node.c_str());
-    msg.addList()=grp;
-
-    grp.clear();
-    grp.addString("isrunning");
-    grp.addString(keyv.c_str());
-    msg.addList()=grp;
-
-    printf(":: %s\n", msg.toString().c_str());
-
-    response=sendMsg(msg, node);
-
-    if (!response.size()) {
-        return false;
-    }
-
-    return response.get(0).asString()=="running";
-}
-
-// end API

--- a/src/libYARP_run/src/yarp/run/Run.cpp
+++ b/src/libYARP_run/src/yarp/run/Run.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <cstring>
 #include <random>
+#include <iomanip>
 
 #if defined(_WIN32)
 # if !defined(WIN32_LEAN_AND_MEAN)

--- a/src/libYARP_run/src/yarp/run/Run.h
+++ b/src/libYARP_run/src/yarp/run/Run.h
@@ -7,10 +7,13 @@
 #ifndef YARP_RUN_RUN_H
 #define YARP_RUN_RUN_H
 
+#include <vector>
+
 #include <cstring>
 #include <yarp/run/api.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/Property.h>
+#include <yarp/os/SystemInfoSerializer.h>
 
 
 class YarpRunInfoVector;
@@ -72,12 +75,20 @@ namespace yarp::run {
 /**
  * \class yarp::os::Run
  * \brief yarprun provides the APIs to a client-server environment that is able to run,
- * kill and monitor applications commands on a remote machin in Windows and Linux.
+ * kill and monitor applications commands on a remote machine in Windows and Linux.
  */
 class YARP_run_API Run
 {
 public:
     // API
+    struct processInfo
+    {
+         int pid=0;
+         std::string tag;
+         std::string status;
+         std::string command;
+         std::string env;
+    };
 
     /**
      * Launch a yarprun server.
@@ -90,46 +101,73 @@ public:
      * - geometry WxH+X+Y (optional)
      * - hold (optional)
      * @param keyv is the tag that will identify the running application. It must be unique in the network.
-     * @return 0=success -1=failed.
+     * @return true=success false=failed.
      */
-    static int start(const std::string &node, yarp::os::Property &command, std::string &keyv);
+    static bool start(const std::string &node, yarp::os::Property &command, std::string &keyv);
+
     /**
      * Terminate an application running on a yarprun server.
      * @param node is the yarprun server port name. It must be unique in the network.
      * @param keyv is the tag that identifies the running application. It must be unique in the network.
-     * @return 0=success -1=failed.
+     * @return true=success false=failed.
      */
-    static int sigterm(const std::string &node, const std::string &keyv);
+    static bool sigterm(const std::string &node, const std::string &keyv);
+
     /**
      * Terminate all applications running on a yarprun server.
      * @param node is the yarprun server port name. It must be unique in the network.
-     * @return 0=success -1=failed.
+     * @return true=success false=failed.
      */
-    static int sigterm(const std::string &node);
+    static bool sigtermall(const std::string &node);
+
     /**
      * Send a SIGNAL to an application running on a yarprun server (Linux only).
      * @param node is the yarprun server port name. It must be unique in the network.
      * @param keyv is the tag that identifies the running application. It must be unique in the network.
      * @param s is the SIGNAL number.
-     * @return 0=success -1=failed.
+     * @return true=success false=failed.
      */
-    static int kill(const std::string &node, const std::string &keyv, int s);
+    static bool kill(const std::string &node, const std::string &keyv, int s);
+
     /**
      * Get a report of all applications running on a yarprun server.
      * @param node is the yarprun server port name. It must be unique in the network.
-     * @param processes is a list of applications running on the remote yarprun server. It must not be allocated
-     * and it is responsibility of the caller to delete it.
-     * @param num_processes return the number of running processes.
+     * @param processes is a list of applications running on the remote yarprun server.
      * @return 0=success -1=failed.
      */
-    // static int ps(const std::string &node, std::string** &processes, int &num_processes);
+    static bool ps(const std::string &node, std::vector<processInfo>& processes);
+
+    /**
+     * Get a report of system information of a yarprun server.
+     * @param node is the yarprun server port name. It must be unique in the network.
+     * @param info is the system information of the remote yarprun server.
+     * @return true=success false=failed.
+     */
+    static bool sysinfo(const std::string& node, yarp::os::SystemInfoSerializer& info);
+
+
     /**
      * Report if an application is still running on a yarprun server.
      * @param node is the yarprun server port name. It must be unique in the network.
      * @param keyv is the tag that identifies the application. It must be unique in the network.
      * @return true=running false=terminated.
      */
-    static bool isRunning(const std::string &node, std::string &keyv);
+    static bool isRunning(const std::string &node, const std::string &keyv);
+
+    /**
+     * Display the path of a file on a yarprun server.
+     * @param node is the yarprun server port name. It must be unique in the network.
+     * @param keyv is the tag that identifies the application. It must be unique in the network.
+     * @return true=running false=terminated.
+     */
+    static bool which(const std::string &node, const std::string &keyv);
+
+    /**
+     * Exit a yarprun server.
+     * @param node is the yarprun server port name. It must be unique in the network.
+     * @return true=success false=failed.
+     */
+    static bool exit(const std::string& node);
 
     // end API
 
@@ -166,6 +204,9 @@ YARP_DISABLE_DLL_INTERFACE_WARNING
     static YarpRunInfoVector *mStdioVector;
     static ZombieHunterThread *mBraveZombieHunter;
     static void CleanZombie(int pid);
+#define READ_FROM_PIPE 0
+#define WRITE_TO_PIPE  1
+#define REDIRECT_TO(from, to) yarp::run::impl::dup2(to, from)
 #endif
 YARP_WARNING_POP
     static yarp::os::Bottle sendMsg(yarp::os::Bottle& msg, std::string target, int RETRY=20, double DELAY=0.5);
@@ -173,10 +214,10 @@ YARP_WARNING_POP
 protected:
     static void Help(const char* msg="");
     static int server();
-    static int executeCmdAndStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result);
-    static int executeCmdStdout(yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName);
-    static int executeCmd(yarp::os::Bottle& msg, yarp::os::Bottle& result);
-    static int userStdio(yarp::os::Bottle& msg, yarp::os::Bottle& result);
+    static int executeCmdAndStdio(const yarp::os::Bottle& msg, yarp::os::Bottle& result);
+    static int executeCmdStdout(const yarp::os::Bottle& msg, yarp::os::Bottle& result, std::string& loggerName);
+    static int executeCmd(const yarp::os::Bottle& msg, yarp::os::Bottle& result);
+    static int userStdio(const yarp::os::Bottle& msg, yarp::os::Bottle& result);
 
     static inline bool IS_PARENT_OF(int pid){ return pid>0; }
     static inline bool IS_NEW_PROCESS(int pid){ return !pid; }

--- a/src/libYARP_run/src/yarp/run/RunClient.cpp
+++ b/src/libYARP_run/src/yarp/run/RunClient.cpp
@@ -1,0 +1,658 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/run/Run.h>
+#include <yarp/run/impl/RunCheckpoints.h>
+#include <yarp/run/impl/RunProcManager.h>
+#include <yarp/run/impl/RunReadWrite.h>
+#include <yarp/run/impl/PlatformStdlib.h>
+#include <yarp/run/impl/PlatformUnistd.h>
+#include <yarp/run/impl/PlatformSysPrctl.h>
+
+#include <yarp/conf/environment.h>
+#include <yarp/conf/filesystem.h>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/os/RpcServer.h>
+#include <yarp/os/Semaphore.h>
+#include <yarp/os/SystemInfo.h>
+#include <yarp/os/SystemInfoSerializer.h>
+#include <yarp/os/Time.h>
+
+#include <yarp/os/impl/NameClient.h>
+#include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/PlatformStdio.h>
+
+#include <cstdio>
+#include <string>
+#include <cstring>
+#include <random>
+
+// CLIENT
+int yarp::run::Run::client(yarp::os::Property& config)
+{
+    // WITH STDIO
+    //
+    if (config.check("cmd") && config.check("stdio"))
+    {
+        ///////////////
+        // syntax check
+        if (config.find("stdio").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote stdio server\n");
+            return YARPRUN_ERROR;
+        }
+        if (config.find("cmd").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing command\n");
+            return YARPRUN_ERROR;
+        }
+        if (!config.check("as") || config.find("as").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing tag\n");
+            return YARPRUN_ERROR;
+        }
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+        //
+        ///////////////
+
+        printf("*********** %s ************\n", config.toString().c_str());
+
+        yarp::os::Bottle msg;
+        msg.addList()=config.findGroup("stdio");
+        msg.addList()=config.findGroup("cmd");
+        msg.addList()=config.findGroup("as");
+        msg.addList()=config.findGroup("on");
+
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("geometry")) {
+            msg.addList() = config.findGroup("geometry");
+        }
+        if (config.check("hold")) {
+            msg.addList() = config.findGroup("hold");
+        }
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
+        if (config.check("log")) {
+            msg.addList() = config.findGroup("log");
+        }
+        /*
+        {
+            yarp::os::Bottle log;
+            log.addString("log");
+            log.addString("log");
+            msg.addList()=log;
+        }
+        */
+
+        std::string on=config.find("on").asString();
+
+        yarp::os::Bottle response=sendMsg(msg, on);
+
+        if (!response.size()) {
+            return YARPRUN_ERROR;
+        }
+
+        if (response.get(0).asInt32() <= 0) {
+            return 2;
+        }
+
+        return 0;
+    }
+
+    // NO STDIO
+    //
+    if (config.check("cmd"))
+    {
+        ///////////////
+        // syntax check
+        if (config.find("cmd").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing command\n");
+            return YARPRUN_ERROR;
+        }
+        if (!config.check("as") || config.find("as").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing tag\n");
+            return YARPRUN_ERROR;
+        }
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+        //
+        ///////////////
+
+        yarp::os::Bottle msg;
+        msg.addList()=config.findGroup("cmd");
+        msg.addList()=config.findGroup("as");
+
+        if (config.check("workdir")) {
+            msg.addList() = config.findGroup("workdir");
+        }
+        if (config.check("log")) {
+            msg.addList() = config.findGroup("log");
+        }
+        /*
+        {
+            yarp::os::Bottle log;
+            log.addString("log");
+            log.addString("log");
+            msg.addList()=log;
+        }
+        */
+        if (config.check("env")) {
+            msg.addList() = config.findGroup("env");
+        }
+
+        yarp::os::Bottle response=sendMsg(msg, config.find("on").asString());
+
+        if (!response.size()) {
+            return YARPRUN_ERROR;
+        }
+
+        if (response.get(0).asInt32() <= 0) {
+            return 2;
+        }
+
+        return 0;
+    }
+
+
+
+
+
+    //----------------------------
+    if (config.check("kill"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+        if (config.findGroup("kill").get(1).asString()=="")
+        {
+            Help("SYNTAX ERROR: missing tag\n");
+            return YARPRUN_ERROR;
+        }
+        if (config.findGroup("kill").get(2).asInt32()==0)
+        {
+            Help("SYNTAX ERROR: missing signum\n");
+            return YARPRUN_ERROR;
+        }
+
+        int ret = kill(config.find("on").asString(),
+                       config.findGroup("kill").get(1).asString(),
+                       config.findGroup("kill").get(2).asInt32());
+
+        return ret?0:2;
+    }
+
+    //----------------------------
+    if (config.check("sigterm"))
+    {
+        if (config.find("sigterm").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing tag");
+            return YARPRUN_ERROR;
+        }
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+
+        sigterm(config.find("on").asString(),
+                config.find("sigterm").asString());
+
+        return 0;
+    }
+
+    //----------------------------
+    if (config.check("sigtermall"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+
+        sigtermall(config.find("on").asString());
+
+        return 0;
+    }
+
+    //----------------------------
+    if (config.check("ps"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+
+        std::vector<processInfo> processes;
+        ps(config.find("on").asString(),processes);
+
+        return 0;
+    }
+
+    //----------------------------
+    if (config.check("isrunning"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+
+        if (config.find("isrunning").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing tag\n");
+            return YARPRUN_ERROR;
+        }
+
+        bool running = isRunning(config.find("on").asString(),
+                                 config.find("isrunning").asString());
+
+        return running?0:2;
+    }
+
+    //----------------------------
+    if (config.check("sysinfo"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+            return YARPRUN_ERROR;
+        }
+
+        yarp::os::SystemInfoSerializer info;
+        bool ret = sysinfo(config.find("on").asString(),info);
+        if (!ret)
+        {
+            fprintf(stdout, "No response. (timeout)\n");
+            return YARPRUN_ERROR;
+        }
+
+        fprintf(stdout, "Platform name    : %s\n", info.platform.name.c_str());
+        fprintf(stdout, "Platform dist    : %s\n", info.platform.distribution.c_str());
+        fprintf(stdout, "Platform release : %s\n", info.platform.release.c_str());
+        fprintf(stdout, "Platform code    : %s\n", info.platform.codename.c_str());
+        fprintf(stdout, "Platform kernel  : %s\n\n", info.platform.kernel.c_str());
+
+        fprintf(stdout, "User Id        : %d\n", info.user.userID);
+        fprintf(stdout, "User name      : %s\n", info.user.userName.c_str());
+        fprintf(stdout, "User real name : %s\n", info.user.realName.c_str());
+        fprintf(stdout, "User home dir  : %s\n\n", info.user.homeDir.c_str());
+
+        fprintf(stdout, "Cpu load Ins.: %d\n", info.load.cpuLoadInstant);
+        fprintf(stdout, "Cpu load 1   : %.2lf\n", info.load.cpuLoad1);
+        fprintf(stdout, "Cpu load 5   : %.2lf\n", info.load.cpuLoad5);
+        fprintf(stdout, "Cpu load 15  : %.2lf\n\n", info.load.cpuLoad15);
+
+        fprintf(stdout, "Memory total : %dM\n", info.memory.totalSpace);
+        fprintf(stdout, "Memory free  : %dM\n\n", info.memory.freeSpace);
+
+        fprintf(stdout, "Storage total : %dM\n", info.storage.totalSpace);
+        fprintf(stdout, "Storage free  : %dM\n\n", info.storage.freeSpace);
+
+        fprintf(stdout, "Processor model     : %s\n", info.processor.model.c_str());
+        fprintf(stdout, "Processor model num : %d\n", info.processor.modelNumber);
+        fprintf(stdout, "Processor family    : %d\n", info.processor.family);
+        fprintf(stdout, "Processor vendor    : %s\n", info.processor.vendor.c_str());
+        fprintf(stdout, "Processor arch      : %s\n", info.processor.architecture.c_str());
+        fprintf(stdout, "Processor cores     : %d\n", info.processor.cores);
+        fprintf(stdout, "Processor siblings  : %d\n", info.processor.siblings);
+        fprintf(stdout, "Processor Mhz       : %.2lf\n\n", info.processor.frequency);
+
+        fprintf(stdout, "Environment variables  :\n%s\n", info.platform.environmentVars.toString().c_str());
+        //fprintf(stdout, "Network IP4 : %s\n", info.network.ip4.c_str());
+        //fprintf(stdout, "Network IP6 : %s\n", info.network.ip6.c_str());
+        //fprintf(stdout, "Network mac : %s\n\n", info.network.mac.c_str());
+
+        return 0;
+    }
+
+    //----------------------------
+    if (config.check("which"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+
+            return YARPRUN_ERROR;
+        }
+
+        bool ret = which(config.find("on").asString(), config.find("which").asString());
+
+        return ret?0:2;
+    }
+
+    //----------------------------
+    if (config.check("exit"))
+    {
+        if (!config.check("on") || config.find("on").asString()=="")
+        {
+            Help("SYNTAX ERROR: missing remote server\n");
+
+            return YARPRUN_ERROR;
+        }
+
+        bool ret = exit(config.find("on").asString());
+
+        return ret?0:2;
+    }
+
+    return 0;
+}
+
+void yarp::run::Run::Help(const char *msg)
+{
+    fprintf(stderr, "%s", msg);
+    fprintf(stderr, "\nUSAGE:\n\n");
+    fprintf(stderr, "yarp run --server SERVERPORT\nrun a server on the local machine\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --as TAG --cmd COMMAND [ARGLIST] [--workdir WORKDIR] [--env ENVIRONMENT]\nrun a command on SERVERPORT server\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --as TAG --stdio STDIOSERVERPORT [--hold] [--geometry WxH+X+Y] --cmd COMMAND [ARGLIST] [--workdir WORKDIR] [--env ENVIRONMENT]\n");
+    fprintf(stderr, "run a command on SERVERPORT server sending I/O to STDIOSERVERPORT server\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --kill TAG SIGNUM\nsend SIGNUM signal to TAG command\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --sigterm TAG\nterminate TAG command\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --sigtermall\nterminate all commands\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --ps\nreport commands running on SERVERPORT\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --isrunning TAG\nTAG command is running?\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --sysinfo\nreport system information of SERVERPORT\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --exit\nstop SERVERPORT server\n\n");
+    fprintf(stderr, "yarp run --on SERVERPORT --which\nsearch for path of provided filename\n\n");
+}
+
+/////////////////////////////////////////////////////////////////
+// API
+/////////////////////////////////////////////////////////////////
+
+bool yarp::run::Run::isRunning(const std::string &node, const std::string &keyv)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("isrunning");
+    grp.addString(keyv.c_str());
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    if (!response.size()) {
+        return false;
+    }
+
+    return response.get(0).asString()=="running";
+}
+
+
+bool yarp::run::Run::sysinfo(const std::string &node, yarp::os::SystemInfoSerializer& info)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("sysinfo");
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+    yarp::os::RpcClient port;
+    //port.setTimeout(5.0);
+    if (!port.open("..."))
+    {
+        fprintf(stderr, "RESPONSE:\n=========\n");
+        fprintf(stderr, "Cannot open port, aborting...\n");
+        return false;
+    }
+    bool connected = yarp::os::Network::connect(port.getName(), node);
+    if (!connected)
+    {
+        fprintf(stderr, "RESPONSE:\n=========\n");
+        fprintf(stderr, "Cannot connect to remote server, aborting...\n");
+        port.close();
+        //yarp::os::Network::unregisterName(port.getName());
+        return false;
+    }
+    RUNLOG("<<<port.write(msg, info)")
+    int ret = port.write(msg, info);
+    RUNLOG(">>>port.write(msg, info)")
+    yarp::os::Network::disconnect(port.getName(), node);
+    port.close();
+    //yarp::os::Network::unregisterName(port.getName());
+    fprintf(stdout, "RESPONSE:\n=========\n\n");
+    if (!ret)
+    {
+        fprintf(stdout, "No response. (timeout)\n");
+        return false;
+    }
+
+    return true;
+}
+
+bool yarp::run::Run::start(const std::string &node, yarp::os::Property &command, std::string &keyv)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    std::string dest_srv=node;
+
+    if (command.check("stdio"))
+    {
+        dest_srv=std::string(command.find("stdio").asString());
+
+        grp.clear();
+        grp.addString("stdio");
+        grp.addString(dest_srv.c_str());
+        msg.addList()=grp;
+
+        if (command.check("geometry"))
+        {
+            grp.clear();
+            grp.addString("geometry");
+            grp.addString(command.find("geometry").asString().c_str());
+            msg.addList()=grp;
+        }
+
+        if (command.check("hold"))
+        {
+            grp.clear();
+            grp.addString("hold");
+            msg.addList()=grp;
+        }
+    }
+
+    grp.clear();
+    grp.addString("as");
+    grp.addString(keyv.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("cmd");
+    grp.addString(command.find("name").asString().c_str());
+    grp.addString(command.find("parameters").asString().c_str());
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, dest_srv);
+
+    char buff[16];
+    sprintf(buff, "%d", response.get(0).asInt32());
+    keyv=std::string(buff);
+
+    return response.get(0).asInt32()>0?true:false;
+}
+
+bool yarp::run::Run::sigterm(const std::string &node, const std::string &keyv)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("sigterm");
+    grp.addString(keyv.c_str());
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    return response.get(0).asString()=="sigterm OK"?true:false;
+}
+
+bool yarp::run::Run::sigtermall(const std::string &node)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("sigtermall");
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    return response.get(0).asString()=="sigtermall OK"?true:false;
+}
+
+bool yarp::run::Run::kill(const std::string &node, const std::string &keyv, int s)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("kill");
+    grp.addString(keyv.c_str());
+    grp.addInt32(s);
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    return response.get(0).asString()=="kill OK"?true:false;
+}
+
+bool yarp::run::Run::ps(const std::string &node, std::vector<processInfo>& processes)
+{
+    yarp::os::Bottle msg, grp, response;
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("ps");
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+    for (size_t i=0; i<response.size(); i++)
+    {
+        response.get(i).toString();
+        processInfo temp;
+        yarp::os::Bottle* b = response.get(i).asList();
+
+        temp.pid = b->get(0).asList()->get(1).asInt32();
+        temp.tag = b->get(1).asList()->get(1).asString();
+        temp.status = b->get(2).asList()->get(1).asString();
+        temp.command = b->get(3).asList()->get(1).asString();
+        temp.env = b->get(4).asList()->get(1).asString();
+        processes.push_back(temp);
+    }
+    return true;
+}
+
+bool yarp::run::Run::which(const std::string &node, const std::string &keyv)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("which");
+    grp.addString(keyv.c_str());
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    if (!response.size()) {
+        return false;
+    }
+
+    return true;
+}
+
+bool yarp::run::Run::exit(const std::string &node)
+{
+    yarp::os::Bottle msg, grp, response;
+
+    grp.clear();
+    grp.addString("on");
+    grp.addString(node.c_str());
+    msg.addList()=grp;
+
+    grp.clear();
+    grp.addString("exit");
+    msg.addList()=grp;
+
+    printf(":: %s\n", msg.toString().c_str());
+
+    response=sendMsg(msg, node);
+
+    if (!response.size()) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/libYARP_run/src/yarp/run/RunServer.cpp
+++ b/src/libYARP_run/src/yarp/run/RunServer.cpp
@@ -1,0 +1,860 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-FileCopyrightText: 2006-2010 RobotCub Consortium
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <yarp/run/Run.h>
+#include <yarp/run/impl/RunCheckpoints.h>
+#include <yarp/run/impl/RunProcManager.h>
+#include <yarp/run/impl/RunReadWrite.h>
+#include <yarp/run/impl/PlatformStdlib.h>
+#include <yarp/run/impl/PlatformUnistd.h>
+#include <yarp/run/impl/PlatformSysPrctl.h>
+
+#include <yarp/conf/environment.h>
+#include <yarp/conf/filesystem.h>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/Os.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/os/RpcServer.h>
+#include <yarp/os/Semaphore.h>
+#include <yarp/os/SystemInfo.h>
+#include <yarp/os/SystemInfoSerializer.h>
+#include <yarp/os/Time.h>
+
+#include <yarp/os/impl/NameClient.h>
+#include <yarp/os/impl/PlatformSignal.h>
+#include <yarp/os/impl/PlatformStdio.h>
+
+#include <cstdio>
+#include <string>
+#include <cstring>
+#include <random>
+
+////// adapted from libYARP_OS: ResourceFinder.cpp
+namespace fs = yarp::conf::filesystem;
+constexpr auto sep = yarp::conf::environment::path_separator;
+constexpr fs::value_type slash = fs::preferred_separator;
+
+void sigint_handler(int sig)
+{
+    YARP_UNUSED(sig);
+    yarp::run::Run::mStresstest=false;
+
+    if (yarp::run::Run::pServerPort)
+    {
+        yarp::os::RpcServer *pClose=yarp::run::Run::pServerPort;
+        yarp::run::Run::pServerPort = nullptr;
+        pClose->close();
+    }
+    //else
+    //{
+    //}
+}
+
+static yarp::os::Bottle parsePaths(const std::string& txt)
+{
+    yarp::os::Bottle result;
+    const char *at = txt.c_str();
+    int slash_tweak = 0;
+    int len = 0;
+    for (char ch : txt) {
+        if (ch==sep) {
+            result.addString(std::string(at, len-slash_tweak));
+            at += len+1;
+            len = 0;
+            slash_tweak = 0;
+            continue;
+        }
+        slash_tweak = (ch==slash && len>0)?1:0;
+        len++;
+    }
+    if (len>0) {
+        result.addString(std::string(at, len-slash_tweak));
+    }
+    return result;
+}
+
+static bool fileExists(const char *fname)
+{
+    FILE *fp = nullptr;
+    fp = fopen(fname, "r");
+    if (!fp) {
+        return false;
+    } else {
+        fclose(fp);
+        return true;
+    }
+}
+
+///////////////////////////
+// WINDOWS SERVER
+#if defined(_WIN32)
+int yarp::run::Run::server()
+{
+    //yarp::os::Semaphore serializer(1); ///?????unused
+
+    yarp::os::RpcServer port;
+
+    if (!port.open(mPortName.c_str()))
+    {
+        yError() << "Yarprun failed to open port: " << mPortName.c_str();
+        return YARPRUN_ERROR;
+    }
+
+    yarp::os::Bottle cmd, reply;
+    cmd.addString("set");
+    cmd.addString(port.getName());
+    cmd.addString("yarprun");
+    cmd.addString("true");
+    yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
+
+    yInfo() << "Yarprun successfully started on port: " << mPortName.c_str();
+
+    pServerPort=&port;
+
+    yarp::os::impl::signal(SIGINT, sigint_handler);
+    yarp::os::impl::signal(SIGTERM, sigint_handler);
+
+    // Enabling cpu load collector on windows
+    //yarp::os::impl::SystemInfo::enableCpuLoadCollector();
+
+    while (pServerPort)
+    {
+        yarp::os::Bottle msg;
+
+        RUNLOG("<<<port.read(msg, true)")
+        if (!port.read(msg, true)) break;
+        RUNLOG(">>>port.read(msg, true)")
+
+        if (!pServerPort) break;
+
+        //printf("<<< %s >>>\n", msg.toString().c_str());
+        //fflush(stdout);
+
+///////////////////////////////////////////////////
+
+        // command with stdio management
+        if (msg.check("stdio"))
+        {
+            std::string strOnPort=msg.find("on").asString();
+            std::string strStdioPort=msg.find("stdio").asString();
+
+            if (strOnPort==mPortName)
+            {
+                std::string strUUID=mPortName+"/"+int2String(getpid())+"/"+msg.find("as").asString()+"-"+int2String(mProcCNT++);
+                yarp::os::Bottle botUUID;
+                botUUID.addString("stdiouuid");
+                botUUID.addString(strUUID.c_str());
+                msg.addList()=botUUID;
+
+                if (mLogged || msg.check("log"))
+                {
+                    std::string strAlias=msg.find("as").asString();
+                    std::string portName="/log";
+                    portName+=mPortName+"/";
+                    std::string command = msg.findGroup("cmd").get(1).asString();
+                    command = command.substr(0, command.find(' '));
+                    command = command.substr(command.find_last_of("\\/") + 1);
+                    portName+=command;
+
+                    yarp::os::Bottle botFwd;
+                    botFwd.addString("forward");
+                    botFwd.addString(portName.c_str());
+                    if (msg.check("log"))
+                    {
+                        yarp::os::Bottle botLogger=msg.findGroup("log");
+
+                        if (botLogger.size()>1)
+                        {
+                            botFwd.addString(botLogger.get(1).asString());
+                        }
+                        else
+                        {
+                            botFwd.addString(mLoggerPort);
+                        }
+                    }
+                    else
+                    {
+                        botFwd.addString(mLoggerPort);
+                    }
+                    msg.addList()=botFwd;
+                }
+
+                yarp::os::Bottle cmdResult;
+                if (executeCmdAndStdio(msg, cmdResult)>0)
+                {
+                    if (strStdioPort==mPortName)
+                    {
+                        yarp::os::Bottle stdioResult;
+                        userStdio(msg, stdioResult);
+                        cmdResult.append(stdioResult);
+                    }
+                    else
+                    {
+                        cmdResult.append(sendMsg(msg, strStdioPort));
+                    }
+                }
+
+                port.reply(cmdResult);
+            }
+            else
+            {
+                yarp::os::Bottle stdioResult;
+                userStdio(msg, stdioResult);
+                port.reply(stdioResult);
+            }
+
+            continue;
+        }
+
+        // without stdio
+        if (msg.check("cmd"))
+        {
+            yarp::os::Bottle cmdResult;
+
+            if (msg.check("log"))
+            {
+                yarp::os::Bottle botLogger=msg.findGroup("log");
+
+                if (botLogger.size()>1)
+                {
+                    std::string loggerName=botLogger.get(1).asString();
+                    executeCmdStdout(msg, cmdResult, loggerName);
+                }
+                else
+                {
+                    executeCmdStdout(msg, cmdResult, mLoggerPort);
+                }
+            }
+            else if (mLogged)
+            {
+                executeCmdStdout(msg, cmdResult, mLoggerPort);
+            }
+            else
+            {
+                executeCmd(msg, cmdResult);
+            }
+            port.reply(cmdResult);
+            continue;
+        }
+
+        if (msg.check("kill"))
+        {
+            std::string alias(msg.findGroup("kill").get(1).asString());
+            int sig=msg.findGroup("kill").get(2).asInt32();
+            yarp::os::Bottle result;
+            result.addString(mProcessVector.Signal(alias, sig)?"kill OK":"kill FAILED");
+            port.reply(result);
+            continue;
+        }
+
+        if (msg.check("sigterm"))
+        {
+            std::string alias(msg.find("sigterm").asString());
+            yarp::os::Bottle result;
+            result.addString(mProcessVector.Signal(alias, SIGTERM)?"sigterm OK":"sigterm FAILED");
+            port.reply(result);
+            continue;
+        }
+
+        if (msg.check("sigtermall"))
+        {
+            mProcessVector.Killall(SIGTERM);
+            yarp::os::Bottle result;
+            result.addString("sigtermall OK");
+            port.reply(result);
+            continue;
+        }
+
+        if (msg.check("ps"))
+        {
+            yarp::os::Bottle result;
+            result.append(mProcessVector.PS());
+            port.reply(result);
+            continue;
+        }
+
+        if (msg.check("isrunning"))
+        {
+            std::string alias(msg.find("isrunning").asString());
+            yarp::os::Bottle result;
+            result.addString(mProcessVector.IsRunning(alias)?"running":"not running");
+            port.reply(result);
+            continue;
+        }
+
+        if (msg.check("killstdio"))
+        {
+            std::string alias(msg.find("killstdio").asString());
+            mStdioVector.Signal(alias, SIGTERM);
+            yarp::os::Bottle result;
+            result.addString("killstdio OK");
+            port.reply(result);
+            continue;
+        }
+
+////////////////////////////////////////////////////////////////////
+
+        if (msg.check("sysinfo"))
+        {
+            yarp::os::SystemInfoSerializer sysinfo;
+            port.reply(sysinfo);
+            continue;
+        }
+
+        if (msg.check("which"))
+        {
+            std::string fileName=msg.find("which").asString();
+            if (fileName!="")
+            {
+                yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::get_string("PATH"));
+                for (int i=0; i<possiblePaths.size(); ++i)
+                {
+                    std::string guessString=possiblePaths.get(i).asString() +
+                    std::string{slash} + fileName;
+                    const char* guess=guessString.c_str();
+                    if (fileExists (guess))
+                    {
+                        fileName= "\"" + std::string(guess) + "\"";
+                        break;
+                    }
+                }
+            }
+            yarp::os::Value fileNameWriter(fileName);
+            port.reply(fileNameWriter);
+            continue;
+        }
+
+        if (msg.check("exit"))
+        {
+            yInfo() << "Yarprun server closing...";
+            pServerPort=0;
+            yarp::os::Bottle result;
+            result.addString("exit OK");
+            port.reply(result);
+            port.close();
+        }
+    }
+
+
+    Run::mStdioVector.Killall(SIGTERM);
+
+    Run::mProcessVector.Killall(SIGTERM);
+
+    yInfo() << "Yarprun server closed";
+    return 0;
+}
+
+///////////////////////
+#else // LINUX SERVER
+///////////////////////
+
+void yarp::run::Run::cleanBeforeExec()
+{
+    // zombie hunter stop
+
+    //yarp::os::impl::signal(SIGPIPE, SIG_IGN);
+    //yarp::os::impl::signal(SIGCHLD, SIG_DFL);
+    //yarp::os::impl::signal(SIGINT, SIG_DFL);
+    //yarp::os::impl::signal(SIGTERM, SIG_DFL);
+
+    if (mProcessVector)
+    {
+        YarpRunInfoVector *p=mProcessVector;
+        mProcessVector = nullptr;
+        delete p;
+    }
+    if (mStdioVector)
+    {
+        YarpRunInfoVector *p=mStdioVector;
+        mStdioVector = nullptr;
+        delete p;
+    }
+    if (mBraveZombieHunter)
+    {
+        ZombieHunterThread *p=mBraveZombieHunter;
+        mBraveZombieHunter = nullptr;
+        p->stop();
+        delete p;
+    }
+
+    //yarp::os::Network::fini();
+}
+
+void yarp::run::Run::writeToPipe(int fd, std::string str)
+{
+    int len = str.length() + 1;
+    int ret;
+    ret = write(fd, &len, sizeof(len));
+    if (ret != sizeof(len)) {
+        fprintf(stderr, "Warning: could not write string length to pipe.\n");
+    }
+    ret = write(fd, str.c_str(), len);
+    if (ret != len) {
+        fprintf(stderr, "Warning: could not write string to pipe.\n");
+    }
+}
+
+int yarp::run::Run::readFromPipe(int fd, char* &data, int& buffsize)
+{
+    int len=0;
+    char* buff=(char*)&len;
+
+    for (int c=4, r=0; c>0; c-=r)
+    {
+        r=read(fd, buff, c);
+
+        if (r < 1) {
+            return -1;
+        }
+
+        buff+=r;
+    }
+
+    if (len <= 0) {
+        return 0;
+    }
+
+    if (len>buffsize)
+    {
+        delete [] data;
+        data=new char[buffsize=1024+(len/1024)*1024];
+    }
+
+    buff=data;
+
+    for (int c=len, r=0; c>0; c-=r)
+    {
+        r=read(fd, buff, c);
+
+        if (r < 1) {
+            return -1;
+        }
+
+        buff+=r;
+    }
+
+    return len;
+}
+
+static void sigchld_handler(int sig)
+{
+    YARP_UNUSED(sig);
+    if (yarp::run::Run::mBraveZombieHunter)
+    {
+        yarp::run::Run::mBraveZombieHunter->sigchldHandler();
+    }
+}
+
+int yarp::run::Run::server()
+{
+    int pipe_server2manager[2];
+    int pipe_manager2server[2];
+
+    if (yarp::run::impl::pipe(pipe_server2manager))
+    {
+        fprintf(stderr, "Can't open pipe because %s\n", strerror(errno));
+        fflush(stderr);
+
+        return YARPRUN_ERROR;
+    }
+
+    if (yarp::run::impl::pipe(pipe_manager2server))
+    {
+        fprintf(stderr, "Can't open pipe because %s\n", strerror(errno));
+        fflush(stderr);
+
+        return YARPRUN_ERROR;
+    }
+
+    int pid_process_manager=yarp::run::impl::fork();
+
+    if (IS_INVALID(pid_process_manager))
+    {
+        int error=errno;
+
+        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
+        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
+        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
+        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
+
+        fprintf(stderr, "Can't fork process manager because %s\n", strerror(error));
+        fflush(stderr);
+
+        return YARPRUN_ERROR;
+    }
+
+    if (IS_PARENT_OF(pid_process_manager))
+    {
+        yarp::os::impl::signal(SIGPIPE, SIG_IGN);
+
+        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
+        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
+
+        yarp::os::RpcServer port;
+
+        if (!port.open(mPortName))
+        {
+            yError() << "Yarprun failed to open port: " << mPortName.c_str();
+
+            if (mPortName[0] != '/') {
+                yError("Invalid port name '%s', it should start with '/'\n", mPortName.c_str());
+            }
+            return YARPRUN_ERROR;
+        }
+        yarp::os::Bottle cmd, reply;
+        cmd.addString("set");
+        cmd.addString(port.getName());
+        cmd.addString("yarprun");
+        cmd.addString("true");
+
+        yarp::os::impl::NameClient::getNameClient().send(cmd, reply);
+
+        yInfo() << "Yarprun successfully started on port: " << mPortName.c_str();
+
+        pServerPort=&port;
+
+        yarp::os::impl::signal(SIGINT, sigint_handler);
+        yarp::os::impl::signal(SIGTERM, sigint_handler);
+
+        int rsp_size=1024;
+        char *rsp_str=new char[rsp_size];
+
+        yarp::os::Bottle msg, response;
+
+        while (pServerPort)
+        {
+            RUNLOG("<<<port.read(msg, true)")
+            if (!port.read(msg, true)) {
+                break;
+            }
+            RUNLOG(">>>port.read(msg, true)")
+
+            if (!pServerPort) {
+                break;
+            }
+
+            if (msg.check("sysinfo"))
+            {
+                yarp::os::SystemInfoSerializer sysinfo;
+                port.reply(sysinfo);
+                continue;
+            }
+
+            if (msg.check("which"))
+            {
+                std::string fileName=msg.find("which").asString();
+                if (fileName!="")
+                {
+                    yarp::os::Bottle possiblePaths = parsePaths(yarp::conf::environment::get_string("PATH"));
+                    for (size_t i=0; i<possiblePaths.size(); ++i)
+                    {
+                        std::string guessString=possiblePaths.get(i).asString() + slash + fileName;
+                        const char* guess=guessString.c_str();
+                        if (fileExists (guess))
+                        {
+                            fileName = guess;
+                            break;
+                        }
+                    }
+                }
+                yarp::os::Value fileNameWriter(fileName);
+                port.reply(fileNameWriter);
+                continue;
+            }
+
+            if (msg.check("exit"))
+            {
+                pServerPort = nullptr;
+                yarp::os::Bottle result;
+                result.addString("exit OK");
+                port.reply(result);
+                port.close();
+                break;
+            }
+
+            RUNLOG("<<<writeToPipe")
+            writeToPipe(pipe_server2manager[WRITE_TO_PIPE], msg.toString());
+            RUNLOG(">>>writeToPipe")
+
+            RUNLOG("<<<readFromPipe")
+            int nread=readFromPipe(pipe_manager2server[READ_FROM_PIPE], rsp_str, rsp_size);
+            RUNLOG(">>>readFromPipe")
+
+            if (nread<0)
+            {
+                fprintf(stderr, "ERROR: broken pipe between server and manager\n");
+                fflush(stderr);
+                break;
+            }
+
+            if (nread)
+            {
+                response.fromString(rsp_str);
+                port.reply(response);
+            }
+        }
+
+        //yarp::os::Network::fini();
+
+        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
+        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
+
+        delete [] rsp_str;
+
+        return 0;
+    }
+
+    if (IS_NEW_PROCESS(pid_process_manager))
+    {
+        yarp::os::impl::signal(SIGPIPE, SIG_IGN);
+
+        CLOSE(pipe_server2manager[WRITE_TO_PIPE]);
+        CLOSE(pipe_manager2server[READ_FROM_PIPE]);
+
+        //yarp::os::Network::init();
+
+        mProcessVector=new YarpRunInfoVector;
+        mStdioVector=new YarpRunInfoVector;
+
+        mBraveZombieHunter=new ZombieHunterThread;
+        mBraveZombieHunter->start();
+
+        yarp::os::impl::signal(SIGCHLD, sigchld_handler);
+        //yarp::os::impl::signal(SIGINT, SIG_IGN);
+        //yarp::os::impl::signal(SIGTERM, SIG_IGN);
+
+        int msg_size=1024;
+        char *msg_str=new char[msg_size];
+
+        yarp::os::Bottle msg;
+
+        //while(readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size)>0)
+        while (true)
+        {
+            RUNLOG("<<<readFromPipe")
+            if (readFromPipe(pipe_server2manager[READ_FROM_PIPE], msg_str, msg_size) <= 0) {
+                break;
+            }
+            RUNLOG(">>>readFromPipe")
+
+            //printf("<<< %s >>>\n", msg_str);
+            //fflush(stdout);
+
+            msg.fromString(msg_str);
+
+            // command with stdio management
+            if (msg.check("stdio"))
+            {
+                std::string strOnPort=msg.find("on").asString();
+                std::string strStdioPort=msg.find("stdio").asString();
+
+                if (strOnPort==mPortName)
+                {
+                    std::string strUUID=mPortName+"/"+int2String(getpid())+"/"+msg.find("as").asString()+"-"+int2String(mProcCNT++);
+                    yarp::os::Bottle botUUID;
+                    botUUID.addString("stdiouuid");
+                    botUUID.addString(strUUID.c_str());
+                    msg.addList()=botUUID;
+
+                    if (mLogged || msg.check("log"))
+                    {
+                        std::string strAlias=msg.find("as").asString();
+                        std::string portName="/log";
+                        portName+=mPortName+"/";
+                        std::string command = msg.findGroup("cmd").get(1).asString();
+                        command = command.substr(0, command.find(' '));
+                        command = command.substr(command.find_last_of("\\/") + 1);
+                        portName+=command;
+
+                        yarp::os::Bottle botFwd;
+                        botFwd.addString("forward");
+                        botFwd.addString(portName.c_str());
+                        if (msg.check("log"))
+                        {
+                            yarp::os::Bottle botLogger=msg.findGroup("log");
+
+                            if (botLogger.size()>1)
+                            {
+                                botFwd.addString(botLogger.get(1).asString());
+                            }
+                            else
+                            {
+                                botFwd.addString(mLoggerPort);
+                            }
+                        }
+                        else
+                        {
+                            botFwd.addString(mLoggerPort);
+                        }
+                        msg.addList()=botFwd;
+
+                        yarp::os::ContactStyle style;
+                        style.persistent=true;
+                        yarp::os::Network::connect(portName, mLoggerPort, style);
+                    }
+
+                    yarp::os::Bottle cmdResult;
+                    if (executeCmdAndStdio(msg, cmdResult)>0)
+                    {
+                        if (strStdioPort==mPortName)
+                        {
+                            yarp::os::Bottle stdioResult;
+                            userStdio(msg, stdioResult);
+                            cmdResult.append(stdioResult);
+                        }
+                        else
+                        {
+                            cmdResult.append(sendMsg(msg, strStdioPort));
+                        }
+                    }
+
+                    RUNLOG("<<<writeToPipe")
+                    writeToPipe(pipe_manager2server[WRITE_TO_PIPE], cmdResult.toString());
+                    RUNLOG(">>>writeToPipe")
+                }
+                else
+                {
+                    yarp::os::Bottle stdioResult;
+                    userStdio(msg, stdioResult);
+                    RUNLOG("<<<writeToPipe")
+                    writeToPipe(pipe_manager2server[WRITE_TO_PIPE], stdioResult.toString());
+                    RUNLOG(">>>writeToPipe")
+                }
+
+                continue;
+            }
+
+            // without stdio
+            if (msg.check("cmd"))
+            {
+                yarp::os::Bottle cmdResult;
+
+                if (msg.check("log"))
+                {
+                    yarp::os::Bottle botLogger=msg.findGroup("log");
+
+                    if (botLogger.size()>1)
+                    {
+                        std::string loggerName=botLogger.get(1).asString();
+                        executeCmdStdout(msg, cmdResult, loggerName);
+                    }
+                    else
+                    {
+                       executeCmdStdout(msg, cmdResult, mLoggerPort);
+                    }
+                }
+                else if (mLogged)
+                {
+                    executeCmdStdout(msg, cmdResult, mLoggerPort);
+                }
+                else
+                {
+                    executeCmd(msg, cmdResult);
+                }
+
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], cmdResult.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("kill"))
+            {
+                std::string alias(msg.findGroup("kill").get(1).asString());
+                int sig=msg.findGroup("kill").get(2).asInt32();
+                yarp::os::Bottle result;
+                result.addString(mProcessVector->Signal(alias, sig)?"kill OK":"kill FAILED");
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("sigterm"))
+            {
+                std::string alias(msg.find("sigterm").asString());
+                yarp::os::Bottle result;
+                result.addString(mProcessVector->Signal(alias, SIGTERM)?"sigterm OK":"sigterm FAILED");
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("sigtermall"))
+            {
+                mProcessVector->Killall(SIGTERM);
+                yarp::os::Bottle result;
+                result.addString("sigtermall OK");
+
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("ps"))
+            {
+                yarp::os::Bottle result;
+                result.append(mProcessVector->PS());
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("isrunning"))
+            {
+                std::string alias(msg.find("isrunning").asString());
+                yarp::os::Bottle result;
+                result.addString(mProcessVector->IsRunning(alias)?"running":"not running");
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+
+            if (msg.check("killstdio"))
+            {
+                std::string alias(msg.find("killstdio").asString());
+                mStdioVector->Signal(alias, SIGTERM);
+                yarp::os::Bottle result;
+                result.addString("killstdio OK");
+                RUNLOG("<<<writeToPipe")
+                writeToPipe(pipe_manager2server[WRITE_TO_PIPE], result.toString());
+                RUNLOG(">>>writeToPipe")
+                continue;
+            }
+        }
+
+        mStdioVector->Killall(SIGTERM);
+
+        mProcessVector->Killall(SIGTERM);
+
+        if (mBraveZombieHunter)
+        {
+            mBraveZombieHunter->stop();
+            delete mBraveZombieHunter;
+            mBraveZombieHunter = nullptr;
+        }
+
+        delete mProcessVector;
+
+        delete mStdioVector;
+
+        //yarp::os::Network::fini();
+
+        CLOSE(pipe_server2manager[READ_FROM_PIPE]);
+        CLOSE(pipe_manager2server[WRITE_TO_PIPE]);
+
+        delete [] msg_str;
+    }
+
+    return 0;
+} // LINUX SERVER
+#endif

--- a/src/libYARP_run/src/yarp/run/RunServer.cpp
+++ b/src/libYARP_run/src/yarp/run/RunServer.cpp
@@ -39,20 +39,25 @@ namespace fs = yarp::conf::filesystem;
 constexpr auto sep = yarp::conf::environment::path_separator;
 constexpr fs::value_type slash = fs::preferred_separator;
 
-void sigint_handler(int sig)
+//This anonymous namespace make this symbol visible only
+//inside this translation unit.
+namespace
 {
-    YARP_UNUSED(sig);
-    yarp::run::Run::mStresstest=false;
-
-    if (yarp::run::Run::pServerPort)
+    void sigint_handler(int sig)
     {
-        yarp::os::RpcServer *pClose=yarp::run::Run::pServerPort;
-        yarp::run::Run::pServerPort = nullptr;
-        pClose->close();
+        YARP_UNUSED(sig);
+        yarp::run::Run::mStresstest=false;
+
+        if (yarp::run::Run::pServerPort)
+        {
+            yarp::os::RpcServer *pClose=yarp::run::Run::pServerPort;
+            yarp::run::Run::pServerPort = nullptr;
+            pClose->close();
+        }
+        //else
+        //{
+        //}
     }
-    //else
-    //{
-    //}
 }
 
 static yarp::os::Bottle parsePaths(const std::string& txt)

--- a/src/libYARP_run/tests/RunTest.cpp
+++ b/src/libYARP_run/tests/RunTest.cpp
@@ -71,7 +71,7 @@ public:
 
 TEST_CASE("run::RunTest", "[yarp::run]")
 {
-    NetworkBase::setLocalMode(false);
+    NetworkBase::setLocalMode(true);
 
     SECTION("testRun")
     {

--- a/src/libYARP_run/tests/RunTest.cpp
+++ b/src/libYARP_run/tests/RunTest.cpp
@@ -58,7 +58,9 @@ public:
     }
 
     void stop()
-    {}
+    {
+        Thread::stop();
+    }
 
     void run() override
     {
@@ -69,15 +71,10 @@ public:
 
 TEST_CASE("run::RunTest", "[yarp::run]")
 {
-
-#if !defined(ENABLE_BROKEN_TESTS)
-    YARP_SKIP_TEST("Skipping YARP_run broken tests")
-#endif
+    NetworkBase::setLocalMode(false);
 
     SECTION("testRun")
     {
-        //this could be local or using an external nameserver, to be decided
-        Network::setLocalMode(true);
         YarpRun runner;
 
         INFO("checking yarprun");
@@ -89,20 +86,83 @@ TEST_CASE("run::RunTest", "[yarp::run]")
         argv[2]="/run";
 
         runner.start(argc, (char**)argv);
+        Time::delay(4);
+        bool ret = true;
 
-        Time::delay(3);
-        Property par;
-        par.put("name", "testModule");
+        ret = yarp::run::Run::isRunning("/run", "should_fail");
+        CHECK(!ret);
 
+        //start a process
+        std::string str1 = "test_module1";
+        Property par1;
+        par1.put("name", "testModule");
+        ret = yarp::run::Run::start("/run", par1, str1);
+        CHECK(ret);
 
-        std::string moduleTag="test_module";
-        yarp::run::Run::start("/run", par, moduleTag);
+        yarp::os::Time::delay(1);
 
-        Time::delay(1);
+        // start another process
+        std::string str2 = "test_module2";
+        Property par2;
+        par2.put("name", "testModule");
+        ret = yarp::run::Run::start("/run", par2, str2);
+        CHECK(ret);
 
-        bool isRunning=yarp::run::Run::isRunning("/run", moduleTag);
-        CHECK(isRunning); // isRunning
+        yarp::os::Time::delay(1);
+
+        // check if the processes are running
+        ret = yarp::run::Run::isRunning("/run", "test_module1");
+        CHECK(ret);
+
+        ret = yarp::run::Run::isRunning("/run", "test_module2");
+        CHECK(ret);
+
+        ret = yarp::run::Run::isRunning("/run", "nonExistingTag");
+        CHECK(!ret);
+
+        // now we have 2 processes running
+        std::vector<yarp::run::Run::processInfo> processes;
+        ret = yarp::run::Run::ps("/run",processes);
+        CHECK(processes.size()==2);
+        CHECK(ret);
+
+        //stop 1 process
+        ret = yarp::run::Run::sigterm("/run", "test_module1");
+        CHECK(ret);
+
+        yarp::os::Time::delay(1);
+
+        // now we have only 1 process running
+        std::vector<yarp::run::Run::processInfo> allprocessesclosed1;
+        ret = yarp::run::Run::ps("/run",allprocessesclosed1);
+        CHECK(allprocessesclosed1.size()==1);
+
+        // stop all processes
+        ret = yarp::run::Run::sigtermall("/run");
+        CHECK(ret);
+
+        yarp::os::Time::delay(1);
+
+        // now we have no processes running
+        std::vector<yarp::run::Run::processInfo> allprocessesclosed0;
+        ret = yarp::run::Run::ps("/run",allprocessesclosed0);
+        CHECK(allprocessesclosed0.size()==0);
+        CHECK(ret);
+
+        // check system info
+        yarp::os::SystemInfoSerializer info;
+        ret = yarp::run::Run::sysinfo("/run", info);
+        CHECK(info.memory.totalSpace!=0);
+        CHECK(ret);
+
+        // terminate the server
+        ret = yarp::run::Run::exit("/run");
+        CHECK(ret);
+
         fprintf(stderr, "done!\n");
-        Network::setLocalMode(false);
+
+        runner.stop();
     }
+
+    NetworkBase::setLocalMode(false);
 }

--- a/src/libYARP_run/tests/module.cpp
+++ b/src/libYARP_run/tests/module.cpp
@@ -29,6 +29,14 @@ public:
         count++;
         printf("[%d] updateModule\n", count);
 
+        /*
+        // Use this to make the module quit after 60 seconds
+        if (count == 60)
+        {
+           return false;
+        }
+        */
+
         return true;
     }
 


### PR DESCRIPTION
This PR improves the yarpmanager console refresh logic.
When refreshing multiple modules running on the same yarprun server, the client now requests the list of running processes only once per server, instead of issuing one request per module. This makes the refresh operation more efficient, significantly reducing the number of calls and the overall time required to update the console state.