### PR TITLE
fixed segfault due to race condition in RGBDSensor_StreamingMsgParser::read

### DIFF
--- a/src/devices/networkWrappers/RGBDSensor_nwc_yarp/RGBDSensor_nwc_yarp_StreamingMsgParser.cpp
+++ b/src/devices/networkWrappers/RGBDSensor_nwc_yarp/RGBDSensor_nwc_yarp_StreamingMsgParser.cpp
@@ -109,11 +109,11 @@ bool RGBDSensor_StreamingMsgParser::read(yarp::sig::FlexImage &rgbImage, yarp::s
     rgbImage = std::get<1>(resultRgb);
     depthImage = std::get<1>(resultDepth);
     if(rgbStamp) {
-        port_rgb->getEnvelope(*rgbStamp);
+        *rgbStamp = std::get<2>(resultRgb);
     }
 
     if(depthStamp) {
-        port_depth->getEnvelope(*depthStamp);
+        *depthStamp = std::get<2>(resultDepth);
     }
     return true;
 }


### PR DESCRIPTION
Fixed a race condition in `RGBDSensor_StreamingMsgParser::read()` that could
cause a segmentation fault. The method retrieved the image timestamps by
calling `port_rgb->getEnvelope()` / `port_depth->getEnvelope()` from the
caller's thread, outside the mutex that protects the buffered frames.

`PortReaderBufferBase::getEnvelope()` reads the `prev` packet pointer without
holding `stateMutex`, so the port's own reader thread could recycle that
packet between the null check and the dereference of `prev->envelope`,
leading to a use-after-free. The stamps are now taken from the snapshot
already returned by `getImage()` under the lock, consistently with what
`readRgb()` and `readDepth()` do.

This also fixes a latent correctness issue: the envelope returned by
`getEnvelope()` belonged to the most recently received frame, which is not
necessarily the frame returned by the same call, so images and timestamps
could be mismatched.