### PR TITLE
SharedLib RTLD_NODELETE 

### DIFF
--- a/src/libYARP_os/src/yarp/os/SharedLibrary.cpp
+++ b/src/libYARP_os/src/yarp/os/SharedLibrary.cpp
@@ -89,7 +89,21 @@ bool SharedLibrary::open(const char* filename)
     }
     return true;
 #else
-    implementation->dll = yarp::os::impl::dlopen(filename, RTLD_LAZY);
+    // NOTE: RTLD_NODELETE is required to work around a known glibc issue
+    // (see e.g. glibc bugzilla #24773 and related reports) where a real
+    // dlclose() of a library that pulled in NSS modules (via
+    // getaddrinfo()/gethostbyname(), used internally by YARP for name
+    // resolution) or that registered thread-specific data destructors,
+    // can lead to a SIGSEGV in __nptl_deallocate_tsd() when a thread
+    // that used those symbols terminates *after* the library has been
+    // unmapped. RTLD_NODELETE keeps the reference counting semantics of
+    // dlopen/dlclose (so open()/close() still behave correctly), but
+    // guarantees the library is never actually unmapped from memory,
+    // sidestepping the glibc bug entirely.
+#ifndef RTLD_NODELETE
+#    define RTLD_NODELETE 0
+#endif
+    implementation->dll = yarp::os::impl::dlopen(filename, RTLD_LAZY | RTLD_NODELETE);
     if (!implementation->dll) {
         implementation->error = implementation->getError();
         return false;


### PR DESCRIPTION
Added flag RTLD_NODELETE to SharedLibrary::open() in NO ACE build, to… prevent segfault on Ubuntu 26.04

RTLD_NODELETE is required to work around a known glibc issue  (see e.g. glibc bugzilla #24773 and related reports) where a real  dlclose() of a library that pulled in NSS modules (via getaddrinfo()/gethostbyname(), used internally by YARP for name  resolution) or that registered thread-specific data destructors, can lead to a SIGSEGV in __nptl_deallocate_tsd() when a thread  that used those symbols terminates *after* the library has been  unmapped. RTLD_NODELETE keeps the reference counting semantics of  dlopen/dlclose (so open()/close() still behave correctly), but guarantees the library is never actually unmapped from memory, sidestepping the glibc bug entirely.

---

Extra details (AI evaluation of this change)

Does this change have any negative effect on memory usage/performance?

RTLD_NODELETE has no impact on normal memory management while the library is in use:

1. It does not duplicate the loaded code.
2. It does not prevent garbage collection of C++ objects created through the plugin factories (those remain normally managed by SharedLibraryClass::close() / pfactory->destroy(content)).
3. It does not affect loading (dlopen) or symbol resolution (dlsym) performance.

What actually changes

1. The only concrete effect is that, when the dynamic linker's internal refcount reaches zero (i.e. when the last dlclose() would normally be executed), the memory pages mapped for that module are not returned to the operating system. This includes:

2. The plugin's code segment (.text) — typically small for YARP plugins (carriers, device drivers), on the order of tens or hundreds of KB.
Static and global data (.data/.bss) belonging to the module, including any static/thread_local variables defined in the plugin.
Linker metadata associated with the module (symbol tables, relocation information, TLS descriptors) — normally just a few KB.

3. The module remains mapped but inactive: it has no active threads, consumes no CPU, and simply occupies virtual address space (with the corresponding physical pages remaining resident, unless the kernel evicts them under memory pressure when they are clean/read-only; this can happen anyway for file-backed code pages shared through mmap).

Is this relevant to YARP in your scenario?

Practically no, for two reasons:

1.  A limited number of plugins, loaded only once.
In most real-world application scenarios (modules, device drivers, carriers), plugins are loaded when the process starts and closed only when the process terminates, rather than being repeatedly opened and closed thousands of times in a loop. The cost of "not freeing" a few hundred KB for a couple of plugins is negligible compared with the overall footprint of a YARP process.
2. The critical case is actually the test suite, where the same libraries are repeatedly opened and closed (Network::sync, carrier plugins in connection tests, etc.). Even in this scenario, because dlopen with the same filename reuses the already-mapped module (the dynamic linker detects that the library is already loaded based on its path/inode and returns the same handle, only incrementing the refcount), there is no multiple accumulation of the same library in memory: it is mapped only once, regardless of how many times you call open()/close() sequentially on the same .so.
When would it become a real problem?

RTLD_NODELETE would become a significant memory issue only in scenarios such as:

- An application that dynamically loads a very large number of different plugins (not the same file multiple times) over a long lifecycle. For example, a plugin loader that continuously scans for and tries hundreds of different .so files at runtime.

In that case, every distinct library that is never unloaded accumulates in memory.

In the case of YARP, the number of distinct carrier/plugins is limited (on the order of a few dozen, defined at build time), so even in a long-running scenario the maximum accumulation is still bounded and known in advance.

Practical conclusion

For YARP, the cost of RTLD_NODELETE is:

- Negligible in terms of memory — a few hundred KB for the entire set of distinct plugins actually used during the lifetime of the process.
- Zero in terms of application-object leaks — those objects are managed separately and are properly destroyed.
- Well justified by the fact that it prevents a real and reproducible crash.
