### PR TITLE
Thrift generator fix

### DIFF
--- a/doc/release/master.md
+++ b/doc/release/master.md
@@ -1,0 +1,11 @@
+YARP <yarp-4.1.0> (UNRELEASED)                                         {#yarp_4_1_0}
+============================
+
+[TOC]
+
+YARP <yarp-4.1.0> Release Notes
+=============================
+
+
+A (partial) list of bug fixed and issues resolved in this release can be found
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-4.1.0%22).

--- a/doc/release/yarp_4_0/000_yarp_4_0.md
+++ b/doc/release/yarp_4_0/000_yarp_4_0.md
@@ -1,0 +1,17 @@
+YARP <yarp-4.0.1> (UNRELEASED)                                         {#yarp_4_0_1}
+============================
+
+[TOC]
+
+YARP <yarp-4.0.1> Release Notes
+=============================
+
+
+A (partial) list of bug fixed and issues resolved in this release can be found
+[here](https://github.com/robotology/yarp/issues?q=label%3A%22Fixed+in%3A+YARP+yarp-4.0.1%22).
+
+## Commands
+
+### `yarpidl_thrift`
+
+* Fixes issue preventing the correct generation of .thrift messages containing complex data type, e.g. list<list<double>> etc.

--- a/doc/release/yarp_4_0/README.md_template
+++ b/doc/release/yarp_4_0/README.md_template
@@ -1,0 +1,14 @@
+This is a placeholder.
+
+Please add in this folder a `.md` file for each branch, pull request or
+important change targeting the relative branch.
+This file will be not included in the documentation (intentionally) because it is not a .md/.dox file.
+
+Each file should have this format
+
+```
+branch_name {#yarp_4_0}
+-----------
+
+* Branch changes
+```

--- a/src/commands/yarpidl_thrift/src/t_yarp_generator.cc
+++ b/src/commands/yarpidl_thrift/src/t_yarp_generator.cc
@@ -48,6 +48,7 @@ class t_yarp_generator : public t_oop_generator
     bool need_common_{false}; //are there consts and typedef that we need to keep in a common file?
     int indent_h_{0};
     int indent_cpp_{0};
+    int nest_level_{0}; // tracks container nesting depth to avoid loop-variable name collisions
 
     // Files
     ofstream_with_content_based_conditional_update f_out_common_;
@@ -436,9 +437,17 @@ std::string t_yarp_generator::type_to_enum(t_type* type)
     } else if (type->is_map()) {
         return "BOTTLE_TAG_LIST";
     } else if (type->is_set()) {
-        return "BOTTLE_TAG_LIST | " + type_to_enum(static_cast<t_set*>(type)->get_elem_type());
+        auto* elem = static_cast<t_set*>(type)->get_elem_type();
+        if (is_complex_type(elem)) {
+            return "BOTTLE_TAG_LIST";
+        }
+        return "BOTTLE_TAG_LIST | " + type_to_enum(elem);
     } else if (type->is_list()) {
-        return "BOTTLE_TAG_LIST | " + type_to_enum(static_cast<t_list*>(type)->get_elem_type());
+        auto* elem = static_cast<t_list*>(type)->get_elem_type();
+        if (is_complex_type(elem)) {
+            return "BOTTLE_TAG_LIST";
+        }
+        return "BOTTLE_TAG_LIST | " + type_to_enum(elem);
     } else if (type->is_xception()) {
         return "::apache::thrift::protocol::T_STRUCT";
     }
@@ -1307,7 +1316,7 @@ void t_yarp_generator::generate_serialize_container(std::ostringstream& f_cpp_,
     } else if (ttype->is_list()) {
         auto* elem_type = static_cast<t_list*>(ttype)->get_elem_type();
         f_cpp_ << indent_cpp() << "if (!writer.writeListBegin("
-                        << type_to_enum(elem_type)
+                        << (get_true_type(elem_type)->is_container() ? "BOTTLE_TAG_LIST" : type_to_enum(elem_type))
                         << ", "
                         << name
                         << ".size()))"
@@ -1576,6 +1585,12 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
 {
     THRIFT_DEBUG_COMMENT(f_cpp_);
 
+    // Use a nesting-depth-specific loop variable name to avoid shadowing
+    // an outer container's loop variable when this container is nested
+    // (e.g. list<map<...>>, map<..., list<...>>, etc.), which would cause
+    // the outer index embedded in "name" to resolve to the wrong variable.
+    const std::string _i_var = "_i" + std::to_string(nest_level_++);
+
     if (ttype->is_map())
     {
         // Begin scope of _csize
@@ -1589,7 +1604,7 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
         f_cpp_ << indent_cpp() << "reader.readMapBegin(_ktype, _vtype, _csize);\n";
 
         // For loop iterates over elements
-        f_cpp_ << indent_cpp() << "for (size_t _i = 0; _i < _csize; ++_i) {\n";
+        f_cpp_ << indent_cpp() << "for (size_t " << _i_var << " = 0; " << _i_var << " < _csize; ++" << _i_var << ") {\n";
         indent_up_cpp();
         {
             generate_deserialize_map_element(f_cpp_, static_cast<t_map*>(ttype), name);
@@ -1615,7 +1630,7 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
         f_cpp_ << indent_cpp() << "reader.readSetBegin(_etype, _csize);\n";
 
         // For loop iterates over elements
-        f_cpp_ << indent_cpp() << "for (size_t _i = 0; _i < _csize; ++_i) {\n";
+        f_cpp_ << indent_cpp() << "for (size_t " << _i_var << " = 0; " << _i_var << " < _csize; ++" << _i_var << ") {\n";
         indent_up_cpp();
         {
             generate_deserialize_set_element(f_cpp_, static_cast<t_set*>(ttype), name);
@@ -1634,7 +1649,9 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
     {
         t_container* tcontainer = static_cast<t_container*>(ttype);
         auto* elem_type = static_cast<t_list*>(ttype)->get_elem_type();
-        bool use_push = tcontainer->has_cpp_name() || (static_cast<t_base_type*>(elem_type)->get_base() == t_base_type::TYPE_BOOL);
+        bool use_push = tcontainer->has_cpp_name() ||
+                        (elem_type->is_base_type() &&
+                         static_cast<t_base_type*>(elem_type)->get_base() == t_base_type::TYPE_BOOL);
 
         // Begin scope of _csize
         f_cpp_ << indent_cpp() << "{\n";
@@ -1652,7 +1669,7 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
         // and skip the check if the remaining string is empty, but this is
         // less error prone, and the check is performed at compile time anyway
         f_cpp_ << indent_cpp() << "// WireReader removes BOTTLE_TAG_LIST from the tag\n";
-        f_cpp_ << indent_cpp() << "constexpr int expected_tag = ((" << type_to_enum(elem_type) << ") & (~BOTTLE_TAG_LIST));\n";
+        f_cpp_ << indent_cpp() << "constexpr int expected_tag = ((" << (get_true_type(elem_type)->is_container() ? "BOTTLE_TAG_LIST" : type_to_enum(elem_type)) << ") & (~BOTTLE_TAG_LIST));\n";
         f_cpp_ << indent_cpp() << "if constexpr (expected_tag != 0) {\n";
         indent_up_cpp();
         {
@@ -1683,10 +1700,10 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
                 f_cpp_ << indent_cpp() << name << ".resize(_csize);\n";
             }
 
-            f_cpp_ << indent_cpp() << "for (size_t _i = 0; _i < _csize; ++_i) {\n";
+            f_cpp_ << indent_cpp() << "for (size_t " << _i_var << " = 0; " << _i_var << " < _csize; ++" << _i_var << ") {\n";
             indent_up_cpp();
             {
-                generate_deserialize_list_element(f_cpp_, static_cast<t_list*>(ttype), name, use_push, name + "[_i]");
+                generate_deserialize_list_element(f_cpp_, static_cast<t_list*>(ttype), name, use_push, name + "[" + _i_var + "]");
             }
             indent_down_cpp();
             f_cpp_ << indent_cpp() << "}\n";
@@ -1699,6 +1716,8 @@ void t_yarp_generator::generate_deserialize_container(std::ostringstream& f_cpp_
         indent_down_cpp();
         f_cpp_ << indent_cpp() << "}\n";
     }
+
+    --nest_level_;
 }
 
 void t_yarp_generator::generate_deserialize_map_element(std::ostringstream& f_cpp_,

--- a/src/commands/yarpidl_thrift/tests/test1/demo1/demo.thrift
+++ b/src/commands/yarpidl_thrift/tests/test1/demo1/demo.thrift
@@ -79,7 +79,15 @@ struct TestSomeLists {
   5: list<i64> a_list_of_i64,
   6: list<double> a_list_of_double,
   7: list<string> a_list_of_string,
-  8: list<binary> a_list_of_binary
+  8: list<binary> a_list_of_binary,
+  9: list<list<double>> a_list_of_list_of_double
+  10: list<list<list<double>>> a_list_of_list_of_list_of_double
+}
+
+struct TestSomeMaps {
+  1: map<string, list<double>> a_map_of_list_of_double,
+  2: map<string, list<list<double>>> a_map_of_list_of_list_of_double,
+  3: list<map<string, double>> a_list_of_maps_of_doubles
 }
 
 /**

--- a/src/commands/yarpidl_thrift/tests/test2/demo/demo.thrift
+++ b/src/commands/yarpidl_thrift/tests/test2/demo/demo.thrift
@@ -79,7 +79,15 @@ struct TestSomeLists {
   5: list<i64> a_list_of_i64,
   6: list<double> a_list_of_double,
   7: list<string> a_list_of_string,
-  8: list<binary> a_list_of_binary
+  8: list<binary> a_list_of_binary,
+  9: list<list<double>> a_list_of_list_of_double
+  10: list<list<list<double>>> a_list_of_list_of_list_of_double
+}
+
+struct TestSomeMaps {
+  1: map<string, list<double>> a_map_of_list_of_double,
+  2: map<string, list<list<double>>> a_map_of_list_of_list_of_double,
+  3: list<map<string, double>> a_list_of_maps_of_doubles
 }
 
 /**

--- a/src/commands/yarpidl_thrift/tests/test2/demo/main.cpp
+++ b/src/commands/yarpidl_thrift/tests/test2/demo/main.cpp
@@ -13,6 +13,7 @@
 #include <TestAnnotatedTypes.h>
 #include <TestSomeMoreTypes.h>
 #include <TestSomeLists.h>
+#include <TestSomeMaps.h>
 #if defined(THRIFT_INCLUDE_PREFIX) && defined(THRIFT_NO_NAMESPACE_PREFIX)
 # include <sub/directory/ClockServer.h>
 #elif defined(THRIFT_INCLUDE_PREFIX)
@@ -818,8 +819,10 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         a.a_i64 = 64;
         a.a_double = 0.64;
         a.a_string = "A string";
-        tmp.read(a);
-        tmp.write(b);
+
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
+
         CHECK(a.a_bool == b.a_bool);
         CHECK(a.a_i16 == b.a_i16);
         CHECK(a.a_i32 == b.a_i32);
@@ -850,8 +853,12 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         memset(a.a_list_of_binary[1].data(), 0, a.a_list_of_binary[1].size());
         a.a_list_of_binary[1][a.a_list_of_binary[1].size() - 1] = 'D';
 
-        tmp.read(a);
-        tmp.write(b);
+        a.a_list_of_list_of_double.resize(2);
+        a.a_list_of_list_of_double[0] = std::vector<double>({-0.64, 0.64});
+        a.a_list_of_list_of_double[1] = std::vector<double>({-0.32, 0.32});
+
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
 
         CHECK(b.a_list_of_bool.size() == a.a_list_of_bool.size());
         CHECK(b.a_list_of_bool[0]   == a.a_list_of_bool[0]);
@@ -879,6 +886,64 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         CHECK(b.a_list_of_binary[1].size() == 12);
         CHECK(b.a_list_of_binary[0][5] == 'C');
         CHECK(b.a_list_of_binary[1][11] == 'D');
+
+        CHECK(b.a_list_of_list_of_double.size() == a.a_list_of_list_of_double.size());
+        CHECK(b.a_list_of_list_of_double[0].size() == a.a_list_of_list_of_double[0].size());
+        CHECK(b.a_list_of_list_of_double[0][0] == a.a_list_of_list_of_double[0][0]);
+        CHECK(b.a_list_of_list_of_double[0][1] == a.a_list_of_list_of_double[0][1]);
+        CHECK(b.a_list_of_list_of_double[1].size() == a.a_list_of_list_of_double[1].size());
+        CHECK(b.a_list_of_list_of_double[1][0] == a.a_list_of_list_of_double[1][0]);
+        CHECK(b.a_list_of_list_of_double[1][1] == a.a_list_of_list_of_double[1][1]);
+    }
+
+    SECTION("test some maps")
+    {
+        TestSomeMaps a;
+        TestSomeMaps b;
+        Bottle tmp;
+
+        a.a_map_of_list_of_double["first"] = std::vector<double>({-0.64, 0.64});
+        a.a_map_of_list_of_double["second"] = std::vector<double>({-0.32, 0.32});
+        a.a_map_of_list_of_list_of_double["first"].push_back(std::vector<double>({-0.16, 0.16}));
+        a.a_map_of_list_of_list_of_double["first"].push_back(std::vector<double>({-0.08, 0.08}));
+        a.a_map_of_list_of_list_of_double["second"].push_back(std::vector<double>({-0.04, 0.04}));
+        a.a_map_of_list_of_list_of_double["second"].push_back(std::vector<double>({-0.02, 0.02}));
+
+        a.a_list_of_maps_of_doubles.push_back(std::map<std::string, double>({{"0first", 0.1}, {"0second", 0.2}}));
+        a.a_list_of_maps_of_doubles.push_back(std::map<std::string, double>({{"1first", 1.1}, {"1second", 1.2}}));
+
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
+
+        CHECK(b.a_map_of_list_of_double.size() == a.a_map_of_list_of_double.size());
+        CHECK(b.a_map_of_list_of_double["first"].size() == a.a_map_of_list_of_double["first"].size());
+        CHECK(b.a_map_of_list_of_double["first"][0] == a.a_map_of_list_of_double["first"][0]);
+        CHECK(b.a_map_of_list_of_double["first"][1] == a.a_map_of_list_of_double["first"][1]);
+        CHECK(b.a_map_of_list_of_double["second"].size() == a.a_map_of_list_of_double["second"].size());
+        CHECK(b.a_map_of_list_of_double["second"][0] == a.a_map_of_list_of_double["second"][0]);
+        CHECK(b.a_map_of_list_of_double["second"][1] == a.a_map_of_list_of_double["second"][1]);
+
+        CHECK(b.a_map_of_list_of_list_of_double.size() == a.a_map_of_list_of_list_of_double.size());
+        CHECK(b.a_map_of_list_of_list_of_double["first"].size() == a.a_map_of_list_of_list_of_double["first"].size());
+        CHECK(b.a_map_of_list_of_list_of_double["first"][0].size() == a.a_map_of_list_of_list_of_double["first"][0].size());
+        CHECK(b.a_map_of_list_of_list_of_double["first"][0][0] == a.a_map_of_list_of_list_of_double["first"][0][0]);
+        CHECK(b.a_map_of_list_of_list_of_double["first"][0][1] == a.a_map_of_list_of_list_of_double["first"][0][1]);
+        CHECK(b.a_map_of_list_of_list_of_double["first"][1].size() == a.a_map_of_list_of_list_of_double["first"][1].size());
+        CHECK(b.a_map_of_list_of_list_of_double["first"][1][0] == a.a_map_of_list_of_list_of_double["first"][1][0]);
+        CHECK(b.a_map_of_list_of_list_of_double["first"][1][1] == a.a_map_of_list_of_list_of_double["first"][1][1]);
+        CHECK(b.a_map_of_list_of_list_of_double["second"].size() == a.a_map_of_list_of_list_of_double["second"].size());
+        CHECK(b.a_map_of_list_of_list_of_double["second"][0].size() == a.a_map_of_list_of_list_of_double["second"][0].size());
+        CHECK(b.a_map_of_list_of_list_of_double["second"][0][0] == a.a_map_of_list_of_list_of_double["second"][0][0]);
+        CHECK(b.a_map_of_list_of_list_of_double["second"][0][1] == a.a_map_of_list_of_list_of_double["second"][0][1]);
+        CHECK(b.a_map_of_list_of_list_of_double["second"][1].size() == a.a_map_of_list_of_list_of_double["second"][1].size());
+        CHECK(b.a_map_of_list_of_list_of_double["second"][1][0] == a.a_map_of_list_of_list_of_double["second"][1][0]);
+        CHECK(b.a_map_of_list_of_list_of_double["second"][1][1] == a.a_map_of_list_of_list_of_double["second"][1][1]);
+
+        CHECK(b.a_list_of_maps_of_doubles.size() == a.a_list_of_maps_of_doubles.size());
+        CHECK(b.a_list_of_maps_of_doubles[0]["0first"] == a.a_list_of_maps_of_doubles[0]["0first"]);
+        CHECK(b.a_list_of_maps_of_doubles[0]["0second"] == a.a_list_of_maps_of_doubles[0]["0second"]);
+        CHECK(b.a_list_of_maps_of_doubles[1]["1first"] == a.a_list_of_maps_of_doubles[1]["1first"]);
+        CHECK(b.a_list_of_maps_of_doubles[1]["1second"] == a.a_list_of_maps_of_doubles[1]["1second"]);
     }
 
     SECTION("test lists with previous data")
@@ -920,8 +985,8 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         memset(b.a_list_of_binary[2].data(), 0, b.a_list_of_binary[2].size());
         b.a_list_of_binary[2][b.a_list_of_binary[2].size() - 1] = 'G';
 
-        tmp.read(a);
-        tmp.write(b);
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
 
         CHECK(b.a_list_of_bool.size() == a.a_list_of_bool.size());
         CHECK(b.a_list_of_bool[0]   == a.a_list_of_bool[0]);
@@ -973,8 +1038,8 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         memset(b.a_list_of_binary[1].data(), 0, b.a_list_of_binary[1].size());
         b.a_list_of_binary[1][b.a_list_of_binary[1].size() - 1] = 'D';
 
-        tmp.read(a);
-        tmp.write(b);
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
 
         CHECK(b.a_list_of_bool.empty());
         CHECK(b.a_list_of_i8.empty());
@@ -999,8 +1064,10 @@ TEST_CASE("IdlThriftTest", "[yarp::idl::thrift]")
         a.a_float32 = 0.32;
         a.a_float64 = 0.64;
         a.a_size = sizeof(TestAnnotatedTypes);
-        tmp.read(a);
-        tmp.write(b);
+
+        REQUIRE(tmp.read(a));
+        REQUIRE(tmp.write(b));
+
         CHECK(a.a_vocab == b.a_vocab);
         CHECK(a.a_ui8 == b.a_ui8);
         CHECK(a.a_ui16 == b.a_ui16);


### PR DESCRIPTION
Fixes issue preventing the correct generation of .thrift messages containing complex data type, e.g. list<list<double>> etc.