### PR TITLE
fixed YARP_COMPILE_GUIS option

### DIFF
--- a/cmake/YarpFindDependencies.cmake
+++ b/cmake/YarpFindDependencies.cmake
@@ -511,7 +511,7 @@ yarp_dependent_option(
 
 yarp_dependent_option(
   YARP_COMPILE_GUIS "Do you want to compile GUIs" ON
-  "YARP_COMPILE_EXECUTABLES;YARP_HAS_Qt5" OFF
+  "YARP_COMPILE_EXECUTABLES" OFF
 )
 yarp_renamed_option(CREATE_GUIS YARP_COMPILE_GUIS) # Deprecated since YARP 3.2
 

--- a/src/devices/fake/fakeFrameGrabber/FakeFrameGrabber_Utils.cpp
+++ b/src/devices/fake/fakeFrameGrabber/FakeFrameGrabber_Utils.cpp
@@ -22,7 +22,7 @@ using namespace yarp::sig::draw;
 namespace {
 YARP_LOG_COMPONENT(FAKEFRAMEGRABBER, "yarp.device.fakeFrameGrabber")
 
-//the following data are used by [time] test
+//the following data are used by `time` test
 constexpr char num[12][16]
 {
     // '0'
@@ -186,7 +186,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
         m_bx = image.width()-1;
     }
 
-    if (m_mode == "[Time]")
+    if (m_mode == "Time")
     {
         {
             if (m_have_bg) {
@@ -205,7 +205,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[ball]")
+    else if (m_mode == "ball")
     {
         {
             if (m_have_bg) {
@@ -234,7 +234,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[grid]")
+    else if (m_mode == "grid")
     {
         {
             size_t ww = image.width();
@@ -254,7 +254,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[size]")
+    else if (m_mode == "size")
     {
         static int count = 0;
         count++;
@@ -291,7 +291,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[line]")
+    else if (m_mode == "line")
     {
         {
             if (m_have_bg) {
@@ -304,7 +304,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[rand]")
+    else if (m_mode == "rand")
     {
         {
             static unsigned char r = 128;
@@ -326,7 +326,7 @@ void FakeFrameGrabber::createTestImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& 
             }
         }
     }
-    else if (m_mode == "[none]")
+    else if (m_mode == "none")
     {
         {
             if (m_have_bg) {


### PR DESCRIPTION
Fixed YARP_COMPILE_GUIS options, it can now be enabled even without QT.
(There exist OpenCV-based GUIs which do not require QT)