### PR TITLE
FrameGrabberControls: propagate device operation results for SET RPCs

### DIFF
--- a/doc/release/yarp_3_12/fix_framegrabbercontrols_setfeature_ack.md
+++ b/doc/release/yarp_3_12/fix_framegrabbercontrols_setfeature_ack.md
@@ -1,0 +1,12 @@
+fix_framegrabbercontrols_setfeature_ack {#yarp_3_12}
+-----------------------
+
+## Devices
+
+### `frameGrabber_nwc_yarp`, `RGBDSensorClient`
+
+* Fixed `FrameGrabberControls_Responder`/`Forwarder` silently reporting RPC
+  transport success instead of the underlying device operation result for
+  `setFeature`, `setActive`, `setMode`, and `setOnePush`. These calls now
+  correctly return `false` when the device rejects the request, matching
+  the existing `RgbVisualParams`/`DepthVisualParams` behavior (#3352).

--- a/src/devices/messages/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.cpp
+++ b/src/devices/messages/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Forwarder.cpp
@@ -56,7 +56,8 @@ bool FrameGrabberControls_Forwarder::setFeature(int feature, double value)
     cmd.addVocab32(VOCAB_FEATURE);
     cmd.addInt32(feature);
     cmd.addFloat64(value);
-    return m_port.write(cmd, response);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
 }
 
 bool FrameGrabberControls_Forwarder::setFeature(int feature, double value1, double value2)
@@ -69,7 +70,8 @@ bool FrameGrabberControls_Forwarder::setFeature(int feature, double value1, doub
     cmd.addInt32(feature);
     cmd.addFloat64(value1);
     cmd.addFloat64(value2);
-    return m_port.write(cmd, response);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
 }
 
 bool FrameGrabberControls_Forwarder::getFeature(int feature, double* value)
@@ -124,7 +126,8 @@ bool FrameGrabberControls_Forwarder::setActive(int feature, bool onoff)
     cmd.addVocab32(VOCAB_ACTIVE);
     cmd.addInt32(feature);
     cmd.addInt32(onoff);
-    return m_port.write(cmd, response);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
 }
 
 bool FrameGrabberControls_Forwarder::getActive(int feature, bool* isActive)
@@ -192,7 +195,8 @@ bool FrameGrabberControls_Forwarder::setMode(int feature, FeatureMode mode)
     cmd.addVocab32(VOCAB_MODE);
     cmd.addInt32(feature);
     cmd.addInt32(mode);
-    return m_port.write(cmd, response);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
 }
 
 bool FrameGrabberControls_Forwarder::getMode(int feature, FeatureMode* mode)
@@ -217,5 +221,6 @@ bool FrameGrabberControls_Forwarder::setOnePush(int feature)
     cmd.addVocab32(VOCAB_SET);
     cmd.addVocab32(VOCAB_ONEPUSH);
     cmd.addInt32(feature);
-    return m_port.write(cmd, response);
+    m_port.write(cmd, response);
+    return response.get(2).asBool();
 }

--- a/src/devices/messages/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.cpp
+++ b/src/devices/messages/framegrabber_protocol/yarp/proto/framegrabber/FrameGrabberControls_Responder.cpp
@@ -96,22 +96,37 @@ bool FrameGrabberControls_Responder::respond(const yarp::os::Bottle& cmd, yarp::
         switch (param) {
         case VOCAB_FEATURE: {
             ok = fgCtrl->setFeature(cmd.get(3).asInt32(), cmd.get(4).asFloat64());
+            response.addVocab32(VOCAB_FRAMEGRABBER_CONTROL);
+            response.addVocab32(VOCAB_SET);
+            response.addInt32(ok);
         } break;
 
         case VOCAB_FEATURE2: {
             ok = fgCtrl->setFeature(cmd.get(3).asInt32(), cmd.get(4).asFloat64(), cmd.get(5).asFloat64());
+            response.addVocab32(VOCAB_FRAMEGRABBER_CONTROL);
+            response.addVocab32(VOCAB_SET);
+            response.addInt32(ok);
         } break;
 
         case VOCAB_ACTIVE: {
             ok = fgCtrl->setActive(cmd.get(3).asInt32(), cmd.get(4).asInt32());
+            response.addVocab32(VOCAB_FRAMEGRABBER_CONTROL);
+            response.addVocab32(VOCAB_SET);
+            response.addInt32(ok);
         } break;
 
         case VOCAB_MODE: {
             ok = fgCtrl->setMode(cmd.get(3).asInt32(), static_cast<FeatureMode>(cmd.get(4).asInt32()));
+            response.addVocab32(VOCAB_FRAMEGRABBER_CONTROL);
+            response.addVocab32(VOCAB_SET);
+            response.addInt32(ok);
         } break;
 
         case VOCAB_ONEPUSH: {
             ok = fgCtrl->setOnePush(cmd.get(3).asInt32());
+            response.addVocab32(VOCAB_FRAMEGRABBER_CONTROL);
+            response.addVocab32(VOCAB_SET);
+            response.addInt32(ok);
         } break;
 
         default:

--- a/src/devices/networkWrappers/frameGrabber_nwc_yarp/tests/frameGrabber_nwc_yarp_test.cpp
+++ b/src/devices/networkWrappers/frameGrabber_nwc_yarp/tests/frameGrabber_nwc_yarp_test.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IRgbVisualParams.h>
 
@@ -83,6 +84,20 @@ void do_nws_nwc_test(bool use_stream)
 
     yarp::dev::tests::exec_IFrameGrabberImage_test_1(igrabber);
     yarp::dev::tests::exec_IRgbVisualParams_test_1(irgbParams);
+
+    {
+        // fakeFrameGrabber::setFeature() unconditionally returns false: this checks that
+        // the nwc/nws RPC round trip actually propagates that failure back to the caller,
+        // instead of reporting success just because the RPC transport completed.
+        yarp::dev::IFrameGrabberControls* ictrl = nullptr;
+        REQUIRE(dd_nwc.view(ictrl));
+        REQUIRE(ictrl);
+        CHECK(ictrl->setFeature(0, 1.0) == false);
+        CHECK(ictrl->setFeature(0, 1.0, 1.0) == false);
+        CHECK(ictrl->setActive(0, true) == false);
+        CHECK(ictrl->setMode(0, MODE_MANUAL) == false);
+        CHECK(ictrl->setOnePush(0) == false);
+    }
 
     yarp::os::SystemClock::delaySystem(0.5);
 


### PR DESCRIPTION
### Description
`FrameGrabberControls_Responder`/`Forwarder` (the RPC pair backing
`setFeature`, `setActive`, `setMode`, `setOnePush` on `IFrameGrabberControls`)
currently discards the real result of the underlying device call:

- `FrameGrabberControls_Responder::respond()` computes `ok` from the actual
  device call (e.g. `fgCtrl->setFeature(...)`), but never writes it into the
  response `Bottle` for `VOCAB_SET` commands.
- `FrameGrabberControls_Forwarder::setFeature()` (and `setFeature2`,
  `setActive`, `setMode`, `setOnePush`) return `m_port.write(cmd, response)`
  directly, which reflects "did the RPC round-trip complete," not "did the
  device accept the request."

**Net effect:** these calls return the success of the RPC transport rather
than the result of the underlying device operation.

| Scenario                | Before  | After   |
|-------------------------|---------|---------|
| Device returns `true`   | `true`  | `true`  |
| Device returns `false`  | `true`  | `false` |

The sibling protocols in the same family, `RgbVisualParams` and
`DepthVisualParams` (`setRgbResolution`, `setRgbFOV`, `setRgbMirroring`,
`setDepthResolution`, etc.), already encode and read back the real result
correctly. This PR brings `FrameGrabberControls` in line with that existing,
working pattern with no new protocol convention is introduced.

### Testing
- `harness_device_frameGrabber_nwc_yarp`: all 170 assertions pass (both RPC
  and streaming-mode sections); confirmed 10 of them fail without this fix
  (reverted the fix, rebuilt, reran all 5 new assertions failed with
  `true == false`).
- `harness_device_RGBDSensorClient`: all 12 assertions pass unchanged.

### Why
Fixes #3352. 

This issue does not affect `master`, where the protocol has already been
replaced by the Thrift/`ReturnValue` implementation introduced in #3184.

### Changes
- `FrameGrabberControls_Responder.cpp`: each `VOCAB_SET` case now adds
  `[VOCAB_FRAMEGRABBER_CONTROL, VOCAB_SET, ok]` to the response, matching
  `RgbVisualParams_Responder`'s convention exactly.
- `FrameGrabberControls_Forwarder.cpp`: `setFeature`, `setFeature` (2-arg),
  `setActive`, `setMode`, `setOnePush` now read `response.get(2).asBool()`
  instead of returning transport-write success.
- Added a regression test in `frameGrabber_nwc_yarp_test.cpp` asserting these
  five calls return `false` when talking to `fakeFrameGrabber` (whose stub
  implementations of these methods always return `false`).

### Compatibility note
This changes the wire response shape for `VOCAB_SET` framegrabber-control
commands from empty to a 3-element Bottle. The only in-tree consumers of
`FrameGrabberControls_Forwarder` are `RGBDSensorClient` and
`frameGrabber_nwc_yarp`, both updated/tested together here. Any out-of-tree
client communicating directly with this RPC protocol (rather than using
`FrameGrabberControls_Forwarder`) may need to account for the updated
response shape.