### PR TITLE
valgrind issue fix: added mutex in ShiftStream

### DIFF
--- a/src/devices/controlBoardRemapper/RemoteControlBoardRemapper.cpp
+++ b/src/devices/controlBoardRemapper/RemoteControlBoardRemapper.cpp
@@ -30,8 +30,6 @@ void RemoteControlBoardRemapper::closeAllRemoteControlBoards()
         if( m_remoteControlBoardDevice )
         {
             m_remoteControlBoardDevice->close();
-            delete m_remoteControlBoardDevice;
-            m_remoteControlBoardDevice = nullptr;
         }
     }
 
@@ -99,7 +97,7 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
 
     // Parameters loaded, open all the remote controlboards
 
-    m_remoteControlBoardDevices.resize(remoteControlBoardsPorts.size(),nullptr);
+    m_remoteControlBoardDevices.resize(remoteControlBoardsPorts.size());
 
     PolyDriverList remoteControlBoardsList;
 
@@ -114,7 +112,7 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
         options.put("local", local);
         options.put("remote", remote);
 
-        m_remoteControlBoardDevices[ctrlBrd] = new PolyDriver();
+        m_remoteControlBoardDevices[ctrlBrd] = std::make_unique<PolyDriver>();
 
         bool ok = m_remoteControlBoardDevices[ctrlBrd]->open(options);
 
@@ -126,7 +124,7 @@ bool RemoteControlBoardRemapper::open(Searchable& config)
         }
 
         // We use the remote name of the controlBoard_nwc_yarp as the key for it, in absence of anything better
-        remoteControlBoardsList.push((m_remoteControlBoardDevices[ctrlBrd]),remote.c_str());
+        remoteControlBoardsList.push((m_remoteControlBoardDevices[ctrlBrd].get()),remote.c_str());
     }
 
     // Device opened, now we open the ControlBoardRemapper and then we call attachAll

--- a/src/devices/controlBoardRemapper/RemoteControlBoardRemapper.h
+++ b/src/devices/controlBoardRemapper/RemoteControlBoardRemapper.h
@@ -97,8 +97,7 @@ private:
     /**
      * List of controlBoard_nwc_yarp devices opened by the RemoteControlBoardRemapper device.
      */
-    std::vector<yarp::dev::PolyDriver*> m_remoteControlBoardDevices;
-
+    std::vector<std::unique_ptr<yarp::dev::PolyDriver>> m_remoteControlBoardDevices;
 
     // Close all opened remote controlboards
     void closeAllRemoteControlBoards();

--- a/src/devices/controlBoardRemapper/tests/CMakeLists.txt
+++ b/src/devices/controlBoardRemapper/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
+create_device_test(controlBoardRemapper_t0)
 create_device_test(controlBoardRemapper_t1)
 create_device_test(controlBoardRemapper_t2)
 create_device_test(controlBoardRemapper_t3)

--- a/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t0_test.cpp
+++ b/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t0_test.cpp
@@ -11,8 +11,8 @@
 
 #include <vector>
 
-#include <yarp/dev/tests/TestUtils.h>
 #include <yarp/dev/tests/ParametersTest.h>
+#include <yarp/dev/tests/TestUtils.h>
 #include <catch2/catch_amalgamated.hpp>
 #include <harness.h>
 
@@ -233,13 +233,12 @@ static void checkRemapperMicro(yarp::dev::PolyDriver & ddRemapper, int rand, siz
 }
 
 
-TEST_CASE("dev::ControlBoardRemapperTest1", "[yarp::dev]")
+TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
 {
     YARP_REQUIRE_PLUGIN("fakeMotionControl", "device");
     YARP_REQUIRE_PLUGIN("fakeMotionControlMicro", "device");
     YARP_REQUIRE_PLUGIN("controlboardremapper", "device");
     YARP_REQUIRE_PLUGIN("controlBoard_nws_yarp", "device");
-    YARP_REQUIRE_PLUGIN("remotecontrolboardremapper", "device");
 
     Network::setLocalMode(true);
 
@@ -315,39 +314,62 @@ TEST_CASE("dev::ControlBoardRemapperTest1", "[yarp::dev]")
             fmcList.push(fmcbs[i].get(),fmcbsNames[i].c_str());
         }
 
-        // Open the remotecontrolboardremapper
-        PolyDriver ddRemoteRemapper;
-        Property pRemoteRemapper;
-        pRemoteRemapper.put("device","remotecontrolboardremapper");
-        pRemoteRemapper.addGroup("axesNames");
-        Bottle & remoteAxesList = pRemoteRemapper.findGroup("axesNames").addList();
-        remoteAxesList.addString("axisA1");
-        remoteAxesList.addString("axisB1");
-        remoteAxesList.addString("axisC1");
-        remoteAxesList.addString("axisB3");
-        remoteAxesList.addString("axisC3");
-        remoteAxesList.addString("axisA2");
+        // Open a controlboardremapper with the wrong axisName,
+        // and make sure that if fails during attachAll
+        PolyDriver ddRemapperWN;
+        Property pRemapperWN;
+        pRemapperWN.put("device","controlboardremapper");
+        pRemapperWN.addGroup("axesNames");
+        Bottle & axesListWN = pRemapperWN.findGroup("axesNames").addList();
+        axesListWN.addString("axisA1");
+        axesListWN.addString("axisB1");
+        axesListWN.addString("axisC1");
+        axesListWN.addString("axisB3");
+        axesListWN.addString("axisC3");
+        axesListWN.addString("axisA2");
+        axesListWN.addString("thisIsAnAxisNameThatDoNotExist");
+
+        REQUIRE(ddRemapperWN.open(pRemapperWN)); // controlboardremapper with wrong names open reported successful
+
+        yarp::dev::IMultipleWrapper *imultwrapWN = nullptr;
+        REQUIRE(ddRemapperWN.view(imultwrapWN)); // interface for multiple wrapper with wrong names correctly opened
+        REQUIRE(imultwrapWN);
+
+        REQUIRE_FALSE(imultwrapWN->attachAll(fmcList)); // attachAll for controlboardremapper with wrong names successful
+
+        // Make sure that a controlboard in which attachAll is not successfull
+        // closes correctly
+        CHECK(ddRemapperWN.close()); // controlboardremapper with wrong names close was successful
+
+        // Open the controlboardremapper
+        PolyDriver ddRemapper;
+        Property pRemapper;
+        pRemapper.put("device","controlboardremapper");
+        pRemapper.addGroup("axesNames");
+        Bottle & axesList = pRemapper.findGroup("axesNames").addList();
+        axesList.addString("axisA1");
+        axesList.addString("axisB1");
+        axesList.addString("axisC1");
+        axesList.addString("axisB3");
+        axesList.addString("axisC3");
+        axesList.addString("axisA2");
         size_t nrOfRemappedAxes = 6;
 
-        Bottle remoteControlBoards;
-        Bottle & remoteControlBoardsList = remoteControlBoards.addList();
-        remoteControlBoardsList.addString("/testRemapperRobot/a");
-        remoteControlBoardsList.addString("/testRemapperRobot/b");
-        remoteControlBoardsList.addString("/testRemapperRobot/c");
-        pRemoteRemapper.put("remoteControlBoards",remoteControlBoards.get(0));
+        REQUIRE(ddRemapper.open(pRemapper)); // controlboardremapper open reported successful
 
-        pRemoteRemapper.put("localPortPrefix","/test/remoteControlBoardRemapper");
+        yarp::dev::IMultipleWrapper *imultwrap = nullptr;
+        REQUIRE(ddRemapper.view(imultwrap)); // interface for multiple wrapper correctly opened
+        REQUIRE(imultwrap);
 
-        Property & opts = pRemoteRemapper.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
-        opts.put("writeStrict","on");
+        REQUIRE(imultwrap->attachAll(fmcList)); // attachAll for controlboardremapper successful
 
-        REQUIRE(ddRemoteRemapper.open(pRemoteRemapper)); // remotecontrolboardremapper open reported successful, testing it
 
-        // Test the remotecontrolboardremapper
-        checkRemapper(ddRemoteRemapper,100,nrOfRemappedAxes);
+        // Test the controlboardremapper
+        checkRemapper(ddRemapper,200,nrOfRemappedAxes);
 
         // Close devices
-        ddRemoteRemapper.close();
+        imultwrap->detachAll();
+        ddRemapper.close();
 
         for(int i=0; i < 3; i++)
         {
@@ -435,39 +457,62 @@ TEST_CASE("dev::ControlBoardRemapperTest1", "[yarp::dev]")
             fmcList.push(fmcbs[i].get(),fmcbsNames[i].c_str());
         }
 
-        // Open the remotecontrolboardremapper
-        PolyDriver ddRemoteRemapper;
-        Property pRemoteRemapper;
-        pRemoteRemapper.put("device","remotecontrolboardremapper");
-        pRemoteRemapper.addGroup("axesNames");
-        Bottle & remoteAxesList = pRemoteRemapper.findGroup("axesNames").addList();
-        remoteAxesList.addString("axisA1");
-        remoteAxesList.addString("axisB1");
-        remoteAxesList.addString("axisC1");
-        remoteAxesList.addString("axisB3");
-        remoteAxesList.addString("axisC3");
-        remoteAxesList.addString("axisA2");
+        // Open a controlboardremapper with the wrong axisName,
+        // and make sure that if fails during attachAll
+        PolyDriver ddRemapperWN;
+        Property pRemapperWN;
+        pRemapperWN.put("device","controlboardremapper");
+        pRemapperWN.addGroup("axesNames");
+        Bottle & axesListWN = pRemapperWN.findGroup("axesNames").addList();
+        axesListWN.addString("axisA1");
+        axesListWN.addString("axisB1");
+        axesListWN.addString("axisC1");
+        axesListWN.addString("axisB3");
+        axesListWN.addString("axisC3");
+        axesListWN.addString("axisA2");
+        axesListWN.addString("thisIsAnAxisNameThatDoNotExist");
+
+        REQUIRE(ddRemapperWN.open(pRemapperWN)); // controlboardremapper with wrong names open reported successful
+
+        yarp::dev::IMultipleWrapper *imultwrapWN = nullptr;
+        REQUIRE(ddRemapperWN.view(imultwrapWN)); // interface for multiple wrapper with wrong names correctly opened
+        REQUIRE(imultwrapWN);
+
+        REQUIRE_FALSE(imultwrapWN->attachAll(fmcList)); // attachAll for controlboardremapper with wrong names successful
+
+        // Make sure that a controlboard in which attachAll is not successfull
+        // closes correctly
+        CHECK(ddRemapperWN.close()); // controlboardremapper with wrong names close was successful
+
+        // Open the controlboardremapper
+        PolyDriver ddRemapper;
+        Property pRemapper;
+        pRemapper.put("device","controlboardremapper");
+        pRemapper.addGroup("axesNames");
+        Bottle & axesList = pRemapper.findGroup("axesNames").addList();
+        axesList.addString("axisA1");
+        axesList.addString("axisB1");
+        axesList.addString("axisC1");
+        axesList.addString("axisB3");
+        axesList.addString("axisC3");
+        axesList.addString("axisA2");
         size_t nrOfRemappedAxes = 6;
 
-        Bottle remoteControlBoards;
-        Bottle & remoteControlBoardsList = remoteControlBoards.addList();
-        remoteControlBoardsList.addString("/testRemapperRobot/a");
-        remoteControlBoardsList.addString("/testRemapperRobot/b");
-        remoteControlBoardsList.addString("/testRemapperRobot/c");
-        pRemoteRemapper.put("remoteControlBoards",remoteControlBoards.get(0));
+        REQUIRE(ddRemapper.open(pRemapper)); // controlboardremapper open reported successful
 
-        pRemoteRemapper.put("localPortPrefix","/test/remoteControlBoardRemapper");
+        yarp::dev::IMultipleWrapper *imultwrap = nullptr;
+        REQUIRE(ddRemapper.view(imultwrap)); // interface for multiple wrapper correctly opened
+        REQUIRE(imultwrap);
 
-        Property & opts = pRemoteRemapper.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
-        opts.put("writeStrict","on");
+        REQUIRE(imultwrap->attachAll(fmcList)); // attachAll for controlboardremapper successful
 
-        REQUIRE(ddRemoteRemapper.open(pRemoteRemapper)); // remotecontrolboardremapper open reported successful, testing it
 
-        // Test the remotecontrolboardremapper
-        checkRemapperMicro(ddRemoteRemapper,100,nrOfRemappedAxes);
+        // Test the controlboardremapper
+        checkRemapperMicro(ddRemapper,200,nrOfRemappedAxes);
 
         // Close devices
-        ddRemoteRemapper.close();
+        imultwrap->detachAll();
+        ddRemapper.close();
 
         for(int i=0; i < 3; i++)
         {

--- a/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t1_test.cpp
+++ b/src/devices/controlBoardRemapper/tests/controlBoardRemapper_t1_test.cpp
@@ -245,8 +245,8 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
     {
         // We first allocate three fakeMotionControl boards
         // and their wrappers that we will remap using the remapper
-        std::vector<PolyDriver *> fmcbs;
-        std::vector<PolyDriver *> wrappers;
+        std::vector<std::unique_ptr<PolyDriver>> fmcbs;
+        std::vector<std::unique_ptr<PolyDriver>> wrappers;
         fmcbs.resize(3);
         wrappers.resize(3);
 
@@ -268,7 +268,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
 
         for(int i=0; i < 3; i++)
         {
-            fmcbs[i] = new PolyDriver();
+            fmcbs[i] = std::make_unique<PolyDriver>();
 
             Property p;
 
@@ -287,7 +287,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
             CHECK(axes == fmcbsSizes[i]); // fakeMotionControlBoard seems functional
 
             // Open the wrapper
-            wrappers[i] = new PolyDriver();
+            wrappers[i] = std::make_unique<PolyDriver>();
 
             if(i==0) { p.fromConfig(wrapperA_file_content); }
             if(i==1) { p.fromConfig(wrapperB_file_content); }
@@ -300,7 +300,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
             REQUIRE(iwrap);
 
             PolyDriverList pdList;
-            pdList.push(fmcbs[i],wrapperNetworks[i].c_str());
+            pdList.push(fmcbs[i].get(), wrapperNetworks[i].c_str());
 
             REQUIRE(iwrap->attachAll(pdList)); // controlBoard_nws_yarp attached successfully to the device
         }
@@ -310,7 +310,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
 
         for(int i=0; i < 3; i++)
         {
-            fmcList.push(fmcbs[i],fmcbsNames[i].c_str());
+            fmcList.push(fmcbs[i].get(),fmcbsNames[i].c_str());
         }
 
         // Open a controlboardremapper with the wrong axisName,
@@ -404,11 +404,10 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
         for(int i=0; i < 3; i++)
         {
             wrappers[i]->close();
-            delete wrappers[i];
-            wrappers[i] = nullptr;
+        }
+        for(int i=0; i < 3; i++)
+        {
             fmcbs[i]->close();
-            delete fmcbs[i];
-            fmcbs[i] = nullptr;
         }
     }
 
@@ -416,8 +415,8 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
     {
         // We first allocate three fakeMotionControl boards
         // and their wrappers that we will remap using the remapper
-        std::vector<PolyDriver *> fmcbs;
-        std::vector<PolyDriver *> wrappers;
+        std::vector<std::unique_ptr<PolyDriver>> fmcbs;
+        std::vector<std::unique_ptr<PolyDriver>> wrappers;
         fmcbs.resize(3);
         wrappers.resize(3);
 
@@ -439,7 +438,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
 
         for(int i=0; i < 3; i++)
         {
-            fmcbs[i] = new PolyDriver();
+            fmcbs[i] = std::make_unique<PolyDriver>();
 
             Property p;
 
@@ -462,7 +461,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
             CHECK(axes == fmcbsSizes[i]); // fakeMotionControlBoard seems functional
 
             // Open the wrapper
-            wrappers[i] = new PolyDriver();
+            wrappers[i] = std::make_unique<PolyDriver>();
 
             if(i==0) { p.fromConfig(wrapperA_file_content); }
             if(i==1) { p.fromConfig(wrapperB_file_content); }
@@ -475,7 +474,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
             REQUIRE(iwrap);
 
             PolyDriverList pdList;
-            pdList.push(fmcbs[i],wrapperNetworks[i].c_str());
+            pdList.push(fmcbs[i].get(),wrapperNetworks[i].c_str());
 
             REQUIRE(iwrap->attachAll(pdList)); // controlBoard_nws_yarp attached successfully to the device
         }
@@ -485,7 +484,7 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
 
         for(int i=0; i < 3; i++)
         {
-            fmcList.push(fmcbs[i],fmcbsNames[i].c_str());
+            fmcList.push(fmcbs[i].get(),fmcbsNames[i].c_str());
         }
 
         // Open a controlboardremapper with the wrong axisName,
@@ -579,11 +578,10 @@ TEST_CASE("dev::ControlBoardRemapperTest", "[yarp::dev]")
         for(int i=0; i < 3; i++)
         {
             wrappers[i]->close();
-            delete wrappers[i];
-            wrappers[i] = nullptr;
+        }
+        for(int i=0; i < 3; i++)
+        {
             fmcbs[i]->close();
-            delete fmcbs[i];
-            fmcbs[i] = nullptr;
         }
     }
 

--- a/src/libYARP_os/src/yarp/os/ShiftStream.cpp
+++ b/src/libYARP_os/src/yarp/os/ShiftStream.cpp
@@ -6,6 +6,8 @@
 
 #include <yarp/os/ShiftStream.h>
 
+#include <mutex>
+
 using yarp::os::Contact;
 using yarp::os::InputStream;
 using yarp::os::OutputStream;
@@ -19,6 +21,7 @@ public:
     ~Private();
     void close();
 
+    std::mutex streamMutex;
     TwoWayStream* stream{nullptr};
     NullStream nullStream;
 };
@@ -32,6 +35,7 @@ ShiftStream::Private::~Private()
 
 void ShiftStream::Private::close()
 {
+    std::lock_guard<std::mutex> lg(streamMutex);
     if (stream != nullptr) {
         stream->close();
         delete stream;
@@ -57,6 +61,7 @@ void ShiftStream::check() const
 InputStream& ShiftStream::getInputStream()
 {
     check();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     if (mPriv->stream == nullptr) {
         return mPriv->nullStream;
     }
@@ -66,6 +71,7 @@ InputStream& ShiftStream::getInputStream()
 OutputStream& ShiftStream::getOutputStream()
 {
     check();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     if (mPriv->stream == nullptr) {
         return mPriv->nullStream;
     }
@@ -75,6 +81,7 @@ OutputStream& ShiftStream::getOutputStream()
 const Contact& ShiftStream::getLocalAddress() const
 {
     check();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     return (mPriv->stream == nullptr) ? mPriv->nullStream.getLocalAddress()
                                       : (mPriv->stream->getLocalAddress());
 }
@@ -82,6 +89,7 @@ const Contact& ShiftStream::getLocalAddress() const
 const Contact& ShiftStream::getRemoteAddress() const
 {
     check();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     return (mPriv->stream == nullptr) ? mPriv->nullStream.getRemoteAddress()
                                       : (mPriv->stream->getRemoteAddress());
 }
@@ -94,11 +102,13 @@ void ShiftStream::close()
 void ShiftStream::takeStream(TwoWayStream* stream)
 {
     close();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     mPriv->stream = stream;
 }
 
 TwoWayStream* ShiftStream::giveStream()
 {
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     TwoWayStream* result = mPriv->stream;
     mPriv->stream = nullptr;
     return result;
@@ -106,16 +116,19 @@ TwoWayStream* ShiftStream::giveStream()
 
 TwoWayStream* ShiftStream::getStream() const
 {
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     return mPriv->stream;
 }
 
 bool ShiftStream::isEmpty() const
 {
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     return mPriv->stream == nullptr;
 }
 
 bool ShiftStream::isOk() const
 {
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     if (mPriv->stream != nullptr) {
         return mPriv->stream->isOk();
     }
@@ -124,6 +137,7 @@ bool ShiftStream::isOk() const
 
 void ShiftStream::reset()
 {
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
     if (mPriv->stream != nullptr) {
         mPriv->stream->reset();
     }
@@ -140,5 +154,14 @@ void ShiftStream::endPacket()
 {
     if (mPriv->stream != nullptr) {
         mPriv->stream->endPacket();
+    }
+}
+
+void ShiftStream::interruptInputStream()
+{
+    check();
+    std::lock_guard<std::mutex> lg(mPriv->streamMutex);
+    if (mPriv->stream != nullptr) {
+        mPriv->stream->getInputStream().interrupt();
     }
 }

--- a/src/libYARP_os/src/yarp/os/ShiftStream.h
+++ b/src/libYARP_os/src/yarp/os/ShiftStream.h
@@ -78,6 +78,8 @@ public:
 
     void endPacket() override;
 
+    void interruptInputStream();
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 private:
     class Private;

--- a/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp
@@ -24,7 +24,7 @@ using namespace yarp::os;
 
 PortCoreOutputUnit::PortCoreOutputUnit(PortCore& owner, int index, OutputProtocol* op) :
         PortCoreUnit(owner, index),
-        op(op),
+        op(op), // shared_ptr takes ownership of the raw pointer
         closing(false),
         finished(false),
         running(false),
@@ -116,8 +116,12 @@ void PortCoreOutputUnit::run()
 
 void PortCoreOutputUnit::runSingleThreaded()
 {
-    if (op != nullptr) {
-        Route route = op->getRoute();
+    // Local copy: guarantees the object stays alive for the duration of
+    // this function, independent of concurrent modifications to `op`.
+    std::shared_ptr<OutputProtocol> localOp = op;
+
+    if (localOp) {
+        Route route = localOp->getRoute();
         setMode();
         getOwner().reportUnit(this, true);
 
@@ -148,24 +152,30 @@ void PortCoreOutputUnit::runSingleThreaded()
 void PortCoreOutputUnit::closeBasic()
 {
     bool waitForOther = false;
-    if (op != nullptr) {
-        op->getConnection().prepareDisconnect();
-        Route route = op->getRoute();
-        if (op->getConnection().isConnectionless() || op->getConnection().isBroadcast()) {
+
+    // Take a local, private, strong reference. This keeps the pointed-to
+    // OutputProtocol alive for the whole function, even if another thread
+    // concurrently resets the shared `op` member (see closeMain()).
+    std::shared_ptr<OutputProtocol> localOp = op;
+
+    if (localOp) {
+        localOp->getConnection().prepareDisconnect();
+        Route route = localOp->getRoute();
+        if (localOp->getConnection().isConnectionless() || localOp->getConnection().isBroadcast()) {
             yCIInfo(PORTCOREOUTPUTUNIT, getName(), "output for route %s asking other side to close by out-of-band means",
                        route.toString().c_str());
             NetworkBase::disconnectInput(route.getToName(),
                                          route.getFromName(),
                                          true);
         } else {
-            if (op->getConnection().canEscape()) {
-                BufferedConnectionWriter buf(op->getConnection().isTextMode(),
-                                             op->getConnection().isBareMode());
+            if (localOp->getConnection().canEscape()) {
+                BufferedConnectionWriter buf(localOp->getConnection().isTextMode(),
+                                             localOp->getConnection().isBareMode());
                 PortCommand pc('\0', std::string("q"));
                 pc.write(buf);
                 //printf("Asked for %s to close...\n",
                 //     op->getRoute().toString().c_str());
-                waitForOther = op->write(buf);
+                waitForOther = localOp->write(buf);
             }
         }
 
@@ -193,18 +203,24 @@ void PortCoreOutputUnit::closeBasic()
     }
 
 
-    if (op != nullptr) {
+    if (localOp) {
         if (waitForOther) {
             // quit is only acknowledged in certain conditions
-            if (op->getConnection().isTextMode() && op->getConnection().supportReply()) {
-                InputStream& is = op->getInputStream();
+            if (localOp->getConnection().isTextMode() && localOp->getConnection().supportReply()) {
+                InputStream& is = localOp->getInputStream();
                 ManagedBytes dummy(1);
                 is.read(dummy.bytes());
             }
         }
-        op->close();
-        delete op;
-        op = nullptr;
+        localOp->close();
+
+        // Release our copy and clear the shared member. The underlying
+        // OutputProtocol is only actually destroyed once every other
+        // outstanding shared_ptr copy (e.g. localOp here, or one held
+        // briefly by another thread in closeMain()/getRoute()) has also
+        // gone out of scope. No explicit delete or additional locking is
+        // needed: shared_ptr's atomic refcounting handles this safely.
+        op.reset();
     }
 }
 
@@ -219,8 +235,12 @@ void PortCoreOutputUnit::closeMain()
     if (running) {
         // give a kick (unfortunately unavoidable)
 
-        if (op != nullptr) {
-            op->interrupt();
+        // Local copy so that even if another thread concurrently clears
+        // `op` inside closeBasic(), the object we call interrupt() on
+        // (if any) remains valid for the duration of this call.
+        std::shared_ptr<OutputProtocol> localOp = op;
+        if (localOp) {
+            localOp->interrupt();
         }
 
         closing = true;
@@ -242,9 +262,10 @@ void PortCoreOutputUnit::closeMain()
 
 Route PortCoreOutputUnit::getRoute()
 {
-    if (op != nullptr) {
-        Route r = op->getRoute();
-        op->beginWrite();
+    std::shared_ptr<OutputProtocol> localOp = op;
+    if (localOp) {
+        Route r = localOp->getRoute();
+        localOp->beginWrite();
         return r;
     }
     return PortCoreUnit::getRoute();
@@ -253,23 +274,27 @@ Route PortCoreOutputUnit::getRoute()
 bool PortCoreOutputUnit::sendHelper()
 {
     bool replied = false;
-    if (op != nullptr) {
+
+    // Local copy for the whole helper, for the same reason as elsewhere.
+    std::shared_ptr<OutputProtocol> localOp = op;
+
+    if (localOp) {
         bool done = false;
-        BufferedConnectionWriter buf(op->getConnection().isTextMode(),
-                                     op->getConnection().isBareMode());
+        BufferedConnectionWriter buf(localOp->getConnection().isTextMode(),
+                                     localOp->getConnection().isBareMode());
         if (cachedReader != nullptr) {
             buf.setReplyHandler(*cachedReader);
         }
 
-        if (op->getSender().modifiesOutgoingData()) {
-            if (op->getSender().acceptOutgoingData(*cachedWriter)) {
-                cachedWriter = &op->getSender().modifyOutgoingData(*cachedWriter);
+        if (localOp->getSender().modifiesOutgoingData()) {
+            if (localOp->getSender().acceptOutgoingData(*cachedWriter)) {
+                cachedWriter = &localOp->getSender().modifyOutgoingData(*cachedWriter);
             } else {
                 return (done = true);
             }
         }
 
-        if (op->getConnection().isLocal()) {
+        if (localOp->getConnection().isLocal()) {
             // WARNING Cast away const qualifier.
             //         This may actually cause bugs when using the local carrier
             //         with something that is actually const (i.e. that is using
@@ -291,9 +316,9 @@ bool PortCoreOutputUnit::sendHelper()
             bool suppressReply = (buf.getReplyHandler() == nullptr);
 
             if (!done) {
-                if (!op->getConnection().canEscape()) {
+                if (!localOp->getConnection().canEscape()) {
                     if (!cachedEnvelope.empty()) {
-                        op->getConnection().handleEnvelope(cachedEnvelope);
+                        localOp->getConnection().handleEnvelope(cachedEnvelope);
                     }
                 } else {
                     buf.addToHeader();
@@ -315,13 +340,13 @@ bool PortCoreOutputUnit::sendHelper()
         }
 
         if (!done) {
-            if (op->getConnection().isActive()) {
-                replied = op->write(buf);
-                if (replied && op->getSender().modifiesReply() && cachedReader != nullptr) {
-                    cachedReader = &op->getSender().modifyReply(*cachedReader);
+            if (localOp->getConnection().isActive()) {
+                replied = localOp->write(buf);
+                if (replied && localOp->getSender().modifiesReply() && cachedReader != nullptr) {
+                    cachedReader = &localOp->getSender().modifyReply(*cachedReader);
                 }
             }
-            if (!op->isOk()) {
+            if (!localOp->isOk()) {
                 done = true;
             }
         }
@@ -352,9 +377,12 @@ void* PortCoreOutputUnit::send(const yarp::os::PortWriter& writer,
 {
     bool replied = false;
 
-    if (op != nullptr) {
-        if (!op->getConnection().isActive()) {
-            return tracker;
+    {
+        std::shared_ptr<OutputProtocol> localOp = op;
+        if (localOp) {
+            if (!localOp->getConnection().isActive()) {
+                return tracker;
+            }
         }
     }
 
@@ -423,19 +451,25 @@ bool PortCoreOutputUnit::isBusy()
 
 void PortCoreOutputUnit::setCarrierParams(const yarp::os::Property& params)
 {
-    if (op != nullptr) {
-        op->getConnection().setCarrierParams(params);
+    std::shared_ptr<OutputProtocol> localOp = op;
+    if (localOp) {
+        localOp->getConnection().setCarrierParams(params);
     }
 }
 
 void PortCoreOutputUnit::getCarrierParams(yarp::os::Property& params)
 {
-    if (op != nullptr) {
-        op->getConnection().getCarrierParams(params);
+    std::shared_ptr<OutputProtocol> localOp = op;
+    if (localOp) {
+        localOp->getConnection().getCarrierParams(params);
     }
 }
 
 OutputProtocol* PortCoreOutputUnit::getOutPutProtocol()
 {
-    return op;
+    // Callers (e.g. PortCore::getTypeOfService()) treat this as a
+    // transient, "use immediately" raw pointer; they do not store it
+    // long-term. Returning op.get() preserves the existing API/ABI while
+    // the shared_ptr keeps the object's lifetime managed safely elsewhere.
+    return op.get();
 }

--- a/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.h
+++ b/src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.h
@@ -12,6 +12,7 @@
 #include <yarp/os/impl/PortCore.h>
 #include <yarp/os/impl/PortCoreUnit.h>
 
+#include <memory>
 #include <mutex>
 
 namespace yarp::os::impl {
@@ -107,7 +108,7 @@ public:
     OutputProtocol* getOutPutProtocol();
 
 private:
-    OutputProtocol *op; ///< protocol object for writing/reading
+    std::shared_ptr<OutputProtocol> op;
     bool closing;       ///< should this connection close
     bool finished;      ///< has this connection finished
     bool running;       ///< is a thread running

--- a/src/libYARP_os/src/yarp/os/impl/Protocol.cpp
+++ b/src/libYARP_os/src/yarp/os/impl/Protocol.cpp
@@ -260,7 +260,7 @@ void Protocol::interrupt()
         sendAck();
     }
     // Break the input stream.
-    shift.getInputStream().interrupt();
+    shift.interruptInputStream();
     active = false;
 }
 


### PR DESCRIPTION
This PR fixes Valgrind reports on tests 21,22, 121, 122:

```
2026-08-22T12:20:28.7616798Z ==46754== Thread 7:
2026-08-22T12:20:28.7616894Z ==46754== Invalid read of size 4
2026-08-22T12:20:28.7617149Z ==46754==    at 0x4B3E7A0: ACE_IPC_SAP::get_handle() const (/usr/include/ace/IPC_SAP.inl:16)
2026-08-22T12:20:28.7617387Z ==46754==    by 0x4B99ED7: ACE_SOCK_Stream::close_writer() (/usr/include/ace/SOCK_Stream.inl:42)
2026-08-22T12:20:28.7617861Z ==46754==    by 0x4B9A27B: yarp::os::impl::SocketTwoWayStream::interrupt() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.h:85)
2026-08-22T12:20:28.7618252Z ==46754==    by 0x4B9551F: yarp::os::impl::Protocol::interrupt() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:263)
2026-08-22T12:20:28.7618707Z ==46754==    by 0x4B91390: yarp::os::impl::PortCoreOutputUnit::closeMain() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:223)
2026-08-22T12:20:28.7619134Z ==46754==    by 0x4B92785: yarp::os::impl::PortCoreOutputUnit::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.h:67)
2026-08-22T12:20:28.7619506Z ==46754==    by 0x4B74923: yarp::os::impl::PortCore::reapUnits() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:575)
2026-08-22T12:20:28.7619860Z ==46754==    by 0x4B719CC: yarp::os::impl::PortCore::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:245)
2026-08-22T12:20:28.7620230Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7620637Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7621232Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7621702Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7622046Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7622550Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7622742Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7622925Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7623123Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7623306Z ==46754==  Address 0x6db7cd8 is 24 bytes inside a block of size 120 free'd
2026-08-22T12:20:28.7623649Z ==46754==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7624376Z ==46754==    by 0x4B9A0BC: yarp::os::impl::SocketTwoWayStream::~SocketTwoWayStream() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.h:56)
2026-08-22T12:20:28.7624774Z ==46754==    by 0x4B164ED: yarp::os::ShiftStream::Private::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/ShiftStream.cpp:37)
2026-08-22T12:20:28.7625118Z ==46754==    by 0x4B16807: yarp::os::ShiftStream::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/ShiftStream.cpp:91)
2026-08-22T12:20:28.7625514Z ==46754==    by 0x4B967EB: yarp::os::impl::Protocol::closeHelper() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:540)
2026-08-22T12:20:28.7625961Z ==46754==    by 0x4B954BB: yarp::os::impl::Protocol::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:249)
2026-08-22T12:20:28.7626418Z ==46754==    by 0x4B910A8: yarp::os::impl::PortCoreOutputUnit::closeBasic() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:205)
2026-08-22T12:20:28.7626867Z ==46754==    by 0x4B91FBA: yarp::os::impl::PortCoreOutputUnit::sendHelper() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:333)
2026-08-22T12:20:28.7627289Z ==46754==    by 0x4B8FF5F: yarp::os::impl::PortCoreOutputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:95)
2026-08-22T12:20:28.7627659Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7628066Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7628486Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7628939Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7629283Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7629668Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7629989Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7630165Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7630367Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7630468Z ==46754==  Block was alloc'd at
2026-08-22T12:20:28.7630769Z ==46754==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7631205Z ==46754==    by 0x4BA38AC: yarp::os::impl::TcpFace::write(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/TcpFace.cpp:122)
2026-08-22T12:20:28.7631692Z ==46754==    by 0x4A8F491: yarp::os::Carriers::connect(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/Carriers.cpp:297)
2026-08-22T12:20:28.7632449Z ==46754==    by 0x4B7780B: yarp::os::impl::PortCore::addOutput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, yarp::os::OutputStream*, bool) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:951)
2026-08-22T12:20:28.7634047Z ==46754==    by 0x4B7E9DE: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#4}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:1851)
2026-08-22T12:20:28.7634547Z ==46754==    by 0x4B8434B: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:2415)
2026-08-22T12:20:28.7635046Z ==46754==    by 0x4B8D0BD: yarp::os::impl::PortCoreInputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreInputUnit.cpp:313)
2026-08-22T12:20:28.7635411Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7635806Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7636229Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7636675Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7637015Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7637412Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7637600Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7637771Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7637969Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7638048Z ==46754== 
2026-08-22T12:20:28.7638147Z ==46754== Invalid read of size 4
2026-08-22T12:20:28.7638362Z ==46754==    at 0x56B95F8: ACE_SOCK::close() (in /usr/lib/x86_64-linux-gnu/libACE-7.0.6.so)
2026-08-22T12:20:28.7638811Z ==46754==    by 0x4B9A307: yarp::os::impl::SocketTwoWayStream::interrupt() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.h:87)
2026-08-22T12:20:28.7639359Z ==46754==    by 0x4B9551F: yarp::os::impl::Protocol::interrupt() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:263)
2026-08-22T12:20:28.7639816Z ==46754==    by 0x4B91390: yarp::os::impl::PortCoreOutputUnit::closeMain() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:223)
2026-08-22T12:20:28.7640245Z ==46754==    by 0x4B92785: yarp::os::impl::PortCoreOutputUnit::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.h:67)
2026-08-22T12:20:28.7640697Z ==46754==    by 0x4B74923: yarp::os::impl::PortCore::reapUnits() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:575)
2026-08-22T12:20:28.7641059Z ==46754==    by 0x4B719CC: yarp::os::impl::PortCore::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:245)
2026-08-22T12:20:28.7641434Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7641840Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7642269Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7642716Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7643047Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7643440Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7643669Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7643938Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7644132Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7644299Z ==46754==  Address 0x6db7cd8 is 24 bytes inside a block of size 120 free'd
2026-08-22T12:20:28.7644635Z ==46754==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7645131Z ==46754==    by 0x4B9A0BC: yarp::os::impl::SocketTwoWayStream::~SocketTwoWayStream() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/SocketTwoWayStream.h:56)
2026-08-22T12:20:28.7645523Z ==46754==    by 0x4B164ED: yarp::os::ShiftStream::Private::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/ShiftStream.cpp:37)
2026-08-22T12:20:28.7645874Z ==46754==    by 0x4B16807: yarp::os::ShiftStream::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/ShiftStream.cpp:91)
2026-08-22T12:20:28.7646256Z ==46754==    by 0x4B967EB: yarp::os::impl::Protocol::closeHelper() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:540)
2026-08-22T12:20:28.7646617Z ==46754==    by 0x4B954BB: yarp::os::impl::Protocol::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:249)
2026-08-22T12:20:28.7647079Z ==46754==    by 0x4B910A8: yarp::os::impl::PortCoreOutputUnit::closeBasic() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:205)
2026-08-22T12:20:28.7647525Z ==46754==    by 0x4B91FBA: yarp::os::impl::PortCoreOutputUnit::sendHelper() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:333)
2026-08-22T12:20:28.7648168Z ==46754==    by 0x4B8FF5F: yarp::os::impl::PortCoreOutputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:95)
2026-08-22T12:20:28.7648532Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7648945Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7649371Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7649892Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7650240Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7650632Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7650807Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7650977Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7651162Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7651261Z ==46754==  Block was alloc'd at
2026-08-22T12:20:28.7651555Z ==46754==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7651995Z ==46754==    by 0x4BA38AC: yarp::os::impl::TcpFace::write(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/TcpFace.cpp:122)
2026-08-22T12:20:28.7652492Z ==46754==    by 0x4A8F491: yarp::os::Carriers::connect(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/Carriers.cpp:297)
2026-08-22T12:20:28.7653230Z ==46754==    by 0x4B7780B: yarp::os::impl::PortCore::addOutput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, yarp::os::OutputStream*, bool) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:951)
2026-08-22T12:20:28.7654833Z ==46754==    by 0x4B7E9DE: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#4}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:1851)
2026-08-22T12:20:28.7655333Z ==46754==    by 0x4B8434B: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:2415)
2026-08-22T12:20:28.7655753Z ==46754==    by 0x4B8D0BD: yarp::os::impl::PortCoreInputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreInputUnit.cpp:313)
2026-08-22T12:20:28.7656122Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7656528Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7656944Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7657565Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7657910Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7658303Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7658564Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7658731Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7658923Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7659003Z ==46754== 
2026-08-22T12:20:28.7659100Z ==46754== Invalid write of size 1
2026-08-22T12:20:28.7659496Z ==46754==    at 0x4B95524: yarp::os::impl::Protocol::interrupt() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:264)
2026-08-22T12:20:28.7659948Z ==46754==    by 0x4B91390: yarp::os::impl::PortCoreOutputUnit::closeMain() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:223)
2026-08-22T12:20:28.7660376Z ==46754==    by 0x4B92785: yarp::os::impl::PortCoreOutputUnit::close() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.h:67)
2026-08-22T12:20:28.7660754Z ==46754==    by 0x4B74923: yarp::os::impl::PortCore::reapUnits() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:575)
2026-08-22T12:20:28.7661105Z ==46754==    by 0x4B719CC: yarp::os::impl::PortCore::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:245)
2026-08-22T12:20:28.7661551Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7661954Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7662379Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7662828Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7663162Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7663557Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7663740Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7664086Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7664317Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7664484Z ==46754==  Address 0x64ac440 is 48 bytes inside a block of size 352 free'd
2026-08-22T12:20:28.7664818Z ==46754==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7665208Z ==46754==    by 0x4B9487A: yarp::os::impl::Protocol::~Protocol() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/Protocol.cpp:60)
2026-08-22T12:20:28.7665665Z ==46754==    by 0x4B910CA: yarp::os::impl::PortCoreOutputUnit::closeBasic() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:206)
2026-08-22T12:20:28.7666273Z ==46754==    by 0x4B91FBA: yarp::os::impl::PortCoreOutputUnit::sendHelper() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:333)
2026-08-22T12:20:28.7666700Z ==46754==    by 0x4B8FF5F: yarp::os::impl::PortCoreOutputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreOutputUnit.cpp:95)
2026-08-22T12:20:28.7667067Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7667547Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7667964Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7668419Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7668755Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7669139Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7669317Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7669477Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7669668Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7669757Z ==46754==  Block was alloc'd at
2026-08-22T12:20:28.7670139Z ==46754==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2026-08-22T12:20:28.7670576Z ==46754==    by 0x4BA3A16: yarp::os::impl::TcpFace::write(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/TcpFace.cpp:142)
2026-08-22T12:20:28.7670982Z ==46754==    by 0x4A8F491: yarp::os::Carriers::connect(yarp::os::Contact const&) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/Carriers.cpp:297)
2026-08-22T12:20:28.7671722Z ==46754==    by 0x4B7780B: yarp::os::impl::PortCore::addOutput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, yarp::os::OutputStream*, bool) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:951)
2026-08-22T12:20:28.7673202Z ==46754==    by 0x4B7E9DE: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#4}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:1851)
2026-08-22T12:20:28.7673683Z ==46754==    by 0x4B8434B: yarp::os::impl::PortCore::adminBlock(yarp::os::ConnectionReader&, void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCore.cpp:2415)
2026-08-22T12:20:28.7674219Z ==46754==    by 0x4B8D0BD: yarp::os::impl::PortCoreInputUnit::run() (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/PortCoreInputUnit.cpp:313)
2026-08-22T12:20:28.7674587Z ==46754==    by 0x4BA51B6: theExecutiveBranch(void*) (build/src/libYARP_os/src/../../../../src/libYARP_os/src/yarp/os/impl/ThreadImpl.cpp:81)
2026-08-22T12:20:28.7675113Z ==46754==    by 0x4BA6A77: void std::__invoke_impl<void, void (*)(void*), void*>(std::__invoke_other, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
2026-08-22T12:20:28.7675554Z ==46754==    by 0x4BA69EA: std::__invoke_result<void (*)(void*), void*>::type std::__invoke<void (*)(void*), void*>(void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:96)
2026-08-22T12:20:28.7676001Z ==46754==    by 0x4BA694A: void std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/usr/include/c++/11/bits/std_thread.h:259)
2026-08-22T12:20:28.7676330Z ==46754==    by 0x4BA68FF: std::thread::_Invoker<std::tuple<void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
2026-08-22T12:20:28.7676797Z ==46754==    by 0x4BA68DF: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
2026-08-22T12:20:28.7676978Z ==46754==    by 0x4D3A252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
2026-08-22T12:20:28.7677162Z ==46754==    by 0x5025A82: start_thread (nptl/./nptl/pthread_create.c:442)
2026-08-22T12:20:28.7677357Z ==46754==    by 0x50B6A43: clone (misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:100)
2026-08-22T12:20:28.7677430Z ==46754== 
```

**Explanation:**

This is a data race between two threads both operating on the same Protocol/OutputProtocol object concurrently, and it's not fixed by the shared_ptr copies (localOp) that were added in closeBasic()/closeMain().
Both localOp copies in closeBasic() and closeMain() point to the same underlying Protocol object — they are just two shared_ptr handles referencing one shared instance, not independent objects. The shared_ptr refcounting only guarantees the Protocol/OutputProtocol wrapper object itself isn't deleted while either thread holds a reference. It does nothing to prevent:

Instead of adding a broad mutex at the `PortCoreOutputUnit` level (which interacts with many other locks: trackerMutex, phase, activate, port-level locks, etc., and is exactly the kind of "wide" lock that tends to cause deadlocks), push the synchronization down into `ShiftStream::Private`, which is the actual owner of the raw `TwoWayStream*` being deleted/dereferenced. 

This is a leaf-level lock: it protects only a single pointer and is never held while calling back into any other YARP component that might try to re-acquire a lock — so there's no possibility of lock-order inversion or reentrancy deadlocks.

Why this is safer than a PortCoreOutputUnit-level mutex:
•	ShiftStream::Private doesn't call back out into PortCore, PortCoreOutputUnit, or any other class that acquires its own locks — it only touches its own stream pointer and delegates to the stream/socket layer, which doesn't reacquire this same lock.
•	The critical sections are tiny (pointer read + delegate call, or pointer swap + delete), so no long-held locks that block other threads for extended periods.
•	It fixes the actual point of contention (stream pointer lifetime) directly rather than trying to prevent all possible concurrent calls to interrupt()/close() at a much coarser level.
