### PR TITLE
MultipleAnalogSensor interfaces migration to yarp::dev::ReturnValue

### DIFF
--- a/src/devices/fake/fakeIMU/FakeIMU.cpp
+++ b/src/devices/fake/fakeIMU/FakeIMU.cpp
@@ -104,29 +104,30 @@ yarp::dev::MAS_status FakeIMU::genericGetStatus(size_t sens_index) const
     return yarp::dev::MAS_status::MAS_OK;
 }
 
-bool FakeIMU::genericGetSensorName(size_t sens_index, std::string &name) const
+ReturnValue FakeIMU::genericGetSensorName(size_t sens_index, std::string &name) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     name = m_sensorName;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakeIMU::genericGetFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue FakeIMU::genericGetFrameName(size_t sens_index, std::string &frameName) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_generic;
     }
 
     frameName = m_frameName;
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t FakeIMU::getNrOfThreeAxisGyroscopes() const
+ReturnValue FakeIMU::getNrOfThreeAxisGyroscopes(size_t& num) const
 {
-    return 1;
+    num =1;
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakeIMU::getThreeAxisGyroscopeStatus(size_t sens_index) const
@@ -134,20 +135,20 @@ yarp::dev::MAS_status FakeIMU::getThreeAxisGyroscopeStatus(size_t sens_index) co
     return genericGetStatus(sens_index);
 }
 
-bool FakeIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
+ReturnValue FakeIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool FakeIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue FakeIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool FakeIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue FakeIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -159,12 +160,13 @@ bool FakeIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector&
     yarp::os::Stamp copyStamp(lastStamp);
     timestamp = copyStamp.getTime();
 
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t FakeIMU::getNrOfThreeAxisLinearAccelerometers() const
+ReturnValue FakeIMU::getNrOfThreeAxisLinearAccelerometers(size_t& num) const
 {
-    return 1;
+    num = 1;
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakeIMU::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
@@ -172,20 +174,20 @@ yarp::dev::MAS_status FakeIMU::getThreeAxisLinearAccelerometerStatus(size_t sens
     return genericGetStatus(sens_index);
 }
 
-bool FakeIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
+ReturnValue FakeIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool FakeIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue FakeIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool FakeIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue FakeIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -197,12 +199,13 @@ bool FakeIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::si
     yarp::os::Stamp copyStamp(lastStamp);
     timestamp = copyStamp.getTime();
 
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t FakeIMU::getNrOfThreeAxisMagnetometers() const
+ReturnValue FakeIMU::getNrOfThreeAxisMagnetometers(size_t& num) const
 {
-    return 1;
+    num = 1;
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakeIMU::getThreeAxisMagnetometerStatus(size_t sens_index) const
@@ -210,20 +213,20 @@ yarp::dev::MAS_status FakeIMU::getThreeAxisMagnetometerStatus(size_t sens_index)
     return genericGetStatus(sens_index);
 }
 
-bool FakeIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const
+ReturnValue FakeIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool FakeIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue FakeIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool FakeIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue FakeIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -235,12 +238,13 @@ bool FakeIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vect
     yarp::os::Stamp copyStamp(lastStamp);
     timestamp = copyStamp.getTime();
 
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t FakeIMU::getNrOfOrientationSensors() const
+ReturnValue FakeIMU::getNrOfOrientationSensors(size_t& num) const
 {
-    return 1;
+   num = 1;
+   return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakeIMU::getOrientationSensorStatus(size_t sens_index) const
@@ -248,20 +252,20 @@ yarp::dev::MAS_status FakeIMU::getOrientationSensorStatus(size_t sens_index) con
     return genericGetStatus(sens_index);
 }
 
-bool FakeIMU::getOrientationSensorName(size_t sens_index, std::string &name) const
+ReturnValue FakeIMU::getOrientationSensorName(size_t sens_index, std::string &name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool FakeIMU::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue FakeIMU::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool FakeIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy_out, double& timestamp) const
+ReturnValue FakeIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy_out, double& timestamp) const
 {
     if (sens_index!=0) {
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     rpy_out.resize(3);
@@ -273,5 +277,5 @@ bool FakeIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp:
     yarp::os::Stamp copyStamp(lastStamp);
     timestamp = copyStamp.getTime();
 
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/fake/fakeIMU/FakeIMU.h
+++ b/src/devices/fake/fakeIMU/FakeIMU.h
@@ -41,37 +41,37 @@ public:
     bool close() override;
 
     /* IThreeAxisGyroscopes methods */
-    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
-    bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisLinearAccelerometers methods */
-    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
-    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisMagnetometers methods */
-    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IOrientationSensors methods */
-    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const override;
     yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
-    bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+    yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
 private:
     yarp::dev::MAS_status genericGetStatus(size_t sens_index) const;
-    bool genericGetSensorName(size_t sens_index, std::string &name) const;
-    bool genericGetFrameName(size_t sens_index, std::string &frameName) const;
+    yarp::dev::ReturnValue genericGetSensorName(size_t sens_index, std::string &name) const;
+    yarp::dev::ReturnValue genericGetFrameName(size_t sens_index, std::string &frameName) const;
 
     bool threadInit() override;
     void run() override;

--- a/src/devices/fake/fakePositionSensor/FakePositionSensor.cpp
+++ b/src/devices/fake/fakePositionSensor/FakePositionSensor.cpp
@@ -91,10 +91,11 @@ void FakePositionSensor::threadRelease()
 }
 
 
-size_t FakePositionSensor::getNrOfPositionSensors() const
+ReturnValue FakePositionSensor::getNrOfPositionSensors(size_t& num) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    return m_position_sensors.size();
+    num = m_position_sensors.size();
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakePositionSensor::getPositionSensorStatus(size_t sens_index) const
@@ -104,35 +105,36 @@ yarp::dev::MAS_status FakePositionSensor::getPositionSensorStatus(size_t sens_in
     return m_position_sensors[sens_index].m_status;
 }
 
-bool FakePositionSensor::getPositionSensorName(size_t sens_index, std::string& name) const
+ReturnValue FakePositionSensor::getPositionSensorName(size_t sens_index, std::string& name) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_position_sensors.size()) return false;
+    if (sens_index >= m_position_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     name = m_position_sensors[sens_index].m_name;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakePositionSensor::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue FakePositionSensor::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_position_sensors.size()) return false;
+    if (sens_index >= m_position_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     frameName = m_position_sensors[sens_index].m_framename;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakePositionSensor::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
+ReturnValue FakePositionSensor::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_position_sensors.size()) return false;
+    if (sens_index >= m_position_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     timestamp = m_position_sensors[sens_index].m_timestamp;
     xyz = m_position_sensors[sens_index].m_data;
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t FakePositionSensor::getNrOfOrientationSensors() const
+ReturnValue FakePositionSensor::getNrOfOrientationSensors(size_t& num) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    return m_orientation_sensors.size();
+    num = m_orientation_sensors.size();
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status FakePositionSensor::getOrientationSensorStatus(size_t sens_index) const
@@ -142,27 +144,27 @@ yarp::dev::MAS_status FakePositionSensor::getOrientationSensorStatus(size_t sens
     return m_orientation_sensors[sens_index].m_status;
 }
 
-bool FakePositionSensor::getOrientationSensorName(size_t sens_index, std::string& name) const
+ReturnValue FakePositionSensor::getOrientationSensorName(size_t sens_index, std::string& name) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_orientation_sensors.size()) return false;
+    if (sens_index >= m_orientation_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     name = m_orientation_sensors[sens_index].m_name;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakePositionSensor::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue FakePositionSensor::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_orientation_sensors.size()) return false;
+    if (sens_index >= m_orientation_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     frameName = m_orientation_sensors[sens_index].m_framename;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool FakePositionSensor::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
+ReturnValue FakePositionSensor::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const
 {
     std::lock_guard<std::mutex> myLockGuard(m_mutex);
-    if (sens_index >= m_orientation_sensors.size()) return false;
+    if (sens_index >= m_orientation_sensors.size()) {return ReturnValue_error_input_out_of_bounds;}
     timestamp = m_orientation_sensors[sens_index].m_timestamp;
     xyz = m_orientation_sensors[sens_index].m_data;
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/fake/fakePositionSensor/FakePositionSensor.h
+++ b/src/devices/fake/fakePositionSensor/FakePositionSensor.h
@@ -65,17 +65,17 @@ public:
     bool close() override;
 
     //Interfaces
-    size_t getNrOfPositionSensors() const override;
+    yarp::dev::ReturnValue getNrOfPositionSensors(size_t& num) const override;
     yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
-    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
-    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getPositionSensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
-    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const override;
     yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    bool getOrientationSensorName(size_t sens_index, std::string& name) const override;
-    bool getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
     // RateThread interface
     void run() override;

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.cpp
@@ -720,34 +720,35 @@ yarp::dev::MAS_status BoschIMU::genericGetStatus(size_t sens_index) const
     return yarp::dev::MAS_status::MAS_OK;
 }
 
-bool BoschIMU::genericGetSensorName(size_t sens_index, std::string& name) const
+ReturnValue BoschIMU::genericGetSensorName(size_t sens_index, std::string& name) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     name = m_sensor_name;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BoschIMU::genericGetFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue BoschIMU::genericGetFrameName(size_t sens_index, std::string& frameName) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     frameName = m_frame_name;
-    return true;
+    return ReturnValue_ok;
 
 }
 
-size_t BoschIMU::getNrOfThreeAxisLinearAccelerometers() const
+ReturnValue BoschIMU::getNrOfThreeAxisLinearAccelerometers(size_t& num) const
 {
-    return 1;
+    num = 1;
+    return ReturnValue_ok;
 }
 
 
@@ -756,22 +757,22 @@ yarp::dev::MAS_status BoschIMU::getThreeAxisLinearAccelerometerStatus(size_t sen
     return genericGetStatus(sens_index);
 }
 
-bool BoschIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
+ReturnValue BoschIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool BoschIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue BoschIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool BoschIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue BoschIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -781,13 +782,13 @@ bool BoschIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::s
     out[2] = data[5];
 
     timestamp = m_timeStamp;
-    return true;
+    return ReturnValue_ok;
 }
 
 
-size_t BoschIMU::getNrOfThreeAxisGyroscopes() const
+ReturnValue BoschIMU::getNrOfThreeAxisGyroscopes(size_t& num) const
 {
-    return 1;
+    return ReturnValue_ok;
 }
 
 
@@ -796,22 +797,22 @@ yarp::dev::MAS_status BoschIMU::getThreeAxisGyroscopeStatus(size_t sens_index) c
     return genericGetStatus(sens_index);
 }
 
-bool BoschIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
+ReturnValue BoschIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool BoschIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue BoschIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool BoschIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue BoschIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -821,12 +822,13 @@ bool BoschIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector
     out[2] = data[8];
 
     timestamp = m_timeStamp;
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t BoschIMU::getNrOfOrientationSensors() const
+ReturnValue BoschIMU::getNrOfOrientationSensors(size_t& num) const
 {
-    return 1;
+    num =1;
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status BoschIMU::getOrientationSensorStatus(size_t sens_index) const
@@ -834,22 +836,22 @@ yarp::dev::MAS_status BoschIMU::getOrientationSensorStatus(size_t sens_index) co
     return genericGetStatus(sens_index);
 }
 
-bool BoschIMU::getOrientationSensorName(size_t sens_index, std::string& name) const
+ReturnValue BoschIMU::getOrientationSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool BoschIMU::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue BoschIMU::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool BoschIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const
+ReturnValue BoschIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     rpy.resize(3);
@@ -859,12 +861,13 @@ bool BoschIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp
     rpy[2] = data[2];
 
     timestamp = m_timeStamp;
-    return true;
+    return ReturnValue_ok;
 }
 
-size_t BoschIMU::getNrOfThreeAxisMagnetometers() const
+ReturnValue BoschIMU::getNrOfThreeAxisMagnetometers(size_t& num) const
 {
-    return 1;
+    num = 1;
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status BoschIMU::getThreeAxisMagnetometerStatus(size_t sens_index) const
@@ -872,22 +875,22 @@ yarp::dev::MAS_status BoschIMU::getThreeAxisMagnetometerStatus(size_t sens_index
     return genericGetStatus(sens_index);
 }
 
-bool BoschIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
+ReturnValue BoschIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
 {
     return genericGetSensorName(sens_index, name);
 }
 
-bool BoschIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue BoschIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(sens_index, frameName);
 }
 
-bool BoschIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue BoschIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if (sens_index != 0)
     {
         yCError(IMUBOSCH_BNO055) << "sens_index must be equal to 0, since there is only one sensor in consideration";
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     out.resize(3);
@@ -898,7 +901,7 @@ bool BoschIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vec
     out[2] = data[11]/ 1000000;
 
     timestamp = m_timeStamp;
-    return true;
+    return ReturnValue_ok;
 }
 
 

--- a/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
+++ b/src/devices/imuBosch_BNO055/imuBosch_BNO055.h
@@ -228,7 +228,7 @@ public:
      * Get the  number of three axis gyroscopes in the device
      * @return 1
      */
-    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t& num) const override;
 
     /**
      * Get the status of three axis gyroscope
@@ -243,7 +243,7 @@ public:
      * @param[out] name name of the sensor
      * @return true/false success/failure
      */
-    bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
 
     /**
      * Get the name of the frame in which three axis gyroscope measurements are expressed
@@ -251,7 +251,7 @@ public:
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
      */
-    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
 
     /**
      * Get three axis gyroscope measurements
@@ -260,14 +260,14 @@ public:
      * @param[out] timestamp timestamp of measurement
      * @return true/false success/failure
      */
-    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisLinearAccelerometers methods */
     /**
      * Get the  number of three axis linear accelerometers in the device
      * @return 1
      */
-    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t& num) const override;
 
     /**
      * Get the status of three axis linear accelerometer
@@ -282,7 +282,7 @@ public:
      * @param[out] name name of the sensor
      * @return true/false success/failure
      */
-    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
 
     /**
      * Get the name of the frame in which three axis linear accelerometer measurements are expressed
@@ -290,7 +290,7 @@ public:
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
      */
-    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
 
     /**
      * Get three axis linear accelerometer measurements
@@ -299,14 +299,14 @@ public:
      * @param[out] timestamp timestamp of measurement
      * @return true/false success/failure
      */
-    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisMagnetometers methods */
     /**
      * Get the  number of three axis magnetometers in the device
      * @return 1
      */
-    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t& num) const override;
 
     /**
      * Get the status of three axis magnetometer
@@ -321,7 +321,7 @@ public:
      * @param[out] name name of the sensor
      * @return true/false success/failure
      */
-    bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
 
     /**
      * Get the name of the frame in which three axis magnetometer measurements are expressed
@@ -329,7 +329,7 @@ public:
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
      */
-    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
 
     /**
      * Get three axis magnetometer measurements
@@ -338,14 +338,14 @@ public:
      * @param[out] timestamp timestamp of measurement
      * @return true/false success/failure
      */
-    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IOrientationSensors methods */
     /**
      * Get the  number of orientation sensors in the device
      * @return 1
      */
-    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const override;
 
     /**
      * Get the status of orientation sensor
@@ -360,7 +360,7 @@ public:
      * @param[out] name name of the sensor
      * @return true/false success/failure
      */
-    bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const override;
 
     /**
      * Get the name of the frame in which orientation sensor measurements are expressed
@@ -368,7 +368,7 @@ public:
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
      */
-    bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
 
     /**
      * Get orientation sensor measurements
@@ -377,7 +377,7 @@ public:
      * @param[out] timestamp timestamp of measurement
      * @return true/false success/failure
      */
-    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+    yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
     /**
      * Initialize process with desired device configurations
@@ -398,8 +398,8 @@ public:
 
 private:
     yarp::dev::MAS_status genericGetStatus(size_t sens_index) const;
-    bool genericGetSensorName(size_t sens_index, std::string &name) const;
-    bool genericGetFrameName(size_t sens_index, std::string &frameName) const;
+    yarp::dev::ReturnValue genericGetSensorName(size_t sens_index, std::string &name) const;
+    yarp::dev::ReturnValue genericGetFrameName(size_t sens_index, std::string &frameName) const;
 
 };
 

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.cpp
@@ -154,8 +154,8 @@ template<typename Interface>
 bool MultipleAnalogSensorsRemapper::genericAttachAll(const MAS_SensorType sensorType,
                                                      std::vector<Interface *>& subDeviceVec,
                                                      const PolyDriverList &polylist,
-                                                     bool (Interface::*getNameMethodPtr)(size_t, std::string&) const,
-                                                     size_t (Interface::*getNrOfSensorsMethodPtr)() const)
+                                                     ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const,
+                                                     ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t& ) const)
 {
     std::map<std::string, SensorInSubDevice> sensorLocationMap;
 
@@ -168,7 +168,13 @@ bool MultipleAnalogSensorsRemapper::genericAttachAll(const MAS_SensorType sensor
 
         if (subDeviceVec[p])
         {
-            size_t nrOfSensorsInSubDevice = MAS_CALL_MEMBER_FN(subDeviceVec[p], getNrOfSensorsMethodPtr)();
+            size_t nrOfSensorsInSubDevice = 0;
+            ReturnValue retnum = MAS_CALL_MEMBER_FN(subDeviceVec[p], getNrOfSensorsMethodPtr)(nrOfSensorsInSubDevice);
+            if (!retnum)
+            {
+                yCError(MULTIPLEANALOGSENSORSREMAPPER) << "Failure in reading number of sensors of type " << MAS_getTagFromEnum(sensorType) << " in device " << polylist[p]->key;
+                return false;
+            }
             for (size_t s=0; s < nrOfSensorsInSubDevice; s++)
             {
                 std::string name;
@@ -294,10 +300,10 @@ MAS_status MultipleAnalogSensorsRemapper::genericGetStatus(const MAS_SensorType 
 }
 
 template<typename Interface>
-bool MultipleAnalogSensorsRemapper::genericGetName(const MAS_SensorType sensorType,
+ReturnValue MultipleAnalogSensorsRemapper::genericGetName(const MAS_SensorType sensorType,
                                                            size_t& sens_index, std::string &name,
                                                            const std::vector<Interface *>& subDeviceVec,
-                                                           bool (Interface::*methodPtr)(size_t, std::string &) const) const
+                                                           yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, std::string &) const) const
 {
     size_t nrOfAvailableSensors = m_indicesMap[sensorType].size();
     if (sens_index >= nrOfAvailableSensors)
@@ -306,7 +312,7 @@ bool MultipleAnalogSensorsRemapper::genericGetName(const MAS_SensorType sensorTy
         {
             yCError(MULTIPLEANALOGSENSORSREMAPPER, "genericGetName sens_index %zu out of range of available sensors (%zu).", sens_index, nrOfAvailableSensors);
         }
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     SensorInSubDevice subDeviceSensor = m_indicesMap[sensorType][sens_index];
@@ -314,10 +320,10 @@ bool MultipleAnalogSensorsRemapper::genericGetName(const MAS_SensorType sensorTy
 }
 
 template<typename Interface>
-bool MultipleAnalogSensorsRemapper::genericGetFrameName(const MAS_SensorType sensorType,
+ReturnValue MultipleAnalogSensorsRemapper::genericGetFrameName(const MAS_SensorType sensorType,
                                                            size_t& sens_index, std::string &name,
                                                            const std::vector<Interface *>& subDeviceVec,
-                                                           bool (Interface::*methodPtr)(size_t, std::string &) const) const
+                                                           yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, std::string &) const) const
 {
     size_t nrOfAvailableSensors = m_indicesMap[sensorType].size();
     if (sens_index >= nrOfAvailableSensors)
@@ -326,7 +332,7 @@ bool MultipleAnalogSensorsRemapper::genericGetFrameName(const MAS_SensorType sen
         {
             yCError(MULTIPLEANALOGSENSORSREMAPPER, "genericGetFrameName sens_index %zu out of range of available sensors (%zu).", sens_index, nrOfAvailableSensors);
         }
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     SensorInSubDevice subDeviceSensor = m_indicesMap[sensorType][sens_index];
@@ -335,10 +341,10 @@ bool MultipleAnalogSensorsRemapper::genericGetFrameName(const MAS_SensorType sen
 
 
 template<typename Interface>
-bool MultipleAnalogSensorsRemapper::genericGetMeasure(const MAS_SensorType sensorType,
+ReturnValue MultipleAnalogSensorsRemapper::genericGetMeasure(const MAS_SensorType sensorType,
                                                            size_t& sens_index, yarp::sig::Vector& out, double& timestamp,
                                                            const std::vector<Interface *>& subDeviceVec,
-                                                           bool (Interface::*methodPtr)(size_t, yarp::sig::Vector&, double&) const) const
+                                                           yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, yarp::sig::Vector&, double&) const) const
 {
     size_t nrOfAvailableSensors = m_indicesMap[sensorType].size();
     if (sens_index >= nrOfAvailableSensors)
@@ -347,7 +353,7 @@ bool MultipleAnalogSensorsRemapper::genericGetMeasure(const MAS_SensorType senso
         {
             yCError(MULTIPLEANALOGSENSORSREMAPPER, "genericGetMeasure sens_index %zu out of range of available sensors (%zu).", sens_index, nrOfAvailableSensors);
         }
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     SensorInSubDevice subDeviceSensor = m_indicesMap[sensorType][sens_index];
@@ -405,9 +411,10 @@ size_t MultipleAnalogSensorsRemapper::get{{SensorTag}}Size(size_t sens_index) co
 
 */
 
-size_t MultipleAnalogSensorsRemapper::getNrOfThreeAxisGyroscopes() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfThreeAxisGyroscopes(size_t& num) const
 {
-    return m_indicesMap[ThreeAxisGyroscopes].size();
+    num = m_indicesMap[ThreeAxisGyroscopes].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeStatus(size_t sens_index) const
@@ -415,24 +422,24 @@ MAS_status MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeStatus(size_t sen
     return genericGetStatus(ThreeAxisGyroscopes, sens_index, m_iThreeAxisGyroscopes, &IThreeAxisGyroscopes::getThreeAxisGyroscopeStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeName(size_t sens_index, std::string& name) const
 {
      return genericGetName(ThreeAxisGyroscopes, sens_index, name, m_iThreeAxisGyroscopes, &IThreeAxisGyroscopes::getThreeAxisGyroscopeName);
 }
-
-bool MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(ThreeAxisGyroscopes, sens_index, frameName, m_iThreeAxisGyroscopes, &IThreeAxisGyroscopes::getThreeAxisGyroscopeFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ThreeAxisGyroscopes, sens_index, out, timestamp, m_iThreeAxisGyroscopes, &IThreeAxisGyroscopes::getThreeAxisGyroscopeMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfThreeAxisLinearAccelerometers() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfThreeAxisLinearAccelerometers(size_t& num) const
 {
-    return m_indicesMap[ThreeAxisLinearAccelerometers].size();
+    num = m_indicesMap[ThreeAxisLinearAccelerometers].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
@@ -440,24 +447,25 @@ MAS_status MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerStatus(
     return genericGetStatus(ThreeAxisLinearAccelerometers, sens_index, m_iThreeAxisLinearAccelerometers, &IThreeAxisLinearAccelerometers::getThreeAxisLinearAccelerometerStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string& name) const
 {
      return genericGetName(ThreeAxisLinearAccelerometers, sens_index, name, m_iThreeAxisLinearAccelerometers, &IThreeAxisLinearAccelerometers::getThreeAxisLinearAccelerometerName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(ThreeAxisLinearAccelerometers, sens_index, frameName, m_iThreeAxisLinearAccelerometers, &IThreeAxisLinearAccelerometers::getThreeAxisLinearAccelerometerFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ThreeAxisLinearAccelerometers, sens_index, out, timestamp, m_iThreeAxisLinearAccelerometers, &IThreeAxisLinearAccelerometers::getThreeAxisLinearAccelerometerMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfThreeAxisAngularAccelerometers() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfThreeAxisAngularAccelerometers(size_t& num) const
 {
-    return m_indicesMap[ThreeAxisAngularAccelerometers].size();
+    num = m_indicesMap[ThreeAxisAngularAccelerometers].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerStatus(size_t sens_index) const
@@ -465,24 +473,25 @@ MAS_status MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerStatus
     return genericGetStatus(ThreeAxisAngularAccelerometers, sens_index, m_iThreeAxisAngularAccelerometers, &IThreeAxisAngularAccelerometers::getThreeAxisAngularAccelerometerStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerName(size_t sens_index, std::string& name) const
 {
      return genericGetName(ThreeAxisAngularAccelerometers, sens_index, name, m_iThreeAxisAngularAccelerometers, &IThreeAxisAngularAccelerometers::getThreeAxisAngularAccelerometerName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(ThreeAxisAngularAccelerometers, sens_index, frameName, m_iThreeAxisAngularAccelerometers, &IThreeAxisAngularAccelerometers::getThreeAxisAngularAccelerometerFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ThreeAxisAngularAccelerometers, sens_index, out, timestamp, m_iThreeAxisAngularAccelerometers, &IThreeAxisAngularAccelerometers::getThreeAxisAngularAccelerometerMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfThreeAxisMagnetometers() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfThreeAxisMagnetometers(size_t& num) const
 {
-    return m_indicesMap[ThreeAxisMagnetometers].size();
+    num = m_indicesMap[ThreeAxisMagnetometers].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerStatus(size_t sens_index) const
@@ -490,24 +499,25 @@ MAS_status MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerStatus(size_t 
     return genericGetStatus(ThreeAxisMagnetometers, sens_index, m_iThreeAxisMagnetometers, &IThreeAxisMagnetometers::getThreeAxisMagnetometerStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
 {
      return genericGetName(ThreeAxisMagnetometers, sens_index, name, m_iThreeAxisMagnetometers, &IThreeAxisMagnetometers::getThreeAxisMagnetometerName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(ThreeAxisMagnetometers, sens_index, frameName, m_iThreeAxisMagnetometers, &IThreeAxisMagnetometers::getThreeAxisMagnetometerFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ThreeAxisMagnetometers, sens_index, out, timestamp, m_iThreeAxisMagnetometers, &IThreeAxisMagnetometers::getThreeAxisMagnetometerMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfPositionSensors() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfPositionSensors(size_t& num) const
 {
-    return m_indicesMap[PositionSensors].size();
+    num = m_indicesMap[PositionSensors].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getPositionSensorStatus(size_t sens_index) const
@@ -515,24 +525,25 @@ MAS_status MultipleAnalogSensorsRemapper::getPositionSensorStatus(size_t sens_in
     return genericGetStatus(PositionSensors, sens_index, m_iPositionSensors, &IPositionSensors::getPositionSensorStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getPositionSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getPositionSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(PositionSensors, sens_index, name, m_iPositionSensors, &IPositionSensors::getPositionSensorName);
 }
 
-bool MultipleAnalogSensorsRemapper::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(PositionSensors, sens_index, frameName, m_iPositionSensors, &IPositionSensors::getPositionSensorFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(PositionSensors, sens_index, out, timestamp, m_iPositionSensors, &IPositionSensors::getPositionSensorMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfLinearVelocitySensors() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfLinearVelocitySensors(size_t& num) const
 {
-    return m_indicesMap[LinearVelocitySensors].size();
+    num =  m_indicesMap[LinearVelocitySensors].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getLinearVelocitySensorStatus(size_t sens_index) const
@@ -540,24 +551,25 @@ MAS_status MultipleAnalogSensorsRemapper::getLinearVelocitySensorStatus(size_t s
     return genericGetStatus(LinearVelocitySensors, sens_index, m_iLinearVelocitySensors, &ILinearVelocitySensors::getLinearVelocitySensorStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getLinearVelocitySensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getLinearVelocitySensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(LinearVelocitySensors, sens_index, name, m_iLinearVelocitySensors, &ILinearVelocitySensors::getLinearVelocitySensorName);
 }
 
-bool MultipleAnalogSensorsRemapper::getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(LinearVelocitySensors, sens_index, frameName, m_iLinearVelocitySensors, &ILinearVelocitySensors::getLinearVelocitySensorFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(LinearVelocitySensors, sens_index, out, timestamp, m_iLinearVelocitySensors, &ILinearVelocitySensors::getLinearVelocitySensorMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfOrientationSensors() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfOrientationSensors(size_t& num) const
 {
-    return m_indicesMap[OrientationSensors].size();
+    num = m_indicesMap[OrientationSensors].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getOrientationSensorStatus(size_t sens_index) const
@@ -565,24 +577,25 @@ MAS_status MultipleAnalogSensorsRemapper::getOrientationSensorStatus(size_t sens
     return genericGetStatus(OrientationSensors, sens_index, m_iOrientationSensors, &IOrientationSensors::getOrientationSensorStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getOrientationSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getOrientationSensorName(size_t sens_index, std::string& name) const
 {
      return genericGetName(OrientationSensors, sens_index, name, m_iOrientationSensors, &IOrientationSensors::getOrientationSensorName);
 }
 
-bool MultipleAnalogSensorsRemapper::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getOrientationSensorFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(OrientationSensors, sens_index, frameName, m_iOrientationSensors, &IOrientationSensors::getOrientationSensorFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(OrientationSensors, sens_index, out, timestamp, m_iOrientationSensors, &IOrientationSensors::getOrientationSensorMeasureAsRollPitchYaw);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfTemperatureSensors() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfTemperatureSensors(size_t& num) const
 {
-    return m_indicesMap[TemperatureSensors].size();
+    num = m_indicesMap[TemperatureSensors].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getTemperatureSensorStatus(size_t sens_index) const
@@ -590,32 +603,33 @@ MAS_status MultipleAnalogSensorsRemapper::getTemperatureSensorStatus(size_t sens
     return genericGetStatus(TemperatureSensors, sens_index, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getTemperatureSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getTemperatureSensorName(size_t sens_index, std::string& name) const
 {
      return genericGetName(TemperatureSensors, sens_index, name, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorName);
 }
 
-bool MultipleAnalogSensorsRemapper::getTemperatureSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getTemperatureSensorFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(TemperatureSensors, sens_index, frameName, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(TemperatureSensors, sens_index, out, timestamp, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorMeasure);
 }
 
-bool MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
 {
     yarp::sig::Vector dummy(1);
-    bool ok = genericGetMeasure(TemperatureSensors, sens_index, dummy, timestamp, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorMeasure);
+    ReturnValue ok = genericGetMeasure(TemperatureSensors, sens_index, dummy, timestamp, m_iTemperatureSensors, &ITemperatureSensors::getTemperatureSensorMeasure);
     out = dummy[0];
     return ok;
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfSixAxisForceTorqueSensors() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfSixAxisForceTorqueSensors(size_t& num) const
 {
-    return m_indicesMap[SixAxisForceTorqueSensors].size();
+    num = m_indicesMap[SixAxisForceTorqueSensors].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorStatus(size_t sens_index) const
@@ -623,24 +637,25 @@ MAS_status MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorStatus(size
     return genericGetStatus(SixAxisForceTorqueSensors, sens_index, m_iSixAxisForceTorqueSensors, &ISixAxisForceTorqueSensors::getSixAxisForceTorqueSensorStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorName(size_t sens_index, std::string& name) const
 {
      return genericGetName(SixAxisForceTorqueSensors, sens_index, name, m_iSixAxisForceTorqueSensors, &ISixAxisForceTorqueSensors::getSixAxisForceTorqueSensorName);
 }
 
-bool MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string& frameName) const
 {
      return genericGetFrameName(SixAxisForceTorqueSensors, sens_index, frameName, m_iSixAxisForceTorqueSensors, &ISixAxisForceTorqueSensors::getSixAxisForceTorqueSensorFrameName);
 }
 
-bool MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(SixAxisForceTorqueSensors, sens_index, out, timestamp, m_iSixAxisForceTorqueSensors, &ISixAxisForceTorqueSensors::getSixAxisForceTorqueSensorMeasure);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfContactLoadCellArrays() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfContactLoadCellArrays(size_t& num) const
 {
-    return m_indicesMap[ContactLoadCellArrays].size();
+    num = m_indicesMap[ContactLoadCellArrays].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getContactLoadCellArrayStatus(size_t sens_index) const
@@ -648,12 +663,12 @@ MAS_status MultipleAnalogSensorsRemapper::getContactLoadCellArrayStatus(size_t s
     return genericGetStatus(ContactLoadCellArrays, sens_index, m_iContactLoadCellArrays, &IContactLoadCellArrays::getContactLoadCellArrayStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getContactLoadCellArrayName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getContactLoadCellArrayName(size_t sens_index, std::string& name) const
 {
      return genericGetName(ContactLoadCellArrays, sens_index, name, m_iContactLoadCellArrays, &IContactLoadCellArrays::getContactLoadCellArrayName);
 }
 
-bool MultipleAnalogSensorsRemapper::getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(ContactLoadCellArrays, sens_index, out, timestamp, m_iContactLoadCellArrays, &IContactLoadCellArrays::getContactLoadCellArrayMeasure);
 }
@@ -663,9 +678,10 @@ size_t MultipleAnalogSensorsRemapper::getContactLoadCellArraySize(size_t sens_in
     return genericGetSize(ContactLoadCellArrays, sens_index, m_iContactLoadCellArrays, &IContactLoadCellArrays::getContactLoadCellArraySize);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfEncoderArrays() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfEncoderArrays(size_t& num) const
 {
-    return m_indicesMap[EncoderArrays].size();
+    num = m_indicesMap[EncoderArrays].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getEncoderArrayStatus(size_t sens_index) const
@@ -673,12 +689,12 @@ MAS_status MultipleAnalogSensorsRemapper::getEncoderArrayStatus(size_t sens_inde
     return genericGetStatus(EncoderArrays, sens_index, m_iEncoderArrays, &IEncoderArrays::getEncoderArrayStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getEncoderArrayName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getEncoderArrayName(size_t sens_index, std::string& name) const
 {
      return genericGetName(EncoderArrays, sens_index, name, m_iEncoderArrays, &IEncoderArrays::getEncoderArrayName);
 }
 
-bool MultipleAnalogSensorsRemapper::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(EncoderArrays, sens_index, out, timestamp, m_iEncoderArrays, &IEncoderArrays::getEncoderArrayMeasure);
 }
@@ -688,9 +704,10 @@ size_t MultipleAnalogSensorsRemapper::getEncoderArraySize(size_t sens_index) con
     return genericGetSize(EncoderArrays, sens_index, m_iEncoderArrays, &IEncoderArrays::getEncoderArraySize);
 }
 
-size_t MultipleAnalogSensorsRemapper::getNrOfSkinPatches() const
+ReturnValue MultipleAnalogSensorsRemapper::getNrOfSkinPatches(size_t& num) const
 {
-    return m_indicesMap[SkinPatches].size();
+    num = m_indicesMap[SkinPatches].size();
+    return ReturnValue_ok;
 }
 
 MAS_status MultipleAnalogSensorsRemapper::getSkinPatchStatus(size_t sens_index) const
@@ -698,12 +715,12 @@ MAS_status MultipleAnalogSensorsRemapper::getSkinPatchStatus(size_t sens_index) 
     return genericGetStatus(SkinPatches, sens_index, m_iSkinPatches, &ISkinPatches::getSkinPatchStatus);
 }
 
-bool MultipleAnalogSensorsRemapper::getSkinPatchName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsRemapper::getSkinPatchName(size_t sens_index, std::string& name) const
 {
      return genericGetName(SkinPatches, sens_index, name, m_iSkinPatches, &ISkinPatches::getSkinPatchName);
 }
 
-bool MultipleAnalogSensorsRemapper::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsRemapper::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
      return genericGetMeasure(SkinPatches, sens_index, out, timestamp, m_iSkinPatches, &ISkinPatches::getSkinPatchMeasure);
 }

--- a/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
+++ b/src/devices/multipleanalogsensorsremapper/MultipleAnalogSensorsRemapper.h
@@ -9,6 +9,7 @@
 
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/ReturnValue.h>
 
 #include <vector>
 #include <map>
@@ -145,20 +146,20 @@ private:
                                 const std::vector<Interface *>& subDeviceVec,
                                 yarp::dev::MAS_status (Interface::*methodPtr)(size_t) const) const;
     template<typename Interface>
-    bool genericGetName(const MAS_SensorType sensorType,
+    yarp::dev::ReturnValue genericGetName(const MAS_SensorType sensorType,
                                 size_t& sens_index, std::string &name,
                                 const std::vector<Interface *>& subDeviceVec,
-                                bool (Interface::*methodPtr)(size_t, std::string&) const) const;
+                                yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, std::string&) const) const;
     template<typename Interface>
-    bool genericGetFrameName(const MAS_SensorType sensorType,
+    yarp::dev::ReturnValue genericGetFrameName(const MAS_SensorType sensorType,
                                 size_t& sens_index, std::string &name,
                                 const std::vector<Interface *>& subDeviceVec,
-                                bool (Interface::*methodPtr)(size_t, std::string&) const) const;
+                                yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, std::string&) const) const;
     template<typename Interface>
-    bool genericGetMeasure(const MAS_SensorType sensorType,
+    yarp::dev::ReturnValue genericGetMeasure(const MAS_SensorType sensorType,
                                  size_t& sens_index, yarp::sig::Vector& out, double& timestamp,
                                  const std::vector<Interface *>& subDeviceVec,
-                                 bool (Interface::*methodPtr)(size_t, yarp::sig::Vector&, double&) const) const;
+                                 yarp::dev::ReturnValue (Interface::*methodPtr)(size_t, yarp::sig::Vector&, double&) const) const;
     template<typename Interface>
     size_t genericGetSize(const MAS_SensorType sensorType,
                                  size_t& sens_index,
@@ -169,8 +170,8 @@ private:
     bool genericAttachAll(const MAS_SensorType sensorType,
                           std::vector<Interface *>& subDeviceVec,
                           const yarp::dev::PolyDriverList &polylist,
-                          bool (Interface::*getNameMethodPtr)(size_t, std::string&) const,
-                          size_t (Interface::*getNrOfSensorsMethodPtr)() const);
+                          yarp::dev::ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const,
+                          yarp::dev::ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t& ) const);
 
 public:
     /* DeviceDriver methods */
@@ -182,89 +183,89 @@ public:
     bool detachAll() override;
 
     /* IThreeAxisGyroscopes methods */
-    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
-    bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisLinearAccelerometers methods */
-    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
-    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisAngularAccelerometers methods */
-    size_t getNrOfThreeAxisAngularAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisAngularAccelerometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisAngularAccelerometerStatus(size_t sens_index) const override;
-    bool getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisMagnetometers methods */
-    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IOrientationSensors methods */
-    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const override;
     yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
-    bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+    yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
     /* ITemperatureSensors methods */
-    size_t getNrOfTemperatureSensors() const override;
+    yarp::dev::ReturnValue getNrOfTemperatureSensors(size_t& num) const override;
     yarp::dev::MAS_status getTemperatureSensorStatus(size_t sens_index) const override;
-    bool getTemperatureSensorName(size_t sens_index, std::string &name) const override;
-    bool getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
-    bool getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getTemperatureSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* ISixAxisForceTorqueSensors */
-    size_t getNrOfSixAxisForceTorqueSensors() const override;
+    yarp::dev::ReturnValue getNrOfSixAxisForceTorqueSensors(size_t& num) const override;
     yarp::dev::MAS_status getSixAxisForceTorqueSensorStatus(size_t sens_index) const override;
-    bool getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
-    bool getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frame) const override;
-    bool getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frame) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IContactLoadCellArrays */
-    size_t getNrOfContactLoadCellArrays() const override;
+    yarp::dev::ReturnValue getNrOfContactLoadCellArrays(size_t& num) const override;
     yarp::dev::MAS_status getContactLoadCellArrayStatus(size_t sens_index) const override;
-    bool getContactLoadCellArrayName(size_t sens_index, std::string &name) const override;
-    bool getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getContactLoadCellArrayName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getContactLoadCellArraySize(size_t sens_index) const override;
 
     /* IEncoderArrays */
-    size_t getNrOfEncoderArrays() const override;
+    yarp::dev::ReturnValue getNrOfEncoderArrays(size_t& num) const override;
     yarp::dev::MAS_status getEncoderArrayStatus(size_t sens_index) const override;
-    bool getEncoderArrayName(size_t sens_index, std::string &name) const override;
-    bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getEncoderArrayName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getEncoderArraySize(size_t sens_index) const override;
 
     /* ISkinPatches */
-    size_t getNrOfSkinPatches() const override;
+    yarp::dev::ReturnValue getNrOfSkinPatches(size_t& num) const override;
     yarp::dev::MAS_status getSkinPatchStatus(size_t sens_index) const override;
-    bool getSkinPatchName(size_t sens_index, std::string &name) const override;
-    bool getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getSkinPatchName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getSkinPatchSize(size_t sens_index) const override;
 
     /* IPositionSensors methods */
-    size_t getNrOfPositionSensors() const override;
+    yarp::dev::ReturnValue getNrOfPositionSensors(size_t& num) const override;
     yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
-    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
-    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getPositionSensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
     /* ILinearVelocitySensors methods */
-    size_t getNrOfLinearVelocitySensors() const override;
+    yarp::dev::ReturnValue getNrOfLinearVelocitySensors(size_t& num) const override;
     yarp::dev::MAS_status getLinearVelocitySensorStatus(size_t sens_index) const override;
-    bool getLinearVelocitySensorName(size_t sens_index, std::string& name) const override;
-    bool getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 };
 
 

--- a/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.cpp
@@ -14,6 +14,8 @@ namespace {
 YARP_LOG_COMPONENT(MULTIPLEANALOGSENSORSCLIENT, "yarp.device.multipleanalogsensorsclient")
 }
 
+using namespace yarp::dev;
+
 void SensorStreamingDataInputPort::onRead(yarp::dev::SensorStreamingData& v)
 {
     std::lock_guard<std::mutex> guard(dataMutex);
@@ -149,14 +151,14 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::genericGetStatus() const
     return m_streamingPort.status;
 }
 
-bool MultipleAnalogSensorsClient::genericGetName(const  std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+ReturnValue MultipleAnalogSensorsClient::genericGetName(const  std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                                                    size_t sens_index, std::string& name) const
 {
     if (m_externalConnection) {
         yCError(MULTIPLEANALOGSENSORSCLIENT,
                 "Missing metadata, the device has been configured with the option"
                 "externalConnection set to true.");
-        return false;
+        return ReturnValue_error_method_failed;
     }
     if (sens_index >= metadataVector.size())
     {
@@ -165,21 +167,21 @@ bool MultipleAnalogSensorsClient::genericGetName(const  std::vector<SensorMetada
                 tag.c_str(),
                 sens_index,
                 metadataVector.size());
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     name = metadataVector[sens_index].name;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool MultipleAnalogSensorsClient::genericGetFrameName(const  std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+ReturnValue MultipleAnalogSensorsClient::genericGetFrameName(const  std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                                                       size_t sens_index, std::string& frameName) const
 {
     if (m_externalConnection) {
         yCError(MULTIPLEANALOGSENSORSCLIENT,
                 "Missing metadata, the device has been configured with the option"
                 "externalConnection set to true.");
-        return false;
+        return ReturnValue_error_method_failed;
     }
     if (sens_index >= metadataVector.size())
     {
@@ -188,14 +190,14 @@ bool MultipleAnalogSensorsClient::genericGetFrameName(const  std::vector<SensorM
                 tag.c_str(),
                 sens_index,
                 metadataVector.size());
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     frameName = metadataVector[sens_index].frameName;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+ReturnValue MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                                                     const yarp::dev::SensorMeasurements& measurementsVector,
                                                     size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
@@ -208,7 +210,7 @@ bool MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMeta
                 "Sensor of type %s with index %lu has non-MAS_OK status.",
                 tag.c_str(),
                 sens_index);
-        return false;
+        return ReturnValue_error_not_ready;
     }
 
     if (m_streamingPort.status != (sens_index >= measurementsVector.measurements.size()))
@@ -218,7 +220,7 @@ bool MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMeta
                 tag.c_str(),
                 sens_index,
                 metadataVector.size());
-        return false;
+        return ReturnValue_error_input_out_of_bounds;
     }
 
     if (!m_externalConnection) {
@@ -228,7 +230,7 @@ bool MultipleAnalogSensorsClient::genericGetMeasure(const std::vector<SensorMeta
     timestamp = measurementsVector.measurements[sens_index].timestamp;
     out = measurementsVector.measurements[sens_index].measurement;
 
-    return true;
+    return ReturnValue_ok;
 }
 
 size_t MultipleAnalogSensorsClient::genericGetSize(const std::vector<SensorMetadata>& metadataVector,
@@ -291,10 +293,11 @@ size_t MultipleAnalogSensorsClient::get{{SensorSingular}}Size(size_t sens_index)
 
 */
 
-size_t MultipleAnalogSensorsClient::getNrOfThreeAxisGyroscopes() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfThreeAxisGyroscopes(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisGyroscopes,
+    num = genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisGyroscopes,
                                  m_streamingPort.receivedData.ThreeAxisGyroscopes);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisGyroscopeStatus(size_t sens_index) const
@@ -302,26 +305,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisGyroscopeStatus(s
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
 {
     return genericGetName(m_sensorsMetadata.ThreeAxisGyroscopes, "ThreeAxisGyroscopes", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.ThreeAxisGyroscopes, "ThreeAxisGyroscopes", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.ThreeAxisGyroscopes, "ThreeAxisGyroscopes",
                              m_streamingPort.receivedData.ThreeAxisGyroscopes, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfThreeAxisLinearAccelerometers() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfThreeAxisLinearAccelerometers(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisLinearAccelerometers,
+    num = genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisLinearAccelerometers,
                                  m_streamingPort.receivedData.ThreeAxisLinearAccelerometers);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
@@ -329,26 +333,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisLinearAcceleromet
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
 {
     return genericGetName(m_sensorsMetadata.ThreeAxisLinearAccelerometers, "ThreeAxisLinearAccelerometers", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.ThreeAxisLinearAccelerometers, "ThreeAxisLinearAccelerometers", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.ThreeAxisLinearAccelerometers, "ThreeAxisLinearAccelerometers",
                              m_streamingPort.receivedData.ThreeAxisLinearAccelerometers, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfThreeAxisAngularAccelerometers() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfThreeAxisAngularAccelerometers(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisAngularAccelerometers,
+    num = genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisAngularAccelerometers,
                                  m_streamingPort.receivedData.ThreeAxisAngularAccelerometers);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerStatus(size_t sens_index) const
@@ -356,26 +361,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisAngularAccelerome
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const
 {
     return genericGetName(m_sensorsMetadata.ThreeAxisAngularAccelerometers, "ThreeAxisAngularAccelerometers", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.ThreeAxisAngularAccelerometers, "ThreeAxisAngularAccelerometers", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.ThreeAxisAngularAccelerometers, "ThreeAxisAngularAccelerometers",
                              m_streamingPort.receivedData.ThreeAxisAngularAccelerometers, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfThreeAxisMagnetometers() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfThreeAxisMagnetometers(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisMagnetometers,
+    num = genericGetNrOfSensors(m_sensorsMetadata.ThreeAxisMagnetometers,
                                  m_streamingPort.receivedData.ThreeAxisMagnetometers);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisMagnetometerStatus(size_t sens_index) const
@@ -383,26 +389,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getThreeAxisMagnetometerStatu
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisMagnetometerName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.ThreeAxisMagnetometers, "ThreeAxisMagnetometers", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.ThreeAxisMagnetometers, "ThreeAxisMagnetometers", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.ThreeAxisMagnetometers, "ThreeAxisMagnetometers",
                              m_streamingPort.receivedData.ThreeAxisMagnetometers, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfOrientationSensors() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfOrientationSensors(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.OrientationSensors,
+    num = genericGetNrOfSensors(m_sensorsMetadata.OrientationSensors,
                                  m_streamingPort.receivedData.OrientationSensors);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getOrientationSensorStatus(size_t sens_index) const
@@ -410,26 +417,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getOrientationSensorStatus(si
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getOrientationSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getOrientationSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.OrientationSensors, "OrientationSensors", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.OrientationSensors, "OrientationSensors", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.OrientationSensors, "OrientationSensors",
                              m_streamingPort.receivedData.OrientationSensors, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfPositionSensors() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfPositionSensors(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.PositionSensors,
+    num = genericGetNrOfSensors(m_sensorsMetadata.PositionSensors,
                                  m_streamingPort.receivedData.PositionSensors);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getPositionSensorStatus(size_t sens_index) const
@@ -437,25 +445,26 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getPositionSensorStatus(size_
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getPositionSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getPositionSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.PositionSensors, "PositionSensors", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsClient::getPositionSensorFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.PositionSensors, "PositionSensors", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.PositionSensors, "PositionSensors", m_streamingPort.receivedData.PositionSensors, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfLinearVelocitySensors() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfLinearVelocitySensors(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.LinearVelocitySensors,
+    num = genericGetNrOfSensors(m_sensorsMetadata.LinearVelocitySensors,
                                  m_streamingPort.receivedData.LinearVelocitySensors);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getLinearVelocitySensorStatus(size_t sens_index) const
@@ -463,25 +472,26 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getLinearVelocitySensorStatus
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getLinearVelocitySensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getLinearVelocitySensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.LinearVelocitySensors, "LinearVelocitySensors", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const
+ReturnValue MultipleAnalogSensorsClient::getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.LinearVelocitySensors, "LinearVelocitySensors", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.LinearVelocitySensors, "LinearVelocitySensors", m_streamingPort.receivedData.LinearVelocitySensors, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfTemperatureSensors() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfTemperatureSensors(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.TemperatureSensors,
+    num = genericGetNrOfSensors(m_sensorsMetadata.TemperatureSensors,
                                  m_streamingPort.receivedData.TemperatureSensors);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getTemperatureSensorStatus(size_t sens_index) const
@@ -489,34 +499,35 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getTemperatureSensorStatus(si
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getTemperatureSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getTemperatureSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.TemperatureSensors, "TemperatureSensors", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.TemperatureSensors, "TemperatureSensors", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.TemperatureSensors, "TemperatureSensors",
                              m_streamingPort.receivedData.TemperatureSensors, sens_index, out, timestamp);
 }
 
-bool MultipleAnalogSensorsClient::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
 {
     yarp::sig::Vector dummy(1);
-    bool ok = this->getTemperatureSensorMeasure(sens_index, dummy, timestamp);
+    ReturnValue ok = this->getTemperatureSensorMeasure(sens_index, dummy, timestamp);
     out = dummy[0];
     return ok;
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfSixAxisForceTorqueSensors() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfSixAxisForceTorqueSensors(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.SixAxisForceTorqueSensors,
+    num = genericGetNrOfSensors(m_sensorsMetadata.SixAxisForceTorqueSensors,
                                  m_streamingPort.receivedData.SixAxisForceTorqueSensors);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorStatus(size_t sens_index) const
@@ -524,26 +535,27 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorSt
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.SixAxisForceTorqueSensors, "SixAxisForceTorqueSensors", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const
+ReturnValue MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     return genericGetFrameName(m_sensorsMetadata.SixAxisForceTorqueSensors, "SixAxisForceTorqueSensors", sens_index, frameName);
 }
 
-bool MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.SixAxisForceTorqueSensors, "SixAxisForceTorqueSensors",
                              m_streamingPort.receivedData.SixAxisForceTorqueSensors, sens_index, out, timestamp);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfContactLoadCellArrays() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfContactLoadCellArrays(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.ContactLoadCellArrays,
+    num = genericGetNrOfSensors(m_sensorsMetadata.ContactLoadCellArrays,
                                  m_streamingPort.receivedData.ContactLoadCellArrays);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getContactLoadCellArrayStatus(size_t sens_index) const
@@ -551,12 +563,12 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getContactLoadCellArrayStatus
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getContactLoadCellArrayName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getContactLoadCellArrayName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.ContactLoadCellArrays, "ContactLoadCellArrays", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.ContactLoadCellArrays, "ContactLoadCellArrays",
                              m_streamingPort.receivedData.ContactLoadCellArrays, sens_index, out, timestamp);
@@ -568,10 +580,11 @@ size_t MultipleAnalogSensorsClient::getContactLoadCellArraySize(size_t sens_inde
                           m_streamingPort.receivedData.ContactLoadCellArrays, sens_index);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfEncoderArrays() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfEncoderArrays(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.EncoderArrays,
+    num = genericGetNrOfSensors(m_sensorsMetadata.EncoderArrays,
                                  m_streamingPort.receivedData.EncoderArrays);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getEncoderArrayStatus(size_t sens_index) const
@@ -579,12 +592,12 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getEncoderArrayStatus(size_t 
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getEncoderArrayName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getEncoderArrayName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.EncoderArrays, "EncoderArrays", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.EncoderArrays, "EncoderArrays",
                              m_streamingPort.receivedData.EncoderArrays, sens_index, out, timestamp);
@@ -596,10 +609,11 @@ size_t MultipleAnalogSensorsClient::getEncoderArraySize(size_t sens_index) const
                           m_streamingPort.receivedData.EncoderArrays, sens_index);
 }
 
-size_t MultipleAnalogSensorsClient::getNrOfSkinPatches() const
+ReturnValue MultipleAnalogSensorsClient::getNrOfSkinPatches(size_t& num) const
 {
-    return genericGetNrOfSensors(m_sensorsMetadata.SkinPatches,
+    num = genericGetNrOfSensors(m_sensorsMetadata.SkinPatches,
                                  m_streamingPort.receivedData.SkinPatches);
+    return ReturnValue_ok;
 }
 
 yarp::dev::MAS_status MultipleAnalogSensorsClient::getSkinPatchStatus(size_t sens_index) const
@@ -607,12 +621,12 @@ yarp::dev::MAS_status MultipleAnalogSensorsClient::getSkinPatchStatus(size_t sen
     return genericGetStatus();
 }
 
-bool MultipleAnalogSensorsClient::getSkinPatchName(size_t sens_index, std::string& name) const
+ReturnValue MultipleAnalogSensorsClient::getSkinPatchName(size_t sens_index, std::string& name) const
 {
     return genericGetName(m_sensorsMetadata.SkinPatches, "SkinPatches", sens_index, name);
 }
 
-bool MultipleAnalogSensorsClient::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+ReturnValue MultipleAnalogSensorsClient::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     return genericGetMeasure(m_sensorsMetadata.SkinPatches, "SkinPatches",
                              m_streamingPort.receivedData.SkinPatches, sens_index, out, timestamp);

--- a/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
+++ b/src/devices/networkWrappers/multipleanalogsensorsclient/MultipleAnalogSensorsClient.h
@@ -14,6 +14,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
 #include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/ReturnValue.h>
 
 #include "MultipleAnalogSensorsClient_ParamsParser.h"
 
@@ -68,11 +69,11 @@ class MultipleAnalogSensorsClient :
     size_t genericGetNrOfSensors(const std::vector<SensorMetadata>& metadataVector,
                                  const  yarp::dev::SensorMeasurements& measurementsVector) const;
     yarp::dev::MAS_status genericGetStatus() const;
-    bool genericGetName(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+    yarp::dev::ReturnValue genericGetName(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                           size_t sens_index, std::string &name) const;
-    bool genericGetFrameName(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+    yarp::dev::ReturnValue genericGetFrameName(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                             size_t sens_index, std::string &frameName) const;
-    bool genericGetMeasure(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
+    yarp::dev::ReturnValue genericGetMeasure(const std::vector<SensorMetadata>& metadataVector, const std::string& tag,
                              const  yarp::dev::SensorMeasurements& measurementsVector,
                              size_t sens_index, yarp::sig::Vector& out, double& timestamp) const;
     size_t genericGetSize(const std::vector<SensorMetadata>& metadataVector,
@@ -85,88 +86,88 @@ public:
     bool close() override;
 
     /* IThreeAxisGyroscopes methods */
-    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
-    bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisLinearAccelerometers methods */
-    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
-    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisAngularAccelerometers methods */
-    size_t getNrOfThreeAxisAngularAccelerometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisAngularAccelerometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisAngularAccelerometerStatus(size_t sens_index) const override;
-    bool getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisMagnetometers methods */
-    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t& num) const override;
     yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
-    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IPositionSensors methods */
-    size_t getNrOfPositionSensors() const override;
+    yarp::dev::ReturnValue getNrOfPositionSensors(size_t& num) const override;
     yarp::dev::MAS_status getPositionSensorStatus(size_t sens_index) const override;
-    bool getPositionSensorName(size_t sens_index, std::string& name) const override;
-    bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getPositionSensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
     /* ILinearVelocitySensors methods */
-    size_t getNrOfLinearVelocitySensors() const override;
+    yarp::dev::ReturnValue getNrOfLinearVelocitySensors(size_t& num) const override;
     yarp::dev::MAS_status getLinearVelocitySensorStatus(size_t sens_index) const override;
-    bool getLinearVelocitySensorName(size_t sens_index, std::string& name) const override;
-    bool getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const override;
-    bool getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorName(size_t sens_index, std::string& name) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const override;
+    yarp::dev::ReturnValue getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
     /* IOrientationSensors methods */
-    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const override;
     yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
-    bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+    yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
     /* ITemperatureSensors methods */
-    size_t getNrOfTemperatureSensors() const override;
+    yarp::dev::ReturnValue getNrOfTemperatureSensors(size_t& num) const override;
     yarp::dev::MAS_status getTemperatureSensorStatus(size_t sens_index) const override;
-    bool getTemperatureSensorName(size_t sens_index, std::string &name) const override;
-    bool getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    bool getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
-    bool getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getTemperatureSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* ISixAxisForceTorqueSensors */
-    size_t getNrOfSixAxisForceTorqueSensors() const override;
+    yarp::dev::ReturnValue getNrOfSixAxisForceTorqueSensors(size_t& num) const override;
     yarp::dev::MAS_status getSixAxisForceTorqueSensorStatus(size_t sens_index) const override;
-    bool getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
-    bool getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frame) const override;
-    bool getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frame) const override;
+    yarp::dev::ReturnValue getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IContactLoadCellArrays */
-    size_t getNrOfContactLoadCellArrays() const override;
+    yarp::dev::ReturnValue getNrOfContactLoadCellArrays(size_t& num) const override;
     yarp::dev::MAS_status getContactLoadCellArrayStatus(size_t sens_index) const override;
-    bool getContactLoadCellArrayName(size_t sens_index, std::string &name) const override;
-    bool getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getContactLoadCellArrayName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getContactLoadCellArraySize(size_t sens_index) const override;
 
     /* IEncoderArrays */
-    size_t getNrOfEncoderArrays() const override;
+    yarp::dev::ReturnValue getNrOfEncoderArrays(size_t& num) const override;
     yarp::dev::MAS_status getEncoderArrayStatus(size_t sens_index) const override;
-    bool getEncoderArrayName(size_t sens_index, std::string &name) const override;
-    bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getEncoderArrayName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getEncoderArraySize(size_t sens_index) const override;
 
     /* ISkinPatches */
-    size_t getNrOfSkinPatches() const override;
+    yarp::dev::ReturnValue getNrOfSkinPatches(size_t& num) const override;
     yarp::dev::MAS_status getSkinPatchStatus(size_t sens_index) const override;
-    bool getSkinPatchName(size_t sens_index, std::string &name) const override;
-    bool getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    yarp::dev::ReturnValue getSkinPatchName(size_t sens_index, std::string &name) const override;
+    yarp::dev::ReturnValue getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     size_t getSkinPatchSize(size_t sens_index) const override;
 };
 

--- a/src/devices/networkWrappers/multipleanalogsensorsclient/tests/multipleAnalogSensorsClient_test.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsclient/tests/multipleAnalogSensorsClient_test.cpp
@@ -51,7 +51,9 @@ TEST_CASE("dev::MultipleAnalogSensorsClientTest", "[yarp::dev]")
         yarp::dev::IOrientationSensors* orientSens=nullptr;
         REQUIRE(imuSensor.view(orientSens)); // IOrientationSensors of fakeIMU correctly opened
         REQUIRE(orientSens);
-        int nrOfSensors = orientSens->getNrOfOrientationSensors();
+        size_t nrOfSensors = 0;
+        auto ret = orientSens->getNrOfOrientationSensors(nrOfSensors);
+        CHECK(ret);
         CHECK(nrOfSensors == 1); // getNrOfOrientationSensors of fakeIMU works correctly
 
         Property pWrapper;

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.cpp
@@ -13,11 +13,14 @@
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/Property.h>
 #include <yarp/dev/PolyDriverList.h>
+#include <yarp/dev/ReturnValue.h>
 
 
 namespace {
 YARP_LOG_COMPONENT(MULTIPLEANALOGSENSORSSERVER, "yarp.device.multipleanalogsensorsserver")
 }
+
+using namespace yarp::dev;
 
 /**
  * Internal identifier of the type of sensors.
@@ -158,37 +161,45 @@ bool MultipleAnalogSensorsServer::close()
 #define MAS_CALL_MEMBER_FN(object, ptrToMember)  ((*object).*(ptrToMember))
 
 template<typename Interface>
-bool MultipleAnalogSensorsServer::populateSensorsMetadata(Interface * wrappedDeviceInterface,
+ReturnValue MultipleAnalogSensorsServer::populateSensorsMetadata(Interface * wrappedDeviceInterface,
                                   std::vector<SensorMetadata>& metadataVector, const std::string& tag,
-                                  size_t (Interface::*getNrOfSensorsMethodPtr)() const,
-                                  bool (Interface::*getNameMethodPtr)(size_t, std::string&) const,
-                                  bool (Interface::*getFrameNameMethodPtr)(size_t, std::string&) const)
+                                  yarp::dev::ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t&) const,
+                                  yarp::dev::ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const,
+                                  yarp::dev::ReturnValue (Interface::*getFrameNameMethodPtr)(size_t, std::string&) const)
 {
     if (wrappedDeviceInterface)
     {
-        size_t nrOfSensors = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNrOfSensorsMethodPtr)();
+        size_t nrOfSensors = 0;
+        ReturnValue retnum = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNrOfSensorsMethodPtr)(nrOfSensors);
+        if (!retnum)
+        {
+            yCError(MULTIPLEANALOGSENSORSSERVER,
+                    "Failure in reading number of sensors of type %s.",
+                    tag.c_str());
+            return retnum;
+        }
         metadataVector.resize(nrOfSensors);
         for (size_t i=0; i < nrOfSensors; i++)
         {
             std::string sensorName;
-            bool ok = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNameMethodPtr)(i, sensorName);
-            if (!ok)
+            ReturnValue ret = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNameMethodPtr)(i, sensorName);
+            if (!ret)
             {
                 yCError(MULTIPLEANALOGSENSORSSERVER,
                         "Failure in reading name of sensor of type %s at index %zu.",
                         tag.c_str(),
                         i);
-                return false;
+                return ret;
             }
             std::string frameName;
-            ok = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getFrameNameMethodPtr)(i, frameName);
-            if (!ok)
+            ret = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getFrameNameMethodPtr)(i, frameName);
+            if (!ret)
             {
                 yCError(MULTIPLEANALOGSENSORSSERVER,
                         "Failure in reading frame name of sensor of type %s at index %zu.",
                         tag.c_str(),
                         i);
-                return false;
+                return ret;
             }
 
             metadataVector[i].name = sensorName;
@@ -201,30 +212,38 @@ bool MultipleAnalogSensorsServer::populateSensorsMetadata(Interface * wrappedDev
     {
         metadataVector.resize(0);
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 template<typename Interface>
-bool MultipleAnalogSensorsServer::populateSensorsMetadataNoFrameName(Interface * wrappedDeviceInterface,
+ReturnValue MultipleAnalogSensorsServer::populateSensorsMetadataNoFrameName(Interface * wrappedDeviceInterface,
                                                                      std::vector<SensorMetadata>& metadataVector, const std::string& tag,
-                                                                     size_t (Interface::*getNrOfSensorsMethodPtr)() const,
-                                                                     bool (Interface::*getNameMethodPtr)(size_t, std::string&) const)
+                                                                     yarp::dev::ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t&) const,
+                                                                     yarp::dev::ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const)
 {
     if (wrappedDeviceInterface)
     {
-        size_t nrOfSensors = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNrOfSensorsMethodPtr)();
+        size_t nrOfSensors = 0;
+        ReturnValue retnum = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNrOfSensorsMethodPtr)(nrOfSensors);
+        if (!retnum)
+        {
+            yCError(MULTIPLEANALOGSENSORSSERVER,
+                    "Failure in reading number of sensors of type %s.",
+                    tag.c_str());
+            return retnum;
+        }
         metadataVector.resize(nrOfSensors);
         for (size_t i=0; i < nrOfSensors; i++)
         {
             std::string sensorName;
-            bool ok = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNameMethodPtr)(i, sensorName);
-            if (!ok)
+            ReturnValue ret = MAS_CALL_MEMBER_FN(wrappedDeviceInterface, getNameMethodPtr)(i, sensorName);
+            if (!ret)
             {
                 yCError(MULTIPLEANALOGSENSORSSERVER,
                         "Failure in reading name of sensor of type  %s at index %zu.",
                         tag.c_str(),
                         i);
-                return false;
+                return ret;
             }
 
             metadataVector[i].name = sensorName;
@@ -237,13 +256,13 @@ bool MultipleAnalogSensorsServer::populateSensorsMetadataNoFrameName(Interface *
     {
         metadataVector.resize(0);
     }
-    return true;
+    return ReturnValue_ok;
 }
 
 
-bool MultipleAnalogSensorsServer::populateAllSensorsMetadata()
+ReturnValue MultipleAnalogSensorsServer::populateAllSensorsMetadata()
 {
-    bool ok = true;
+    ReturnValue ok = ReturnValue_ok;
     ok = ok && populateSensorsMetadata(m_iThreeAxisGyroscopes, m_sensorMetadata.ThreeAxisGyroscopes, "ThreeAxisGyroscopes",
                                        &yarp::dev::IThreeAxisGyroscopes::getNrOfThreeAxisGyroscopes,
                                        &yarp::dev::IThreeAxisGyroscopes::getThreeAxisGyroscopeName,
@@ -464,7 +483,7 @@ bool MultipleAnalogSensorsServer::genericStreamData(Interface* wrappedDeviceInte
                                                     const std::vector< SensorMetadata >& metadataVector,
                                                     std::vector< typename yarp::dev::SensorMeasurement >& streamingDataVector,
                                                     yarp::dev::MAS_status (Interface::*getStatusMethodPtr)(size_t) const,
-                                                    bool (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const,
+                                                    ReturnValue (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const,
                                                     const char* sensorType)
 {
     if (wrappedDeviceInterface)

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/MultipleAnalogSensorsServer.h
@@ -13,6 +13,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/WrapperSingle.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+#include <yarp/dev/ReturnValue.h>
 
 // Thrift-generated classes
 #include <yarp/dev/SensorMeasurement.h>
@@ -63,18 +64,19 @@ class MultipleAnalogSensorsServer :
 
     // Metadata to be server via the RPC port
     SensorRPCData m_sensorMetadata;
-    bool populateAllSensorsMetadata();
+    yarp::dev::ReturnValue populateAllSensorsMetadata();
+
     template<typename Interface>
-    bool populateSensorsMetadata(Interface * wrappedDeviceInterface,
+    yarp::dev::ReturnValue populateSensorsMetadata(Interface * wrappedDeviceInterface,
                                  std::vector<SensorMetadata>& metadataVector, const std::string& tag,
-                                 size_t (Interface::*getNrOfSensorsMethodPtr)() const,
-                                 bool (Interface::*getNameMethodPtr)(size_t, std::string&) const,
-                                 bool (Interface::*getFrameNameMethodPtr)(size_t, std::string&) const);
+                                 yarp::dev::ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t&) const,
+                                 yarp::dev::ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const,
+                                 yarp::dev::ReturnValue (Interface::*getFrameNameMethodPtr)(size_t, std::string&) const);
     template<typename Interface>
-    bool populateSensorsMetadataNoFrameName(Interface * wrappedDeviceInterface,
+    yarp::dev::ReturnValue populateSensorsMetadataNoFrameName(Interface * wrappedDeviceInterface,
                                             std::vector<SensorMetadata>& metadataVector, const std::string& tag,
-                                            size_t (Interface::*getNrOfSensorsMethodPtr)() const,
-                                            bool (Interface::*getNameMethodPtr)(size_t, std::string&) const);
+                                            yarp::dev::ReturnValue (Interface::*getNrOfSensorsMethodPtr)(size_t&) const,
+                                            yarp::dev::ReturnValue (Interface::*getNameMethodPtr)(size_t, std::string&) const);
 
 
     // Helper methods to resize measure buffers
@@ -97,7 +99,7 @@ class MultipleAnalogSensorsServer :
                            const std::vector< SensorMetadata >& metadataVector,
                            std::vector<  typename yarp::dev::SensorMeasurement >& streamingDataVector,
                            yarp::dev::MAS_status (Interface::*getStatusMethodPtr)(size_t) const,
-                           bool (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const,
+                           yarp::dev::ReturnValue (Interface::*getMeasureMethodPtr)(size_t, yarp::sig::Vector&, double&) const,
                            const char* sensorType);
 
 

--- a/src/devices/networkWrappers/multipleanalogsensorsserver/tests/multipleAnalogSensorsServer_test.cpp
+++ b/src/devices/networkWrappers/multipleanalogsensorsserver/tests/multipleAnalogSensorsServer_test.cpp
@@ -66,7 +66,9 @@ TEST_CASE("dev::MultipleAnalogSensorsServerTest", "[yarp::dev]")
         yarp::dev::IOrientationSensors* orientSens=nullptr;
         REQUIRE(imuSensor.view(orientSens)); // IOrientationSensors of fakeIMU correctly opened
         REQUIRE(orientSens);
-        int nrOfSensors = orientSens->getNrOfOrientationSensors();
+        size_t nrOfSensors = 0;
+        auto ret = orientSens->getNrOfOrientationSensors(nrOfSensors);
+        CHECK(ret);
         CHECK(nrOfSensors == 1); // getNrOfOrientationSensors of fakeIMU works correctly
 
         Property pWrapper;

--- a/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
+++ b/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <string>
 
+#include <yarp/dev/ReturnValue.h>
 #include <yarp/dev/api.h>
 #include <yarp/sig/Vector.h>
 
@@ -61,7 +62,7 @@ public:
     /**
      * Get the number of three axis gyroscopes exposed by this sensor.
      */
-    virtual size_t getNrOfThreeAxisGyroscopes() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -76,7 +77,7 @@ public:
      * @param[in] sens_index The index of the specified sensor (should be between 0 and getNrOfThreeAxisGyroscopes()-1).
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
@@ -84,7 +85,7 @@ public:
      * @param[in] sens_index The index of the specified sensor (should be between 0 and getNrOfThreeAxisGyroscopes()-1).
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * \brief Get the last reading of the gyroscope.
@@ -94,7 +95,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~IThreeAxisGyroscopes(){}
 };
@@ -115,7 +116,7 @@ public:
     /**
      * \brief Get the number of three axis linear accelerometers exposed by this device.
      */
-    virtual size_t getNrOfThreeAxisLinearAccelerometers() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -126,13 +127,13 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -142,7 +143,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~IThreeAxisLinearAccelerometers(){}
 };
@@ -153,7 +154,7 @@ public:
     /**
      * \brief Get the number of three axis angular accelerometers exposed by this device.
      */
-    virtual size_t getNrOfThreeAxisAngularAccelerometers() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisAngularAccelerometers(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -164,13 +165,13 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisAngularAccelerometerName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisAngularAccelerometerFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -180,7 +181,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisAngularAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~IThreeAxisAngularAccelerometers(){}
 };
@@ -200,7 +201,7 @@ public:
     /**
      * Get the number of magnetometers exposed by this device.
      */
-    virtual size_t getNrOfThreeAxisMagnetometers() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -211,13 +212,13 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -227,7 +228,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~IThreeAxisMagnetometers(){}
 };
@@ -251,7 +252,7 @@ public:
     /**
      * Get the number of position sensors exposed by this device.
      */
-    virtual size_t getNrOfPositionSensors() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfPositionSensors(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -262,7 +263,7 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getPositionSensorName(size_t sens_index, std::string& name) const = 0;
+    virtual yarp::dev::ReturnValue getPositionSensorName(size_t sens_index, std::string& name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
@@ -272,7 +273,7 @@ public:
      *
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const = 0;
+    virtual yarp::dev::ReturnValue getPositionSensorFrameName(size_t sens_index, std::string& frameName) const = 0;
 
     /**
      * Get the last reading of the position sensor as x y z.
@@ -282,7 +283,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const = 0;
 
     virtual ~IPositionSensors()
     {
@@ -295,7 +296,7 @@ public:
     /**
      * Get the number of linear velocity sensors exposed by this device.
      */
-    virtual size_t getNrOfLinearVelocitySensors() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfLinearVelocitySensors(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -306,7 +307,7 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getLinearVelocitySensorName(size_t sens_index, std::string& name) const = 0;
+    virtual yarp::dev::ReturnValue getLinearVelocitySensorName(size_t sens_index, std::string& name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
@@ -316,7 +317,7 @@ public:
      *
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const = 0;
+    virtual yarp::dev::ReturnValue getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const = 0;
 
     /**
      * Get the last reading of the linear velocity sensor as x y z.
@@ -326,7 +327,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const = 0;
 
     virtual ~ILinearVelocitySensors()
     {
@@ -353,7 +354,7 @@ public:
     /**
      * Get the number of orientation sensors exposed by this device.
      */
-    virtual size_t getNrOfOrientationSensors() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfOrientationSensors(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -364,7 +365,7 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getOrientationSensorName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
@@ -374,7 +375,7 @@ public:
      *
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the orientation sensor as roll pitch yaw.
@@ -423,7 +424,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const = 0;
 
     virtual ~IOrientationSensors(){}
 };
@@ -444,7 +445,7 @@ public:
     /**
      * Get the number of temperature sensors exposed by this device.
      */
-    virtual size_t getNrOfTemperatureSensors() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfTemperatureSensors(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -454,18 +455,18 @@ public:
     /**
      * Get the name of the specified sensor.
      */
-    virtual bool getTemperatureSensorName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getTemperatureSensorName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
      */
-    virtual bool getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
      * TODO(traversaro) : make the method swig-friendly
      */
-    virtual bool getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -475,7 +476,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
 
     virtual ~ITemperatureSensors(){}
@@ -498,7 +499,7 @@ public:
     /**
      * Get the number of six axis force torque sensors exposed by this device.
      */
-    virtual size_t getNrOfSixAxisForceTorqueSensors() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfSixAxisForceTorqueSensors(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -508,12 +509,12 @@ public:
     /**
      * Get the name of the specified sensor.
      */
-    virtual bool getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the name of the frame of the specified sensor.
      */
-    virtual bool getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -523,7 +524,7 @@ public:
      *                 The measure is expressed in Newton for the first three elements, Newton Meters for the last three elements.
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      */
-    virtual bool getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     virtual ~ISixAxisForceTorqueSensors(){}
 };
@@ -546,7 +547,7 @@ public:
     /**
      * Get the number of contact load cell array exposed by this device.
      */
-    virtual size_t getNrOfContactLoadCellArrays() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfContactLoadCellArrays(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -557,7 +558,7 @@ public:
      * Get the name of the specified sensor.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getContactLoadCellArrayName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getContactLoadCellArrayName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -568,7 +569,7 @@ public:
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      * @return false if an error occurred, true otherwise.
      */
-    virtual bool getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getContactLoadCellArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     /**
      * Get the size of the specified contact load cell array
@@ -599,7 +600,7 @@ public:
     /**
      * Get the number of encoder arrays exposed by this device.
      */
-    virtual size_t getNrOfEncoderArrays() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfEncoderArrays(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -609,7 +610,7 @@ public:
     /**
      * Get the name of the specified sensor.
      */
-    virtual bool getEncoderArrayName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getEncoderArrayName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -619,7 +620,7 @@ public:
      *                 The measure is expressed in Newton.
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      */
-    virtual bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     /**
      * Get the size of the specified encoder array
@@ -648,7 +649,7 @@ public:
     /**
      * Get the number of skin patches exposed by this device.
      */
-    virtual size_t getNrOfSkinPatches() const = 0;
+    virtual yarp::dev::ReturnValue getNrOfSkinPatches(size_t& num) const = 0;
 
     /**
      * Get the status of the specified sensor.
@@ -658,7 +659,7 @@ public:
     /**
      * Get the name of the specified sensor.
      */
-    virtual bool getSkinPatchName(size_t sens_index, std::string &name) const = 0;
+    virtual yarp::dev::ReturnValue getSkinPatchName(size_t sens_index, std::string &name) const = 0;
 
     /**
      * Get the last reading of the specified sensor.
@@ -668,7 +669,7 @@ public:
      *                 The measure is expressed in implementation-specific unit of measure.
      * @param[out] timestamp The timestamp of the requested measure, expressed in seconds.
      */
-    virtual bool getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
+    virtual yarp::dev::ReturnValue getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
 
     /**
      * Get the size of the specified skin patch

--- a/src/libYARP_dev/src/yarp/dev/tests/IOrientationSensorsTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/IOrientationSensorsTest.h
@@ -18,7 +18,9 @@ namespace yarp::dev::tests
     {
         REQUIRE(ios != nullptr);
 
-        int nrOfSensors = ios->getNrOfOrientationSensors();
+        size_t nrOfSensors = 0;
+        auto ret = ios->getNrOfOrientationSensors(nrOfSensors);
+        CHECK(ret);
         CHECK(nrOfSensors > 0); // getNrOfOrientationSensors of multipleanalogsensorsclient works correctly
 
         yarp::sig::Vector sensorMeasure(3, 0.0), clientMeasure(3, 0.0);

--- a/src/libYARP_dev/src/yarp/dev/tests/IPositionSensorsTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/IPositionSensorsTest.h
@@ -18,7 +18,9 @@ namespace yarp::dev::tests
     {
         REQUIRE(ios != nullptr);
 
-        int nrOfSensors = ios->getNrOfPositionSensors();
+        size_t nrOfSensors = 0;
+        auto ret = ios->getNrOfPositionSensors(nrOfSensors);
+        CHECK(ret);
         CHECK(nrOfSensors == 1); // getNrOfPositionSensors of multipleanalogsensorsclient works correctly
 
         yarp::sig::Vector sensorMeasure(3, 0.0), clientMeasure(3, 0.0);


### PR DESCRIPTION
Several methods of MultipleAnalogSensor (MAS) interfaces migrated from returning bool to returning yarp::dev::ReturnValue