### PR TITLE
YARP_stats add dependencies to YARP_companion

### DIFF
--- a/src/libYARP_stats/src/CMakeLists.txt
+++ b/src/libYARP_stats/src/CMakeLists.txt
@@ -68,8 +68,12 @@ target_include_directories(YARP_stats
 )
 target_compile_features(YARP_stats PUBLIC cxx_std_17)
 
-target_link_libraries(YARP_stats PRIVATE YARP::YARP_os YARP::YARP_profiler)
-list(APPEND YARP_stats_PRIVATE_DEPS YARP_os)
+target_link_libraries(YARP_stats PUBLIC  YARP::YARP_companion
+                                 PRIVATE YARP::YARP_os
+                                         YARP::YARP_profiler)
+
+list(APPEND YARP_stats_PUBLIC_DEPS YARP_companion)
+list(APPEND YARP_stats_PRIVATE_DEPS YARP_os YARP_profiler)
 
 set_property(TARGET YARP_stats PROPERTY PUBLIC_HEADER ${YARP_stats_HDRS} ${YARP_stats_idl_HDRS})
 set_property(TARGET YARP_stats PROPERTY VERSION ${YARP_VERSION_SHORT})


### PR DESCRIPTION
Updated target_link_libraries to include YARP_companion and adjusted private dependencies.

It should fix this failure:
- https://github.com/robotology/robotology-superbuild/actions/runs/33051215209/job/98463856576?pr=1945