### PR TITLE
Fix IJoypadControl: removed getStickDoF

### DIFF
--- a/src/devices/SDLJoypad/SDLJoypad.cpp
+++ b/src/devices/SDLJoypad/SDLJoypad.cpp
@@ -287,17 +287,6 @@ ReturnValue SDLJoypad::getStickCount(size_t& stick_count)
     return ReturnValue_ok;
 }
 
-ReturnValue SDLJoypad::getStickDoF(size_t stick_id, size_t& DoF)
-{
-    if(stick_id > m_sticks.size()-1)
-    {
-        yCError(SDLJOYPAD) << "SDL_Joypad: stick_id out of bounds when calling 'getStickDoF'' method";
-        return ReturnValue_error_input_out_of_bounds;
-    }
-    DoF = 2;
-    return ReturnValue_ok;
-}
-
 ReturnValue SDLJoypad::getButton(size_t button_id, double& value)
 {
     if(button_id > m_buttonCount - 1)

--- a/src/devices/SDLJoypad/SDLJoypad.h
+++ b/src/devices/SDLJoypad/SDLJoypad.h
@@ -100,7 +100,6 @@ public:
     yarp::dev::ReturnValue getTrackballCount(size_t& trackball_count) override;
     yarp::dev::ReturnValue getTouchSurfaceCount(size_t& touch_count) override;
     yarp::dev::ReturnValue getStickCount(size_t& stick_count) override;
-    yarp::dev::ReturnValue getStickDoF(size_t  stick_id, size_t& DoF) override;
     yarp::dev::ReturnValue getButton(size_t  button_id, double& value) override;
     yarp::dev::ReturnValue getTrackball(size_t  trackball_id, yarp::dev::TrackballData& value) override;
     yarp::dev::ReturnValue getHat(size_t  hat_id, unsigned char& value) override;

--- a/src/devices/fake/fakeJoypad/FakeJoypad.cpp
+++ b/src/devices/fake/fakeJoypad/FakeJoypad.cpp
@@ -102,7 +102,7 @@ ReturnValue FakeJoypad::getStick(size_t stick_id, yarp::dev::StickData& value, J
 {
     if (stick_id > m_stickCount)
     {
-        yCError(FAKEJOYPAD) << "stick_id out of bounds when calling 'getStickDoF' method";
+        yCError(FAKEJOYPAD) << "stick_id out of bounds when calling 'getStick' method";
         return ReturnValue_error_input_out_of_bounds;
     }
     if (coordinate_mode == yarp::dev::IJoypadController::JoypadCtrl_coordinateMode::JypCtrlcoord_CARTESIAN)

--- a/src/devices/fake/fakeJoypad/FakeJoypad.cpp
+++ b/src/devices/fake/fakeJoypad/FakeJoypad.cpp
@@ -76,17 +76,6 @@ ReturnValue FakeJoypad::getStickCount(size_t& stick_count)
     return ReturnValue_ok;
 }
 
-ReturnValue FakeJoypad::getStickDoF(size_t stick_id, size_t& DoF)
-{
-    if(stick_id > m_stickCount)
-    {
-        yCError(FAKEJOYPAD) << "stick_id out of bounds when calling 'getStickDoF' method";
-        return ReturnValue_error_input_out_of_bounds;
-    }
-    DoF = 2;
-    return ReturnValue_ok;
-}
-
 ReturnValue FakeJoypad::getButton(size_t button_id, double& value)
 {
     if (button_id > m_buttonCount)

--- a/src/devices/fake/fakeJoypad/FakeJoypad.h
+++ b/src/devices/fake/fakeJoypad/FakeJoypad.h
@@ -49,7 +49,6 @@ public:
     yarp::dev::ReturnValue getTrackballCount(size_t& trackball_count) override;
     yarp::dev::ReturnValue getTouchSurfaceCount(size_t& touch_count) override;
     yarp::dev::ReturnValue getStickCount(size_t& stick_count) override;
-    yarp::dev::ReturnValue getStickDoF(size_t  stick_id, size_t& DoF) override;
     yarp::dev::ReturnValue getButton(size_t  button_id, double& value) override;
     yarp::dev::ReturnValue getTrackball(size_t  trackball_id, yarp::dev::TrackballData& value) override;
     yarp::dev::ReturnValue getHat(size_t  hat_id, unsigned char& value) override;

--- a/src/devices/messages/IJoypadControlMsgs/IJoypadControlMsgs.thrift
+++ b/src/devices/messages/IJoypadControlMsgs/IJoypadControlMsgs.thrift
@@ -146,7 +146,10 @@ struct return_getTouch{
     2: list<yTouchData> value;
 }
 
-
+struct return_getAllAxes{
+    1: yReturnValue ret;
+    2: list<double> value;
+}
 
 service IJoypadControlMsgs {
     return_getAxisCount         getAxisCount();
@@ -160,6 +163,7 @@ service IJoypadControlMsgs {
     return_getTrackball         getTrackball(1: i32 trackball_id);
     return_getHat               getHat(1: i32 hat_id);
     return_getAxis              getAxis(1: i32 axis_id);
+    return_getAllAxes           getAllAxes();
     return_getStick             getStick(1: i32 stick_id, 2: yJoyStickMode mode);
     return_getTouch             getTouch(1: i32 touch_id);
 }

--- a/src/devices/messages/IJoypadControlMsgs/IJoypadControlMsgs.thrift
+++ b/src/devices/messages/IJoypadControlMsgs/IJoypadControlMsgs.thrift
@@ -115,11 +115,6 @@ struct return_getButtonCount{
     2: i32 button_count;
 }
 
-struct return_getStickDoF{
-    1: yReturnValue ret;
-    2: i32 DoF;
-}
-
 struct return_getButton{
     1: yReturnValue ret;
     2: double value;
@@ -161,7 +156,6 @@ service IJoypadControlMsgs {
     return_getTouchSurfaceCount getTouchSurfaceCount();
     return_getStickCount        getStickCount();
 
-    return_getStickDoF          getStickDoF(1: i32 stick_id);
     return_getButton            getButton(1: i32 button_id);
     return_getTrackball         getTrackball(1: i32 trackball_id);
     return_getHat               getHat(1: i32 hat_id);

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/IJoypadControlMsgs_index.txt
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/IJoypadControlMsgs_index.txt
@@ -1,9 +1,3 @@
-yarp/dev/TrackballData.h
-yarp/dev/TrackballData.cpp
-yarp/dev/TouchData.h
-yarp/dev/TouchData.cpp
-yarp/dev/StickData.h
-yarp/dev/StickData.cpp
 yarp/dev/ButtonDataList.h
 yarp/dev/ButtonDataList.cpp
 yarp/dev/AxisDataList.h
@@ -32,8 +26,6 @@ yarp/dev/return_getStickCount.h
 yarp/dev/return_getStickCount.cpp
 yarp/dev/return_getButtonCount.h
 yarp/dev/return_getButtonCount.cpp
-yarp/dev/return_getStickDoF.h
-yarp/dev/return_getStickDoF.cpp
 yarp/dev/return_getButton.h
 yarp/dev/return_getButton.cpp
 yarp/dev/return_getTrackball.h
@@ -46,5 +38,7 @@ yarp/dev/return_getStick.h
 yarp/dev/return_getStick.cpp
 yarp/dev/return_getTouch.h
 yarp/dev/return_getTouch.cpp
+yarp/dev/return_getAllAxes.h
+yarp/dev/return_getAllAxes.cpp
 yarp/dev/IJoypadControlMsgs.h
 yarp/dev/IJoypadControlMsgs.cpp

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/AllJoyData.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/AllJoyData.cpp
@@ -17,8 +17,8 @@ AllJoyData::AllJoyData(const std::vector<double>& ButtonDataVal,
                        const std::vector<double>& AxisDataVal,
                        const std::vector<std::int8_t>& HatsDataVal,
                        const std::vector<MultipleTouches>& TouchDataVal,
-                       const std::vector<StickData>& StickDataVal,
-                       const std::vector<TrackballData>& TrackballDataVal) :
+                       const std::vector<yarp::dev::StickData>& StickDataVal,
+                       const std::vector<yarp::dev::TrackballData>& TrackballDataVal) :
         WirePortable(),
         ButtonDataVal(ButtonDataVal),
         AxisDataVal(AxisDataVal),
@@ -390,12 +390,12 @@ bool AllJoyData::read_TouchDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         TouchDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(TouchDataVal[_i])) {
+            if (!reader.readNested(TouchDataVal[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -441,12 +441,12 @@ bool AllJoyData::nested_read_TouchDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         TouchDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(TouchDataVal[_i])) {
+            if (!reader.readNested(TouchDataVal[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -492,12 +492,12 @@ bool AllJoyData::read_StickDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         StickDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(StickDataVal[_i])) {
+            if (!reader.readNested(StickDataVal[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -543,12 +543,12 @@ bool AllJoyData::nested_read_StickDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         StickDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(StickDataVal[_i])) {
+            if (!reader.readNested(StickDataVal[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -594,12 +594,12 @@ bool AllJoyData::read_TrackballDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         TrackballDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(TrackballDataVal[_i])) {
+            if (!reader.readNested(TrackballDataVal[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -645,12 +645,12 @@ bool AllJoyData::nested_read_TrackballDataVal(yarp::os::idl::WireReader& reader)
             }
         }
         TrackballDataVal.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(TrackballDataVal[_i])) {
+            if (!reader.readNested(TrackballDataVal[_i0])) {
                 reader.fail();
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/AllJoyData.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/AllJoyData.h
@@ -28,8 +28,8 @@ public:
     std::vector<double> AxisDataVal{};
     std::vector<std::int8_t> HatsDataVal{};
     std::vector<MultipleTouches> TouchDataVal{};
-    std::vector<StickData> StickDataVal{};
-    std::vector<TrackballData> TrackballDataVal{};
+    std::vector<yarp::dev::StickData> StickDataVal{};
+    std::vector<yarp::dev::TrackballData> TrackballDataVal{};
 
     // Default constructor
     AllJoyData() = default;
@@ -39,8 +39,8 @@ public:
                const std::vector<double>& AxisDataVal,
                const std::vector<std::int8_t>& HatsDataVal,
                const std::vector<MultipleTouches>& TouchDataVal,
-               const std::vector<StickData>& StickDataVal,
-               const std::vector<TrackballData>& TrackballDataVal);
+               const std::vector<yarp::dev::StickData>& StickDataVal,
+               const std::vector<yarp::dev::TrackballData>& TrackballDataVal);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.cpp
@@ -455,69 +455,6 @@ public:
     static constexpr const char* s_help{""};
 };
 
-// getStickDoF helper class declaration
-class IJoypadControlMsgs_getStickDoF_helper :
-        public yarp::os::Portable
-{
-public:
-    IJoypadControlMsgs_getStickDoF_helper() = default;
-    explicit IJoypadControlMsgs_getStickDoF_helper(const std::int32_t stick_id);
-    bool write(yarp::os::ConnectionWriter& connection) const override;
-    bool read(yarp::os::ConnectionReader& connection) override;
-
-    class Command :
-            public yarp::os::idl::WirePortable
-    {
-    public:
-        Command() = default;
-        explicit Command(const std::int32_t stick_id);
-
-        ~Command() override = default;
-
-        bool write(yarp::os::ConnectionWriter& connection) const override;
-        bool read(yarp::os::ConnectionReader& connection) override;
-
-        bool write(const yarp::os::idl::WireWriter& writer) const override;
-        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
-        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
-
-        bool read(yarp::os::idl::WireReader& reader) override;
-        bool readTag(yarp::os::idl::WireReader& reader);
-        bool readArgs(yarp::os::idl::WireReader& reader);
-
-        std::int32_t stick_id{0};
-    };
-
-    class Reply :
-            public yarp::os::idl::WirePortable
-    {
-    public:
-        Reply() = default;
-        ~Reply() override = default;
-
-        bool write(yarp::os::ConnectionWriter& connection) const override;
-        bool read(yarp::os::ConnectionReader& connection) override;
-
-        bool write(const yarp::os::idl::WireWriter& writer) const override;
-        bool read(yarp::os::idl::WireReader& reader) override;
-
-        return_getStickDoF return_helper{};
-    };
-
-    using funcptr_t = return_getStickDoF (*)(const std::int32_t);
-    void call(IJoypadControlMsgs* ptr);
-
-    Command cmd;
-    Reply reply;
-
-    static constexpr const char* s_tag{"getStickDoF"};
-    static constexpr size_t s_tag_len{1};
-    static constexpr size_t s_cmd_len{2};
-    static constexpr size_t s_reply_len{2};
-    static constexpr const char* s_prototype{"return_getStickDoF IJoypadControlMsgs::getStickDoF(const std::int32_t stick_id)"};
-    static constexpr const char* s_help{""};
-};
-
 // getButton helper class declaration
 class IJoypadControlMsgs_getButton_helper :
         public yarp::os::Portable
@@ -639,7 +576,7 @@ public:
     static constexpr const char* s_tag{"getTrackball"};
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{2};
-    static constexpr size_t s_reply_len{3};
+    static constexpr size_t s_reply_len{2};
     static constexpr const char* s_prototype{"return_getTrackball IJoypadControlMsgs::getTrackball(const std::int32_t trackball_id)"};
     static constexpr const char* s_help{""};
 };
@@ -829,7 +766,7 @@ public:
     static constexpr const char* s_tag{"getStick"};
     static constexpr size_t s_tag_len{1};
     static constexpr size_t s_cmd_len{3};
-    static constexpr size_t s_reply_len{4};
+    static constexpr size_t s_reply_len{3};
     static constexpr const char* s_prototype{"return_getStick IJoypadControlMsgs::getStick(const std::int32_t stick_id, const yarp::dev::IJoypadController::JoypadCtrl_coordinateMode mode)"};
     static constexpr const char* s_help{""};
 };
@@ -1693,160 +1630,6 @@ bool IJoypadControlMsgs_getStickCount_helper::Reply::read(yarp::os::idl::WireRea
 void IJoypadControlMsgs_getStickCount_helper::call(IJoypadControlMsgs* ptr)
 {
     reply.return_helper = ptr->getStickCount();
-}
-
-// getStickDoF helper class implementation
-IJoypadControlMsgs_getStickDoF_helper::IJoypadControlMsgs_getStickDoF_helper(const std::int32_t stick_id) :
-        cmd{stick_id}
-{
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::write(yarp::os::ConnectionWriter& connection) const
-{
-    return cmd.write(connection);
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::read(yarp::os::ConnectionReader& connection)
-{
-    return reply.read(connection);
-}
-
-IJoypadControlMsgs_getStickDoF_helper::Command::Command(const std::int32_t stick_id) :
-        stick_id{stick_id}
-{
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::write(yarp::os::ConnectionWriter& connection) const
-{
-    yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(s_cmd_len)) {
-        return false;
-    }
-    return write(writer);
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::read(yarp::os::ConnectionReader& connection)
-{
-    yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader()) {
-        reader.fail();
-        return false;
-    }
-    return read(reader);
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
-{
-    if (!writeTag(writer)) {
-        return false;
-    }
-    if (!writeArgs(writer)) {
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
-{
-    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
-{
-    if (!writer.writeI32(stick_id)) {
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::read(yarp::os::idl::WireReader& reader)
-{
-    if (!readTag(reader)) {
-        return false;
-    }
-    if (!readArgs(reader)) {
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::readTag(yarp::os::idl::WireReader& reader)
-{
-    std::string tag = reader.readTag(s_tag_len);
-    if (reader.isError()) {
-        return false;
-    }
-    if (tag != s_tag) {
-        reader.fail();
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
-{
-    if (reader.noMore()) {
-        reader.fail();
-        return false;
-    }
-    if (!reader.readI32(stick_id)) {
-        reader.fail();
-        return false;
-    }
-    if (!reader.noMore()) {
-        reader.fail();
-        return false;
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
-{
-    yarp::os::idl::WireWriter writer(connection);
-    return write(writer);
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Reply::read(yarp::os::ConnectionReader& connection)
-{
-    yarp::os::idl::WireReader reader(connection);
-    return read(reader);
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
-{
-    if (!writer.isNull()) {
-        if (!writer.writeListHeader(s_reply_len)) {
-            return false;
-        }
-        if (!writer.write(return_helper)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool IJoypadControlMsgs_getStickDoF_helper::Reply::read(yarp::os::idl::WireReader& reader)
-{
-    if (!reader.readListReturn()) {
-        return false;
-    }
-    if (reader.noMore()) {
-        reader.fail();
-        return false;
-    }
-    if (!reader.read(return_helper)) {
-        reader.fail();
-        return false;
-    }
-    return true;
-}
-
-void IJoypadControlMsgs_getStickDoF_helper::call(IJoypadControlMsgs* ptr)
-{
-    reply.return_helper = ptr->getStickDoF(cmd.stick_id);
 }
 
 // getButton helper class implementation
@@ -2853,16 +2636,6 @@ return_getStickCount IJoypadControlMsgs::getStickCount()
     return ok ? helper.reply.return_helper : return_getStickCount{};
 }
 
-return_getStickDoF IJoypadControlMsgs::getStickDoF(const std::int32_t stick_id)
-{
-    if (!yarp().canWrite()) {
-        yError("Missing server method '%s'?", IJoypadControlMsgs_getStickDoF_helper::s_prototype);
-    }
-    IJoypadControlMsgs_getStickDoF_helper helper{stick_id};
-    bool ok = yarp().write(helper, helper);
-    return ok ? helper.reply.return_helper : return_getStickDoF{};
-}
-
 return_getButton IJoypadControlMsgs::getButton(const std::int32_t button_id)
 {
     if (!yarp().canWrite()) {
@@ -2936,7 +2709,6 @@ std::vector<std::string> IJoypadControlMsgs::help(const std::string& functionNam
         helpString.emplace_back(IJoypadControlMsgs_getHatCount_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getTouchSurfaceCount_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getStickCount_helper::s_tag);
-        helpString.emplace_back(IJoypadControlMsgs_getStickDoF_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getButton_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getTrackball_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getHat_helper::s_tag);
@@ -2962,9 +2734,6 @@ std::vector<std::string> IJoypadControlMsgs::help(const std::string& functionNam
         }
         if (functionName == IJoypadControlMsgs_getStickCount_helper::s_tag) {
             helpString.emplace_back(IJoypadControlMsgs_getStickCount_helper::s_prototype);
-        }
-        if (functionName == IJoypadControlMsgs_getStickDoF_helper::s_tag) {
-            helpString.emplace_back(IJoypadControlMsgs_getStickDoF_helper::s_prototype);
         }
         if (functionName == IJoypadControlMsgs_getButton_helper::s_tag) {
             helpString.emplace_back(IJoypadControlMsgs_getButton_helper::s_prototype);
@@ -3113,21 +2882,6 @@ bool IJoypadControlMsgs::read(yarp::os::ConnectionReader& connection)
         }
         if (tag == IJoypadControlMsgs_getStickCount_helper::s_tag) {
             IJoypadControlMsgs_getStickCount_helper helper;
-            if (!helper.cmd.readArgs(reader)) {
-                return false;
-            }
-
-            helper.call(this);
-
-            yarp::os::idl::WireWriter writer(reader);
-            if (!helper.reply.write(writer)) {
-                return false;
-            }
-            reader.accept();
-            return true;
-        }
-        if (tag == IJoypadControlMsgs_getStickDoF_helper::s_tag) {
-            IJoypadControlMsgs_getStickDoF_helper helper;
             if (!helper.cmd.readArgs(reader)) {
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.cpp
@@ -707,6 +707,64 @@ public:
     static constexpr const char* s_help{""};
 };
 
+// getAllAxes helper class declaration
+class IJoypadControlMsgs_getAllAxes_helper :
+        public yarp::os::Portable
+{
+public:
+    IJoypadControlMsgs_getAllAxes_helper() = default;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    class Command :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Command() = default;
+        ~Command() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
+        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
+
+        bool read(yarp::os::idl::WireReader& reader) override;
+        bool readTag(yarp::os::idl::WireReader& reader);
+        bool readArgs(yarp::os::idl::WireReader& reader);
+    };
+
+    class Reply :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Reply() = default;
+        ~Reply() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool read(yarp::os::idl::WireReader& reader) override;
+
+        return_getAllAxes return_helper{};
+    };
+
+    using funcptr_t = return_getAllAxes (*)();
+    void call(IJoypadControlMsgs* ptr);
+
+    Command cmd;
+    Reply reply;
+
+    static constexpr const char* s_tag{"getAllAxes"};
+    static constexpr size_t s_tag_len{1};
+    static constexpr size_t s_cmd_len{1};
+    static constexpr size_t s_reply_len{2};
+    static constexpr const char* s_prototype{"return_getAllAxes IJoypadControlMsgs::getAllAxes()"};
+    static constexpr const char* s_help{""};
+};
+
 // getStick helper class declaration
 class IJoypadControlMsgs_getStick_helper :
         public yarp::os::Portable
@@ -2248,6 +2306,139 @@ void IJoypadControlMsgs_getAxis_helper::call(IJoypadControlMsgs* ptr)
     reply.return_helper = ptr->getAxis(cmd.axis_id);
 }
 
+// getAllAxes helper class implementation
+bool IJoypadControlMsgs_getAllAxes_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    return cmd.write(connection);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::read(yarp::os::ConnectionReader& connection)
+{
+    return reply.read(connection);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(s_cmd_len)) {
+        return false;
+    }
+    return write(writer);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+    return read(reader);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writeTag(writer)) {
+        return false;
+    }
+    if (!writeArgs(writer)) {
+        return false;
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer [[maybe_unused]]) const
+{
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::read(yarp::os::idl::WireReader& reader)
+{
+    if (!readTag(reader)) {
+        return false;
+    }
+    if (!readArgs(reader)) {
+        return false;
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::readTag(yarp::os::idl::WireReader& reader)
+{
+    std::string tag = reader.readTag(s_tag_len);
+    if (reader.isError()) {
+        return false;
+    }
+    if (tag != s_tag) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    return write(writer);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Reply::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    return read(reader);
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.isNull()) {
+        if (!writer.writeListHeader(s_reply_len)) {
+            return false;
+        }
+        if (!writer.write(return_helper)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool IJoypadControlMsgs_getAllAxes_helper::Reply::read(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+void IJoypadControlMsgs_getAllAxes_helper::call(IJoypadControlMsgs* ptr)
+{
+    reply.return_helper = ptr->getAllAxes();
+}
+
 // getStick helper class implementation
 IJoypadControlMsgs_getStick_helper::IJoypadControlMsgs_getStick_helper(const std::int32_t stick_id, const yarp::dev::IJoypadController::JoypadCtrl_coordinateMode mode) :
         cmd{stick_id, mode}
@@ -2676,6 +2867,16 @@ return_getAxis IJoypadControlMsgs::getAxis(const std::int32_t axis_id)
     return ok ? helper.reply.return_helper : return_getAxis{};
 }
 
+return_getAllAxes IJoypadControlMsgs::getAllAxes()
+{
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", IJoypadControlMsgs_getAllAxes_helper::s_prototype);
+    }
+    IJoypadControlMsgs_getAllAxes_helper helper{};
+    bool ok = yarp().write(helper, helper);
+    return ok ? helper.reply.return_helper : return_getAllAxes{};
+}
+
 return_getStick IJoypadControlMsgs::getStick(const std::int32_t stick_id, const yarp::dev::IJoypadController::JoypadCtrl_coordinateMode mode)
 {
     if (!yarp().canWrite()) {
@@ -2713,6 +2914,7 @@ std::vector<std::string> IJoypadControlMsgs::help(const std::string& functionNam
         helpString.emplace_back(IJoypadControlMsgs_getTrackball_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getHat_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getAxis_helper::s_tag);
+        helpString.emplace_back(IJoypadControlMsgs_getAllAxes_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getStick_helper::s_tag);
         helpString.emplace_back(IJoypadControlMsgs_getTouch_helper::s_tag);
         helpString.emplace_back("help");
@@ -2746,6 +2948,9 @@ std::vector<std::string> IJoypadControlMsgs::help(const std::string& functionNam
         }
         if (functionName == IJoypadControlMsgs_getAxis_helper::s_tag) {
             helpString.emplace_back(IJoypadControlMsgs_getAxis_helper::s_prototype);
+        }
+        if (functionName == IJoypadControlMsgs_getAllAxes_helper::s_tag) {
+            helpString.emplace_back(IJoypadControlMsgs_getAllAxes_helper::s_prototype);
         }
         if (functionName == IJoypadControlMsgs_getStick_helper::s_tag) {
             helpString.emplace_back(IJoypadControlMsgs_getStick_helper::s_prototype);
@@ -2942,6 +3147,21 @@ bool IJoypadControlMsgs::read(yarp::os::ConnectionReader& connection)
         }
         if (tag == IJoypadControlMsgs_getAxis_helper::s_tag) {
             IJoypadControlMsgs_getAxis_helper helper;
+            if (!helper.cmd.readArgs(reader)) {
+                return false;
+            }
+
+            helper.call(this);
+
+            yarp::os::idl::WireWriter writer(reader);
+            if (!helper.reply.write(writer)) {
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == IJoypadControlMsgs_getAllAxes_helper::s_tag) {
+            IJoypadControlMsgs_getAllAxes_helper helper;
             if (!helper.cmd.readArgs(reader)) {
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.h
@@ -23,7 +23,6 @@
 #include <yarp/dev/return_getHatCount.h>
 #include <yarp/dev/return_getStick.h>
 #include <yarp/dev/return_getStickCount.h>
-#include <yarp/dev/return_getStickDoF.h>
 #include <yarp/dev/return_getTouch.h>
 #include <yarp/dev/return_getTouchSurfaceCount.h>
 #include <yarp/dev/return_getTrackball.h>
@@ -55,8 +54,6 @@ public:
     virtual return_getTouchSurfaceCount getTouchSurfaceCount();
 
     virtual return_getStickCount getStickCount();
-
-    virtual return_getStickDoF getStickDoF(const std::int32_t stick_id);
 
     virtual return_getButton getButton(const std::int32_t button_id);
 

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/IJoypadControlMsgs.h
@@ -15,6 +15,7 @@
 #include <yarp/os/idl/WireTypes.h>
 #include <yarp/os/ApplicationNetworkProtocolVersion.h>
 #include <yarp/dev/IJoypadController.h>
+#include <yarp/dev/return_getAllAxes.h>
 #include <yarp/dev/return_getAxis.h>
 #include <yarp/dev/return_getAxisCount.h>
 #include <yarp/dev/return_getButton.h>
@@ -62,6 +63,8 @@ public:
     virtual return_getHat getHat(const std::int32_t hat_id);
 
     virtual return_getAxis getAxis(const std::int32_t axis_id);
+
+    virtual return_getAllAxes getAllAxes();
 
     virtual return_getStick getStick(const std::int32_t stick_id, const yarp::dev::IJoypadController::JoypadCtrl_coordinateMode mode);
 

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/MultipleTouches.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/MultipleTouches.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev {
 
 // Constructor with field values
-MultipleTouches::MultipleTouches(const std::vector<TouchData>& touches) :
+MultipleTouches::MultipleTouches(const std::vector<yarp::dev::TouchData>& touches) :
         WirePortable(),
         touches(touches)
 {
@@ -98,12 +98,12 @@ bool MultipleTouches::read_touches(yarp::os::idl::WireReader& reader)
             }
         }
         touches.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(touches[_i])) {
+            if (!reader.readNested(touches[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -149,12 +149,12 @@ bool MultipleTouches::nested_read_touches(yarp::os::idl::WireReader& reader)
             }
         }
         touches.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(touches[_i])) {
+            if (!reader.readNested(touches[_i0])) {
                 reader.fail();
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/MultipleTouches.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/MultipleTouches.h
@@ -22,13 +22,13 @@ class MultipleTouches :
 {
 public:
     // Fields
-    std::vector<TouchData> touches{};
+    std::vector<yarp::dev::TouchData> touches{};
 
     // Default constructor
     MultipleTouches() = default;
 
     // Constructor with field values
-    MultipleTouches(const std::vector<TouchData>& touches);
+    MultipleTouches(const std::vector<yarp::dev::TouchData>& touches);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/StickDataList.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/StickDataList.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev {
 
 // Constructor with field values
-StickDataList::StickDataList(const std::vector<StickData>& value) :
+StickDataList::StickDataList(const std::vector<yarp::dev::StickData>& value) :
         WirePortable(),
         value(value)
 {
@@ -98,12 +98,12 @@ bool StickDataList::read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -149,12 +149,12 @@ bool StickDataList::nested_read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/StickDataList.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/StickDataList.h
@@ -22,13 +22,13 @@ class StickDataList :
 {
 public:
     // Fields
-    std::vector<StickData> value{};
+    std::vector<yarp::dev::StickData> value{};
 
     // Default constructor
     StickDataList() = default;
 
     // Constructor with field values
-    StickDataList(const std::vector<StickData>& value);
+    StickDataList(const std::vector<yarp::dev::StickData>& value);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TouchesDataList.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TouchesDataList.cpp
@@ -98,12 +98,12 @@ bool TouchesDataList::read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -149,12 +149,12 @@ bool TouchesDataList::nested_read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TrackballDataList.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TrackballDataList.cpp
@@ -13,7 +13,7 @@
 namespace yarp::dev {
 
 // Constructor with field values
-TrackballDataList::TrackballDataList(const std::vector<TrackballData>& value) :
+TrackballDataList::TrackballDataList(const std::vector<yarp::dev::TrackballData>& value) :
         WirePortable(),
         value(value)
 {
@@ -98,12 +98,12 @@ bool TrackballDataList::read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }
@@ -149,12 +149,12 @@ bool TrackballDataList::nested_read_value(yarp::os::idl::WireReader& reader)
             }
         }
         value.resize(_csize);
-        for (size_t _i = 0; _i < _csize; ++_i) {
+        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
             if (reader.noMore()) {
                 reader.fail();
                 return false;
             }
-            if (!reader.readNested(value[_i])) {
+            if (!reader.readNested(value[_i0])) {
                 reader.fail();
                 return false;
             }

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TrackballDataList.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/TrackballDataList.h
@@ -22,13 +22,13 @@ class TrackballDataList :
 {
 public:
     // Fields
-    std::vector<TrackballData> value{};
+    std::vector<yarp::dev::TrackballData> value{};
 
     // Default constructor
     TrackballDataList() = default;
 
     // Constructor with field values
-    TrackballDataList(const std::vector<TrackballData>& value);
+    TrackballDataList(const std::vector<yarp::dev::TrackballData>& value);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getAllAxes.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getAllAxes.cpp
@@ -8,13 +8,13 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
-#include <yarp/dev/return_getTouch.h>
+#include <yarp/dev/return_getAllAxes.h>
 
 namespace yarp::dev {
 
 // Constructor with field values
-return_getTouch::return_getTouch(const yarp::dev::ReturnValue& ret,
-                                 const std::vector<yarp::dev::TouchData>& value) :
+return_getAllAxes::return_getAllAxes(const yarp::dev::ReturnValue& ret,
+                                     const std::vector<double>& value) :
         WirePortable(),
         ret(ret),
         value(value)
@@ -22,7 +22,7 @@ return_getTouch::return_getTouch(const yarp::dev::ReturnValue& ret,
 }
 
 // Read structure on a Wire
-bool return_getTouch::read(yarp::os::idl::WireReader& reader)
+bool return_getAllAxes::read(yarp::os::idl::WireReader& reader)
 {
     if (!nested_read_ret(reader)) {
         return false;
@@ -37,7 +37,7 @@ bool return_getTouch::read(yarp::os::idl::WireReader& reader)
 }
 
 // Read structure on a Connection
-bool return_getTouch::read(yarp::os::ConnectionReader& connection)
+bool return_getAllAxes::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
     if (!reader.readListHeader(2)) {
@@ -50,7 +50,7 @@ bool return_getTouch::read(yarp::os::ConnectionReader& connection)
 }
 
 // Write structure on a Wire
-bool return_getTouch::write(const yarp::os::idl::WireWriter& writer) const
+bool return_getAllAxes::write(const yarp::os::idl::WireWriter& writer) const
 {
     if (!nested_write_ret(writer)) {
         return false;
@@ -65,7 +65,7 @@ bool return_getTouch::write(const yarp::os::idl::WireWriter& writer) const
 }
 
 // Write structure on a Connection
-bool return_getTouch::write(yarp::os::ConnectionWriter& connection) const
+bool return_getAllAxes::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
     if (!writer.writeListHeader(2)) {
@@ -78,7 +78,7 @@ bool return_getTouch::write(yarp::os::ConnectionWriter& connection) const
 }
 
 // Convert to a printable string
-std::string return_getTouch::toString() const
+std::string return_getAllAxes::toString() const
 {
     yarp::os::Bottle b;
     if (!yarp::os::Portable::copyPortable(*this, b)) {
@@ -88,7 +88,7 @@ std::string return_getTouch::toString() const
 }
 
 // read ret field
-bool return_getTouch::read_ret(yarp::os::idl::WireReader& reader)
+bool return_getAllAxes::read_ret(yarp::os::idl::WireReader& reader)
 {
     if (reader.noMore()) {
         reader.fail();
@@ -102,7 +102,7 @@ bool return_getTouch::read_ret(yarp::os::idl::WireReader& reader)
 }
 
 // write ret field
-bool return_getTouch::write_ret(const yarp::os::idl::WireWriter& writer) const
+bool return_getAllAxes::write_ret(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.write(ret)) {
         return false;
@@ -111,7 +111,7 @@ bool return_getTouch::write_ret(const yarp::os::idl::WireWriter& writer) const
 }
 
 // read (nested) ret field
-bool return_getTouch::nested_read_ret(yarp::os::idl::WireReader& reader)
+bool return_getAllAxes::nested_read_ret(yarp::os::idl::WireReader& reader)
 {
     if (reader.noMore()) {
         reader.fail();
@@ -125,7 +125,7 @@ bool return_getTouch::nested_read_ret(yarp::os::idl::WireReader& reader)
 }
 
 // write (nested) ret field
-bool return_getTouch::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
+bool return_getAllAxes::nested_write_ret(const yarp::os::idl::WireWriter& writer) const
 {
     if (!writer.writeNested(ret)) {
         return false;
@@ -134,7 +134,7 @@ bool return_getTouch::nested_write_ret(const yarp::os::idl::WireWriter& writer) 
 }
 
 // read value field
-bool return_getTouch::read_value(yarp::os::idl::WireReader& reader)
+bool return_getAllAxes::read_value(yarp::os::idl::WireReader& reader)
 {
     if (reader.noMore()) {
         reader.fail();
@@ -145,22 +145,15 @@ bool return_getTouch::read_value(yarp::os::idl::WireReader& reader)
         yarp::os::idl::WireState _etype;
         reader.readListBegin(_etype, _csize);
         // WireReader removes BOTTLE_TAG_LIST from the tag
-        constexpr int expected_tag = ((BOTTLE_TAG_LIST) & (~BOTTLE_TAG_LIST));
+        constexpr int expected_tag = ((BOTTLE_TAG_FLOAT64) & (~BOTTLE_TAG_LIST));
         if constexpr (expected_tag != 0) {
             if (_csize != 0 && _etype.code != expected_tag) {
                 return false;
             }
         }
         value.resize(_csize);
-        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
-            if (reader.noMore()) {
-                reader.fail();
-                return false;
-            }
-            if (!reader.readNested(value[_i0])) {
-                reader.fail();
-                return false;
-            }
+        if (_csize != 0 && !reader.readBlock(reinterpret_cast<char*>(value.data()), value.size() * sizeof(double))) {
+            return false;
         }
         reader.readListEnd();
     }
@@ -168,15 +161,13 @@ bool return_getTouch::read_value(yarp::os::idl::WireReader& reader)
 }
 
 // write value field
-bool return_getTouch::write_value(const yarp::os::idl::WireWriter& writer) const
+bool return_getAllAxes::write_value(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeListBegin(BOTTLE_TAG_LIST, value.size())) {
+    if (!writer.writeListBegin(BOTTLE_TAG_FLOAT64, value.size())) {
         return false;
     }
-    for (const auto& _item : value) {
-        if (!writer.writeNested(_item)) {
-            return false;
-        }
+    if (!writer.writeBlock(reinterpret_cast<const char*>(value.data()), value.size() * sizeof(double))) {
+        return false;
     }
     if (!writer.writeListEnd()) {
         return false;
@@ -185,7 +176,7 @@ bool return_getTouch::write_value(const yarp::os::idl::WireWriter& writer) const
 }
 
 // read (nested) value field
-bool return_getTouch::nested_read_value(yarp::os::idl::WireReader& reader)
+bool return_getAllAxes::nested_read_value(yarp::os::idl::WireReader& reader)
 {
     if (reader.noMore()) {
         reader.fail();
@@ -196,22 +187,15 @@ bool return_getTouch::nested_read_value(yarp::os::idl::WireReader& reader)
         yarp::os::idl::WireState _etype;
         reader.readListBegin(_etype, _csize);
         // WireReader removes BOTTLE_TAG_LIST from the tag
-        constexpr int expected_tag = ((BOTTLE_TAG_LIST) & (~BOTTLE_TAG_LIST));
+        constexpr int expected_tag = ((BOTTLE_TAG_FLOAT64) & (~BOTTLE_TAG_LIST));
         if constexpr (expected_tag != 0) {
             if (_csize != 0 && _etype.code != expected_tag) {
                 return false;
             }
         }
         value.resize(_csize);
-        for (size_t _i0 = 0; _i0 < _csize; ++_i0) {
-            if (reader.noMore()) {
-                reader.fail();
-                return false;
-            }
-            if (!reader.readNested(value[_i0])) {
-                reader.fail();
-                return false;
-            }
+        if (_csize != 0 && !reader.readBlock(reinterpret_cast<char*>(value.data()), value.size() * sizeof(double))) {
+            return false;
         }
         reader.readListEnd();
     }
@@ -219,15 +203,13 @@ bool return_getTouch::nested_read_value(yarp::os::idl::WireReader& reader)
 }
 
 // write (nested) value field
-bool return_getTouch::nested_write_value(const yarp::os::idl::WireWriter& writer) const
+bool return_getAllAxes::nested_write_value(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeListBegin(BOTTLE_TAG_LIST, value.size())) {
+    if (!writer.writeListBegin(BOTTLE_TAG_FLOAT64, value.size())) {
         return false;
     }
-    for (const auto& _item : value) {
-        if (!writer.writeNested(_item)) {
-            return false;
-        }
+    if (!writer.writeBlock(reinterpret_cast<const char*>(value.data()), value.size() * sizeof(double))) {
+        return false;
     }
     if (!writer.writeListEnd()) {
         return false;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getAllAxes.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getAllAxes.h
@@ -8,30 +8,29 @@
 // This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
-#ifndef YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETTRACKBALL_H
-#define YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETTRACKBALL_H
+#ifndef YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETALLAXES_H
+#define YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETALLAXES_H
 
 #include <yarp/os/Wire.h>
 #include <yarp/os/idl/WireTypes.h>
 #include <yarp/dev/ReturnValue.h>
-#include <yarp/dev/TrackballData.h>
 
 namespace yarp::dev {
 
-class return_getTrackball :
+class return_getAllAxes :
         public yarp::os::idl::WirePortable
 {
 public:
     // Fields
     yarp::dev::ReturnValue ret{};
-    yarp::dev::TrackballData value{};
+    std::vector<double> value{};
 
     // Default constructor
-    return_getTrackball() = default;
+    return_getAllAxes() = default;
 
     // Constructor with field values
-    return_getTrackball(const yarp::dev::ReturnValue& ret,
-                        const yarp::dev::TrackballData& value);
+    return_getAllAxes(const yarp::dev::ReturnValue& ret,
+                      const std::vector<double>& value);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;
@@ -49,7 +48,7 @@ public:
     std::string toString() const;
 
     // If you want to serialize this class without nesting, use this helper
-    typedef yarp::os::idl::Unwrapped<return_getTrackball> unwrapped;
+    typedef yarp::os::idl::Unwrapped<return_getAllAxes> unwrapped;
 
 private:
     // read/write ret field
@@ -67,4 +66,4 @@ private:
 
 } // namespace yarp::dev
 
-#endif // YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETTRACKBALL_H
+#endif // YARP_THRIFT_GENERATOR_STRUCT_RETURN_GETALLAXES_H

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getStick.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getStick.cpp
@@ -14,7 +14,7 @@ namespace yarp::dev {
 
 // Constructor with field values
 return_getStick::return_getStick(const yarp::dev::ReturnValue& ret,
-                                 const StickData& value,
+                                 const yarp::dev::StickData& value,
                                  const std::int16_t coordinate_mode_enum) :
         WirePortable(),
         ret(ret),
@@ -29,7 +29,7 @@ bool return_getStick::read(yarp::os::idl::WireReader& reader)
     if (!nested_read_ret(reader)) {
         return false;
     }
-    if (!read_value(reader)) {
+    if (!nested_read_value(reader)) {
         return false;
     }
     if (!read_coordinate_mode_enum(reader)) {
@@ -45,7 +45,7 @@ bool return_getStick::read(yarp::os::idl::WireReader& reader)
 bool return_getStick::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(4)) {
+    if (!reader.readListHeader(3)) {
         return false;
     }
     if (!read(reader)) {
@@ -60,7 +60,7 @@ bool return_getStick::write(const yarp::os::idl::WireWriter& writer) const
     if (!nested_write_ret(writer)) {
         return false;
     }
-    if (!write_value(writer)) {
+    if (!nested_write_value(writer)) {
         return false;
     }
     if (!write_coordinate_mode_enum(writer)) {
@@ -76,7 +76,7 @@ bool return_getStick::write(const yarp::os::idl::WireWriter& writer) const
 bool return_getStick::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(4)) {
+    if (!writer.writeListHeader(3)) {
         return false;
     }
     if (!write(writer)) {

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getStick.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getStick.h
@@ -24,7 +24,7 @@ class return_getStick :
 public:
     // Fields
     yarp::dev::ReturnValue ret{};
-    StickData value{};
+    yarp::dev::StickData value{};
     std::int16_t coordinate_mode_enum{0};
 
     // Default constructor
@@ -32,7 +32,7 @@ public:
 
     // Constructor with field values
     return_getStick(const yarp::dev::ReturnValue& ret,
-                    const StickData& value,
+                    const yarp::dev::StickData& value,
                     const std::int16_t coordinate_mode_enum);
 
     // Read structure on a Wire

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getTouch.h
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getTouch.h
@@ -24,14 +24,14 @@ class return_getTouch :
 public:
     // Fields
     yarp::dev::ReturnValue ret{};
-    std::vector<TouchData> value{};
+    std::vector<yarp::dev::TouchData> value{};
 
     // Default constructor
     return_getTouch() = default;
 
     // Constructor with field values
     return_getTouch(const yarp::dev::ReturnValue& ret,
-                    const std::vector<TouchData>& value);
+                    const std::vector<yarp::dev::TouchData>& value);
 
     // Read structure on a Wire
     bool read(yarp::os::idl::WireReader& reader) override;

--- a/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getTrackball.cpp
+++ b/src/devices/messages/IJoypadControlMsgs/idl_generated_code/yarp/dev/return_getTrackball.cpp
@@ -14,7 +14,7 @@ namespace yarp::dev {
 
 // Constructor with field values
 return_getTrackball::return_getTrackball(const yarp::dev::ReturnValue& ret,
-                                         const TrackballData& value) :
+                                         const yarp::dev::TrackballData& value) :
         WirePortable(),
         ret(ret),
         value(value)
@@ -27,7 +27,7 @@ bool return_getTrackball::read(yarp::os::idl::WireReader& reader)
     if (!nested_read_ret(reader)) {
         return false;
     }
-    if (!read_value(reader)) {
+    if (!nested_read_value(reader)) {
         return false;
     }
     if (reader.isError()) {
@@ -40,7 +40,7 @@ bool return_getTrackball::read(yarp::os::idl::WireReader& reader)
 bool return_getTrackball::read(yarp::os::ConnectionReader& connection)
 {
     yarp::os::idl::WireReader reader(connection);
-    if (!reader.readListHeader(3)) {
+    if (!reader.readListHeader(2)) {
         return false;
     }
     if (!read(reader)) {
@@ -55,7 +55,7 @@ bool return_getTrackball::write(const yarp::os::idl::WireWriter& writer) const
     if (!nested_write_ret(writer)) {
         return false;
     }
-    if (!write_value(writer)) {
+    if (!nested_write_value(writer)) {
         return false;
     }
     if (writer.isError()) {
@@ -68,7 +68,7 @@ bool return_getTrackball::write(const yarp::os::idl::WireWriter& writer) const
 bool return_getTrackball::write(yarp::os::ConnectionWriter& connection) const
 {
     yarp::os::idl::WireWriter writer(connection);
-    if (!writer.writeListHeader(3)) {
+    if (!writer.writeListHeader(2)) {
         return false;
     }
     if (!write(writer)) {

--- a/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.cpp
@@ -285,6 +285,31 @@ ReturnValue JoypadControl_nwc_yarp::getHat(size_t hat_id, unsigned char& value)
     }
 }
 
+ReturnValue JoypadControl_nwc_yarp::getAllAxes(std::vector<double>& value)
+{
+    if(!m_use_streaming)
+    {
+        auto ret = m_rpcMsgs.getAllAxes();
+        value = ret.value;
+        return ret.ret;
+    }
+    else
+    {
+        if (m_use_all_port)
+        {
+            auto tmp = m_allJoyDataPort.getData();
+            value = tmp.AxisDataVal;
+            return ReturnValue_ok;
+        }
+        else
+        {
+            auto tmp = m_axisPort.getData();
+            value = tmp.value;
+            return ReturnValue_ok;
+        }
+    }
+}
+
 ReturnValue JoypadControl_nwc_yarp::getAxis(size_t axis_id, double& value)
 {
     if(!m_use_streaming)

--- a/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.cpp
+++ b/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.cpp
@@ -173,13 +173,6 @@ ReturnValue JoypadControl_nwc_yarp::getStickCount(size_t& stick_count)
     return ret.ret;
 }
 
-ReturnValue JoypadControl_nwc_yarp::getStickDoF(size_t stick_id, size_t& DoF)
-{
-    auto ret = m_rpcMsgs.getStickDoF(stick_id);
-    DoF = ret.DoF;
-    return ret.ret;
-}
-
 ReturnValue JoypadControl_nwc_yarp::getButton(size_t button_id, double& value)
 {
     if(!m_use_streaming)

--- a/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.h
+++ b/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.h
@@ -113,6 +113,7 @@ public:
     yarp::dev::ReturnValue getTrackball(size_t trackball_id, yarp::dev::TrackballData& value) override;
     yarp::dev::ReturnValue getHat(size_t hat_id, unsigned char& value) override;
     yarp::dev::ReturnValue getAxis(size_t axis_id, double& value) override;
+    yarp::dev::ReturnValue getAllAxes(std::vector<double>& values) override;
     yarp::dev::ReturnValue getStick(size_t stick_id, yarp::dev::StickData& value, JoypadCtrl_coordinateMode coordinate_mode) override;
     yarp::dev::ReturnValue getTouch(size_t touch_id, std::vector<yarp::dev::TouchData>& value) override;
 };

--- a/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.h
+++ b/src/devices/networkWrappers/joypadControl_nwc_yarp/JoypadControl_nwc_yarp.h
@@ -109,7 +109,6 @@ public:
     yarp::dev::ReturnValue getHatCount(size_t& Hat_count) override;
     yarp::dev::ReturnValue getTouchSurfaceCount(size_t& touch_count) override;
     yarp::dev::ReturnValue getStickCount(size_t& stick_count) override;
-    yarp::dev::ReturnValue getStickDoF(size_t stick_id, size_t& DoF) override;
     yarp::dev::ReturnValue getButton(size_t button_id, double& value) override;
     yarp::dev::ReturnValue getTrackball(size_t trackball_id, yarp::dev::TrackballData& value) override;
     yarp::dev::ReturnValue getHat(size_t hat_id, unsigned char& value) override;

--- a/src/devices/networkWrappers/joypadControl_nws_yarp/JoypadControl_nws_yarp.cpp
+++ b/src/devices/networkWrappers/joypadControl_nws_yarp/JoypadControl_nws_yarp.cpp
@@ -49,7 +49,6 @@ class IJoypadControlRPCd : public yarp::dev::IJoypadControlMsgs
     return_getHatCount getHatCount() override;
     return_getTouchSurfaceCount getTouchSurfaceCount() override;
     return_getStickCount getStickCount() override;
-    return_getStickDoF getStickDoF(const std::int32_t stick_id) override;
     return_getButton getButton(const std::int32_t button_id) override;
     return_getTrackball getTrackball(const std::int32_t trackball_id) override;
     return_getHat getHat(const std::int32_t hat_id) override;
@@ -180,22 +179,6 @@ return_getTrackball IJoypadControlRPCd::getTrackball(const std::int32_t id)
 
     size_t temp=0;
     ret.ret = m_iJoy->getTrackball(id, ret.value);
-    return ret;
-}
-
-return_getStickDoF IJoypadControlRPCd::getStickDoF(const std::int32_t id)
-{
-    return_getStickDoF ret;
-
-    if (!m_iJoy) {
-        yCError(JOYPADCONTROLSERVER, "Invalid interface");
-        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
-        return ret;
-    }
-
-    size_t temp=0;
-    ret.ret = m_iJoy->getStickDoF(id, temp);
-    ret.DoF= temp;
     return ret;
 }
 

--- a/src/devices/networkWrappers/joypadControl_nws_yarp/JoypadControl_nws_yarp.cpp
+++ b/src/devices/networkWrappers/joypadControl_nws_yarp/JoypadControl_nws_yarp.cpp
@@ -53,6 +53,7 @@ class IJoypadControlRPCd : public yarp::dev::IJoypadControlMsgs
     return_getTrackball getTrackball(const std::int32_t trackball_id) override;
     return_getHat getHat(const std::int32_t hat_id) override;
     return_getAxis getAxis(const std::int32_t axis_id) override;
+    return_getAllAxes getAllAxes() override;
     return_getStick getStick(const std::int32_t stick_id, yarp::dev::IJoypadController::JoypadCtrl_coordinateMode mode) override;
     return_getTouch getTouch(const std::int32_t touch_id) override;
 };
@@ -195,6 +196,21 @@ return_getHat IJoypadControlRPCd::getHat(const std::int32_t id)
     unsigned char temp = 0;
     ret.ret = m_iJoy->getHat(id, temp);
     ret.value= temp;
+    return ret;
+}
+
+return_getAllAxes IJoypadControlRPCd::getAllAxes()
+{
+    return_getAllAxes ret;
+
+    if (!m_iJoy) {
+        yCError(JOYPADCONTROLSERVER, "Invalid interface");
+        ret.ret = ReturnValue::return_code::return_value_error_not_ready;
+        return ret;
+    }
+
+    std::vector<double> vals;
+    ret.ret = m_iJoy->getAllAxes(ret.value);
     return ret;
 }
 

--- a/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
@@ -5,4 +5,24 @@
 
 #include <yarp/dev/IJoypadController.h>
 
-yarp::dev::IJoypadController::~IJoypadController() = default;
+using namespace yarp::dev;
+
+IJoypadController::~IJoypadController() = default;
+
+ReturnValue IJoypadController::getAllAxes(std::vector<double>& values)
+{
+    size_t num_of_axes = 0;
+    ReturnValue ret = this->getAxisCount(num_of_axes);
+    if (!ret)
+    {
+        return ret;
+    }
+    for (size_t i = 0; i < num_of_axes; i++)
+    {
+        double value = 0.0;
+        ret = this->getAxis(i, value);
+        values.push_back(value);
+    }
+
+    return ReturnValue::ReturnValue_ok;
+}

--- a/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
+++ b/src/libYARP_dev/src/yarp/dev/IJoypadController.cpp
@@ -24,5 +24,5 @@ ReturnValue IJoypadController::getAllAxes(std::vector<double>& values)
         values.push_back(value);
     }
 
-    return ReturnValue::ReturnValue_ok;
+    return ReturnValue_ok;
 }

--- a/src/libYARP_dev/src/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/src/yarp/dev/IJoypadController.h
@@ -85,15 +85,6 @@ public:
     virtual yarp::dev::ReturnValue getStickCount(size_t& stick_count) = 0;
 
     /**
-     * @brief Get the Degree Of Freedom count for desired stick.
-     *
-     * @param stick_id Id of the stick. must be > -1 && < getStickCount(), return false otherwise.
-     * @param DoF an unsigned int reference that will contain the value.
-     * @return true if succeeded, false otherwise
-     */
-    virtual yarp::dev::ReturnValue getStickDoF(size_t stick_id, size_t& DoF) = 0;
-
-    /**
      * @brief Get the value of a button.
      *
      * From 0-unpressed to 1-fullpressed and values in the middle in the

--- a/src/libYARP_dev/src/yarp/dev/IJoypadController.h
+++ b/src/libYARP_dev/src/yarp/dev/IJoypadController.h
@@ -126,6 +126,14 @@ public:
     virtual yarp::dev::ReturnValue getAxis(size_t axis_id, double& value) = 0;
 
     /**
+     * @brief Get the values of all available joystick axes.
+     *
+     * @param values the vector containing the axes values.
+     * @return true if succeeded, false otherwise.
+     */
+    virtual yarp::dev::ReturnValue getAllAxes(std::vector<double>& values);
+
+    /**
      * @brief Get the value of a stick if present, return false otherwise.
      *
      * @param stick_id Id of the stick to get. must be > -1 && < getStickCount(), return false otherwise.

--- a/src/libYARP_dev/src/yarp/dev/tests/IJoypadControllerTest.h
+++ b/src/libYARP_dev/src/yarp/dev/tests/IJoypadControllerTest.h
@@ -48,6 +48,17 @@ namespace yarp::dev::tests
 
         //-----
 
+        std::vector<double> axesvals;
+        b = iJoy->getAllAxes(axesvals);
+        CHECK(b);
+        REQUIRE(axesvals.size() == 4);
+        for (size_t i=0; i<4; i++)
+        {
+            CHECK (axesvals[i] == i*10);
+        }
+
+        //-----
+
         for (size_t i=0; i<4; i++)
         {
            b = iJoy->getAxis(i, value);


### PR DESCRIPTION
remove method `IJoypadControl::getStickDoF(size_t  stick_id, size_t& DoF)`

Related to: https://github.com/robotology/yarp/issues/3370