### PR TITLE
Fix signed overflow when the Stamp sequence counter wraps

### DIFF
--- a/doc/release/yarp_4_0/stamp_sequence_rollover.md
+++ b/doc/release/yarp_4_0/stamp_sequence_rollover.md
@@ -1,0 +1,4 @@
+stamp_sequence_rollover {#yarp_4_0}
+-----------------------
+
+* Fixed signed overflow when `yarp::os::Stamp` wraps its sequence number to zero.

--- a/src/libYARP_os/src/yarp/os/Stamp.cpp
+++ b/src/libYARP_os/src/yarp/os/Stamp.cpp
@@ -125,18 +125,20 @@ void yarp::os::Stamp::update()
 {
     double now = Time::now();
 
-    sequenceNumber++;
-    if (sequenceNumber > getMaxCount() || sequenceNumber < 0) {
+    if (sequenceNumber >= getMaxCount() || sequenceNumber < 0) {
         sequenceNumber = 0;
+    } else {
+        sequenceNumber++;
     }
     timeStamp = now;
 }
 
 void yarp::os::Stamp::update(double time)
 {
-    sequenceNumber++;
-    if (sequenceNumber > getMaxCount() || sequenceNumber < 0) {
+    if (sequenceNumber >= getMaxCount() || sequenceNumber < 0) {
         sequenceNumber = 0;
+    } else {
+        sequenceNumber++;
     }
     timeStamp = time;
 }

--- a/src/libYARP_os/tests/StampTest.cpp
+++ b/src/libYARP_os/tests/StampTest.cpp
@@ -134,6 +134,23 @@ TEST_CASE("os::StampTest", "[yarp::os]")
         checkEnvelope("tcp");
     }
 
+    SECTION("sequence number wraps with an explicit timestamp")
+    {
+        Stamp stamp(Stamp().getMaxCount(), 1.0);
+        stamp.update(2.0);
+        CHECK(stamp.getCount() == 0);
+        CHECK(stamp.getTime() == 2.0);
+        CHECK(stamp.isValid());
+    }
+
+    SECTION("sequence number wraps with the current time")
+    {
+        Stamp stamp(Stamp().getMaxCount(), 1.0);
+        stamp.update();
+        CHECK(stamp.getCount() == 0);
+        CHECK(stamp.isValid());
+    }
+
     SECTION("checking envelopes work (text mode)")
     {
         checkEnvelope("text");


### PR DESCRIPTION
Both `Stamp::update()` overloads increment the sequence number before checking whether it has reached the limit. At `INT_MAX`, this causes signed integer overflow before the counter can wrap to zero.

Check the limit before incrementing. Adds rollover tests for both overloads. The Stamp and Header tests pass with `-fsanitize=signed-integer-overflow -fno-sanitize-recover=signed-integer-overflow`; both new cases fail on the original code.
